### PR TITLE
docs(oxfmt): annotate each config option with supported languages

### DIFF
--- a/apps/oxfmt/src-js/config.generated.ts
+++ b/apps/oxfmt/src-js/config.generated.ts
@@ -34,6 +34,7 @@ export interface Oxfmtrc {
   /**
    * Include parentheses around a sole arrow function parameter.
    *
+   * - Languages: JS, JSX, TS, TSX
    * - Default: `"always"`
    */
   arrowParens?: ArrowParensConfig;
@@ -41,20 +42,21 @@ export interface Oxfmtrc {
    * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
    * instead of being alone on the next line (does not apply to self closing elements).
    *
+   * - Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte
    * - Default: `false`
    */
   bracketSameLine?: boolean;
   /**
    * Print spaces between brackets in object literals.
    *
+   * - Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML
    * - Default: `true`
    */
   bracketSpacing?: boolean;
   /**
    * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
    *
-   * NOTE: XXX-in-JS support is incomplete.
-   *
+   * - Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)
    * - Default: `"auto"`
    */
   embeddedLanguageFormatting?: EmbeddedLanguageFormattingConfig;
@@ -63,6 +65,7 @@ export interface Oxfmtrc {
    *
    * NOTE: `"auto"` is not supported.
    *
+   * - Languages: All
    * - Default: `"lf"`
    * - Overrides `.editorconfig.end_of_line`
    */
@@ -70,6 +73,7 @@ export interface Oxfmtrc {
   /**
    * Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
    *
+   * - Languages: HTML, Angular, Vue, Handlebars, Svelte
    * - Default: `"css"`
    */
   htmlWhitespaceSensitivity?: HtmlWhitespaceSensitivityConfig;
@@ -83,6 +87,7 @@ export interface Oxfmtrc {
   /**
    * Whether to insert a final newline at the end of the file.
    *
+   * - Languages: All
    * - Default: `true`
    * - Overrides `.editorconfig.insert_final_newline`
    */
@@ -96,12 +101,14 @@ export interface Oxfmtrc {
    *
    * Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
    *
+   * - Languages: JS, JSX, TS, TSX
    * - Default: Disabled
    */
   jsdoc?: JsdocUserConfig;
   /**
    * Use single quotes instead of double quotes in JSX.
    *
+   * - Languages: JSX, TSX
    * - Default: `false`
    */
   jsxSingleQuote?: boolean;
@@ -111,6 +118,7 @@ export interface Oxfmtrc {
    * By default, formats objects as multi-line if there is a newline prior to the first property.
    * Authors can use this heuristic to contextually improve readability, though it has some downsides.
    *
+   * - Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5
    * - Default: `"preserve"`
    */
   objectWrap?: ObjectWrapConfig;
@@ -126,6 +134,7 @@ export interface Oxfmtrc {
    *
    * If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
    *
+   * - Languages: All
    * - Default: `100`
    * - Overrides `.editorconfig.max_line_length`
    */
@@ -137,24 +146,28 @@ export interface Oxfmtrc {
    * To wrap prose to the print width, change this option to "always".
    * If you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use "never".
    *
+   * - Languages: Markdown, MDX, YAML
    * - Default: `"preserve"`
    */
   proseWrap?: ProseWrapConfig;
   /**
    * Change when properties in objects are quoted.
    *
+   * - Languages: JS, JSX, TS, TSX
    * - Default: `"as-needed"`
    */
   quoteProps?: QuotePropsConfig;
   /**
    * Print semicolons at the ends of statements.
    *
+   * - Languages: JS, JSX, TS, TSX
    * - Default: `true`
    */
   semi?: boolean;
   /**
    * Enforce single attribute per line in HTML, Vue, and JSX.
    *
+   * - Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte
    * - Default: `false`
    */
   singleAttributePerLine?: boolean;
@@ -163,6 +176,7 @@ export interface Oxfmtrc {
    *
    * For JSX, you can set the `jsxSingleQuote` option.
    *
+   * - Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte
    * - Default: `false`
    * - Overrides `.editorconfig.quote_type`
    */
@@ -175,6 +189,7 @@ export interface Oxfmtrc {
    *
    * Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
    *
+   * - Languages: JS, JSX, TS, TSX
    * - Default: Disabled
    */
   sortImports?: SortImportsUserConfig;
@@ -185,6 +200,7 @@ export interface Oxfmtrc {
    * But we believe it is clearer and easier to navigate.
    * For details, see each field's documentation.
    *
+   * - Languages: JSON (`package.json` only)
    * - Default: `true`
    */
   sortPackageJson?: SortPackageJsonUserConfig;
@@ -197,6 +213,7 @@ export interface Oxfmtrc {
    *
    * Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
    *
+   * - Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte
    * - Default: Disabled
    */
   sortTailwindcss?: SortTailwindcssUserConfig;
@@ -211,12 +228,14 @@ export interface Oxfmtrc {
    * but Oxfmt does NOT bundle or auto-install it.
    * You must install `svelte` yourself in your project, formatting will fail at runtime otherwise.
    *
+   * - Languages: Svelte
    * - Default: Disabled
    */
   svelte?: SvelteUserConfig;
   /**
    * Specify the number of spaces per indentation-level.
    *
+   * - Languages: All
    * - Default: `2`
    * - Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)
    */
@@ -226,12 +245,14 @@ export interface Oxfmtrc {
    *
    * A single-line array, for example, never gets trailing commas.
    *
+   * - Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML
    * - Default: `"all"`
    */
   trailingComma?: TrailingCommaConfig;
   /**
    * Indent lines with tabs instead of spaces.
    *
+   * - Languages: All
    * - Default: `false`
    * - Overrides `.editorconfig.indent_style`
    */
@@ -239,6 +260,7 @@ export interface Oxfmtrc {
   /**
    * Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.
    *
+   * - Languages: Vue
    * - Default: `false`
    */
   vueIndentScriptAndStyle?: boolean;
@@ -339,6 +361,7 @@ export interface FormatConfig {
   /**
    * Include parentheses around a sole arrow function parameter.
    *
+   * - Languages: JS, JSX, TS, TSX
    * - Default: `"always"`
    */
   arrowParens?: ArrowParensConfig;
@@ -346,20 +369,21 @@ export interface FormatConfig {
    * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
    * instead of being alone on the next line (does not apply to self closing elements).
    *
+   * - Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte
    * - Default: `false`
    */
   bracketSameLine?: boolean;
   /**
    * Print spaces between brackets in object literals.
    *
+   * - Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML
    * - Default: `true`
    */
   bracketSpacing?: boolean;
   /**
    * Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
    *
-   * NOTE: XXX-in-JS support is incomplete.
-   *
+   * - Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)
    * - Default: `"auto"`
    */
   embeddedLanguageFormatting?: EmbeddedLanguageFormattingConfig;
@@ -368,6 +392,7 @@ export interface FormatConfig {
    *
    * NOTE: `"auto"` is not supported.
    *
+   * - Languages: All
    * - Default: `"lf"`
    * - Overrides `.editorconfig.end_of_line`
    */
@@ -375,12 +400,14 @@ export interface FormatConfig {
   /**
    * Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
    *
+   * - Languages: HTML, Angular, Vue, Handlebars, Svelte
    * - Default: `"css"`
    */
   htmlWhitespaceSensitivity?: HtmlWhitespaceSensitivityConfig;
   /**
    * Whether to insert a final newline at the end of the file.
    *
+   * - Languages: All
    * - Default: `true`
    * - Overrides `.editorconfig.insert_final_newline`
    */
@@ -394,12 +421,14 @@ export interface FormatConfig {
    *
    * Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
    *
+   * - Languages: JS, JSX, TS, TSX
    * - Default: Disabled
    */
   jsdoc?: JsdocUserConfig;
   /**
    * Use single quotes instead of double quotes in JSX.
    *
+   * - Languages: JSX, TSX
    * - Default: `false`
    */
   jsxSingleQuote?: boolean;
@@ -409,6 +438,7 @@ export interface FormatConfig {
    * By default, formats objects as multi-line if there is a newline prior to the first property.
    * Authors can use this heuristic to contextually improve readability, though it has some downsides.
    *
+   * - Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5
    * - Default: `"preserve"`
    */
   objectWrap?: ObjectWrapConfig;
@@ -417,6 +447,7 @@ export interface FormatConfig {
    *
    * If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
    *
+   * - Languages: All
    * - Default: `100`
    * - Overrides `.editorconfig.max_line_length`
    */
@@ -428,24 +459,28 @@ export interface FormatConfig {
    * To wrap prose to the print width, change this option to "always".
    * If you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use "never".
    *
+   * - Languages: Markdown, MDX, YAML
    * - Default: `"preserve"`
    */
   proseWrap?: ProseWrapConfig;
   /**
    * Change when properties in objects are quoted.
    *
+   * - Languages: JS, JSX, TS, TSX
    * - Default: `"as-needed"`
    */
   quoteProps?: QuotePropsConfig;
   /**
    * Print semicolons at the ends of statements.
    *
+   * - Languages: JS, JSX, TS, TSX
    * - Default: `true`
    */
   semi?: boolean;
   /**
    * Enforce single attribute per line in HTML, Vue, and JSX.
    *
+   * - Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte
    * - Default: `false`
    */
   singleAttributePerLine?: boolean;
@@ -454,6 +489,7 @@ export interface FormatConfig {
    *
    * For JSX, you can set the `jsxSingleQuote` option.
    *
+   * - Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte
    * - Default: `false`
    * - Overrides `.editorconfig.quote_type`
    */
@@ -466,6 +502,7 @@ export interface FormatConfig {
    *
    * Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
    *
+   * - Languages: JS, JSX, TS, TSX
    * - Default: Disabled
    */
   sortImports?: SortImportsUserConfig;
@@ -476,6 +513,7 @@ export interface FormatConfig {
    * But we believe it is clearer and easier to navigate.
    * For details, see each field's documentation.
    *
+   * - Languages: JSON (`package.json` only)
    * - Default: `true`
    */
   sortPackageJson?: SortPackageJsonUserConfig;
@@ -488,6 +526,7 @@ export interface FormatConfig {
    *
    * Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
    *
+   * - Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte
    * - Default: Disabled
    */
   sortTailwindcss?: SortTailwindcssUserConfig;
@@ -502,12 +541,14 @@ export interface FormatConfig {
    * but Oxfmt does NOT bundle or auto-install it.
    * You must install `svelte` yourself in your project, formatting will fail at runtime otherwise.
    *
+   * - Languages: Svelte
    * - Default: Disabled
    */
   svelte?: SvelteUserConfig;
   /**
    * Specify the number of spaces per indentation-level.
    *
+   * - Languages: All
    * - Default: `2`
    * - Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)
    */
@@ -517,12 +558,14 @@ export interface FormatConfig {
    *
    * A single-line array, for example, never gets trailing commas.
    *
+   * - Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML
    * - Default: `"all"`
    */
   trailingComma?: TrailingCommaConfig;
   /**
    * Indent lines with tabs instead of spaces.
    *
+   * - Languages: All
    * - Default: `false`
    * - Overrides `.editorconfig.indent_style`
    */
@@ -530,6 +573,7 @@ export interface FormatConfig {
   /**
    * Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.
    *
+   * - Languages: Vue
    * - Default: `false`
    */
   vueIndentScriptAndStyle?: boolean;

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -57,12 +57,14 @@ pub struct FormatConfig {
     // ============================================================================================
     /// Indent lines with tabs instead of spaces.
     ///
+    /// - Languages: All
     /// - Default: `false`
     /// - Overrides `.editorconfig.indent_style`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_tabs: Option<bool>,
     /// Specify the number of spaces per indentation-level.
     ///
+    /// - Languages: All
     /// - Default: `2`
     /// - Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -71,6 +73,7 @@ pub struct FormatConfig {
     ///
     /// NOTE: `"auto"` is not supported.
     ///
+    /// - Languages: All
     /// - Default: `"lf"`
     /// - Overrides `.editorconfig.end_of_line`
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -79,6 +82,7 @@ pub struct FormatConfig {
     ///
     /// If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
     ///
+    /// - Languages: All
     /// - Default: `100`
     /// - Overrides `.editorconfig.max_line_length`
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -88,17 +92,20 @@ pub struct FormatConfig {
     ///
     /// For JSX, you can set the `jsxSingleQuote` option.
     ///
+    /// - Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte
     /// - Default: `false`
     /// - Overrides `.editorconfig.quote_type`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub single_quote: Option<bool>,
     /// Use single quotes instead of double quotes in JSX.
     ///
+    /// - Languages: JSX, TSX
     /// - Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jsx_single_quote: Option<bool>,
     /// Change when properties in objects are quoted.
     ///
+    /// - Languages: JS, JSX, TS, TSX
     /// - Default: `"as-needed"`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quote_props: Option<QuotePropsConfig>,
@@ -106,27 +113,32 @@ pub struct FormatConfig {
     ///
     /// A single-line array, for example, never gets trailing commas.
     ///
+    /// - Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML
     /// - Default: `"all"`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trailing_comma: Option<TrailingCommaConfig>,
     /// Print semicolons at the ends of statements.
     ///
+    /// - Languages: JS, JSX, TS, TSX
     /// - Default: `true`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub semi: Option<bool>,
     /// Include parentheses around a sole arrow function parameter.
     ///
+    /// - Languages: JS, JSX, TS, TSX
     /// - Default: `"always"`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arrow_parens: Option<ArrowParensConfig>,
     /// Print spaces between brackets in object literals.
     ///
+    /// - Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML
     /// - Default: `true`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bracket_spacing: Option<bool>,
     /// Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
     /// instead of being alone on the next line (does not apply to self closing elements).
     ///
+    /// - Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte
     /// - Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bracket_same_line: Option<bool>,
@@ -135,11 +147,13 @@ pub struct FormatConfig {
     /// By default, formats objects as multi-line if there is a newline prior to the first property.
     /// Authors can use this heuristic to contextually improve readability, though it has some downsides.
     ///
+    /// - Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5
     /// - Default: `"preserve"`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object_wrap: Option<ObjectWrapConfig>,
     /// Enforce single attribute per line in HTML, Vue, and JSX.
     ///
+    /// - Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte
     /// - Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub single_attribute_per_line: Option<bool>,
@@ -163,8 +177,7 @@ pub struct FormatConfig {
 
     /// Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
     ///
-    /// NOTE: XXX-in-JS support is incomplete.
-    ///
+    /// - Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)
     /// - Default: `"auto"`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embedded_language_formatting: Option<EmbeddedLanguageFormattingConfig>,
@@ -178,16 +191,19 @@ pub struct FormatConfig {
     /// To wrap prose to the print width, change this option to "always".
     /// If you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use "never".
     ///
+    /// - Languages: Markdown, MDX, YAML
     /// - Default: `"preserve"`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prose_wrap: Option<ProseWrapConfig>,
     /// Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
     ///
+    /// - Languages: HTML, Angular, Vue, Handlebars, Svelte
     /// - Default: `"css"`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub html_whitespace_sensitivity: Option<HtmlWhitespaceSensitivityConfig>,
     /// Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.
     ///
+    /// - Languages: Vue
     /// - Default: `false`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vue_indent_script_and_style: Option<bool>,
@@ -197,6 +213,7 @@ pub struct FormatConfig {
     // ============================================================================================
     /// Whether to insert a final newline at the end of the file.
     ///
+    /// - Languages: All
     /// - Default: `true`
     /// - Overrides `.editorconfig.insert_final_newline`
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -209,6 +226,7 @@ pub struct FormatConfig {
     ///
     /// Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
     ///
+    /// - Languages: JS, JSX, TS, TSX
     /// - Default: Disabled
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(alias = "experimentalSortImports")]
@@ -220,6 +238,7 @@ pub struct FormatConfig {
     /// But we believe it is clearer and easier to navigate.
     /// For details, see each field's documentation.
     ///
+    /// - Languages: JSON (`package.json` only)
     /// - Default: `true`
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(alias = "experimentalSortPackageJson")]
@@ -233,6 +252,7 @@ pub struct FormatConfig {
     ///
     /// Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
     ///
+    /// - Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte
     /// - Default: Disabled
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(alias = "experimentalTailwindcss")]
@@ -246,6 +266,7 @@ pub struct FormatConfig {
     ///
     /// Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
     ///
+    /// - Languages: JS, JSX, TS, TSX
     /// - Default: Disabled
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub jsdoc: Option<JsdocUserConfig>,
@@ -260,6 +281,7 @@ pub struct FormatConfig {
     /// but Oxfmt does NOT bundle or auto-install it.
     /// You must install `svelte` yourself in your project, formatting will fail at runtime otherwise.
     ///
+    /// - Languages: Svelte
     /// - Default: Disabled
     #[serde(skip_serializing_if = "Option::is_none")]
     pub svelte: Option<SvelteUserConfig>,

--- a/npm/oxfmt/configuration_schema.json
+++ b/npm/oxfmt/configuration_schema.json
@@ -5,50 +5,50 @@
   "type": "object",
   "properties": {
     "arrowParens": {
-      "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
+      "description": "Include parentheses around a sole arrow function parameter.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"always\"`",
       "allOf": [
         {
           "$ref": "#/definitions/ArrowParensConfig"
         }
       ],
-      "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
+      "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"always\"`"
     },
     "bracketSameLine": {
-      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
+      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`",
       "type": "boolean",
-      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
+      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`"
     },
     "bracketSpacing": {
-      "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
+      "description": "Print spaces between brackets in object literals.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML\n- Default: `true`",
       "type": "boolean",
-      "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
+      "markdownDescription": "Print spaces between brackets in object literals.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML\n- Default: `true`"
     },
     "embeddedLanguageFormatting": {
-      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
+      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)\n- Default: `\"auto\"`",
       "allOf": [
         {
           "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
         }
       ],
-      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
+      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)\n- Default: `\"auto\"`"
     },
     "endOfLine": {
-      "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
+      "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Languages: All\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
       "allOf": [
         {
           "$ref": "#/definitions/EndOfLineConfig"
         }
       ],
-      "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
+      "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Languages: All\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
     },
     "htmlWhitespaceSensitivity": {
-      "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
+      "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Languages: HTML, Angular, Vue, Handlebars, Svelte\n- Default: `\"css\"`",
       "allOf": [
         {
           "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
         }
       ],
-      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
+      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Languages: HTML, Angular, Vue, Handlebars, Svelte\n- Default: `\"css\"`"
     },
     "ignorePatterns": {
       "description": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
@@ -59,32 +59,32 @@
       "markdownDescription": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`"
     },
     "insertFinalNewline": {
-      "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
+      "description": "Whether to insert a final newline at the end of the file.\n\n- Languages: All\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
       "type": "boolean",
-      "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
+      "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Languages: All\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
     },
     "jsdoc": {
-      "description": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+      "description": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled",
       "allOf": [
         {
           "$ref": "#/definitions/JsdocUserConfig"
         }
       ],
-      "markdownDescription": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+      "markdownDescription": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled"
     },
     "jsxSingleQuote": {
-      "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
+      "description": "Use single quotes instead of double quotes in JSX.\n\n- Languages: JSX, TSX\n- Default: `false`",
       "type": "boolean",
-      "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`"
+      "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Languages: JSX, TSX\n- Default: `false`"
     },
     "objectWrap": {
-      "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
+      "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5\n- Default: `\"preserve\"`",
       "allOf": [
         {
           "$ref": "#/definitions/ObjectWrapConfig"
         }
       ],
-      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
+      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5\n- Default: `\"preserve\"`"
     },
     "overrides": {
       "description": "File-specific overrides.\nWhen a file matches multiple overrides, the later override takes precedence (array order matters).\n\n- Default: `[]`",
@@ -95,106 +95,106 @@
       "markdownDescription": "File-specific overrides.\nWhen a file matches multiple overrides, the later override takes precedence (array order matters).\n\n- Default: `[]`"
     },
     "printWidth": {
-      "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
+      "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Languages: All\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
       "type": "integer",
       "format": "uint16",
       "minimum": 0.0,
-      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
+      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Languages: All\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
     },
     "proseWrap": {
-      "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
+      "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Languages: Markdown, MDX, YAML\n- Default: `\"preserve\"`",
       "allOf": [
         {
           "$ref": "#/definitions/ProseWrapConfig"
         }
       ],
-      "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
+      "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Languages: Markdown, MDX, YAML\n- Default: `\"preserve\"`"
     },
     "quoteProps": {
-      "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
+      "description": "Change when properties in objects are quoted.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"as-needed\"`",
       "allOf": [
         {
           "$ref": "#/definitions/QuotePropsConfig"
         }
       ],
-      "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
+      "markdownDescription": "Change when properties in objects are quoted.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"as-needed\"`"
     },
     "semi": {
-      "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
+      "description": "Print semicolons at the ends of statements.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `true`",
       "type": "boolean",
-      "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
+      "markdownDescription": "Print semicolons at the ends of statements.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `true`"
     },
     "singleAttributePerLine": {
-      "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
+      "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`",
       "type": "boolean",
-      "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
+      "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`"
     },
     "singleQuote": {
-      "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`\n- Overrides `.editorconfig.quote_type`",
+      "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte\n- Default: `false`\n- Overrides `.editorconfig.quote_type`",
       "type": "boolean",
-      "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`\n- Overrides `.editorconfig.quote_type`"
+      "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte\n- Default: `false`\n- Overrides `.editorconfig.quote_type`"
     },
     "sortImports": {
-      "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+      "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled",
       "allOf": [
         {
           "$ref": "#/definitions/SortImportsUserConfig"
         }
       ],
-      "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+      "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled"
     },
     "sortPackageJson": {
-      "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
+      "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Languages: JSON (`package.json` only)\n- Default: `true`",
       "allOf": [
         {
           "$ref": "#/definitions/SortPackageJsonUserConfig"
         }
       ],
-      "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
+      "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Languages: JSON (`package.json` only)\n- Default: `true`"
     },
     "sortTailwindcss": {
-      "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+      "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte\n- Default: Disabled",
       "allOf": [
         {
           "$ref": "#/definitions/SortTailwindcssUserConfig"
         }
       ],
-      "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+      "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte\n- Default: Disabled"
     },
     "svelte": {
-      "description": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Default: Disabled",
+      "description": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Languages: Svelte\n- Default: Disabled",
       "allOf": [
         {
           "$ref": "#/definitions/SvelteUserConfig"
         }
       ],
-      "markdownDescription": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Default: Disabled"
+      "markdownDescription": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Languages: Svelte\n- Default: Disabled"
     },
     "tabWidth": {
-      "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)",
+      "description": "Specify the number of spaces per indentation-level.\n\n- Languages: All\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)",
       "type": "integer",
       "format": "uint8",
       "minimum": 0.0,
-      "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)"
+      "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Languages: All\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)"
     },
     "trailingComma": {
-      "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
+      "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML\n- Default: `\"all\"`",
       "allOf": [
         {
           "$ref": "#/definitions/TrailingCommaConfig"
         }
       ],
-      "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
+      "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML\n- Default: `\"all\"`"
     },
     "useTabs": {
-      "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
+      "description": "Indent lines with tabs instead of spaces.\n\n- Languages: All\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
       "type": "boolean",
-      "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
+      "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Languages: All\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
     },
     "vueIndentScriptAndStyle": {
-      "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
+      "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Languages: Vue\n- Default: `false`",
       "type": "boolean",
-      "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
+      "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Languages: Vue\n- Default: `false`"
     }
   },
   "allowComments": true,
@@ -259,180 +259,180 @@
       "type": "object",
       "properties": {
         "arrowParens": {
-          "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
+          "description": "Include parentheses around a sole arrow function parameter.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"always\"`",
           "allOf": [
             {
               "$ref": "#/definitions/ArrowParensConfig"
             }
           ],
-          "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
+          "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"always\"`"
         },
         "bracketSameLine": {
-          "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
+          "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`",
           "type": "boolean",
-          "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
+          "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`"
         },
         "bracketSpacing": {
-          "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
+          "description": "Print spaces between brackets in object literals.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML\n- Default: `true`",
           "type": "boolean",
-          "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
+          "markdownDescription": "Print spaces between brackets in object literals.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML\n- Default: `true`"
         },
         "embeddedLanguageFormatting": {
-          "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
+          "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)\n- Default: `\"auto\"`",
           "allOf": [
             {
               "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
             }
           ],
-          "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
+          "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)\n- Default: `\"auto\"`"
         },
         "endOfLine": {
-          "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
+          "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Languages: All\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
           "allOf": [
             {
               "$ref": "#/definitions/EndOfLineConfig"
             }
           ],
-          "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
+          "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Languages: All\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
         },
         "htmlWhitespaceSensitivity": {
-          "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
+          "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Languages: HTML, Angular, Vue, Handlebars, Svelte\n- Default: `\"css\"`",
           "allOf": [
             {
               "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
             }
           ],
-          "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
+          "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Languages: HTML, Angular, Vue, Handlebars, Svelte\n- Default: `\"css\"`"
         },
         "insertFinalNewline": {
-          "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
+          "description": "Whether to insert a final newline at the end of the file.\n\n- Languages: All\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
           "type": "boolean",
-          "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
+          "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Languages: All\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
         },
         "jsdoc": {
-          "description": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+          "description": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled",
           "allOf": [
             {
               "$ref": "#/definitions/JsdocUserConfig"
             }
           ],
-          "markdownDescription": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+          "markdownDescription": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled"
         },
         "jsxSingleQuote": {
-          "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
+          "description": "Use single quotes instead of double quotes in JSX.\n\n- Languages: JSX, TSX\n- Default: `false`",
           "type": "boolean",
-          "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`"
+          "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Languages: JSX, TSX\n- Default: `false`"
         },
         "objectWrap": {
-          "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
+          "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5\n- Default: `\"preserve\"`",
           "allOf": [
             {
               "$ref": "#/definitions/ObjectWrapConfig"
             }
           ],
-          "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
+          "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5\n- Default: `\"preserve\"`"
         },
         "printWidth": {
-          "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
+          "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Languages: All\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
           "type": "integer",
           "format": "uint16",
           "minimum": 0.0,
-          "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
+          "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Languages: All\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
         },
         "proseWrap": {
-          "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
+          "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Languages: Markdown, MDX, YAML\n- Default: `\"preserve\"`",
           "allOf": [
             {
               "$ref": "#/definitions/ProseWrapConfig"
             }
           ],
-          "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
+          "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Languages: Markdown, MDX, YAML\n- Default: `\"preserve\"`"
         },
         "quoteProps": {
-          "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
+          "description": "Change when properties in objects are quoted.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"as-needed\"`",
           "allOf": [
             {
               "$ref": "#/definitions/QuotePropsConfig"
             }
           ],
-          "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
+          "markdownDescription": "Change when properties in objects are quoted.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"as-needed\"`"
         },
         "semi": {
-          "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
+          "description": "Print semicolons at the ends of statements.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `true`",
           "type": "boolean",
-          "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
+          "markdownDescription": "Print semicolons at the ends of statements.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `true`"
         },
         "singleAttributePerLine": {
-          "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
+          "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`",
           "type": "boolean",
-          "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
+          "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`"
         },
         "singleQuote": {
-          "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`\n- Overrides `.editorconfig.quote_type`",
+          "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte\n- Default: `false`\n- Overrides `.editorconfig.quote_type`",
           "type": "boolean",
-          "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`\n- Overrides `.editorconfig.quote_type`"
+          "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte\n- Default: `false`\n- Overrides `.editorconfig.quote_type`"
         },
         "sortImports": {
-          "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+          "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled",
           "allOf": [
             {
               "$ref": "#/definitions/SortImportsUserConfig"
             }
           ],
-          "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+          "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled"
         },
         "sortPackageJson": {
-          "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
+          "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Languages: JSON (`package.json` only)\n- Default: `true`",
           "allOf": [
             {
               "$ref": "#/definitions/SortPackageJsonUserConfig"
             }
           ],
-          "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
+          "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Languages: JSON (`package.json` only)\n- Default: `true`"
         },
         "sortTailwindcss": {
-          "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+          "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte\n- Default: Disabled",
           "allOf": [
             {
               "$ref": "#/definitions/SortTailwindcssUserConfig"
             }
           ],
-          "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+          "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte\n- Default: Disabled"
         },
         "svelte": {
-          "description": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Default: Disabled",
+          "description": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Languages: Svelte\n- Default: Disabled",
           "allOf": [
             {
               "$ref": "#/definitions/SvelteUserConfig"
             }
           ],
-          "markdownDescription": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Default: Disabled"
+          "markdownDescription": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Languages: Svelte\n- Default: Disabled"
         },
         "tabWidth": {
-          "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)",
+          "description": "Specify the number of spaces per indentation-level.\n\n- Languages: All\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)",
           "type": "integer",
           "format": "uint8",
           "minimum": 0.0,
-          "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)"
+          "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Languages: All\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)"
         },
         "trailingComma": {
-          "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
+          "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML\n- Default: `\"all\"`",
           "allOf": [
             {
               "$ref": "#/definitions/TrailingCommaConfig"
             }
           ],
-          "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
+          "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML\n- Default: `\"all\"`"
         },
         "useTabs": {
-          "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
+          "description": "Indent lines with tabs instead of spaces.\n\n- Languages: All\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
           "type": "boolean",
-          "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
+          "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Languages: All\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
         },
         "vueIndentScriptAndStyle": {
-          "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
+          "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Languages: Vue\n- Default: `false`",
           "type": "boolean",
-          "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
+          "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Languages: Vue\n- Default: `false`"
         }
       }
     },

--- a/tasks/website_formatter/src/snapshots/schema_json.snap
+++ b/tasks/website_formatter/src/snapshots/schema_json.snap
@@ -9,50 +9,50 @@ expression: json
   "type": "object",
   "properties": {
     "arrowParens": {
-      "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
+      "description": "Include parentheses around a sole arrow function parameter.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"always\"`",
       "allOf": [
         {
           "$ref": "#/definitions/ArrowParensConfig"
         }
       ],
-      "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
+      "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"always\"`"
     },
     "bracketSameLine": {
-      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
+      "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`",
       "type": "boolean",
-      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
+      "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`"
     },
     "bracketSpacing": {
-      "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
+      "description": "Print spaces between brackets in object literals.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML\n- Default: `true`",
       "type": "boolean",
-      "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
+      "markdownDescription": "Print spaces between brackets in object literals.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML\n- Default: `true`"
     },
     "embeddedLanguageFormatting": {
-      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
+      "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)\n- Default: `\"auto\"`",
       "allOf": [
         {
           "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
         }
       ],
-      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
+      "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)\n- Default: `\"auto\"`"
     },
     "endOfLine": {
-      "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
+      "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Languages: All\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
       "allOf": [
         {
           "$ref": "#/definitions/EndOfLineConfig"
         }
       ],
-      "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
+      "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Languages: All\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
     },
     "htmlWhitespaceSensitivity": {
-      "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
+      "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Languages: HTML, Angular, Vue, Handlebars, Svelte\n- Default: `\"css\"`",
       "allOf": [
         {
           "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
         }
       ],
-      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
+      "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Languages: HTML, Angular, Vue, Handlebars, Svelte\n- Default: `\"css\"`"
     },
     "ignorePatterns": {
       "description": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`",
@@ -63,32 +63,32 @@ expression: json
       "markdownDescription": "Ignore files matching these glob patterns.\nPatterns are based on the location of the Oxfmt configuration file.\n\n- Default: `[]`"
     },
     "insertFinalNewline": {
-      "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
+      "description": "Whether to insert a final newline at the end of the file.\n\n- Languages: All\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
       "type": "boolean",
-      "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
+      "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Languages: All\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
     },
     "jsdoc": {
-      "description": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+      "description": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled",
       "allOf": [
         {
           "$ref": "#/definitions/JsdocUserConfig"
         }
       ],
-      "markdownDescription": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+      "markdownDescription": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled"
     },
     "jsxSingleQuote": {
-      "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
+      "description": "Use single quotes instead of double quotes in JSX.\n\n- Languages: JSX, TSX\n- Default: `false`",
       "type": "boolean",
-      "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`"
+      "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Languages: JSX, TSX\n- Default: `false`"
     },
     "objectWrap": {
-      "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
+      "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5\n- Default: `\"preserve\"`",
       "allOf": [
         {
           "$ref": "#/definitions/ObjectWrapConfig"
         }
       ],
-      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
+      "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5\n- Default: `\"preserve\"`"
     },
     "overrides": {
       "description": "File-specific overrides.\nWhen a file matches multiple overrides, the later override takes precedence (array order matters).\n\n- Default: `[]`",
@@ -99,106 +99,106 @@ expression: json
       "markdownDescription": "File-specific overrides.\nWhen a file matches multiple overrides, the later override takes precedence (array order matters).\n\n- Default: `[]`"
     },
     "printWidth": {
-      "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
+      "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Languages: All\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
       "type": "integer",
       "format": "uint16",
       "minimum": 0.0,
-      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
+      "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Languages: All\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
     },
     "proseWrap": {
-      "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
+      "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Languages: Markdown, MDX, YAML\n- Default: `\"preserve\"`",
       "allOf": [
         {
           "$ref": "#/definitions/ProseWrapConfig"
         }
       ],
-      "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
+      "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Languages: Markdown, MDX, YAML\n- Default: `\"preserve\"`"
     },
     "quoteProps": {
-      "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
+      "description": "Change when properties in objects are quoted.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"as-needed\"`",
       "allOf": [
         {
           "$ref": "#/definitions/QuotePropsConfig"
         }
       ],
-      "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
+      "markdownDescription": "Change when properties in objects are quoted.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"as-needed\"`"
     },
     "semi": {
-      "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
+      "description": "Print semicolons at the ends of statements.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `true`",
       "type": "boolean",
-      "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
+      "markdownDescription": "Print semicolons at the ends of statements.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `true`"
     },
     "singleAttributePerLine": {
-      "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
+      "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`",
       "type": "boolean",
-      "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
+      "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`"
     },
     "singleQuote": {
-      "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`\n- Overrides `.editorconfig.quote_type`",
+      "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte\n- Default: `false`\n- Overrides `.editorconfig.quote_type`",
       "type": "boolean",
-      "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`\n- Overrides `.editorconfig.quote_type`"
+      "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte\n- Default: `false`\n- Overrides `.editorconfig.quote_type`"
     },
     "sortImports": {
-      "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+      "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled",
       "allOf": [
         {
           "$ref": "#/definitions/SortImportsUserConfig"
         }
       ],
-      "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+      "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled"
     },
     "sortPackageJson": {
-      "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
+      "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Languages: JSON (`package.json` only)\n- Default: `true`",
       "allOf": [
         {
           "$ref": "#/definitions/SortPackageJsonUserConfig"
         }
       ],
-      "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
+      "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Languages: JSON (`package.json` only)\n- Default: `true`"
     },
     "sortTailwindcss": {
-      "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+      "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte\n- Default: Disabled",
       "allOf": [
         {
           "$ref": "#/definitions/SortTailwindcssUserConfig"
         }
       ],
-      "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+      "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte\n- Default: Disabled"
     },
     "svelte": {
-      "description": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Default: Disabled",
+      "description": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Languages: Svelte\n- Default: Disabled",
       "allOf": [
         {
           "$ref": "#/definitions/SvelteUserConfig"
         }
       ],
-      "markdownDescription": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Default: Disabled"
+      "markdownDescription": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Languages: Svelte\n- Default: Disabled"
     },
     "tabWidth": {
-      "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)",
+      "description": "Specify the number of spaces per indentation-level.\n\n- Languages: All\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)",
       "type": "integer",
       "format": "uint8",
       "minimum": 0.0,
-      "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)"
+      "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Languages: All\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)"
     },
     "trailingComma": {
-      "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
+      "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML\n- Default: `\"all\"`",
       "allOf": [
         {
           "$ref": "#/definitions/TrailingCommaConfig"
         }
       ],
-      "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
+      "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML\n- Default: `\"all\"`"
     },
     "useTabs": {
-      "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
+      "description": "Indent lines with tabs instead of spaces.\n\n- Languages: All\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
       "type": "boolean",
-      "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
+      "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Languages: All\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
     },
     "vueIndentScriptAndStyle": {
-      "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
+      "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Languages: Vue\n- Default: `false`",
       "type": "boolean",
-      "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
+      "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Languages: Vue\n- Default: `false`"
     }
   },
   "allowComments": true,
@@ -263,180 +263,180 @@ expression: json
       "type": "object",
       "properties": {
         "arrowParens": {
-          "description": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`",
+          "description": "Include parentheses around a sole arrow function parameter.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"always\"`",
           "allOf": [
             {
               "$ref": "#/definitions/ArrowParensConfig"
             }
           ],
-          "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Default: `\"always\"`"
+          "markdownDescription": "Include parentheses around a sole arrow function parameter.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"always\"`"
         },
         "bracketSameLine": {
-          "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`",
+          "description": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`",
           "type": "boolean",
-          "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Default: `false`"
+          "markdownDescription": "Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,\ninstead of being alone on the next line (does not apply to self closing elements).\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`"
         },
         "bracketSpacing": {
-          "description": "Print spaces between brackets in object literals.\n\n- Default: `true`",
+          "description": "Print spaces between brackets in object literals.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML\n- Default: `true`",
           "type": "boolean",
-          "markdownDescription": "Print spaces between brackets in object literals.\n\n- Default: `true`"
+          "markdownDescription": "Print spaces between brackets in object literals.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML\n- Default: `true`"
         },
         "embeddedLanguageFormatting": {
-          "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`",
+          "description": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)\n- Default: `\"auto\"`",
           "allOf": [
             {
               "$ref": "#/definitions/EmbeddedLanguageFormattingConfig"
             }
           ],
-          "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\nNOTE: XXX-in-JS support is incomplete.\n\n- Default: `\"auto\"`"
+          "markdownDescription": "Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)\n- Default: `\"auto\"`"
         },
         "endOfLine": {
-          "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
+          "description": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Languages: All\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`",
           "allOf": [
             {
               "$ref": "#/definitions/EndOfLineConfig"
             }
           ],
-          "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
+          "markdownDescription": "Which end of line characters to apply.\n\nNOTE: `\"auto\"` is not supported.\n\n- Languages: All\n- Default: `\"lf\"`\n- Overrides `.editorconfig.end_of_line`"
         },
         "htmlWhitespaceSensitivity": {
-          "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`",
+          "description": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Languages: HTML, Angular, Vue, Handlebars, Svelte\n- Default: `\"css\"`",
           "allOf": [
             {
               "$ref": "#/definitions/HtmlWhitespaceSensitivityConfig"
             }
           ],
-          "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Default: `\"css\"`"
+          "markdownDescription": "Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.\n\n- Languages: HTML, Angular, Vue, Handlebars, Svelte\n- Default: `\"css\"`"
         },
         "insertFinalNewline": {
-          "description": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
+          "description": "Whether to insert a final newline at the end of the file.\n\n- Languages: All\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`",
           "type": "boolean",
-          "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
+          "markdownDescription": "Whether to insert a final newline at the end of the file.\n\n- Languages: All\n- Default: `true`\n- Overrides `.editorconfig.insert_final_newline`"
         },
         "jsdoc": {
-          "description": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+          "description": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled",
           "allOf": [
             {
               "$ref": "#/definitions/JsdocUserConfig"
             }
           ],
-          "markdownDescription": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+          "markdownDescription": "Enable JSDoc comment formatting.\n\nWhen enabled, JSDoc comments are normalized and reformatted:\ntag aliases are canonicalized, descriptions are capitalized,\nlong lines are wrapped, and short comments are collapsed to single-line.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled"
         },
         "jsxSingleQuote": {
-          "description": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`",
+          "description": "Use single quotes instead of double quotes in JSX.\n\n- Languages: JSX, TSX\n- Default: `false`",
           "type": "boolean",
-          "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Default: `false`"
+          "markdownDescription": "Use single quotes instead of double quotes in JSX.\n\n- Languages: JSX, TSX\n- Default: `false`"
         },
         "objectWrap": {
-          "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`",
+          "description": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5\n- Default: `\"preserve\"`",
           "allOf": [
             {
               "$ref": "#/definitions/ObjectWrapConfig"
             }
           ],
-          "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Default: `\"preserve\"`"
+          "markdownDescription": "How to wrap object literals when they could fit on one line or span multiple lines.\n\nBy default, formats objects as multi-line if there is a newline prior to the first property.\nAuthors can use this heuristic to contextually improve readability, though it has some downsides.\n\n- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5\n- Default: `\"preserve\"`"
         },
         "printWidth": {
-          "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
+          "description": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Languages: All\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`",
           "type": "integer",
           "format": "uint16",
           "minimum": 0.0,
-          "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
+          "markdownDescription": "Specify the line length that the printer will wrap on.\n\nIf you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.\n\n- Languages: All\n- Default: `100`\n- Overrides `.editorconfig.max_line_length`"
         },
         "proseWrap": {
-          "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`",
+          "description": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Languages: Markdown, MDX, YAML\n- Default: `\"preserve\"`",
           "allOf": [
             {
               "$ref": "#/definitions/ProseWrapConfig"
             }
           ],
-          "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Default: `\"preserve\"`"
+          "markdownDescription": "How to wrap prose.\n\nBy default, formatter will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket.\nTo wrap prose to the print width, change this option to \"always\".\nIf you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use \"never\".\n\n- Languages: Markdown, MDX, YAML\n- Default: `\"preserve\"`"
         },
         "quoteProps": {
-          "description": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`",
+          "description": "Change when properties in objects are quoted.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"as-needed\"`",
           "allOf": [
             {
               "$ref": "#/definitions/QuotePropsConfig"
             }
           ],
-          "markdownDescription": "Change when properties in objects are quoted.\n\n- Default: `\"as-needed\"`"
+          "markdownDescription": "Change when properties in objects are quoted.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `\"as-needed\"`"
         },
         "semi": {
-          "description": "Print semicolons at the ends of statements.\n\n- Default: `true`",
+          "description": "Print semicolons at the ends of statements.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `true`",
           "type": "boolean",
-          "markdownDescription": "Print semicolons at the ends of statements.\n\n- Default: `true`"
+          "markdownDescription": "Print semicolons at the ends of statements.\n\n- Languages: JS, JSX, TS, TSX\n- Default: `true`"
         },
         "singleAttributePerLine": {
-          "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`",
+          "description": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`",
           "type": "boolean",
-          "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Default: `false`"
+          "markdownDescription": "Enforce single attribute per line in HTML, Vue, and JSX.\n\n- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte\n- Default: `false`"
         },
         "singleQuote": {
-          "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`\n- Overrides `.editorconfig.quote_type`",
+          "description": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte\n- Default: `false`\n- Overrides `.editorconfig.quote_type`",
           "type": "boolean",
-          "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Default: `false`\n- Overrides `.editorconfig.quote_type`"
+          "markdownDescription": "Use single quotes instead of double quotes.\n\nFor JSX, you can set the `jsxSingleQuote` option.\n\n- Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte\n- Default: `false`\n- Overrides `.editorconfig.quote_type`"
         },
         "sortImports": {
-          "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+          "description": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled",
           "allOf": [
             {
               "$ref": "#/definitions/SortImportsUserConfig"
             }
           ],
-          "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+          "markdownDescription": "Sort import statements.\n\nUsing the similar algorithm as [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX\n- Default: Disabled"
         },
         "sortPackageJson": {
-          "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`",
+          "description": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Languages: JSON (`package.json` only)\n- Default: `true`",
           "allOf": [
             {
               "$ref": "#/definitions/SortPackageJsonUserConfig"
             }
           ],
-          "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Default: `true`"
+          "markdownDescription": "Sort `package.json` keys.\n\nThe algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://github.com/matzkoh/prettier-plugin-packagejson).\nBut we believe it is clearer and easier to navigate.\nFor details, see each field's documentation.\n\n- Languages: JSON (`package.json` only)\n- Default: `true`"
         },
         "sortTailwindcss": {
-          "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled",
+          "description": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte\n- Default: Disabled",
           "allOf": [
             {
               "$ref": "#/definitions/SortTailwindcssUserConfig"
             }
           ],
-          "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Default: Disabled"
+          "markdownDescription": "Sort Tailwind CSS classes.\n\nUsing the same algorithm as [prettier-plugin-tailwindcss](https://github.com/tailwindlabs/prettier-plugin-tailwindcss).\nOption names omit the `tailwind` prefix used in the original plugin (e.g., `config` instead of `tailwindConfig`).\nFor details, see each field's documentation.\n\nPass `true` or an object to enable with defaults, or omit/set `false` to disable.\n\n- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte\n- Default: Disabled"
         },
         "svelte": {
-          "description": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Default: Disabled",
+          "description": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Languages: Svelte\n- Default: Disabled",
           "allOf": [
             {
               "$ref": "#/definitions/SvelteUserConfig"
             }
           ],
-          "markdownDescription": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Default: Disabled"
+          "markdownDescription": "Options for `prettier-plugin-svelte`.\n\nPass `true` or an object to enable `.svelte` file formatting,\nor `false` (handy in overrides) / omit to disable.\nSetting `true` resets to defaults — any options inherited from a parent scope are dropped.\n\nNOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`) at runtime,\nbut Oxfmt does NOT bundle or auto-install it.\nYou must install `svelte` yourself in your project, formatting will fail at runtime otherwise.\n\n- Languages: Svelte\n- Default: Disabled"
         },
         "tabWidth": {
-          "description": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)",
+          "description": "Specify the number of spaces per indentation-level.\n\n- Languages: All\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)",
           "type": "integer",
           "format": "uint8",
           "minimum": 0.0,
-          "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)"
+          "markdownDescription": "Specify the number of spaces per indentation-level.\n\n- Languages: All\n- Default: `2`\n- Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)"
         },
         "trailingComma": {
-          "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`",
+          "description": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML\n- Default: `\"all\"`",
           "allOf": [
             {
               "$ref": "#/definitions/TrailingCommaConfig"
             }
           ],
-          "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Default: `\"all\"`"
+          "markdownDescription": "Print trailing commas wherever possible in multi-line comma-separated syntactic structures.\n\nA single-line array, for example, never gets trailing commas.\n\n- Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML\n- Default: `\"all\"`"
         },
         "useTabs": {
-          "description": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
+          "description": "Indent lines with tabs instead of spaces.\n\n- Languages: All\n- Default: `false`\n- Overrides `.editorconfig.indent_style`",
           "type": "boolean",
-          "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
+          "markdownDescription": "Indent lines with tabs instead of spaces.\n\n- Languages: All\n- Default: `false`\n- Overrides `.editorconfig.indent_style`"
         },
         "vueIndentScriptAndStyle": {
-          "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`",
+          "description": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Languages: Vue\n- Default: `false`",
           "type": "boolean",
-          "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Default: `false`"
+          "markdownDescription": "Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.\n\n- Languages: Vue\n- Default: `false`"
         }
       }
     },

--- a/tasks/website_formatter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_formatter/src/snapshots/schema_markdown.snap
@@ -19,6 +19,7 @@ type: `"always" | "avoid"`
 
 Include parentheses around a sole arrow function parameter.
 
+- Languages: JS, JSX, TS, TSX
 - Default: `"always"`
 
 
@@ -30,6 +31,7 @@ type: `boolean`
 Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
 instead of being alone on the next line (does not apply to self closing elements).
 
+- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte
 - Default: `false`
 
 
@@ -40,6 +42,7 @@ type: `boolean`
 
 Print spaces between brackets in object literals.
 
+- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML
 - Default: `true`
 
 
@@ -50,8 +53,7 @@ type: `"auto" | "off"`
 
 Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
 
-NOTE: XXX-in-JS support is incomplete.
-
+- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)
 - Default: `"auto"`
 
 
@@ -64,6 +66,7 @@ Which end of line characters to apply.
 
 NOTE: `"auto"` is not supported.
 
+- Languages: All
 - Default: `"lf"`
 - Overrides `.editorconfig.end_of_line`
 
@@ -75,6 +78,7 @@ type: `"css" | "strict" | "ignore"`
 
 Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
 
+- Languages: HTML, Angular, Vue, Handlebars, Svelte
 - Default: `"css"`
 
 
@@ -96,6 +100,7 @@ type: `boolean`
 
 Whether to insert a final newline at the end of the file.
 
+- Languages: All
 - Default: `true`
 - Overrides `.editorconfig.insert_final_newline`
 
@@ -113,6 +118,7 @@ long lines are wrapped, and short comments are collapsed to single-line.
 
 Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
 
+- Languages: JS, JSX, TS, TSX
 - Default: Disabled
 
 
@@ -240,6 +246,7 @@ type: `boolean`
 
 Use single quotes instead of double quotes in JSX.
 
+- Languages: JSX, TSX
 - Default: `false`
 
 
@@ -253,6 +260,7 @@ How to wrap object literals when they could fit on one line or span multiple lin
 By default, formats objects as multi-line if there is a newline prior to the first property.
 Authors can use this heuristic to contextually improve readability, though it has some downsides.
 
+- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5
 - Default: `"preserve"`
 
 
@@ -312,6 +320,7 @@ type: `"always" | "avoid"`
 
 Include parentheses around a sole arrow function parameter.
 
+- Languages: JS, JSX, TS, TSX
 - Default: `"always"`
 
 
@@ -323,6 +332,7 @@ type: `boolean`
 Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line,
 instead of being alone on the next line (does not apply to self closing elements).
 
+- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte
 - Default: `false`
 
 
@@ -333,6 +343,7 @@ type: `boolean`
 
 Print spaces between brackets in object literals.
 
+- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5, GraphQL, YAML
 - Default: `true`
 
 
@@ -343,8 +354,7 @@ type: `"auto" | "off"`
 
 Control whether to format embedded parts (For example, CSS-in-JS, or JS-in-Vue, etc.) in the file.
 
-NOTE: XXX-in-JS support is incomplete.
-
+- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Svelte, Markdown, MDX (languages with embedded code)
 - Default: `"auto"`
 
 
@@ -357,6 +367,7 @@ Which end of line characters to apply.
 
 NOTE: `"auto"` is not supported.
 
+- Languages: All
 - Default: `"lf"`
 - Overrides `.editorconfig.end_of_line`
 
@@ -368,6 +379,7 @@ type: `"css" | "strict" | "ignore"`
 
 Specify the global whitespace sensitivity for HTML, Vue, Angular, and Handlebars.
 
+- Languages: HTML, Angular, Vue, Handlebars, Svelte
 - Default: `"css"`
 
 
@@ -378,6 +390,7 @@ type: `boolean`
 
 Whether to insert a final newline at the end of the file.
 
+- Languages: All
 - Default: `true`
 - Overrides `.editorconfig.insert_final_newline`
 
@@ -395,6 +408,7 @@ long lines are wrapped, and short comments are collapsed to single-line.
 
 Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
 
+- Languages: JS, JSX, TS, TSX
 - Default: Disabled
 
 
@@ -522,6 +536,7 @@ type: `boolean`
 
 Use single quotes instead of double quotes in JSX.
 
+- Languages: JSX, TSX
 - Default: `false`
 
 
@@ -535,6 +550,7 @@ How to wrap object literals when they could fit on one line or span multiple lin
 By default, formats objects as multi-line if there is a newline prior to the first property.
 Authors can use this heuristic to contextually improve readability, though it has some downsides.
 
+- Languages: JS, JSX, TS, TSX, JSON, JSONC, JSON5
 - Default: `"preserve"`
 
 
@@ -547,6 +563,7 @@ Specify the line length that the printer will wrap on.
 
 If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
 
+- Languages: All
 - Default: `100`
 - Overrides `.editorconfig.max_line_length`
 
@@ -562,6 +579,7 @@ By default, formatter will not change wrapping in markdown text since some servi
 To wrap prose to the print width, change this option to "always".
 If you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use "never".
 
+- Languages: Markdown, MDX, YAML
 - Default: `"preserve"`
 
 
@@ -572,6 +590,7 @@ type: `"as-needed" | "consistent" | "preserve"`
 
 Change when properties in objects are quoted.
 
+- Languages: JS, JSX, TS, TSX
 - Default: `"as-needed"`
 
 
@@ -582,6 +601,7 @@ type: `boolean`
 
 Print semicolons at the ends of statements.
 
+- Languages: JS, JSX, TS, TSX
 - Default: `true`
 
 
@@ -592,6 +612,7 @@ type: `boolean`
 
 Enforce single attribute per line in HTML, Vue, and JSX.
 
+- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte
 - Default: `false`
 
 
@@ -604,6 +625,7 @@ Use single quotes instead of double quotes.
 
 For JSX, you can set the `jsxSingleQuote` option.
 
+- Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte
 - Default: `false`
 - Overrides `.editorconfig.quote_type`
 
@@ -620,6 +642,7 @@ For details, see each field's documentation.
 
 Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
 
+- Languages: JS, JSX, TS, TSX
 - Default: Disabled
 
 
@@ -876,6 +899,7 @@ The algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://
 But we believe it is clearer and easier to navigate.
 For details, see each field's documentation.
 
+- Languages: JSON (`package.json` only)
 - Default: `true`
 
 
@@ -902,6 +926,7 @@ For details, see each field's documentation.
 
 Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
 
+- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte
 - Default: Disabled
 
 
@@ -990,6 +1015,7 @@ NOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`)
 but Oxfmt does NOT bundle or auto-install it.
 You must install `svelte` yourself in your project, formatting will fail at runtime otherwise.
 
+- Languages: Svelte
 - Default: Disabled
 
 
@@ -1032,6 +1058,7 @@ type: `integer`
 
 Specify the number of spaces per indentation-level.
 
+- Languages: All
 - Default: `2`
 - Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)
 
@@ -1045,6 +1072,7 @@ Print trailing commas wherever possible in multi-line comma-separated syntactic 
 
 A single-line array, for example, never gets trailing commas.
 
+- Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML
 - Default: `"all"`
 
 
@@ -1055,6 +1083,7 @@ type: `boolean`
 
 Indent lines with tabs instead of spaces.
 
+- Languages: All
 - Default: `false`
 - Overrides `.editorconfig.indent_style`
 
@@ -1066,6 +1095,7 @@ type: `boolean`
 
 Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.
 
+- Languages: Vue
 - Default: `false`
 
 
@@ -1078,6 +1108,7 @@ Specify the line length that the printer will wrap on.
 
 If you don't want line wrapping when formatting Markdown, you can set the `proseWrap` option to disable it.
 
+- Languages: All
 - Default: `100`
 - Overrides `.editorconfig.max_line_length`
 
@@ -1093,6 +1124,7 @@ By default, formatter will not change wrapping in markdown text since some servi
 To wrap prose to the print width, change this option to "always".
 If you want to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use "never".
 
+- Languages: Markdown, MDX, YAML
 - Default: `"preserve"`
 
 
@@ -1103,6 +1135,7 @@ type: `"as-needed" | "consistent" | "preserve"`
 
 Change when properties in objects are quoted.
 
+- Languages: JS, JSX, TS, TSX
 - Default: `"as-needed"`
 
 
@@ -1113,6 +1146,7 @@ type: `boolean`
 
 Print semicolons at the ends of statements.
 
+- Languages: JS, JSX, TS, TSX
 - Default: `true`
 
 
@@ -1123,6 +1157,7 @@ type: `boolean`
 
 Enforce single attribute per line in HTML, Vue, and JSX.
 
+- Languages: JSX, TSX, HTML, Angular, Vue, MJML, Svelte
 - Default: `false`
 
 
@@ -1135,6 +1170,7 @@ Use single quotes instead of double quotes.
 
 For JSX, you can set the `jsxSingleQuote` option.
 
+- Languages: JS, JSX, TS, TSX, CSS, Less, SCSS, Markdown, MDX, YAML, Handlebars, Svelte
 - Default: `false`
 - Overrides `.editorconfig.quote_type`
 
@@ -1151,6 +1187,7 @@ For details, see each field's documentation.
 
 Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
 
+- Languages: JS, JSX, TS, TSX
 - Default: Disabled
 
 
@@ -1407,6 +1444,7 @@ The algorithm is NOT compatible with [prettier-plugin-sort-packagejson](https://
 But we believe it is clearer and easier to navigate.
 For details, see each field's documentation.
 
+- Languages: JSON (`package.json` only)
 - Default: `true`
 
 
@@ -1433,6 +1471,7 @@ For details, see each field's documentation.
 
 Pass `true` or an object to enable with defaults, or omit/set `false` to disable.
 
+- Languages: JS, JSX, TS, TSX, HTML, Vue, Angular, Handlebars, CSS, SCSS, Less, Svelte
 - Default: Disabled
 
 
@@ -1521,6 +1560,7 @@ NOTE: `prettier-plugin-svelte` requires the `svelte` package (`svelte/compiler`)
 but Oxfmt does NOT bundle or auto-install it.
 You must install `svelte` yourself in your project, formatting will fail at runtime otherwise.
 
+- Languages: Svelte
 - Default: Disabled
 
 
@@ -1563,6 +1603,7 @@ type: `integer`
 
 Specify the number of spaces per indentation-level.
 
+- Languages: All
 - Default: `2`
 - Overrides `.editorconfig.indent_size` (falls back to `.editorconfig.tab_width`)
 
@@ -1576,6 +1617,7 @@ Print trailing commas wherever possible in multi-line comma-separated syntactic 
 
 A single-line array, for example, never gets trailing commas.
 
+- Languages: JS, JSX, TS, TSX, JSONC, JSON5, TOML, CSS, Less, SCSS, YAML
 - Default: `"all"`
 
 
@@ -1586,6 +1628,7 @@ type: `boolean`
 
 Indent lines with tabs instead of spaces.
 
+- Languages: All
 - Default: `false`
 - Overrides `.editorconfig.indent_style`
 
@@ -1597,4 +1640,5 @@ type: `boolean`
 
 Whether or not to indent the code inside `<script>` and `<style>` tags in Vue files.
 
+- Languages: Vue
 - Default: `false`


### PR DESCRIPTION
Currently, our config file is Prettier-compatible, which is not easy to tell which options apply to which languages.

(I've felt this way for a while, so) I've added some notes to clarify.