### PR TITLE
fix(linter/no-map-spread): remove ineffective autofix

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -231,26 +231,21 @@ declare_oxc_lint!(
     /// let d = arr.concat(set); // [1, 2, 3, 4]
     /// ```
     ///
-    /// ### Automatic Fixing
-    /// This rule can automatically fix violations caused by object spreads, but
-    /// does not fix arrays. Object spreads will get replaced with
-    /// [`Object.assign`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign).  Array fixing may be added in the future.
+    /// ### Fix Suggestions
+    /// This rule can suggest fixes for violations caused by object spreads, but
+    /// does not fix arrays. Object spreads can get replaced with
+    /// [`Object.assign`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign). Array fixing may be added in the future.
     ///
     /// Object expressions with a single element (the spread) are not fixed.
     /// ```js
     /// arr.map(x => ({ ...x })) // not fixed
     /// ```
     ///
-    /// A `fix` is available (using `--fix`) for objects with "normal" elements before the
-    /// spread. Since `Object.apply` mutates the first argument, and a new
-    /// object will be created with those elements, the spread identifier will
-    /// not be mutated. In effect, the spread semantics are preserved
+    /// Object expressions with "normal" properties before the spread are not
+    /// fixed, because preserving semantics with `Object.assign` requires
+    /// allocating a new object.
     /// ```js
-    /// // before
-    /// arr.map(({ x, y }) => ({ x, ...y }))
-    ///
-    /// // after
-    /// arr.map(({ x, y }) => (Object.assign({ x }, y)))
+    /// arr.map(({ x, y }) => ({ x, ...y })) // not fixed
     /// ```
     ///
     /// A suggestion (using `--fix-suggestions`) is provided when a spread is
@@ -318,7 +313,7 @@ declare_oxc_lint!(
     NoMapSpread,
     oxc,
     perf,
-    conditional_fix_suggestion,
+    conditional_suggestion,
     config = NoMapSpreadConfig,
     version = "0.11.0",
 );
@@ -380,14 +375,14 @@ impl Rule for NoMapSpread {
             let diagnostic = no_map_spread_diagnostic(map_call_site, &spread, returned_span);
             if let Some(obj) = spread.as_object() {
                 debug_assert!(!obj.properties.is_empty());
-                if obj.properties.first().is_some_and(ObjectPropertyKind::is_spread) {
+                if obj.properties.len() > 1
+                    && obj.properties.first().is_some_and(ObjectPropertyKind::is_spread)
+                {
                     ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
                         fix_spread_to_object_assign(fixer, obj)
                     });
                 } else {
-                    ctx.diagnostic_with_fix(diagnostic, |fixer| {
-                        fix_spread_to_object_assign(fixer, obj)
-                    });
+                    ctx.diagnostic(diagnostic);
                 }
             } else {
                 ctx.diagnostic(diagnostic);
@@ -720,7 +715,10 @@ where
 fn test() {
     use serde_json::json;
 
-    use crate::tester::Tester;
+    use crate::{
+        fixer::FixKind,
+        tester::{ExpectFixTestCase, Tester},
+    };
 
     let pass = vec![
         ("let a = b.map(x => x)", None),
@@ -813,28 +811,32 @@ fn test() {
         ("const foo = a => a.map(x => ({ ...(x ?? y) }))", Some(json!([{ "ignoreArgs": false }]))),
     ];
 
-    let fix = vec![
+    let fix: Vec<ExpectFixTestCase> = vec![
         // single spreads cannot be fixed with `Object.assign`. We'll assume the
         // spread is happening intentionally, to force a shallow clone. Maybe we
         // shouldn't even report these cases?
-        ("let a = b.map(x => ({ ...x }))", "let a = b.map(x => ({ ...x }))"),
+        ("let a = b.map(x => ({ ...x }))", "let a = b.map(x => ({ ...x }))").into(),
         // two
         (
             "let a = b.map(({ x, y }) => ({ ...x, ...y }))",
             "let a = b.map(({ x, y }) => (Object.assign(x, y)))",
-        ),
+        )
+        .into(),
         (
             "let a = b.map(({ x, y }) => { return { ...x, ...y }; })",
             "let a = b.map(({ x, y }) => { return Object.assign(x, y); })",
-        ),
+        )
+        .into(),
         (
             "let a = b.map(({ x, y }) => ({ x, ...y }))",
-            "let a = b.map(({ x, y }) => (Object.assign({ x }, y)))",
-        ),
+            "let a = b.map(({ x, y }) => ({ x, ...y }))",
+        )
+        .into(),
         (
             "let a = b.map(({ x, y }) => ({ ...x, y }))",
             "let a = b.map(({ x, y }) => (Object.assign(x, { y })))",
-        ),
+        )
+        .into(),
         // three
         (
             "let a = b.map(({ x, y, z }) => ({ ...x, y, z }))",
@@ -842,18 +844,25 @@ fn test() {
 	y,
 	z
 })))",
-        ),
+        )
+        .into(),
         (
             "let a = b.map(({ x, y, z }) => ({ x, ...y, z }))",
-            "let a = b.map(({ x, y, z }) => (Object.assign({ x }, y, { z })))",
-        ),
+            "let a = b.map(({ x, y, z }) => ({ x, ...y, z }))",
+        )
+        .into(),
         (
             "let a = b.map(({ x, y, z }) => ({ x, y, ...z }))",
-            "let a = b.map(({ x, y, z }) => (Object.assign({
-	x,
-	y
-}, z)))",
-        ),
+            "let a = b.map(({ x, y, z }) => ({ x, y, ...z }))",
+        )
+        .into(),
+        (
+            "head.push({ link: [...assets.js.map((attrs: any) => ({ rel: 'modulepreload', ...attrs }))] })",
+            "head.push({ link: [...assets.js.map((attrs: any) => ({ rel: 'modulepreload', ...attrs }))] })",
+            None,
+            FixKind::SafeFix,
+        )
+        .into(),
     ];
 
     Tester::new(NoMapSpread::NAME, NoMapSpread::PLUGIN, pass, fail)


### PR DESCRIPTION
The no-map-spread autofix rewrote object literals like `{ rel, ...attrs }` to `Object.assign({ rel }, attrs)`, which still allocates a fresh object and does not satisfy the rule's in-place mutation guidance. This narrows the fixer to suggestion-only cases that can mutate the spread object and adds a regression case for the reported array spread map shape.

Fixes #22954.