### PR TITLE
feat(react_compiler): integrate the Rust port of the React Compiler

### DIFF
--- a/.github/scripts/generate-benchmark-matrix.js
+++ b/.github/scripts/generate-benchmark-matrix.js
@@ -21,6 +21,7 @@ const ALL_COMPONENTS = [
   "codegen",
   "formatter",
   "pipeline",
+  "react_compiler",
   "linter",
 ];
 
@@ -60,6 +61,9 @@ function checkGlobalChanges(changedFiles) {
 function getFeatureForComponent(component) {
   if (component === "linter") {
     return "linter";
+  }
+  if (component === "react_compiler") {
+    return "react_compiler";
   }
   return "compiler";
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.6",
+ "subtle",
 ]
 
 [[package]]
@@ -700,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -776,6 +777,159 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "forked_react_compiler"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34495a9926779b57310fd72e031fafdabc90f7c62e188aa5317ca08a115cce21"
+dependencies = [
+ "forked_react_compiler_ast",
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "forked_react_compiler_inference",
+ "forked_react_compiler_lowering",
+ "forked_react_compiler_optimization",
+ "forked_react_compiler_reactive_scopes",
+ "forked_react_compiler_ssa",
+ "forked_react_compiler_typeinference",
+ "forked_react_compiler_validation",
+ "indexmap",
+ "regex-lite",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "forked_react_compiler_ast"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ed273c27b68afe5b5f3bec2cd0215d6507f93921bf93a63b77f4362699c67e"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "forked_react_compiler_diagnostics"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0c5c845634ca8381a4dba94fc53f757c85de2e1e29711ef8fd7b5a4ca1fe9f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "forked_react_compiler_hir"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bbec4ac046d8eac451b16c75d51d7709b10cbfdc8a52e7c580e1e45239491b"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "indexmap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "forked_react_compiler_inference"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c910dd22822ab23c29d2e969f3e3ca9302fb10c065fcf48b83344dab715e798"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "forked_react_compiler_lowering",
+ "forked_react_compiler_optimization",
+ "forked_react_compiler_ssa",
+ "forked_react_compiler_utils",
+ "indexmap",
+]
+
+[[package]]
+name = "forked_react_compiler_lowering"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d891d2ea5d43aa948c56a036960059f405489c60089e57c261be4f35f05d815"
+dependencies = [
+ "forked_react_compiler_ast",
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "indexmap",
+ "serde_json",
+]
+
+[[package]]
+name = "forked_react_compiler_optimization"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8611f21629cf6333c1b634e1bca816c863d4cba48d4ac1f42d61203835797de9"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "forked_react_compiler_lowering",
+ "forked_react_compiler_ssa",
+ "indexmap",
+]
+
+[[package]]
+name = "forked_react_compiler_reactive_scopes"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "294a00391f2051dec90669fdff54397a464b16bb568117b48a959bed56d2798b"
+dependencies = [
+ "forked_react_compiler_ast",
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "hmac",
+ "indexmap",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "forked_react_compiler_ssa"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4782ac57df264c71abaabf68e90b9e3a96f3d607e772bc9ee6e9d26654614aa"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "forked_react_compiler_lowering",
+ "indexmap",
+]
+
+[[package]]
+name = "forked_react_compiler_typeinference"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15d9379f0f48a565d82ed03de02946571af209057cfdc81fe09355518e587a54"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "forked_react_compiler_ssa",
+]
+
+[[package]]
+name = "forked_react_compiler_utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531d2adbbfa861f9669f70e49eb1cc27e8817a7f1d000bee3e2c71a2d82217ec"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
+name = "forked_react_compiler_validation"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f8b2c12e00b41dc87bc2c63656b473047dcdf75b1f5dc545ca93a308d53a89"
+dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_hir",
+ "indexmap",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -1013,6 +1167,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -1554,7 +1717,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1653,6 +1816,7 @@ dependencies = [
  "oxc_mangler",
  "oxc_minifier",
  "oxc_parser",
+ "oxc_react_compiler",
  "oxc_regular_expression",
  "oxc_semantic",
  "oxc_span",
@@ -1826,6 +1990,7 @@ dependencies = [
  "oxc_mangler",
  "oxc_minifier",
  "oxc_parser",
+ "oxc_react_compiler",
  "oxc_semantic",
  "oxc_span",
  "oxc_tasks_common",
@@ -2359,6 +2524,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_react_compiler"
+version = "0.134.0"
+dependencies = [
+ "forked_react_compiler",
+ "forked_react_compiler_ast",
+ "forked_react_compiler_hir",
+ "indexmap",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_codegen",
+ "oxc_diagnostics",
+ "oxc_parser",
+ "oxc_semantic",
+ "oxc_span",
+ "oxc_syntax",
+ "rustc-hash",
+ "serde_json",
+]
+
+[[package]]
 name = "oxc_regular_expression"
 version = "0.134.0"
 dependencies = [
@@ -2563,6 +2749,7 @@ dependencies = [
  "napi-derive",
  "oxc",
  "oxc_napi",
+ "oxc_react_compiler",
  "oxc_sourcemap",
  "rustc-hash",
 ]
@@ -3043,6 +3230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,7 +3311,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3213,7 +3406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3508,7 +3701,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4037,7 +4230,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,7 @@ oxc_parser = { version = "0.134.0", path = "crates/oxc_parser", features = [
   "regular_expression",
 ] } # JS/TS parser
 oxc_parser_napi = { version = "0.134.0", path = "napi/parser" } # Node.js parser binding
+oxc_react_compiler = { version = "0.134.0", path = "crates/oxc_react_compiler" } # React Compiler integration (experimental)
 oxc_regular_expression = { version = "0.134.0", path = "crates/oxc_regular_expression" } # Regex parser
 oxc_semantic = { version = "0.134.0", path = "crates/oxc_semantic" } # Semantic analysis
 oxc_span = { version = "0.134.0", path = "crates/oxc_span" } # Source positions

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -36,6 +36,7 @@ oxc_isolated_declarations = { workspace = true, optional = true }
 oxc_mangler = { workspace = true, optional = true }
 oxc_minifier = { workspace = true, optional = true }
 oxc_parser = { workspace = true, features = [] }
+oxc_react_compiler = { workspace = true, optional = true }
 oxc_regular_expression = { workspace = true, optional = true }
 oxc_semantic = { workspace = true, optional = true }
 oxc_span = { workspace = true }
@@ -58,7 +59,7 @@ full = [
 ]
 
 semantic = ["oxc_semantic"]
-transformer = ["oxc_transformer", "oxc_transformer_plugins"]
+transformer = ["oxc_transformer", "oxc_transformer_plugins", "oxc_react_compiler"]
 minifier = ["oxc_mangler", "oxc_minifier"]
 codegen = ["oxc_codegen", "oxc_codegen/sourcemap"]
 mangler = ["oxc_mangler"]

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -8,6 +8,7 @@ use oxc_isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOption
 use oxc_mangler::{MangleOptions, Mangler, ManglerReturn};
 use oxc_minifier::{CompressOptions, Compressor};
 use oxc_parser::{ParseOptions, Parser, ParserReturn};
+use oxc_react_compiler::{self, PluginOptions as ReactCompilerOptions};
 use oxc_semantic::{Scoping, SemanticBuilder, SemanticBuilderReturn};
 use oxc_span::SourceType;
 use oxc_transformer::{TransformOptions, Transformer, TransformerReturn};
@@ -67,6 +68,13 @@ pub trait CompilerInterface {
     }
 
     fn transform_options(&self) -> Option<&TransformOptions> {
+        None
+    }
+
+    /// Options for the [React Compiler], which runs before all other transforms.
+    ///
+    /// [React Compiler]: oxc_react_compiler
+    fn react_compiler_options(&self) -> Option<ReactCompilerOptions> {
         None
     }
 
@@ -148,6 +156,15 @@ pub trait CompilerInterface {
         let stats = semantic_return.semantic.stats();
         let mut scoping = semantic_return.semantic.into_scoping();
 
+        /* React Compiler */
+
+        // Runs first, on the pristine AST, before every other transform.
+        let mut errors = Vec::new();
+        if let Some(options) = self.react_compiler_options() {
+            scoping =
+                oxc_react_compiler::run(&mut program, &allocator, scoping, &options, &mut errors);
+        }
+
         /* Transform */
 
         if let Some(options) = self.transform_options() {
@@ -155,8 +172,16 @@ pub trait CompilerInterface {
                 self.transform(options, &allocator, &mut program, source_path, scoping);
 
             if !transformer_return.errors.is_empty() {
-                self.handle_errors(transformer_return.errors);
+                errors.append(&mut transformer_return.errors);
+                self.handle_errors(errors);
                 return;
+            }
+
+            // The React Compiler always leaves a valid program (compiled on
+            // success, original on bail-out), so its diagnostics are reported but
+            // never abort codegen.
+            if !errors.is_empty() {
+                self.handle_errors(errors);
             }
 
             if self.after_transform(&mut program, &mut transformer_return).is_break() {
@@ -164,6 +189,10 @@ pub trait CompilerInterface {
             }
 
             (scoping) = transformer_return.scoping;
+        } else if !errors.is_empty() {
+            // The React Compiler ran without a transform; surface its diagnostics
+            // but never abort — it always leaves a valid program.
+            self.handle_errors(errors);
         }
 
         let inject_options = self.inject_options();

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -1,0 +1,66 @@
+# oxc_react_compiler
+#
+# Native oxc integration for the Rust port of React Compiler (facebook/react#36173).
+#
+# This crate owns the oxc <-> react_compiler_ast conversion layer. The React
+# Compiler *core* crates are frontend-agnostic (they depend on serde/indexmap
+# only, never on oxc), so we consume them from crates.io (a published MIT fork of
+# facebook/react#36173) and keep the AST/scope conversion on our side, written
+# against the live workspace oxc AST.
+
+[package]
+name = "oxc_react_compiler"
+version = "0.134.0"
+publish = true
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "oxc integration for the Rust port of React Compiler"
+
+[lib]
+doctest = false
+
+[dependencies]
+oxc_allocator = { workspace = true }
+oxc_ast = { workspace = true }
+oxc_ast_visit = { workspace = true }
+oxc_codegen = { workspace = true }
+oxc_diagnostics = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_semantic = { workspace = true }
+oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
+
+# React Compiler core crates — frontend-agnostic (no oxc deps). Published fork of
+# facebook/react#36173 (MIT). `package` keeps the in-code name `react_compiler*`.
+react_compiler = { package = "forked_react_compiler", version = "0.1.3" }
+react_compiler_ast = { package = "forked_react_compiler_ast", version = "0.1.3" }
+react_compiler_hir = { package = "forked_react_compiler_hir", version = "0.1.3" }
+
+indexmap = { workspace = true, features = ["serde"] }
+rustc-hash = { workspace = true }
+serde_json = { workspace = true, features = ["raw_value"] }
+
+# The `src/` conversion modules are vendored close to upstream `react_compiler_oxc`
+# (kept near byte-for-byte to ease re-syncing), so relax the handful of lints they
+# trip here rather than editing the code. Defining `[lints.clippy]` means this crate
+# does not inherit `[lints] workspace = true`, which keeps the in-house restriction
+# lints (`todo!`/`unimplemented!`/...) off the vendored code while clippy's default
+# correctness and perf checks still apply.
+[lints.clippy]
+disallowed_types = "allow" # `react_compiler_ast`'s `ScopeInfo`/`ScopeData` fields are std `HashMap`
+collapsible_if = "allow"
+needless_return = "allow"
+unnecessary_unwrap = "allow"
+
+# The vendored modules' doc comments reference types like `Vec<PatternLike>`
+# without backticks; relax rustdoc for them rather than editing upstream code.
+[lints.rustdoc]
+broken_intra_doc_links = "allow"
+invalid_html_tags = "allow"
+bare_urls = "allow"

--- a/crates/oxc_react_compiler/README.md
+++ b/crates/oxc_react_compiler/README.md
@@ -1,0 +1,18 @@
+# Oxc React Compiler
+
+oxc integration for the Rust port of the [React Compiler](https://github.com/facebook/react/pull/36173).
+
+## Overview
+
+This crate owns the oxc &harr; `react_compiler_ast` (Babel) conversion layer and runs the React
+Compiler over an oxc AST, memoizing React components and hooks. The compiler _core_ crates are
+front-end agnostic (they never depend on oxc), so they are consumed from crates.io as a published
+fork; the AST and scope conversion lives here, written against the live oxc AST.
+
+## API
+
+- `transform` — run the compiler and return the compiled oxc `Program` plus diagnostics.
+- `run` — standalone pass that rewrites a program in place and returns the scoping the rest of the
+  pipeline should use.
+- `lint` — report diagnostics only, without emitting code.
+- `default_plugin_options` / `PluginOptions` — configure which functions are compiled and how.

--- a/crates/oxc_react_compiler/examples/react_compiler.rs
+++ b/crates/oxc_react_compiler/examples/react_compiler.rs
@@ -1,0 +1,63 @@
+//! # React Compiler Example
+//!
+//! Runs the Rust port of React Compiler ([facebook/react#36173]) over a file
+//! through the oxc frontend (parse + semantic -> convert -> compile -> convert
+//! back -> codegen) and prints the memoized output.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! just example react_compiler MyFile.jsx
+//! ```
+//!
+//! [facebook/react#36173]: https://github.com/facebook/react/pull/36173
+
+use std::path::Path;
+
+use oxc_allocator::Allocator;
+use oxc_codegen::Codegen;
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+use oxc_span::SourceType;
+
+use oxc_react_compiler::{default_plugin_options, transform};
+
+/// Compile a React component with the Rust React Compiler and print the result.
+fn main() {
+    let name = std::env::args().nth(1).unwrap_or_else(|| {
+        eprintln!("usage: cargo run -p oxc_react_compiler --example react_compiler -- <FILE>");
+        std::process::exit(1);
+    });
+    let path = Path::new(&name);
+    let source_text =
+        std::fs::read_to_string(path).unwrap_or_else(|err| panic!("{name} not found.\n{err}"));
+    let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::tsx());
+
+    println!("Original ({name}):\n");
+    println!("{source_text}");
+
+    let allocator = Allocator::default();
+    let program = Parser::new(&allocator, &source_text, source_type).parse().program;
+    let semantic = SemanticBuilder::new().build(&program).semantic;
+
+    let result = transform(&program, &semantic, &allocator, default_plugin_options());
+
+    if !result.diagnostics.is_empty() {
+        println!("Diagnostics:\n");
+        for diagnostic in &result.diagnostics {
+            println!("{diagnostic:?}");
+        }
+        println!();
+    }
+
+    match result.program {
+        Some(compiled) => {
+            let output = Codegen::new().build(&compiled).code;
+            println!("Compiled:\n");
+            println!("{output}");
+        }
+        None => {
+            println!("No changes: no React component or hook found (or compilation bailed out).");
+        }
+    }
+}

--- a/crates/oxc_react_compiler/src/apply_renames.rs
+++ b/crates/oxc_react_compiler/src/apply_renames.rs
@@ -1,0 +1,158 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//! Apply the React Compiler's binding renames to identifiers in uncompiled
+//! sibling code (compiled functions already carry the renamed identifiers).
+
+use oxc_ast::ast::*;
+use oxc_ast_visit::VisitMut;
+use oxc_ast_visit::walk_mut;
+use react_compiler::entrypoint::compile_result::BindingRenameInfo;
+use react_compiler_ast::scope::BindingId;
+use react_compiler_ast::scope::ScopeInfo;
+use rustc_hash::FxHashMap;
+
+/// Map each `span.start` of a renamed-binding reference to its new name.
+pub fn build_rename_plan(
+    scope_info: &ScopeInfo,
+    renames: &[BindingRenameInfo],
+) -> FxHashMap<u32, String> {
+    if renames.is_empty() {
+        return FxHashMap::default();
+    }
+
+    let renames_by_declaration: FxHashMap<u32, &BindingRenameInfo> =
+        renames.iter().map(|rename| (rename.declaration_start, rename)).collect();
+
+    let mut renamed_bindings: FxHashMap<BindingId, String> = FxHashMap::default();
+    for binding in &scope_info.bindings {
+        let Some(rename) =
+            binding.declaration_start.and_then(|start| renames_by_declaration.get(&start))
+        else {
+            continue;
+        };
+        if binding.name == rename.original {
+            renamed_bindings.insert(binding.id, rename.renamed.clone());
+        }
+    }
+
+    if renamed_bindings.is_empty() {
+        return FxHashMap::default();
+    }
+
+    // `ref_node_id_to_binding` is node-id keyed; in OXC node_id == span.start.
+    scope_info
+        .ref_node_id_to_binding
+        .iter()
+        .filter_map(|(&position, binding_id)| {
+            if scope_info.bindings[binding_id.0 as usize].declaration_start == Some(position) {
+                return None;
+            }
+            renamed_bindings.get(binding_id).map(|renamed| (position, renamed.clone()))
+        })
+        .collect()
+}
+
+/// Walk the program and apply `rename_plan` (keyed by `span.start`), expanding
+/// shorthand properties `{x}` → `{x: x_0}` when the value is renamed.
+pub fn apply_renames<'a>(
+    program: &mut Program<'a>,
+    rename_plan: &FxHashMap<u32, String>,
+    allocator: &'a oxc_allocator::Allocator,
+) {
+    if rename_plan.is_empty() {
+        return;
+    }
+    walk_mut::walk_program(&mut RenameApplyVisitor { rename_plan, allocator }, program);
+}
+
+struct RenameApplyVisitor<'a, 'p> {
+    rename_plan: &'p FxHashMap<u32, String>,
+    allocator: &'a oxc_allocator::Allocator,
+}
+
+impl<'a, 'p> RenameApplyVisitor<'a, 'p> {
+    fn renamed_at(&self, position: u32) -> Option<&str> {
+        self.rename_plan.get(&position).map(|s| s.as_str())
+    }
+}
+
+impl<'a> VisitMut<'a> for RenameApplyVisitor<'a, '_> {
+    fn visit_identifier_reference(&mut self, ident: &mut IdentifierReference<'a>) {
+        if let Some(renamed) = self.renamed_at(ident.span.start) {
+            ident.name = oxc_allocator::StringBuilder::from_str_in(renamed, self.allocator)
+                .into_str()
+                .into();
+        }
+    }
+
+    fn visit_binding_identifier(&mut self, ident: &mut BindingIdentifier<'a>) {
+        if let Some(renamed) = self.renamed_at(ident.span.start) {
+            ident.name = oxc_allocator::StringBuilder::from_str_in(renamed, self.allocator)
+                .into_str()
+                .into();
+        }
+    }
+
+    /// Rename the object of a member expression, never a static property name.
+    fn visit_member_expression(&mut self, expr: &mut MemberExpression<'a>) {
+        match expr {
+            MemberExpression::StaticMemberExpression(static_expr) => {
+                self.visit_expression(&mut static_expr.object);
+            }
+            MemberExpression::ComputedMemberExpression(computed_expr) => {
+                self.visit_expression(&mut computed_expr.object);
+                self.visit_expression(&mut computed_expr.expression);
+            }
+            MemberExpression::PrivateFieldExpression(private_expr) => {
+                self.visit_expression(&mut private_expr.object);
+            }
+        }
+    }
+
+    /// Expand a renamed shorthand object property `{x}` into `{x: x_0}`.
+    fn visit_object_property(&mut self, prop: &mut ObjectProperty<'a>) {
+        if prop.shorthand {
+            if let Expression::Identifier(ref ident) = prop.value {
+                if let Some(renamed) = self.renamed_at(ident.span.start) {
+                    prop.shorthand = false;
+                    if let Expression::Identifier(ref mut ident) = prop.value {
+                        ident.name =
+                            oxc_allocator::StringBuilder::from_str_in(renamed, self.allocator)
+                                .into_str()
+                                .into();
+                    }
+                    return;
+                }
+            }
+        }
+        if prop.computed {
+            self.visit_property_key(&mut prop.key);
+        }
+        self.visit_expression(&mut prop.value);
+    }
+
+    /// Expand a renamed shorthand binding property `{x}` into `{x: x_0}`.
+    fn visit_binding_property(&mut self, prop: &mut BindingProperty<'a>) {
+        if prop.shorthand {
+            if let BindingPattern::BindingIdentifier(ref ident) = prop.value {
+                if let Some(renamed) = self.renamed_at(ident.span.start) {
+                    prop.shorthand = false;
+                    if let BindingPattern::BindingIdentifier(ref mut ident) = prop.value {
+                        ident.name =
+                            oxc_allocator::StringBuilder::from_str_in(renamed, self.allocator)
+                                .into_str()
+                                .into();
+                    }
+                    return;
+                }
+            }
+        }
+        if prop.computed {
+            self.visit_property_key(&mut prop.key);
+        }
+        self.visit_binding_pattern(&mut prop.value);
+    }
+}

--- a/crates/oxc_react_compiler/src/convert_ast.rs
+++ b/crates/oxc_react_compiler/src/convert_ast.rs
@@ -1,0 +1,3195 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+use oxc_ast::ast as oxc;
+use oxc_span::GetSpan;
+use oxc_span::Span;
+use react_compiler_ast::File;
+use react_compiler_ast::InterpreterDirective;
+use react_compiler_ast::Program;
+use react_compiler_ast::SourceType;
+use react_compiler_ast::common::BaseNode;
+use react_compiler_ast::common::Comment;
+use react_compiler_ast::common::CommentData;
+use react_compiler_ast::common::Position;
+use react_compiler_ast::common::SourceLocation;
+use react_compiler_ast::declarations::*;
+use react_compiler_ast::expressions::*;
+use react_compiler_ast::jsx::*;
+use react_compiler_ast::literals::*;
+use react_compiler_ast::operators::*;
+use react_compiler_ast::patterns::*;
+use react_compiler_ast::statements::*;
+
+/// Decode XML/HTML entities in JSX text (`&amp;` → `&`, `&gt;` → `>`, `&#123;`
+/// → `{`, `&#x1F600;` → emoji, …) so the Babel `JSXText.value` is the decoded
+/// text, matching Babel's parser. oxc keeps JSX text raw in the AST, so the
+/// bridge to the Babel AST must decode here. Mirrors `oxc_transformer`'s JSX
+/// entity decoder; unrecognized `&…;` sequences are kept verbatim.
+fn decode_jsx_entities(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.char_indices();
+    let mut prev = 0;
+    while let Some((i, c)) = chars.next() {
+        if c != '&' {
+            continue;
+        }
+        let mut start = i;
+        let mut end = None;
+        for (j, c) in chars.by_ref() {
+            if c == ';' {
+                end = Some(j);
+                break;
+            } else if c == '&' {
+                start = j;
+            }
+        }
+        let Some(end) = end else { break };
+        out.push_str(&s[prev..start]);
+        prev = end + 1;
+        let word = &s[start + 1..end];
+        let decoded = if let Some(num) = word.strip_prefix('#') {
+            if let Some(hex) = num.strip_prefix(['x', 'X']) {
+                u32::from_str_radix(hex, 16).ok().and_then(char::from_u32)
+            } else {
+                num.parse::<u32>().ok().and_then(char::from_u32)
+            }
+        } else {
+            oxc_syntax::xml_entities::XML_ENTITIES.get(word).copied()
+        };
+        match decoded {
+            Some(c) => out.push(c),
+            // Not a recognized entity — keep the `&…;` literal.
+            None => {
+                out.push('&');
+                out.push_str(word);
+                out.push(';');
+            }
+        }
+    }
+    out.push_str(&s[prev..]);
+    out
+}
+
+/// Converts an OXC AST to the React compiler's Babel-compatible AST.
+pub fn convert_program(program: &oxc::Program, source_text: &str) -> File {
+    let ctx = ConvertCtx::new(source_text);
+    let base = ctx.make_base_node(program.span);
+
+    let mut body = Vec::new();
+    for stmt in &program.body {
+        body.push(ctx.convert_statement(stmt));
+    }
+
+    let directives = program.directives.iter().map(|d| ctx.convert_directive(d)).collect();
+
+    let source_type = match program.source_type.is_module() {
+        true => SourceType::Module,
+        false => SourceType::Script,
+    };
+
+    // Convert OXC comments
+    let comments = ctx.convert_comments(&program.comments);
+
+    File {
+        base: ctx.make_base_node(program.span),
+        program: Program {
+            base,
+            body,
+            directives,
+            source_type,
+            interpreter: program.hashbang.as_ref().map(|hashbang| InterpreterDirective {
+                base: ctx.make_base_node(hashbang.span),
+                value: hashbang.value.to_string(),
+            }),
+            source_file: None,
+        },
+        comments,
+        errors: vec![],
+    }
+}
+
+struct ConvertCtx<'a> {
+    source_text: &'a str,
+    line_offsets: Vec<u32>,
+}
+
+impl<'a> ConvertCtx<'a> {
+    fn new(source_text: &'a str) -> Self {
+        let mut line_offsets = vec![0];
+        for (i, ch) in source_text.char_indices() {
+            if ch == '\n' {
+                line_offsets.push((i + 1) as u32);
+            }
+        }
+        Self { source_text, line_offsets }
+    }
+
+    fn make_base_node(&self, span: Span) -> BaseNode {
+        BaseNode {
+            node_type: None,
+            start: Some(span.start),
+            end: Some(span.end),
+            loc: Some(self.source_location(span)),
+            range: None,
+            extra: None,
+            node_id: Some(span.start),
+            leading_comments: None,
+            inner_comments: None,
+            trailing_comments: None,
+        }
+    }
+
+    fn make_typed_json_base(
+        &self,
+        type_name: &str,
+        span: Span,
+    ) -> serde_json::Map<String, serde_json::Value> {
+        let mut obj = serde_json::Map::new();
+        obj.insert("type".to_string(), serde_json::Value::String(type_name.to_string()));
+        obj.insert("start".to_string(), serde_json::Value::from(span.start));
+        obj.insert("end".to_string(), serde_json::Value::from(span.end));
+        obj.insert(
+            "loc".to_string(),
+            serde_json::to_value(self.source_location(span)).unwrap_or(serde_json::Value::Null),
+        );
+        obj.insert("_nodeId".to_string(), serde_json::Value::from(span.start));
+        obj
+    }
+
+    fn convert_ts_type_annotation_json(
+        &self,
+        type_annotation: &oxc::TSTypeAnnotation,
+    ) -> Box<serde_json::Value> {
+        let mut obj = self.make_typed_json_base("TSTypeAnnotation", type_annotation.span);
+        obj.insert(
+            "typeAnnotation".to_string(),
+            self.convert_ts_type_json_value(&type_annotation.type_annotation),
+        );
+        Box::new(serde_json::Value::Object(obj))
+    }
+
+    fn convert_ts_type_parameter_instantiation_json(
+        &self,
+        type_arguments: &oxc::TSTypeParameterInstantiation,
+    ) -> Box<serde_json::Value> {
+        let mut obj =
+            self.make_typed_json_base("TSTypeParameterInstantiation", type_arguments.span);
+        obj.insert(
+            "params".to_string(),
+            serde_json::Value::Array(
+                type_arguments
+                    .params
+                    .iter()
+                    .map(|ty| self.convert_ts_type_json_value(ty))
+                    .collect(),
+            ),
+        );
+        Box::new(serde_json::Value::Object(obj))
+    }
+
+    fn convert_ts_type_json(&self, ty: &oxc::TSType) -> Box<serde_json::Value> {
+        Box::new(self.convert_ts_type_json_value(ty))
+    }
+
+    fn convert_ts_type_json_value(&self, ty: &oxc::TSType) -> serde_json::Value {
+        let type_name = match ty {
+            oxc::TSType::TSAnyKeyword(_) => "TSAnyKeyword",
+            oxc::TSType::TSBigIntKeyword(_) => "TSBigIntKeyword",
+            oxc::TSType::TSBooleanKeyword(_) => "TSBooleanKeyword",
+            oxc::TSType::TSIntrinsicKeyword(_) => "TSIntrinsicKeyword",
+            oxc::TSType::TSNeverKeyword(_) => "TSNeverKeyword",
+            oxc::TSType::TSNullKeyword(_) => "TSNullKeyword",
+            oxc::TSType::TSNumberKeyword(_) => "TSNumberKeyword",
+            oxc::TSType::TSObjectKeyword(_) => "TSObjectKeyword",
+            oxc::TSType::TSStringKeyword(_) => "TSStringKeyword",
+            oxc::TSType::TSSymbolKeyword(_) => "TSSymbolKeyword",
+            oxc::TSType::TSThisType(_) => "TSThisType",
+            oxc::TSType::TSUndefinedKeyword(_) => "TSUndefinedKeyword",
+            oxc::TSType::TSUnknownKeyword(_) => "TSUnknownKeyword",
+            oxc::TSType::TSVoidKeyword(_) => "TSVoidKeyword",
+            oxc::TSType::TSArrayType(_) => "TSArrayType",
+            oxc::TSType::TSUnionType(_) => "TSUnionType",
+            oxc::TSType::TSParenthesizedType(_) => "TSParenthesizedType",
+            oxc::TSType::TSLiteralType(_) => "TSLiteralType",
+            oxc::TSType::TSTypeReference(_) => "TSTypeReference",
+            oxc::TSType::TSTypeOperatorType(_) => "TSTypeOperator",
+            oxc::TSType::TSTupleType(_) => "TSTupleType",
+            oxc::TSType::TSIntersectionType(_) => "TSIntersectionType",
+            oxc::TSType::TSTypeLiteral(_) => "TSTypeLiteral",
+            oxc::TSType::TSTypeQuery(_) => "TSTypeQuery",
+            oxc::TSType::TSFunctionType(_) => "TSFunctionType",
+            oxc::TSType::TSConstructorType(_) => "TSConstructorType",
+            oxc::TSType::TSConditionalType(_) => "TSConditionalType",
+            oxc::TSType::TSIndexedAccessType(_) => "TSIndexedAccessType",
+            oxc::TSType::TSInferType(_) => "TSInferType",
+            oxc::TSType::TSImportType(_) => "TSImportType",
+            oxc::TSType::TSMappedType(_) => "TSMappedType",
+            oxc::TSType::TSNamedTupleMember(_) => "TSNamedTupleMember",
+            oxc::TSType::TSTemplateLiteralType(_) => "TSTemplateLiteralType",
+            oxc::TSType::TSTypePredicate(_) => "TSTypePredicate",
+            oxc::TSType::JSDocNullableType(_) => "JSDocNullableType",
+            oxc::TSType::JSDocNonNullableType(_) => "JSDocNonNullableType",
+            oxc::TSType::JSDocUnknownType(_) => "JSDocUnknownType",
+        };
+
+        let mut obj = self.make_typed_json_base(type_name, ty.span());
+        match ty {
+            oxc::TSType::TSArrayType(array) => {
+                obj.insert(
+                    "elementType".to_string(),
+                    self.convert_ts_type_json_value(&array.element_type),
+                );
+            }
+            oxc::TSType::TSUnionType(union) => {
+                obj.insert(
+                    "types".to_string(),
+                    serde_json::Value::Array(
+                        union.types.iter().map(|ty| self.convert_ts_type_json_value(ty)).collect(),
+                    ),
+                );
+            }
+            oxc::TSType::TSParenthesizedType(parenthesized) => {
+                obj.insert(
+                    "typeAnnotation".to_string(),
+                    self.convert_ts_type_json_value(&parenthesized.type_annotation),
+                );
+            }
+            oxc::TSType::TSTypeReference(reference) => {
+                obj.insert(
+                    "typeName".to_string(),
+                    self.convert_ts_type_name_json_value(&reference.type_name),
+                );
+                if let Some(type_arguments) = &reference.type_arguments {
+                    obj.insert(
+                        "typeParameters".to_string(),
+                        *self.convert_ts_type_parameter_instantiation_json(type_arguments),
+                    );
+                }
+            }
+            oxc::TSType::TSTypeQuery(query) => {
+                obj.insert(
+                    "exprName".to_string(),
+                    self.convert_ts_type_query_expr_name_json_value(&query.expr_name),
+                );
+                if let Some(type_arguments) = &query.type_arguments {
+                    obj.insert(
+                        "typeParameters".to_string(),
+                        *self.convert_ts_type_parameter_instantiation_json(type_arguments),
+                    );
+                }
+            }
+            oxc::TSType::TSIndexedAccessType(indexed) => {
+                obj.insert(
+                    "objectType".to_string(),
+                    self.convert_ts_type_json_value(&indexed.object_type),
+                );
+                obj.insert(
+                    "indexType".to_string(),
+                    self.convert_ts_type_json_value(&indexed.index_type),
+                );
+            }
+            oxc::TSType::TSTypeOperatorType(operator) => {
+                let operator_name = match operator.operator {
+                    oxc::TSTypeOperatorOperator::Keyof => "keyof",
+                    oxc::TSTypeOperatorOperator::Unique => "unique",
+                    oxc::TSTypeOperatorOperator::Readonly => "readonly",
+                };
+                obj.insert(
+                    "operator".to_string(),
+                    serde_json::Value::String(operator_name.to_string()),
+                );
+                obj.insert(
+                    "typeAnnotation".to_string(),
+                    self.convert_ts_type_json_value(&operator.type_annotation),
+                );
+            }
+            oxc::TSType::TSLiteralType(literal) => {
+                obj.insert(
+                    "literal".to_string(),
+                    self.convert_ts_literal_json_value(&literal.literal),
+                );
+            }
+            _ => {}
+        }
+        serde_json::Value::Object(obj)
+    }
+
+    fn convert_ts_type_name_json_value(&self, type_name: &oxc::TSTypeName) -> serde_json::Value {
+        match type_name {
+            oxc::TSTypeName::IdentifierReference(identifier) => {
+                let mut obj = self.make_typed_json_base("Identifier", identifier.span);
+                obj.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(identifier.name.to_string()),
+                );
+                serde_json::Value::Object(obj)
+            }
+            oxc::TSTypeName::QualifiedName(qualified) => {
+                let mut obj = self.make_typed_json_base("TSQualifiedName", qualified.span);
+                obj.insert(
+                    "left".to_string(),
+                    self.convert_ts_type_name_json_value(&qualified.left),
+                );
+                let mut right = self.make_typed_json_base("Identifier", qualified.right.span);
+                right.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(qualified.right.name.to_string()),
+                );
+                obj.insert("right".to_string(), serde_json::Value::Object(right));
+                serde_json::Value::Object(obj)
+            }
+            oxc::TSTypeName::ThisExpression(this) => {
+                serde_json::Value::Object(self.make_typed_json_base("TSThisType", this.span))
+            }
+        }
+    }
+
+    fn convert_ts_type_query_expr_name_json_value(
+        &self,
+        expr_name: &oxc::TSTypeQueryExprName,
+    ) -> serde_json::Value {
+        match expr_name {
+            oxc::TSTypeQueryExprName::IdentifierReference(identifier) => {
+                let mut obj = self.make_typed_json_base("Identifier", identifier.span);
+                obj.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(identifier.name.to_string()),
+                );
+                serde_json::Value::Object(obj)
+            }
+            oxc::TSTypeQueryExprName::QualifiedName(qualified) => {
+                let mut obj = self.make_typed_json_base("TSQualifiedName", qualified.span);
+                obj.insert(
+                    "left".to_string(),
+                    self.convert_ts_type_name_json_value(&qualified.left),
+                );
+                let mut right = self.make_typed_json_base("Identifier", qualified.right.span);
+                right.insert(
+                    "name".to_string(),
+                    serde_json::Value::String(qualified.right.name.to_string()),
+                );
+                obj.insert("right".to_string(), serde_json::Value::Object(right));
+                serde_json::Value::Object(obj)
+            }
+            oxc::TSTypeQueryExprName::ThisExpression(this) => {
+                serde_json::Value::Object(self.make_typed_json_base("TSThisType", this.span))
+            }
+            oxc::TSTypeQueryExprName::TSImportType(import) => {
+                serde_json::Value::Object(self.make_typed_json_base("TSImportType", import.span))
+            }
+        }
+    }
+
+    fn convert_ts_literal_json_value(&self, literal: &oxc::TSLiteral) -> serde_json::Value {
+        match literal {
+            oxc::TSLiteral::BooleanLiteral(literal) => {
+                let mut obj = self.make_typed_json_base("BooleanLiteral", literal.span);
+                obj.insert("value".to_string(), serde_json::Value::Bool(literal.value));
+                serde_json::Value::Object(obj)
+            }
+            oxc::TSLiteral::NumericLiteral(literal) => {
+                let mut obj = self.make_typed_json_base("NumericLiteral", literal.span);
+                obj.insert("value".to_string(), serde_json::Value::from(literal.value));
+                serde_json::Value::Object(obj)
+            }
+            oxc::TSLiteral::StringLiteral(literal) => {
+                let mut obj = self.make_typed_json_base("StringLiteral", literal.span);
+                obj.insert(
+                    "value".to_string(),
+                    serde_json::Value::String(literal.value.to_string()),
+                );
+                serde_json::Value::Object(obj)
+            }
+            oxc::TSLiteral::BigIntLiteral(literal) => {
+                let mut obj = self.make_typed_json_base("BigIntLiteral", literal.span);
+                obj.insert(
+                    "value".to_string(),
+                    serde_json::Value::String(literal.value.to_string()),
+                );
+                serde_json::Value::Object(obj)
+            }
+            other => {
+                serde_json::Value::Object(self.make_typed_json_base("TSLiteral", other.span()))
+            }
+        }
+    }
+
+    fn position(&self, offset: u32) -> Position {
+        let line_idx = match self.line_offsets.binary_search(&offset) {
+            Ok(idx) => idx,
+            Err(idx) => idx.saturating_sub(1),
+        };
+        let line_start = self.line_offsets[line_idx];
+        Position { line: (line_idx + 1) as u32, column: offset - line_start, index: Some(offset) }
+    }
+
+    fn source_location(&self, span: Span) -> SourceLocation {
+        SourceLocation {
+            start: self.position(span.start),
+            end: self.position(span.end),
+            filename: None,
+            identifier_name: None,
+        }
+    }
+
+    fn convert_comments(&self, comments: &[oxc::Comment]) -> Vec<Comment> {
+        comments
+            .iter()
+            .map(|comment| {
+                let base = self.make_base_node(comment.span);
+                // OXC comment spans include delimiters (// or /* */), so we need
+                // to strip them to get the content-only value that the compiler expects.
+                let raw = &self.source_text[comment.span.start as usize..comment.span.end as usize];
+                let value = match comment.kind {
+                    oxc::CommentKind::Line => {
+                        // Strip leading //
+                        raw.strip_prefix("//").unwrap_or(raw).trim().to_string()
+                    }
+                    oxc::CommentKind::SingleLineBlock | oxc::CommentKind::MultiLineBlock => {
+                        // Strip leading /* and trailing */
+                        let stripped =
+                            raw.strip_prefix("/*").unwrap_or(raw).strip_suffix("*/").unwrap_or(raw);
+                        stripped.trim().to_string()
+                    }
+                };
+                let comment_data =
+                    CommentData { value, start: base.start, end: base.end, loc: base.loc.clone() };
+                match comment.kind {
+                    oxc::CommentKind::Line => Comment::CommentLine(comment_data),
+                    oxc::CommentKind::SingleLineBlock | oxc::CommentKind::MultiLineBlock => {
+                        Comment::CommentBlock(comment_data)
+                    }
+                }
+            })
+            .collect()
+    }
+
+    fn convert_directive(&self, directive: &oxc::Directive) -> Directive {
+        let base = self.make_base_node(directive.span);
+        Directive {
+            base,
+            value: DirectiveLiteral {
+                base: self.make_base_node(directive.expression.span),
+                value: directive.expression.value.to_string(),
+            },
+        }
+    }
+
+    fn convert_statement(&self, stmt: &oxc::Statement) -> Statement {
+        match stmt {
+            oxc::Statement::BlockStatement(s) => {
+                Statement::BlockStatement(self.convert_block_statement(s))
+            }
+            oxc::Statement::ReturnStatement(s) => {
+                Statement::ReturnStatement(self.convert_return_statement(s))
+            }
+            oxc::Statement::IfStatement(s) => Statement::IfStatement(self.convert_if_statement(s)),
+            oxc::Statement::ForStatement(s) => {
+                Statement::ForStatement(self.convert_for_statement(s))
+            }
+            oxc::Statement::WhileStatement(s) => {
+                Statement::WhileStatement(self.convert_while_statement(s))
+            }
+            oxc::Statement::DoWhileStatement(s) => {
+                Statement::DoWhileStatement(self.convert_do_while_statement(s))
+            }
+            oxc::Statement::ForInStatement(s) => {
+                Statement::ForInStatement(self.convert_for_in_statement(s))
+            }
+            oxc::Statement::ForOfStatement(s) => {
+                Statement::ForOfStatement(self.convert_for_of_statement(s))
+            }
+            oxc::Statement::SwitchStatement(s) => {
+                Statement::SwitchStatement(self.convert_switch_statement(s))
+            }
+            oxc::Statement::ThrowStatement(s) => {
+                Statement::ThrowStatement(self.convert_throw_statement(s))
+            }
+            oxc::Statement::TryStatement(s) => {
+                Statement::TryStatement(self.convert_try_statement(s))
+            }
+            oxc::Statement::BreakStatement(s) => {
+                Statement::BreakStatement(self.convert_break_statement(s))
+            }
+            oxc::Statement::ContinueStatement(s) => {
+                Statement::ContinueStatement(self.convert_continue_statement(s))
+            }
+            oxc::Statement::LabeledStatement(s) => {
+                Statement::LabeledStatement(self.convert_labeled_statement(s))
+            }
+            oxc::Statement::ExpressionStatement(s) => {
+                Statement::ExpressionStatement(self.convert_expression_statement(s))
+            }
+            oxc::Statement::EmptyStatement(s) => {
+                Statement::EmptyStatement(EmptyStatement { base: self.make_base_node(s.span) })
+            }
+            oxc::Statement::DebuggerStatement(s) => {
+                Statement::DebuggerStatement(DebuggerStatement {
+                    base: self.make_base_node(s.span),
+                })
+            }
+            oxc::Statement::WithStatement(s) => {
+                Statement::WithStatement(self.convert_with_statement(s))
+            }
+            // Declaration variants (inherited)
+            oxc::Statement::VariableDeclaration(v) => {
+                Statement::VariableDeclaration(self.convert_variable_declaration(v))
+            }
+            oxc::Statement::FunctionDeclaration(f) => {
+                if f.body.is_none() {
+                    Statement::TSDeclareFunction(self.convert_ts_declare_function(f))
+                } else {
+                    Statement::FunctionDeclaration(self.convert_function_declaration(f))
+                }
+            }
+            oxc::Statement::ClassDeclaration(c) => {
+                Statement::ClassDeclaration(self.convert_class_declaration(c))
+            }
+            oxc::Statement::TSTypeAliasDeclaration(t) => {
+                Statement::TSTypeAliasDeclaration(self.convert_ts_type_alias_declaration(t))
+            }
+            oxc::Statement::TSInterfaceDeclaration(t) => {
+                Statement::TSInterfaceDeclaration(self.convert_ts_interface_declaration(t))
+            }
+            oxc::Statement::TSEnumDeclaration(t) => {
+                Statement::TSEnumDeclaration(self.convert_ts_enum_declaration(t))
+            }
+            oxc::Statement::TSModuleDeclaration(t) => {
+                Statement::TSModuleDeclaration(self.convert_ts_module_declaration(t))
+            }
+            oxc::Statement::TSImportEqualsDeclaration(t) => {
+                // `import x = require(...)` / `import x = ns` — TS-only, no
+                // dedicated Babel node. Round-trips via source re-parse.
+                Statement::TSModuleDeclaration(
+                    self.convert_ts_declaration_passthrough(t.span, false),
+                )
+            }
+            // ModuleDeclaration variants (inherited directly into Statement)
+            oxc::Statement::ImportDeclaration(i) => {
+                Statement::ImportDeclaration(self.convert_import_declaration(i))
+            }
+            oxc::Statement::ExportAllDeclaration(e) => {
+                Statement::ExportAllDeclaration(self.convert_export_all_declaration(e))
+            }
+            oxc::Statement::ExportDefaultDeclaration(e) => {
+                Statement::ExportDefaultDeclaration(self.convert_export_default_declaration(e))
+            }
+            oxc::Statement::ExportNamedDeclaration(e) => {
+                Statement::ExportNamedDeclaration(self.convert_export_named_declaration(e))
+            }
+            oxc::Statement::TSExportAssignment(t) => {
+                // `export = expr` — TS-only. Round-trips via source re-parse.
+                Statement::TSModuleDeclaration(
+                    self.convert_ts_declaration_passthrough(t.span, false),
+                )
+            }
+            oxc::Statement::TSNamespaceExportDeclaration(t) => {
+                // `export as namespace X` — TS-only. Round-trips via source re-parse.
+                Statement::TSModuleDeclaration(
+                    self.convert_ts_declaration_passthrough(t.span, false),
+                )
+            }
+            oxc::Statement::TSGlobalDeclaration(t) => {
+                // `declare global { ... }` — modeled as a `global` TSModuleDeclaration.
+                Statement::TSModuleDeclaration(
+                    self.convert_ts_declaration_passthrough(t.span, true),
+                )
+            }
+        }
+    }
+
+    fn convert_block_statement(&self, block: &oxc::BlockStatement) -> BlockStatement {
+        let base = self.make_base_node(block.span);
+        let body = block.body.iter().map(|s| self.convert_statement(s)).collect();
+        BlockStatement { base, body, directives: vec![] }
+    }
+
+    fn convert_return_statement(&self, ret: &oxc::ReturnStatement) -> ReturnStatement {
+        ReturnStatement {
+            base: self.make_base_node(ret.span),
+            argument: ret.argument.as_ref().map(|e| Box::new(self.convert_expression(e))),
+        }
+    }
+
+    fn convert_if_statement(&self, if_stmt: &oxc::IfStatement) -> IfStatement {
+        IfStatement {
+            base: self.make_base_node(if_stmt.span),
+            test: Box::new(self.convert_expression(&if_stmt.test)),
+            consequent: Box::new(self.convert_statement(&if_stmt.consequent)),
+            alternate: if_stmt.alternate.as_ref().map(|a| Box::new(self.convert_statement(a))),
+        }
+    }
+
+    fn convert_for_statement(&self, for_stmt: &oxc::ForStatement) -> ForStatement {
+        ForStatement {
+            base: self.make_base_node(for_stmt.span),
+            init: for_stmt.init.as_ref().map(|init| {
+                Box::new(match init {
+                    oxc::ForStatementInit::VariableDeclaration(v) => {
+                        ForInit::VariableDeclaration(self.convert_variable_declaration(v))
+                    }
+                    _ => ForInit::Expression(Box::new(self.convert_expression_like(init))),
+                })
+            }),
+            test: for_stmt.test.as_ref().map(|t| Box::new(self.convert_expression(t))),
+            update: for_stmt.update.as_ref().map(|u| Box::new(self.convert_expression(u))),
+            body: Box::new(self.convert_statement(&for_stmt.body)),
+        }
+    }
+
+    fn convert_while_statement(&self, while_stmt: &oxc::WhileStatement) -> WhileStatement {
+        WhileStatement {
+            base: self.make_base_node(while_stmt.span),
+            test: Box::new(self.convert_expression(&while_stmt.test)),
+            body: Box::new(self.convert_statement(&while_stmt.body)),
+        }
+    }
+
+    fn convert_do_while_statement(&self, do_while: &oxc::DoWhileStatement) -> DoWhileStatement {
+        DoWhileStatement {
+            base: self.make_base_node(do_while.span),
+            test: Box::new(self.convert_expression(&do_while.test)),
+            body: Box::new(self.convert_statement(&do_while.body)),
+        }
+    }
+
+    fn convert_for_in_statement(&self, for_in: &oxc::ForInStatement) -> ForInStatement {
+        ForInStatement {
+            base: self.make_base_node(for_in.span),
+            left: Box::new(self.convert_for_in_of_left(&for_in.left)),
+            right: Box::new(self.convert_expression(&for_in.right)),
+            body: Box::new(self.convert_statement(&for_in.body)),
+        }
+    }
+
+    fn convert_for_of_statement(&self, for_of: &oxc::ForOfStatement) -> ForOfStatement {
+        ForOfStatement {
+            base: self.make_base_node(for_of.span),
+            left: Box::new(self.convert_for_in_of_left(&for_of.left)),
+            right: Box::new(self.convert_expression(&for_of.right)),
+            body: Box::new(self.convert_statement(&for_of.body)),
+            is_await: for_of.r#await,
+        }
+    }
+
+    fn convert_for_in_of_left(&self, left: &oxc::ForStatementLeft) -> ForInOfLeft {
+        match left {
+            oxc::ForStatementLeft::VariableDeclaration(v) => {
+                ForInOfLeft::VariableDeclaration(self.convert_variable_declaration(v))
+            }
+            oxc::ForStatementLeft::AssignmentTargetIdentifier(i) => {
+                ForInOfLeft::Pattern(Box::new(PatternLike::Identifier(Identifier {
+                    base: self.make_base_node(i.span),
+                    name: i.name.to_string(),
+                    type_annotation: None,
+                    optional: None,
+                    decorators: None,
+                })))
+            }
+            oxc::ForStatementLeft::ArrayAssignmentTarget(a) => {
+                ForInOfLeft::Pattern(Box::new(self.convert_array_assignment_target(a)))
+            }
+            oxc::ForStatementLeft::ObjectAssignmentTarget(o) => {
+                ForInOfLeft::Pattern(Box::new(self.convert_object_assignment_target(o)))
+            }
+            oxc::ForStatementLeft::ComputedMemberExpression(m) => {
+                let mem = MemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression(&m.object)),
+                    property: Box::new(self.convert_expression(&m.expression)),
+                    computed: true,
+                };
+                ForInOfLeft::Pattern(Box::new(PatternLike::MemberExpression(mem)))
+            }
+            oxc::ForStatementLeft::StaticMemberExpression(m) => {
+                let mem = MemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression(&m.object)),
+                    property: Box::new(Expression::Identifier(
+                        self.convert_identifier_name(&m.property),
+                    )),
+                    computed: false,
+                };
+                ForInOfLeft::Pattern(Box::new(PatternLike::MemberExpression(mem)))
+            }
+            oxc::ForStatementLeft::PrivateFieldExpression(p) => {
+                let mem = MemberExpression {
+                    base: self.make_base_node(p.span),
+                    object: Box::new(self.convert_expression(&p.object)),
+                    property: Box::new(Expression::PrivateName(PrivateName {
+                        base: self.make_base_node(p.field.span),
+                        id: Identifier {
+                            base: self.make_base_node(p.field.span),
+                            name: p.field.name.to_string(),
+                            type_annotation: None,
+                            optional: None,
+                            decorators: None,
+                        },
+                    })),
+                    computed: false,
+                };
+                ForInOfLeft::Pattern(Box::new(PatternLike::MemberExpression(mem)))
+            }
+            oxc::ForStatementLeft::TSAsExpression(t) => ForInOfLeft::Pattern(Box::new(
+                PatternLike::TSAsExpression(self.convert_ts_as_expression(t)),
+            )),
+            oxc::ForStatementLeft::TSSatisfiesExpression(t) => ForInOfLeft::Pattern(Box::new(
+                PatternLike::TSSatisfiesExpression(self.convert_ts_satisfies_expression(t)),
+            )),
+            oxc::ForStatementLeft::TSNonNullExpression(t) => ForInOfLeft::Pattern(Box::new(
+                PatternLike::TSNonNullExpression(self.convert_ts_non_null_expression(t)),
+            )),
+            oxc::ForStatementLeft::TSTypeAssertion(t) => ForInOfLeft::Pattern(Box::new(
+                PatternLike::TSTypeAssertion(self.convert_ts_type_assertion(t)),
+            )),
+        }
+    }
+
+    fn convert_switch_statement(&self, switch: &oxc::SwitchStatement) -> SwitchStatement {
+        SwitchStatement {
+            base: self.make_base_node(switch.span),
+            discriminant: Box::new(self.convert_expression(&switch.discriminant)),
+            cases: switch.cases.iter().map(|c| self.convert_switch_case(c)).collect(),
+        }
+    }
+
+    fn convert_switch_case(&self, case: &oxc::SwitchCase) -> SwitchCase {
+        SwitchCase {
+            base: self.make_base_node(case.span),
+            test: case.test.as_ref().map(|t| Box::new(self.convert_expression(t))),
+            consequent: case.consequent.iter().map(|s| self.convert_statement(s)).collect(),
+        }
+    }
+
+    fn convert_throw_statement(&self, throw: &oxc::ThrowStatement) -> ThrowStatement {
+        ThrowStatement {
+            base: self.make_base_node(throw.span),
+            argument: Box::new(self.convert_expression(&throw.argument)),
+        }
+    }
+
+    fn convert_try_statement(&self, try_stmt: &oxc::TryStatement) -> TryStatement {
+        TryStatement {
+            base: self.make_base_node(try_stmt.span),
+            block: self.convert_block_statement(&try_stmt.block),
+            handler: try_stmt.handler.as_ref().map(|h| self.convert_catch_clause(h)),
+            finalizer: try_stmt.finalizer.as_ref().map(|f| self.convert_block_statement(f)),
+        }
+    }
+
+    fn convert_catch_clause(&self, catch: &oxc::CatchClause) -> CatchClause {
+        CatchClause {
+            base: self.make_base_node(catch.span),
+            param: catch.param.as_ref().map(|p| {
+                let mut pattern = self.convert_binding_pattern(&p.pattern);
+                if let Some(type_annotation) = &p.type_annotation {
+                    Self::set_pattern_type_annotation(
+                        &mut pattern,
+                        self.convert_ts_type_annotation_json(type_annotation),
+                    );
+                }
+                pattern
+            }),
+            body: self.convert_block_statement(&catch.body),
+        }
+    }
+
+    fn convert_break_statement(&self, brk: &oxc::BreakStatement) -> BreakStatement {
+        BreakStatement {
+            base: self.make_base_node(brk.span),
+            label: brk.label.as_ref().map(|l| self.convert_label_identifier(l)),
+        }
+    }
+
+    fn convert_continue_statement(&self, cont: &oxc::ContinueStatement) -> ContinueStatement {
+        ContinueStatement {
+            base: self.make_base_node(cont.span),
+            label: cont.label.as_ref().map(|l| self.convert_label_identifier(l)),
+        }
+    }
+
+    fn convert_labeled_statement(&self, labeled: &oxc::LabeledStatement) -> LabeledStatement {
+        LabeledStatement {
+            base: self.make_base_node(labeled.span),
+            label: self.convert_label_identifier(&labeled.label),
+            body: Box::new(self.convert_statement(&labeled.body)),
+        }
+    }
+
+    fn convert_expression_statement(
+        &self,
+        expr_stmt: &oxc::ExpressionStatement,
+    ) -> ExpressionStatement {
+        ExpressionStatement {
+            base: self.make_base_node(expr_stmt.span),
+            expression: Box::new(self.convert_expression(&expr_stmt.expression)),
+        }
+    }
+
+    fn convert_with_statement(&self, with: &oxc::WithStatement) -> WithStatement {
+        WithStatement {
+            base: self.make_base_node(with.span),
+            object: Box::new(self.convert_expression(&with.object)),
+            body: Box::new(self.convert_statement(&with.body)),
+        }
+    }
+
+    fn convert_variable_declaration(&self, var: &oxc::VariableDeclaration) -> VariableDeclaration {
+        VariableDeclaration {
+            base: self.make_base_node(var.span),
+            declarations: var
+                .declarations
+                .iter()
+                .map(|d| self.convert_variable_declarator(d))
+                .collect(),
+            kind: match var.kind {
+                oxc::VariableDeclarationKind::Var => VariableDeclarationKind::Var,
+                oxc::VariableDeclarationKind::Let => VariableDeclarationKind::Let,
+                oxc::VariableDeclarationKind::Const => VariableDeclarationKind::Const,
+                oxc::VariableDeclarationKind::Using => VariableDeclarationKind::Using,
+                oxc::VariableDeclarationKind::AwaitUsing => {
+                    // Map to Using for now
+                    VariableDeclarationKind::Using
+                }
+            },
+            declare: if var.declare { Some(true) } else { None },
+        }
+    }
+
+    fn convert_variable_declarator(
+        &self,
+        declarator: &oxc::VariableDeclarator,
+    ) -> VariableDeclarator {
+        VariableDeclarator {
+            base: self.make_base_node(declarator.span),
+            id: self.convert_binding_pattern(&declarator.id),
+            init: declarator.init.as_ref().map(|i| Box::new(self.convert_expression(i))),
+            definite: if declarator.definite { Some(true) } else { None },
+        }
+    }
+
+    fn convert_function_declaration(&self, func: &oxc::Function) -> FunctionDeclaration {
+        FunctionDeclaration {
+            base: self.make_base_node(func.span),
+            id: func.id.as_ref().map(|id| self.convert_binding_identifier(id)),
+            params: self.convert_formal_parameters(&func.params),
+            body: self.convert_optional_function_body(func.body.as_deref(), func.span),
+            generator: func.generator,
+            is_async: func.r#async,
+            declare: if func.declare { Some(true) } else { None },
+            return_type: func.return_type.as_ref().map(|t| self.convert_ts_type_annotation_json(t)),
+            type_parameters: func
+                .type_parameters
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+            predicate: None,
+            component_declaration: false,
+            hook_declaration: false,
+        }
+    }
+
+    fn convert_ts_declare_function(&self, func: &oxc::Function) -> TSDeclareFunction {
+        TSDeclareFunction {
+            base: self.make_base_node(func.span),
+            id: func.id.as_ref().map(|id| self.convert_binding_identifier(id)),
+            params: self
+                .convert_formal_parameters(&func.params)
+                .into_iter()
+                .map(|param| serde_json::to_value(param).unwrap_or(serde_json::Value::Null))
+                .collect(),
+            is_async: if func.r#async { Some(true) } else { None },
+            declare: if func.declare { Some(true) } else { None },
+            generator: if func.generator { Some(true) } else { None },
+            return_type: func.return_type.as_ref().map(|t| self.convert_ts_type_annotation_json(t)),
+            type_parameters: func
+                .type_parameters
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+        }
+    }
+
+    fn convert_class_declaration(&self, class: &oxc::Class) -> ClassDeclaration {
+        ClassDeclaration {
+            base: self.make_base_node(class.span),
+            id: class.id.as_ref().map(|id| self.convert_binding_identifier(id)),
+            super_class: class.super_class.as_ref().map(|s| Box::new(self.convert_expression(s))),
+            body: ClassBody {
+                base: self.make_base_node(class.body.span),
+                body: class.body.body.iter().map(|_item| serde_json::Value::Null).collect(),
+            },
+            decorators: if class.decorators.is_empty() {
+                None
+            } else {
+                Some(class.decorators.iter().map(|_d| serde_json::Value::Null).collect())
+            },
+            is_abstract: if class.r#abstract { Some(true) } else { None },
+            declare: if class.declare { Some(true) } else { None },
+            implements: if class.implements.is_empty() {
+                None
+            } else {
+                Some(class.implements.iter().map(|_i| serde_json::Value::Null).collect())
+            },
+            super_type_parameters: class
+                .super_type_arguments
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+            type_parameters: class
+                .type_parameters
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+            mixins: None,
+        }
+    }
+
+    fn convert_import_declaration(&self, import: &oxc::ImportDeclaration) -> ImportDeclaration {
+        ImportDeclaration {
+            base: self.make_base_node(import.span),
+            specifiers: import
+                .specifiers
+                .as_ref()
+                .map(|specs| {
+                    specs
+                        .iter()
+                        .flat_map(|s| self.convert_import_declaration_specifier(s))
+                        .collect()
+                })
+                .unwrap_or_default(),
+            source: StringLiteral {
+                base: self.make_base_node(import.source.span),
+                value: import.source.value.to_string(),
+            },
+            import_kind: match import.import_kind {
+                oxc::ImportOrExportKind::Value => None,
+                oxc::ImportOrExportKind::Type => Some(ImportKind::Type),
+            },
+            assertions: None,
+            attributes: if import.with_clause.is_some() {
+                Some(
+                    import
+                        .with_clause
+                        .as_ref()
+                        .unwrap()
+                        .with_entries
+                        .iter()
+                        .map(|e| self.convert_import_attribute(e))
+                        .collect(),
+                )
+            } else {
+                None
+            },
+        }
+    }
+
+    fn convert_import_declaration_specifier(
+        &self,
+        spec: &oxc::ImportDeclarationSpecifier,
+    ) -> Option<ImportSpecifier> {
+        match spec {
+            oxc::ImportDeclarationSpecifier::ImportSpecifier(s) => {
+                Some(ImportSpecifier::ImportSpecifier(ImportSpecifierData {
+                    base: self.make_base_node(s.span),
+                    local: self.convert_binding_identifier(&s.local),
+                    imported: self.convert_module_export_name(&s.imported),
+                    import_kind: match s.import_kind {
+                        oxc::ImportOrExportKind::Value => None,
+                        oxc::ImportOrExportKind::Type => Some(ImportKind::Type),
+                    },
+                }))
+            }
+            oxc::ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
+                Some(ImportSpecifier::ImportDefaultSpecifier(ImportDefaultSpecifierData {
+                    base: self.make_base_node(s.span),
+                    local: self.convert_binding_identifier(&s.local),
+                }))
+            }
+            oxc::ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => {
+                Some(ImportSpecifier::ImportNamespaceSpecifier(ImportNamespaceSpecifierData {
+                    base: self.make_base_node(s.span),
+                    local: self.convert_binding_identifier(&s.local),
+                }))
+            }
+        }
+    }
+
+    fn convert_import_attribute(&self, attr: &oxc::ImportAttribute) -> ImportAttribute {
+        ImportAttribute {
+            base: self.make_base_node(attr.span),
+            key: self.convert_import_attribute_key(&attr.key),
+            value: StringLiteral {
+                base: self.make_base_node(attr.value.span),
+                value: attr.value.value.to_string(),
+            },
+        }
+    }
+
+    fn convert_import_attribute_key(&self, key: &oxc::ImportAttributeKey) -> Identifier {
+        match key {
+            oxc::ImportAttributeKey::Identifier(id) => Identifier {
+                base: self.make_base_node(id.span),
+                name: id.name.to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            },
+            oxc::ImportAttributeKey::StringLiteral(s) => Identifier {
+                base: self.make_base_node(s.span),
+                name: s.value.to_string(),
+                type_annotation: None,
+                optional: None,
+                decorators: None,
+            },
+        }
+    }
+
+    fn convert_module_export_name(&self, name: &oxc::ModuleExportName) -> ModuleExportName {
+        match name {
+            oxc::ModuleExportName::IdentifierName(id) => {
+                ModuleExportName::Identifier(self.convert_identifier_name(id))
+            }
+            oxc::ModuleExportName::IdentifierReference(id) => {
+                ModuleExportName::Identifier(self.convert_identifier_reference(id))
+            }
+            oxc::ModuleExportName::StringLiteral(s) => {
+                ModuleExportName::StringLiteral(StringLiteral {
+                    base: self.make_base_node(s.span),
+                    value: s.value.to_string(),
+                })
+            }
+        }
+    }
+
+    fn convert_export_all_declaration(
+        &self,
+        export: &oxc::ExportAllDeclaration,
+    ) -> ExportAllDeclaration {
+        ExportAllDeclaration {
+            base: self.make_base_node(export.span),
+            source: StringLiteral {
+                base: self.make_base_node(export.source.span),
+                value: export.source.value.to_string(),
+            },
+            export_kind: match export.export_kind {
+                oxc::ImportOrExportKind::Value => None,
+                oxc::ImportOrExportKind::Type => Some(ExportKind::Type),
+            },
+            assertions: None,
+            attributes: if export.with_clause.is_some() {
+                Some(
+                    export
+                        .with_clause
+                        .as_ref()
+                        .unwrap()
+                        .with_entries
+                        .iter()
+                        .map(|e| self.convert_import_attribute(e))
+                        .collect(),
+                )
+            } else {
+                None
+            },
+        }
+    }
+
+    fn convert_export_default_declaration(
+        &self,
+        export: &oxc::ExportDefaultDeclaration,
+    ) -> ExportDefaultDeclaration {
+        let declaration = match &export.declaration {
+            oxc::ExportDefaultDeclarationKind::FunctionDeclaration(f) => {
+                ExportDefaultDecl::FunctionDeclaration(self.convert_function_declaration(f))
+            }
+            oxc::ExportDefaultDeclarationKind::ClassDeclaration(c) => {
+                ExportDefaultDecl::ClassDeclaration(self.convert_class_declaration(c))
+            }
+            oxc::ExportDefaultDeclarationKind::TSInterfaceDeclaration(i) => {
+                // `export default interface X {}` is type-only and has no Babel
+                // representation here. The compiler never analyzes it; the
+                // reverse converter recognizes this placeholder by source span
+                // and re-parses the original type-only export.
+                ExportDefaultDecl::Expression(Box::new(Expression::NullLiteral(NullLiteral {
+                    base: self.make_base_node(i.span),
+                })))
+            }
+            _ => {
+                // All expression variants
+                ExportDefaultDecl::Expression(Box::new(
+                    self.convert_export_default_expr(&export.declaration),
+                ))
+            }
+        };
+
+        ExportDefaultDeclaration {
+            base: self.make_base_node(export.span),
+            declaration: Box::new(declaration),
+            export_kind: None,
+        }
+    }
+
+    fn convert_export_default_expr(&self, kind: &oxc::ExportDefaultDeclarationKind) -> Expression {
+        match kind {
+            oxc::ExportDefaultDeclarationKind::FunctionDeclaration(_)
+            | oxc::ExportDefaultDeclarationKind::ClassDeclaration(_)
+            | oxc::ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => {
+                panic!("Should be handled separately")
+            }
+            other => self.convert_expression_from_export_default(other),
+        }
+    }
+
+    fn convert_export_named_declaration(
+        &self,
+        export: &oxc::ExportNamedDeclaration,
+    ) -> ExportNamedDeclaration {
+        ExportNamedDeclaration {
+            base: self.make_base_node(export.span),
+            declaration: export.declaration.as_ref().map(|d| {
+                Box::new(match d {
+                    oxc::Declaration::VariableDeclaration(v) => {
+                        Declaration::VariableDeclaration(self.convert_variable_declaration(v))
+                    }
+                    oxc::Declaration::FunctionDeclaration(f) => {
+                        if f.body.is_none() {
+                            Declaration::TSDeclareFunction(self.convert_ts_declare_function(f))
+                        } else {
+                            Declaration::FunctionDeclaration(self.convert_function_declaration(f))
+                        }
+                    }
+                    oxc::Declaration::ClassDeclaration(c) => {
+                        Declaration::ClassDeclaration(self.convert_class_declaration(c))
+                    }
+                    oxc::Declaration::TSTypeAliasDeclaration(t) => {
+                        Declaration::TSTypeAliasDeclaration(
+                            self.convert_ts_type_alias_declaration(t),
+                        )
+                    }
+                    oxc::Declaration::TSInterfaceDeclaration(t) => {
+                        Declaration::TSInterfaceDeclaration(
+                            self.convert_ts_interface_declaration(t),
+                        )
+                    }
+                    oxc::Declaration::TSEnumDeclaration(t) => {
+                        Declaration::TSEnumDeclaration(self.convert_ts_enum_declaration(t))
+                    }
+                    oxc::Declaration::TSModuleDeclaration(t) => {
+                        Declaration::TSModuleDeclaration(self.convert_ts_module_declaration(t))
+                    }
+                    oxc::Declaration::TSImportEqualsDeclaration(t) => {
+                        // `export import x = require(...)` — TS-only.
+                        Declaration::TSModuleDeclaration(
+                            self.convert_ts_declaration_passthrough(t.span, false),
+                        )
+                    }
+                    oxc::Declaration::TSGlobalDeclaration(t) => {
+                        // `export declare global { ... }` — TS-only.
+                        Declaration::TSModuleDeclaration(
+                            self.convert_ts_declaration_passthrough(t.span, true),
+                        )
+                    }
+                })
+            }),
+            specifiers: export
+                .specifiers
+                .iter()
+                .map(|s| self.convert_export_specifier(s))
+                .collect(),
+            source: export.source.as_ref().map(|s| StringLiteral {
+                base: self.make_base_node(s.span),
+                value: s.value.to_string(),
+            }),
+            export_kind: match export.export_kind {
+                oxc::ImportOrExportKind::Value => None,
+                oxc::ImportOrExportKind::Type => Some(ExportKind::Type),
+            },
+            assertions: None,
+            attributes: if export.with_clause.is_some() {
+                Some(
+                    export
+                        .with_clause
+                        .as_ref()
+                        .unwrap()
+                        .with_entries
+                        .iter()
+                        .map(|e| self.convert_import_attribute(e))
+                        .collect(),
+                )
+            } else {
+                None
+            },
+        }
+    }
+
+    fn convert_export_specifier(&self, spec: &oxc::ExportSpecifier) -> ExportSpecifier {
+        // ExportSpecifier is now a struct in OXC v0.121, not an enum
+        ExportSpecifier::ExportSpecifier(ExportSpecifierData {
+            base: self.make_base_node(spec.span),
+            local: self.convert_module_export_name(&spec.local),
+            exported: self.convert_module_export_name(&spec.exported),
+            export_kind: match spec.export_kind {
+                oxc::ImportOrExportKind::Value => None,
+                oxc::ImportOrExportKind::Type => Some(ExportKind::Type),
+            },
+        })
+    }
+
+    fn convert_ts_type_alias_declaration(
+        &self,
+        type_alias: &oxc::TSTypeAliasDeclaration,
+    ) -> TSTypeAliasDeclaration {
+        TSTypeAliasDeclaration {
+            base: self.make_base_node(type_alias.span),
+            id: self.convert_binding_identifier(&type_alias.id),
+            type_annotation: self.convert_ts_type_json(&type_alias.type_annotation),
+            type_parameters: type_alias
+                .type_parameters
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+            declare: if type_alias.declare { Some(true) } else { None },
+        }
+    }
+
+    fn convert_ts_interface_declaration(
+        &self,
+        interface: &oxc::TSInterfaceDeclaration,
+    ) -> TSInterfaceDeclaration {
+        TSInterfaceDeclaration {
+            base: self.make_base_node(interface.span),
+            id: self.convert_binding_identifier(&interface.id),
+            body: Box::new(serde_json::Value::Null),
+            type_parameters: interface
+                .type_parameters
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+            extends: if interface.extends.is_empty() {
+                None
+            } else {
+                Some(interface.extends.iter().map(|_e| serde_json::Value::Null).collect())
+            },
+            declare: if interface.declare { Some(true) } else { None },
+        }
+    }
+
+    fn convert_ts_enum_declaration(&self, ts_enum: &oxc::TSEnumDeclaration) -> TSEnumDeclaration {
+        TSEnumDeclaration {
+            base: self.make_base_node(ts_enum.span),
+            id: self.convert_binding_identifier(&ts_enum.id),
+            members: ts_enum.body.members.iter().map(|_m| serde_json::Value::Null).collect(),
+            declare: if ts_enum.declare { Some(true) } else { None },
+            is_const: if ts_enum.r#const { Some(true) } else { None },
+        }
+    }
+
+    fn convert_ts_module_declaration(
+        &self,
+        module: &oxc::TSModuleDeclaration,
+    ) -> TSModuleDeclaration {
+        TSModuleDeclaration {
+            base: self.make_base_node(module.span),
+            id: Box::new(serde_json::Value::Null),
+            body: Box::new(serde_json::Value::Null),
+            declare: if module.declare { Some(true) } else { None },
+            global: None,
+        }
+    }
+
+    /// Build a placeholder `TSModuleDeclaration` carrying only the original
+    /// span. The React compiler does not analyze type-level TypeScript
+    /// constructs, and `react_compiler_ast` has no dedicated Babel node for
+    /// several of them (`declare global`, `export =`, `export as namespace`,
+    /// `import x = require(...)`). They only need to round-trip back to OXC,
+    /// which the reverse converter does by re-parsing the original source slice
+    /// at `[start, end)`. Reusing the `TSModuleDeclaration` variant keeps these
+    /// statements routed through that source-extraction path.
+    fn convert_ts_declaration_passthrough(&self, span: Span, global: bool) -> TSModuleDeclaration {
+        TSModuleDeclaration {
+            base: self.make_base_node(span),
+            id: Box::new(serde_json::Value::Null),
+            body: Box::new(serde_json::Value::Null),
+            declare: None,
+            global: if global { Some(true) } else { None },
+        }
+    }
+
+    fn convert_expression(&self, expr: &oxc::Expression) -> Expression {
+        match expr {
+            oxc::Expression::BooleanLiteral(b) => Expression::BooleanLiteral(BooleanLiteral {
+                base: self.make_base_node(b.span),
+                value: b.value,
+            }),
+            oxc::Expression::NullLiteral(n) => {
+                Expression::NullLiteral(NullLiteral { base: self.make_base_node(n.span) })
+            }
+            oxc::Expression::NumericLiteral(n) => Expression::NumericLiteral(NumericLiteral {
+                base: self.make_base_node(n.span),
+                value: n.value,
+                extra: None,
+            }),
+            oxc::Expression::BigIntLiteral(b) => {
+                Expression::BigIntLiteral(self.convert_big_int_literal(b))
+            }
+            oxc::Expression::RegExpLiteral(r) => Expression::RegExpLiteral(RegExpLiteral {
+                base: self.make_base_node(r.span),
+                pattern: r.regex.pattern.text.to_string(),
+                flags: r.regex.flags.to_string(),
+            }),
+            oxc::Expression::StringLiteral(s) => Expression::StringLiteral(StringLiteral {
+                base: self.make_base_node(s.span),
+                value: s.value.to_string(),
+            }),
+            oxc::Expression::TemplateLiteral(t) => {
+                Expression::TemplateLiteral(self.convert_template_literal(t))
+            }
+            oxc::Expression::Identifier(id) => {
+                Expression::Identifier(self.convert_identifier_reference(id))
+            }
+            oxc::Expression::MetaProperty(m) => {
+                Expression::MetaProperty(self.convert_meta_property(m))
+            }
+            oxc::Expression::Super(s) => {
+                Expression::Super(Super { base: self.make_base_node(s.span) })
+            }
+            oxc::Expression::ArrayExpression(a) => {
+                Expression::ArrayExpression(self.convert_array_expression(a))
+            }
+            oxc::Expression::ArrowFunctionExpression(a) => {
+                Expression::ArrowFunctionExpression(self.convert_arrow_function_expression(a))
+            }
+            oxc::Expression::AssignmentExpression(a) => {
+                Expression::AssignmentExpression(self.convert_assignment_expression(a))
+            }
+            oxc::Expression::AwaitExpression(a) => {
+                Expression::AwaitExpression(self.convert_await_expression(a))
+            }
+            oxc::Expression::BinaryExpression(b) => {
+                Expression::BinaryExpression(self.convert_binary_expression(b))
+            }
+            oxc::Expression::CallExpression(c) => {
+                Expression::CallExpression(self.convert_call_expression(c))
+            }
+            oxc::Expression::ChainExpression(c) => self.convert_chain_expression(c),
+            oxc::Expression::ClassExpression(c) => {
+                Expression::ClassExpression(self.convert_class_expression(c))
+            }
+            oxc::Expression::ConditionalExpression(c) => {
+                Expression::ConditionalExpression(self.convert_conditional_expression(c))
+            }
+            oxc::Expression::FunctionExpression(f) => {
+                Expression::FunctionExpression(self.convert_function_expression(f))
+            }
+            oxc::Expression::ImportExpression(i) => {
+                // OXC models `import('foo')` as ImportExpression { source, options }.
+                // Babel/compiler AST models it as CallExpression { callee: Import, arguments: [source] }.
+                let mut args = vec![self.convert_expression(&i.source)];
+                if let Some(ref opts) = i.options {
+                    args.push(self.convert_expression(opts));
+                }
+                Expression::CallExpression(CallExpression {
+                    base: self.make_base_node(i.span),
+                    callee: Box::new(Expression::Import(Import {
+                        base: self.make_base_node(i.span),
+                    })),
+                    arguments: args,
+                    optional: None,
+                    type_arguments: None,
+                    type_parameters: None,
+                })
+            }
+            oxc::Expression::LogicalExpression(l) => {
+                Expression::LogicalExpression(self.convert_logical_expression(l))
+            }
+            oxc::Expression::NewExpression(n) => {
+                Expression::NewExpression(self.convert_new_expression(n))
+            }
+            oxc::Expression::ObjectExpression(o) => {
+                Expression::ObjectExpression(self.convert_object_expression(o))
+            }
+            oxc::Expression::ParenthesizedExpression(p) => {
+                Expression::ParenthesizedExpression(self.convert_parenthesized_expression(p))
+            }
+            oxc::Expression::SequenceExpression(s) => {
+                Expression::SequenceExpression(self.convert_sequence_expression(s))
+            }
+            oxc::Expression::TaggedTemplateExpression(t) => {
+                Expression::TaggedTemplateExpression(self.convert_tagged_template_expression(t))
+            }
+            oxc::Expression::ThisExpression(t) => {
+                Expression::ThisExpression(ThisExpression { base: self.make_base_node(t.span) })
+            }
+            oxc::Expression::UnaryExpression(u) => {
+                Expression::UnaryExpression(self.convert_unary_expression(u))
+            }
+            oxc::Expression::UpdateExpression(u) => {
+                Expression::UpdateExpression(self.convert_update_expression(u))
+            }
+            oxc::Expression::YieldExpression(y) => {
+                Expression::YieldExpression(self.convert_yield_expression(y))
+            }
+            oxc::Expression::PrivateInExpression(p) => {
+                Expression::BinaryExpression(self.convert_private_in_expression(p))
+            }
+            oxc::Expression::JSXElement(j) => {
+                Expression::JSXElement(Box::new(self.convert_jsx_element(j)))
+            }
+            oxc::Expression::JSXFragment(j) => {
+                Expression::JSXFragment(self.convert_jsx_fragment(j))
+            }
+            oxc::Expression::TSAsExpression(t) => {
+                Expression::TSAsExpression(self.convert_ts_as_expression(t))
+            }
+            oxc::Expression::TSSatisfiesExpression(t) => {
+                Expression::TSSatisfiesExpression(self.convert_ts_satisfies_expression(t))
+            }
+            oxc::Expression::TSTypeAssertion(t) => {
+                Expression::TSTypeAssertion(self.convert_ts_type_assertion(t))
+            }
+            oxc::Expression::TSNonNullExpression(t) => {
+                Expression::TSNonNullExpression(self.convert_ts_non_null_expression(t))
+            }
+            oxc::Expression::TSInstantiationExpression(t) => {
+                Expression::TSInstantiationExpression(self.convert_ts_instantiation_expression(t))
+            }
+            oxc::Expression::ComputedMemberExpression(m) => {
+                Expression::MemberExpression(MemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression(&m.object)),
+                    property: Box::new(self.convert_expression(&m.expression)),
+                    computed: true,
+                })
+            }
+            oxc::Expression::StaticMemberExpression(m) => {
+                Expression::MemberExpression(MemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression(&m.object)),
+                    property: Box::new(Expression::Identifier(
+                        self.convert_identifier_name(&m.property),
+                    )),
+                    computed: false,
+                })
+            }
+            oxc::Expression::PrivateFieldExpression(p) => {
+                Expression::MemberExpression(MemberExpression {
+                    base: self.make_base_node(p.span),
+                    object: Box::new(self.convert_expression(&p.object)),
+                    property: Box::new(Expression::PrivateName(PrivateName {
+                        base: self.make_base_node(p.field.span),
+                        id: Identifier {
+                            base: self.make_base_node(p.field.span),
+                            name: p.field.name.to_string(),
+                            type_annotation: None,
+                            optional: None,
+                            decorators: None,
+                        },
+                    })),
+                    computed: false,
+                })
+            }
+            oxc::Expression::V8IntrinsicExpression(_) => {
+                // `%DebugPrint(x)` etc. OXC only parses these when the
+                // `allow_v8_intrinsics` ParseOptions flag is set, which the
+                // React compiler never enables (it parses with defaults). There
+                // is no Babel node to map them to, so they are unreachable here.
+                unreachable!(
+                    "V8IntrinsicExpression: oxc does not emit this without ParseOptions::allow_v8_intrinsics"
+                )
+            }
+        }
+    }
+
+    fn convert_template_literal(&self, template: &oxc::TemplateLiteral) -> TemplateLiteral {
+        TemplateLiteral {
+            base: self.make_base_node(template.span),
+            quasis: template.quasis.iter().map(|q| self.convert_template_element(q)).collect(),
+            expressions: template.expressions.iter().map(|e| self.convert_expression(e)).collect(),
+        }
+    }
+
+    fn convert_template_element(&self, element: &oxc::TemplateElement) -> TemplateElement {
+        TemplateElement {
+            base: self.make_base_node(element.span),
+            value: TemplateElementValue {
+                raw: element.value.raw.to_string(),
+                cooked: element.value.cooked.as_ref().map(|s| s.to_string()),
+            },
+            tail: element.tail,
+        }
+    }
+
+    fn convert_meta_property(&self, meta: &oxc::MetaProperty) -> MetaProperty {
+        MetaProperty {
+            base: self.make_base_node(meta.span),
+            meta: self.convert_identifier_name(&meta.meta),
+            property: self.convert_identifier_name(&meta.property),
+        }
+    }
+
+    fn convert_array_expression(&self, array: &oxc::ArrayExpression) -> ArrayExpression {
+        ArrayExpression {
+            base: self.make_base_node(array.span),
+            elements: array
+                .elements
+                .iter()
+                .map(|e| match e {
+                    oxc::ArrayExpressionElement::SpreadElement(s) => {
+                        Some(Expression::SpreadElement(SpreadElement {
+                            base: self.make_base_node(s.span),
+                            argument: Box::new(self.convert_expression(&s.argument)),
+                        }))
+                    }
+                    oxc::ArrayExpressionElement::Elision(_) => None,
+                    other => Some(self.convert_expression_from_array_element(other)),
+                })
+                .collect(),
+        }
+    }
+
+    fn convert_arrow_function_expression(
+        &self,
+        arrow: &oxc::ArrowFunctionExpression,
+    ) -> ArrowFunctionExpression {
+        let body = if arrow.expression {
+            // When expression is true, the body contains a single expression statement
+            let expr = match &arrow.body.statements[0] {
+                oxc::Statement::ExpressionStatement(es) => self.convert_expression(&es.expression),
+                _ => panic!("Expected ExpressionStatement in arrow expression body"),
+            };
+            ArrowFunctionBody::Expression(Box::new(expr))
+        } else {
+            ArrowFunctionBody::BlockStatement(self.convert_function_body(&arrow.body))
+        };
+
+        ArrowFunctionExpression {
+            base: self.make_base_node(arrow.span),
+            params: self.convert_formal_parameters(&arrow.params),
+            body: Box::new(body),
+            id: None,
+            generator: false,
+            is_async: arrow.r#async,
+            expression: if arrow.expression { Some(true) } else { None },
+            return_type: arrow
+                .return_type
+                .as_ref()
+                .map(|t| self.convert_ts_type_annotation_json(t)),
+            type_parameters: arrow
+                .type_parameters
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+            predicate: None,
+        }
+    }
+
+    fn convert_assignment_expression(
+        &self,
+        assign: &oxc::AssignmentExpression,
+    ) -> AssignmentExpression {
+        AssignmentExpression {
+            base: self.make_base_node(assign.span),
+            operator: self.convert_assignment_operator(assign.operator),
+            left: Box::new(self.convert_assignment_target(&assign.left)),
+            right: Box::new(self.convert_expression(&assign.right)),
+        }
+    }
+
+    fn convert_assignment_operator(&self, op: oxc::AssignmentOperator) -> AssignmentOperator {
+        match op {
+            oxc::AssignmentOperator::Assign => AssignmentOperator::Assign,
+            oxc::AssignmentOperator::Addition => AssignmentOperator::AddAssign,
+            oxc::AssignmentOperator::Subtraction => AssignmentOperator::SubAssign,
+            oxc::AssignmentOperator::Multiplication => AssignmentOperator::MulAssign,
+            oxc::AssignmentOperator::Division => AssignmentOperator::DivAssign,
+            oxc::AssignmentOperator::Remainder => AssignmentOperator::RemAssign,
+            oxc::AssignmentOperator::ShiftLeft => AssignmentOperator::ShlAssign,
+            oxc::AssignmentOperator::ShiftRight => AssignmentOperator::ShrAssign,
+            oxc::AssignmentOperator::ShiftRightZeroFill => AssignmentOperator::UShrAssign,
+            oxc::AssignmentOperator::BitwiseOR => AssignmentOperator::BitOrAssign,
+            oxc::AssignmentOperator::BitwiseXOR => AssignmentOperator::BitXorAssign,
+            oxc::AssignmentOperator::BitwiseAnd => AssignmentOperator::BitAndAssign,
+            oxc::AssignmentOperator::LogicalAnd => AssignmentOperator::AndAssign,
+            oxc::AssignmentOperator::LogicalOr => AssignmentOperator::OrAssign,
+            oxc::AssignmentOperator::LogicalNullish => AssignmentOperator::NullishAssign,
+            oxc::AssignmentOperator::Exponential => AssignmentOperator::ExpAssign,
+        }
+    }
+
+    fn convert_assignment_target(&self, target: &oxc::AssignmentTarget) -> PatternLike {
+        match target {
+            oxc::AssignmentTarget::AssignmentTargetIdentifier(id) => {
+                PatternLike::Identifier(Identifier {
+                    base: self.make_base_node(id.span),
+                    name: id.name.to_string(),
+                    type_annotation: None,
+                    optional: None,
+                    decorators: None,
+                })
+            }
+            oxc::AssignmentTarget::ComputedMemberExpression(m) => {
+                PatternLike::MemberExpression(MemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression(&m.object)),
+                    property: Box::new(self.convert_expression(&m.expression)),
+                    computed: true,
+                })
+            }
+            oxc::AssignmentTarget::StaticMemberExpression(m) => {
+                PatternLike::MemberExpression(MemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression(&m.object)),
+                    property: Box::new(Expression::Identifier(
+                        self.convert_identifier_name(&m.property),
+                    )),
+                    computed: false,
+                })
+            }
+            oxc::AssignmentTarget::PrivateFieldExpression(p) => {
+                PatternLike::MemberExpression(MemberExpression {
+                    base: self.make_base_node(p.span),
+                    object: Box::new(self.convert_expression(&p.object)),
+                    property: Box::new(Expression::PrivateName(PrivateName {
+                        base: self.make_base_node(p.field.span),
+                        id: Identifier {
+                            base: self.make_base_node(p.field.span),
+                            name: p.field.name.to_string(),
+                            type_annotation: None,
+                            optional: None,
+                            decorators: None,
+                        },
+                    })),
+                    computed: false,
+                })
+            }
+            oxc::AssignmentTarget::ArrayAssignmentTarget(a) => {
+                self.convert_array_assignment_target(a)
+            }
+            oxc::AssignmentTarget::ObjectAssignmentTarget(o) => {
+                self.convert_object_assignment_target(o)
+            }
+            oxc::AssignmentTarget::TSAsExpression(t) => {
+                PatternLike::TSAsExpression(self.convert_ts_as_expression(t))
+            }
+            oxc::AssignmentTarget::TSSatisfiesExpression(t) => {
+                PatternLike::TSSatisfiesExpression(self.convert_ts_satisfies_expression(t))
+            }
+            oxc::AssignmentTarget::TSNonNullExpression(t) => {
+                PatternLike::TSNonNullExpression(self.convert_ts_non_null_expression(t))
+            }
+            oxc::AssignmentTarget::TSTypeAssertion(t) => {
+                PatternLike::TSTypeAssertion(self.convert_ts_type_assertion(t))
+            }
+        }
+    }
+
+    fn convert_array_assignment_target(&self, arr: &oxc::ArrayAssignmentTarget) -> PatternLike {
+        PatternLike::ArrayPattern(ArrayPattern {
+            base: self.make_base_node(arr.span),
+            elements: arr
+                .elements
+                .iter()
+                .map(|e| match e {
+                    Some(oxc::AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(d)) => {
+                        Some(PatternLike::AssignmentPattern(AssignmentPattern {
+                            base: self.make_base_node(d.span),
+                            left: Box::new(self.convert_assignment_target(&d.binding)),
+                            right: Box::new(self.convert_expression(&d.init)),
+                            type_annotation: None,
+                            decorators: None,
+                        }))
+                    }
+                    Some(other) => {
+                        Some(self.convert_assignment_target_maybe_default_as_target(other))
+                    }
+                    None => None,
+                })
+                .collect(),
+            type_annotation: None,
+            decorators: None,
+        })
+    }
+
+    /// Convert an AssignmentTargetMaybeDefault that is NOT an AssignmentTargetWithDefault
+    /// to a PatternLike by extracting the underlying AssignmentTarget
+    fn convert_assignment_target_maybe_default_as_target(
+        &self,
+        target: &oxc::AssignmentTargetMaybeDefault,
+    ) -> PatternLike {
+        match target {
+            oxc::AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(_) => {
+                unreachable!("handled separately")
+            }
+            oxc::AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(id) => {
+                PatternLike::Identifier(Identifier {
+                    base: self.make_base_node(id.span),
+                    name: id.name.to_string(),
+                    type_annotation: None,
+                    optional: None,
+                    decorators: None,
+                })
+            }
+            oxc::AssignmentTargetMaybeDefault::ComputedMemberExpression(m) => {
+                PatternLike::MemberExpression(MemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression(&m.object)),
+                    property: Box::new(self.convert_expression(&m.expression)),
+                    computed: true,
+                })
+            }
+            oxc::AssignmentTargetMaybeDefault::StaticMemberExpression(m) => {
+                PatternLike::MemberExpression(MemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression(&m.object)),
+                    property: Box::new(Expression::Identifier(
+                        self.convert_identifier_name(&m.property),
+                    )),
+                    computed: false,
+                })
+            }
+            oxc::AssignmentTargetMaybeDefault::PrivateFieldExpression(p) => {
+                PatternLike::MemberExpression(MemberExpression {
+                    base: self.make_base_node(p.span),
+                    object: Box::new(self.convert_expression(&p.object)),
+                    property: Box::new(Expression::PrivateName(PrivateName {
+                        base: self.make_base_node(p.field.span),
+                        id: Identifier {
+                            base: self.make_base_node(p.field.span),
+                            name: p.field.name.to_string(),
+                            type_annotation: None,
+                            optional: None,
+                            decorators: None,
+                        },
+                    })),
+                    computed: false,
+                })
+            }
+            oxc::AssignmentTargetMaybeDefault::ArrayAssignmentTarget(a) => {
+                self.convert_array_assignment_target(a)
+            }
+            oxc::AssignmentTargetMaybeDefault::ObjectAssignmentTarget(o) => {
+                self.convert_object_assignment_target(o)
+            }
+            oxc::AssignmentTargetMaybeDefault::TSAsExpression(t) => {
+                PatternLike::TSAsExpression(self.convert_ts_as_expression(t))
+            }
+            oxc::AssignmentTargetMaybeDefault::TSSatisfiesExpression(t) => {
+                PatternLike::TSSatisfiesExpression(self.convert_ts_satisfies_expression(t))
+            }
+            oxc::AssignmentTargetMaybeDefault::TSNonNullExpression(t) => {
+                PatternLike::TSNonNullExpression(self.convert_ts_non_null_expression(t))
+            }
+            oxc::AssignmentTargetMaybeDefault::TSTypeAssertion(t) => {
+                PatternLike::TSTypeAssertion(self.convert_ts_type_assertion(t))
+            }
+        }
+    }
+
+    fn convert_object_assignment_target(&self, obj: &oxc::ObjectAssignmentTarget) -> PatternLike {
+        let mut properties: Vec<ObjectPatternProperty> = obj
+            .properties
+            .iter()
+            .map(|p| match p {
+                oxc::AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(id) => {
+                    let ident = PatternLike::Identifier(Identifier {
+                        base: self.make_base_node(id.binding.span),
+                        name: id.binding.name.to_string(),
+                        type_annotation: None,
+                        optional: None,
+                        decorators: None,
+                    });
+                    let value = if let Some(init) = &id.init {
+                        Box::new(PatternLike::AssignmentPattern(AssignmentPattern {
+                            base: self.make_base_node(id.span),
+                            left: Box::new(ident),
+                            right: Box::new(self.convert_expression(init)),
+                            type_annotation: None,
+                            decorators: None,
+                        }))
+                    } else {
+                        Box::new(ident)
+                    };
+                    ObjectPatternProperty::ObjectProperty(ObjectPatternProp {
+                        base: self.make_base_node(id.span),
+                        key: Box::new(Expression::Identifier(Identifier {
+                            base: self.make_base_node(id.binding.span),
+                            name: id.binding.name.to_string(),
+                            type_annotation: None,
+                            optional: None,
+                            decorators: None,
+                        })),
+                        value,
+                        computed: false,
+                        shorthand: true,
+                        decorators: None,
+                        method: None,
+                    })
+                }
+                oxc::AssignmentTargetProperty::AssignmentTargetPropertyProperty(prop) => {
+                    let value = match &prop.binding {
+                        oxc::AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(d) => {
+                            Box::new(PatternLike::AssignmentPattern(AssignmentPattern {
+                                base: self.make_base_node(d.span),
+                                left: Box::new(self.convert_assignment_target(&d.binding)),
+                                right: Box::new(self.convert_expression(&d.init)),
+                                type_annotation: None,
+                                decorators: None,
+                            }))
+                        }
+                        other => {
+                            Box::new(self.convert_assignment_target_maybe_default_as_target(other))
+                        }
+                    };
+                    ObjectPatternProperty::ObjectProperty(ObjectPatternProp {
+                        base: self.make_base_node(prop.span),
+                        key: Box::new(self.convert_property_key(&prop.name)),
+                        value,
+                        computed: prop.computed,
+                        shorthand: false,
+                        decorators: None,
+                        method: None,
+                    })
+                }
+            })
+            .collect();
+
+        // Handle rest element separately (it's now a separate field)
+        if let Some(rest) = &obj.rest {
+            properties.push(ObjectPatternProperty::RestElement(RestElement {
+                base: self.make_base_node(rest.span),
+                argument: Box::new(self.convert_assignment_target(&rest.target)),
+                type_annotation: None,
+                decorators: None,
+            }));
+        }
+
+        PatternLike::ObjectPattern(ObjectPattern {
+            base: self.make_base_node(obj.span),
+            properties,
+            type_annotation: None,
+            decorators: None,
+        })
+    }
+
+    fn convert_await_expression(&self, await_expr: &oxc::AwaitExpression) -> AwaitExpression {
+        AwaitExpression {
+            base: self.make_base_node(await_expr.span),
+            argument: Box::new(self.convert_expression(&await_expr.argument)),
+        }
+    }
+
+    fn convert_binary_expression(&self, binary: &oxc::BinaryExpression) -> BinaryExpression {
+        BinaryExpression {
+            base: self.make_base_node(binary.span),
+            operator: self.convert_binary_operator(binary.operator),
+            left: Box::new(self.convert_expression(&binary.left)),
+            right: Box::new(self.convert_expression(&binary.right)),
+        }
+    }
+
+    /// Convert `#field in obj`. Babel models this as a `BinaryExpression` with
+    /// the `in` operator and a `PrivateName` left operand.
+    fn convert_private_in_expression(
+        &self,
+        private_in: &oxc::PrivateInExpression,
+    ) -> BinaryExpression {
+        BinaryExpression {
+            base: self.make_base_node(private_in.span),
+            operator: BinaryOperator::In,
+            left: Box::new(Expression::PrivateName(PrivateName {
+                base: self.make_base_node(private_in.left.span),
+                id: Identifier {
+                    base: self.make_base_node(private_in.left.span),
+                    name: private_in.left.name.to_string(),
+                    type_annotation: None,
+                    optional: None,
+                    decorators: None,
+                },
+            })),
+            right: Box::new(self.convert_expression(&private_in.right)),
+        }
+    }
+
+    fn convert_binary_operator(&self, op: oxc::BinaryOperator) -> BinaryOperator {
+        match op {
+            oxc::BinaryOperator::Equality => BinaryOperator::Eq,
+            oxc::BinaryOperator::Inequality => BinaryOperator::Neq,
+            oxc::BinaryOperator::StrictEquality => BinaryOperator::StrictEq,
+            oxc::BinaryOperator::StrictInequality => BinaryOperator::StrictNeq,
+            oxc::BinaryOperator::LessThan => BinaryOperator::Lt,
+            oxc::BinaryOperator::LessEqualThan => BinaryOperator::Lte,
+            oxc::BinaryOperator::GreaterThan => BinaryOperator::Gt,
+            oxc::BinaryOperator::GreaterEqualThan => BinaryOperator::Gte,
+            oxc::BinaryOperator::ShiftLeft => BinaryOperator::Shl,
+            oxc::BinaryOperator::ShiftRight => BinaryOperator::Shr,
+            oxc::BinaryOperator::ShiftRightZeroFill => BinaryOperator::UShr,
+            oxc::BinaryOperator::Addition => BinaryOperator::Add,
+            oxc::BinaryOperator::Subtraction => BinaryOperator::Sub,
+            oxc::BinaryOperator::Multiplication => BinaryOperator::Mul,
+            oxc::BinaryOperator::Division => BinaryOperator::Div,
+            oxc::BinaryOperator::Remainder => BinaryOperator::Rem,
+            oxc::BinaryOperator::BitwiseOR => BinaryOperator::BitOr,
+            oxc::BinaryOperator::BitwiseXOR => BinaryOperator::BitXor,
+            oxc::BinaryOperator::BitwiseAnd => BinaryOperator::BitAnd,
+            oxc::BinaryOperator::In => BinaryOperator::In,
+            oxc::BinaryOperator::Instanceof => BinaryOperator::Instanceof,
+            oxc::BinaryOperator::Exponential => BinaryOperator::Exp,
+        }
+    }
+
+    fn convert_call_expression(&self, call: &oxc::CallExpression) -> CallExpression {
+        CallExpression {
+            base: self.make_base_node(call.span),
+            callee: Box::new(self.convert_expression(&call.callee)),
+            arguments: call.arguments.iter().map(|a| self.convert_argument(a)).collect(),
+            type_parameters: call
+                .type_arguments
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+            type_arguments: None,
+            optional: if call.optional { Some(true) } else { None },
+        }
+    }
+
+    fn convert_argument(&self, arg: &oxc::Argument) -> Expression {
+        match arg {
+            oxc::Argument::SpreadElement(s) => Expression::SpreadElement(SpreadElement {
+                base: self.make_base_node(s.span),
+                argument: Box::new(self.convert_expression(&s.argument)),
+            }),
+            other => self.convert_expression_from_argument(other),
+        }
+    }
+
+    fn convert_chain_expression(&self, chain: &oxc::ChainExpression) -> Expression {
+        // ChainExpression wraps optional call/member expressions in Babel
+        match &chain.expression {
+            oxc::ChainElement::CallExpression(c) => {
+                Expression::OptionalCallExpression(OptionalCallExpression {
+                    base: self.make_base_node(c.span),
+                    callee: Box::new(self.convert_expression_in_chain(&c.callee)),
+                    arguments: c.arguments.iter().map(|a| self.convert_argument(a)).collect(),
+                    optional: c.optional,
+                    type_parameters: c
+                        .type_arguments
+                        .as_ref()
+                        .map(|_t| Box::new(serde_json::Value::Null)),
+                    type_arguments: None,
+                })
+            }
+            oxc::ChainElement::ComputedMemberExpression(m) => {
+                Expression::OptionalMemberExpression(OptionalMemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression_in_chain(&m.object)),
+                    property: Box::new(self.convert_expression(&m.expression)),
+                    computed: true,
+                    optional: m.optional,
+                })
+            }
+            oxc::ChainElement::StaticMemberExpression(m) => {
+                Expression::OptionalMemberExpression(OptionalMemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression_in_chain(&m.object)),
+                    property: Box::new(Expression::Identifier(
+                        self.convert_identifier_name(&m.property),
+                    )),
+                    computed: false,
+                    optional: m.optional,
+                })
+            }
+            oxc::ChainElement::PrivateFieldExpression(p) => {
+                Expression::OptionalMemberExpression(OptionalMemberExpression {
+                    base: self.make_base_node(p.span),
+                    object: Box::new(self.convert_expression_in_chain(&p.object)),
+                    property: Box::new(Expression::PrivateName(PrivateName {
+                        base: self.make_base_node(p.field.span),
+                        id: Identifier {
+                            base: self.make_base_node(p.field.span),
+                            name: p.field.name.to_string(),
+                            type_annotation: None,
+                            optional: None,
+                            decorators: None,
+                        },
+                    })),
+                    computed: false,
+                    optional: p.optional,
+                })
+            }
+            oxc::ChainElement::TSNonNullExpression(t) => {
+                // `foo?.bar!` — the non-null assertion is the outermost chain
+                // element. Wrap the (chain-aware) inner expression in a Babel
+                // `TSNonNullExpression`.
+                Expression::TSNonNullExpression(TSNonNullExpression {
+                    base: self.make_base_node(t.span),
+                    expression: Box::new(self.convert_expression_in_chain(&t.expression)),
+                })
+            }
+        }
+    }
+
+    /// Check if an expression within a chain contains any optional access.
+    fn expr_contains_optional(expr: &oxc::Expression) -> bool {
+        match expr {
+            oxc::Expression::CallExpression(c) => {
+                c.optional || Self::expr_contains_optional(&c.callee)
+            }
+            oxc::Expression::StaticMemberExpression(m) => {
+                m.optional || Self::expr_contains_optional(&m.object)
+            }
+            oxc::Expression::ComputedMemberExpression(m) => {
+                m.optional || Self::expr_contains_optional(&m.object)
+            }
+            oxc::Expression::PrivateFieldExpression(p) => {
+                p.optional || Self::expr_contains_optional(&p.object)
+            }
+            _ => false,
+        }
+    }
+
+    /// Convert an expression that appears as callee/object inside a ChainExpression.
+    /// In OXC, `a?.b?.c` is a single ChainExpression with nested CallExpression/
+    /// MemberExpression nodes that have `optional: true`. In Babel, each optional
+    /// node is an OptionalCallExpression/OptionalMemberExpression. Non-optional
+    /// nodes that appear AFTER the first `?.` become OptionalMember/Call with
+    /// `optional: false`, while non-optional nodes BEFORE the first `?.` are
+    /// regular MemberExpression/CallExpression nodes.
+    fn convert_expression_in_chain(&self, expr: &oxc::Expression) -> Expression {
+        match expr {
+            oxc::Expression::CallExpression(c) if c.optional => {
+                Expression::OptionalCallExpression(OptionalCallExpression {
+                    base: self.make_base_node(c.span),
+                    callee: Box::new(self.convert_expression_in_chain(&c.callee)),
+                    arguments: c.arguments.iter().map(|a| self.convert_argument(a)).collect(),
+                    optional: true,
+                    type_parameters: c
+                        .type_arguments
+                        .as_ref()
+                        .map(|_t| Box::new(serde_json::Value::Null)),
+                    type_arguments: None,
+                })
+            }
+            oxc::Expression::StaticMemberExpression(m) if m.optional => {
+                Expression::OptionalMemberExpression(OptionalMemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression_in_chain(&m.object)),
+                    property: Box::new(Expression::Identifier(
+                        self.convert_identifier_name(&m.property),
+                    )),
+                    computed: false,
+                    optional: true,
+                })
+            }
+            oxc::Expression::ComputedMemberExpression(m) if m.optional => {
+                Expression::OptionalMemberExpression(OptionalMemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression_in_chain(&m.object)),
+                    property: Box::new(self.convert_expression(&m.expression)),
+                    computed: true,
+                    optional: true,
+                })
+            }
+            // Non-optional expressions inside chains: need to check if the
+            // object/callee still contains optional parts. If so, this node
+            // is AFTER the first `?.` and should be OptionalMember/Call with
+            // optional: false. If not, it's BEFORE the first `?.` and should
+            // be a regular MemberExpression/CallExpression.
+            oxc::Expression::CallExpression(c) if Self::expr_contains_optional(&c.callee) => {
+                Expression::OptionalCallExpression(OptionalCallExpression {
+                    base: self.make_base_node(c.span),
+                    callee: Box::new(self.convert_expression_in_chain(&c.callee)),
+                    arguments: c.arguments.iter().map(|a| self.convert_argument(a)).collect(),
+                    optional: false,
+                    type_parameters: c
+                        .type_arguments
+                        .as_ref()
+                        .map(|_t| Box::new(serde_json::Value::Null)),
+                    type_arguments: None,
+                })
+            }
+            oxc::Expression::StaticMemberExpression(m)
+                if Self::expr_contains_optional(&m.object) =>
+            {
+                Expression::OptionalMemberExpression(OptionalMemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression_in_chain(&m.object)),
+                    property: Box::new(Expression::Identifier(
+                        self.convert_identifier_name(&m.property),
+                    )),
+                    computed: false,
+                    optional: false,
+                })
+            }
+            oxc::Expression::ComputedMemberExpression(m)
+                if Self::expr_contains_optional(&m.object) =>
+            {
+                Expression::OptionalMemberExpression(OptionalMemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression_in_chain(&m.object)),
+                    property: Box::new(self.convert_expression(&m.expression)),
+                    computed: true,
+                    optional: false,
+                })
+            }
+            // No optional in the sub-tree — this is the base receiver before
+            // the first `?.`. Convert as a regular expression.
+            _ => self.convert_expression(expr),
+        }
+    }
+
+    fn convert_class_expression(&self, class: &oxc::Class) -> ClassExpression {
+        ClassExpression {
+            base: self.make_base_node(class.span),
+            id: class.id.as_ref().map(|id| self.convert_binding_identifier(id)),
+            super_class: class.super_class.as_ref().map(|s| Box::new(self.convert_expression(s))),
+            body: ClassBody {
+                base: self.make_base_node(class.body.span),
+                body: class.body.body.iter().map(|_item| serde_json::Value::Null).collect(),
+            },
+            decorators: if class.decorators.is_empty() {
+                None
+            } else {
+                Some(class.decorators.iter().map(|_d| serde_json::Value::Null).collect())
+            },
+            implements: if class.implements.is_empty() {
+                None
+            } else {
+                Some(class.implements.iter().map(|_i| serde_json::Value::Null).collect())
+            },
+            super_type_parameters: class
+                .super_type_arguments
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+            type_parameters: class
+                .type_parameters
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+        }
+    }
+
+    fn convert_big_int_literal(&self, lit: &oxc::BigIntLiteral) -> BigIntLiteral {
+        BigIntLiteral { base: self.make_base_node(lit.span), value: lit.value.to_string() }
+    }
+
+    fn convert_conditional_expression(
+        &self,
+        cond: &oxc::ConditionalExpression,
+    ) -> ConditionalExpression {
+        ConditionalExpression {
+            base: self.make_base_node(cond.span),
+            test: Box::new(self.convert_expression(&cond.test)),
+            consequent: Box::new(self.convert_expression(&cond.consequent)),
+            alternate: Box::new(self.convert_expression(&cond.alternate)),
+        }
+    }
+
+    fn convert_function_expression(&self, func: &oxc::Function) -> FunctionExpression {
+        FunctionExpression {
+            base: self.make_base_node(func.span),
+            id: func.id.as_ref().map(|id| self.convert_binding_identifier(id)),
+            params: self.convert_formal_parameters(&func.params),
+            body: self.convert_optional_function_body(func.body.as_deref(), func.span),
+            generator: func.generator,
+            is_async: func.r#async,
+            return_type: func.return_type.as_ref().map(|t| self.convert_ts_type_annotation_json(t)),
+            type_parameters: func
+                .type_parameters
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+            predicate: None,
+        }
+    }
+
+    fn convert_logical_expression(&self, logical: &oxc::LogicalExpression) -> LogicalExpression {
+        LogicalExpression {
+            base: self.make_base_node(logical.span),
+            operator: self.convert_logical_operator(logical.operator),
+            left: Box::new(self.convert_expression(&logical.left)),
+            right: Box::new(self.convert_expression(&logical.right)),
+        }
+    }
+
+    fn convert_logical_operator(&self, op: oxc::LogicalOperator) -> LogicalOperator {
+        match op {
+            oxc::LogicalOperator::Or => LogicalOperator::Or,
+            oxc::LogicalOperator::And => LogicalOperator::And,
+            oxc::LogicalOperator::Coalesce => LogicalOperator::NullishCoalescing,
+        }
+    }
+
+    fn convert_new_expression(&self, new: &oxc::NewExpression) -> NewExpression {
+        NewExpression {
+            base: self.make_base_node(new.span),
+            callee: Box::new(self.convert_expression(&new.callee)),
+            arguments: new.arguments.iter().map(|a| self.convert_argument(a)).collect(),
+            type_parameters: new
+                .type_arguments
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+            type_arguments: None,
+        }
+    }
+
+    fn convert_object_expression(&self, obj: &oxc::ObjectExpression) -> ObjectExpression {
+        ObjectExpression {
+            base: self.make_base_node(obj.span),
+            properties: obj
+                .properties
+                .iter()
+                .map(|p| self.convert_object_property_kind(p))
+                .collect(),
+        }
+    }
+
+    fn convert_object_property_kind(
+        &self,
+        prop: &oxc::ObjectPropertyKind,
+    ) -> ObjectExpressionProperty {
+        match prop {
+            oxc::ObjectPropertyKind::ObjectProperty(p) => {
+                // When method is true or kind is Get/Set, convert to ObjectMethod
+                // to match Babel's AST representation of method shorthand.
+                if p.method || matches!(p.kind, oxc::PropertyKind::Get | oxc::PropertyKind::Set) {
+                    if let oxc::Expression::FunctionExpression(func) = &p.value {
+                        let method_kind = match p.kind {
+                            oxc::PropertyKind::Get => ObjectMethodKind::Get,
+                            oxc::PropertyKind::Set => ObjectMethodKind::Set,
+                            _ => ObjectMethodKind::Method,
+                        };
+                        let params: Vec<PatternLike> = self.convert_formal_parameters(&func.params);
+                        let body = func
+                            .body
+                            .as_ref()
+                            .map(|b| self.convert_function_body(b))
+                            .unwrap_or_else(|| BlockStatement {
+                                base: BaseNode::default(),
+                                body: vec![],
+                                directives: vec![],
+                            });
+                        return ObjectExpressionProperty::ObjectMethod(ObjectMethod {
+                            base: self.make_base_node(p.span),
+                            method: p.method,
+                            kind: method_kind,
+                            key: Box::new(self.convert_property_key(&p.key)),
+                            params,
+                            body,
+                            computed: p.computed,
+                            id: func.id.as_ref().map(|id| self.convert_binding_identifier(id)),
+                            generator: func.generator,
+                            is_async: func.r#async,
+                            decorators: None,
+                            return_type: func
+                                .return_type
+                                .as_ref()
+                                .map(|t| self.convert_ts_type_annotation_json(t)),
+                            type_parameters: func
+                                .type_parameters
+                                .as_ref()
+                                .map(|_| Box::new(serde_json::Value::Null)),
+                            predicate: None,
+                        });
+                    }
+                }
+                ObjectExpressionProperty::ObjectProperty(self.convert_object_property(p))
+            }
+            oxc::ObjectPropertyKind::SpreadProperty(s) => {
+                ObjectExpressionProperty::SpreadElement(SpreadElement {
+                    base: self.make_base_node(s.span),
+                    argument: Box::new(self.convert_expression(&s.argument)),
+                })
+            }
+        }
+    }
+
+    fn convert_object_property(&self, prop: &oxc::ObjectProperty) -> ObjectProperty {
+        ObjectProperty {
+            base: self.make_base_node(prop.span),
+            key: Box::new(self.convert_property_key(&prop.key)),
+            value: Box::new(self.convert_expression(&prop.value)),
+            computed: prop.computed,
+            shorthand: prop.shorthand,
+            decorators: None,
+            method: if prop.method { Some(true) } else { None },
+        }
+    }
+
+    fn convert_property_key(&self, key: &oxc::PropertyKey) -> Expression {
+        match key {
+            oxc::PropertyKey::StaticIdentifier(id) => {
+                Expression::Identifier(self.convert_identifier_name(id))
+            }
+            oxc::PropertyKey::PrivateIdentifier(id) => Expression::PrivateName(PrivateName {
+                base: self.make_base_node(id.span),
+                id: Identifier {
+                    base: self.make_base_node(id.span),
+                    name: id.name.to_string(),
+                    type_annotation: None,
+                    optional: None,
+                    decorators: None,
+                },
+            }),
+            other => self.convert_expression_from_property_key(other),
+        }
+    }
+
+    fn convert_parenthesized_expression(
+        &self,
+        paren: &oxc::ParenthesizedExpression,
+    ) -> ParenthesizedExpression {
+        ParenthesizedExpression {
+            base: self.make_base_node(paren.span),
+            expression: Box::new(self.convert_expression(&paren.expression)),
+        }
+    }
+
+    fn convert_sequence_expression(&self, seq: &oxc::SequenceExpression) -> SequenceExpression {
+        SequenceExpression {
+            base: self.make_base_node(seq.span),
+            expressions: seq.expressions.iter().map(|e| self.convert_expression(e)).collect(),
+        }
+    }
+
+    fn convert_tagged_template_expression(
+        &self,
+        tagged: &oxc::TaggedTemplateExpression,
+    ) -> TaggedTemplateExpression {
+        TaggedTemplateExpression {
+            base: self.make_base_node(tagged.span),
+            tag: Box::new(self.convert_expression(&tagged.tag)),
+            quasi: self.convert_template_literal(&tagged.quasi),
+            type_parameters: tagged
+                .type_arguments
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+        }
+    }
+
+    fn convert_unary_expression(&self, unary: &oxc::UnaryExpression) -> UnaryExpression {
+        UnaryExpression {
+            base: self.make_base_node(unary.span),
+            operator: self.convert_unary_operator(unary.operator),
+            prefix: true,
+            argument: Box::new(self.convert_expression(&unary.argument)),
+        }
+    }
+
+    fn convert_unary_operator(&self, op: oxc::UnaryOperator) -> UnaryOperator {
+        match op {
+            oxc::UnaryOperator::UnaryNegation => UnaryOperator::Neg,
+            oxc::UnaryOperator::UnaryPlus => UnaryOperator::Plus,
+            oxc::UnaryOperator::LogicalNot => UnaryOperator::Not,
+            oxc::UnaryOperator::BitwiseNot => UnaryOperator::BitNot,
+            oxc::UnaryOperator::Typeof => UnaryOperator::TypeOf,
+            oxc::UnaryOperator::Void => UnaryOperator::Void,
+            oxc::UnaryOperator::Delete => UnaryOperator::Delete,
+        }
+    }
+
+    fn convert_update_expression(&self, update: &oxc::UpdateExpression) -> UpdateExpression {
+        UpdateExpression {
+            base: self.make_base_node(update.span),
+            operator: self.convert_update_operator(update.operator),
+            argument: Box::new(
+                self.convert_simple_assignment_target_as_expression(&update.argument),
+            ),
+            prefix: update.prefix,
+        }
+    }
+
+    fn convert_simple_assignment_target_as_expression(
+        &self,
+        target: &oxc::SimpleAssignmentTarget,
+    ) -> Expression {
+        match target {
+            oxc::SimpleAssignmentTarget::AssignmentTargetIdentifier(id) => {
+                Expression::Identifier(Identifier {
+                    base: self.make_base_node(id.span),
+                    name: id.name.to_string(),
+                    type_annotation: None,
+                    optional: None,
+                    decorators: None,
+                })
+            }
+            oxc::SimpleAssignmentTarget::ComputedMemberExpression(m) => {
+                Expression::MemberExpression(MemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression(&m.object)),
+                    property: Box::new(self.convert_expression(&m.expression)),
+                    computed: true,
+                })
+            }
+            oxc::SimpleAssignmentTarget::StaticMemberExpression(m) => {
+                Expression::MemberExpression(MemberExpression {
+                    base: self.make_base_node(m.span),
+                    object: Box::new(self.convert_expression(&m.object)),
+                    property: Box::new(Expression::Identifier(
+                        self.convert_identifier_name(&m.property),
+                    )),
+                    computed: false,
+                })
+            }
+            oxc::SimpleAssignmentTarget::PrivateFieldExpression(p) => {
+                Expression::MemberExpression(MemberExpression {
+                    base: self.make_base_node(p.span),
+                    object: Box::new(self.convert_expression(&p.object)),
+                    property: Box::new(Expression::PrivateName(PrivateName {
+                        base: self.make_base_node(p.field.span),
+                        id: Identifier {
+                            base: self.make_base_node(p.field.span),
+                            name: p.field.name.to_string(),
+                            type_annotation: None,
+                            optional: None,
+                            decorators: None,
+                        },
+                    })),
+                    computed: false,
+                })
+            }
+            oxc::SimpleAssignmentTarget::TSAsExpression(t) => {
+                self.convert_expression(&t.expression)
+            }
+            oxc::SimpleAssignmentTarget::TSSatisfiesExpression(t) => {
+                self.convert_expression(&t.expression)
+            }
+            oxc::SimpleAssignmentTarget::TSNonNullExpression(t) => {
+                self.convert_expression(&t.expression)
+            }
+            oxc::SimpleAssignmentTarget::TSTypeAssertion(t) => {
+                self.convert_expression(&t.expression)
+            }
+        }
+    }
+
+    fn convert_update_operator(&self, op: oxc::UpdateOperator) -> UpdateOperator {
+        match op {
+            oxc::UpdateOperator::Increment => UpdateOperator::Increment,
+            oxc::UpdateOperator::Decrement => UpdateOperator::Decrement,
+        }
+    }
+
+    fn convert_yield_expression(&self, yield_expr: &oxc::YieldExpression) -> YieldExpression {
+        YieldExpression {
+            base: self.make_base_node(yield_expr.span),
+            argument: yield_expr.argument.as_ref().map(|a| Box::new(self.convert_expression(a))),
+            delegate: yield_expr.delegate,
+        }
+    }
+
+    fn convert_ts_as_expression(&self, ts_as: &oxc::TSAsExpression) -> TSAsExpression {
+        TSAsExpression {
+            base: self.make_base_node(ts_as.span),
+            expression: Box::new(self.convert_expression(&ts_as.expression)),
+            type_annotation: self.convert_ts_type_json(&ts_as.type_annotation),
+        }
+    }
+
+    fn convert_ts_satisfies_expression(
+        &self,
+        ts_sat: &oxc::TSSatisfiesExpression,
+    ) -> TSSatisfiesExpression {
+        TSSatisfiesExpression {
+            base: self.make_base_node(ts_sat.span),
+            expression: Box::new(self.convert_expression(&ts_sat.expression)),
+            type_annotation: self.convert_ts_type_json(&ts_sat.type_annotation),
+        }
+    }
+
+    fn convert_ts_type_assertion(&self, ts_assert: &oxc::TSTypeAssertion) -> TSTypeAssertion {
+        TSTypeAssertion {
+            base: self.make_base_node(ts_assert.span),
+            expression: Box::new(self.convert_expression(&ts_assert.expression)),
+            type_annotation: self.convert_ts_type_json(&ts_assert.type_annotation),
+        }
+    }
+
+    fn convert_ts_non_null_expression(
+        &self,
+        ts_non_null: &oxc::TSNonNullExpression,
+    ) -> TSNonNullExpression {
+        TSNonNullExpression {
+            base: self.make_base_node(ts_non_null.span),
+            expression: Box::new(self.convert_expression(&ts_non_null.expression)),
+        }
+    }
+
+    fn convert_ts_instantiation_expression(
+        &self,
+        ts_inst: &oxc::TSInstantiationExpression,
+    ) -> TSInstantiationExpression {
+        TSInstantiationExpression {
+            base: self.make_base_node(ts_inst.span),
+            expression: Box::new(self.convert_expression(&ts_inst.expression)),
+            type_parameters: self
+                .convert_ts_type_parameter_instantiation_json(&ts_inst.type_arguments),
+        }
+    }
+
+    fn convert_jsx_element(&self, jsx: &oxc::JSXElement) -> JSXElement {
+        JSXElement {
+            base: self.make_base_node(jsx.span),
+            opening_element: self.convert_jsx_opening_element(&jsx.opening_element),
+            closing_element: jsx
+                .closing_element
+                .as_ref()
+                .map(|c| self.convert_jsx_closing_element(c)),
+            children: jsx.children.iter().map(|c| self.convert_jsx_child(c)).collect(),
+            self_closing: None,
+        }
+    }
+
+    fn convert_jsx_fragment(&self, jsx: &oxc::JSXFragment) -> JSXFragment {
+        JSXFragment {
+            base: self.make_base_node(jsx.span),
+            opening_fragment: JSXOpeningFragment {
+                base: self.make_base_node(jsx.opening_fragment.span),
+            },
+            closing_fragment: JSXClosingFragment {
+                base: self.make_base_node(jsx.closing_fragment.span),
+            },
+            children: jsx.children.iter().map(|c| self.convert_jsx_child(c)).collect(),
+        }
+    }
+
+    fn convert_jsx_opening_element(&self, opening: &oxc::JSXOpeningElement) -> JSXOpeningElement {
+        // In OXC v0.121, self_closing is computed (not a field), and type_parameters -> type_arguments
+        // Determine self_closing from absence of closing element (handled at JSXElement level)
+        JSXOpeningElement {
+            base: self.make_base_node(opening.span),
+            name: self.convert_jsx_element_name(&opening.name),
+            attributes: opening
+                .attributes
+                .iter()
+                .map(|a| self.convert_jsx_attribute_item(a))
+                .collect(),
+            self_closing: false, // Will be set properly at JSXElement level if needed
+            type_parameters: opening
+                .type_arguments
+                .as_ref()
+                .map(|_t| Box::new(serde_json::Value::Null)),
+        }
+    }
+
+    fn convert_jsx_closing_element(&self, closing: &oxc::JSXClosingElement) -> JSXClosingElement {
+        JSXClosingElement {
+            base: self.make_base_node(closing.span),
+            name: self.convert_jsx_element_name(&closing.name),
+        }
+    }
+
+    fn convert_jsx_element_name(&self, name: &oxc::JSXElementName) -> JSXElementName {
+        match name {
+            oxc::JSXElementName::Identifier(id) => JSXElementName::JSXIdentifier(JSXIdentifier {
+                base: self.make_base_node(id.span),
+                name: id.name.to_string(),
+            }),
+            oxc::JSXElementName::IdentifierReference(id) => {
+                JSXElementName::JSXIdentifier(JSXIdentifier {
+                    base: self.make_base_node(id.span),
+                    name: id.name.to_string(),
+                })
+            }
+            oxc::JSXElementName::NamespacedName(ns) => {
+                JSXElementName::JSXNamespacedName(JSXNamespacedName {
+                    base: self.make_base_node(ns.span),
+                    namespace: JSXIdentifier {
+                        base: self.make_base_node(ns.namespace.span),
+                        name: ns.namespace.name.to_string(),
+                    },
+                    name: JSXIdentifier {
+                        base: self.make_base_node(ns.name.span),
+                        name: ns.name.name.to_string(),
+                    },
+                })
+            }
+            oxc::JSXElementName::MemberExpression(mem) => {
+                JSXElementName::JSXMemberExpression(self.convert_jsx_member_expression(mem))
+            }
+            oxc::JSXElementName::ThisExpression(t) => {
+                JSXElementName::JSXIdentifier(JSXIdentifier {
+                    base: self.make_base_node(t.span),
+                    name: "this".to_string(),
+                })
+            }
+        }
+    }
+
+    fn convert_jsx_member_expression(&self, mem: &oxc::JSXMemberExpression) -> JSXMemberExpression {
+        JSXMemberExpression {
+            base: self.make_base_node(mem.span),
+            object: Box::new(self.convert_jsx_member_expression_object(&mem.object)),
+            property: JSXIdentifier {
+                base: self.make_base_node(mem.property.span),
+                name: mem.property.name.to_string(),
+            },
+        }
+    }
+
+    fn convert_jsx_member_expression_object(
+        &self,
+        obj: &oxc::JSXMemberExpressionObject,
+    ) -> JSXMemberExprObject {
+        match obj {
+            oxc::JSXMemberExpressionObject::IdentifierReference(id) => {
+                JSXMemberExprObject::JSXIdentifier(JSXIdentifier {
+                    base: self.make_base_node(id.span),
+                    name: id.name.to_string(),
+                })
+            }
+            oxc::JSXMemberExpressionObject::MemberExpression(mem) => {
+                JSXMemberExprObject::JSXMemberExpression(Box::new(
+                    self.convert_jsx_member_expression(mem),
+                ))
+            }
+            oxc::JSXMemberExpressionObject::ThisExpression(t) => {
+                // JSX `<this.Foo />` - convert to identifier
+                JSXMemberExprObject::JSXIdentifier(JSXIdentifier {
+                    base: self.make_base_node(t.span),
+                    name: "this".to_string(),
+                })
+            }
+        }
+    }
+
+    fn convert_jsx_attribute_item(&self, attr: &oxc::JSXAttributeItem) -> JSXAttributeItem {
+        match attr {
+            oxc::JSXAttributeItem::Attribute(a) => {
+                JSXAttributeItem::JSXAttribute(self.convert_jsx_attribute(a))
+            }
+            oxc::JSXAttributeItem::SpreadAttribute(s) => {
+                JSXAttributeItem::JSXSpreadAttribute(JSXSpreadAttribute {
+                    base: self.make_base_node(s.span),
+                    argument: Box::new(self.convert_expression(&s.argument)),
+                })
+            }
+        }
+    }
+
+    fn convert_jsx_attribute(&self, attr: &oxc::JSXAttribute) -> JSXAttribute {
+        JSXAttribute {
+            base: self.make_base_node(attr.span),
+            name: self.convert_jsx_attribute_name(&attr.name),
+            value: attr.value.as_ref().map(|v| self.convert_jsx_attribute_value(v)),
+        }
+    }
+
+    fn convert_jsx_attribute_name(&self, name: &oxc::JSXAttributeName) -> JSXAttributeName {
+        match name {
+            oxc::JSXAttributeName::Identifier(id) => {
+                JSXAttributeName::JSXIdentifier(JSXIdentifier {
+                    base: self.make_base_node(id.span),
+                    name: id.name.to_string(),
+                })
+            }
+            oxc::JSXAttributeName::NamespacedName(ns) => {
+                JSXAttributeName::JSXNamespacedName(JSXNamespacedName {
+                    base: self.make_base_node(ns.span),
+                    namespace: JSXIdentifier {
+                        base: self.make_base_node(ns.namespace.span),
+                        name: ns.namespace.name.to_string(),
+                    },
+                    name: JSXIdentifier {
+                        base: self.make_base_node(ns.name.span),
+                        name: ns.name.name.to_string(),
+                    },
+                })
+            }
+        }
+    }
+
+    fn convert_jsx_attribute_value(&self, value: &oxc::JSXAttributeValue) -> JSXAttributeValue {
+        match value {
+            oxc::JSXAttributeValue::StringLiteral(s) => {
+                JSXAttributeValue::StringLiteral(StringLiteral {
+                    base: self.make_base_node(s.span),
+                    value: decode_jsx_entities(s.value.as_str()),
+                })
+            }
+            oxc::JSXAttributeValue::ExpressionContainer(e) => {
+                JSXAttributeValue::JSXExpressionContainer(self.convert_jsx_expression_container(e))
+            }
+            oxc::JSXAttributeValue::Element(e) => {
+                JSXAttributeValue::JSXElement(Box::new(self.convert_jsx_element(e)))
+            }
+            oxc::JSXAttributeValue::Fragment(f) => {
+                JSXAttributeValue::JSXFragment(self.convert_jsx_fragment(f))
+            }
+        }
+    }
+
+    fn convert_jsx_expression_container(
+        &self,
+        container: &oxc::JSXExpressionContainer,
+    ) -> JSXExpressionContainer {
+        JSXExpressionContainer {
+            base: self.make_base_node(container.span),
+            expression: match &container.expression {
+                oxc::JSXExpression::EmptyExpression(e) => {
+                    JSXExpressionContainerExpr::JSXEmptyExpression(JSXEmptyExpression {
+                        base: self.make_base_node(e.span),
+                    })
+                }
+                other => JSXExpressionContainerExpr::Expression(Box::new(
+                    self.convert_expression_from_jsx_expression(other),
+                )),
+            },
+        }
+    }
+
+    fn convert_jsx_child(&self, child: &oxc::JSXChild) -> JSXChild {
+        match child {
+            oxc::JSXChild::Element(e) => {
+                JSXChild::JSXElement(Box::new(self.convert_jsx_element(e)))
+            }
+            oxc::JSXChild::Fragment(f) => JSXChild::JSXFragment(self.convert_jsx_fragment(f)),
+            oxc::JSXChild::ExpressionContainer(e) => {
+                JSXChild::JSXExpressionContainer(self.convert_jsx_expression_container(e))
+            }
+            oxc::JSXChild::Spread(s) => JSXChild::JSXSpreadChild(JSXSpreadChild {
+                base: self.make_base_node(s.span),
+                expression: Box::new(self.convert_expression(&s.expression)),
+            }),
+            oxc::JSXChild::Text(t) => JSXChild::JSXText(JSXText {
+                base: self.make_base_node(t.span),
+                value: decode_jsx_entities(t.value.as_str()),
+            }),
+        }
+    }
+
+    fn convert_binding_pattern(&self, pattern: &oxc::BindingPattern) -> PatternLike {
+        match pattern {
+            oxc::BindingPattern::BindingIdentifier(id) => {
+                PatternLike::Identifier(self.convert_binding_identifier(id))
+            }
+            oxc::BindingPattern::ObjectPattern(obj) => {
+                PatternLike::ObjectPattern(self.convert_object_pattern(obj))
+            }
+            oxc::BindingPattern::ArrayPattern(arr) => {
+                PatternLike::ArrayPattern(self.convert_array_pattern(arr))
+            }
+            oxc::BindingPattern::AssignmentPattern(assign) => {
+                PatternLike::AssignmentPattern(self.convert_assignment_pattern(assign))
+            }
+        }
+    }
+
+    fn convert_binding_identifier(&self, id: &oxc::BindingIdentifier) -> Identifier {
+        Identifier {
+            base: self.make_base_node(id.span),
+            name: id.name.to_string(),
+            type_annotation: None,
+            optional: None,
+            decorators: None,
+        }
+    }
+
+    fn convert_identifier_name(&self, id: &oxc::IdentifierName) -> Identifier {
+        Identifier {
+            base: self.make_base_node(id.span),
+            name: id.name.to_string(),
+            type_annotation: None,
+            optional: None,
+            decorators: None,
+        }
+    }
+
+    fn convert_label_identifier(&self, id: &oxc::LabelIdentifier) -> Identifier {
+        Identifier {
+            base: self.make_base_node(id.span),
+            name: id.name.to_string(),
+            type_annotation: None,
+            optional: None,
+            decorators: None,
+        }
+    }
+
+    fn convert_identifier_reference(&self, id: &oxc::IdentifierReference) -> Identifier {
+        Identifier {
+            base: self.make_base_node(id.span),
+            name: id.name.to_string(),
+            type_annotation: None,
+            optional: None,
+            decorators: None,
+        }
+    }
+
+    fn convert_object_pattern(&self, obj: &oxc::ObjectPattern) -> ObjectPattern {
+        let mut properties: Vec<ObjectPatternProperty> =
+            obj.properties.iter().map(|p| self.convert_binding_property(p)).collect();
+
+        // Handle rest element (separate field in OXC v0.121)
+        if let Some(rest) = &obj.rest {
+            properties
+                .push(ObjectPatternProperty::RestElement(self.convert_binding_rest_element(rest)));
+        }
+
+        ObjectPattern {
+            base: self.make_base_node(obj.span),
+            properties,
+            type_annotation: None,
+            decorators: None,
+        }
+    }
+
+    fn convert_binding_property(&self, prop: &oxc::BindingProperty) -> ObjectPatternProperty {
+        // BindingProperty is now a struct (not an enum) in OXC v0.121
+        ObjectPatternProperty::ObjectProperty(ObjectPatternProp {
+            base: self.make_base_node(prop.span),
+            key: Box::new(self.convert_property_key(&prop.key)),
+            value: Box::new(self.convert_binding_pattern(&prop.value)),
+            computed: prop.computed,
+            shorthand: prop.shorthand,
+            decorators: None,
+            method: None,
+        })
+    }
+
+    fn convert_array_pattern(&self, arr: &oxc::ArrayPattern) -> ArrayPattern {
+        let mut elements: Vec<Option<PatternLike>> = arr
+            .elements
+            .iter()
+            .map(|e| e.as_ref().map(|p| self.convert_binding_pattern(p)))
+            .collect();
+
+        // Handle rest element (separate field in OXC v0.121)
+        if let Some(rest) = &arr.rest {
+            elements.push(Some(PatternLike::RestElement(self.convert_binding_rest_element(rest))));
+        }
+
+        ArrayPattern {
+            base: self.make_base_node(arr.span),
+            elements,
+            type_annotation: None,
+            decorators: None,
+        }
+    }
+
+    fn convert_assignment_pattern(&self, assign: &oxc::AssignmentPattern) -> AssignmentPattern {
+        AssignmentPattern {
+            base: self.make_base_node(assign.span),
+            left: Box::new(self.convert_binding_pattern(&assign.left)),
+            right: Box::new(self.convert_expression(&assign.right)),
+            type_annotation: None,
+            decorators: None,
+        }
+    }
+
+    fn convert_binding_rest_element(&self, rest: &oxc::BindingRestElement) -> RestElement {
+        RestElement {
+            base: self.make_base_node(rest.span),
+            argument: Box::new(self.convert_binding_pattern(&rest.argument)),
+            type_annotation: None,
+            decorators: None,
+        }
+    }
+
+    /// Convert FormalParameters (items + optional rest) to a Vec<PatternLike>.
+    /// OXC stores rest parameters separately from items, but Babel includes them
+    /// in the same params array.
+    fn convert_formal_parameters(&self, params: &oxc::FormalParameters) -> Vec<PatternLike> {
+        let mut result: Vec<PatternLike> =
+            params.items.iter().map(|p| self.convert_formal_parameter(p)).collect();
+        if let Some(rest) = &params.rest {
+            result.push(PatternLike::RestElement(RestElement {
+                base: self.make_base_node(rest.rest.span),
+                argument: Box::new(self.convert_binding_pattern(&rest.rest.argument)),
+                type_annotation: rest
+                    .type_annotation
+                    .as_ref()
+                    .map(|type_annotation| self.convert_ts_type_annotation_json(type_annotation)),
+                decorators: None,
+            }));
+        }
+        result
+    }
+
+    fn convert_formal_parameter(&self, param: &oxc::FormalParameter) -> PatternLike {
+        let mut pattern = self.convert_binding_pattern(&param.pattern);
+
+        if param.optional
+            && let PatternLike::Identifier(id) = &mut pattern
+        {
+            id.optional = Some(true);
+        }
+
+        // Add type annotation if present (now on FormalParameter, not BindingPattern)
+        if let Some(type_annotation) = &param.type_annotation {
+            let type_json = self.convert_ts_type_annotation_json(type_annotation);
+            Self::set_pattern_type_annotation(&mut pattern, type_json);
+        }
+
+        // Handle default parameter values: OXC stores default values in
+        // FormalParameter.initializer rather than using BindingPattern::AssignmentPattern.
+        // Babel/TS expects them as AssignmentPattern in the params array.
+        if let Some(ref initializer) = param.initializer {
+            let right = self.convert_expression(initializer);
+            pattern = PatternLike::AssignmentPattern(AssignmentPattern {
+                base: self.make_base_node(param.span),
+                left: Box::new(pattern),
+                right: Box::new(right),
+                type_annotation: None,
+                decorators: None,
+            });
+        }
+
+        pattern
+    }
+
+    fn set_pattern_type_annotation(
+        pattern: &mut PatternLike,
+        type_annotation: Box<serde_json::Value>,
+    ) {
+        match pattern {
+            PatternLike::Identifier(id) => {
+                id.type_annotation = Some(type_annotation);
+            }
+            PatternLike::ObjectPattern(obj) => {
+                obj.type_annotation = Some(type_annotation);
+            }
+            PatternLike::ArrayPattern(arr) => {
+                arr.type_annotation = Some(type_annotation);
+            }
+            PatternLike::AssignmentPattern(assign) => {
+                assign.type_annotation = Some(type_annotation);
+            }
+            PatternLike::RestElement(rest) => {
+                rest.type_annotation = Some(type_annotation);
+            }
+            PatternLike::MemberExpression(_)
+            | PatternLike::TSAsExpression(_)
+            | PatternLike::TSSatisfiesExpression(_)
+            | PatternLike::TSNonNullExpression(_)
+            | PatternLike::TSTypeAssertion(_)
+            | PatternLike::TypeCastExpression(_) => {}
+        }
+    }
+
+    fn convert_function_body(&self, body: &oxc::FunctionBody) -> BlockStatement {
+        BlockStatement {
+            base: self.make_base_node(body.span),
+            body: body.statements.iter().map(|s| self.convert_statement(s)).collect(),
+            directives: body.directives.iter().map(|d| self.convert_directive(d)).collect(),
+        }
+    }
+
+    /// Convert an optional function body. TypeScript overload signatures and
+    /// ambient (`declare`) function declarations have no body, but Babel's
+    /// `FunctionDeclaration`/`FunctionExpression` require one. These are
+    /// type-level constructs the compiler never analyzes, so emit an empty
+    /// block as a placeholder spanning the function.
+    fn convert_optional_function_body(
+        &self,
+        body: Option<&oxc::FunctionBody>,
+        fallback_span: Span,
+    ) -> BlockStatement {
+        match body {
+            Some(body) => self.convert_function_body(body),
+            None => BlockStatement {
+                base: self.make_base_node(fallback_span),
+                body: vec![],
+                directives: vec![],
+            },
+        }
+    }
+
+    // ============================================================
+    // Helper methods for converting Expression-inheriting enums
+    // These handle the case where OXC enums inherit from Expression
+    // via @inherit and each variant has a differently-typed Box.
+    // ============================================================
+
+    /// Convert Argument expression variants (not SpreadElement) to Expression
+    fn convert_expression_from_argument(&self, arg: &oxc::Argument) -> Expression {
+        self.convert_expression_like(arg)
+    }
+
+    /// Convert ArrayExpressionElement expression variants to Expression
+    fn convert_expression_from_array_element(
+        &self,
+        elem: &oxc::ArrayExpressionElement,
+    ) -> Expression {
+        self.convert_expression_like(elem)
+    }
+
+    /// Convert ExportDefaultDeclarationKind expression variants to Expression
+    fn convert_expression_from_export_default(
+        &self,
+        kind: &oxc::ExportDefaultDeclarationKind,
+    ) -> Expression {
+        self.convert_expression_like(kind)
+    }
+
+    /// Convert PropertyKey expression variants to Expression
+    fn convert_expression_from_property_key(&self, key: &oxc::PropertyKey) -> Expression {
+        self.convert_expression_like(key)
+    }
+
+    /// Convert JSXExpression expression variants to Expression
+    fn convert_expression_from_jsx_expression(&self, expr: &oxc::JSXExpression) -> Expression {
+        self.convert_expression_like(expr)
+    }
+
+    /// Generic helper to convert any enum that inherits Expression variants.
+    /// Uses the ExpressionLike trait.
+    fn convert_expression_like<T: ExpressionLike>(&self, value: &T) -> Expression {
+        value.convert_with(self)
+    }
+}
+
+/// Trait for enums that inherit Expression variants.
+/// Each implementing type matches its Expression-inherited variants and
+/// delegates to ConvertCtx::convert_expression by constructing the equivalent
+/// Expression variant.
+trait ExpressionLike {
+    fn convert_with(&self, ctx: &ConvertCtx) -> Expression;
+}
+
+/// Macro to implement ExpressionLike for enums that @inherit Expression.
+/// Each variant name matches the Expression variant name, so we can
+/// deref the inner Box and call the appropriate convert method.
+macro_rules! impl_expression_like {
+    ($enum_ty:ty, [$($non_expr_variant:pat => $non_expr_handler:expr),*]) => {
+        impl<'a> ExpressionLike for $enum_ty {
+            fn convert_with(&self, ctx: &ConvertCtx) -> Expression {
+                match self {
+                    $($non_expr_variant => $non_expr_handler,)*
+                    // Expression-inherited variants
+                    Self::BooleanLiteral(e) => Expression::BooleanLiteral(BooleanLiteral {
+                        base: ctx.make_base_node(e.span),
+                        value: e.value,
+                    }),
+                    Self::NullLiteral(e) => Expression::NullLiteral(NullLiteral {
+                        base: ctx.make_base_node(e.span),
+                    }),
+                    Self::NumericLiteral(e) => Expression::NumericLiteral(NumericLiteral {
+                        base: ctx.make_base_node(e.span),
+                        value: e.value,
+                        extra: None,
+                    }),
+                    Self::BigIntLiteral(e) => {
+                        Expression::BigIntLiteral(ctx.convert_big_int_literal(e))
+                    },
+                    Self::RegExpLiteral(e) => Expression::RegExpLiteral(RegExpLiteral {
+                        base: ctx.make_base_node(e.span),
+                        pattern: e.regex.pattern.text.to_string(),
+                        flags: e.regex.flags.to_string(),
+                    }),
+                    Self::StringLiteral(e) => Expression::StringLiteral(StringLiteral {
+                        base: ctx.make_base_node(e.span),
+                        value: e.value.to_string(),
+                    }),
+                    Self::TemplateLiteral(e) => Expression::TemplateLiteral(ctx.convert_template_literal(e)),
+                    Self::Identifier(e) => Expression::Identifier(ctx.convert_identifier_reference(e)),
+                    Self::MetaProperty(e) => Expression::MetaProperty(ctx.convert_meta_property(e)),
+                    Self::Super(e) => Expression::Super(Super { base: ctx.make_base_node(e.span) }),
+                    Self::ArrayExpression(e) => Expression::ArrayExpression(ctx.convert_array_expression(e)),
+                    Self::ArrowFunctionExpression(e) => Expression::ArrowFunctionExpression(ctx.convert_arrow_function_expression(e)),
+                    Self::AssignmentExpression(e) => Expression::AssignmentExpression(ctx.convert_assignment_expression(e)),
+                    Self::AwaitExpression(e) => Expression::AwaitExpression(ctx.convert_await_expression(e)),
+                    Self::BinaryExpression(e) => Expression::BinaryExpression(ctx.convert_binary_expression(e)),
+                    Self::CallExpression(e) => Expression::CallExpression(ctx.convert_call_expression(e)),
+                    Self::ChainExpression(e) => ctx.convert_chain_expression(e),
+                    Self::ClassExpression(e) => Expression::ClassExpression(ctx.convert_class_expression(e)),
+                    Self::ConditionalExpression(e) => Expression::ConditionalExpression(ctx.convert_conditional_expression(e)),
+                    Self::FunctionExpression(e) => Expression::FunctionExpression(ctx.convert_function_expression(e)),
+                    Self::ImportExpression(i) => {
+                        let mut args = vec![ctx.convert_expression(&i.source)];
+                        if let Some(ref opts) = i.options {
+                            args.push(ctx.convert_expression(opts));
+                        }
+                        Expression::CallExpression(CallExpression {
+                            base: ctx.make_base_node(i.span),
+                            callee: Box::new(Expression::Import(Import {
+                                base: ctx.make_base_node(i.span),
+                            })),
+                            arguments: args,
+                            optional: None,
+                            type_arguments: None,
+                            type_parameters: None,
+                        })
+                    }
+                    Self::LogicalExpression(e) => Expression::LogicalExpression(ctx.convert_logical_expression(e)),
+                    Self::NewExpression(e) => Expression::NewExpression(ctx.convert_new_expression(e)),
+                    Self::ObjectExpression(e) => Expression::ObjectExpression(ctx.convert_object_expression(e)),
+                    Self::ParenthesizedExpression(e) => Expression::ParenthesizedExpression(ctx.convert_parenthesized_expression(e)),
+                    Self::SequenceExpression(e) => Expression::SequenceExpression(ctx.convert_sequence_expression(e)),
+                    Self::TaggedTemplateExpression(e) => Expression::TaggedTemplateExpression(ctx.convert_tagged_template_expression(e)),
+                    Self::ThisExpression(e) => Expression::ThisExpression(ThisExpression { base: ctx.make_base_node(e.span) }),
+                    Self::UnaryExpression(e) => Expression::UnaryExpression(ctx.convert_unary_expression(e)),
+                    Self::UpdateExpression(e) => Expression::UpdateExpression(ctx.convert_update_expression(e)),
+                    Self::YieldExpression(e) => Expression::YieldExpression(ctx.convert_yield_expression(e)),
+                    Self::PrivateInExpression(e) => Expression::BinaryExpression(ctx.convert_private_in_expression(e)),
+                    Self::JSXElement(e) => Expression::JSXElement(Box::new(ctx.convert_jsx_element(e))),
+                    Self::JSXFragment(e) => Expression::JSXFragment(ctx.convert_jsx_fragment(e)),
+                    Self::TSAsExpression(e) => Expression::TSAsExpression(ctx.convert_ts_as_expression(e)),
+                    Self::TSSatisfiesExpression(e) => Expression::TSSatisfiesExpression(ctx.convert_ts_satisfies_expression(e)),
+                    Self::TSTypeAssertion(e) => Expression::TSTypeAssertion(ctx.convert_ts_type_assertion(e)),
+                    Self::TSNonNullExpression(e) => Expression::TSNonNullExpression(ctx.convert_ts_non_null_expression(e)),
+                    Self::TSInstantiationExpression(e) => Expression::TSInstantiationExpression(ctx.convert_ts_instantiation_expression(e)),
+                    Self::ComputedMemberExpression(e) => Expression::MemberExpression(MemberExpression {
+                        base: ctx.make_base_node(e.span),
+                        object: Box::new(ctx.convert_expression(&e.object)),
+                        property: Box::new(ctx.convert_expression(&e.expression)),
+                        computed: true,
+                    }),
+                    Self::StaticMemberExpression(e) => Expression::MemberExpression(MemberExpression {
+                        base: ctx.make_base_node(e.span),
+                        object: Box::new(ctx.convert_expression(&e.object)),
+                        property: Box::new(Expression::Identifier(ctx.convert_identifier_name(&e.property))),
+                        computed: false,
+                    }),
+                    Self::PrivateFieldExpression(e) => Expression::MemberExpression(MemberExpression {
+                        base: ctx.make_base_node(e.span),
+                        object: Box::new(ctx.convert_expression(&e.object)),
+                        property: Box::new(Expression::PrivateName(PrivateName {
+                            base: ctx.make_base_node(e.field.span),
+                            id: Identifier {
+                                base: ctx.make_base_node(e.field.span),
+                                name: e.field.name.to_string(),
+                                type_annotation: None,
+                                optional: None,
+                                decorators: None,
+                            },
+                        })),
+                        computed: false,
+                    }),
+                    Self::V8IntrinsicExpression(_) => unreachable!(
+                        "V8IntrinsicExpression: oxc does not emit this without ParseOptions::allow_v8_intrinsics"
+                    ),
+                }
+            }
+        }
+    };
+}
+
+// ForStatementInit: VariableDeclaration + @inherit Expression
+impl_expression_like!(oxc::ForStatementInit<'a>, [
+    Self::VariableDeclaration(_) => unreachable!("handled separately")
+]);
+
+// Argument: SpreadElement + @inherit Expression
+impl_expression_like!(oxc::Argument<'a>, [
+    Self::SpreadElement(_) => unreachable!("handled separately")
+]);
+
+// ArrayExpressionElement: SpreadElement + Elision + @inherit Expression
+impl_expression_like!(oxc::ArrayExpressionElement<'a>, [
+    Self::SpreadElement(_) => unreachable!("handled separately"),
+    Self::Elision(_) => unreachable!("handled separately")
+]);
+
+// ExportDefaultDeclarationKind: FunctionDeclaration + ClassDeclaration + TSInterfaceDeclaration + @inherit Expression
+impl_expression_like!(oxc::ExportDefaultDeclarationKind<'a>, [
+    Self::FunctionDeclaration(_) => unreachable!("handled separately"),
+    Self::ClassDeclaration(_) => unreachable!("handled separately"),
+    Self::TSInterfaceDeclaration(_) => unreachable!("handled separately")
+]);
+
+// PropertyKey: StaticIdentifier + PrivateIdentifier + @inherit Expression
+impl_expression_like!(oxc::PropertyKey<'a>, [
+    Self::StaticIdentifier(_) => unreachable!("handled separately"),
+    Self::PrivateIdentifier(_) => unreachable!("handled separately")
+]);
+
+// JSXExpression: EmptyExpression + @inherit Expression
+impl_expression_like!(oxc::JSXExpression<'a>, [
+    Self::EmptyExpression(_) => unreachable!("handled separately")
+]);

--- a/crates/oxc_react_compiler/src/convert_ast_reverse.rs
+++ b/crates/oxc_react_compiler/src/convert_ast_reverse.rs
@@ -1,0 +1,3085 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+//! Reverse AST converter: react_compiler_ast (Babel format) → OXC AST.
+//!
+//! This is the inverse of `convert_ast.rs`. It takes a `react_compiler_ast::File`
+//! (which represents the compiler's Babel-compatible output) and produces OXC AST
+//! nodes allocated in an OXC arena, suitable for code generation via `oxc_codegen`.
+
+use oxc_allocator::{Allocator, Box as ArenaBox};
+use oxc_ast::ast as oxc;
+use oxc_ast_visit::VisitMut;
+use oxc_span::SPAN;
+use oxc_span::Span;
+use oxc_syntax::identifier::is_identifier_name;
+use react_compiler_ast::common::BaseNode;
+use react_compiler_ast::declarations::*;
+use react_compiler_ast::expressions::*;
+use react_compiler_ast::jsx::*;
+use react_compiler_ast::operators::*;
+use react_compiler_ast::patterns::*;
+use react_compiler_ast::statements::*;
+
+fn set_statement_span(stmt: &mut oxc::Statement<'_>, span: Span) {
+    use oxc_span::GetSpanMut;
+    match stmt {
+        oxc::Statement::ImportDeclaration(d) => *d.span_mut() = span,
+        oxc::Statement::VariableDeclaration(d) => *d.span_mut() = span,
+        oxc::Statement::FunctionDeclaration(d) => *d.span_mut() = span,
+        oxc::Statement::ExportNamedDeclaration(d) => *d.span_mut() = span,
+        oxc::Statement::ExportDefaultDeclaration(d) => *d.span_mut() = span,
+        oxc::Statement::ExportAllDeclaration(d) => *d.span_mut() = span,
+        oxc::Statement::ExpressionStatement(s) => *s.span_mut() = span,
+        oxc::Statement::IfStatement(s) => *s.span_mut() = span,
+        oxc::Statement::ForStatement(s) => *s.span_mut() = span,
+        oxc::Statement::WhileStatement(s) => *s.span_mut() = span,
+        oxc::Statement::DoWhileStatement(s) => *s.span_mut() = span,
+        oxc::Statement::ForInStatement(s) => *s.span_mut() = span,
+        oxc::Statement::ForOfStatement(s) => *s.span_mut() = span,
+        oxc::Statement::SwitchStatement(s) => *s.span_mut() = span,
+        oxc::Statement::ThrowStatement(s) => *s.span_mut() = span,
+        oxc::Statement::TryStatement(s) => *s.span_mut() = span,
+        oxc::Statement::BreakStatement(s) => *s.span_mut() = span,
+        oxc::Statement::ContinueStatement(s) => *s.span_mut() = span,
+        oxc::Statement::LabeledStatement(s) => *s.span_mut() = span,
+        oxc::Statement::BlockStatement(s) => *s.span_mut() = span,
+        oxc::Statement::ReturnStatement(s) => *s.span_mut() = span,
+        oxc::Statement::WithStatement(s) => *s.span_mut() = span,
+        oxc::Statement::EmptyStatement(s) => *s.span_mut() = span,
+        oxc::Statement::DebuggerStatement(s) => *s.span_mut() = span,
+        _ => {} // ClassDeclaration etc. - leave as-is
+    }
+}
+
+fn encode_jsx_text(raw: &str) -> String {
+    let mut escaped = String::with_capacity(raw.len());
+    for ch in raw.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '{' => escaped.push_str("&#123;"),
+            '}' => escaped.push_str("&#125;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+struct SpanShift {
+    offset: u32,
+}
+
+impl VisitMut<'_> for SpanShift {
+    fn visit_span(&mut self, span: &mut Span) {
+        span.start = span.start.saturating_add(self.offset);
+        span.end = span.end.saturating_add(self.offset);
+    }
+}
+
+/// Convert a `react_compiler_ast::File` into an OXC `Program` allocated in the given arena.
+pub fn convert_program_to_oxc<'a>(
+    file: &react_compiler_ast::File,
+    allocator: &'a Allocator,
+) -> oxc::Program<'a> {
+    let ctx = ReverseCtx::new(allocator, None);
+    ctx.convert_program(&file.program)
+}
+
+/// Convert with source text available for extracting TS declarations.
+pub fn convert_program_to_oxc_with_source<'a>(
+    file: &react_compiler_ast::File,
+    allocator: &'a Allocator,
+    source_text: &str,
+) -> oxc::Program<'a> {
+    let ctx = ReverseCtx::new(allocator, Some(source_text.to_string()));
+    ctx.convert_program(&file.program)
+}
+
+struct ReverseCtx<'a> {
+    allocator: &'a Allocator,
+    builder: oxc_ast::AstBuilder<'a>,
+    source_text: Option<String>,
+}
+
+impl<'a> ReverseCtx<'a> {
+    fn new(allocator: &'a Allocator, source_text: Option<String>) -> Self {
+        Self { allocator, builder: oxc_ast::AstBuilder::new(allocator), source_text }
+    }
+
+    /// Extract a statement from the original source text using the base node's
+    /// start/end positions. Re-parses the snippet with OXC to get a proper AST node.
+    fn extract_source_stmt(&self, base: &BaseNode) -> Option<oxc::Statement<'a>> {
+        let text = self.source_text_for_base(base)?;
+        self.parse_source_stmt_text_at(text, base.start? as usize)
+    }
+
+    fn parse_source_stmt_text_at(
+        &self,
+        text: &str,
+        original_start: usize,
+    ) -> Option<oxc::Statement<'a>> {
+        let text_ref = self.copy_source_text_to_allocator(text);
+        let parsed =
+            oxc_parser::Parser::new(self.allocator, text_ref, oxc_span::SourceType::tsx()).parse();
+        if parsed.panicked || parsed.program.body.is_empty() {
+            return None;
+        }
+        let mut stmt = parsed.program.body.into_iter().next()?;
+        if original_start > 0 {
+            let mut shifter = SpanShift { offset: original_start as u32 };
+            shifter.visit_statement(&mut stmt);
+        }
+        Some(stmt)
+    }
+
+    /// Extract an expression from the original source text using the base
+    /// node's start/end positions.
+    fn extract_source_expr(&self, base: &BaseNode) -> Option<oxc::Expression<'a>> {
+        let text = self.source_text_for_base(base)?;
+        self.parse_source_expr_text_at(text, base.start? as usize)
+    }
+
+    fn parse_source_expr_text_at(
+        &self,
+        text: &str,
+        original_start: usize,
+    ) -> Option<oxc::Expression<'a>> {
+        let text_ref = self.copy_source_text_to_allocator(text);
+        let mut expr =
+            oxc_parser::Parser::new(self.allocator, text_ref, oxc_span::SourceType::tsx())
+                .parse_expression()
+                .ok()?;
+        if original_start > 0 {
+            let mut shifter = SpanShift { offset: original_start as u32 };
+            shifter.visit_expression(&mut expr);
+        }
+        Some(expr)
+    }
+
+    fn parse_source_ts_type_text_at(
+        &self,
+        text: &str,
+        original_start: usize,
+    ) -> Option<oxc::TSType<'a>> {
+        const PREFIX: &str = "let __oxc_type = __oxc_value as ";
+        let wrapped = format!("{PREFIX}{text};");
+        let stmt =
+            self.parse_source_stmt_text_at(&wrapped, original_start.saturating_sub(PREFIX.len()))?;
+        let oxc::Statement::VariableDeclaration(decl) = stmt else { return None };
+        let decl = decl.unbox();
+        let init = decl.declarations.into_iter().next()?.init?;
+        let oxc::Expression::TSAsExpression(ts_as) = init else { return None };
+        Some(ts_as.unbox().type_annotation)
+    }
+
+    fn copy_source_text_to_allocator(&self, text: &str) -> &'a str {
+        oxc_allocator::StringBuilder::from_str_in(text, self.allocator).into_str()
+    }
+
+    fn extract_source_class_expression(
+        &self,
+        class: &react_compiler_ast::expressions::ClassExpression,
+    ) -> Option<oxc::Expression<'a>> {
+        let expr = self.extract_source_expr(&class.base)?;
+        if matches!(expr, oxc::Expression::ClassExpression(_)) { Some(expr) } else { None }
+    }
+
+    fn extract_source_call_type_arguments(
+        &self,
+        base: &BaseNode,
+    ) -> Option<ArenaBox<'a, oxc::TSTypeParameterInstantiation<'a>>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::CallExpression(call) => call.unbox().type_arguments,
+            oxc::Expression::ChainExpression(chain) => match chain.unbox().expression {
+                oxc::ChainElement::CallExpression(call) => call.unbox().type_arguments,
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn extract_source_call_arguments(&self, base: &BaseNode) -> Option<Vec<oxc::Argument<'a>>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::CallExpression(call) => {
+                Some(call.unbox().arguments.into_iter().collect())
+            }
+            oxc::Expression::ChainExpression(chain) => match chain.unbox().expression {
+                oxc::ChainElement::CallExpression(call) => {
+                    Some(call.unbox().arguments.into_iter().collect())
+                }
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    fn extract_source_new_type_arguments(
+        &self,
+        base: &BaseNode,
+    ) -> Option<ArenaBox<'a, oxc::TSTypeParameterInstantiation<'a>>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::NewExpression(new) => new.unbox().type_arguments,
+            _ => None,
+        }
+    }
+
+    fn extract_source_new_arguments(&self, base: &BaseNode) -> Option<Vec<oxc::Argument<'a>>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::NewExpression(new) => {
+                Some(new.unbox().arguments.into_iter().collect())
+            }
+            _ => None,
+        }
+    }
+
+    fn extract_source_tagged_template_type_arguments(
+        &self,
+        base: &BaseNode,
+    ) -> Option<ArenaBox<'a, oxc::TSTypeParameterInstantiation<'a>>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::TaggedTemplateExpression(tagged) => tagged.unbox().type_arguments,
+            _ => None,
+        }
+    }
+
+    fn extract_source_jsx_type_arguments(
+        &self,
+        base: &BaseNode,
+    ) -> Option<ArenaBox<'a, oxc::TSTypeParameterInstantiation<'a>>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::JSXElement(element) => {
+                element.unbox().opening_element.unbox().type_arguments
+            }
+            _ => None,
+        }
+    }
+
+    fn extract_source_ts_as_type(&self, base: &BaseNode) -> Option<oxc::TSType<'a>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::TSAsExpression(expr) => Some(expr.unbox().type_annotation),
+            _ => None,
+        }
+    }
+
+    fn extract_source_ts_type_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<oxc::TSType<'a>> {
+        let value =
+            if value.get("type").and_then(serde_json::Value::as_str) == Some("TSTypeAnnotation") {
+                value.get("typeAnnotation")?
+            } else {
+                value
+            };
+        let source = self.source_text.as_deref()?;
+        let start = value.get("start")?.as_u64()? as usize;
+        let end = value.get("end")?.as_u64()? as usize;
+        if start >= source.len() || end > source.len() || start >= end {
+            return None;
+        }
+        self.parse_source_ts_type_text_at(&source[start..end], start)
+    }
+
+    fn span_from_json_value(&self, value: &serde_json::Value) -> Span {
+        let start = value.get("start").and_then(serde_json::Value::as_u64);
+        let end = value.get("end").and_then(serde_json::Value::as_u64);
+        match (start, end) {
+            (Some(start), Some(end)) => Span::new(start as u32, end as u32),
+            (Some(start), None) => Span::new(start as u32, start as u32),
+            _ => SPAN,
+        }
+    }
+
+    fn convert_ts_type_annotation_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<ArenaBox<'a, oxc::TSTypeAnnotation<'a>>> {
+        let ty =
+            if value.get("type").and_then(serde_json::Value::as_str) == Some("TSTypeAnnotation") {
+                let type_annotation = value.get("typeAnnotation")?;
+                self.convert_ts_type_from_json(type_annotation).or_else(|| {
+                    if Self::ts_type_json_contains_type_query(type_annotation) {
+                        None
+                    } else {
+                        self.extract_source_ts_type_from_json(value)
+                    }
+                })?
+            } else {
+                self.convert_ts_type_from_json(value)?
+            };
+        Some(self.builder.alloc_ts_type_annotation(SPAN, ty))
+    }
+
+    fn convert_ts_type_from_json(&self, value: &serde_json::Value) -> Option<oxc::TSType<'a>> {
+        if !Self::ts_type_json_contains_type_query(value)
+            && let Some(ty) = self.extract_source_ts_type_from_json(value)
+        {
+            return Some(ty);
+        }
+
+        match value.get("type")?.as_str()? {
+            "TSAnyKeyword" => Some(self.builder.ts_type_any_keyword(SPAN)),
+            "TSBigIntKeyword" => Some(self.builder.ts_type_big_int_keyword(SPAN)),
+            "TSBooleanKeyword" => Some(self.builder.ts_type_boolean_keyword(SPAN)),
+            "TSIntrinsicKeyword" => Some(self.builder.ts_type_intrinsic_keyword(SPAN)),
+            "TSNeverKeyword" => Some(self.builder.ts_type_never_keyword(SPAN)),
+            "TSNullKeyword" => Some(self.builder.ts_type_null_keyword(SPAN)),
+            "TSNumberKeyword" => Some(self.builder.ts_type_number_keyword(SPAN)),
+            "TSObjectKeyword" => Some(self.builder.ts_type_object_keyword(SPAN)),
+            "TSStringKeyword" => Some(self.builder.ts_type_string_keyword(SPAN)),
+            "TSSymbolKeyword" => Some(self.builder.ts_type_symbol_keyword(SPAN)),
+            "TSThisType" => Some(self.builder.ts_type_this_type(SPAN)),
+            "TSUndefinedKeyword" => Some(self.builder.ts_type_undefined_keyword(SPAN)),
+            "TSUnknownKeyword" => Some(self.builder.ts_type_unknown_keyword(SPAN)),
+            "TSVoidKeyword" => Some(self.builder.ts_type_void_keyword(SPAN)),
+            "TSArrayType" => {
+                let element_type = self.convert_ts_type_from_json(value.get("elementType")?)?;
+                Some(self.builder.ts_type_array_type(SPAN, element_type))
+            }
+            "TSUnionType" => {
+                let types = value.get("types")?.as_array()?;
+                let types = self.builder.vec_from_iter(
+                    types.iter().filter_map(|ty| self.convert_ts_type_from_json(ty)),
+                );
+                Some(self.builder.ts_type_union_type(SPAN, types))
+            }
+            "TSParenthesizedType" => {
+                let type_annotation =
+                    self.convert_ts_type_from_json(value.get("typeAnnotation")?)?;
+                Some(self.builder.ts_type_parenthesized_type(SPAN, type_annotation))
+            }
+            "TSTypeOperator" => {
+                let operator = match value.get("operator")?.as_str()? {
+                    "keyof" => oxc::TSTypeOperatorOperator::Keyof,
+                    "unique" => oxc::TSTypeOperatorOperator::Unique,
+                    "readonly" => oxc::TSTypeOperatorOperator::Readonly,
+                    _ => return None,
+                };
+                let type_annotation =
+                    self.convert_ts_type_from_json(value.get("typeAnnotation")?)?;
+                Some(self.builder.ts_type_type_operator_type(SPAN, operator, type_annotation))
+            }
+            "TSTypeReference" => {
+                let type_name = self.convert_ts_type_name_from_json(value.get("typeName")?)?;
+                let type_arguments =
+                    value.get("typeParameters").or_else(|| value.get("typeArguments")).and_then(
+                        |value| self.convert_ts_type_parameter_instantiation_from_json(value),
+                    );
+                Some(self.builder.ts_type_type_reference(SPAN, type_name, type_arguments))
+            }
+            "TSTypeQuery" => {
+                let expr_name =
+                    self.convert_ts_type_query_expr_name_from_json(value.get("exprName")?)?;
+                let type_arguments =
+                    value.get("typeParameters").or_else(|| value.get("typeArguments")).and_then(
+                        |value| self.convert_ts_type_parameter_instantiation_from_json(value),
+                    );
+                Some(self.builder.ts_type_type_query(
+                    self.span_from_json_value(value),
+                    expr_name,
+                    type_arguments,
+                ))
+            }
+            "TSIndexedAccessType" => {
+                let object_type = self.convert_ts_type_from_json(value.get("objectType")?)?;
+                let index_type = self.convert_ts_type_from_json(value.get("indexType")?)?;
+                Some(self.builder.ts_type_indexed_access_type(
+                    self.span_from_json_value(value),
+                    object_type,
+                    index_type,
+                ))
+            }
+            "TSLiteralType" => {
+                let literal = self.convert_ts_literal_from_json(value.get("literal")?)?;
+                Some(self.builder.ts_type_literal_type(SPAN, literal))
+            }
+            _ => None,
+        }
+    }
+
+    fn convert_ts_type_name_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<oxc::TSTypeName<'a>> {
+        match value.get("type")?.as_str()? {
+            "Identifier" => Some(self.builder.ts_type_name_identifier_reference(
+                self.span_from_json_value(value),
+                self.atom(value.get("name")?.as_str()?),
+            )),
+            "TSQualifiedName" => {
+                let left = self.convert_ts_type_name_from_json(value.get("left")?)?;
+                let right_value = value.get("right")?;
+                let right = self.builder.identifier_name(
+                    self.span_from_json_value(right_value),
+                    self.atom(right_value.get("name")?.as_str()?),
+                );
+                Some(self.builder.ts_type_name_qualified_name(
+                    self.span_from_json_value(value),
+                    left,
+                    right,
+                ))
+            }
+            "TSThisType" | "ThisExpression" => {
+                Some(self.builder.ts_type_name_this_expression(self.span_from_json_value(value)))
+            }
+            _ => None,
+        }
+    }
+
+    fn convert_ts_type_query_expr_name_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<oxc::TSTypeQueryExprName<'a>> {
+        match self.convert_ts_type_name_from_json(value)? {
+            oxc::TSTypeName::IdentifierReference(identifier) => {
+                Some(oxc::TSTypeQueryExprName::IdentifierReference(identifier))
+            }
+            oxc::TSTypeName::QualifiedName(qualified) => {
+                Some(oxc::TSTypeQueryExprName::QualifiedName(qualified))
+            }
+            oxc::TSTypeName::ThisExpression(this) => {
+                Some(oxc::TSTypeQueryExprName::ThisExpression(this))
+            }
+        }
+    }
+
+    fn convert_ts_type_parameter_instantiation_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<ArenaBox<'a, oxc::TSTypeParameterInstantiation<'a>>> {
+        let params = value.get("params")?.as_array()?;
+        let params = self
+            .builder
+            .vec_from_iter(params.iter().filter_map(|ty| self.convert_ts_type_from_json(ty)));
+        Some(self.builder.alloc_ts_type_parameter_instantiation(SPAN, params))
+    }
+
+    fn convert_ts_literal_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<oxc::TSLiteral<'a>> {
+        match value.get("type")?.as_str()? {
+            "BooleanLiteral" => {
+                Some(self.builder.ts_literal_boolean_literal(SPAN, value.get("value")?.as_bool()?))
+            }
+            "NumericLiteral" => Some(self.builder.ts_literal_numeric_literal(
+                SPAN,
+                value.get("value")?.as_f64()?,
+                None,
+                oxc::NumberBase::Decimal,
+            )),
+            "StringLiteral" => Some(self.builder.ts_literal_string_literal(
+                SPAN,
+                self.atom(value.get("value")?.as_str()?),
+                None,
+            )),
+            "BigIntLiteral" => Some(self.builder.ts_literal_big_int_literal(
+                SPAN,
+                self.atom(value.get("value")?.as_str()?),
+                None,
+                oxc::BigintBase::Decimal,
+            )),
+            _ => None,
+        }
+    }
+
+    fn ts_type_json_contains_type_query(value: &serde_json::Value) -> bool {
+        match value {
+            serde_json::Value::Object(obj) => {
+                let is_rename_sensitive_type_query =
+                    obj.get("type").and_then(serde_json::Value::as_str) == Some("TSTypeQuery")
+                        && obj
+                            .get("exprName")
+                            .and_then(|expr| expr.get("type"))
+                            .and_then(serde_json::Value::as_str)
+                            != Some("TSImportType");
+                is_rename_sensitive_type_query
+                    || obj.values().any(Self::ts_type_json_contains_type_query)
+            }
+            serde_json::Value::Array(values) => {
+                values.iter().any(Self::ts_type_json_contains_type_query)
+            }
+            _ => false,
+        }
+    }
+
+    fn ts_type_contains_type_query(ty: &oxc::TSType<'a>) -> bool {
+        match ty {
+            oxc::TSType::TSTypeQuery(_) => true,
+            oxc::TSType::TSArrayType(ty) => Self::ts_type_contains_type_query(&ty.element_type),
+            oxc::TSType::TSUnionType(ty) => ty.types.iter().any(Self::ts_type_contains_type_query),
+            oxc::TSType::TSIntersectionType(ty) => {
+                ty.types.iter().any(Self::ts_type_contains_type_query)
+            }
+            oxc::TSType::TSParenthesizedType(ty) => {
+                Self::ts_type_contains_type_query(&ty.type_annotation)
+            }
+            oxc::TSType::TSTypeOperatorType(ty) => {
+                Self::ts_type_contains_type_query(&ty.type_annotation)
+            }
+            oxc::TSType::TSIndexedAccessType(ty) => {
+                Self::ts_type_contains_type_query(&ty.object_type)
+                    || Self::ts_type_contains_type_query(&ty.index_type)
+            }
+            oxc::TSType::TSTypeReference(ty) => {
+                ty.type_arguments.as_ref().is_some_and(|type_arguments| {
+                    Self::ts_type_arguments_contain_type_query(type_arguments)
+                })
+            }
+            _ => false,
+        }
+    }
+
+    fn ts_type_arguments_contain_type_query(
+        type_arguments: &oxc::TSTypeParameterInstantiation<'a>,
+    ) -> bool {
+        type_arguments.params.iter().any(Self::ts_type_contains_type_query)
+    }
+
+    fn extract_source_ts_satisfies_type(&self, base: &BaseNode) -> Option<oxc::TSType<'a>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::TSSatisfiesExpression(expr) => Some(expr.unbox().type_annotation),
+            _ => None,
+        }
+    }
+
+    fn extract_source_ts_type_assertion_type(&self, base: &BaseNode) -> Option<oxc::TSType<'a>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::TSTypeAssertion(expr) => Some(expr.unbox().type_annotation),
+            _ => None,
+        }
+    }
+
+    fn extract_source_ts_instantiation_type_arguments(
+        &self,
+        base: &BaseNode,
+    ) -> Option<ArenaBox<'a, oxc::TSTypeParameterInstantiation<'a>>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::TSInstantiationExpression(expr) => Some(expr.unbox().type_arguments),
+            _ => None,
+        }
+    }
+
+    fn wrap_expression_with_source_ts(
+        &self,
+        base: &BaseNode,
+        expression: oxc::Expression<'a>,
+    ) -> Result<oxc::Expression<'a>, oxc::Expression<'a>> {
+        let Some(text) = self.source_text_for_base(base) else {
+            return Err(expression);
+        };
+        if !text.contains(" as ") && !text.contains(" satisfies ") && !text.contains('<') {
+            return Err(expression);
+        }
+
+        let Some(start) = base.start else {
+            return Err(expression);
+        };
+        match self.parse_source_expr_text_at(text, start as usize) {
+            Some(source_expr) => self.wrap_expression_with_source_ts_expr(source_expr, expression),
+            None => Err(expression),
+        }
+    }
+
+    fn wrap_expression_with_source_ts_expr(
+        &self,
+        source_expr: oxc::Expression<'a>,
+        expression: oxc::Expression<'a>,
+    ) -> Result<oxc::Expression<'a>, oxc::Expression<'a>> {
+        if Self::is_ts_expression_wrapper(&expression) {
+            return Err(expression);
+        }
+        match source_expr {
+            oxc::Expression::TSAsExpression(expr) => {
+                let expr = expr.unbox();
+                if Self::ts_type_contains_type_query(&expr.type_annotation) {
+                    return Err(expression);
+                }
+                Ok(self.builder.expression_ts_as(SPAN, expression, expr.type_annotation))
+            }
+            oxc::Expression::TSSatisfiesExpression(expr) => {
+                let expr = expr.unbox();
+                if Self::ts_type_contains_type_query(&expr.type_annotation) {
+                    return Err(expression);
+                }
+                Ok(self.builder.expression_ts_satisfies(SPAN, expression, expr.type_annotation))
+            }
+            oxc::Expression::TSTypeAssertion(expr) => {
+                let expr = expr.unbox();
+                if Self::ts_type_contains_type_query(&expr.type_annotation) {
+                    return Err(expression);
+                }
+                Ok(self.builder.expression_ts_type_assertion(
+                    SPAN,
+                    expr.type_annotation,
+                    expression,
+                ))
+            }
+            oxc::Expression::TSInstantiationExpression(expr) => {
+                let expr = expr.unbox();
+                if Self::ts_type_arguments_contain_type_query(&expr.type_arguments) {
+                    return Err(expression);
+                }
+                Ok(self.builder.expression_ts_instantiation(SPAN, expression, expr.type_arguments))
+            }
+            _ => Err(expression),
+        }
+    }
+
+    fn wrap_expression_with_source_argument_ts(
+        &self,
+        source_arg: oxc::Argument<'a>,
+        expression: oxc::Expression<'a>,
+    ) -> Result<oxc::Expression<'a>, oxc::Expression<'a>> {
+        if Self::is_ts_expression_wrapper(&expression) {
+            return Err(expression);
+        }
+        match source_arg {
+            oxc::Argument::TSAsExpression(expr) => {
+                let expr = expr.unbox();
+                if Self::ts_type_contains_type_query(&expr.type_annotation) {
+                    return Err(expression);
+                }
+                Ok(self.builder.expression_ts_as(SPAN, expression, expr.type_annotation))
+            }
+            oxc::Argument::TSSatisfiesExpression(expr) => {
+                let expr = expr.unbox();
+                if Self::ts_type_contains_type_query(&expr.type_annotation) {
+                    return Err(expression);
+                }
+                Ok(self.builder.expression_ts_satisfies(SPAN, expression, expr.type_annotation))
+            }
+            oxc::Argument::TSTypeAssertion(expr) => {
+                let expr = expr.unbox();
+                if Self::ts_type_contains_type_query(&expr.type_annotation) {
+                    return Err(expression);
+                }
+                Ok(self.builder.expression_ts_type_assertion(
+                    SPAN,
+                    expr.type_annotation,
+                    expression,
+                ))
+            }
+            oxc::Argument::TSInstantiationExpression(expr) => {
+                let expr = expr.unbox();
+                if Self::ts_type_arguments_contain_type_query(&expr.type_arguments) {
+                    return Err(expression);
+                }
+                Ok(self.builder.expression_ts_instantiation(SPAN, expression, expr.type_arguments))
+            }
+            _ => Err(expression),
+        }
+    }
+
+    fn is_ts_expression_wrapper(expression: &oxc::Expression<'a>) -> bool {
+        matches!(
+            expression,
+            oxc::Expression::TSAsExpression(_)
+                | oxc::Expression::TSSatisfiesExpression(_)
+                | oxc::Expression::TSTypeAssertion(_)
+                | oxc::Expression::TSInstantiationExpression(_)
+        )
+    }
+
+    fn expression_base(expr: &Expression) -> Option<&BaseNode> {
+        match expr {
+            Expression::Identifier(expr) => Some(&expr.base),
+            Expression::StringLiteral(expr) => Some(&expr.base),
+            Expression::NumericLiteral(expr) => Some(&expr.base),
+            Expression::BooleanLiteral(expr) => Some(&expr.base),
+            Expression::NullLiteral(expr) => Some(&expr.base),
+            Expression::BigIntLiteral(expr) => Some(&expr.base),
+            Expression::RegExpLiteral(expr) => Some(&expr.base),
+            Expression::CallExpression(expr) => Some(&expr.base),
+            Expression::MemberExpression(expr) => Some(&expr.base),
+            Expression::OptionalCallExpression(expr) => Some(&expr.base),
+            Expression::OptionalMemberExpression(expr) => Some(&expr.base),
+            Expression::BinaryExpression(expr) => Some(&expr.base),
+            Expression::LogicalExpression(expr) => Some(&expr.base),
+            Expression::UnaryExpression(expr) => Some(&expr.base),
+            Expression::UpdateExpression(expr) => Some(&expr.base),
+            Expression::ConditionalExpression(expr) => Some(&expr.base),
+            Expression::AssignmentExpression(expr) => Some(&expr.base),
+            Expression::SequenceExpression(expr) => Some(&expr.base),
+            Expression::ArrowFunctionExpression(expr) => Some(&expr.base),
+            Expression::FunctionExpression(expr) => Some(&expr.base),
+            Expression::ObjectExpression(expr) => Some(&expr.base),
+            Expression::ArrayExpression(expr) => Some(&expr.base),
+            Expression::NewExpression(expr) => Some(&expr.base),
+            Expression::TemplateLiteral(expr) => Some(&expr.base),
+            Expression::TaggedTemplateExpression(expr) => Some(&expr.base),
+            Expression::AwaitExpression(expr) => Some(&expr.base),
+            Expression::YieldExpression(expr) => Some(&expr.base),
+            Expression::SpreadElement(expr) => Some(&expr.base),
+            Expression::MetaProperty(expr) => Some(&expr.base),
+            Expression::ClassExpression(expr) => Some(&expr.base),
+            Expression::PrivateName(expr) => Some(&expr.base),
+            Expression::Super(expr) => Some(&expr.base),
+            Expression::Import(expr) => Some(&expr.base),
+            Expression::ThisExpression(expr) => Some(&expr.base),
+            Expression::ParenthesizedExpression(expr) => Some(&expr.base),
+            Expression::JSXElement(expr) => Some(&expr.base),
+            Expression::JSXFragment(expr) => Some(&expr.base),
+            Expression::AssignmentPattern(expr) => Some(&expr.base),
+            Expression::TSAsExpression(_)
+            | Expression::TSSatisfiesExpression(_)
+            | Expression::TSNonNullExpression(_)
+            | Expression::TSTypeAssertion(_)
+            | Expression::TSInstantiationExpression(_)
+            | Expression::TypeCastExpression(_) => None,
+        }
+    }
+
+    fn extract_source_variable_declarator(
+        &self,
+        base: &BaseNode,
+        kind: oxc::VariableDeclarationKind,
+    ) -> Option<oxc::VariableDeclarator<'a>> {
+        let text = self.source_text_for_base(base)?;
+        if !text.contains(':') && !text.contains('!') {
+            return None;
+        }
+
+        let keyword = match kind {
+            oxc::VariableDeclarationKind::Var => "var",
+            oxc::VariableDeclarationKind::Let => "let",
+            oxc::VariableDeclarationKind::Const => "const",
+            oxc::VariableDeclarationKind::Using | oxc::VariableDeclarationKind::AwaitUsing => {
+                "using"
+            }
+        };
+        let wrapped = format!("{keyword} {text};");
+        let stmt = self.parse_source_stmt_text_at(
+            &wrapped,
+            (base.start? as usize).saturating_sub(keyword.len() + 1),
+        )?;
+        let oxc::Statement::VariableDeclaration(decl) = stmt else { return None };
+        decl.unbox().declarations.into_iter().next()
+    }
+
+    fn extract_source_object_property_value(&self, base: &BaseNode) -> Option<oxc::Expression<'a>> {
+        let text = self.source_text_for_base(base)?;
+        let wrapped = format!("({{{text}}})");
+        let expr =
+            self.parse_source_expr_text_at(&wrapped, (base.start? as usize).saturating_sub(2))?;
+        let oxc::Expression::ObjectExpression(obj) = expr else { return None };
+        let mut properties = obj.unbox().properties.into_iter();
+        let Some(oxc::ObjectPropertyKind::ObjectProperty(prop)) = properties.next() else {
+            return None;
+        };
+        Some(prop.unbox().value)
+    }
+
+    fn extract_source_function_declaration(&self, base: &BaseNode) -> Option<oxc::Function<'a>> {
+        let stmt = self.extract_source_stmt(base)?;
+        let oxc::Statement::FunctionDeclaration(func) = stmt else { return None };
+        Some(func.unbox())
+    }
+
+    fn extract_source_function_expression(&self, base: &BaseNode) -> Option<oxc::Function<'a>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::FunctionExpression(func) => Some(func.unbox()),
+            _ => None,
+        }
+    }
+
+    fn extract_source_arrow_function(
+        &self,
+        base: &BaseNode,
+    ) -> Option<oxc::ArrowFunctionExpression<'a>> {
+        match self.extract_source_expr(base)? {
+            oxc::Expression::ArrowFunctionExpression(arrow) => Some(arrow.unbox()),
+            _ => None,
+        }
+    }
+
+    fn extract_source_object_method_function(&self, base: &BaseNode) -> Option<oxc::Function<'a>> {
+        let text = self.source_text_for_base(base)?;
+        let wrapped = format!("({{{text}}})");
+        let expr =
+            self.parse_source_expr_text_at(&wrapped, (base.start? as usize).saturating_sub(2))?;
+        let oxc::Expression::ObjectExpression(obj) = expr else { return None };
+        let mut properties = obj.unbox().properties.into_iter();
+        let Some(oxc::ObjectPropertyKind::ObjectProperty(prop)) = properties.next() else {
+            return None;
+        };
+        let prop = prop.unbox();
+        if !prop.method {
+            return None;
+        }
+        let oxc::Expression::FunctionExpression(func) = prop.value else { return None };
+        Some(func.unbox())
+    }
+
+    fn apply_function_signature_from_source(
+        &self,
+        func: &mut oxc::Function<'a>,
+        source_func: oxc::Function<'a>,
+    ) {
+        func.type_parameters = source_func.type_parameters;
+        func.this_param = source_func.this_param;
+        func.return_type = source_func.return_type;
+        self.apply_formal_parameters_ts_from_source(&mut func.params, source_func.params);
+    }
+
+    fn apply_arrow_signature_from_source(
+        &self,
+        arrow: &mut oxc::ArrowFunctionExpression<'a>,
+        source_arrow: oxc::ArrowFunctionExpression<'a>,
+    ) {
+        arrow.type_parameters = source_arrow.type_parameters;
+        arrow.return_type = source_arrow.return_type;
+        self.apply_formal_parameters_ts_from_source(&mut arrow.params, source_arrow.params);
+    }
+
+    fn apply_formal_parameters_ts_from_source(
+        &self,
+        params: &mut ArenaBox<'a, oxc::FormalParameters<'a>>,
+        source_params: ArenaBox<'a, oxc::FormalParameters<'a>>,
+    ) {
+        let source_params = source_params.unbox();
+        for (param, source_param) in params.items.iter_mut().zip(source_params.items) {
+            param.decorators = source_param.decorators;
+            param.type_annotation = source_param.type_annotation;
+            param.optional = source_param.optional;
+            param.accessibility = source_param.accessibility;
+            param.readonly = source_param.readonly;
+            param.r#override = source_param.r#override;
+        }
+
+        if let (Some(rest), Some(source_rest)) = (&mut params.rest, source_params.rest) {
+            let source_rest = source_rest.unbox();
+            rest.decorators = source_rest.decorators;
+            rest.type_annotation = source_rest.type_annotation;
+        }
+    }
+
+    fn block_initializes_react_cache(&self, block: &BlockStatement) -> bool {
+        block.body.iter().any(|stmt| {
+            let Statement::VariableDeclaration(decl) = stmt else { return false };
+            decl.declarations.iter().any(|declarator| {
+                declarator.init.as_deref().is_some_and(Self::is_react_cache_call_expression)
+            })
+        })
+    }
+
+    fn is_react_cache_call_expression(expr: &Expression) -> bool {
+        let Expression::CallExpression(call) = expr else { return false };
+        matches!(call.callee.as_ref(), Expression::Identifier(id) if id.name == "_c")
+    }
+
+    fn source_text_for_base(&self, base: &BaseNode) -> Option<&str> {
+        let source = self.source_text.as_deref()?;
+        let start = base.start? as usize;
+        let end = base.end? as usize;
+        if start >= source.len() || end > source.len() || start >= end {
+            return None;
+        }
+        Some(&source[start..end])
+    }
+
+    fn import_declaration_has_empty_named_specifiers(&self, decl: &ImportDeclaration) -> bool {
+        if let Some(text) = self.source_text_for_base(&decl.base) {
+            let Some(mut rest) = text.trim_start().strip_prefix("import").map(str::trim_start)
+            else {
+                return false;
+            };
+            if let Some(after_type) = rest.strip_prefix("type")
+                && after_type.chars().next().is_some_and(char::is_whitespace)
+            {
+                rest = after_type.trim_start();
+            }
+            return rest.starts_with("{}");
+        }
+
+        matches!(decl.import_kind, Some(ImportKind::Type | ImportKind::Typeof))
+    }
+
+    fn export_named_needs_source_stmt(&self, decl: &ExportNamedDeclaration) -> bool {
+        matches!(
+            decl.declaration.as_deref(),
+            Some(
+                Declaration::ClassDeclaration(_)
+                    | Declaration::TSTypeAliasDeclaration(_)
+                    | Declaration::TSInterfaceDeclaration(_)
+                    | Declaration::TSEnumDeclaration(_)
+                    | Declaration::TSModuleDeclaration(_)
+                    | Declaration::TSDeclareFunction(_)
+                    | Declaration::TypeAlias(_)
+                    | Declaration::OpaqueType(_)
+                    | Declaration::InterfaceDeclaration(_)
+                    | Declaration::EnumDeclaration(_)
+            )
+        )
+    }
+
+    fn export_default_needs_source_stmt(&self, decl: &ExportDefaultDeclaration) -> bool {
+        match decl.declaration.as_ref() {
+            ExportDefaultDecl::ClassDeclaration(_) => true,
+            ExportDefaultDecl::Expression(expr) => self.is_export_default_interface(expr, decl),
+            ExportDefaultDecl::FunctionDeclaration(_) | ExportDefaultDecl::EnumDeclaration(_) => {
+                false
+            }
+        }
+    }
+
+    fn is_export_default_interface(
+        &self,
+        expr: &Expression,
+        decl: &ExportDefaultDeclaration,
+    ) -> bool {
+        let Expression::NullLiteral(null) = expr else { return false };
+        self.source_text_for_base(&decl.base)
+            .is_some_and(|text| text.trim_start().starts_with("export default interface"))
+            || self
+                .source_text_for_base(&null.base)
+                .is_some_and(|text| text.trim_start().starts_with("interface"))
+    }
+
+    /// Allocate a string in the arena and return a `&str` with lifetime 'a.
+    ///
+    /// The returned `&'a str` converts into both `Ident` and `Str` (identifier
+    /// and string-literal name types), so it feeds every `AstBuilder` method.
+    fn atom(&self, s: &str) -> &'a str {
+        oxc_allocator::StringBuilder::from_str_in(s, self.allocator).into_str()
+    }
+
+    /// Convert a BaseNode's start/end into an OXC Span.
+    /// Returns SPAN (0,0) if the base has no position info.
+    fn span_from_base(&self, base: &BaseNode) -> Span {
+        match (base.start, base.end) {
+            (Some(start), Some(end)) => Span::new(start, end),
+            (Some(start), None) => Span::new(start, start),
+            _ => SPAN,
+        }
+    }
+
+    // ===== Program =====
+
+    fn convert_program(&self, program: &react_compiler_ast::Program) -> oxc::Program<'a> {
+        let source_type = match program.source_type {
+            react_compiler_ast::SourceType::Module => oxc_span::SourceType::mjs(),
+            react_compiler_ast::SourceType::Script => oxc_span::SourceType::cjs(),
+        };
+
+        // Use convert_statements_with_spans for the top-level body so that
+        // original source positions are preserved. This allows comments from
+        // the original source to be correctly attached to statements.
+        let body = self.convert_statements_with_spans(&program.body);
+        let directives = self.convert_directives(&program.directives);
+        let hashbang = program.interpreter.as_ref().map(|interpreter| {
+            self.builder
+                .hashbang(self.span_from_base(&interpreter.base), self.atom(&interpreter.value))
+        });
+        let comments = self.builder.vec();
+
+        self.builder.program(SPAN, source_type, "", comments, hashbang, directives, body)
+    }
+
+    // ===== Directives =====
+
+    fn convert_directives(
+        &self,
+        directives: &[Directive],
+    ) -> oxc_allocator::Vec<'a, oxc::Directive<'a>> {
+        self.builder.vec_from_iter(directives.iter().map(|d| self.convert_directive(d)))
+    }
+
+    fn convert_directive(&self, d: &Directive) -> oxc::Directive<'a> {
+        let expression = self.builder.string_literal(SPAN, self.atom(&d.value.value), None);
+        self.builder.directive(SPAN, expression, self.atom(&d.value.value))
+    }
+
+    // ===== Statements =====
+
+    /// Convert statements preserving span info from the Babel AST.
+    /// This is used for top-level program body where span positions
+    /// are needed for comment attachment.
+    fn convert_statements_with_spans(
+        &self,
+        stmts: &[Statement],
+    ) -> oxc_allocator::Vec<'a, oxc::Statement<'a>> {
+        self.builder.vec_from_iter(stmts.iter().map(|s| {
+            let span = self.get_statement_span(s);
+            let mut oxc_stmt = self.convert_statement(s);
+            if span != SPAN {
+                set_statement_span(&mut oxc_stmt, span);
+            }
+            oxc_stmt
+        }))
+    }
+
+    /// Extract the span from a Babel AST Statement's base node.
+    fn get_statement_span(&self, stmt: &Statement) -> Span {
+        let base = match stmt {
+            Statement::BlockStatement(s) => &s.base,
+            Statement::ReturnStatement(s) => &s.base,
+            Statement::ExpressionStatement(s) => &s.base,
+            Statement::IfStatement(s) => &s.base,
+            Statement::ForStatement(s) => &s.base,
+            Statement::WhileStatement(s) => &s.base,
+            Statement::DoWhileStatement(s) => &s.base,
+            Statement::ForInStatement(s) => &s.base,
+            Statement::ForOfStatement(s) => &s.base,
+            Statement::SwitchStatement(s) => &s.base,
+            Statement::ThrowStatement(s) => &s.base,
+            Statement::TryStatement(s) => &s.base,
+            Statement::BreakStatement(s) => &s.base,
+            Statement::ContinueStatement(s) => &s.base,
+            Statement::LabeledStatement(s) => &s.base,
+            Statement::EmptyStatement(s) => &s.base,
+            Statement::DebuggerStatement(s) => &s.base,
+            Statement::WithStatement(s) => &s.base,
+            Statement::VariableDeclaration(d) => &d.base,
+            Statement::FunctionDeclaration(f) => &f.base,
+            Statement::ClassDeclaration(c) => &c.base,
+            Statement::ImportDeclaration(d) => &d.base,
+            Statement::ExportNamedDeclaration(d) => &d.base,
+            Statement::ExportDefaultDeclaration(d) => &d.base,
+            Statement::ExportAllDeclaration(d) => &d.base,
+            _ => return SPAN,
+        };
+        self.span_from_base(base)
+    }
+
+    fn convert_statement(&self, stmt: &Statement) -> oxc::Statement<'a> {
+        match stmt {
+            Statement::BlockStatement(s) => {
+                self.builder.statement_block(SPAN, self.convert_statement_vec(&s.body))
+            }
+            Statement::ReturnStatement(s) => self
+                .builder
+                .statement_return(SPAN, s.argument.as_ref().map(|a| self.convert_expression(a))),
+            Statement::ExpressionStatement(s) => {
+                self.builder.statement_expression(SPAN, self.convert_expression(&s.expression))
+            }
+            Statement::IfStatement(s) => self.builder.statement_if(
+                SPAN,
+                self.convert_expression(&s.test),
+                self.convert_statement(&s.consequent),
+                s.alternate.as_ref().map(|a| self.convert_statement(a)),
+            ),
+            Statement::ForStatement(s) => {
+                let init = s.init.as_ref().map(|i| self.convert_for_init(i));
+                let test = s.test.as_ref().map(|t| self.convert_expression(t));
+                let update = s.update.as_ref().map(|u| self.convert_expression(u));
+                let body = self.convert_statement(&s.body);
+                self.builder.statement_for(SPAN, init, test, update, body)
+            }
+            Statement::WhileStatement(s) => self.builder.statement_while(
+                SPAN,
+                self.convert_expression(&s.test),
+                self.convert_statement(&s.body),
+            ),
+            Statement::DoWhileStatement(s) => self.builder.statement_do_while(
+                SPAN,
+                self.convert_statement(&s.body),
+                self.convert_expression(&s.test),
+            ),
+            Statement::ForInStatement(s) => self.builder.statement_for_in(
+                SPAN,
+                self.convert_for_in_of_left(&s.left),
+                self.convert_expression(&s.right),
+                self.convert_statement(&s.body),
+            ),
+            Statement::ForOfStatement(s) => self.builder.statement_for_of(
+                SPAN,
+                s.is_await,
+                self.convert_for_in_of_left(&s.left),
+                self.convert_expression(&s.right),
+                self.convert_statement(&s.body),
+            ),
+            Statement::SwitchStatement(s) => {
+                let cases = self.builder.vec_from_iter(s.cases.iter().map(|c| {
+                    self.builder.switch_case(
+                        SPAN,
+                        c.test.as_ref().map(|t| self.convert_expression(t)),
+                        self.convert_statement_vec(&c.consequent),
+                    )
+                }));
+                self.builder.statement_switch(SPAN, self.convert_expression(&s.discriminant), cases)
+            }
+            Statement::ThrowStatement(s) => {
+                self.builder.statement_throw(SPAN, self.convert_expression(&s.argument))
+            }
+            Statement::TryStatement(s) => {
+                let block = self.convert_block_statement(&s.block);
+                let handler = s.handler.as_ref().map(|h| self.convert_catch_clause(h));
+                let finalizer = s.finalizer.as_ref().map(|f| self.convert_block_statement(f));
+                self.builder.statement_try(SPAN, block, handler, finalizer)
+            }
+            Statement::BreakStatement(s) => {
+                let label = s
+                    .label
+                    .as_ref()
+                    .map(|l| self.builder.label_identifier(SPAN, self.atom(&l.name)));
+                self.builder.statement_break(SPAN, label)
+            }
+            Statement::ContinueStatement(s) => {
+                let label = s
+                    .label
+                    .as_ref()
+                    .map(|l| self.builder.label_identifier(SPAN, self.atom(&l.name)));
+                self.builder.statement_continue(SPAN, label)
+            }
+            Statement::LabeledStatement(s) => {
+                let label = self.builder.label_identifier(SPAN, self.atom(&s.label.name));
+                self.builder.statement_labeled(SPAN, label, self.convert_statement(&s.body))
+            }
+            Statement::EmptyStatement(_) => self.builder.statement_empty(SPAN),
+            Statement::DebuggerStatement(_) => self.builder.statement_debugger(SPAN),
+            Statement::WithStatement(s) => self.builder.statement_with(
+                SPAN,
+                self.convert_expression(&s.object),
+                self.convert_statement(&s.body),
+            ),
+            Statement::VariableDeclaration(d) => {
+                let decl = self.convert_variable_declaration(d);
+                oxc::Statement::VariableDeclaration(self.builder.alloc(decl))
+            }
+            Statement::FunctionDeclaration(f) => {
+                let func = self.convert_function_decl(f, oxc::FunctionType::FunctionDeclaration);
+                oxc::Statement::FunctionDeclaration(self.builder.alloc(func))
+            }
+            // The compiler never compiles classes, so the converter stubs out the
+            // class body (members -> null forward, empty reverse). Re-parse the
+            // original class from source to preserve its members; fall back to the
+            // structural (member-less) conversion only if the slice is unavailable.
+            Statement::ClassDeclaration(c) => {
+                self.extract_source_stmt(&c.base).unwrap_or_else(|| {
+                    oxc::Statement::ClassDeclaration(
+                        self.builder.alloc(self.convert_class_declaration(c)),
+                    )
+                })
+            }
+            Statement::ImportDeclaration(d) => {
+                if d.specifiers.is_empty()
+                    && let Some(stmt) = self.extract_source_stmt(&d.base)
+                {
+                    return stmt;
+                }
+                let decl = self.convert_import_declaration(d);
+                oxc::Statement::ImportDeclaration(self.builder.alloc(decl))
+            }
+            Statement::ExportNamedDeclaration(d) => {
+                if self.export_named_needs_source_stmt(d) {
+                    if let Some(stmt) = self.extract_source_stmt(&d.base) {
+                        return stmt;
+                    }
+                }
+                let decl = self.convert_export_named_declaration(d);
+                oxc::Statement::ExportNamedDeclaration(self.builder.alloc(decl))
+            }
+            Statement::ExportDefaultDeclaration(d) => {
+                if self.export_default_needs_source_stmt(d) {
+                    return self.extract_source_stmt(&d.base).unwrap_or_else(|| {
+                        if matches!(d.declaration.as_ref(), ExportDefaultDecl::Expression(_)) {
+                            self.builder.statement_empty(SPAN)
+                        } else {
+                            let decl = self.convert_export_default_declaration(d);
+                            oxc::Statement::ExportDefaultDeclaration(self.builder.alloc(decl))
+                        }
+                    });
+                }
+                let decl = self.convert_export_default_declaration(d);
+                oxc::Statement::ExportDefaultDeclaration(self.builder.alloc(decl))
+            }
+            Statement::ExportAllDeclaration(d) => {
+                if let Some(stmt) = self.extract_source_stmt(&d.base) {
+                    return stmt;
+                }
+                let decl = self.convert_export_all_declaration(d);
+                oxc::Statement::ExportAllDeclaration(self.builder.alloc(decl))
+            }
+            // TS/Flow declarations - try to extract from source text, fall back to empty
+            Statement::TSTypeAliasDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or_else(|| self.builder.statement_empty(SPAN)),
+            Statement::TSInterfaceDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or_else(|| self.builder.statement_empty(SPAN)),
+            Statement::TSEnumDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or_else(|| self.builder.statement_empty(SPAN)),
+            Statement::TSModuleDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or_else(|| self.builder.statement_empty(SPAN)),
+            Statement::TSDeclareFunction(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or_else(|| self.builder.statement_empty(SPAN)),
+            Statement::TypeAlias(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or_else(|| self.builder.statement_empty(SPAN)),
+            Statement::OpaqueType(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or_else(|| self.builder.statement_empty(SPAN)),
+            Statement::InterfaceDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or_else(|| self.builder.statement_empty(SPAN)),
+            Statement::EnumDeclaration(d) => self
+                .extract_source_stmt(&d.base)
+                .unwrap_or_else(|| self.builder.statement_empty(SPAN)),
+            Statement::DeclareVariable(_)
+            | Statement::DeclareFunction(_)
+            | Statement::DeclareClass(_)
+            | Statement::DeclareModule(_)
+            | Statement::DeclareModuleExports(_)
+            | Statement::DeclareExportDeclaration(_)
+            | Statement::DeclareExportAllDeclaration(_)
+            | Statement::DeclareInterface(_)
+            | Statement::DeclareTypeAlias(_)
+            | Statement::DeclareOpaqueType(_) => self.builder.statement_empty(SPAN),
+            Statement::Unknown(s) => self
+                .extract_source_stmt(s.base())
+                .unwrap_or_else(|| self.builder.statement_empty(SPAN)),
+        }
+    }
+
+    fn convert_statement_vec(
+        &self,
+        stmts: &[Statement],
+    ) -> oxc_allocator::Vec<'a, oxc::Statement<'a>> {
+        self.builder.vec_from_iter(stmts.iter().map(|s| self.convert_statement(s)))
+    }
+
+    fn convert_block_statement(&self, block: &BlockStatement) -> oxc::BlockStatement<'a> {
+        self.builder.block_statement(SPAN, self.convert_statement_vec(&block.body))
+    }
+
+    fn convert_catch_clause(&self, clause: &CatchClause) -> oxc::CatchClause<'a> {
+        let param = clause.param.as_ref().map(|p| {
+            let pattern = self.convert_pattern_to_binding_pattern(p);
+            let type_annotation = self.pattern_type_annotation(p);
+            self.builder.catch_parameter(SPAN, pattern, type_annotation)
+        });
+        self.builder.catch_clause(SPAN, param, self.convert_block_statement(&clause.body))
+    }
+
+    fn convert_for_init(&self, init: &ForInit) -> oxc::ForStatementInit<'a> {
+        match init {
+            ForInit::VariableDeclaration(v) => {
+                let decl = self.convert_variable_declaration(v);
+                oxc::ForStatementInit::VariableDeclaration(self.builder.alloc(decl))
+            }
+            ForInit::Expression(e) => oxc::ForStatementInit::from(self.convert_expression(e)),
+        }
+    }
+
+    fn convert_for_in_of_left(&self, left: &ForInOfLeft) -> oxc::ForStatementLeft<'a> {
+        match left {
+            ForInOfLeft::VariableDeclaration(v) => {
+                let decl = self.convert_variable_declaration(v);
+                oxc::ForStatementLeft::VariableDeclaration(self.builder.alloc(decl))
+            }
+            ForInOfLeft::Pattern(p) => {
+                let target = self.convert_pattern_to_assignment_target(p);
+                oxc::ForStatementLeft::from(target)
+            }
+        }
+    }
+
+    fn convert_variable_declaration(
+        &self,
+        decl: &VariableDeclaration,
+    ) -> oxc::VariableDeclaration<'a> {
+        let kind = match decl.kind {
+            VariableDeclarationKind::Var => oxc::VariableDeclarationKind::Var,
+            VariableDeclarationKind::Let => oxc::VariableDeclarationKind::Let,
+            VariableDeclarationKind::Const => oxc::VariableDeclarationKind::Const,
+            VariableDeclarationKind::Using => oxc::VariableDeclarationKind::Using,
+        };
+        let declarators = self.builder.vec_from_iter(
+            decl.declarations.iter().map(|d| self.convert_variable_declarator(d, kind)),
+        );
+        let declare = decl.declare.unwrap_or(false);
+        self.builder.variable_declaration(SPAN, kind, declarators, declare)
+    }
+
+    fn convert_variable_declarator(
+        &self,
+        d: &VariableDeclarator,
+        kind: oxc::VariableDeclarationKind,
+    ) -> oxc::VariableDeclarator<'a> {
+        let id = self.convert_pattern_to_binding_pattern(&d.id);
+        let definite = d.definite.unwrap_or(false);
+        let source_declarator = self.extract_source_variable_declarator(&d.base, kind);
+        let (type_annotation, source_init) = source_declarator.map_or((None, None), |d| {
+            let oxc::VariableDeclarator { type_annotation, init, .. } = d;
+            (type_annotation, init)
+        });
+        let init = d.init.as_ref().map(|e| {
+            let converted = self.convert_expression(e);
+            match source_init {
+                Some(source_init) => {
+                    match self.wrap_expression_with_source_ts_expr(source_init, converted) {
+                        Ok(wrapped) => wrapped,
+                        Err(converted) => converted,
+                    }
+                }
+                None => converted,
+            }
+        });
+        self.builder.variable_declarator(SPAN, kind, id, type_annotation, init, definite)
+    }
+
+    // ===== Expressions =====
+
+    fn convert_expression(&self, expr: &Expression) -> oxc::Expression<'a> {
+        let converted = match expr {
+            Expression::Identifier(id) => {
+                self.builder.expression_identifier(SPAN, self.atom(&id.name))
+            }
+            Expression::StringLiteral(lit) => {
+                self.builder.expression_string_literal(SPAN, self.atom(&lit.value), None)
+            }
+            Expression::NumericLiteral(lit) => self.builder.expression_numeric_literal(
+                SPAN,
+                lit.value,
+                None,
+                oxc::NumberBase::Decimal,
+            ),
+            Expression::BooleanLiteral(lit) => {
+                self.builder.expression_boolean_literal(SPAN, lit.value)
+            }
+            Expression::NullLiteral(_) => self.builder.expression_null_literal(SPAN),
+            Expression::BigIntLiteral(lit) => self.builder.expression_big_int_literal(
+                SPAN,
+                self.atom(lit.value.strip_suffix('n').unwrap_or(&lit.value)),
+                None,
+                oxc::BigintBase::Decimal,
+            ),
+            Expression::RegExpLiteral(lit) => {
+                let flags = self.parse_regexp_flags(&lit.flags);
+                let pattern =
+                    oxc::RegExpPattern { text: self.atom(&lit.pattern).into(), pattern: None };
+                let regex = oxc::RegExp { pattern, flags };
+                self.builder.expression_reg_exp_literal(SPAN, regex, None)
+            }
+            Expression::CallExpression(call) => {
+                if let Some(import_expr) = self.convert_dynamic_import_call(call) {
+                    return import_expr;
+                }
+                let callee = self.convert_expression(&call.callee);
+                let args = self.convert_arguments_with_source(
+                    &call.arguments,
+                    self.extract_source_call_arguments(&call.base),
+                );
+                let type_arguments =
+                    if call.type_parameters.is_some() || call.type_arguments.is_some() {
+                        self.extract_source_call_type_arguments(&call.base)
+                    } else {
+                        None
+                    };
+                self.builder.expression_call(SPAN, callee, type_arguments, args, false)
+            }
+            Expression::MemberExpression(m) => self.convert_member_expression(m),
+            Expression::OptionalCallExpression(call) => {
+                let callee = self.convert_expression_for_chain(&call.callee);
+                let args = self.convert_arguments_with_source(
+                    &call.arguments,
+                    self.extract_source_call_arguments(&call.base),
+                );
+                let type_arguments =
+                    if call.type_parameters.is_some() || call.type_arguments.is_some() {
+                        self.extract_source_call_type_arguments(&call.base)
+                    } else {
+                        None
+                    };
+                let chain_call = self.builder.chain_element_call_expression(
+                    SPAN,
+                    callee,
+                    type_arguments,
+                    args,
+                    call.optional,
+                );
+                self.builder.expression_chain(SPAN, chain_call)
+            }
+            Expression::OptionalMemberExpression(m) => {
+                let chain_elem = self.convert_optional_member_to_chain_element(m);
+                self.builder.expression_chain(SPAN, chain_elem)
+            }
+            Expression::BinaryExpression(bin) => {
+                let op = self.convert_binary_operator(&bin.operator);
+                self.builder.expression_binary(
+                    SPAN,
+                    self.convert_expression(&bin.left),
+                    op,
+                    self.convert_expression(&bin.right),
+                )
+            }
+            Expression::LogicalExpression(log) => {
+                let op = self.convert_logical_operator(&log.operator);
+                self.builder.expression_logical(
+                    SPAN,
+                    self.convert_expression(&log.left),
+                    op,
+                    self.convert_expression(&log.right),
+                )
+            }
+            Expression::UnaryExpression(un) => {
+                let op = self.convert_unary_operator(&un.operator);
+                self.builder.expression_unary(SPAN, op, self.convert_expression(&un.argument))
+            }
+            Expression::UpdateExpression(up) => {
+                let op = self.convert_update_operator(&up.operator);
+                let arg = self.convert_expression_to_simple_assignment_target(&up.argument);
+                self.builder.expression_update(SPAN, op, up.prefix, arg)
+            }
+            Expression::ConditionalExpression(cond) => self.builder.expression_conditional(
+                SPAN,
+                self.convert_expression(&cond.test),
+                self.convert_expression(&cond.consequent),
+                self.convert_expression(&cond.alternate),
+            ),
+            Expression::AssignmentExpression(assign) => {
+                let op = self.convert_assignment_operator(&assign.operator);
+                let left = self.convert_pattern_to_assignment_target(&assign.left);
+                self.builder.expression_assignment(
+                    SPAN,
+                    op,
+                    left,
+                    self.convert_expression(&assign.right),
+                )
+            }
+            Expression::SequenceExpression(seq) => {
+                let exprs = self
+                    .builder
+                    .vec_from_iter(seq.expressions.iter().map(|e| self.convert_expression(e)));
+                self.builder.expression_sequence(SPAN, exprs)
+            }
+            Expression::ArrowFunctionExpression(arrow) => self.convert_arrow_function(arrow),
+            Expression::FunctionExpression(func) => {
+                let f = self.convert_function_expr(func);
+                oxc::Expression::FunctionExpression(self.builder.alloc(f))
+            }
+            Expression::ObjectExpression(obj) => {
+                let properties = self.builder.vec_from_iter(
+                    obj.properties.iter().map(|p| self.convert_object_expression_property(p)),
+                );
+                self.builder.expression_object(SPAN, properties)
+            }
+            Expression::ArrayExpression(arr) => {
+                let elements = self
+                    .builder
+                    .vec_from_iter(arr.elements.iter().map(|e| self.convert_array_element(e)));
+                self.builder.expression_array(SPAN, elements)
+            }
+            Expression::NewExpression(n) => {
+                let callee = self.convert_expression(&n.callee);
+                let args = self.convert_arguments_with_source(
+                    &n.arguments,
+                    self.extract_source_new_arguments(&n.base),
+                );
+                let type_arguments = if n.type_parameters.is_some() || n.type_arguments.is_some() {
+                    self.extract_source_new_type_arguments(&n.base)
+                } else {
+                    None
+                };
+                self.builder.expression_new(SPAN, callee, type_arguments, args)
+            }
+            Expression::TemplateLiteral(tl) => {
+                let template = self.convert_template_literal(tl);
+                oxc::Expression::TemplateLiteral(self.builder.alloc(template))
+            }
+            Expression::TaggedTemplateExpression(tag) => {
+                let t = self.convert_expression(&tag.tag);
+                let quasi = self.convert_template_literal(&tag.quasi);
+                let type_arguments = if tag.type_parameters.is_some() {
+                    self.extract_source_tagged_template_type_arguments(&tag.base)
+                } else {
+                    None
+                };
+                self.builder.expression_tagged_template(SPAN, t, type_arguments, quasi)
+            }
+            Expression::AwaitExpression(a) => {
+                self.builder.expression_await(SPAN, self.convert_expression(&a.argument))
+            }
+            Expression::YieldExpression(y) => self.builder.expression_yield(
+                SPAN,
+                y.delegate,
+                y.argument.as_ref().map(|a| self.convert_expression(a)),
+            ),
+            Expression::SpreadElement(s) => {
+                // SpreadElement can't be a standalone expression in OXC.
+                // Return the argument directly as a fallback.
+                self.convert_expression(&s.argument)
+            }
+            Expression::MetaProperty(mp) => {
+                let meta = self.builder.identifier_name(SPAN, self.atom(&mp.meta.name));
+                let property = self.builder.identifier_name(SPAN, self.atom(&mp.property.name));
+                self.builder.expression_meta_property(SPAN, meta, property)
+            }
+            Expression::ClassExpression(c) => {
+                if let Some(expr) = self.extract_source_class_expression(c) {
+                    return expr;
+                }
+                let class = self.convert_class_to_oxc(c, oxc::ClassType::ClassExpression);
+                oxc::Expression::ClassExpression(self.builder.alloc(class))
+            }
+            Expression::PrivateName(_) => {
+                self.builder.expression_identifier(SPAN, self.atom("__private__"))
+            }
+            Expression::Super(_) => self.builder.expression_super(SPAN),
+            Expression::Import(_) => {
+                self.builder.expression_identifier(SPAN, self.atom("__import__"))
+            }
+            Expression::ThisExpression(_) => self.builder.expression_this(SPAN),
+            Expression::ParenthesizedExpression(p) => {
+                self.builder.expression_parenthesized(SPAN, self.convert_expression(&p.expression))
+            }
+            Expression::JSXElement(el) => {
+                let element = self.convert_jsx_element(el);
+                oxc::Expression::JSXElement(self.builder.alloc(element))
+            }
+            Expression::JSXFragment(frag) => {
+                let fragment = self.convert_jsx_fragment(frag);
+                oxc::Expression::JSXFragment(self.builder.alloc(fragment))
+            }
+            // TS expressions carry their actual type AST as `null` through the
+            // React AST bridge. Rebuild the wrapper with the converted child
+            // expression and recover only the type from the original source.
+            Expression::TSAsExpression(e) => {
+                let expression = self.convert_expression(&e.expression);
+                let type_annotation =
+                    self.convert_ts_type_from_json(&e.type_annotation).or_else(|| {
+                        if Self::ts_type_json_contains_type_query(&e.type_annotation) {
+                            None
+                        } else {
+                            self.extract_source_ts_as_type(&e.base)
+                        }
+                    });
+                if let Some(type_annotation) = type_annotation {
+                    self.builder.expression_ts_as(SPAN, expression, type_annotation)
+                } else {
+                    expression
+                }
+            }
+            Expression::TSSatisfiesExpression(e) => {
+                let expression = self.convert_expression(&e.expression);
+                let type_annotation =
+                    self.convert_ts_type_from_json(&e.type_annotation).or_else(|| {
+                        if Self::ts_type_json_contains_type_query(&e.type_annotation) {
+                            None
+                        } else {
+                            self.extract_source_ts_satisfies_type(&e.base)
+                        }
+                    });
+                if let Some(type_annotation) = type_annotation {
+                    self.builder.expression_ts_satisfies(SPAN, expression, type_annotation)
+                } else {
+                    expression
+                }
+            }
+            Expression::TSNonNullExpression(e) => {
+                self.builder.expression_ts_non_null(SPAN, self.convert_expression(&e.expression))
+            }
+            Expression::TSTypeAssertion(e) => {
+                let expression = self.convert_expression(&e.expression);
+                let type_annotation =
+                    self.convert_ts_type_from_json(&e.type_annotation).or_else(|| {
+                        if Self::ts_type_json_contains_type_query(&e.type_annotation) {
+                            None
+                        } else {
+                            self.extract_source_ts_type_assertion_type(&e.base)
+                        }
+                    });
+                if let Some(type_annotation) = type_annotation {
+                    self.builder.expression_ts_type_assertion(SPAN, type_annotation, expression)
+                } else {
+                    expression
+                }
+            }
+            Expression::TSInstantiationExpression(e) => {
+                let expression = self.convert_expression(&e.expression);
+                if let Some(type_arguments) =
+                    self.extract_source_ts_instantiation_type_arguments(&e.base)
+                {
+                    self.builder.expression_ts_instantiation(SPAN, expression, type_arguments)
+                } else {
+                    expression
+                }
+            }
+            Expression::TypeCastExpression(e) => self.convert_expression(&e.expression),
+            Expression::AssignmentPattern(p) => {
+                let left = self.convert_pattern_to_assignment_target(&p.left);
+                self.builder.expression_assignment(
+                    SPAN,
+                    oxc_syntax::operator::AssignmentOperator::Assign,
+                    left,
+                    self.convert_expression(&p.right),
+                )
+            }
+        };
+
+        if let Some(base) = Self::expression_base(expr) {
+            match self.wrap_expression_with_source_ts(base, converted) {
+                Ok(wrapped) => wrapped,
+                Err(converted) => converted,
+            }
+        } else {
+            converted
+        }
+    }
+
+    fn convert_dynamic_import_call(&self, call: &CallExpression) -> Option<oxc::Expression<'a>> {
+        if !matches!(call.callee.as_ref(), Expression::Import(_)) {
+            return None;
+        }
+        let source = call.arguments.first().map(|arg| self.convert_expression(arg))?;
+        let options = call.arguments.get(1).map(|arg| self.convert_expression(arg));
+        Some(self.builder.expression_import(SPAN, source, options, None))
+    }
+
+    /// Convert an expression that may be used inside a chain (optional chaining).
+    fn convert_expression_for_chain(&self, expr: &Expression) -> oxc::Expression<'a> {
+        match expr {
+            Expression::OptionalMemberExpression(m) => {
+                self.convert_optional_member_to_expression(m)
+            }
+            Expression::OptionalCallExpression(call) => {
+                let callee = self.convert_expression_for_chain(&call.callee);
+                let args = self.convert_arguments_with_source(
+                    &call.arguments,
+                    self.extract_source_call_arguments(&call.base),
+                );
+                let type_arguments =
+                    if call.type_parameters.is_some() || call.type_arguments.is_some() {
+                        self.extract_source_call_type_arguments(&call.base)
+                    } else {
+                        None
+                    };
+                let call_expr =
+                    self.builder.call_expression(SPAN, callee, type_arguments, args, call.optional);
+                oxc::Expression::CallExpression(self.builder.alloc(call_expr))
+            }
+            _ => self.convert_expression(expr),
+        }
+    }
+
+    fn convert_member_expression(&self, m: &MemberExpression) -> oxc::Expression<'a> {
+        let object = self.convert_expression(&m.object);
+        if m.computed {
+            let property = self.convert_expression(&m.property);
+            oxc::Expression::ComputedMemberExpression(
+                self.builder
+                    .alloc(self.builder.computed_member_expression(SPAN, object, property, false)),
+            )
+        } else {
+            let prop_name = self.expression_to_identifier_name(&m.property);
+            oxc::Expression::StaticMemberExpression(
+                self.builder
+                    .alloc(self.builder.static_member_expression(SPAN, object, prop_name, false)),
+            )
+        }
+    }
+
+    fn convert_optional_member_to_chain_element(
+        &self,
+        m: &OptionalMemberExpression,
+    ) -> oxc::ChainElement<'a> {
+        let object = self.convert_expression_for_chain(&m.object);
+        if m.computed {
+            let property = self.convert_expression(&m.property);
+            oxc::ChainElement::ComputedMemberExpression(
+                self.builder.alloc(
+                    self.builder.computed_member_expression(SPAN, object, property, m.optional),
+                ),
+            )
+        } else {
+            let prop_name = self.expression_to_identifier_name(&m.property);
+            oxc::ChainElement::StaticMemberExpression(
+                self.builder.alloc(
+                    self.builder.static_member_expression(SPAN, object, prop_name, m.optional),
+                ),
+            )
+        }
+    }
+
+    fn convert_optional_member_to_expression(
+        &self,
+        m: &OptionalMemberExpression,
+    ) -> oxc::Expression<'a> {
+        let object = self.convert_expression_for_chain(&m.object);
+        if m.computed {
+            let property = self.convert_expression(&m.property);
+            oxc::Expression::ComputedMemberExpression(
+                self.builder.alloc(
+                    self.builder.computed_member_expression(SPAN, object, property, m.optional),
+                ),
+            )
+        } else {
+            let prop_name = self.expression_to_identifier_name(&m.property);
+            oxc::Expression::StaticMemberExpression(
+                self.builder.alloc(
+                    self.builder.static_member_expression(SPAN, object, prop_name, m.optional),
+                ),
+            )
+        }
+    }
+
+    fn expression_to_identifier_name(&self, expr: &Expression) -> oxc::IdentifierName<'a> {
+        match expr {
+            Expression::Identifier(id) => self.builder.identifier_name(SPAN, self.atom(&id.name)),
+            _ => self.builder.identifier_name(SPAN, self.atom("__unknown__")),
+        }
+    }
+
+    fn convert_arguments_with_source(
+        &self,
+        args: &[Expression],
+        source_args: Option<Vec<oxc::Argument<'a>>>,
+    ) -> oxc_allocator::Vec<'a, oxc::Argument<'a>> {
+        let mut source_args = source_args.map(Vec::into_iter);
+        self.builder.vec_from_iter(args.iter().map(|arg| {
+            let source_arg = source_args.as_mut().and_then(Iterator::next);
+            self.convert_argument_with_source(arg, source_arg)
+        }))
+    }
+
+    fn convert_argument_with_source(
+        &self,
+        arg: &Expression,
+        source_arg: Option<oxc::Argument<'a>>,
+    ) -> oxc::Argument<'a> {
+        match arg {
+            Expression::SpreadElement(s) => {
+                let converted = self.convert_expression(&s.argument);
+                let converted = match source_arg {
+                    Some(oxc::Argument::SpreadElement(source_spread)) => {
+                        match self.wrap_expression_with_source_ts_expr(
+                            source_spread.unbox().argument,
+                            converted,
+                        ) {
+                            Ok(wrapped) => wrapped,
+                            Err(converted) => converted,
+                        }
+                    }
+                    Some(source_arg) => {
+                        match self.wrap_expression_with_source_argument_ts(source_arg, converted) {
+                            Ok(wrapped) => wrapped,
+                            Err(converted) => converted,
+                        }
+                    }
+                    None => converted,
+                };
+                self.builder.argument_spread_element(SPAN, converted)
+            }
+            _ => {
+                let converted = self.convert_expression(arg);
+                let converted = match source_arg {
+                    Some(source_arg) => {
+                        match self.wrap_expression_with_source_argument_ts(source_arg, converted) {
+                            Ok(wrapped) => wrapped,
+                            Err(converted) => converted,
+                        }
+                    }
+                    None => converted,
+                };
+                oxc::Argument::from(converted)
+            }
+        }
+    }
+
+    fn convert_array_element(&self, elem: &Option<Expression>) -> oxc::ArrayExpressionElement<'a> {
+        match elem {
+            None => self.builder.array_expression_element_elision(SPAN),
+            Some(Expression::SpreadElement(s)) => {
+                self.builder.array_expression_element_spread_element(
+                    SPAN,
+                    self.convert_expression(&s.argument),
+                )
+            }
+            Some(e) => oxc::ArrayExpressionElement::from(self.convert_expression(e)),
+        }
+    }
+
+    fn convert_object_expression_property(
+        &self,
+        prop: &ObjectExpressionProperty,
+    ) -> oxc::ObjectPropertyKind<'a> {
+        match prop {
+            ObjectExpressionProperty::ObjectProperty(p) => {
+                let key = self.convert_expression_to_property_key(&p.key);
+                let value = self.convert_expression(&p.value);
+                let value = match self.extract_source_object_property_value(&p.base) {
+                    Some(source_value) => {
+                        match self.wrap_expression_with_source_ts_expr(source_value, value) {
+                            Ok(wrapped) => wrapped,
+                            Err(value) => value,
+                        }
+                    }
+                    None => value,
+                };
+                let method = p.method.unwrap_or(false);
+                let obj_prop = self.builder.object_property(
+                    SPAN,
+                    oxc::PropertyKind::Init,
+                    key,
+                    value,
+                    method,
+                    p.shorthand,
+                    p.computed,
+                );
+                oxc::ObjectPropertyKind::ObjectProperty(self.builder.alloc(obj_prop))
+            }
+            ObjectExpressionProperty::ObjectMethod(m) => {
+                let kind = match m.kind {
+                    ObjectMethodKind::Method => oxc::PropertyKind::Init,
+                    ObjectMethodKind::Get => oxc::PropertyKind::Get,
+                    ObjectMethodKind::Set => oxc::PropertyKind::Set,
+                };
+                let key = self.convert_expression_to_property_key(&m.key);
+                let func = self.convert_object_method_to_function(m);
+                let func_expr = oxc::Expression::FunctionExpression(self.builder.alloc(func));
+                let obj_prop = self.builder.object_property(
+                    SPAN, kind, key, func_expr, m.method, false, // shorthand
+                    m.computed,
+                );
+                oxc::ObjectPropertyKind::ObjectProperty(self.builder.alloc(obj_prop))
+            }
+            ObjectExpressionProperty::SpreadElement(s) => {
+                let spread =
+                    self.builder.spread_element(SPAN, self.convert_expression(&s.argument));
+                oxc::ObjectPropertyKind::SpreadProperty(self.builder.alloc(spread))
+            }
+        }
+    }
+
+    fn convert_expression_to_property_key(&self, expr: &Expression) -> oxc::PropertyKey<'a> {
+        match expr {
+            Expression::Identifier(id) => {
+                self.builder.property_key_static_identifier(SPAN, self.atom(&id.name))
+            }
+            Expression::StringLiteral(s) => {
+                let lit = self.builder.string_literal(SPAN, self.atom(&s.value), None);
+                oxc::PropertyKey::StringLiteral(self.builder.alloc(lit))
+            }
+            Expression::NumericLiteral(n) => {
+                let lit =
+                    self.builder.numeric_literal(SPAN, n.value, None, oxc::NumberBase::Decimal);
+                oxc::PropertyKey::NumericLiteral(self.builder.alloc(lit))
+            }
+            Expression::PrivateName(p) => {
+                self.builder.property_key_private_identifier(SPAN, self.atom(&p.id.name))
+            }
+            _ => oxc::PropertyKey::from(self.convert_expression(expr)),
+        }
+    }
+
+    fn convert_template_literal(
+        &self,
+        tl: &react_compiler_ast::expressions::TemplateLiteral,
+    ) -> oxc::TemplateLiteral<'a> {
+        let quasis = self.builder.vec_from_iter(tl.quasis.iter().map(|q| {
+            let raw = self.atom(&q.value.raw).into();
+            let cooked = q.value.cooked.as_ref().map(|c| self.atom(c).into());
+            let value = oxc::TemplateElementValue { raw, cooked };
+            self.builder.template_element(SPAN, value, q.tail)
+        }));
+        let expressions =
+            self.builder.vec_from_iter(tl.expressions.iter().map(|e| self.convert_expression(e)));
+        self.builder.template_literal(SPAN, quasis, expressions)
+    }
+
+    // ===== Functions =====
+
+    fn convert_function_decl(
+        &self,
+        f: &FunctionDeclaration,
+        fn_type: oxc::FunctionType,
+    ) -> oxc::Function<'a> {
+        let id = f.id.as_ref().map(|id| self.builder.binding_identifier(SPAN, self.atom(&id.name)));
+        let params = self.convert_params_to_formal_parameters(&f.params);
+        let body = self.convert_block_to_function_body(&f.body);
+        let mut func = self.builder.function(
+            SPAN,
+            fn_type,
+            id,
+            f.generator,
+            f.is_async,
+            f.declare.unwrap_or(false),
+            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            None::<oxc_allocator::Box<'a, oxc::TSThisParameter<'a>>>,
+            params,
+            None::<oxc_allocator::Box<'a, oxc::TSTypeAnnotation<'a>>>,
+            Some(body),
+        );
+        if !self.block_initializes_react_cache(&f.body)
+            && let Some(source_func) = self.extract_source_function_declaration(&f.base)
+        {
+            let source_has_no_body = source_func.body.is_none();
+            self.apply_function_signature_from_source(&mut func, source_func);
+            if source_has_no_body {
+                func.body = None;
+            }
+        }
+        func
+    }
+
+    fn convert_class_declaration(&self, c: &ClassDeclaration) -> oxc::Class<'a> {
+        let id = c.id.as_ref().map(|id| self.builder.binding_identifier(SPAN, self.atom(&id.name)));
+        let super_class = c.super_class.as_ref().map(|s| self.convert_expression(s));
+        let body = self.builder.class_body(SPAN, self.builder.vec());
+        self.builder.class(
+            SPAN,
+            oxc::ClassType::ClassDeclaration,
+            self.builder.vec(), // decorators
+            id,
+            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            super_class,
+            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterInstantiation<'a>>>,
+            self.builder.vec(), // implements
+            body,
+            c.is_abstract.unwrap_or(false),
+            c.declare.unwrap_or(false),
+        )
+    }
+
+    fn convert_class_to_oxc(
+        &self,
+        c: &react_compiler_ast::expressions::ClassExpression,
+        class_type: oxc::ClassType,
+    ) -> oxc::Class<'a> {
+        let id = c.id.as_ref().map(|id| self.builder.binding_identifier(SPAN, self.atom(&id.name)));
+        let super_class = c.super_class.as_ref().map(|s| self.convert_expression(s));
+        let body = self.builder.class_body(SPAN, self.builder.vec());
+        self.builder.class(
+            SPAN,
+            class_type,
+            self.builder.vec(), // decorators
+            id,
+            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            super_class,
+            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterInstantiation<'a>>>,
+            self.builder.vec(), // implements
+            body,
+            false, // is_abstract
+            false, // declare
+        )
+    }
+
+    fn convert_function_expr(&self, f: &FunctionExpression) -> oxc::Function<'a> {
+        let id = f.id.as_ref().map(|id| self.builder.binding_identifier(SPAN, self.atom(&id.name)));
+        let params = self.convert_params_to_formal_parameters(&f.params);
+        let body = self.convert_block_to_function_body(&f.body);
+        let initializes_react_cache = self.block_initializes_react_cache(&f.body);
+        let return_type = if initializes_react_cache {
+            None
+        } else {
+            f.return_type
+                .as_deref()
+                .and_then(|value| self.convert_ts_type_annotation_from_json(value))
+        };
+        let mut func = self.builder.function(
+            SPAN,
+            oxc::FunctionType::FunctionExpression,
+            id,
+            f.generator,
+            f.is_async,
+            false,
+            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            None::<oxc_allocator::Box<'a, oxc::TSThisParameter<'a>>>,
+            params,
+            return_type,
+            Some(body),
+        );
+        if !initializes_react_cache
+            && let Some(source_func) = self.extract_source_function_expression(&f.base)
+        {
+            self.apply_function_signature_from_source(&mut func, source_func);
+        }
+        func
+    }
+
+    fn convert_object_method_to_function(&self, m: &ObjectMethod) -> oxc::Function<'a> {
+        let params = self.convert_params_to_formal_parameters(&m.params);
+        let body = self.convert_block_to_function_body(&m.body);
+        let initializes_react_cache = self.block_initializes_react_cache(&m.body);
+        let return_type = if initializes_react_cache {
+            None
+        } else {
+            m.return_type
+                .as_deref()
+                .and_then(|value| self.convert_ts_type_annotation_from_json(value))
+        };
+        let mut func = self.builder.function(
+            SPAN,
+            oxc::FunctionType::FunctionExpression,
+            None,
+            m.generator,
+            m.is_async,
+            false,
+            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            None::<oxc_allocator::Box<'a, oxc::TSThisParameter<'a>>>,
+            params,
+            return_type,
+            Some(body),
+        );
+        if !initializes_react_cache
+            && let Some(source_func) = self.extract_source_object_method_function(&m.base)
+        {
+            self.apply_function_signature_from_source(&mut func, source_func);
+        }
+        func
+    }
+
+    fn convert_arrow_function(&self, arrow: &ArrowFunctionExpression) -> oxc::Expression<'a> {
+        let is_expression = arrow.expression.unwrap_or(false);
+        let params = self.convert_params_to_formal_parameters(&arrow.params);
+        let arrow_initializes_react_cache = match &*arrow.body {
+            ArrowFunctionBody::BlockStatement(block) => self.block_initializes_react_cache(block),
+            ArrowFunctionBody::Expression(_) => false,
+        };
+
+        let body = match &*arrow.body {
+            ArrowFunctionBody::BlockStatement(block) => self.convert_block_to_function_body(block),
+            ArrowFunctionBody::Expression(expr) => {
+                let oxc_expr = self.convert_expression(expr);
+                let stmt = self.builder.statement_expression(SPAN, oxc_expr);
+                let stmts = self.builder.vec_from_iter(std::iter::once(stmt));
+                self.builder.function_body(SPAN, self.builder.vec(), stmts)
+            }
+        };
+
+        let mut arrow_expr = self.builder.arrow_function_expression(
+            SPAN,
+            is_expression,
+            arrow.is_async,
+            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            params,
+            if arrow_initializes_react_cache {
+                None
+            } else {
+                arrow
+                    .return_type
+                    .as_deref()
+                    .and_then(|value| self.convert_ts_type_annotation_from_json(value))
+            },
+            body,
+        );
+        if !arrow_initializes_react_cache
+            && let Some(source_arrow) = self.extract_source_arrow_function(&arrow.base)
+        {
+            self.apply_arrow_signature_from_source(&mut arrow_expr, source_arrow);
+        }
+        oxc::Expression::ArrowFunctionExpression(self.builder.alloc(arrow_expr))
+    }
+
+    fn convert_block_to_function_body(&self, block: &BlockStatement) -> oxc::FunctionBody<'a> {
+        let stmts = self.convert_statement_vec(&block.body);
+        let directives = self.convert_directives(&block.directives);
+        self.builder.function_body(SPAN, directives, stmts)
+    }
+
+    fn convert_params_to_formal_parameters(
+        &self,
+        params: &[PatternLike],
+    ) -> oxc::FormalParameters<'a> {
+        let mut items: Vec<oxc::FormalParameter<'a>> = Vec::new();
+        let mut rest: Option<oxc::FormalParameterRest<'a>> = None;
+
+        for param in params {
+            match param {
+                PatternLike::RestElement(r) => {
+                    let arg = self.convert_pattern_to_binding_pattern(&r.argument);
+                    let rest_elem = self.builder.binding_rest_element(SPAN, arg);
+                    let type_annotation = r
+                        .type_annotation
+                        .as_deref()
+                        .and_then(|value| self.convert_ts_type_annotation_from_json(value));
+                    rest = Some(self.builder.formal_parameter_rest(
+                        SPAN,
+                        self.builder.vec(),
+                        rest_elem,
+                        type_annotation,
+                    ));
+                }
+                PatternLike::AssignmentPattern(ap) => {
+                    // OXC stores default parameter values in FormalParameter.initializer
+                    // rather than using BindingPattern::AssignmentPattern (which OXC considers
+                    // invalid in FormalParameter position).
+                    let left = self.convert_pattern_to_binding_pattern(&ap.left);
+                    let right = self.convert_expression(&ap.right);
+                    let initializer = Some(oxc_allocator::Box::new_in(right, self.allocator));
+                    let type_annotation = self
+                        .pattern_type_annotation(param)
+                        .or_else(|| self.pattern_type_annotation(&ap.left));
+                    let optional = self.pattern_optional(param) || self.pattern_optional(&ap.left);
+                    let fp = self.builder.formal_parameter(
+                        SPAN,
+                        self.builder.vec(), // decorators
+                        left,
+                        type_annotation,
+                        initializer,
+                        optional,
+                        None,  // accessibility
+                        false, // readonly
+                        false, // override
+                    );
+                    items.push(fp);
+                }
+                _ => {
+                    let pattern = self.convert_pattern_to_binding_pattern(param);
+                    let type_annotation = self.pattern_type_annotation(param);
+                    let optional = self.pattern_optional(param);
+                    let fp = self.builder.formal_parameter(
+                        SPAN,
+                        self.builder.vec(), // decorators
+                        pattern,
+                        type_annotation,
+                        None::<oxc_allocator::Box<'a, oxc::Expression<'a>>>,
+                        optional,
+                        None,  // accessibility
+                        false, // readonly
+                        false, // override
+                    );
+                    items.push(fp);
+                }
+            }
+        }
+
+        let items_vec = self.builder.vec_from_iter(items);
+        self.builder.formal_parameters(
+            SPAN,
+            oxc::FormalParameterKind::FormalParameter,
+            items_vec,
+            rest,
+        )
+    }
+
+    fn pattern_optional(&self, pattern: &PatternLike) -> bool {
+        match pattern {
+            PatternLike::Identifier(id) => id.optional.unwrap_or(false),
+            PatternLike::AssignmentPattern(assign) => self.pattern_optional(&assign.left),
+            PatternLike::RestElement(rest) => self.pattern_optional(&rest.argument),
+            PatternLike::ObjectPattern(_)
+            | PatternLike::ArrayPattern(_)
+            | PatternLike::MemberExpression(_)
+            | PatternLike::TSAsExpression(_)
+            | PatternLike::TSSatisfiesExpression(_)
+            | PatternLike::TSNonNullExpression(_)
+            | PatternLike::TSTypeAssertion(_)
+            | PatternLike::TypeCastExpression(_) => false,
+        }
+    }
+
+    fn pattern_type_annotation(
+        &self,
+        pattern: &PatternLike,
+    ) -> Option<ArenaBox<'a, oxc::TSTypeAnnotation<'a>>> {
+        let value = match pattern {
+            PatternLike::Identifier(id) => id.type_annotation.as_deref(),
+            PatternLike::ObjectPattern(obj) => obj.type_annotation.as_deref(),
+            PatternLike::ArrayPattern(arr) => arr.type_annotation.as_deref(),
+            PatternLike::AssignmentPattern(assign) => assign.type_annotation.as_deref(),
+            PatternLike::RestElement(rest) => rest.type_annotation.as_deref(),
+            PatternLike::MemberExpression(_)
+            | PatternLike::TSAsExpression(_)
+            | PatternLike::TSSatisfiesExpression(_)
+            | PatternLike::TSNonNullExpression(_)
+            | PatternLike::TSTypeAssertion(_)
+            | PatternLike::TypeCastExpression(_) => None,
+        }?;
+        self.convert_ts_type_annotation_from_json(value)
+    }
+
+    // ===== Patterns → BindingPattern =====
+
+    fn convert_pattern_to_binding_pattern(&self, pattern: &PatternLike) -> oxc::BindingPattern<'a> {
+        match pattern {
+            PatternLike::Identifier(id) => {
+                self.builder.binding_pattern_binding_identifier(SPAN, self.atom(&id.name))
+            }
+            PatternLike::ObjectPattern(obj) => {
+                let mut properties: Vec<oxc::BindingProperty<'a>> = Vec::new();
+                let mut rest: Option<oxc::BindingRestElement<'a>> = None;
+
+                for prop in &obj.properties {
+                    match prop {
+                        ObjectPatternProperty::ObjectProperty(p) => {
+                            let key = self.convert_expression_to_property_key(&p.key);
+                            let value = self.convert_pattern_to_binding_pattern(&p.value);
+                            let bp = self.builder.binding_property(
+                                SPAN,
+                                key,
+                                value,
+                                p.shorthand,
+                                p.computed,
+                            );
+                            properties.push(bp);
+                        }
+                        ObjectPatternProperty::RestElement(r) => {
+                            let arg = self.convert_pattern_to_binding_pattern(&r.argument);
+                            rest = Some(self.builder.binding_rest_element(SPAN, arg));
+                        }
+                    }
+                }
+
+                let props_vec = self.builder.vec_from_iter(properties);
+                self.builder.binding_pattern_object_pattern(SPAN, props_vec, rest)
+            }
+            PatternLike::ArrayPattern(arr) => {
+                let mut elements: Vec<Option<oxc::BindingPattern<'a>>> = Vec::new();
+                let mut rest: Option<oxc::BindingRestElement<'a>> = None;
+
+                for elem in &arr.elements {
+                    match elem {
+                        None => elements.push(None),
+                        Some(PatternLike::RestElement(r)) => {
+                            let arg = self.convert_pattern_to_binding_pattern(&r.argument);
+                            rest = Some(self.builder.binding_rest_element(SPAN, arg));
+                        }
+                        Some(p) => {
+                            elements.push(Some(self.convert_pattern_to_binding_pattern(p)));
+                        }
+                    }
+                }
+
+                let elems_vec = self.builder.vec_from_iter(elements);
+                self.builder.binding_pattern_array_pattern(SPAN, elems_vec, rest)
+            }
+            PatternLike::AssignmentPattern(ap) => {
+                let left = self.convert_pattern_to_binding_pattern(&ap.left);
+                let right = self.convert_expression(&ap.right);
+                self.builder.binding_pattern_assignment_pattern(SPAN, left, right)
+            }
+            PatternLike::RestElement(r) => self.convert_pattern_to_binding_pattern(&r.argument),
+            PatternLike::MemberExpression(_)
+            | PatternLike::TSAsExpression(_)
+            | PatternLike::TSSatisfiesExpression(_)
+            | PatternLike::TSNonNullExpression(_)
+            | PatternLike::TSTypeAssertion(_)
+            | PatternLike::TypeCastExpression(_) => self
+                .builder
+                .binding_pattern_binding_identifier(SPAN, self.atom("__member_pattern__")),
+        }
+    }
+
+    // ===== Patterns → AssignmentTarget =====
+
+    fn convert_pattern_to_assignment_target(
+        &self,
+        pattern: &PatternLike,
+    ) -> oxc::AssignmentTarget<'a> {
+        match pattern {
+            PatternLike::Identifier(id) => self
+                .builder
+                .simple_assignment_target_assignment_target_identifier(SPAN, self.atom(&id.name))
+                .into(),
+            PatternLike::MemberExpression(m) => {
+                let object = self.convert_expression(&m.object);
+                if m.computed {
+                    let property = self.convert_expression(&m.property);
+                    let mem =
+                        self.builder.computed_member_expression(SPAN, object, property, false);
+                    oxc::AssignmentTarget::ComputedMemberExpression(self.builder.alloc(mem))
+                } else {
+                    let prop_name = self.expression_to_identifier_name(&m.property);
+                    let mem = self.builder.static_member_expression(SPAN, object, prop_name, false);
+                    oxc::AssignmentTarget::StaticMemberExpression(self.builder.alloc(mem))
+                }
+            }
+            PatternLike::ObjectPattern(obj) => {
+                let mut properties: Vec<oxc::AssignmentTargetProperty<'a>> = Vec::new();
+                let mut rest: Option<oxc::AssignmentTargetRest<'a>> = None;
+
+                for prop in &obj.properties {
+                    match prop {
+                        ObjectPatternProperty::ObjectProperty(p) => {
+                            if p.shorthand {
+                                // Shorthand: { x } means { x: x }
+                                // Use AssignmentTargetPropertyIdentifier
+                                if let Expression::Identifier(id) = &*p.key {
+                                    let binding = self
+                                        .builder
+                                        .identifier_reference(SPAN, self.atom(&id.name));
+                                    let init = match &*p.value {
+                                        PatternLike::AssignmentPattern(ap) => {
+                                            Some(self.convert_expression(&ap.right))
+                                        }
+                                        _ => None,
+                                    };
+                                    let atp = self
+                                        .builder
+                                        .assignment_target_property_assignment_target_property_identifier(
+                                            SPAN, binding, init,
+                                        );
+                                    properties.push(atp);
+                                } else {
+                                    // Fallback to non-shorthand
+                                    let key = self.convert_expression_to_property_key(&p.key);
+                                    let binding = self
+                                        .convert_pattern_to_assignment_target_maybe_default(
+                                            &p.value,
+                                        );
+                                    let atp = self
+                                        .builder
+                                        .assignment_target_property_assignment_target_property_property(
+                                            SPAN, key, binding, p.computed,
+                                        );
+                                    properties.push(atp);
+                                }
+                            } else {
+                                let key = self.convert_expression_to_property_key(&p.key);
+                                let binding = self
+                                    .convert_pattern_to_assignment_target_maybe_default(&p.value);
+                                let atp = self
+                                    .builder
+                                    .assignment_target_property_assignment_target_property_property(
+                                        SPAN, key, binding, p.computed,
+                                    );
+                                properties.push(atp);
+                            }
+                        }
+                        ObjectPatternProperty::RestElement(r) => {
+                            let target = self.convert_pattern_to_assignment_target(&r.argument);
+                            rest = Some(self.builder.assignment_target_rest(SPAN, target));
+                        }
+                    }
+                }
+
+                let props_vec = self.builder.vec_from_iter(properties);
+                self.builder
+                    .assignment_target_pattern_object_assignment_target(SPAN, props_vec, rest)
+                    .into()
+            }
+            PatternLike::ArrayPattern(arr) => {
+                let mut elements: Vec<Option<oxc::AssignmentTargetMaybeDefault<'a>>> = Vec::new();
+                let mut rest: Option<oxc::AssignmentTargetRest<'a>> = None;
+
+                for elem in &arr.elements {
+                    match elem {
+                        None => elements.push(None),
+                        Some(PatternLike::RestElement(r)) => {
+                            let target = self.convert_pattern_to_assignment_target(&r.argument);
+                            rest = Some(self.builder.assignment_target_rest(SPAN, target));
+                        }
+                        Some(p) => {
+                            elements.push(Some(
+                                self.convert_pattern_to_assignment_target_maybe_default(p),
+                            ));
+                        }
+                    }
+                }
+
+                let elems_vec = self.builder.vec_from_iter(elements);
+                self.builder
+                    .assignment_target_pattern_array_assignment_target(SPAN, elems_vec, rest)
+                    .into()
+            }
+            PatternLike::AssignmentPattern(ap) => {
+                // For assignment LHS, use the left side
+                self.convert_pattern_to_assignment_target(&ap.left)
+            }
+            PatternLike::RestElement(r) => self.convert_pattern_to_assignment_target(&r.argument),
+            PatternLike::TSAsExpression(e) => {
+                self.convert_ts_as_expression_to_simple_assignment_target(e).into()
+            }
+            PatternLike::TSSatisfiesExpression(e) => {
+                self.convert_ts_satisfies_expression_to_simple_assignment_target(e).into()
+            }
+            PatternLike::TSNonNullExpression(e) => {
+                self.convert_ts_non_null_expression_to_simple_assignment_target(e).into()
+            }
+            PatternLike::TSTypeAssertion(e) => {
+                self.convert_ts_type_assertion_to_simple_assignment_target(e).into()
+            }
+            PatternLike::TypeCastExpression(_) => self
+                .builder
+                .simple_assignment_target_assignment_target_identifier(
+                    SPAN,
+                    self.atom("__unknown__"),
+                )
+                .into(),
+        }
+    }
+
+    fn convert_pattern_to_assignment_target_maybe_default(
+        &self,
+        pattern: &PatternLike,
+    ) -> oxc::AssignmentTargetMaybeDefault<'a> {
+        match pattern {
+            PatternLike::AssignmentPattern(ap) => {
+                let binding = self.convert_pattern_to_assignment_target(&ap.left);
+                let init = self.convert_expression(&ap.right);
+                self.builder.assignment_target_maybe_default_assignment_target_with_default(
+                    SPAN, binding, init,
+                )
+            }
+            _ => {
+                let target = self.convert_pattern_to_assignment_target(pattern);
+                oxc::AssignmentTargetMaybeDefault::from(target)
+            }
+        }
+    }
+
+    fn convert_expression_to_simple_assignment_target(
+        &self,
+        expr: &Expression,
+    ) -> oxc::SimpleAssignmentTarget<'a> {
+        match expr {
+            Expression::Identifier(id) => self
+                .builder
+                .simple_assignment_target_assignment_target_identifier(SPAN, self.atom(&id.name)),
+            Expression::MemberExpression(m) => {
+                let object = self.convert_expression(&m.object);
+                if m.computed {
+                    let property = self.convert_expression(&m.property);
+                    let mem =
+                        self.builder.computed_member_expression(SPAN, object, property, false);
+                    oxc::SimpleAssignmentTarget::ComputedMemberExpression(self.builder.alloc(mem))
+                } else {
+                    let prop_name = self.expression_to_identifier_name(&m.property);
+                    let mem = self.builder.static_member_expression(SPAN, object, prop_name, false);
+                    oxc::SimpleAssignmentTarget::StaticMemberExpression(self.builder.alloc(mem))
+                }
+            }
+            Expression::TSAsExpression(e) => {
+                self.convert_ts_as_expression_to_simple_assignment_target(e)
+            }
+            Expression::TSSatisfiesExpression(e) => {
+                self.convert_ts_satisfies_expression_to_simple_assignment_target(e)
+            }
+            Expression::TSNonNullExpression(e) => {
+                self.convert_ts_non_null_expression_to_simple_assignment_target(e)
+            }
+            Expression::TSTypeAssertion(e) => {
+                self.convert_ts_type_assertion_to_simple_assignment_target(e)
+            }
+            _ => self.builder.simple_assignment_target_assignment_target_identifier(
+                SPAN,
+                self.atom("__unknown__"),
+            ),
+        }
+    }
+
+    fn convert_ts_as_expression_to_simple_assignment_target(
+        &self,
+        expr: &TSAsExpression,
+    ) -> oxc::SimpleAssignmentTarget<'a> {
+        let expression = self.convert_expression(&expr.expression);
+        if let Some(type_annotation) =
+            self.convert_ts_type_from_json(&expr.type_annotation).or_else(|| {
+                if Self::ts_type_json_contains_type_query(&expr.type_annotation) {
+                    None
+                } else {
+                    self.extract_source_ts_as_type(&expr.base)
+                }
+            })
+        {
+            self.builder.simple_assignment_target_ts_as_expression(
+                SPAN,
+                expression,
+                type_annotation,
+            )
+        } else {
+            self.convert_expression_to_simple_assignment_target(&expr.expression)
+        }
+    }
+
+    fn convert_ts_satisfies_expression_to_simple_assignment_target(
+        &self,
+        expr: &TSSatisfiesExpression,
+    ) -> oxc::SimpleAssignmentTarget<'a> {
+        let expression = self.convert_expression(&expr.expression);
+        if let Some(type_annotation) =
+            self.convert_ts_type_from_json(&expr.type_annotation).or_else(|| {
+                if Self::ts_type_json_contains_type_query(&expr.type_annotation) {
+                    None
+                } else {
+                    self.extract_source_ts_satisfies_type(&expr.base)
+                }
+            })
+        {
+            self.builder.simple_assignment_target_ts_satisfies_expression(
+                SPAN,
+                expression,
+                type_annotation,
+            )
+        } else {
+            self.convert_expression_to_simple_assignment_target(&expr.expression)
+        }
+    }
+
+    fn convert_ts_non_null_expression_to_simple_assignment_target(
+        &self,
+        expr: &TSNonNullExpression,
+    ) -> oxc::SimpleAssignmentTarget<'a> {
+        let expression = self.convert_expression(&expr.expression);
+        self.builder.simple_assignment_target_ts_non_null_expression(SPAN, expression)
+    }
+
+    fn convert_ts_type_assertion_to_simple_assignment_target(
+        &self,
+        expr: &TSTypeAssertion,
+    ) -> oxc::SimpleAssignmentTarget<'a> {
+        let expression = self.convert_expression(&expr.expression);
+        if let Some(type_annotation) =
+            self.convert_ts_type_from_json(&expr.type_annotation).or_else(|| {
+                if Self::ts_type_json_contains_type_query(&expr.type_annotation) {
+                    None
+                } else {
+                    self.extract_source_ts_type_assertion_type(&expr.base)
+                }
+            })
+        {
+            self.builder.simple_assignment_target_ts_type_assertion(
+                SPAN,
+                type_annotation,
+                expression,
+            )
+        } else {
+            self.convert_expression_to_simple_assignment_target(&expr.expression)
+        }
+    }
+
+    // ===== JSX =====
+
+    fn convert_jsx_element(&self, el: &JSXElement) -> oxc::JSXElement<'a> {
+        let opening = self.convert_jsx_opening_element(&el.opening_element, Some(&el.base));
+        let children =
+            self.builder.vec_from_iter(el.children.iter().map(|c| self.convert_jsx_child(c)));
+        let closing = el.closing_element.as_ref().map(|c| self.convert_jsx_closing_element(c));
+        self.builder.jsx_element(SPAN, opening, children, closing)
+    }
+
+    fn convert_jsx_opening_element(
+        &self,
+        el: &JSXOpeningElement,
+        element_base: Option<&BaseNode>,
+    ) -> oxc::JSXOpeningElement<'a> {
+        let name = self.convert_jsx_element_name(&el.name);
+        let attrs = self
+            .builder
+            .vec_from_iter(el.attributes.iter().map(|a| self.convert_jsx_attribute_item(a)));
+        let type_arguments = self
+            .extract_source_jsx_type_arguments(&el.base)
+            .or_else(|| element_base.and_then(|base| self.extract_source_jsx_type_arguments(base)));
+        self.builder.jsx_opening_element(SPAN, name, type_arguments, attrs)
+    }
+
+    fn convert_jsx_closing_element(&self, el: &JSXClosingElement) -> oxc::JSXClosingElement<'a> {
+        let name = self.convert_jsx_element_name(&el.name);
+        self.builder.jsx_closing_element(SPAN, name)
+    }
+
+    fn convert_jsx_element_name(&self, name: &JSXElementName) -> oxc::JSXElementName<'a> {
+        match name {
+            JSXElementName::JSXIdentifier(id) => {
+                let first_char = id.name.chars().next().unwrap_or('a');
+                if first_char.is_uppercase() || id.name.contains('.') {
+                    self.builder.jsx_element_name_identifier_reference(SPAN, self.atom(&id.name))
+                } else {
+                    self.builder.jsx_element_name_identifier(SPAN, self.atom(&id.name))
+                }
+            }
+            JSXElementName::JSXMemberExpression(m) => {
+                let member = self.convert_jsx_member_expression(m);
+                self.builder.jsx_element_name_member_expression(
+                    SPAN,
+                    member.object,
+                    member.property,
+                )
+            }
+            JSXElementName::JSXNamespacedName(ns) => {
+                let namespace = self.builder.jsx_identifier(SPAN, self.atom(&ns.namespace.name));
+                let name = self.builder.jsx_identifier(SPAN, self.atom(&ns.name.name));
+                self.builder.jsx_element_name_namespaced_name(SPAN, namespace, name)
+            }
+        }
+    }
+
+    fn convert_jsx_member_expression(
+        &self,
+        m: &JSXMemberExpression,
+    ) -> oxc::JSXMemberExpression<'a> {
+        let object = self.convert_jsx_member_expression_object(&m.object);
+        let property = self.builder.jsx_identifier(SPAN, self.atom(&m.property.name));
+        self.builder.jsx_member_expression(SPAN, object, property)
+    }
+
+    fn convert_jsx_member_expression_object(
+        &self,
+        obj: &JSXMemberExprObject,
+    ) -> oxc::JSXMemberExpressionObject<'a> {
+        match obj {
+            JSXMemberExprObject::JSXIdentifier(id) => self
+                .builder
+                .jsx_member_expression_object_identifier_reference(SPAN, self.atom(&id.name)),
+            JSXMemberExprObject::JSXMemberExpression(m) => {
+                let member = self.convert_jsx_member_expression(m);
+                self.builder.jsx_member_expression_object_member_expression(
+                    SPAN,
+                    member.object,
+                    member.property,
+                )
+            }
+        }
+    }
+
+    fn convert_jsx_attribute_item(&self, item: &JSXAttributeItem) -> oxc::JSXAttributeItem<'a> {
+        match item {
+            JSXAttributeItem::JSXAttribute(attr) => {
+                let name = self.convert_jsx_attribute_name(&attr.name);
+                let value = attr.value.as_ref().map(|v| self.convert_jsx_attribute_value(v));
+                self.builder.jsx_attribute_item_attribute(SPAN, name, value)
+            }
+            JSXAttributeItem::JSXSpreadAttribute(s) => self
+                .builder
+                .jsx_attribute_item_spread_attribute(SPAN, self.convert_expression(&s.argument)),
+        }
+    }
+
+    fn convert_jsx_attribute_name(&self, name: &JSXAttributeName) -> oxc::JSXAttributeName<'a> {
+        match name {
+            JSXAttributeName::JSXIdentifier(id) => {
+                self.builder.jsx_attribute_name_identifier(SPAN, self.atom(&id.name))
+            }
+            JSXAttributeName::JSXNamespacedName(ns) => {
+                let namespace = self.builder.jsx_identifier(SPAN, self.atom(&ns.namespace.name));
+                let name = self.builder.jsx_identifier(SPAN, self.atom(&ns.name.name));
+                self.builder.jsx_attribute_name_namespaced_name(SPAN, namespace, name)
+            }
+        }
+    }
+
+    fn convert_jsx_attribute_value(&self, value: &JSXAttributeValue) -> oxc::JSXAttributeValue<'a> {
+        match value {
+            JSXAttributeValue::StringLiteral(s) => {
+                self.builder.jsx_attribute_value_string_literal(SPAN, self.atom(&s.value), None)
+            }
+            JSXAttributeValue::JSXExpressionContainer(ec) => {
+                let expr = self.convert_jsx_expression_container_expr(&ec.expression);
+                self.builder.jsx_attribute_value_expression_container(SPAN, expr)
+            }
+            JSXAttributeValue::JSXElement(el) => {
+                let element = self.convert_jsx_element(el);
+                let opening = element.opening_element;
+                let closing = element.closing_element;
+                self.builder.jsx_attribute_value_element(SPAN, opening, element.children, closing)
+            }
+            JSXAttributeValue::JSXFragment(frag) => {
+                let fragment = self.convert_jsx_fragment(frag);
+                self.builder.jsx_attribute_value_fragment(
+                    SPAN,
+                    fragment.opening_fragment,
+                    fragment.children,
+                    fragment.closing_fragment,
+                )
+            }
+        }
+    }
+
+    fn convert_jsx_expression_container_expr(
+        &self,
+        expr: &JSXExpressionContainerExpr,
+    ) -> oxc::JSXExpression<'a> {
+        match expr {
+            JSXExpressionContainerExpr::JSXEmptyExpression(_) => {
+                self.builder.jsx_expression_empty_expression(SPAN)
+            }
+            JSXExpressionContainerExpr::Expression(e) => {
+                oxc::JSXExpression::from(self.convert_expression(e))
+            }
+        }
+    }
+
+    fn convert_jsx_child(&self, child: &JSXChild) -> oxc::JSXChild<'a> {
+        match child {
+            JSXChild::JSXText(t) => {
+                let value = encode_jsx_text(&t.value);
+                self.builder.jsx_child_text(SPAN, self.atom(&value), None)
+            }
+            JSXChild::JSXElement(el) => {
+                let element = self.convert_jsx_element(el);
+                let opening = element.opening_element;
+                let closing = element.closing_element;
+                self.builder.jsx_child_element(SPAN, opening, element.children, closing)
+            }
+            JSXChild::JSXFragment(frag) => {
+                let fragment = self.convert_jsx_fragment(frag);
+                self.builder.jsx_child_fragment(
+                    SPAN,
+                    fragment.opening_fragment,
+                    fragment.children,
+                    fragment.closing_fragment,
+                )
+            }
+            JSXChild::JSXExpressionContainer(ec) => {
+                let expr = self.convert_jsx_expression_container_expr(&ec.expression);
+                self.builder.jsx_child_expression_container(SPAN, expr)
+            }
+            JSXChild::JSXSpreadChild(s) => {
+                self.builder.jsx_child_spread(SPAN, self.convert_expression(&s.expression))
+            }
+        }
+    }
+
+    fn convert_jsx_fragment(&self, frag: &JSXFragment) -> oxc::JSXFragment<'a> {
+        let opening = self.builder.jsx_opening_fragment(SPAN);
+        let closing = self.builder.jsx_closing_fragment(SPAN);
+        let children =
+            self.builder.vec_from_iter(frag.children.iter().map(|c| self.convert_jsx_child(c)));
+        self.builder.jsx_fragment(SPAN, opening, children, closing)
+    }
+
+    // ===== Import/Export =====
+
+    fn convert_import_declaration(&self, decl: &ImportDeclaration) -> oxc::ImportDeclaration<'a> {
+        let specifiers = self
+            .builder
+            .vec_from_iter(decl.specifiers.iter().map(|s| self.convert_import_specifier(s)));
+        let specifiers =
+            if specifiers.is_empty() && !self.import_declaration_has_empty_named_specifiers(decl) {
+                None
+            } else {
+                Some(specifiers)
+            };
+        let source = self.builder.string_literal(SPAN, self.atom(&decl.source.value), None);
+        let import_kind = match decl.import_kind.as_ref() {
+            Some(ImportKind::Type) => oxc::ImportOrExportKind::Type,
+            _ => oxc::ImportOrExportKind::Value,
+        };
+        let with_clause =
+            self.convert_with_clause(decl.attributes.as_deref().or(decl.assertions.as_deref()));
+        self.builder.import_declaration(
+            SPAN,
+            specifiers,
+            source,
+            None, // phase
+            with_clause,
+            import_kind,
+        )
+    }
+
+    fn convert_with_clause(
+        &self,
+        attributes: Option<&[ImportAttribute]>,
+    ) -> Option<oxc_allocator::Box<'a, oxc::WithClause<'a>>> {
+        attributes.map(|attributes| {
+            let with_entries = self
+                .builder
+                .vec_from_iter(attributes.iter().map(|attr| self.convert_import_attribute(attr)));
+            self.builder.alloc_with_clause(SPAN, oxc::WithClauseKeyword::With, with_entries)
+        })
+    }
+
+    fn convert_import_attribute(&self, attr: &ImportAttribute) -> oxc::ImportAttribute<'a> {
+        let key_was_quoted = self
+            .source_text_for_base(&attr.key.base)
+            .is_some_and(|text| matches!(text.trim_start().as_bytes().first(), Some(b'"' | b'\'')));
+        let key = if key_was_quoted || !is_identifier_name(&attr.key.name) {
+            self.builder.import_attribute_key_string_literal(SPAN, self.atom(&attr.key.name), None)
+        } else {
+            self.builder.import_attribute_key_identifier(SPAN, self.atom(&attr.key.name))
+        };
+        let value = self.builder.string_literal(SPAN, self.atom(&attr.value.value), None);
+        self.builder.import_attribute(SPAN, key, value)
+    }
+
+    fn convert_import_specifier(
+        &self,
+        spec: &react_compiler_ast::declarations::ImportSpecifier,
+    ) -> oxc::ImportDeclarationSpecifier<'a> {
+        match spec {
+            react_compiler_ast::declarations::ImportSpecifier::ImportSpecifier(s) => {
+                let local = self.builder.binding_identifier(SPAN, self.atom(&s.local.name));
+                let imported = self.convert_module_export_name(&s.imported);
+                let import_kind = match s.import_kind.as_ref() {
+                    Some(ImportKind::Type) => oxc::ImportOrExportKind::Type,
+                    _ => oxc::ImportOrExportKind::Value,
+                };
+                let is = self.builder.import_specifier(SPAN, imported, local, import_kind);
+                oxc::ImportDeclarationSpecifier::ImportSpecifier(self.builder.alloc(is))
+            }
+            react_compiler_ast::declarations::ImportSpecifier::ImportDefaultSpecifier(s) => {
+                let local = self.builder.binding_identifier(SPAN, self.atom(&s.local.name));
+                let ids = self.builder.import_default_specifier(SPAN, local);
+                oxc::ImportDeclarationSpecifier::ImportDefaultSpecifier(self.builder.alloc(ids))
+            }
+            react_compiler_ast::declarations::ImportSpecifier::ImportNamespaceSpecifier(s) => {
+                let local = self.builder.binding_identifier(SPAN, self.atom(&s.local.name));
+                let ins = self.builder.import_namespace_specifier(SPAN, local);
+                oxc::ImportDeclarationSpecifier::ImportNamespaceSpecifier(self.builder.alloc(ins))
+            }
+        }
+    }
+
+    fn convert_module_export_name(
+        &self,
+        name: &react_compiler_ast::declarations::ModuleExportName,
+    ) -> oxc::ModuleExportName<'a> {
+        match name {
+            react_compiler_ast::declarations::ModuleExportName::Identifier(id) => {
+                oxc::ModuleExportName::IdentifierName(
+                    self.builder.identifier_name(SPAN, self.atom(&id.name)),
+                )
+            }
+            react_compiler_ast::declarations::ModuleExportName::StringLiteral(s) => {
+                oxc::ModuleExportName::StringLiteral(self.builder.string_literal(
+                    SPAN,
+                    self.atom(&s.value),
+                    None,
+                ))
+            }
+        }
+    }
+
+    fn convert_export_named_declaration(
+        &self,
+        decl: &ExportNamedDeclaration,
+    ) -> oxc::ExportNamedDeclaration<'a> {
+        let declaration = decl.declaration.as_ref().map(|d| self.convert_declaration(d));
+        let specifiers = self
+            .builder
+            .vec_from_iter(decl.specifiers.iter().map(|s| self.convert_export_specifier(s)));
+        let source = decl
+            .source
+            .as_ref()
+            .map(|s| self.builder.string_literal(SPAN, self.atom(&s.value), None));
+        let export_kind = match decl.export_kind.as_ref() {
+            Some(ExportKind::Type) => oxc::ImportOrExportKind::Type,
+            _ => oxc::ImportOrExportKind::Value,
+        };
+        let with_clause =
+            self.convert_with_clause(decl.attributes.as_deref().or(decl.assertions.as_deref()));
+        self.builder.export_named_declaration(
+            SPAN,
+            declaration,
+            specifiers,
+            source,
+            export_kind,
+            with_clause,
+        )
+    }
+
+    fn convert_declaration(&self, decl: &Declaration) -> oxc::Declaration<'a> {
+        match decl {
+            Declaration::FunctionDeclaration(f) => {
+                let func = self.convert_function_decl(f, oxc::FunctionType::FunctionDeclaration);
+                oxc::Declaration::FunctionDeclaration(self.builder.alloc(func))
+            }
+            Declaration::VariableDeclaration(v) => {
+                let d = self.convert_variable_declaration(v);
+                oxc::Declaration::VariableDeclaration(self.builder.alloc(d))
+            }
+            Declaration::ClassDeclaration(c) => {
+                let class = self.convert_class_declaration(c);
+                oxc::Declaration::ClassDeclaration(self.builder.alloc(class))
+            }
+            _ => {
+                let d = self.builder.variable_declaration(
+                    SPAN,
+                    oxc::VariableDeclarationKind::Const,
+                    self.builder.vec(),
+                    true,
+                );
+                oxc::Declaration::VariableDeclaration(self.builder.alloc(d))
+            }
+        }
+    }
+
+    fn convert_export_specifier(
+        &self,
+        spec: &react_compiler_ast::declarations::ExportSpecifier,
+    ) -> oxc::ExportSpecifier<'a> {
+        match spec {
+            react_compiler_ast::declarations::ExportSpecifier::ExportSpecifier(s) => {
+                let local = self.convert_module_export_name(&s.local);
+                let exported = self.convert_module_export_name(&s.exported);
+                let export_kind = match s.export_kind.as_ref() {
+                    Some(ExportKind::Type) => oxc::ImportOrExportKind::Type,
+                    _ => oxc::ImportOrExportKind::Value,
+                };
+                self.builder.export_specifier(SPAN, local, exported, export_kind)
+            }
+            react_compiler_ast::declarations::ExportSpecifier::ExportDefaultSpecifier(s) => {
+                let name = oxc::ModuleExportName::IdentifierName(
+                    self.builder.identifier_name(SPAN, self.atom(&s.exported.name)),
+                );
+                let default_name = oxc::ModuleExportName::IdentifierName(
+                    self.builder.identifier_name(SPAN, self.atom("default")),
+                );
+                self.builder.export_specifier(
+                    SPAN,
+                    name,
+                    default_name,
+                    oxc::ImportOrExportKind::Value,
+                )
+            }
+            react_compiler_ast::declarations::ExportSpecifier::ExportNamespaceSpecifier(s) => {
+                let exported = self.convert_module_export_name(&s.exported);
+                let star = oxc::ModuleExportName::IdentifierName(
+                    self.builder.identifier_name(SPAN, self.atom("*")),
+                );
+                self.builder.export_specifier(SPAN, star, exported, oxc::ImportOrExportKind::Value)
+            }
+        }
+    }
+
+    fn convert_export_default_declaration(
+        &self,
+        decl: &ExportDefaultDeclaration,
+    ) -> oxc::ExportDefaultDeclaration<'a> {
+        let declaration = self.convert_export_default_decl(&decl.declaration);
+        self.builder.export_default_declaration(SPAN, declaration)
+    }
+
+    fn convert_export_default_decl(
+        &self,
+        decl: &ExportDefaultDecl,
+    ) -> oxc::ExportDefaultDeclarationKind<'a> {
+        match decl {
+            ExportDefaultDecl::FunctionDeclaration(f) => {
+                let func = self.convert_function_decl(f, oxc::FunctionType::FunctionDeclaration);
+                oxc::ExportDefaultDeclarationKind::FunctionDeclaration(self.builder.alloc(func))
+            }
+            ExportDefaultDecl::ClassDeclaration(c) => {
+                let class = self.convert_class_declaration(c);
+                oxc::ExportDefaultDeclarationKind::ClassDeclaration(self.builder.alloc(class))
+            }
+            ExportDefaultDecl::EnumDeclaration(_) => {
+                // Flow enum declarations cannot be represented in OXC AST;
+                // emit a null placeholder to preserve the export shape.
+                oxc::ExportDefaultDeclarationKind::from(
+                    self.builder.expression_null_literal(oxc::Span::default()),
+                )
+            }
+            ExportDefaultDecl::Expression(e) => {
+                oxc::ExportDefaultDeclarationKind::from(self.convert_expression(e))
+            }
+        }
+    }
+
+    fn convert_export_all_declaration(
+        &self,
+        decl: &ExportAllDeclaration,
+    ) -> oxc::ExportAllDeclaration<'a> {
+        let source = self.builder.string_literal(SPAN, self.atom(&decl.source.value), None);
+        let export_kind = match decl.export_kind.as_ref() {
+            Some(ExportKind::Type) => oxc::ImportOrExportKind::Type,
+            _ => oxc::ImportOrExportKind::Value,
+        };
+        let with_clause =
+            self.convert_with_clause(decl.attributes.as_deref().or(decl.assertions.as_deref()));
+        self.builder.export_all_declaration(
+            SPAN,
+            None, // exported
+            source,
+            with_clause,
+            export_kind,
+        )
+    }
+
+    // ===== Operators =====
+
+    fn convert_binary_operator(&self, op: &BinaryOperator) -> oxc_syntax::operator::BinaryOperator {
+        use oxc_syntax::operator::BinaryOperator as OxcBinOp;
+        match op {
+            BinaryOperator::Add => OxcBinOp::Addition,
+            BinaryOperator::Sub => OxcBinOp::Subtraction,
+            BinaryOperator::Mul => OxcBinOp::Multiplication,
+            BinaryOperator::Div => OxcBinOp::Division,
+            BinaryOperator::Rem => OxcBinOp::Remainder,
+            BinaryOperator::Exp => OxcBinOp::Exponential,
+            BinaryOperator::Eq => OxcBinOp::Equality,
+            BinaryOperator::StrictEq => OxcBinOp::StrictEquality,
+            BinaryOperator::Neq => OxcBinOp::Inequality,
+            BinaryOperator::StrictNeq => OxcBinOp::StrictInequality,
+            BinaryOperator::Lt => OxcBinOp::LessThan,
+            BinaryOperator::Lte => OxcBinOp::LessEqualThan,
+            BinaryOperator::Gt => OxcBinOp::GreaterThan,
+            BinaryOperator::Gte => OxcBinOp::GreaterEqualThan,
+            BinaryOperator::Shl => OxcBinOp::ShiftLeft,
+            BinaryOperator::Shr => OxcBinOp::ShiftRight,
+            BinaryOperator::UShr => OxcBinOp::ShiftRightZeroFill,
+            BinaryOperator::BitOr => OxcBinOp::BitwiseOR,
+            BinaryOperator::BitXor => OxcBinOp::BitwiseXOR,
+            BinaryOperator::BitAnd => OxcBinOp::BitwiseAnd,
+            BinaryOperator::In => OxcBinOp::In,
+            BinaryOperator::Instanceof => OxcBinOp::Instanceof,
+            BinaryOperator::Pipeline => OxcBinOp::BitwiseOR, // no pipeline in OXC
+        }
+    }
+
+    fn convert_logical_operator(
+        &self,
+        op: &LogicalOperator,
+    ) -> oxc_syntax::operator::LogicalOperator {
+        use oxc_syntax::operator::LogicalOperator as OxcLogOp;
+        match op {
+            LogicalOperator::Or => OxcLogOp::Or,
+            LogicalOperator::And => OxcLogOp::And,
+            LogicalOperator::NullishCoalescing => OxcLogOp::Coalesce,
+        }
+    }
+
+    fn convert_unary_operator(&self, op: &UnaryOperator) -> oxc_syntax::operator::UnaryOperator {
+        use oxc_syntax::operator::UnaryOperator as OxcUnOp;
+        match op {
+            UnaryOperator::Neg => OxcUnOp::UnaryNegation,
+            UnaryOperator::Plus => OxcUnOp::UnaryPlus,
+            UnaryOperator::Not => OxcUnOp::LogicalNot,
+            UnaryOperator::BitNot => OxcUnOp::BitwiseNot,
+            UnaryOperator::TypeOf => OxcUnOp::Typeof,
+            UnaryOperator::Void => OxcUnOp::Void,
+            UnaryOperator::Delete => OxcUnOp::Delete,
+            UnaryOperator::Throw => OxcUnOp::Void, // no throw-as-unary in OXC
+        }
+    }
+
+    fn convert_update_operator(&self, op: &UpdateOperator) -> oxc_syntax::operator::UpdateOperator {
+        use oxc_syntax::operator::UpdateOperator as OxcUpOp;
+        match op {
+            UpdateOperator::Increment => OxcUpOp::Increment,
+            UpdateOperator::Decrement => OxcUpOp::Decrement,
+        }
+    }
+
+    fn convert_assignment_operator(
+        &self,
+        op: &AssignmentOperator,
+    ) -> oxc_syntax::operator::AssignmentOperator {
+        use oxc_syntax::operator::AssignmentOperator as OxcAssOp;
+        match op {
+            AssignmentOperator::Assign => OxcAssOp::Assign,
+            AssignmentOperator::AddAssign => OxcAssOp::Addition,
+            AssignmentOperator::SubAssign => OxcAssOp::Subtraction,
+            AssignmentOperator::MulAssign => OxcAssOp::Multiplication,
+            AssignmentOperator::DivAssign => OxcAssOp::Division,
+            AssignmentOperator::RemAssign => OxcAssOp::Remainder,
+            AssignmentOperator::ExpAssign => OxcAssOp::Exponential,
+            AssignmentOperator::ShlAssign => OxcAssOp::ShiftLeft,
+            AssignmentOperator::ShrAssign => OxcAssOp::ShiftRight,
+            AssignmentOperator::UShrAssign => OxcAssOp::ShiftRightZeroFill,
+            AssignmentOperator::BitOrAssign => OxcAssOp::BitwiseOR,
+            AssignmentOperator::BitXorAssign => OxcAssOp::BitwiseXOR,
+            AssignmentOperator::BitAndAssign => OxcAssOp::BitwiseAnd,
+            AssignmentOperator::OrAssign => OxcAssOp::LogicalOr,
+            AssignmentOperator::AndAssign => OxcAssOp::LogicalAnd,
+            AssignmentOperator::NullishAssign => OxcAssOp::LogicalNullish,
+        }
+    }
+
+    fn parse_regexp_flags(&self, flags_str: &str) -> oxc::RegExpFlags {
+        let mut flags = oxc::RegExpFlags::empty();
+        for ch in flags_str.chars() {
+            match ch {
+                'd' => flags |= oxc::RegExpFlags::D,
+                'g' => flags |= oxc::RegExpFlags::G,
+                'i' => flags |= oxc::RegExpFlags::I,
+                'm' => flags |= oxc::RegExpFlags::M,
+                's' => flags |= oxc::RegExpFlags::S,
+                'u' => flags |= oxc::RegExpFlags::U,
+                'v' => flags |= oxc::RegExpFlags::V,
+                'y' => flags |= oxc::RegExpFlags::Y,
+                _ => {}
+            }
+        }
+        flags
+    }
+}

--- a/crates/oxc_react_compiler/src/convert_scope.rs
+++ b/crates/oxc_react_compiler/src/convert_scope.rs
@@ -1,0 +1,519 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use std::collections::HashMap;
+
+use indexmap::IndexMap;
+use oxc_ast::AstKind;
+use oxc_ast::ast::Program;
+use oxc_semantic::Semantic;
+use oxc_span::GetSpan;
+use oxc_syntax::symbol::SymbolFlags;
+use react_compiler_ast::scope::*;
+use rustc_hash::FxHashMap;
+
+/// Convert OXC's semantic analysis into React Compiler's ScopeInfo.
+pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo {
+    let scoping = semantic.scoping();
+    let nodes = semantic.nodes();
+
+    let mut scopes: Vec<ScopeData> = Vec::new();
+    let mut bindings: Vec<BindingData> = Vec::new();
+    let mut node_to_scope: HashMap<u32, ScopeId> = HashMap::new();
+    let mut node_to_scope_end: HashMap<u32, u32> = HashMap::new();
+    // In OXC, span.start is used as node_id (OXC spans are unique).
+    let mut node_id_to_scope: HashMap<u32, ScopeId> = HashMap::new();
+    let mut ref_node_id_to_binding: IndexMap<u32, BindingId> = IndexMap::new();
+
+    let mut symbol_to_binding: FxHashMap<oxc_syntax::symbol::SymbolId, BindingId> =
+        FxHashMap::default();
+
+    // First pass: Create all bindings from symbols
+    for symbol_id in scoping.symbol_ids() {
+        let symbol_flags = scoping.symbol_flags(symbol_id);
+        let name = scoping.symbol_name(symbol_id).to_string();
+
+        let kind = get_binding_kind(symbol_flags, semantic, symbol_id);
+
+        let (declaration_type, declaration_start) =
+            get_declaration_info(semantic, symbol_id, &name);
+
+        let import = if matches!(kind, BindingKind::Module) {
+            get_import_data(semantic, symbol_id)
+        } else {
+            None
+        };
+
+        let binding_id = BindingId(bindings.len() as u32);
+        symbol_to_binding.insert(symbol_id, binding_id);
+
+        bindings.push(BindingData {
+            id: binding_id,
+            name,
+            kind,
+            scope: ScopeId(0), // Placeholder, filled in second pass
+            declaration_type,
+            declaration_start,
+            declaration_node_id: declaration_start,
+            import,
+        });
+    }
+
+    // Second pass: Create all scopes and update binding scope references
+    for scope_id in scoping.scope_descendants_from_root() {
+        let scope_flags = scoping.scope_flags(scope_id);
+        let parent = scoping.scope_parent_id(scope_id);
+
+        let our_scope_id = ScopeId(scope_id.index() as u32);
+
+        let kind = get_scope_kind(scope_flags, semantic, scope_id);
+
+        let mut scope_bindings: HashMap<String, BindingId> = HashMap::new();
+        for symbol_id in scoping.iter_bindings_in(scope_id) {
+            if let Some(&binding_id) = symbol_to_binding.get(&symbol_id) {
+                let name = bindings[binding_id.0 as usize].name.clone();
+                scope_bindings.insert(name, binding_id);
+                bindings[binding_id.0 as usize].scope = our_scope_id;
+            }
+        }
+
+        let node_id = scoping.get_node_id(scope_id);
+        let node = nodes.get_node(node_id);
+        let span = node.kind().span();
+        let start = span.start;
+        let end = span.end;
+        // For function scopes inside object methods, also map the parent
+        // ObjectProperty start so the compiler can look up the scope using the
+        // ObjectMethod's start position (which matches the property start in Babel).
+        if matches!(kind, ScopeKind::Function) {
+            if let AstKind::Function(_) = node.kind() {
+                let parent_node_id = nodes.parent_id(node_id);
+                let parent_node = nodes.get_node(parent_node_id);
+                match parent_node.kind() {
+                    AstKind::ObjectProperty(prop)
+                        if prop.method
+                            || matches!(
+                                prop.kind,
+                                oxc_ast::ast::PropertyKind::Get | oxc_ast::ast::PropertyKind::Set
+                            ) =>
+                    {
+                        let prop_start = parent_node.kind().span().start;
+                        if prop_start != start {
+                            node_to_scope.insert(prop_start, our_scope_id);
+                            node_to_scope_end.insert(prop_start, end);
+                            node_id_to_scope.insert(prop_start, our_scope_id);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        if end > start {
+            node_to_scope.insert(start, our_scope_id);
+            node_to_scope_end.insert(start, end);
+        } else {
+            node_to_scope.insert(start, our_scope_id);
+        }
+        node_id_to_scope.insert(start, our_scope_id);
+
+        scopes.push(ScopeData {
+            id: our_scope_id,
+            parent: parent.map(|p| ScopeId(p.index() as u32)),
+            kind,
+            bindings: scope_bindings,
+        });
+    }
+
+    // Third pass: Map all resolved references to bindings
+    for symbol_id in scoping.symbol_ids() {
+        if let Some(&binding_id) = symbol_to_binding.get(&symbol_id) {
+            for &ref_id in scoping.get_resolved_reference_ids(symbol_id) {
+                let reference = scoping.get_reference(ref_id);
+                let ref_node = nodes.get_node(reference.node_id());
+                let start = ref_node.kind().span().start;
+                ref_node_id_to_binding.insert(start, binding_id);
+            }
+        }
+    }
+
+    // Also map declaration identifiers to their bindings
+    for symbol_id in scoping.symbol_ids() {
+        if let Some(&binding_id) = symbol_to_binding.get(&symbol_id) {
+            if let Some(start) = bindings[binding_id.0 as usize].declaration_start {
+                ref_node_id_to_binding.entry(start).or_insert(binding_id);
+            }
+        }
+    }
+
+    // Map `export default function Foo` — Babel treats the ExportDefaultDeclaration
+    // as a reference to the function's binding. OXC doesn't create a reference for
+    // the export itself, so we add one at the export statement's start position.
+    for stmt in &_program.body {
+        if let oxc_ast::ast::Statement::ExportDefaultDeclaration(export) = stmt {
+            if let oxc_ast::ast::ExportDefaultDeclarationKind::FunctionDeclaration(func) =
+                &export.declaration
+            {
+                if let Some(id) = &func.id {
+                    let name = id.name.as_str();
+                    if let Some(symbol_id) = id.symbol_id.get() {
+                        if let Some(&binding_id) = symbol_to_binding.get(&symbol_id) {
+                            let export_start = export.span().start;
+                            ref_node_id_to_binding.entry(export_start).or_insert(binding_id);
+                        }
+                    } else {
+                        // Fallback: look up binding by name
+                        for (sym_id, &bind_id) in &symbol_to_binding {
+                            if scoping.symbol_name(*sym_id) == name {
+                                let export_start = export.span().start;
+                                ref_node_id_to_binding.entry(export_start).or_insert(bind_id);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Map `export default function Foo` — Babel treats the ExportDefaultDeclaration
+    // as a reference to the function's binding. OXC doesn't create a reference for
+    // the export itself, so we add one at the export statement's start position.
+    for stmt in &_program.body {
+        if let oxc_ast::ast::Statement::ExportDefaultDeclaration(export) = stmt {
+            if let oxc_ast::ast::ExportDefaultDeclarationKind::FunctionDeclaration(func) =
+                &export.declaration
+            {
+                if let Some(id) = &func.id {
+                    let name = id.name.as_str();
+                    if let Some(symbol_id) = id.symbol_id.get() {
+                        if let Some(&binding_id) = symbol_to_binding.get(&symbol_id) {
+                            ref_node_id_to_binding.entry(export.span().start).or_insert(binding_id);
+                        }
+                    } else {
+                        // Fallback: look up binding by name
+                        for (sym_id, &bind_id) in &symbol_to_binding {
+                            if scoping.symbol_name(*sym_id) == name {
+                                ref_node_id_to_binding
+                                    .entry(export.span().start)
+                                    .or_insert(bind_id);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let program_scope = ScopeId(scoping.root_scope_id().index() as u32);
+
+    ScopeInfo {
+        scopes,
+        bindings,
+        node_to_scope,
+        node_to_scope_end,
+        reference_to_binding: IndexMap::new(),
+        ref_node_id_to_binding,
+        node_id_to_scope,
+        program_scope,
+    }
+}
+
+/// Map OXC ScopeFlags to our ScopeKind.
+fn get_scope_kind(
+    flags: oxc_syntax::scope::ScopeFlags,
+    semantic: &Semantic,
+    scope_id: oxc_syntax::scope::ScopeId,
+) -> ScopeKind {
+    if flags.contains(oxc_syntax::scope::ScopeFlags::Top) {
+        return ScopeKind::Program;
+    }
+
+    if flags.intersects(oxc_syntax::scope::ScopeFlags::Function) {
+        return ScopeKind::Function;
+    }
+
+    if flags.contains(oxc_syntax::scope::ScopeFlags::CatchClause) {
+        return ScopeKind::Catch;
+    }
+
+    if flags.contains(oxc_syntax::scope::ScopeFlags::ClassStaticBlock) {
+        return ScopeKind::Class;
+    }
+
+    // Check the AST node to determine if it's a for loop, class, or switch
+    let node_id = semantic.scoping().get_node_id(scope_id);
+    let node = semantic.nodes().get_node(node_id);
+    match node.kind() {
+        AstKind::ForStatement(_) | AstKind::ForInStatement(_) | AstKind::ForOfStatement(_) => {
+            ScopeKind::For
+        }
+        AstKind::Class(_) => ScopeKind::Class,
+        AstKind::SwitchStatement(_) => ScopeKind::Switch,
+        _ => ScopeKind::Block,
+    }
+}
+
+/// Map OXC SymbolFlags to our BindingKind.
+fn get_binding_kind(
+    flags: SymbolFlags,
+    semantic: &Semantic,
+    symbol_id: oxc_syntax::symbol::SymbolId,
+) -> BindingKind {
+    if flags.contains(SymbolFlags::Import) {
+        return BindingKind::Module;
+    }
+
+    // Check the declaration node first — FormalParameter and CatchParameter
+    // need to be detected before the FunctionScopedVariable flag check, because
+    // OXC marks function parameters and catch parameters with FunctionScopedVariable.
+    let decl_node = semantic.symbol_declaration(symbol_id);
+    match decl_node.kind() {
+        AstKind::FormalParameter(_) => return BindingKind::Param,
+        AstKind::FormalParameterRest(_) => return BindingKind::Param,
+        AstKind::CatchParameter(_) => return BindingKind::Let,
+        AstKind::TSTypeAliasDeclaration(_) => return BindingKind::Local,
+        AstKind::TSEnumDeclaration(_) => return BindingKind::Local,
+        AstKind::TSModuleDeclaration(_) => return BindingKind::Local,
+        AstKind::Function(_) => {
+            if flags.contains(SymbolFlags::Function) {
+                return BindingKind::Hoisted;
+            }
+            return BindingKind::Local;
+        }
+        AstKind::Class(_) => return BindingKind::Local,
+        _ => {}
+    }
+
+    if flags.contains(SymbolFlags::FunctionScopedVariable) {
+        return BindingKind::Var;
+    }
+
+    if flags.contains(SymbolFlags::BlockScopedVariable) {
+        if flags.contains(SymbolFlags::ConstVariable) {
+            return BindingKind::Const;
+        } else {
+            return BindingKind::Let;
+        }
+    }
+
+    if flags.contains(SymbolFlags::Function) {
+        BindingKind::Hoisted
+    } else if flags.contains(SymbolFlags::Class) {
+        BindingKind::Local
+    } else {
+        BindingKind::Unknown
+    }
+}
+
+/// Get the declaration type string and start position for a binding.
+fn get_declaration_info(
+    semantic: &Semantic,
+    symbol_id: oxc_syntax::symbol::SymbolId,
+    name: &str,
+) -> (String, Option<u32>) {
+    let decl_node = semantic.symbol_declaration(symbol_id);
+    let declaration_type = ast_kind_to_string(decl_node.kind());
+    let declaration_start = find_binding_identifier_start(decl_node.kind(), name);
+    (declaration_type, declaration_start)
+}
+
+/// Convert an AstKind to its Babel-equivalent string representation.
+fn ast_kind_to_string(kind: AstKind) -> String {
+    match kind {
+        AstKind::BindingIdentifier(_) => "BindingIdentifier",
+        AstKind::VariableDeclarator(_) => "VariableDeclarator",
+        AstKind::Function(f) => {
+            if f.is_declaration() {
+                "FunctionDeclaration"
+            } else {
+                "FunctionExpression"
+            }
+        }
+        AstKind::Class(c) => {
+            if c.is_declaration() {
+                "ClassDeclaration"
+            } else {
+                "ClassExpression"
+            }
+        }
+        AstKind::FormalParameter(_) => "FormalParameter",
+        AstKind::FormalParameterRest(_) => "FormalParameter",
+        AstKind::ImportSpecifier(_) => "ImportSpecifier",
+        AstKind::ImportDefaultSpecifier(_) => "ImportDefaultSpecifier",
+        AstKind::ImportNamespaceSpecifier(_) => "ImportNamespaceSpecifier",
+        AstKind::CatchClause(_) => "CatchClause",
+        AstKind::CatchParameter(_) => "CatchClause",
+        AstKind::TSTypeAliasDeclaration(_) => "TSTypeAliasDeclaration",
+        AstKind::TSEnumDeclaration(_) => "TSEnumDeclaration",
+        AstKind::TSModuleDeclaration(_) => "TSModuleDeclaration",
+        _ => "Unknown",
+    }
+    .to_string()
+}
+
+/// Find the binding identifier's start position within an AST node.
+fn find_binding_identifier_start(kind: AstKind, name: &str) -> Option<u32> {
+    match kind {
+        AstKind::BindingIdentifier(ident) => {
+            if ident.name.as_str() == name {
+                Some(ident.span.start)
+            } else {
+                None
+            }
+        }
+        AstKind::VariableDeclarator(decl) => find_identifier_in_pattern(&decl.id, name),
+        AstKind::Function(func) => func
+            .id
+            .as_ref()
+            .and_then(|id| if id.name.as_str() == name { Some(id.span.start) } else { None }),
+        AstKind::Class(class) => class
+            .id
+            .as_ref()
+            .and_then(|id| if id.name.as_str() == name { Some(id.span.start) } else { None }),
+        AstKind::FormalParameter(param) => find_identifier_in_pattern(&param.pattern, name),
+        AstKind::FormalParameterRest(rest) => find_identifier_in_pattern(&rest.rest.argument, name),
+        AstKind::ImportSpecifier(spec) => Some(spec.local.span.start),
+        AstKind::ImportDefaultSpecifier(spec) => Some(spec.local.span.start),
+        AstKind::ImportNamespaceSpecifier(spec) => Some(spec.local.span.start),
+        AstKind::CatchClause(catch) => {
+            catch.param.as_ref().and_then(|p| find_identifier_in_pattern(&p.pattern, name))
+        }
+        AstKind::CatchParameter(param) => find_identifier_in_pattern(&param.pattern, name),
+        AstKind::TSTypeAliasDeclaration(decl) => {
+            if decl.id.name.as_str() == name {
+                Some(decl.id.span.start)
+            } else {
+                None
+            }
+        }
+        AstKind::TSEnumDeclaration(decl) => {
+            if decl.id.name.as_str() == name {
+                Some(decl.id.span.start)
+            } else {
+                None
+            }
+        }
+        AstKind::TSModuleDeclaration(decl) => {
+            match &decl.id {
+                oxc_ast::ast::TSModuleDeclarationName::Identifier(id) => {
+                    if id.name.as_str() == name { Some(id.span.start) } else { None }
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Recursively find a binding identifier within a binding pattern.
+fn find_identifier_in_pattern(pattern: &oxc_ast::ast::BindingPattern, name: &str) -> Option<u32> {
+    use oxc_ast::ast::BindingPattern;
+
+    match pattern {
+        BindingPattern::BindingIdentifier(ident) => {
+            if ident.name.as_str() == name {
+                Some(ident.span.start)
+            } else {
+                None
+            }
+        }
+        BindingPattern::ObjectPattern(obj) => {
+            for prop in &obj.properties {
+                if let Some(start) = find_identifier_in_pattern(&prop.value, name) {
+                    return Some(start);
+                }
+            }
+            if let Some(rest) = &obj.rest {
+                if let Some(start) = find_identifier_in_pattern(&rest.argument, name) {
+                    return Some(start);
+                }
+            }
+            None
+        }
+        BindingPattern::ArrayPattern(arr) => {
+            for element in arr.elements.iter().flatten() {
+                if let Some(start) = find_identifier_in_pattern(element, name) {
+                    return Some(start);
+                }
+            }
+            if let Some(rest) = &arr.rest {
+                if let Some(start) = find_identifier_in_pattern(&rest.argument, name) {
+                    return Some(start);
+                }
+            }
+            None
+        }
+        BindingPattern::AssignmentPattern(assign) => find_identifier_in_pattern(&assign.left, name),
+    }
+}
+
+/// Extract import data for a module binding.
+fn get_import_data(
+    semantic: &Semantic,
+    symbol_id: oxc_syntax::symbol::SymbolId,
+) -> Option<ImportBindingData> {
+    let decl_node = semantic.symbol_declaration(symbol_id);
+
+    match decl_node.kind() {
+        AstKind::ImportDefaultSpecifier(_) => {
+            let import_decl = find_import_declaration(semantic, decl_node.id())?;
+            Some(ImportBindingData {
+                source: import_decl.source.value.to_string(),
+                kind: ImportBindingKind::Default,
+                imported: None,
+            })
+        }
+        AstKind::ImportNamespaceSpecifier(_) => {
+            let import_decl = find_import_declaration(semantic, decl_node.id())?;
+            Some(ImportBindingData {
+                source: import_decl.source.value.to_string(),
+                kind: ImportBindingKind::Namespace,
+                imported: None,
+            })
+        }
+        AstKind::ImportSpecifier(spec) => {
+            let import_decl = find_import_declaration(semantic, decl_node.id())?;
+            let imported_name = match &spec.imported {
+                oxc_ast::ast::ModuleExportName::IdentifierName(ident) => ident.name.to_string(),
+                oxc_ast::ast::ModuleExportName::IdentifierReference(ident) => {
+                    ident.name.to_string()
+                }
+                oxc_ast::ast::ModuleExportName::StringLiteral(lit) => lit.value.to_string(),
+            };
+            Some(ImportBindingData {
+                source: import_decl.source.value.to_string(),
+                kind: ImportBindingKind::Named,
+                imported: Some(imported_name),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Find the ImportDeclaration node that contains the given import specifier.
+fn find_import_declaration<'a>(
+    semantic: &'a Semantic,
+    specifier_node_id: oxc_semantic::NodeId,
+) -> Option<&'a oxc_ast::ast::ImportDeclaration<'a>> {
+    let mut current_id = specifier_node_id;
+    // Walk up the parent chain (max 10 levels to avoid infinite loop)
+    for _ in 0..10 {
+        let parent_id = semantic.nodes().parent_id(current_id);
+        if parent_id == current_id {
+            // Root node, no more parents
+            return None;
+        }
+        let parent_node = semantic.nodes().get_node(parent_id);
+
+        if let AstKind::ImportDeclaration(decl) = parent_node.kind() {
+            return Some(decl);
+        }
+
+        current_id = parent_id;
+    }
+    None
+}

--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use oxc_diagnostics::OxcDiagnostic;
+use react_compiler::entrypoint::compile_result::{
+    CompileResult, CompilerErrorDetailInfo, LoggerEvent,
+};
+
+/// Convert a `CompileResult` into OXC diagnostics.
+pub fn compile_result_to_diagnostics(result: &CompileResult) -> Vec<OxcDiagnostic> {
+    let mut diagnostics = Vec::new();
+
+    match result {
+        CompileResult::Success { events, .. } => {
+            for event in events {
+                if let Some(diag) = event_to_diagnostic(event) {
+                    diagnostics.push(diag);
+                }
+            }
+        }
+        CompileResult::Error { error, events, .. } => {
+            diagnostics.push(error_info_to_diagnostic(error));
+            for event in events {
+                if let Some(diag) = event_to_diagnostic(event) {
+                    diagnostics.push(diag);
+                }
+            }
+        }
+    }
+
+    diagnostics
+}
+
+fn error_info_to_diagnostic(
+    error: &react_compiler::entrypoint::compile_result::CompilerErrorInfo,
+) -> OxcDiagnostic {
+    let message = format!("[ReactCompiler] {}", error.reason);
+    let mut diag = OxcDiagnostic::error(message);
+
+    if let Some(description) = &error.description {
+        diag = diag.with_help(description.clone());
+    }
+
+    diag
+}
+
+/// Map a detail to an [`OxcDiagnostic`] at the compiler's own *display* severity
+/// (`Error`/`Warning`/`Hint`; `Off` is suppressed). Fatality is separate, decided
+/// by `panicThreshold` ([`CompileResult::Error`]).
+fn error_detail_to_diagnostic(detail: &CompilerErrorDetailInfo) -> Option<OxcDiagnostic> {
+    let message = if let Some(description) = &detail.description {
+        format!("[ReactCompiler] {}: {}. {}", detail.category, detail.reason, description)
+    } else {
+        format!("[ReactCompiler] {}: {}", detail.category, detail.reason)
+    };
+
+    let diagnostic = match detail.severity.as_str() {
+        "Off" => return None,
+        "Error" => OxcDiagnostic::error(message),
+        // `Warning`, `Hint`, and any unknown future value surface as warnings.
+        _ => OxcDiagnostic::warn(message),
+    };
+    Some(diagnostic)
+}
+
+fn event_to_diagnostic(event: &LoggerEvent) -> Option<OxcDiagnostic> {
+    match event {
+        LoggerEvent::CompileSuccess { .. } | LoggerEvent::CompileSkip { .. } => None,
+        LoggerEvent::CompileError { detail, .. }
+        | LoggerEvent::CompileErrorWithLoc { detail, .. } => error_detail_to_diagnostic(detail),
+        LoggerEvent::CompileUnexpectedThrow { data, .. } => {
+            Some(OxcDiagnostic::error(format!("[ReactCompiler] Unexpected error: {}", data)))
+        }
+        LoggerEvent::PipelineError { data, .. } => {
+            Some(OxcDiagnostic::error(format!("[ReactCompiler] Pipeline error: {}", data)))
+        }
+    }
+}

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -1,0 +1,638 @@
+pub mod apply_renames;
+pub mod convert_ast;
+pub mod convert_ast_reverse;
+pub mod convert_scope;
+pub mod diagnostics;
+pub mod prefilter;
+
+use apply_renames::build_rename_plan;
+use convert_ast::convert_program;
+use convert_scope::convert_scope_info;
+use diagnostics::compile_result_to_diagnostics;
+use prefilter::{has_react_like_functions, has_resource_management_declarations};
+use react_compiler::entrypoint::compile_result::LoggerEvent;
+use react_compiler_hir::environment_config::EnvironmentConfig;
+use rustc_hash::FxHashSet;
+// Re-exported so integrations needn't depend on the upstream `react_compiler` crate.
+pub use react_compiler::entrypoint::plugin_options::{
+    CompilerTarget, DynamicGatingConfig, GatingConfig, PluginOptions,
+};
+
+/// [`PluginOptions`] with the compiler's standard defaults (it has no `Default`).
+/// Override fields with struct-update syntax: `PluginOptions { ..default_plugin_options() }`.
+pub fn default_plugin_options() -> PluginOptions {
+    PluginOptions {
+        should_compile: true,
+        enable_reanimated: false,
+        is_dev: false,
+        filename: None,
+        compilation_mode: "infer".to_string(),
+        panic_threshold: "none".to_string(),
+        target: CompilerTarget::Version("19".to_string()),
+        gating: None,
+        dynamic_gating: None,
+        no_emit: false,
+        output_mode: None,
+        eslint_suppression_rules: None,
+        flow_suppressions: true,
+        ignore_use_no_forget: false,
+        custom_opt_out_directives: None,
+        environment: EnvironmentConfig::default(),
+        source_code: None,
+        profiling: false,
+        debug: false,
+    }
+}
+
+pub struct TransformResult<'a> {
+    /// Compiled, ready-to-codegen OXC AST; `None` if the compiler made no changes.
+    pub program: Option<oxc_ast::ast::Program<'a>>,
+    pub diagnostics: Vec<oxc_diagnostics::OxcDiagnostic>,
+    pub events: Vec<LoggerEvent>,
+}
+
+pub struct LintResult {
+    pub diagnostics: Vec<oxc_diagnostics::OxcDiagnostic>,
+}
+
+/// Transform a pre-parsed program. `program` is `None` when nothing was compiled.
+pub fn transform<'a>(
+    program: &oxc_ast::ast::Program<'a>,
+    semantic: &oxc_semantic::Semantic,
+    allocator: &'a oxc_allocator::Allocator,
+    options: PluginOptions,
+) -> TransformResult<'a> {
+    let source_text = program.source_text;
+
+    // Skip files with no React-like functions, unless the mode compiles everything.
+    if !matches!(options.compilation_mode.as_str(), "all" | "annotation")
+        && !has_react_like_functions(program)
+    {
+        return TransformResult { program: None, diagnostics: vec![], events: vec![] };
+    }
+
+    // `using`/`await using` disposal semantics aren't preserved yet — skip the file.
+    if has_resource_management_declarations(program) {
+        return TransformResult { program: None, diagnostics: vec![], events: vec![] };
+    }
+
+    let file = convert_program(program, source_text);
+    let scope_info = convert_scope_info(semantic, program);
+    let result =
+        react_compiler::entrypoint::program::compile_program(file, scope_info.clone(), options);
+
+    let diagnostics = compile_result_to_diagnostics(&result);
+    let (program_ast, events, renames) = match result {
+        react_compiler::entrypoint::compile_result::CompileResult::Success {
+            ast,
+            events,
+            renames,
+            ..
+        } => (ast, events, renames),
+        react_compiler::entrypoint::compile_result::CompileResult::Error { events, .. } => {
+            (None, events, Vec::new())
+        }
+    };
+
+    // Rename plan maps source positions of uncompiled references to new names.
+    let rename_plan = build_rename_plan(&scope_info, &renames);
+
+    let compiled_program = program_ast.map(|file: react_compiler_ast::File| {
+        let mut compiled =
+            convert_ast_reverse::convert_program_to_oxc_with_source(&file, allocator, source_text);
+        compiled.source_type = program.source_type;
+        apply_renames::apply_renames(&mut compiled, &rename_plan, allocator);
+        preserve_comments(&mut compiled, source_text, allocator);
+        compiled
+    });
+
+    TransformResult { program: compiled_program, diagnostics, events }
+}
+
+/// Re-parse the source for comments and keep those attached to top-level
+/// statements of the compiled program, so codegen can re-emit them.
+fn preserve_comments<'a>(
+    program: &mut oxc_ast::ast::Program<'a>,
+    source_text: &str,
+    allocator: &'a oxc_allocator::Allocator,
+) {
+    let comment_allocator = oxc_allocator::Allocator::default();
+    let source_type = oxc_span::SourceType::tsx();
+    let parsed = oxc_parser::Parser::new(&comment_allocator, source_text, source_type).parse();
+
+    // Keep only comments attached to a top-level statement; inner comments have
+    // `attached_to` positions that match no top-level statement.
+    let mut top_level_starts = FxHashSet::default();
+    top_level_starts.insert(0u32);
+    for stmt in &program.body {
+        use oxc_span::GetSpan;
+        let start = stmt.span().start;
+        if start > 0 {
+            top_level_starts.insert(start);
+        }
+    }
+
+    // Copy only comments attached to top-level statements.
+    let mut comments =
+        oxc_allocator::Vec::with_capacity_in(parsed.program.comments.len(), allocator);
+    for comment in &parsed.program.comments {
+        if top_level_starts.contains(&comment.attached_to) {
+            comments.push(*comment);
+        }
+    }
+    program.comments = comments;
+
+    // Copy the source into `allocator` so codegen can read comment content from spans.
+    let source_in_alloc = oxc_allocator::StringBuilder::from_str_in(source_text, allocator);
+    program.source_text = source_in_alloc.into_str();
+}
+
+/// Convenience wrapper — parses source text, runs semantic analysis, then transforms.
+pub fn transform_source<'a>(
+    source_text: &'a str,
+    source_type: oxc_span::SourceType,
+    allocator: &'a oxc_allocator::Allocator,
+    options: PluginOptions,
+) -> TransformResult<'a> {
+    let parsed = oxc_parser::Parser::new(allocator, source_text, source_type).parse();
+
+    let semantic =
+        oxc_semantic::SemanticBuilder::new().with_enum_eval(true).build(&parsed.program).semantic;
+
+    transform(&parsed.program, &semantic, allocator, options)
+}
+
+/// Lint a pre-parsed program — like [`transform`] but only collects diagnostics.
+pub fn lint(
+    program: &oxc_ast::ast::Program,
+    semantic: &oxc_semantic::Semantic,
+    options: PluginOptions,
+) -> LintResult {
+    let mut opts = options;
+    opts.no_emit = true;
+
+    // `no_emit` yields `program: None`; a local arena for the conversion suffices.
+    let allocator = oxc_allocator::Allocator::default();
+    let result = transform(program, semantic, &allocator, opts);
+    LintResult { diagnostics: result.diagnostics }
+}
+
+/// Convenience wrapper — parses source text, runs semantic analysis, then lints.
+pub fn lint_source(
+    source_text: &str,
+    source_type: oxc_span::SourceType,
+    options: PluginOptions,
+) -> LintResult {
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed = oxc_parser::Parser::new(&allocator, source_text, source_type).parse();
+
+    let semantic =
+        oxc_semantic::SemanticBuilder::new().with_enum_eval(true).build(&parsed.program).semantic;
+
+    lint(&parsed.program, &semantic, options)
+}
+
+/// Run the React Compiler as a standalone pass, returning the `Scoping` for the
+/// rest of the pipeline (rebuilt if the program changed). Must run **first**, on
+/// the pristine AST, before any other transform.
+pub fn run<'a>(
+    program: &mut oxc_ast::ast::Program<'a>,
+    allocator: &'a oxc_allocator::Allocator,
+    scoping: oxc_semantic::Scoping,
+    options: &PluginOptions,
+    errors: &mut std::vec::Vec<oxc_diagnostics::OxcDiagnostic>,
+) -> oxc_semantic::Scoping {
+    // `compiled` lives in `allocator`, not borrowed from `*program`, so the
+    // reassignment below is sound.
+    let result = {
+        let semantic =
+            oxc_semantic::SemanticBuilder::new().with_enum_eval(true).build(program).semantic;
+        transform(program, &semantic, allocator, options.clone())
+    };
+    errors.extend(result.diagnostics);
+
+    let Some(compiled) = result.program else {
+        return scoping;
+    };
+    *program = compiled;
+
+    // Rebuild scoping for downstream transforms.
+    oxc_semantic::SemanticBuilder::new().with_enum_eval(true).build(program).semantic.into_scoping()
+}
+
+// End-to-end smoke tests: oxc parse + semantic -> convert -> compile -> convert
+// back -> codegen.
+#[cfg(test)]
+mod tests {
+    use react_compiler::entrypoint::plugin_options::PluginOptions;
+
+    use super::transform_source;
+
+    fn options() -> PluginOptions {
+        // Only the non-`#[serde(default)]` fields are required; the rest default.
+        serde_json::from_value(serde_json::json!({
+            "shouldCompile": true,
+            "enableReanimated": false,
+            "isDev": false,
+            "filename": "Component.jsx",
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn memoizes_a_component_end_to_end() {
+        let source = "function Component(props) {\n  \
+            return <div onClick={() => props.onClick()}>{props.text}</div>;\n}\n";
+
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+
+        assert!(result.diagnostics.is_empty(), "unexpected diagnostics: {:?}", result.diagnostics);
+        let program = result.program.expect("React Compiler should have transformed the component");
+
+        let output = oxc_codegen::Codegen::new().build(&program).code;
+
+        assert!(
+            output.contains("react/compiler-runtime"),
+            "expected the compiler-runtime cache import in output:\n{output}"
+        );
+        assert!(
+            output.contains("_c("),
+            "expected memo cache reads (`_c(...)`) in output:\n{output}"
+        );
+    }
+
+    #[test]
+    fn skips_non_react_code() {
+        let source = "function add(a, b) {\n  return a + b;\n}\n";
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        assert!(result.program.is_none(), "non-React code must not be transformed");
+    }
+
+    /// TypeScript-only constructs (`declare global`, `import =`, `export =`,
+    /// overload signatures, `#field in obj`) round-trip without panicking while the
+    /// component still compiles.
+    #[test]
+    fn typescript_only_constructs_round_trip() {
+        let source = "\
+import legacy = require('legacy');\n\
+declare global {\n  interface Window { __APP__: number; }\n}\n\
+declare function ambient(x: number): void;\n\
+function overloaded(x: number): number;\n\
+function overloaded(x: string): string;\n\
+function overloaded(x: unknown): unknown { return x; }\n\
+class Brand {\n  #brand = 1;\n  static isBrand(obj: object) { return #brand in obj; }\n}\n\
+function Component(props) {\n  return <div>{props.text}</div>;\n}\n\
+export = legacy;\n";
+
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let program = result.program.unwrap_or_else(|| {
+            panic!("component should be compiled; diagnostics: {:?}", result.diagnostics)
+        });
+        let output = oxc_codegen::Codegen::new().build(&program).code;
+        assert!(
+            output.contains("react/compiler-runtime"),
+            "expected compiler-runtime import in output:\n{output}"
+        );
+        assert!(output.contains("declare global"), "`declare global` lost:\n{output}");
+        assert!(output.contains("import legacy"), "`import =` lost:\n{output}");
+        assert!(
+            output.contains("function overloaded(x: number): number;"),
+            "overload signature lost:\n{output}"
+        );
+        assert!(
+            !output.contains("function overloaded(x: number): number {}"),
+            "overload signature gained an empty body:\n{output}"
+        );
+        assert!(output.contains("export = legacy"), "`export =` lost:\n{output}");
+    }
+
+    /// TS wrappers in assignment-target / for-head positions must not crash the
+    /// converter (the compiler may still decline to compile them).
+    #[test]
+    fn ts_wrapped_assignment_targets_do_not_panic() {
+        let cases = [
+            "function Component(props) {\n  let x = 0;\n  (x as number) = props.x;\n  return <div>{x}</div>;\n}\n",
+            "function Component(props) {\n  let x = 0;\n  x! = props.x;\n  return <div>{x}</div>;\n}\n",
+            "function Component(props) {\n  const o = props.o;\n  for ((o.k as string) in props.src) {}\n  return <div />;\n}\n",
+            "function Component(props) {\n  const o = props.o;\n  for (o.k! of props.src) {}\n  return <div />;\n}\n",
+            "function Component(props) {\n  let [a] = props.p;\n  ([a!] = props.q);\n  return <div>{a}</div>;\n}\n",
+        ];
+        let opts = options();
+        for source in cases {
+            let allocator = oxc_allocator::Allocator::default();
+            let _ = transform_source(source, oxc_span::SourceType::tsx(), &allocator, opts.clone());
+        }
+    }
+
+    /// Class bodies are stubbed by the converter and re-parsed from source on the
+    /// way back, so members survive.
+    #[test]
+    fn class_body_is_preserved() {
+        let source = "\
+class Store {\n  count = 0;\n  increment() {\n    this.count++;\n  }\n}\n\
+function Component(props) {\n  return <div>{props.text}</div>;\n}\n";
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let program = result.program.expect("component should be compiled");
+        let output = oxc_codegen::Codegen::new().build(&program).code;
+        assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
+        assert!(output.contains("count = 0"), "class field lost:\n{output}");
+        assert!(output.contains("increment("), "class method lost:\n{output}");
+    }
+
+    #[test]
+    fn unsupported_sibling_ast_forms_are_preserved() {
+        let source = "\
+import './style.css';\n\
+export * as ns from './mod';\n\
+function helper() {\n\
+  const C = class {\n\
+    method() {\n\
+      return 1;\n\
+    }\n\
+  };\n\
+  return 123n + BigInt(new C().method());\n\
+}\n\
+function Component(props) {\n\
+  return <div>{props.text}</div>;\n\
+}\n";
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let program = result.program.expect("component should be compiled");
+        let output = oxc_codegen::Codegen::new().build(&program).code;
+
+        assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
+        assert!(output.contains("import \"./style.css\";"), "bare import changed:\n{output}");
+        assert!(
+            !output.contains("import {} from \"./style.css\""),
+            "bare import became an empty named import:\n{output}"
+        );
+        assert!(
+            output.contains("export * as ns from \"./mod\";"),
+            "namespace export lost:\n{output}"
+        );
+        assert!(output.contains("method() {"), "class expression method lost:\n{output}");
+        assert!(output.contains("return 1;"), "class expression body lost:\n{output}");
+        assert!(output.contains("123n"), "BigInt literal lost:\n{output}");
+        assert!(!output.contains("123nn"), "BigInt literal gained an extra suffix:\n{output}");
+    }
+
+    #[test]
+    fn typescript_surface_syntax_is_preserved_around_compiled_code() {
+        let source = "\
+import { createContext, forwardRef } from 'react';\n\
+type Props = { text: string };\n\
+declare const Generic: React.FC<Props>;\n\
+declare const tag: <T>(strings: TemplateStringsArray) => string;\n\
+class Box<T> {}\n\
+const settings = { mode: 'dark' } as const;\n\
+const Context = createContext<Props | undefined>(undefined);\n\
+const typedValue: string = settings.mode as string;\n\
+const checked = settings.mode satisfies string;\n\
+const boxed = new Box<Props>();\n\
+const tagged = tag<Props>`value`;\n\
+const Wrapped = forwardRef<HTMLDivElement, Props>(({ text }: Props, ref): JSX.Element => {\n\
+  const label: string = text satisfies string;\n\
+  return <div ref={ref}>{label}</div>;\n\
+});\n\
+function renderGeneric(props: Props): JSX.Element {\n\
+  'use no memo';\n\
+  try {\n\
+    return <Generic<Props> text={props.text} />;\n\
+  } catch (error: unknown) {\n\
+    return <Generic<Props> text={String(error)} />;\n\
+  }\n\
+}\n\
+function Component(props: Props): JSX.Element {\n\
+  return <Context.Provider value={{ text: props.text } as Props}>\n\
+    <Wrapped text={props.text} />\n\
+  </Context.Provider>;\n\
+}\n";
+
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let program = result.program.unwrap_or_else(|| {
+            panic!("component should compile; diagnostics: {:?}", result.diagnostics)
+        });
+        let output = oxc_codegen::Codegen::new().build(&program).code;
+
+        assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
+        assert!(output.contains("as const"), "`as const` lost:\n{output}");
+        assert!(
+            output.contains("declare const Generic: React.FC<Props>"),
+            "declared variable type annotation lost:\n{output}"
+        );
+        assert!(
+            output.contains("createContext<Props | undefined>"),
+            "call type arguments lost:\n{output}"
+        );
+        assert!(output.contains("typedValue: string"), "variable type annotation lost:\n{output}");
+        assert!(output.contains("as string"), "`as` expression lost:\n{output}");
+        assert!(output.contains("satisfies string"), "`satisfies` expression lost:\n{output}");
+        assert!(output.contains("new Box<Props>()"), "`new` type arguments lost:\n{output}");
+        assert!(
+            output.contains("tag<Props>`value`"),
+            "tagged template type arguments lost:\n{output}"
+        );
+        assert!(
+            output.contains("forwardRef<HTMLDivElement, Props>"),
+            "generic forwardRef call lost type arguments:\n{output}"
+        );
+        assert!(output.contains(": Props"), "parameter type lost:\n{output}");
+        assert!(output.contains(": JSX.Element"), "return type lost:\n{output}");
+        assert!(output.contains("catch (error: unknown)"), "catch type lost:\n{output}");
+        assert!(output.contains("<Generic<Props>"), "generic JSX type arguments lost:\n{output}");
+    }
+
+    #[test]
+    fn type_query_casts_are_renamed_with_value_bindings() {
+        let source = "\
+type Field = { value?: string; optionsInputs?: Record<string, string> };\n\
+function Component({ fields }: { fields: Field[] }) {\n\
+  const field = { value: 'outer', optionsInputs: {} };\n\
+  const nodes = fields.map((field, index) => {\n\
+    const options = [{ value: field.value }];\n\
+    const firstOptionInput = field.optionsInputs?.[options?.[0]?.value as keyof typeof field.optionsInputs];\n\
+    return <div key={index}>{firstOptionInput}{field.value}</div>;\n\
+  });\n\
+  return <>{nodes}{field.value}</>;\n\
+}\n";
+
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let program = result.program.expect("component should be compiled");
+        let output = oxc_codegen::Codegen::new().build(&program).code;
+
+        assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
+        assert!(
+            !output.contains("typeof field.optionsInputs"),
+            "stale type query source was restored:\n{output}"
+        );
+        assert!(
+            output.contains("typeof field_0.optionsInputs"),
+            "type query binding was not renamed with the value binding:\n{output}"
+        );
+    }
+
+    fn rename_collision_source_and_offset() -> (&'static str, usize) {
+        let rename_source = "\
+function makeResults(items, names) {\n\
+  const results = [...items.map((x) => use(x.value)), ...names.map((x) => use(x))];\n\
+  return results;\n\
+}\n";
+        let collision_offset = rename_source
+            .find("use(x))")
+            .map(|index| index + "use(".len())
+            .expect("test source should contain the renamed reference");
+        (rename_source, collision_offset)
+    }
+
+    fn assert_has_rename_collision_setup(output: &str) {
+        assert!(
+            output.contains("function _temp2(x_0)") || output.contains("function _temp(x_0)"),
+            "test setup did not produce a compiler rename:\n{output}"
+        );
+    }
+
+    #[test]
+    fn source_extracted_class_spans_do_not_collide_with_rename_plan() {
+        let (rename_source, collision_offset) = rename_collision_source_and_offset();
+
+        let class_prefix = "export class C {\n  m() {\n    ";
+        let declarator_prefix = "const [octokit, ";
+        let padding_len = collision_offset
+            .checked_sub(class_prefix.len() + declarator_prefix.len())
+            .expect("class binding should be padded to the earlier rename position");
+        let source = format!(
+            "{rename_source}{class_prefix}{}{declarator_prefix}ghRepository] = foo();\n    return ghRepository.full_name;\n  }}\n}}\n",
+            " ".repeat(padding_len)
+        );
+
+        let allocator = oxc_allocator::Allocator::default();
+        let mut opts = options();
+        opts.compilation_mode = "all".to_string();
+        let result = transform_source(&source, oxc_span::SourceType::tsx(), &allocator, opts);
+        let program = result.program.expect("file should be compiled");
+        let output = oxc_codegen::Codegen::new().build(&program).code;
+
+        assert_has_rename_collision_setup(&output);
+        assert!(
+            output.contains("const [octokit, ghRepository] = foo()"),
+            "source-preserved class binding was renamed by an unrelated plan entry:\n{output}"
+        );
+        assert!(!output.contains("const [octokit, x_0]"), "class binding was corrupted:\n{output}");
+    }
+
+    #[test]
+    fn jsx_attribute_string_entities_are_decoded() {
+        let source = "\
+function Component(props) {\n\
+  return <TemplateLinkSection label={props.label} piiWarning='Use the iframe&apos;s payload.' />;\n\
+}\n";
+
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let program = result.program.expect("component should be compiled");
+        let output = oxc_codegen::Codegen::new().build(&program).code;
+
+        assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
+        assert!(
+            output.contains("iframe's payload"),
+            "JSX string attribute entity was not decoded:\n{output}"
+        );
+        assert!(
+            !output.contains("iframe&apos;s payload"),
+            "JSX string attribute entity leaked into runtime string:\n{output}"
+        );
+    }
+
+    #[test]
+    fn resource_management_declarations_bail_out() {
+        let cases = [
+            "\
+function Component(props) {\n  using x = sideEffect();\n  return <div>{props.text}</div>;\n}\n",
+            "\
+async function Component(props) {\n  await using x = sideEffect();\n  return <div>{props.text}</div>;\n}\n",
+        ];
+
+        for source in cases {
+            let allocator = oxc_allocator::Allocator::default();
+            let result =
+                transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+
+            assert!(result.program.is_none(), "resource management should skip React Compiler");
+            assert!(
+                result.diagnostics.is_empty(),
+                "unexpected diagnostics: {:?}",
+                result.diagnostics
+            );
+        }
+    }
+
+    #[test]
+    fn exported_typescript_runtime_declarations_are_preserved() {
+        let source = "\
+export enum E { A }\n\
+export namespace N {\n  export const value = E.A;\n}\n\
+function Component(props) {\n  return <div>{E.A}{N.value}{props.text}</div>;\n}\n";
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let program = result.program.expect("component should be compiled");
+        let output = oxc_codegen::Codegen::new().build(&program).code;
+
+        assert!(output.contains("export enum E"), "exported enum lost:\n{output}");
+        assert!(output.contains("A"), "enum member lost:\n{output}");
+        assert!(output.contains("export namespace N"), "exported namespace lost:\n{output}");
+        assert!(output.contains("value = E.A"), "namespace body lost:\n{output}");
+        assert!(
+            !output.contains("declare const"),
+            "exported TS declaration became a placeholder:\n{output}"
+        );
+    }
+
+    /// A `React.memo(...)` component is anonymous; the prefilter must still see it.
+    #[test]
+    fn memo_wrapped_component_compiles() {
+        let source = "React.memo((props) => {\n  return <div>{props.text}</div>;\n});\n";
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let program = result.program.expect("memo-wrapped component should compile");
+        let output = oxc_codegen::Codegen::new().build(&program).code;
+        assert!(output.contains("react/compiler-runtime"), "should memoize:\n{output}");
+        assert!(output.contains("_c("), "expected memo cache reads:\n{output}");
+    }
+
+    /// Diagnostics are surfaced at the compiler's own severity, not flattened.
+    #[test]
+    fn diagnostics_preserve_compiler_severity() {
+        use oxc_diagnostics::Severity;
+
+        // A Rules of Hooks violation is an `Error`-severity diagnostic.
+        let source = "function Component(props) {\n  if (props.cond) {\n    useState(0);\n  }\n  return <div>{props.text}</div>;\n}\n";
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        assert!(
+            result.diagnostics.iter().any(|d| d.severity == Severity::Error),
+            "Rules of Hooks violation should be reported as an error: {:?}",
+            result.diagnostics
+        );
+
+        // A local named `fbt` is an unsupported-syntax bail-out — a warning, not an error.
+        let source = "function Component() {\n  const fbt = \"span\";\n  return <fbt desc=\"label\">Hello</fbt>;\n}\n";
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        assert!(
+            result.diagnostics.iter().any(|d| d.severity == Severity::Warning),
+            "fbt bail-out should be reported as a warning: {:?}",
+            result.diagnostics
+        );
+        assert!(
+            result.diagnostics.iter().all(|d| d.severity != Severity::Error),
+            "fbt warning must not be reported as an error: {:?}",
+            result.diagnostics
+        );
+    }
+}

--- a/crates/oxc_react_compiler/src/prefilter.rs
+++ b/crates/oxc_react_compiler/src/prefilter.rs
@@ -1,0 +1,187 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+//
+// This source code is licensed under the MIT license found in the
+// LICENSE file in the root directory of this source tree.
+
+use oxc_ast::ast::{
+    AssignmentTarget, CallExpression, Expression, Function, Program, VariableDeclarator,
+};
+use oxc_ast_visit::{Visit, walk};
+
+/// Whether the program contains a component (Uppercase name) or hook (`use[A-Z0-9]`).
+pub fn has_react_like_functions(program: &Program) -> bool {
+    let mut visitor = ReactLikeVisitor { found: false, current_name: None };
+    visitor.visit_program(program);
+    visitor.found
+}
+
+pub fn has_resource_management_declarations(program: &Program) -> bool {
+    let mut visitor = ResourceManagementVisitor { found: false };
+    visitor.visit_program(program);
+    visitor.found
+}
+
+use react_compiler_hir::environment::is_react_like_name;
+
+/// `memo`/`forwardRef` (optionally `React.`-qualified): their callback is a
+/// component even when anonymous, so such files must not be skipped.
+fn is_component_wrapper(callee: &Expression) -> bool {
+    let is_wrapper = |name: &str| matches!(name, "memo" | "forwardRef");
+    match callee {
+        Expression::Identifier(id) => is_wrapper(&id.name),
+        Expression::StaticMemberExpression(m) => is_wrapper(&m.property.name),
+        _ => false,
+    }
+}
+
+struct ReactLikeVisitor {
+    found: bool,
+    current_name: Option<String>,
+}
+
+struct ResourceManagementVisitor {
+    found: bool,
+}
+
+impl<'a> Visit<'a> for ResourceManagementVisitor {
+    fn visit_variable_declaration(&mut self, decl: &oxc_ast::ast::VariableDeclaration<'a>) {
+        if self.found {
+            return;
+        }
+        if decl.kind.is_using() {
+            self.found = true;
+            return;
+        }
+        walk::walk_variable_declaration(self, decl);
+    }
+}
+
+impl<'a> Visit<'a> for ReactLikeVisitor {
+    fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
+        if self.found {
+            return;
+        }
+
+        let name = match &decl.id {
+            oxc_ast::ast::BindingPattern::BindingIdentifier(ident) => Some(ident.name.to_string()),
+            _ => None,
+        };
+
+        let prev_name = self.current_name.take();
+        self.current_name = name;
+
+        if let Some(init) = &decl.init {
+            self.visit_expression(init);
+        }
+
+        self.current_name = prev_name;
+    }
+
+    fn visit_assignment_expression(&mut self, expr: &oxc_ast::ast::AssignmentExpression<'a>) {
+        if self.found {
+            return;
+        }
+
+        let name = match &expr.left {
+            AssignmentTarget::AssignmentTargetIdentifier(ident) => Some(ident.name.to_string()),
+            _ => None,
+        };
+
+        let prev_name = self.current_name.take();
+        self.current_name = name;
+
+        self.visit_expression(&expr.right);
+
+        self.current_name = prev_name;
+    }
+
+    fn visit_function(&mut self, func: &Function<'a>, _flags: oxc_semantic::ScopeFlags) {
+        if self.found {
+            return;
+        }
+
+        if let Some(id) = &func.id {
+            if is_react_like_name(&id.name) {
+                self.found = true;
+                return;
+            }
+        }
+
+        if func.id.is_none() {
+            if let Some(name) = &self.current_name {
+                if is_react_like_name(name) {
+                    self.found = true;
+                    return;
+                }
+            }
+        }
+
+        // Don't traverse into the function body
+    }
+
+    fn visit_arrow_function_expression(
+        &mut self,
+        _expr: &oxc_ast::ast::ArrowFunctionExpression<'a>,
+    ) {
+        if self.found {
+            return;
+        }
+
+        if let Some(name) = &self.current_name {
+            if is_react_like_name(name) {
+                self.found = true;
+                return;
+            }
+        }
+
+        // Don't traverse into the function body
+    }
+
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        if self.found {
+            return;
+        }
+        // A function passed to `memo`/`forwardRef` is a component even without a
+        // React-like name.
+        if is_component_wrapper(&call.callee)
+            && call.arguments.iter().any(|arg| {
+                matches!(
+                    arg.as_expression(),
+                    Some(
+                        Expression::FunctionExpression(_) | Expression::ArrowFunctionExpression(_)
+                    )
+                )
+            })
+        {
+            self.found = true;
+            return;
+        }
+        walk::walk_call_expression(self, call);
+    }
+
+    fn visit_class(&mut self, _class: &oxc_ast::ast::Class<'a>) {
+        // Skip class bodies entirely
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_react_like_name() {
+        assert!(is_react_like_name("Component"));
+        assert!(is_react_like_name("MyComponent"));
+        assert!(is_react_like_name("A"));
+        assert!(is_react_like_name("useState"));
+        assert!(is_react_like_name("useEffect"));
+        assert!(is_react_like_name("use0"));
+
+        assert!(!is_react_like_name("component"));
+        assert!(!is_react_like_name("myFunction"));
+        assert!(!is_react_like_name("use"));
+        assert!(!is_react_like_name("user"));
+        assert!(!is_react_like_name("useful"));
+        assert!(!is_react_like_name(""));
+    }
+}

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -24,6 +24,7 @@ doctest = false
 [dependencies]
 oxc = { workspace = true, features = ["full"] }
 oxc_napi = { workspace = true }
+oxc_react_compiler = { workspace = true } # build the React Compiler `PluginOptions`
 oxc_sourcemap = { workspace = true, features = ["napi"] }
 
 rustc-hash = { workspace = true }

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -329,6 +329,97 @@ export interface PluginsOptions {
   taggedTemplateEscape?: boolean
 }
 
+/** Dynamic gating for {@link ReactCompilerOptions#dynamicGating}. */
+export interface ReactCompilerDynamicGating {
+  /** Module the gating import comes from. */
+  source: string
+}
+
+/** Static gating for {@link ReactCompilerOptions#gating}. */
+export interface ReactCompilerGating {
+  /** Module the gating import comes from. */
+  source: string
+  /** Imported specifier used as the gate. */
+  importSpecifierName: string
+}
+
+/**
+ * Options for the experimental [React Compiler](https://github.com/facebook/react/pull/36173).
+ *
+ * Mirrors the compiler's `PluginOptions`. The deep `environment` configuration
+ * (inference / validation flags) is not surfaced here.
+ *
+ * @see {@link TransformOptions#reactCompiler}
+ */
+export interface ReactCompilerOptions {
+  /**
+   * Which functions to compile.
+   *
+   * @default 'infer'
+   */
+  compilationMode?: 'infer' | 'syntax' | 'annotation' | 'all'
+  /**
+   * What to do when a function cannot be compiled.
+   *
+   * @default 'none'
+   */
+  panicThreshold?: 'none' | 'critical_errors' | 'all_errors'
+  /**
+   * React runtime version target. `17` and `18` require the
+   * `react-compiler-runtime` package; `19` ships the runtime in `react`.
+   *
+   * @default '19'
+   */
+  target?: '17' | '18' | '19'
+  /**
+   * Analyze and report diagnostics only; emit no transformed code.
+   *
+   * @default false
+   */
+  noEmit?: boolean
+  /**
+   * Compiler output mode.
+   *
+   * @default undefined
+   */
+  outputMode?: 'client' | 'ssr' | 'lint'
+  /**
+   * Compile even functions marked with the `"use no memo"` / `"use no forget"`
+   * opt-out directives.
+   *
+   * @default false
+   */
+  ignoreUseNoForget?: boolean
+  /**
+   * Treat Flow suppression comments as opt-outs.
+   *
+   * @default true
+   */
+  flowSuppressions?: boolean
+  /**
+   * Enable `react-native-reanimated` support.
+   *
+   * @default false
+   */
+  enableReanimated?: boolean
+  /**
+   * Development mode (extra validation / instrumentation).
+   *
+   * @default false
+   */
+  isDev?: boolean
+  /** Source file name, used for the fast-refresh hash and in diagnostics. */
+  filename?: string
+  /** ESLint rules whose suppressions opt a function out of compilation. */
+  eslintSuppressionRules?: Array<string>
+  /** Extra directives that opt a function out of compilation. */
+  customOptOutDirectives?: Array<string>
+  /** Also emit a gated (feature-flagged) version of each compiled function. */
+  gating?: ReactCompilerGating
+  /** Dynamically-gated compilation. */
+  dynamicGating?: ReactCompilerDynamicGating
+}
+
 export interface ReactRefreshOptions {
   /**
    * Specify the identifier of the refresh registration variable.
@@ -506,6 +597,14 @@ export interface TransformOptions {
   inject?: Record<string, string | [string, string]>
   /** Decorator plugin */
   decorator?: DecoratorOptions
+  /**
+   * Enable the experimental [React Compiler](https://github.com/facebook/react/pull/36173).
+   *
+   * `true` enables it with default options; an object enables it with the
+   * given options; `false` or omitted disables it. When enabled, the compiler
+   * runs as the first transform and memoizes React components and hooks.
+   */
+  reactCompiler?: boolean | ReactCompilerOptions
   /**
    * Third-party plugins to use.
    * @see {@link https://oxc.rs/docs/guide/usage/transformer/plugins}

--- a/napi/transform/src/lib.rs
+++ b/napi/transform/src/lib.rs
@@ -14,5 +14,8 @@ static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 mod isolated_declaration;
 pub use isolated_declaration::*;
 
+mod react_compiler;
+pub use react_compiler::*;
+
 mod transformer;
 pub use transformer::*;

--- a/napi/transform/src/react_compiler.rs
+++ b/napi/transform/src/react_compiler.rs
@@ -1,0 +1,167 @@
+//! React Compiler options for the transform binding.
+//!
+//! A curated, JS-facing mirror of the React Compiler `PluginOptions` (the deep
+//! `environment` config is not surfaced), resolved into the concrete options the
+//! transformer consumes.
+
+use napi::Either;
+use napi_derive::napi;
+
+/// Options for the experimental [React Compiler](https://github.com/facebook/react/pull/36173).
+///
+/// Mirrors the compiler's `PluginOptions`. The deep `environment` configuration
+/// (inference / validation flags) is not surfaced here.
+///
+/// @see {@link TransformOptions#reactCompiler}
+#[napi(object)]
+#[derive(Default, Debug)]
+pub struct ReactCompilerOptions {
+    /// Which functions to compile.
+    ///
+    /// @default 'infer'
+    #[napi(ts_type = "'infer' | 'syntax' | 'annotation' | 'all'")]
+    pub compilation_mode: Option<String>,
+
+    /// What to do when a function cannot be compiled.
+    ///
+    /// @default 'none'
+    #[napi(ts_type = "'none' | 'critical_errors' | 'all_errors'")]
+    pub panic_threshold: Option<String>,
+
+    /// React runtime version target. `17` and `18` require the
+    /// `react-compiler-runtime` package; `19` ships the runtime in `react`.
+    ///
+    /// @default '19'
+    #[napi(ts_type = "'17' | '18' | '19'")]
+    pub target: Option<String>,
+
+    /// Analyze and report diagnostics only; emit no transformed code.
+    ///
+    /// @default false
+    pub no_emit: Option<bool>,
+
+    /// Compiler output mode.
+    ///
+    /// @default undefined
+    #[napi(ts_type = "'client' | 'ssr' | 'lint'")]
+    pub output_mode: Option<String>,
+
+    /// Compile even functions marked with the `"use no memo"` / `"use no forget"`
+    /// opt-out directives.
+    ///
+    /// @default false
+    pub ignore_use_no_forget: Option<bool>,
+
+    /// Treat Flow suppression comments as opt-outs.
+    ///
+    /// @default true
+    pub flow_suppressions: Option<bool>,
+
+    /// Enable `react-native-reanimated` support.
+    ///
+    /// @default false
+    pub enable_reanimated: Option<bool>,
+
+    /// Development mode (extra validation / instrumentation).
+    ///
+    /// @default false
+    pub is_dev: Option<bool>,
+
+    /// Source file name, used for the fast-refresh hash and in diagnostics.
+    pub filename: Option<String>,
+
+    /// ESLint rules whose suppressions opt a function out of compilation.
+    pub eslint_suppression_rules: Option<Vec<String>>,
+
+    /// Extra directives that opt a function out of compilation.
+    pub custom_opt_out_directives: Option<Vec<String>>,
+
+    /// Also emit a gated (feature-flagged) version of each compiled function.
+    pub gating: Option<ReactCompilerGating>,
+
+    /// Dynamically-gated compilation.
+    pub dynamic_gating: Option<ReactCompilerDynamicGating>,
+}
+
+/// Static gating for {@link ReactCompilerOptions#gating}.
+#[napi(object)]
+#[derive(Debug)]
+pub struct ReactCompilerGating {
+    /// Module the gating import comes from.
+    pub source: String,
+    /// Imported specifier used as the gate.
+    pub import_specifier_name: String,
+}
+
+/// Dynamic gating for {@link ReactCompilerOptions#dynamicGating}.
+#[napi(object)]
+#[derive(Debug)]
+pub struct ReactCompilerDynamicGating {
+    /// Module the gating import comes from.
+    pub source: String,
+}
+
+/// Resolve the JS `reactCompiler` option into the compiler's `PluginOptions`:
+/// `true` → default options, an object → those options, `false`/absent → disabled.
+pub fn resolve(
+    option: Option<Either<bool, ReactCompilerOptions>>,
+) -> Option<oxc_react_compiler::PluginOptions> {
+    match option {
+        Some(Either::A(true)) => Some(oxc_react_compiler::default_plugin_options()),
+        Some(Either::B(options)) => Some(options.into_plugin_options()),
+        Some(Either::A(false)) | None => None,
+    }
+}
+
+impl ReactCompilerOptions {
+    fn into_plugin_options(self) -> oxc_react_compiler::PluginOptions {
+        let mut options = oxc_react_compiler::default_plugin_options();
+        if let Some(compilation_mode) = self.compilation_mode {
+            options.compilation_mode = compilation_mode;
+        }
+        if let Some(panic_threshold) = self.panic_threshold {
+            options.panic_threshold = panic_threshold;
+        }
+        if let Some(target) = self.target {
+            options.target = oxc_react_compiler::CompilerTarget::Version(target);
+        }
+        if let Some(no_emit) = self.no_emit {
+            options.no_emit = no_emit;
+        }
+        if self.output_mode.is_some() {
+            options.output_mode = self.output_mode;
+        }
+        if let Some(ignore_use_no_forget) = self.ignore_use_no_forget {
+            options.ignore_use_no_forget = ignore_use_no_forget;
+        }
+        if let Some(flow_suppressions) = self.flow_suppressions {
+            options.flow_suppressions = flow_suppressions;
+        }
+        if let Some(enable_reanimated) = self.enable_reanimated {
+            options.enable_reanimated = enable_reanimated;
+        }
+        if let Some(is_dev) = self.is_dev {
+            options.is_dev = is_dev;
+        }
+        if self.filename.is_some() {
+            options.filename = self.filename;
+        }
+        if self.eslint_suppression_rules.is_some() {
+            options.eslint_suppression_rules = self.eslint_suppression_rules;
+        }
+        if self.custom_opt_out_directives.is_some() {
+            options.custom_opt_out_directives = self.custom_opt_out_directives;
+        }
+        if let Some(gating) = self.gating {
+            options.gating = Some(oxc_react_compiler::GatingConfig {
+                source: gating.source,
+                import_specifier_name: gating.import_specifier_name,
+            });
+        }
+        if let Some(dynamic_gating) = self.dynamic_gating {
+            options.dynamic_gating =
+                Some(oxc_react_compiler::DynamicGatingConfig { source: dynamic_gating.source });
+        }
+        options
+    }
+}

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -30,7 +30,7 @@ use oxc::{
 use oxc_napi::{OxcError, get_source_type};
 use oxc_sourcemap::napi::SourceMap;
 
-use crate::IsolatedDeclarationsOptions;
+use crate::{IsolatedDeclarationsOptions, react_compiler::ReactCompilerOptions};
 
 #[derive(Default)]
 #[napi(object)]
@@ -149,6 +149,14 @@ pub struct TransformOptions {
     /// Decorator plugin
     pub decorator: Option<DecoratorOptions>,
 
+    /// Enable the experimental [React Compiler](https://github.com/facebook/react/pull/36173).
+    ///
+    /// `true` enables it with default options; an object enables it with the
+    /// given options; `false` or omitted disables it. When enabled, the compiler
+    /// runs as the first transform and memoizes React components and hooks.
+    #[napi(ts_type = "boolean | ReactCompilerOptions")]
+    pub react_compiler: Option<Either<bool, ReactCompilerOptions>>,
+
     /// Third-party plugins to use.
     /// @see {@link https://oxc.rs/docs/guide/usage/transformer/plugins}
     pub plugins: Option<PluginsOptions>,
@@ -195,6 +203,16 @@ impl TryFrom<TransformOptions> for oxc::transformer::TransformOptions {
                 .map(oxc::transformer::PluginsOptions::from)
                 .unwrap_or_default(),
         })
+    }
+}
+
+impl TransformOptions {
+    /// Take the `reactCompiler` option and resolve it into the compiler's
+    /// `PluginOptions`. The React Compiler is a standalone pass driven by the
+    /// [`CompilerInterface`], so it is not part of
+    /// `oxc::transformer::TransformOptions`.
+    fn take_react_compiler(&mut self) -> Option<oxc_react_compiler::PluginOptions> {
+        crate::react_compiler::resolve(self.react_compiler.take())
     }
 }
 
@@ -742,6 +760,8 @@ struct Compiler {
 
     define: Option<ReplaceGlobalDefinesConfig>,
     inject: Option<InjectGlobalVariablesConfig>,
+    #[expect(clippy::struct_field_names)]
+    react_compiler: Option<oxc_react_compiler::PluginOptions>,
 
     helpers_used: FxHashMap<String, String>,
     errors: Vec<OxcDiagnostic>,
@@ -794,6 +814,8 @@ impl Compiler {
             .transpose()?
             .map(InjectGlobalVariablesConfig::new);
 
+        let react_compiler = options.as_mut().and_then(TransformOptions::take_react_compiler);
+
         let transform_options = match options {
             Some(options) => oxc::transformer::TransformOptions::try_from(options)
                 .map_err(|err| vec![OxcDiagnostic::error(err)])?,
@@ -810,6 +832,7 @@ impl Compiler {
             declaration_map: None,
             define,
             inject,
+            react_compiler,
             helpers_used: FxHashMap::default(),
             errors: vec![],
         })
@@ -841,6 +864,10 @@ impl CompilerInterface for Compiler {
 
     fn inject_options(&self) -> Option<InjectGlobalVariablesConfig> {
         self.inject.clone()
+    }
+
+    fn react_compiler_options(&self) -> Option<oxc_react_compiler::PluginOptions> {
+        self.react_compiler.clone()
     }
 
     fn after_codegen(&mut self, ret: CodegenReturn) {

--- a/napi/transform/test/reactCompiler.test.ts
+++ b/napi/transform/test/reactCompiler.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import { transformSync } from "../index";
+
+// A single fixture exercising every concern the React Compiler integration has to
+// handle together: a memoizable component using a hook, TypeScript types, JSX, ES
+// module syntax, and top-level comments. The compiler runs first on the pristine
+// AST, then the rest of the transform pipeline (TypeScript, JSX) runs on its
+// output, and codegen emits the result.
+const fixture = `// @license MIT
+import { useState } from "react";
+
+interface Props {
+  text: string;
+  onClick: () => void;
+}
+
+// Memoized component: exercises hooks, TS types, JSX and comments.
+export function Component(props: Props) {
+  const [count, setCount] = useState<number>(0);
+  return (
+    <div onClick={() => props.onClick()}>
+      {props.text}: {count}
+    </div>
+  );
+}
+`;
+
+describe("reactCompiler", () => {
+  it("memoizes, composes with the TS + JSX transforms, and preserves comments", () => {
+    const { code, errors } = transformSync("Component.tsx", fixture, {
+      reactCompiler: true,
+      jsx: { runtime: "automatic" },
+    });
+
+    expect(errors).toEqual([]);
+
+    // React Compiler memoized the component.
+    expect(code).toContain("react/compiler-runtime");
+    expect(code).toContain("_c(");
+
+    // JSX was lowered via the automatic runtime — no raw JSX remains.
+    expect(code).toContain("jsx");
+    expect(code).not.toContain("<div");
+
+    // TypeScript was stripped: the interface, annotations and generic are gone.
+    expect(code).not.toContain("interface Props");
+    expect(code).not.toContain(": Props");
+    expect(code).not.toContain("<number>");
+
+    // The hook call and ES module syntax survive.
+    expect(code).toContain("useState(");
+    expect(code).toContain("export function Component");
+
+    // Top-level comments survive react_compiler -> transformer -> codegen.
+    expect(code).toContain("@license MIT");
+    expect(code).toContain("Memoized component");
+  });
+
+  it("accepts a ReactCompilerOptions object", () => {
+    const { code } = transformSync("Component.tsx", fixture, {
+      reactCompiler: { compilationMode: "all" },
+    });
+    expect(code).toContain("react/compiler-runtime");
+    expect(code).toContain("_c(");
+  });
+
+  // Each option below changes observable output, proving it is forwarded to the compiler.
+
+  it("forwards `target` — 17/18 import the standalone runtime package", () => {
+    const { code } = transformSync("Component.tsx", fixture, {
+      reactCompiler: { target: "18" },
+      jsx: { runtime: "automatic" },
+    });
+    expect(code).toContain("react-compiler-runtime");
+    expect(code).not.toContain("react/compiler-runtime");
+  });
+
+  it("forwards `gating` — emits a feature-gated component", () => {
+    const { code } = transformSync("Component.tsx", fixture, {
+      reactCompiler: {
+        gating: { source: "my-gating-module", importSpecifierName: "isForgetEnabled" },
+      },
+      jsx: { runtime: "automatic" },
+    });
+    expect(code).toContain("my-gating-module");
+    expect(code).toContain("isForgetEnabled");
+  });
+
+  it("forwards `ignoreUseNoForget` — compiles a `use no memo` function", () => {
+    const source = `function Component(props) {
+  "use no memo";
+  return <div>{props.text}</div>;
+}
+`;
+    const optedOut = transformSync("Component.jsx", source, {
+      reactCompiler: true,
+      jsx: { runtime: "automatic" },
+    });
+    expect(optedOut.code).not.toContain("_c(");
+
+    const overridden = transformSync("Component.jsx", source, {
+      reactCompiler: { ignoreUseNoForget: true },
+      jsx: { runtime: "automatic" },
+    });
+    expect(overridden.code).toContain("_c(");
+  });
+
+  it("emits code when React Compiler reports warnings", () => {
+    const { code, errors } = transformSync(
+      "Component.jsx",
+      `
+function Component() {
+  const fbt = "span";
+  return <fbt desc="label">Hello</fbt>;
+}
+`,
+      {
+        reactCompiler: true,
+        jsx: { runtime: "automatic" },
+      },
+    );
+
+    expect(code).not.toBe("");
+    expect(code).toContain("function Component");
+    expect(errors.some((error) => error.severity === "Warning")).toBe(true);
+    expect(errors.some((error) => error.severity === "Error")).toBe(false);
+  });
+
+  it("reports React Compiler errors at error severity without aborting codegen", () => {
+    const { code, errors } = transformSync(
+      "Component.jsx",
+      `
+function Component(props) {
+  if (props.cond) {
+    useState(0);
+  }
+  return <div>{props.text}</div>;
+}
+`,
+      {
+        reactCompiler: true,
+        jsx: { runtime: "automatic" },
+      },
+    );
+
+    // The Rules of Hooks violation is surfaced at error severity (not flattened
+    // to a warning)...
+    expect(errors.some((error) => error.severity === "Error")).toBe(true);
+    // ...but the React Compiler leaves a valid program, so codegen still runs
+    // and the component is emitted rather than the whole file being dropped.
+    expect(code).not.toBe("");
+    expect(code).toContain("function Component");
+  });
+
+  it("keeps enum values available for the downstream TypeScript transform", () => {
+    const { code, errors } = transformSync(
+      "Component.tsx",
+      `
+enum E {
+  A = 1,
+  B = A + 1,
+}
+
+function Component() {
+  return <div>{E.B}</div>;
+}
+`,
+      {
+        reactCompiler: true,
+        jsx: { runtime: "automatic" },
+      },
+    );
+
+    expect(errors).toEqual([]);
+    expect(code).toContain('E[E["B"] = 2] = "B"');
+  });
+
+  it("does nothing when `reactCompiler` is omitted (the default) or `false`", () => {
+    for (const options of [{}, { reactCompiler: false }]) {
+      const { code } = transformSync("Component.tsx", fixture, options);
+      expect(code).not.toContain("react/compiler-runtime");
+      expect(code).not.toContain("_c(");
+    }
+  });
+});

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -54,6 +54,11 @@ harness = false
 name = "pipeline"
 harness = false
 
+[[bench]]
+name = "react_compiler"
+harness = false
+required-features = ["react_compiler"]
+
 # Only run in CI
 [[bench]]
 name = "parser_napi"
@@ -77,6 +82,7 @@ oxc_parser = { workspace = true, features = [
   "benchmarking",
   "regular_expression",
 ], optional = true }
+oxc_react_compiler = { workspace = true, optional = true }
 oxc_semantic = { workspace = true, optional = true }
 oxc_span = { workspace = true, optional = true, features = ["schemars", "serialize"] }
 oxc_tasks_common = { workspace = true, optional = true }
@@ -125,6 +131,14 @@ linter = [
   "dep:oxc_tasks_common",
   "oxc_semantic/cfg",
 ]
+react_compiler = [
+  "dep:oxc_allocator",
+  "dep:oxc_parser",
+  "dep:oxc_react_compiler",
+  "dep:oxc_semantic",
+  "dep:oxc_span",
+  "dep:oxc_tasks_common",
+]
 
 [dev-dependencies]
 rustc-hash = { workspace = true }
@@ -142,6 +156,7 @@ ignored = [
   "oxc_mangler",
   "oxc_minifier",
   "oxc_parser",
+  "oxc_react_compiler",
   "oxc_semantic",
   "oxc_span",
   "oxc_tasks_common",

--- a/tasks/benchmark/benches/react_compiler.rs
+++ b/tasks/benchmark/benches/react_compiler.rs
@@ -1,0 +1,42 @@
+use oxc_allocator::Allocator;
+use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use oxc_parser::{Parser, ParserReturn};
+use oxc_react_compiler::{default_plugin_options, transform};
+use oxc_semantic::SemanticBuilder;
+use oxc_tasks_common::TestFiles;
+
+fn bench_react_compiler(criterion: &mut Criterion) {
+    let mut group = criterion.benchmark_group("react_compiler");
+
+    for file in TestFiles::minimal().files() {
+        let id = BenchmarkId::from_parameter(&file.file_name);
+        let source_text = &file.source_text;
+        let source_type = file.source_type;
+
+        let options = default_plugin_options();
+
+        // Create `Allocator` outside of `bench_function`, so the same allocator is
+        // used for both the warmup and measurement phases.
+        let mut allocator = Allocator::default();
+
+        group.bench_function(id, |b| {
+            b.iter_with_setup_wrapper(|runner| {
+                // Reset allocator at start of each iteration.
+                allocator.reset();
+
+                // Create fresh AST + semantic data for each iteration. The compiler
+                // reads them and allocates the compiled program in the same arena.
+                let ParserReturn { program, .. } =
+                    Parser::new(&allocator, source_text, source_type).parse();
+                let semantic = SemanticBuilder::new().build(&program).semantic;
+
+                runner.run(|| transform(&program, &semantic, &allocator, options.clone()));
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(react_compiler, bench_react_compiler);
+criterion_main!(react_compiler);


### PR DESCRIPTION
Closes https://github.com/oxc-project/oxc/issues/10048

Integrates the Rust port of the React Compiler ([facebook/react#36173](https://github.com/facebook/react/pull/36173)) into oxc.

## Notes (resolved)

- Published crates can't reference Git URLs, so using this from Rolldown needs the React Compiler crates on crates.io. ✅ Published as a fork at https://crates.io/crates/forked_react_compiler; this PR depends on those `forked_react_compiler*` crates so people can get earlier access.
- The React Compiler crates had no license field. ✅ The published fork carries `license = "MIT"` (per the React repo's MIT license), so Cargo Deny and Security Analysis pass.

## Benchmark

**Wall-clock overhead vs plain transform** (release `transformSync`, same `jsx: automatic`, toggling only `reactCompiler`):

| fixture | without | with | overhead |
| --- | --- | --- | --- |
| RadixUIAdoptionSection.jsx (2.5 KiB) | 0.03 ms | 1.81 ms | +1.8 ms |
| excalidraw `App.tsx` (406 KiB) | 4.09 ms | 14.49 ms | +10.4 ms (3.5×) |

So roughly a fixed ~1.8 ms floor per file plus a per-size cost — about **3.5× the transform time** on a large real-world component.

## Binary size

Linking the React Compiler pulls the whole compiler pipeline (HIR, lowering, inference, SSA, optimization, reactive scopes, validation) plus the oxc⇄Babel AST conversion into the binding. Release build of the napi transform addon (`transform.darwin-arm64.node`, `--release`, stripped), darwin-arm64:

| build | size |
| --- | --- |
| baseline (`main`) | 3.51 MiB |
| with React Compiler | 8.66 MiB |
| **delta** | **+5.14 MiB (+146%, 2.46×)** |
