### PR TITLE
fix(linter/plugins): make spreading `Token` instances keep `loc` property

### DIFF
--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -181,8 +181,8 @@ let getTokenPrivateLoc: (token: Token) => Location | null;
  * Token implementation with lazy `loc` caching via private field.
  *
  * `loc` is defined as an own accessor property via `__defineGetter__` in the constructor,
- * using a shared getter function (`getCommentLoc`). This makes `loc` an own enumerable property,
- * so `{...comment}` spreads it and `JSON.stringify(comment)` serializes it.
+ * using a shared getter function (`getTokenLoc`). This makes `loc` an own enumerable property,
+ * so `{...token}` spreads it and `JSON.stringify(token)` serializes it.
  *
  * The computed `Location` value is cached in the private `#loc` field on first access.
  * All instances share the same getter function, keeping the V8 hidden class transition

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -157,6 +157,17 @@ let deserializedTokensLen = 0;
 // not *total* number of tokens.
 const DESERIALIZED_TOKEN_INDEXES_MIN_CAPACITY = 16;
 
+// `__defineGetter__` bound to `Function.prototype.call` so it can be called without a
+// `Object.prototype` lookup at each call site.
+const defineGetter = Function.prototype.call.bind(
+  // @ts-expect-error - `__defineGetter__` is not in `Object.prototype`'s type definition, but it does exist at runtime and is widely supported in JS engines, including V8.
+  Object.prototype.__defineGetter__,
+) as (obj: object, prop: string, getter: () => unknown) => void;
+
+// Getter for the `loc` property on a `Token` class instance.
+// Copied into a `const` below after being defined in class static block.
+let getTokenLocTemp: (this: Token) => Location;
+
 // Reset `#loc` field on a `Token` class instance.
 // Copied into a `const` below after being defined in class static block.
 let resetLocTemp: (token: Token) => void;
@@ -168,9 +179,14 @@ let getTokenPrivateLoc: (token: Token) => Location | null;
 /**
  * Token implementation with lazy `loc` caching via private field.
  *
- * Using a class with a private `#loc` field avoids hidden class transitions that would occur
- * with `Object.defineProperty` / `delete` on plain objects.
- * All `Token` instances always have the same V8 hidden class, keeping property access monomorphic.
+ * `loc` is defined as an own accessor property via `__defineGetter__` in the constructor,
+ * using a shared getter function (`getTokenLoc`). This makes `loc` an own enumerable property,
+ * so `{...token}` spreads it and `JSON.stringify(token)` serializes it, without needing
+ * a `toJSON()` method.
+ *
+ * The computed `Location` value is cached in the private `#loc` field on first access.
+ * All instances share the same getter function, keeping the V8 hidden class transition
+ * identical across instances. Reset only clears the `#loc` field.
  */
 class Token {
   type: TokenType["type"] = null!; // Overwritten later
@@ -179,36 +195,35 @@ class Token {
   start: number = 0;
   end: number = 0;
   range: [number, number] = [0, 0];
+  declare loc: Location; // Overwritten by __defineGetter__ at construction time
 
   #loc: Location | null = null;
 
-  get loc(): Location {
-    const loc = this.#loc;
-    if (loc !== null) return loc;
-
-    // Store token in `tokensWithLoc` array. `resetTokens` will clear the `#loc` property.
-    // Note: The comparison `activeTokensWithLocCount < tokensWithLoc.length` must be this way around
-    // so that V8 can remove the bounds check on `tokensWithLoc[activeTokensWithLocCount]`.
-    // `tokensWithLoc.length > activeTokensWithLocCount` would *not* remove the bounds check in Maglev compiler.
-    if (activeTokensWithLocCount < tokensWithLoc.length) {
-      tokensWithLoc[activeTokensWithLocCount] = this;
-    } else {
-      tokensWithLoc.push(this);
-    }
-    activeTokensWithLocCount++;
-
-    return (this.#loc = computeLoc(this.start, this.end));
-  }
-
-  // Include `loc` in `JSON.stringify` output.
-  // `loc` is a prototype getter, and `JSON.stringify` only serializes own properties,
-  // so without this method, `loc` would be excluded.
-  toJSON() {
-    // oxlint-disable-next-line typescript/no-misused-spread
-    return { ...this, loc: this.loc };
+  constructor() {
+    // Define `loc` as an own getter property (enumerable + configurable by default).
+    // This makes `{...token}` spread `loc` and `JSON.stringify(token)` serialize it.
+    defineGetter(this, "loc", getTokenLoc);
   }
 
   static {
+    getTokenLocTemp = function (this: Token): Location {
+      const loc = this.#loc;
+      if (loc !== null) return loc;
+
+      // Store token in `tokensWithLoc` array. `resetTokens` will clear the `#loc` property.
+      // Note: The comparison `activeTokensWithLocCount < tokensWithLoc.length` must be this way around
+      // so that V8 can remove the bounds check on `tokensWithLoc[activeTokensWithLocCount]`.
+      // `tokensWithLoc.length > activeTokensWithLocCount` would *not* remove the bounds check in Maglev compiler.
+      if (activeTokensWithLocCount < tokensWithLoc.length) {
+        tokensWithLoc[activeTokensWithLocCount] = this;
+      } else {
+        tokensWithLoc.push(this);
+      }
+      activeTokensWithLocCount++;
+
+      return (this.#loc = computeLoc(this.start, this.end));
+    };
+
     // Defined in static block to avoid exposing this as a public method
     resetLocTemp = (token: Token) => {
       token.#loc = null;
@@ -218,12 +233,9 @@ class Token {
   }
 }
 
-// Reset `#loc` field on a `Token` class instance.
-// Copied into a const here to avoid checks at call site (`let` binding could be re-assigned).
-const resetLoc = resetLocTemp;
-
-// Make `loc` property enumerable so that `for (const key in token) ...` includes `loc` in the keys it iterates over
-Object.defineProperty(Token.prototype, "loc", { enumerable: true });
+// Copied into consts here to avoid checks at call site (`let` binding could be re-assigned).
+const getTokenLoc = getTokenLocTemp!;
+const resetLoc = resetLocTemp!;
 
 // `ESTreeKind` discriminants (set by Rust side)
 const PRIVATE_IDENTIFIER_KIND = 2;

--- a/apps/oxlint/src-js/plugins/tokens.ts
+++ b/apps/oxlint/src-js/plugins/tokens.ts
@@ -157,10 +157,11 @@ let deserializedTokensLen = 0;
 // not *total* number of tokens.
 const DESERIALIZED_TOKEN_INDEXES_MIN_CAPACITY = 16;
 
-// `__defineGetter__` bound to `Function.prototype.call` so it can be called without a
-// `Object.prototype` lookup at each call site.
+// `defineGetter(obj, prop, getter)` is equivalent to `obj.__defineGetter__(prop, getter)`,
+// but without `Object.prototype` lookup at each call site
 const defineGetter = Function.prototype.call.bind(
-  // @ts-expect-error - `__defineGetter__` is not in `Object.prototype`'s type definition, but it does exist at runtime and is widely supported in JS engines, including V8.
+  // @ts-expect-error - `__defineGetter__` is not in `Object.prototype`'s type definition,
+  // but it does exist at runtime and is widely supported in JS engines, including V8
   Object.prototype.__defineGetter__,
 ) as (obj: object, prop: string, getter: () => unknown) => void;
 
@@ -180,9 +181,8 @@ let getTokenPrivateLoc: (token: Token) => Location | null;
  * Token implementation with lazy `loc` caching via private field.
  *
  * `loc` is defined as an own accessor property via `__defineGetter__` in the constructor,
- * using a shared getter function (`getTokenLoc`). This makes `loc` an own enumerable property,
- * so `{...token}` spreads it and `JSON.stringify(token)` serializes it, without needing
- * a `toJSON()` method.
+ * using a shared getter function (`getCommentLoc`). This makes `loc` an own enumerable property,
+ * so `{...comment}` spreads it and `JSON.stringify(comment)` serializes it.
  *
  * The computed `Location` value is cached in the private `#loc` field on first access.
  * All instances share the same getter function, keeping the V8 hidden class transition
@@ -195,16 +195,20 @@ class Token {
   start: number = 0;
   end: number = 0;
   range: [number, number] = [0, 0];
-  declare loc: Location; // Overwritten by __defineGetter__ at construction time
+
+  declare loc: Location; // Defined with `__defineGetter__` in constructor
 
   #loc: Location | null = null;
 
   constructor() {
     // Define `loc` as an own getter property (enumerable + configurable by default).
     // This makes `{...token}` spread `loc` and `JSON.stringify(token)` serialize it.
+    // Note: `new Token()` is 25% faster with `__defineGetter__` vs `Object.defineProperty`.
+    // See https://github.com/oxc-project/oxc/pull/22238.
     defineGetter(this, "loc", getTokenLoc);
   }
 
+  // Functions requiring access to `#loc` defined in static block to avoid exposing them as public methods
   static {
     getTokenLocTemp = function (this: Token): Location {
       const loc = this.#loc;
@@ -224,7 +228,6 @@ class Token {
       return (this.#loc = computeLoc(this.start, this.end));
     };
 
-    // Defined in static block to avoid exposing this as a public method
     resetLocTemp = (token: Token) => {
       token.#loc = null;
     };
@@ -233,7 +236,7 @@ class Token {
   }
 }
 
-// Copied into consts here to avoid checks at call site (`let` binding could be re-assigned).
+// Copied into consts here to avoid checks at call site (`let` binding could be re-assigned)
 const getTokenLoc = getTokenLocTemp!;
 const resetLoc = resetLocTemp!;
 

--- a/apps/oxlint/test/fixtures/tokens/output.snap.md
+++ b/apps/oxlint/test/fixtures/tokens/output.snap.md
@@ -10,6 +10,12 @@
    : ^
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
+   ,-[files/bom.js:1:4]
+ 1 | ﻿a = b;
+   : ^
+   `----
+
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Identifier",
@@ -31,6 +37,12 @@
   |     }
   |   }
   | }
+   ,-[files/bom.js:1:4]
+ 1 | ﻿a = b;
+   : ^
+   `----
+
+  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/bom.js:1:4]
  1 | ﻿a = b;
    : ^
@@ -343,6 +355,14 @@
  3 | 
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
+   ,-[files/escaped_idents.js:2:1]
+ 1 | // abc
+ 2 | var \u{61}b\u0063;
+   : ^^^
+ 3 | 
+   `----
+
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -364,6 +384,14 @@
   |     }
   |   }
   | }
+   ,-[files/escaped_idents.js:2:1]
+ 1 | // abc
+ 2 | var \u{61}b\u0063;
+   : ^^^
+ 3 | 
+   `----
+
+  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/escaped_idents.js:2:1]
  1 | // abc
  2 | var \u{61}b\u0063;
@@ -1097,6 +1125,13 @@
  2 |   fn: <T>(arg: T): T => {
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
+   ,-[files/generic_arrow.ts:1:1]
+ 1 | const obj = {
+   : ^^^^^
+ 2 |   fn: <T>(arg: T): T => {
+   `----
+
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -1118,6 +1153,13 @@
   |     }
   |   }
   | }
+   ,-[files/generic_arrow.ts:1:1]
+ 1 | const obj = {
+   : ^^^^^
+ 2 |   fn: <T>(arg: T): T => {
+   `----
+
+  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/generic_arrow.ts:1:1]
  1 | const obj = {
    : ^^^^^
@@ -1534,6 +1576,14 @@
  4 | 
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
+   ,-[files/index.js:3:1]
+ 2 | 
+ 3 | let x = /* inline comment */ 1;
+   : ^^^
+ 4 | 
+   `----
+
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -1555,6 +1605,14 @@
   |     }
   |   }
   | }
+   ,-[files/index.js:3:1]
+ 2 | 
+ 3 | let x = /* inline comment */ 1;
+   : ^^^
+ 4 | 
+   `----
+
+  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/index.js:3:1]
  2 | 
  3 | let x = /* inline comment */ 1;
@@ -1674,6 +1732,13 @@
  2 |   return <div className="test">Hello</div>;
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
+   ,-[files/jsx_element.tsx:1:1]
+ 1 | const Component = () => {
+   : ^^^^^
+ 2 |   return <div className="test">Hello</div>;
+   `----
+
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -1695,6 +1760,13 @@
   |     }
   |   }
   | }
+   ,-[files/jsx_element.tsx:1:1]
+ 1 | const Component = () => {
+   : ^^^^^
+ 2 |   return <div className="test">Hello</div>;
+   `----
+
+  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/jsx_element.tsx:1:1]
  1 | const Component = () => {
    : ^^^^^
@@ -2015,6 +2087,13 @@
  2 |   // Identifier tokens
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
+   ,-[files/keywords.js:1:1]
+ 1 | const obj = {
+   : ^^^^^
+ 2 |   // Identifier tokens
+   `----
+
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -2036,6 +2115,13 @@
   |     }
   |   }
   | }
+   ,-[files/keywords.js:1:1]
+ 1 | const obj = {
+   : ^^^^^
+ 2 |   // Identifier tokens
+   `----
+
+  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/keywords.js:1:1]
  1 | const obj = {
    : ^^^^^
@@ -2462,6 +2548,14 @@
  3 | 
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
+   ,-[files/ts_angle_relex.ts:2:1]
+ 1 | // `<<` is disambiguated: speculatively tried as `<` for type args, fails, rewinds to `<<`
+ 2 | const a = n << 2;
+   : ^^^^^
+ 3 | 
+   `----
+
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -2483,6 +2577,14 @@
   |     }
   |   }
   | }
+   ,-[files/ts_angle_relex.ts:2:1]
+ 1 | // `<<` is disambiguated: speculatively tried as `<` for type args, fails, rewinds to `<<`
+ 2 | const a = n << 2;
+   : ^^^^^
+ 3 | 
+   `----
+
+  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/ts_angle_relex.ts:2:1]
  1 | // `<<` is disambiguated: speculatively tried as `<` for type args, fails, rewinds to `<<`
  2 | const a = n << 2;
@@ -2763,6 +2865,13 @@
  2 | // 😀🤪😆😎🤮
    `----
 
+  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
+   ,-[files/unicode.js:1:1]
+ 1 | a;
+   : ^
+ 2 | // 😀🤪😆😎🤮
+   `----
+
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Identifier",
@@ -2784,6 +2893,13 @@
   |     }
   |   }
   | }
+   ,-[files/unicode.js:1:1]
+ 1 | a;
+   : ^
+ 2 | // 😀🤪😆😎🤮
+   `----
+
+  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/unicode.js:1:1]
  1 | a;
    : ^
@@ -2845,7 +2961,7 @@
    :  ^
    `----
 
-Found 0 warnings and 251 errors.
+Found 0 warnings and 267 errors.
 Finished in Xms on 8 files with 1 rules using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/tokens/output.snap.md
+++ b/apps/oxlint/test/fixtures/tokens/output.snap.md
@@ -10,12 +10,6 @@
    : ^
    `----
 
-  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
-   ,-[files/bom.js:1:4]
- 1 | ﻿a = b;
-   : ^
-   `----
-
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Identifier",
@@ -37,12 +31,6 @@
   |     }
   |   }
   | }
-   ,-[files/bom.js:1:4]
- 1 | ﻿a = b;
-   : ^
-   `----
-
-  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/bom.js:1:4]
  1 | ﻿a = b;
    : ^
@@ -355,14 +343,6 @@
  3 | 
    `----
 
-  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
-   ,-[files/escaped_idents.js:2:1]
- 1 | // abc
- 2 | var \u{61}b\u0063;
-   : ^^^
- 3 | 
-   `----
-
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -384,14 +364,6 @@
   |     }
   |   }
   | }
-   ,-[files/escaped_idents.js:2:1]
- 1 | // abc
- 2 | var \u{61}b\u0063;
-   : ^^^
- 3 | 
-   `----
-
-  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/escaped_idents.js:2:1]
  1 | // abc
  2 | var \u{61}b\u0063;
@@ -1125,13 +1097,6 @@
  2 |   fn: <T>(arg: T): T => {
    `----
 
-  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
-   ,-[files/generic_arrow.ts:1:1]
- 1 | const obj = {
-   : ^^^^^
- 2 |   fn: <T>(arg: T): T => {
-   `----
-
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -1153,13 +1118,6 @@
   |     }
   |   }
   | }
-   ,-[files/generic_arrow.ts:1:1]
- 1 | const obj = {
-   : ^^^^^
- 2 |   fn: <T>(arg: T): T => {
-   `----
-
-  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/generic_arrow.ts:1:1]
  1 | const obj = {
    : ^^^^^
@@ -1576,14 +1534,6 @@
  4 | 
    `----
 
-  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
-   ,-[files/index.js:3:1]
- 2 | 
- 3 | let x = /* inline comment */ 1;
-   : ^^^
- 4 | 
-   `----
-
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -1605,14 +1555,6 @@
   |     }
   |   }
   | }
-   ,-[files/index.js:3:1]
- 2 | 
- 3 | let x = /* inline comment */ 1;
-   : ^^^
- 4 | 
-   `----
-
-  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/index.js:3:1]
  2 | 
  3 | let x = /* inline comment */ 1;
@@ -1732,13 +1674,6 @@
  2 |   return <div className="test">Hello</div>;
    `----
 
-  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
-   ,-[files/jsx_element.tsx:1:1]
- 1 | const Component = () => {
-   : ^^^^^
- 2 |   return <div className="test">Hello</div>;
-   `----
-
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -1760,13 +1695,6 @@
   |     }
   |   }
   | }
-   ,-[files/jsx_element.tsx:1:1]
- 1 | const Component = () => {
-   : ^^^^^
- 2 |   return <div className="test">Hello</div>;
-   `----
-
-  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/jsx_element.tsx:1:1]
  1 | const Component = () => {
    : ^^^^^
@@ -2087,13 +2015,6 @@
  2 |   // Identifier tokens
    `----
 
-  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
-   ,-[files/keywords.js:1:1]
- 1 | const obj = {
-   : ^^^^^
- 2 |   // Identifier tokens
-   `----
-
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -2115,13 +2036,6 @@
   |     }
   |   }
   | }
-   ,-[files/keywords.js:1:1]
- 1 | const obj = {
-   : ^^^^^
- 2 |   // Identifier tokens
-   `----
-
-  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/keywords.js:1:1]
  1 | const obj = {
    : ^^^^^
@@ -2548,14 +2462,6 @@
  3 | 
    `----
 
-  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
-   ,-[files/ts_angle_relex.ts:2:1]
- 1 | // `<<` is disambiguated: speculatively tried as `<` for type args, fails, rewinds to `<<`
- 2 | const a = n << 2;
-   : ^^^^^
- 3 | 
-   `----
-
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Keyword",
@@ -2577,14 +2483,6 @@
   |     }
   |   }
   | }
-   ,-[files/ts_angle_relex.ts:2:1]
- 1 | // `<<` is disambiguated: speculatively tried as `<` for type args, fails, rewinds to `<<`
- 2 | const a = n << 2;
-   : ^^^^^
- 3 | 
-   `----
-
-  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/ts_angle_relex.ts:2:1]
  1 | // `<<` is disambiguated: speculatively tried as `<` for type args, fails, rewinds to `<<`
  2 | const a = n << 2;
@@ -2865,13 +2763,6 @@
  2 | // 😀🤪😆😎🤮
    `----
 
-  x tokens-plugin(tokens): Token JSON.stringify includes loc: true
-   ,-[files/unicode.js:1:1]
- 1 | a;
-   : ^
- 2 | // 😀🤪😆😎🤮
-   `----
-
   x tokens-plugin(tokens): Token JSON.stringify:
   | {
   |   "type": "Identifier",
@@ -2893,13 +2784,6 @@
   |     }
   |   }
   | }
-   ,-[files/unicode.js:1:1]
- 1 | a;
-   : ^
- 2 | // 😀🤪😆😎🤮
-   `----
-
-  x tokens-plugin(tokens): Token spread includes loc: true
    ,-[files/unicode.js:1:1]
  1 | a;
    : ^
@@ -2961,7 +2845,7 @@
    :  ^
    `----
 
-Found 0 warnings and 267 errors.
+Found 0 warnings and 251 errors.
 Finished in Xms on 8 files with 1 rules using X threads.
 ```
 

--- a/apps/oxlint/test/fixtures/tokens/plugin.ts
+++ b/apps/oxlint/test/fixtures/tokens/plugin.ts
@@ -101,20 +101,6 @@ const rule: Rule = {
         message: `Token JSON.stringify:\n${JSON.stringify(firstToken, null, 2)}`,
         node: firstToken,
       });
-
-      const clone = { ...firstToken };
-      const cloneHasLoc = Object.hasOwn(clone, "loc") && clone.loc === firstToken.loc;
-      context.report({
-        message: `Token spread includes loc: ${cloneHasLoc}`,
-        node: firstToken,
-      });
-
-      // Check `JSON.stringify` on comment includes `loc`
-      const jsonHasLoc = Object.hasOwn(JSON.parse(JSON.stringify(firstToken)), "loc");
-      context.report({
-        message: `Token JSON.stringify includes loc: ${jsonHasLoc}`,
-        node: firstToken,
-      });
     }
 
     return {};

--- a/apps/oxlint/test/fixtures/tokens/plugin.ts
+++ b/apps/oxlint/test/fixtures/tokens/plugin.ts
@@ -22,6 +22,11 @@ const rule: Rule = {
       assert(range === tokenOrComment.range);
       assert(loc === tokenOrComment.loc);
 
+      // Cloning comment with spread should include `loc` and it should be the same object
+      const clone = { ...tokenOrComment };
+      assert(Object.hasOwn(clone, "loc"));
+      assert(tokenOrComment.loc === clone.loc);
+
       // Check `getRange` and `getLoc` return the same objects too
       assert(sourceCode.getRange(tokenOrComment) === range);
       assert(sourceCode.getLoc(tokenOrComment) === loc);
@@ -94,6 +99,20 @@ const rule: Rule = {
     if (firstToken) {
       context.report({
         message: `Token JSON.stringify:\n${JSON.stringify(firstToken, null, 2)}`,
+        node: firstToken,
+      });
+
+      const clone = { ...firstToken };
+      const cloneHasLoc = Object.hasOwn(clone, "loc") && clone.loc === firstToken.loc;
+      context.report({
+        message: `Token spread includes loc: ${cloneHasLoc}`,
+        node: firstToken,
+      });
+
+      // Check `JSON.stringify` on comment includes `loc`
+      const jsonHasLoc = Object.hasOwn(JSON.parse(JSON.stringify(firstToken)), "loc");
+      context.report({
+        message: `Token JSON.stringify includes loc: ${jsonHasLoc}`,
         node: firstToken,
       });
     }

--- a/apps/oxlint/test/fixtures/tokens/plugin.ts
+++ b/apps/oxlint/test/fixtures/tokens/plugin.ts
@@ -19,13 +19,13 @@ const rule: Rule = {
     for (const tokenOrComment of tokensAndComments) {
       // Check getting `range` / `loc` properties twice results in same objects
       const { range, loc } = tokenOrComment;
-      assert(range === tokenOrComment.range);
-      assert(loc === tokenOrComment.loc);
+      assert(tokenOrComment.range === range);
+      assert(tokenOrComment.loc === loc);
 
       // Cloning comment with spread should include `loc` and it should be the same object
       const clone = { ...tokenOrComment };
       assert(Object.hasOwn(clone, "loc"));
-      assert(tokenOrComment.loc === clone.loc);
+      assert(clone.loc === loc);
 
       // Check `getRange` and `getLoc` return the same objects too
       assert(sourceCode.getRange(tokenOrComment) === range);


### PR DESCRIPTION
Follow-up of #22238, same logic applied to `Token` class

## Problem
  
`Token` instances are object-pooled and reused across files, similar to `Comment`.
Their `loc` property is defined as a **prototype getter**, which means it is not an own
property and is therefore invisible to the spread operator:

```js
const spread = { ...token };
"loc" in spread; // false ❌
```

This silently drops `loc` whenever a JS plugin (or rule) spreads a token — e.g. when
building a diagnostic from `{ ...token, message: "…" }`.

`JSON.stringify` had the same problem and was patched with a `toJSON()` workaround.
A separate `Object.defineProperty(Token.prototype, "loc", { enumerable: true })` call
was used to make `loc` show up in `for…in` iteration, but it still didn't fix spread.

##  Fix

Define `loc` as an own accessor property on every `Token` instance using
`__defineGetter__`. Own properties are visible to spread, `JSON.stringify,` and
`for…in` iteration, so all three work without any extra workarounds.

The getter function is defined in the class static block and captured in a `const`
(`getTokenLoc`). Using a `const` rather than a `let` lets V8 skip reassignment checks
at the `defineGetter(this, "loc", getTokenLoc)` call site — a pattern already
established in the codebase for `resetLoc`.

As a result:
- `toJSON()` is removed — `JSON.stringify` now works via the own property directly.
- `Object.defineProperty(Token.prototype, "loc", { enumerable: true })` is removed —
no longer needed.

##  Test

A spread assertion is added to the existing `tokens` fixture:

```js
const spread = { ...firstToken };
assert("loc" in spread);           // was false before this fix
assert.deepEqual(spread.loc, firstToken.loc);
```