### PR TITLE
feat(linter/vue): implement require-default-prop rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1331,6 +1331,7 @@ export interface DummyRuleMap {
   "vue/prefer-import-from-vue"?: DummyRule;
   "vue/prop-name-casing"?: DummyRule;
   "vue/require-default-export"?: DummyRule;
+  "vue/require-default-prop"?: DummyRule;
   "vue/require-direct-export"?: DummyRule;
   "vue/require-prop-type-constructor"?: DummyRule;
   "vue/require-prop-types"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5148,6 +5148,12 @@ impl RuleRunner for crate::rules::vue::require_default_export::RequireDefaultExp
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::vue::require_default_prop::RequireDefaultProp {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ObjectExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::require_direct_export::RequireDirectExport {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ExportDefaultDeclaration]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -820,6 +820,7 @@ pub use crate::rules::vue::no_watch_after_await::NoWatchAfterAwait as VueNoWatch
 pub use crate::rules::vue::prefer_import_from_vue::PreferImportFromVue as VuePreferImportFromVue;
 pub use crate::rules::vue::prop_name_casing::PropNameCasing as VuePropNameCasing;
 pub use crate::rules::vue::require_default_export::RequireDefaultExport as VueRequireDefaultExport;
+pub use crate::rules::vue::require_default_prop::RequireDefaultProp as VueRequireDefaultProp;
 pub use crate::rules::vue::require_direct_export::RequireDirectExport as VueRequireDirectExport;
 pub use crate::rules::vue::require_prop_type_constructor::RequirePropTypeConstructor as VueRequirePropTypeConstructor;
 pub use crate::rules::vue::require_prop_types::RequirePropTypes as VueRequirePropTypes;
@@ -1662,6 +1663,7 @@ pub enum RuleEnum {
     VuePreferImportFromVue(VuePreferImportFromVue),
     VuePropNameCasing(VuePropNameCasing),
     VueRequireDefaultExport(VueRequireDefaultExport),
+    VueRequireDefaultProp(VueRequireDefaultProp),
     VueRequireDirectExport(VueRequireDirectExport),
     VueRequirePropTypeConstructor(VueRequirePropTypeConstructor),
     VueRequirePropTypes(VueRequirePropTypes),
@@ -2591,7 +2593,8 @@ const VUE_NO_WATCH_AFTER_AWAIT_ID: usize = VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID 
 const VUE_PREFER_IMPORT_FROM_VUE_ID: usize = VUE_NO_WATCH_AFTER_AWAIT_ID + 1usize;
 const VUE_PROP_NAME_CASING_ID: usize = VUE_PREFER_IMPORT_FROM_VUE_ID + 1usize;
 const VUE_REQUIRE_DEFAULT_EXPORT_ID: usize = VUE_PROP_NAME_CASING_ID + 1usize;
-const VUE_REQUIRE_DIRECT_EXPORT_ID: usize = VUE_REQUIRE_DEFAULT_EXPORT_ID + 1usize;
+const VUE_REQUIRE_DEFAULT_PROP_ID: usize = VUE_REQUIRE_DEFAULT_EXPORT_ID + 1usize;
+const VUE_REQUIRE_DIRECT_EXPORT_ID: usize = VUE_REQUIRE_DEFAULT_PROP_ID + 1usize;
 const VUE_REQUIRE_PROP_TYPE_CONSTRUCTOR_ID: usize = VUE_REQUIRE_DIRECT_EXPORT_ID + 1usize;
 const VUE_REQUIRE_PROP_TYPES_ID: usize = VUE_REQUIRE_PROP_TYPE_CONSTRUCTOR_ID + 1usize;
 const VUE_REQUIRE_RENDER_RETURN_ID: usize = VUE_REQUIRE_PROP_TYPES_ID + 1usize;
@@ -3544,6 +3547,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VUE_PREFER_IMPORT_FROM_VUE_ID,
             Self::VuePropNameCasing(_) => VUE_PROP_NAME_CASING_ID,
             Self::VueRequireDefaultExport(_) => VUE_REQUIRE_DEFAULT_EXPORT_ID,
+            Self::VueRequireDefaultProp(_) => VUE_REQUIRE_DEFAULT_PROP_ID,
             Self::VueRequireDirectExport(_) => VUE_REQUIRE_DIRECT_EXPORT_ID,
             Self::VueRequirePropTypeConstructor(_) => VUE_REQUIRE_PROP_TYPE_CONSTRUCTOR_ID,
             Self::VueRequirePropTypes(_) => VUE_REQUIRE_PROP_TYPES_ID,
@@ -4482,6 +4486,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::NAME,
             Self::VuePropNameCasing(_) => VuePropNameCasing::NAME,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::NAME,
+            Self::VueRequireDefaultProp(_) => VueRequireDefaultProp::NAME,
             Self::VueRequireDirectExport(_) => VueRequireDirectExport::NAME,
             Self::VueRequirePropTypeConstructor(_) => VueRequirePropTypeConstructor::NAME,
             Self::VueRequirePropTypes(_) => VueRequirePropTypes::NAME,
@@ -5478,6 +5483,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::CATEGORY,
             Self::VuePropNameCasing(_) => VuePropNameCasing::CATEGORY,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::CATEGORY,
+            Self::VueRequireDefaultProp(_) => VueRequireDefaultProp::CATEGORY,
             Self::VueRequireDirectExport(_) => VueRequireDirectExport::CATEGORY,
             Self::VueRequirePropTypeConstructor(_) => VueRequirePropTypeConstructor::CATEGORY,
             Self::VueRequirePropTypes(_) => VueRequirePropTypes::CATEGORY,
@@ -6417,6 +6423,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::FIX,
             Self::VuePropNameCasing(_) => VuePropNameCasing::FIX,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::FIX,
+            Self::VueRequireDefaultProp(_) => VueRequireDefaultProp::FIX,
             Self::VueRequireDirectExport(_) => VueRequireDirectExport::FIX,
             Self::VueRequirePropTypeConstructor(_) => VueRequirePropTypeConstructor::FIX,
             Self::VueRequirePropTypes(_) => VueRequirePropTypes::FIX,
@@ -7616,6 +7623,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::documentation(),
             Self::VuePropNameCasing(_) => VuePropNameCasing::documentation(),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::documentation(),
+            Self::VueRequireDefaultProp(_) => VueRequireDefaultProp::documentation(),
             Self::VueRequireDirectExport(_) => VueRequireDirectExport::documentation(),
             Self::VueRequirePropTypeConstructor(_) => {
                 VueRequirePropTypeConstructor::documentation()
@@ -9973,6 +9981,8 @@ impl RuleEnum {
                 .or_else(|| VuePropNameCasing::schema(generator)),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::config_schema(generator)
                 .or_else(|| VueRequireDefaultExport::schema(generator)),
+            Self::VueRequireDefaultProp(_) => VueRequireDefaultProp::config_schema(generator)
+                .or_else(|| VueRequireDefaultProp::schema(generator)),
             Self::VueRequireDirectExport(_) => VueRequireDirectExport::config_schema(generator)
                 .or_else(|| VueRequireDirectExport::schema(generator)),
             Self::VueRequirePropTypeConstructor(_) => {
@@ -10821,6 +10831,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => "vue",
             Self::VuePropNameCasing(_) => "vue",
             Self::VueRequireDefaultExport(_) => "vue",
+            Self::VueRequireDefaultProp(_) => "vue",
             Self::VueRequireDirectExport(_) => "vue",
             Self::VueRequirePropTypeConstructor(_) => "vue",
             Self::VueRequirePropTypes(_) => "vue",
@@ -13458,6 +13469,9 @@ impl RuleEnum {
             Self::VueRequireDefaultExport(_) => Ok(Self::VueRequireDefaultExport(
                 VueRequireDefaultExport::from_configuration(value)?,
             )),
+            Self::VueRequireDefaultProp(_) => {
+                Ok(Self::VueRequireDefaultProp(VueRequireDefaultProp::from_configuration(value)?))
+            }
             Self::VueRequireDirectExport(_) => {
                 Ok(Self::VueRequireDirectExport(VueRequireDirectExport::from_configuration(value)?))
             }
@@ -14314,6 +14328,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.to_configuration(),
             Self::VuePropNameCasing(rule) => rule.to_configuration(),
             Self::VueRequireDefaultExport(rule) => rule.to_configuration(),
+            Self::VueRequireDefaultProp(rule) => rule.to_configuration(),
             Self::VueRequireDirectExport(rule) => rule.to_configuration(),
             Self::VueRequirePropTypeConstructor(rule) => rule.to_configuration(),
             Self::VueRequirePropTypes(rule) => rule.to_configuration(),
@@ -15152,6 +15167,7 @@ impl RuleEnum {
                 Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
                 Self::VuePropNameCasing(rule) => rule.run(node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
+                Self::VueRequireDefaultProp(rule) => rule.run(node, ctx),
                 Self::VueRequireDirectExport(rule) => rule.run(node, ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run(node, ctx),
                 Self::VueRequirePropTypes(rule) => rule.run(node, ctx),
@@ -15983,6 +15999,7 @@ impl RuleEnum {
                 Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
                 Self::VuePropNameCasing(rule) => rule.run(node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
+                Self::VueRequireDefaultProp(rule) => rule.run(node, ctx),
                 Self::VueRequireDirectExport(rule) => rule.run(node, ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run(node, ctx),
                 Self::VueRequirePropTypes(rule) => rule.run(node, ctx),
@@ -16821,6 +16838,7 @@ impl RuleEnum {
                 Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
                 Self::VuePropNameCasing(rule) => rule.run_once(ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
+                Self::VueRequireDefaultProp(rule) => rule.run_once(ctx),
                 Self::VueRequireDirectExport(rule) => rule.run_once(ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run_once(ctx),
                 Self::VueRequirePropTypes(rule) => rule.run_once(ctx),
@@ -17652,6 +17670,7 @@ impl RuleEnum {
                 Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
                 Self::VuePropNameCasing(rule) => rule.run_once(ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
+                Self::VueRequireDefaultProp(rule) => rule.run_once(ctx),
                 Self::VueRequireDirectExport(rule) => rule.run_once(ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run_once(ctx),
                 Self::VueRequirePropTypes(rule) => rule.run_once(ctx),
@@ -18747,6 +18766,7 @@ impl RuleEnum {
                 Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VuePropNameCasing(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueRequireDefaultProp(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireDirectExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequirePropTypes(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19834,6 +19854,7 @@ impl RuleEnum {
                 Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VuePropNameCasing(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueRequireDefaultProp(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequireDirectExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequirePropTypeConstructor(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueRequirePropTypes(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20663,6 +20684,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.should_run(ctx),
             Self::VuePropNameCasing(rule) => rule.should_run(ctx),
             Self::VueRequireDefaultExport(rule) => rule.should_run(ctx),
+            Self::VueRequireDefaultProp(rule) => rule.should_run(ctx),
             Self::VueRequireDirectExport(rule) => rule.should_run(ctx),
             Self::VueRequirePropTypeConstructor(rule) => rule.should_run(ctx),
             Self::VueRequirePropTypes(rule) => rule.should_run(ctx),
@@ -21861,6 +21883,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::IS_TSGOLINT_RULE,
             Self::VuePropNameCasing(_) => VuePropNameCasing::IS_TSGOLINT_RULE,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::IS_TSGOLINT_RULE,
+            Self::VueRequireDefaultProp(_) => VueRequireDefaultProp::IS_TSGOLINT_RULE,
             Self::VueRequireDirectExport(_) => VueRequireDirectExport::IS_TSGOLINT_RULE,
             Self::VueRequirePropTypeConstructor(_) => {
                 VueRequirePropTypeConstructor::IS_TSGOLINT_RULE
@@ -22861,6 +22884,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::VERSION,
             Self::VuePropNameCasing(_) => VuePropNameCasing::VERSION,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::VERSION,
+            Self::VueRequireDefaultProp(_) => VueRequireDefaultProp::VERSION,
             Self::VueRequireDirectExport(_) => VueRequireDirectExport::VERSION,
             Self::VueRequirePropTypeConstructor(_) => VueRequirePropTypeConstructor::VERSION,
             Self::VueRequirePropTypes(_) => VueRequirePropTypes::VERSION,
@@ -23896,6 +23920,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::HAS_CONFIG,
             Self::VuePropNameCasing(_) => VuePropNameCasing::HAS_CONFIG,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::HAS_CONFIG,
+            Self::VueRequireDefaultProp(_) => VueRequireDefaultProp::HAS_CONFIG,
             Self::VueRequireDirectExport(_) => VueRequireDirectExport::HAS_CONFIG,
             Self::VueRequirePropTypeConstructor(_) => VueRequirePropTypeConstructor::HAS_CONFIG,
             Self::VueRequirePropTypes(_) => VueRequirePropTypes::HAS_CONFIG,
@@ -24724,6 +24749,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.types_info(),
             Self::VuePropNameCasing(rule) => rule.types_info(),
             Self::VueRequireDefaultExport(rule) => rule.types_info(),
+            Self::VueRequireDefaultProp(rule) => rule.types_info(),
             Self::VueRequireDirectExport(rule) => rule.types_info(),
             Self::VueRequirePropTypeConstructor(rule) => rule.types_info(),
             Self::VueRequirePropTypes(rule) => rule.types_info(),
@@ -25552,6 +25578,7 @@ impl RuleEnum {
             Self::VuePreferImportFromVue(rule) => rule.run_info(),
             Self::VuePropNameCasing(rule) => rule.run_info(),
             Self::VueRequireDefaultExport(rule) => rule.run_info(),
+            Self::VueRequireDefaultProp(rule) => rule.run_info(),
             Self::VueRequireDirectExport(rule) => rule.run_info(),
             Self::VueRequirePropTypeConstructor(rule) => rule.run_info(),
             Self::VueRequirePropTypes(rule) => rule.run_info(),
@@ -26512,6 +26539,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VuePreferImportFromVue(VuePreferImportFromVue::default()),
         RuleEnum::VuePropNameCasing(VuePropNameCasing::default()),
         RuleEnum::VueRequireDefaultExport(VueRequireDefaultExport::default()),
+        RuleEnum::VueRequireDefaultProp(VueRequireDefaultProp::default()),
         RuleEnum::VueRequireDirectExport(VueRequireDirectExport::default()),
         RuleEnum::VueRequirePropTypeConstructor(VueRequirePropTypeConstructor::default()),
         RuleEnum::VueRequirePropTypes(VueRequirePropTypes::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -872,6 +872,7 @@ pub(crate) mod vue {
     pub mod prefer_import_from_vue;
     pub mod prop_name_casing;
     pub mod require_default_export;
+    pub mod require_default_prop;
     pub mod require_direct_export;
     pub mod require_prop_type_constructor;
     pub mod require_prop_types;

--- a/crates/oxc_linter/src/rules/vue/require_default_prop.rs
+++ b/crates/oxc_linter/src/rules/vue/require_default_prop.rs
@@ -1,0 +1,907 @@
+use rustc_hash::FxHashSet;
+
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrayExpressionElement, BindingPattern, CallExpression, Expression, ObjectExpression,
+        ObjectPropertyKind, PropertyKey, TSSignature, TSType, TSTypeName,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    ast_util::get_declaration_from_reference_id,
+    context::LintContext,
+    frameworks::FrameworkOptions,
+    rule::Rule,
+    utils::{find_property, is_vue_component_options_object_excluding_instance},
+};
+
+const NATIVE_TYPES: [&str; 7] =
+    ["String", "Number", "Boolean", "Function", "Object", "Array", "Symbol"];
+
+fn require_default_prop_diagnostic(span: Span, prop_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prop '{prop_name}' requires default value to be set."))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RequireDefaultProp;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Requires default value to be set for props that are not marked as
+    /// `required`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A prop that is neither required nor given a default is implicitly
+    /// `undefined` when omitted. Forcing a default keeps the component's
+    /// behavior explicit and avoids `undefined` leaking into the template and
+    /// logic. `Boolean` props are exempt because they already default to
+    /// `false`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   props: {
+    ///     name: String,
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   props: {
+    ///     name: {
+    ///       type: String,
+    ///       default: '',
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    RequireDefaultProp,
+    vue,
+    style,
+    version = "next",
+);
+
+/// Tracks how default values may be supplied for `<script setup>` props, so a
+/// prop covered by `withDefaults` or a destructure default is not flagged.
+#[derive(Default)]
+struct PropsContext {
+    using_destructure: bool,
+    destructure_defaults: FxHashSet<String>,
+    with_defaults: Option<FxHashSet<String>>,
+}
+
+impl Rule for RequireDefaultProp {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::ObjectExpression(obj) => {
+                if !is_vue_component_options_object_excluding_instance(node, ctx) {
+                    return;
+                }
+                let Some(props_prop) = find_property(obj, "props") else { return };
+                if let Expression::ObjectExpression(props_obj) =
+                    props_prop.value.get_inner_expression()
+                {
+                    check_object_props(props_obj, ctx, &PropsContext::default());
+                }
+            }
+            AstKind::CallExpression(call) => {
+                if ctx.frameworks_options() != FrameworkOptions::VueSetup {
+                    return;
+                }
+                let Some(ident) = call.callee.get_identifier_reference() else { return };
+                match ident.name.as_str() {
+                    // A `defineProps` wrapped by `withDefaults` is handled by the
+                    // `withDefaults` branch, which also knows the default values.
+                    "defineProps" if !is_wrapped_by_with_defaults(node, ctx) => {
+                        let props_ctx = destructure_context(node, ctx, None);
+                        handle_define_props(call, ctx, &props_ctx);
+                    }
+                    "withDefaults" if call.arguments.len() == 2 => {
+                        handle_with_defaults(node, call, ctx);
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn handle_with_defaults<'a>(node: &AstNode<'a>, call: &CallExpression<'a>, ctx: &LintContext<'a>) {
+    let Some(first) = call.arguments.first().and_then(|a| a.as_expression()) else { return };
+    let Some(second) = call.arguments.get(1).and_then(|a| a.as_expression()) else { return };
+    let Expression::CallExpression(define_props) = first.get_inner_expression() else { return };
+    if !define_props.callee.get_identifier_reference().is_some_and(|i| i.name == "defineProps") {
+        return;
+    }
+    let with_defaults = object_keys(second.get_inner_expression());
+    let props_ctx = destructure_context(node, ctx, Some(with_defaults));
+    handle_define_props(define_props, ctx, &props_ctx);
+}
+
+fn handle_define_props<'a>(call: &CallExpression<'a>, ctx: &LintContext<'a>, pc: &PropsContext) {
+    if let Some(arg) = call.arguments.first().and_then(|a| a.as_expression()) {
+        if let Expression::ObjectExpression(obj) = arg.get_inner_expression() {
+            check_object_props(obj, ctx, pc);
+        }
+        return;
+    }
+    if let Some(type_args) = call.type_arguments.as_ref()
+        && let Some(first) = type_args.params.first()
+    {
+        check_type_props(first, ctx, pc);
+    }
+}
+
+/// Resolves the enclosing `const { foo = 1 } = …` destructure (if any) into the
+/// set of prop names that already carry a default.
+fn destructure_context<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+    with_defaults: Option<FxHashSet<String>>,
+) -> PropsContext {
+    let mut pc = PropsContext { with_defaults, ..PropsContext::default() };
+    let declarator = ctx.nodes().ancestors(node.id()).find_map(|ancestor| {
+        if let AstKind::VariableDeclarator(decl) = ancestor.kind() { Some(decl) } else { None }
+    });
+    if let Some(decl) = declarator
+        && let BindingPattern::ObjectPattern(pattern) = &decl.id
+    {
+        pc.using_destructure = true;
+        for prop in &pattern.properties {
+            if matches!(prop.value, BindingPattern::AssignmentPattern(_))
+                && let Some(name) = prop.key.static_name()
+            {
+                pc.destructure_defaults.insert(name.to_string());
+            }
+        }
+    }
+    pc
+}
+
+fn is_wrapped_by_with_defaults(node: &AstNode, ctx: &LintContext) -> bool {
+    matches!(
+        ctx.nodes().parent_node(node.id()).kind(),
+        AstKind::CallExpression(call)
+            if call.callee.get_identifier_reference().is_some_and(|i| i.name == "withDefaults")
+    )
+}
+
+fn object_keys(expr: &Expression) -> FxHashSet<String> {
+    let Expression::ObjectExpression(obj) = expr else { return FxHashSet::default() };
+    obj.properties
+        .iter()
+        .filter_map(|prop| match prop {
+            ObjectPropertyKind::ObjectProperty(prop) => {
+                prop.key.static_name().map(|name| name.to_string())
+            }
+            ObjectPropertyKind::SpreadProperty(_) => None,
+        })
+        .collect()
+}
+
+fn check_object_props<'a>(obj: &ObjectExpression<'a>, ctx: &LintContext<'a>, pc: &PropsContext) {
+    for prop in &obj.properties {
+        let ObjectPropertyKind::ObjectProperty(prop) = prop else { continue };
+        if prop.shorthand {
+            continue;
+        }
+        let value = prop.value.get_inner_expression();
+        if !is_without_default_value(value) || is_boolean_prop(value) {
+            continue;
+        }
+        let name = prop.key.static_name();
+        if pc.using_destructure {
+            match &name {
+                // A computed key whose name is unknown is ignored under a destructure.
+                None => continue,
+                Some(name) if pc.destructure_defaults.contains(name.as_ref()) => continue,
+                _ => {}
+            }
+        }
+        let display = match &name {
+            Some(name) => name.to_string(),
+            None => format!("[{}]", prop.key.span().source_text(ctx.source_text())),
+        };
+        ctx.diagnostic(require_default_prop_diagnostic(prop.span(), &display));
+    }
+}
+
+/// Mirrors upstream `flattenTypeNodes`: a `defineProps<T>()` type is walked
+/// recursively so unions, intersections and `interface`/`type` references are
+/// all resolved down to their property signatures.
+fn check_type_props<'a>(ts_type: &TSType<'a>, ctx: &LintContext<'a>, pc: &PropsContext) {
+    match ts_type {
+        TSType::TSTypeLiteral(literal) => {
+            for signature in &literal.members {
+                check_type_signature(signature, ctx, pc);
+            }
+        }
+        TSType::TSUnionType(union) => {
+            for member in &union.types {
+                check_type_props(member, ctx, pc);
+            }
+        }
+        TSType::TSIntersectionType(intersection) => {
+            for member in &intersection.types {
+                check_type_props(member, ctx, pc);
+            }
+        }
+        TSType::TSTypeReference(type_ref) => {
+            let TSTypeName::IdentifierReference(ident) = &type_ref.type_name else { return };
+            let reference = ctx.scoping().get_reference(ident.reference_id());
+            if !reference.is_type() {
+                return;
+            }
+            let Some(declaration) =
+                get_declaration_from_reference_id(ident.reference_id(), ctx.semantic())
+            else {
+                return;
+            };
+            match declaration.kind() {
+                AstKind::TSInterfaceDeclaration(interface) => {
+                    for signature in &interface.body.body {
+                        check_type_signature(signature, ctx, pc);
+                    }
+                }
+                AstKind::TSTypeAliasDeclaration(alias) => {
+                    check_type_props(&alias.type_annotation, ctx, pc);
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    }
+}
+
+fn check_type_signature<'a>(signature: &TSSignature<'a>, ctx: &LintContext<'a>, pc: &PropsContext) {
+    let (key, optional) = match signature {
+        TSSignature::TSPropertySignature(sig) => (&sig.key, sig.optional),
+        TSSignature::TSMethodSignature(sig) => (&sig.key, sig.optional),
+        _ => return,
+    };
+    // A required (non-optional) prop never needs a default.
+    if !optional {
+        return;
+    }
+    let Some(name) = key.static_name() else { return };
+    if is_single_boolean_type(signature) {
+        return;
+    }
+    // Without `withDefaults`/destructure there is nowhere to attach a default,
+    // so a bare `defineProps<T>()` type prop is never reported.
+    if pc.with_defaults.is_none() && !pc.using_destructure {
+        return;
+    }
+    if pc.with_defaults.as_ref().is_some_and(|keys| keys.contains(name.as_ref())) {
+        return;
+    }
+    if pc.using_destructure && pc.destructure_defaults.contains(name.as_ref()) {
+        return;
+    }
+    ctx.diagnostic(require_default_prop_diagnostic(signature.span(), name.as_ref()));
+}
+
+/// Mirrors upstream `isWithoutDefaultValue`. The value is already unwrapped of
+/// `as`/parenthesized expressions by the caller.
+fn is_without_default_value(value: &Expression) -> bool {
+    match value {
+        Expression::ObjectExpression(obj) => !prop_is_required(obj) && !prop_has_default(obj),
+        Expression::Identifier(ident) => NATIVE_TYPES.contains(&ident.name.as_str()),
+        // A call/member expression is assumed to produce the default value.
+        Expression::CallExpression(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::PrivateFieldExpression(_) => false,
+        _ => true,
+    }
+}
+
+fn prop_is_required(obj: &ObjectExpression) -> bool {
+    obj.properties.iter().any(|prop| {
+        matches!(prop, ObjectPropertyKind::ObjectProperty(prop)
+            if prop.key.static_name().as_deref() == Some("required")
+                && matches!(prop.value.get_inner_expression(), Expression::BooleanLiteral(lit) if lit.value))
+    })
+}
+
+fn prop_has_default(obj: &ObjectExpression) -> bool {
+    obj.properties.iter().any(|prop| {
+        matches!(prop, ObjectPropertyKind::ObjectProperty(prop)
+            if prop.key.static_name().as_deref() == Some("default"))
+    })
+}
+
+fn is_boolean_prop(value: &Expression) -> bool {
+    if is_value_node_of_boolean_type(value) {
+        return true;
+    }
+    let Expression::ObjectExpression(obj) = value else { return false };
+    obj.properties.iter().any(|prop| {
+        matches!(prop, ObjectPropertyKind::ObjectProperty(prop)
+            if matches!(&prop.key, PropertyKey::StaticIdentifier(key) if key.name == "type")
+                && is_value_node_of_boolean_type(prop.value.get_inner_expression()))
+    })
+}
+
+fn is_value_node_of_boolean_type(value: &Expression) -> bool {
+    match value {
+        Expression::Identifier(ident) => ident.name == "Boolean",
+        Expression::ArrayExpression(arr) => {
+            let mut elements = arr
+                .elements
+                .iter()
+                .filter(|element| !matches!(element, ArrayExpressionElement::Elision(_)));
+            match (elements.next(), elements.next()) {
+                (Some(first), None) => first.as_expression().is_some_and(|element| {
+                    matches!(element.get_inner_expression(), Expression::Identifier(ident) if ident.name == "Boolean")
+                }),
+                _ => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+fn is_single_boolean_type(signature: &TSSignature) -> bool {
+    let TSSignature::TSPropertySignature(sig) = signature else { return false };
+    sig.type_annotation
+        .as_ref()
+        .is_some_and(|annotation| matches!(annotation.type_annotation, TSType::TSBooleanKeyword(_)))
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("
+                  <script>
+                    export default {
+                      props: {
+                        a: {
+                          type: Number,
+                          required: true
+                        },
+                        b: {
+                          type: Number,
+                          default: 0
+                        },
+                        c: {
+                          type: Number,
+                          required: false,
+                          default: 0
+                        },
+                        d: {
+                          type: String,
+                          required: false,
+                          'default': 'lorem'
+                        },
+                        e: {
+                          type: Boolean
+                        },
+                        f: {
+                          type: Boolean,
+                          required: false
+                        },
+                        g: {
+                          type: Boolean,
+                          default: true
+                        },
+                        h: {
+                          type: [Boolean]
+                        },
+                        i: Boolean,
+                        j: [Boolean],
+                      }
+                    }
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+        ("
+                  <script>
+                    export default {
+                      props: {
+                        ...x,
+                        a: {
+                          ...y,
+                          type: Number,
+                          required: true
+                        },
+                        b: {
+                          type: Number,
+                          default: 0
+                        }
+                      }
+                    }
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+        ("
+                  <script>
+                    const x = {
+                      type: Object,
+                      default() {
+                        return {
+                          foo: 1,
+                          bar: 2
+                        }
+                      }
+                    }
+                    export default {
+                      props: {
+                        a: {
+                          ...x,
+                          default() {
+                            return {
+                              ...x.default(),
+                              baz: 3
+                            }
+                          }
+                        }
+                      }
+                    }
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+        (r#"
+                  <script lang="ts">
+                    export default (Vue as VueConstructor<Vue>).extend({
+                      props: {
+                        a: {
+                          type: String,
+                          required: true
+                        } as PropOptions<string>
+                      }
+                    });
+                  </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))),
+        (r#"
+                  <script lang="ts">
+                    export default Vue.extend({
+                      props: {
+                        a: {
+                          type: String,
+                          required: true
+                        } as PropOptions<string>
+                      }
+                    });
+                  </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))),
+        ("
+                  <script>
+                    export default {
+                      props: {
+                        bar,
+                        baz: prop,
+                        baz1: prop.foo,
+                        bar2: foo()
+                      }
+                    }
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+        ("
+                  <script>
+                    export default {
+                      props: {
+                        foo: {
+                          ...foo,
+                          default: 0
+                        },
+                      }
+                    }
+                  </script>
+                  ", None, None, Some(PathBuf::from("destructuring-test.vue"))),
+        ("
+                  <script>
+                    export default {
+                      props: {
+                        foo: {
+                          [bar]: true,
+                          default: 0
+                        },
+                      }
+                    }
+                  </script>
+                  ", None, None, Some(PathBuf::from("unknown-prop-details-test.vue"))),
+        ("
+                  <script>
+                  export default {
+                    props: ['foo']
+                  }
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+        ("
+                  <script>
+                    export default {
+                      props: {
+                        a: {
+                          type: [,Boolean]
+                        },
+                        b: [,Boolean],
+                      }
+                    }
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+        ("
+                  <script setup>
+                  defineProps({
+                    foo: {
+                      type: String,
+                      default: ''
+                    }
+                  })
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+        ("
+                  <script setup>
+                  defineProps(['foo'])
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))),
+        (r#"
+                  <script setup lang="ts">
+                  interface Props {
+                    foo?: number
+                  }
+                  defineProps<Props>()
+                  </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        (r#"
+                  <script setup lang="ts">
+                  interface Props {
+                    foo?: number
+                  }
+                  withDefaults(defineProps<Props>(), {foo:42})
+                  </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        (r#"
+                  <script setup lang="ts">
+                  interface Props {
+                    foo?: number
+                  }
+                  defineProps<Props>({
+                    foo:{
+                      default: 42
+                    }
+                  })
+                  </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        (r#"
+                  <template>
+                    <div>
+                      {{ required }}
+                      {{ optional }}
+                    </div>
+                  </template>
+            
+                  <script setup lang="ts">
+                  import { defineProps, withDefaults } from 'vue';
+            
+                  interface Props {
+                    required: boolean;
+                    optional?: boolean;
+                  }
+            
+                  const props = withDefaults(defineProps<Props>(), {
+                    optional: false,
+                  });
+                  </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        (r#"
+                  <script setup lang="ts">
+                  interface Props {
+                    optional?: boolean;
+                  }
+            
+                  const props = defineProps<Props>();
+                  </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        (r#"
+                  <script setup lang="ts">
+                  const defaultProps = {
+                    foo: 'foo',
+                  }
+                  withDefaults(defineProps<{
+                    foo: string;
+                    bar?: number;
+                  }>(), {
+                    ...defaultProps,
+                    bar: 42,
+                  })
+                  </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        ("
+                  <script setup>
+                  const {foo=42,bar=42} = defineProps({foo: Number, bar: {type: Number}})
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions },
+        ("
+                  <script setup>
+                  const {foo,bar} = defineProps({foo: Boolean, bar: {type: Boolean}})
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions },
+        ("
+                  <script setup>
+                  // ignore
+                  const {bar = 42, foo = 42} = defineProps({[x]: Number, bar: {type: Number}})
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions },
+        ("
+                  <script setup>
+                  const {bar=42} = defineProps({foo: {type: Number, required: true}, bar: {type: Number, required: false}})
+                  </script>
+                  ", None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions },
+        (r#"
+                  <script setup lang="ts">
+                  const {foo = 42, bar} = defineProps<{foo?: number; bar: number}>()
+                  </script>
+                  "#, None, None, Some(PathBuf::from("test.vue"))), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } }
+    ];
+
+    let fail = vec![
+        (
+            r#"
+                  <script setup lang="ts">
+                  type Props = { foo?: number }
+                  withDefaults(defineProps<Props>(), {})
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("type-alias.vue")),
+        ),
+        (
+            r#"
+                  <script setup lang="ts">
+                  interface A { foo?: number }
+                  interface B { bar?: number }
+                  withDefaults(defineProps<A & B>(), {})
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("intersection.vue")),
+        ),
+        (
+            r#"
+                  <script setup lang="ts">
+                  type Props = { foo?: number } | { bar?: number }
+                  withDefaults(defineProps<Props>(), {})
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("union.vue")),
+        ),
+        (
+            "
+                  <script>
+                    export default {
+                      props: {
+                        a: Number,
+                        b: [Number, String],
+                        c: {
+                          type: Number
+                        },
+                        d: {
+                          type: Number,
+                          required: false
+                        },
+                        e: [Boolean, String],
+                        f: {
+                          type: [Boolean, String],
+                        }
+                      }
+                    }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                  <script lang="ts">
+                    export default (Vue as VueConstructor<Vue>).extend({
+                      props: {
+                        a: {
+                          type: String
+                        } as PropOptions<string>
+                      }
+                    });
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                  <script lang="ts">
+                    export default Vue.extend({
+                      props: {
+                        a: {
+                          type: String
+                        } as PropOptions<string>
+                      }
+                    });
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                    export default {
+                      props: {
+                        a: String,
+                        'b': String,
+                        ['c']: String,
+                        [`d`]: String,
+                      }
+                    };
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                    export default {
+                      props: {
+                        [foo]: String,
+                        [bar()]: String,
+                        [baz.baz]: String,
+                      }
+                    };
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                    export default {
+                      props: {
+                        foo: {
+                          ...foo
+                        },
+                      }
+                    }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("destructuring-test.vue")),
+        ),
+        (
+            "
+                  <script>
+                    export default {
+                      props: {
+                        foo: {
+                          [bar]: true
+                        },
+                      }
+                    }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("unknown-prop-details-test.vue")),
+        ),
+        (
+            "
+                  <script>
+                    export default {
+                      props: {
+                        bar,
+                        baz: prop?.foo,
+                        bar1: foo?.(),
+                      }
+                    }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script setup>
+                  defineProps({
+                    foo: String
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions },
+        (
+            r#"
+                  <script setup lang="ts">
+                  const defaultProps = {
+                    foo: 'foo',
+                  }
+                  withDefaults(defineProps<{
+                    foo: string;
+                    bar?: number;
+                  }>(), {
+                    ...defaultProps,
+                  })
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        (
+            r#"
+                  <script setup lang="ts">
+                  interface Props {
+                    foo?: number
+                  }
+                  withDefaults(defineProps<Props>(), {bar:42})
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        (
+            "
+                  <script setup>
+                  const {foo,bar} = defineProps({foo: Boolean, bar: {type: String}})
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions },
+        (
+            "
+                  <script setup>
+                  const {foo,bar} = defineProps({foo: Number, bar: {type: Number}})
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions },
+        (
+            r#"
+                  <script setup lang="ts">
+                  const {foo, bar} = defineProps<{foo?: number; bar: number}>()
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("type-with-props-destructure.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } }
+    ];
+
+    Tester::new(RequireDefaultProp::NAME, RequireDefaultProp::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vue_require_default_prop.snap
+++ b/crates/oxc_linter/src/snapshots/vue_require_default_prop.snap
@@ -1,0 +1,259 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(require-default-prop): Prop 'foo' requires default value to be set.
+   ╭─[require_default_prop.tsx:3:34]
+ 2 │                   <script setup lang="ts">
+ 3 │                   type Props = { foo?: number }
+   ·                                  ────────────
+ 4 │                   withDefaults(defineProps<Props>(), {})
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'foo' requires default value to be set.
+   ╭─[require_default_prop.tsx:3:33]
+ 2 │                   <script setup lang="ts">
+ 3 │                   interface A { foo?: number }
+   ·                                 ────────────
+ 4 │                   interface B { bar?: number }
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'bar' requires default value to be set.
+   ╭─[require_default_prop.tsx:4:33]
+ 3 │                   interface A { foo?: number }
+ 4 │                   interface B { bar?: number }
+   ·                                 ────────────
+ 5 │                   withDefaults(defineProps<A & B>(), {})
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'foo' requires default value to be set.
+   ╭─[require_default_prop.tsx:3:34]
+ 2 │                   <script setup lang="ts">
+ 3 │                   type Props = { foo?: number } | { bar?: number }
+   ·                                  ────────────
+ 4 │                   withDefaults(defineProps<Props>(), {})
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'bar' requires default value to be set.
+   ╭─[require_default_prop.tsx:3:53]
+ 2 │                   <script setup lang="ts">
+ 3 │                   type Props = { foo?: number } | { bar?: number }
+   ·                                                     ────────────
+ 4 │                   withDefaults(defineProps<Props>(), {})
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'a' requires default value to be set.
+   ╭─[require_default_prop.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         a: Number,
+   ·                         ─────────
+ 6 │                         b: [Number, String],
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'b' requires default value to be set.
+   ╭─[require_default_prop.tsx:6:25]
+ 5 │                         a: Number,
+ 6 │                         b: [Number, String],
+   ·                         ───────────────────
+ 7 │                         c: {
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'c' requires default value to be set.
+    ╭─[require_default_prop.tsx:7:25]
+  6 │                             b: [Number, String],
+  7 │ ╭─▶                         c: {
+  8 │ │                             type: Number
+  9 │ ╰─▶                         },
+ 10 │                             d: {
+    ╰────
+
+  ⚠ vue(require-default-prop): Prop 'd' requires default value to be set.
+    ╭─[require_default_prop.tsx:10:25]
+  9 │                             },
+ 10 │ ╭─▶                         d: {
+ 11 │ │                             type: Number,
+ 12 │ │                             required: false
+ 13 │ ╰─▶                         },
+ 14 │                             e: [Boolean, String],
+    ╰────
+
+  ⚠ vue(require-default-prop): Prop 'e' requires default value to be set.
+    ╭─[require_default_prop.tsx:14:25]
+ 13 │                         },
+ 14 │                         e: [Boolean, String],
+    ·                         ────────────────────
+ 15 │                         f: {
+    ╰────
+
+  ⚠ vue(require-default-prop): Prop 'f' requires default value to be set.
+    ╭─[require_default_prop.tsx:15:25]
+ 14 │                             e: [Boolean, String],
+ 15 │ ╭─▶                         f: {
+ 16 │ │                             type: [Boolean, String],
+ 17 │ ╰─▶                         }
+ 18 │                           }
+    ╰────
+
+  ⚠ vue(require-default-prop): Prop 'a' requires default value to be set.
+   ╭─[require_default_prop.tsx:5:25]
+ 4 │                           props: {
+ 5 │ ╭─▶                         a: {
+ 6 │ │                             type: String
+ 7 │ ╰─▶                         } as PropOptions<string>
+ 8 │                           }
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'a' requires default value to be set.
+   ╭─[require_default_prop.tsx:5:25]
+ 4 │                           props: {
+ 5 │ ╭─▶                         a: {
+ 6 │ │                             type: String
+ 7 │ ╰─▶                         } as PropOptions<string>
+ 8 │                           }
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'a' requires default value to be set.
+   ╭─[require_default_prop.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         a: String,
+   ·                         ─────────
+ 6 │                         'b': String,
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'b' requires default value to be set.
+   ╭─[require_default_prop.tsx:6:25]
+ 5 │                         a: String,
+ 6 │                         'b': String,
+   ·                         ───────────
+ 7 │                         ['c']: String,
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'c' requires default value to be set.
+   ╭─[require_default_prop.tsx:7:25]
+ 6 │                         'b': String,
+ 7 │                         ['c']: String,
+   ·                         ─────────────
+ 8 │                         [`d`]: String,
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'd' requires default value to be set.
+   ╭─[require_default_prop.tsx:8:25]
+ 7 │                         ['c']: String,
+ 8 │                         [`d`]: String,
+   ·                         ─────────────
+ 9 │                       }
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop '[foo]' requires default value to be set.
+   ╭─[require_default_prop.tsx:5:25]
+ 4 │                       props: {
+ 5 │                         [foo]: String,
+   ·                         ─────────────
+ 6 │                         [bar()]: String,
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop '[bar()]' requires default value to be set.
+   ╭─[require_default_prop.tsx:6:25]
+ 5 │                         [foo]: String,
+ 6 │                         [bar()]: String,
+   ·                         ───────────────
+ 7 │                         [baz.baz]: String,
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop '[baz.baz]' requires default value to be set.
+   ╭─[require_default_prop.tsx:7:25]
+ 6 │                         [bar()]: String,
+ 7 │                         [baz.baz]: String,
+   ·                         ─────────────────
+ 8 │                       }
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'foo' requires default value to be set.
+   ╭─[require_default_prop.tsx:5:25]
+ 4 │                           props: {
+ 5 │ ╭─▶                         foo: {
+ 6 │ │                             ...foo
+ 7 │ ╰─▶                         },
+ 8 │                           }
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'foo' requires default value to be set.
+   ╭─[require_default_prop.tsx:5:25]
+ 4 │                           props: {
+ 5 │ ╭─▶                         foo: {
+ 6 │ │                             [bar]: true
+ 7 │ ╰─▶                         },
+ 8 │                           }
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'baz' requires default value to be set.
+   ╭─[require_default_prop.tsx:6:25]
+ 5 │                         bar,
+ 6 │                         baz: prop?.foo,
+   ·                         ──────────────
+ 7 │                         bar1: foo?.(),
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'bar1' requires default value to be set.
+   ╭─[require_default_prop.tsx:7:25]
+ 6 │                         baz: prop?.foo,
+ 7 │                         bar1: foo?.(),
+   ·                         ─────────────
+ 8 │                       }
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'foo' requires default value to be set.
+   ╭─[require_default_prop.tsx:4:21]
+ 3 │                   defineProps({
+ 4 │                     foo: String
+   ·                     ───────────
+ 5 │                   })
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'bar' requires default value to be set.
+   ╭─[require_default_prop.tsx:8:21]
+ 7 │                     foo: string;
+ 8 │                     bar?: number;
+   ·                     ─────────────
+ 9 │                   }>(), {
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'foo' requires default value to be set.
+   ╭─[require_default_prop.tsx:4:21]
+ 3 │                   interface Props {
+ 4 │                     foo?: number
+   ·                     ────────────
+ 5 │                   }
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'bar' requires default value to be set.
+   ╭─[require_default_prop.tsx:3:64]
+ 2 │                   <script setup>
+ 3 │                   const {foo,bar} = defineProps({foo: Boolean, bar: {type: String}})
+   ·                                                                ───────────────────
+ 4 │                   </script>
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'foo' requires default value to be set.
+   ╭─[require_default_prop.tsx:3:50]
+ 2 │                   <script setup>
+ 3 │                   const {foo,bar} = defineProps({foo: Number, bar: {type: Number}})
+   ·                                                  ───────────
+ 4 │                   </script>
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'bar' requires default value to be set.
+   ╭─[require_default_prop.tsx:3:63]
+ 2 │                   <script setup>
+ 3 │                   const {foo,bar} = defineProps({foo: Number, bar: {type: Number}})
+   ·                                                               ───────────────────
+ 4 │                   </script>
+   ╰────
+
+  ⚠ vue(require-default-prop): Prop 'foo' requires default value to be set.
+   ╭─[require_default_prop.tsx:3:51]
+ 2 │                   <script setup lang="ts">
+ 3 │                   const {foo, bar} = defineProps<{foo?: number; bar: number}>()
+   ·                                                   ─────────────
+ 4 │                   </script>
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2674,6 +2674,9 @@
         "vue/require-default-export": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/require-default-prop": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/require-direct-export": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -2678,6 +2678,9 @@ expression: json
         "vue/require-default-export": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vue/require-default-prop": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vue/require-direct-export": {
           "$ref": "#/definitions/DummyRule"
         },


### PR DESCRIPTION
implement `vue/require-default-prop` from eslint-plugin-vue

The TS type resolution logic here (`check_type_props` / `check_type_signature`) is duplicated across several other vue rules (`no-reserved-keys`, `no-reserved-props`, `max-props`, `prop-name-casing`, `no-required-prop-with-default`). I'll extract it into a shared util in a follow-up PR.