### PR TITLE
feat(linter/vitest): implement `prefer-to-be-disabled` rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4816,6 +4816,11 @@ impl RuleRunner for crate::rules::vitest::prefer_to_be::PreferToBe {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::prefer_to_be_disabled::PreferToBeDisabled {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -772,6 +772,7 @@ pub use crate::rules::vitest::prefer_spy_on::PreferSpyOn as VitestPreferSpyOn;
 pub use crate::rules::vitest::prefer_strict_boolean_matchers::PreferStrictBooleanMatchers as VitestPreferStrictBooleanMatchers;
 pub use crate::rules::vitest::prefer_strict_equal::PreferStrictEqual as VitestPreferStrictEqual;
 pub use crate::rules::vitest::prefer_to_be::PreferToBe as VitestPreferToBe;
+pub use crate::rules::vitest::prefer_to_be_disabled::PreferToBeDisabled as VitestPreferToBeDisabled;
 pub use crate::rules::vitest::prefer_to_be_falsy::PreferToBeFalsy as VitestPreferToBeFalsy;
 pub use crate::rules::vitest::prefer_to_be_object::PreferToBeObject as VitestPreferToBeObject;
 pub use crate::rules::vitest::prefer_to_be_truthy::PreferToBeTruthy as VitestPreferToBeTruthy;
@@ -1603,6 +1604,7 @@ pub enum RuleEnum {
     VitestPreferStrictBooleanMatchers(VitestPreferStrictBooleanMatchers),
     VitestPreferStrictEqual(VitestPreferStrictEqual),
     VitestPreferToBe(VitestPreferToBe),
+    VitestPreferToBeDisabled(VitestPreferToBeDisabled),
     VitestPreferToBeFalsy(VitestPreferToBeFalsy),
     VitestPreferToBeObject(VitestPreferToBeObject),
     VitestPreferToBeTruthy(VitestPreferToBeTruthy),
@@ -2526,7 +2528,8 @@ const VITEST_PREFER_SPY_ON_ID: usize = VITEST_PREFER_SNAPSHOT_HINT_ID + 1usize;
 const VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID: usize = VITEST_PREFER_SPY_ON_ID + 1usize;
 const VITEST_PREFER_STRICT_EQUAL_ID: usize = VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID + 1usize;
 const VITEST_PREFER_TO_BE_ID: usize = VITEST_PREFER_STRICT_EQUAL_ID + 1usize;
-const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_TO_BE_ID + 1usize;
+const VITEST_PREFER_TO_BE_DISABLED_ID: usize = VITEST_PREFER_TO_BE_ID + 1usize;
+const VITEST_PREFER_TO_BE_FALSY_ID: usize = VITEST_PREFER_TO_BE_DISABLED_ID + 1usize;
 const VITEST_PREFER_TO_BE_OBJECT_ID: usize = VITEST_PREFER_TO_BE_FALSY_ID + 1usize;
 const VITEST_PREFER_TO_BE_TRUTHY_ID: usize = VITEST_PREFER_TO_BE_OBJECT_ID + 1usize;
 const VITEST_PREFER_TO_CONTAIN_ID: usize = VITEST_PREFER_TO_BE_TRUTHY_ID + 1usize;
@@ -3477,6 +3480,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(_) => VITEST_PREFER_STRICT_BOOLEAN_MATCHERS_ID,
             Self::VitestPreferStrictEqual(_) => VITEST_PREFER_STRICT_EQUAL_ID,
             Self::VitestPreferToBe(_) => VITEST_PREFER_TO_BE_ID,
+            Self::VitestPreferToBeDisabled(_) => VITEST_PREFER_TO_BE_DISABLED_ID,
             Self::VitestPreferToBeFalsy(_) => VITEST_PREFER_TO_BE_FALSY_ID,
             Self::VitestPreferToBeObject(_) => VITEST_PREFER_TO_BE_OBJECT_ID,
             Self::VitestPreferToBeTruthy(_) => VITEST_PREFER_TO_BE_TRUTHY_ID,
@@ -4415,6 +4419,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(_) => VitestPreferStrictBooleanMatchers::NAME,
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::NAME,
             Self::VitestPreferToBe(_) => VitestPreferToBe::NAME,
+            Self::VitestPreferToBeDisabled(_) => VitestPreferToBeDisabled::NAME,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::NAME,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::NAME,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::NAME,
@@ -5405,6 +5410,7 @@ impl RuleEnum {
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::CATEGORY,
             Self::VitestPreferToBe(_) => VitestPreferToBe::CATEGORY,
+            Self::VitestPreferToBeDisabled(_) => VitestPreferToBeDisabled::CATEGORY,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::CATEGORY,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::CATEGORY,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::CATEGORY,
@@ -6346,6 +6352,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(_) => VitestPreferStrictBooleanMatchers::FIX,
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::FIX,
             Self::VitestPreferToBe(_) => VitestPreferToBe::FIX,
+            Self::VitestPreferToBeDisabled(_) => VitestPreferToBeDisabled::FIX,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::FIX,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::FIX,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::FIX,
@@ -7523,6 +7530,7 @@ impl RuleEnum {
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::documentation(),
             Self::VitestPreferToBe(_) => VitestPreferToBe::documentation(),
+            Self::VitestPreferToBeDisabled(_) => VitestPreferToBeDisabled::documentation(),
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::documentation(),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::documentation(),
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::documentation(),
@@ -9798,6 +9806,8 @@ impl RuleEnum {
                 .or_else(|| VitestPreferStrictEqual::schema(generator)),
             Self::VitestPreferToBe(_) => VitestPreferToBe::config_schema(generator)
                 .or_else(|| VitestPreferToBe::schema(generator)),
+            Self::VitestPreferToBeDisabled(_) => VitestPreferToBeDisabled::config_schema(generator)
+                .or_else(|| VitestPreferToBeDisabled::schema(generator)),
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::config_schema(generator)
                 .or_else(|| VitestPreferToBeFalsy::schema(generator)),
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::config_schema(generator)
@@ -10746,6 +10756,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(_) => "vitest",
             Self::VitestPreferStrictEqual(_) => "vitest",
             Self::VitestPreferToBe(_) => "vitest",
+            Self::VitestPreferToBeDisabled(_) => "vitest",
             Self::VitestPreferToBeFalsy(_) => "vitest",
             Self::VitestPreferToBeObject(_) => "vitest",
             Self::VitestPreferToBeTruthy(_) => "vitest",
@@ -13261,6 +13272,9 @@ impl RuleEnum {
             Self::VitestPreferToBe(_) => {
                 Ok(Self::VitestPreferToBe(VitestPreferToBe::from_configuration(value)?))
             }
+            Self::VitestPreferToBeDisabled(_) => Ok(Self::VitestPreferToBeDisabled(
+                VitestPreferToBeDisabled::from_configuration(value)?,
+            )),
             Self::VitestPreferToBeFalsy(_) => {
                 Ok(Self::VitestPreferToBeFalsy(VitestPreferToBeFalsy::from_configuration(value)?))
             }
@@ -14229,6 +14243,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.to_configuration(),
             Self::VitestPreferStrictEqual(rule) => rule.to_configuration(),
             Self::VitestPreferToBe(rule) => rule.to_configuration(),
+            Self::VitestPreferToBeDisabled(rule) => rule.to_configuration(),
             Self::VitestPreferToBeFalsy(rule) => rule.to_configuration(),
             Self::VitestPreferToBeObject(rule) => rule.to_configuration(),
             Self::VitestPreferToBeTruthy(rule) => rule.to_configuration(),
@@ -15065,6 +15080,7 @@ impl RuleEnum {
                 Self::VitestPreferStrictBooleanMatchers(rule) => rule.run(node, ctx),
                 Self::VitestPreferStrictEqual(rule) => rule.run(node, ctx),
                 Self::VitestPreferToBe(rule) => rule.run(node, ctx),
+                Self::VitestPreferToBeDisabled(rule) => rule.run(node, ctx),
                 Self::VitestPreferToBeFalsy(rule) => rule.run(node, ctx),
                 Self::VitestPreferToBeObject(rule) => rule.run(node, ctx),
                 Self::VitestPreferToBeTruthy(rule) => rule.run(node, ctx),
@@ -15894,6 +15910,7 @@ impl RuleEnum {
                 Self::VitestPreferStrictBooleanMatchers(rule) => rule.run(node, ctx),
                 Self::VitestPreferStrictEqual(rule) => rule.run(node, ctx),
                 Self::VitestPreferToBe(rule) => rule.run(node, ctx),
+                Self::VitestPreferToBeDisabled(rule) => rule.run(node, ctx),
                 Self::VitestPreferToBeFalsy(rule) => rule.run(node, ctx),
                 Self::VitestPreferToBeObject(rule) => rule.run(node, ctx),
                 Self::VitestPreferToBeTruthy(rule) => rule.run(node, ctx),
@@ -16730,6 +16747,7 @@ impl RuleEnum {
                 Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_once(ctx),
                 Self::VitestPreferStrictEqual(rule) => rule.run_once(ctx),
                 Self::VitestPreferToBe(rule) => rule.run_once(ctx),
+                Self::VitestPreferToBeDisabled(rule) => rule.run_once(ctx),
                 Self::VitestPreferToBeFalsy(rule) => rule.run_once(ctx),
                 Self::VitestPreferToBeObject(rule) => rule.run_once(ctx),
                 Self::VitestPreferToBeTruthy(rule) => rule.run_once(ctx),
@@ -17559,6 +17577,7 @@ impl RuleEnum {
                 Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_once(ctx),
                 Self::VitestPreferStrictEqual(rule) => rule.run_once(ctx),
                 Self::VitestPreferToBe(rule) => rule.run_once(ctx),
+                Self::VitestPreferToBeDisabled(rule) => rule.run_once(ctx),
                 Self::VitestPreferToBeFalsy(rule) => rule.run_once(ctx),
                 Self::VitestPreferToBeObject(rule) => rule.run_once(ctx),
                 Self::VitestPreferToBeTruthy(rule) => rule.run_once(ctx),
@@ -18638,6 +18657,7 @@ impl RuleEnum {
                 }
                 Self::VitestPreferStrictEqual(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferToBe(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VitestPreferToBeDisabled(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferToBeFalsy(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferToBeObject(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferToBeTruthy(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19723,6 +19743,7 @@ impl RuleEnum {
                 }
                 Self::VitestPreferStrictEqual(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferToBe(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VitestPreferToBeDisabled(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferToBeFalsy(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferToBeObject(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestPreferToBeTruthy(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20566,6 +20587,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.should_run(ctx),
             Self::VitestPreferStrictEqual(rule) => rule.should_run(ctx),
             Self::VitestPreferToBe(rule) => rule.should_run(ctx),
+            Self::VitestPreferToBeDisabled(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeFalsy(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeObject(rule) => rule.should_run(ctx),
             Self::VitestPreferToBeTruthy(rule) => rule.should_run(ctx),
@@ -21738,6 +21760,7 @@ impl RuleEnum {
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::IS_TSGOLINT_RULE,
             Self::VitestPreferToBe(_) => VitestPreferToBe::IS_TSGOLINT_RULE,
+            Self::VitestPreferToBeDisabled(_) => VitestPreferToBeDisabled::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::IS_TSGOLINT_RULE,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::IS_TSGOLINT_RULE,
@@ -22752,6 +22775,7 @@ impl RuleEnum {
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::VERSION,
             Self::VitestPreferToBe(_) => VitestPreferToBe::VERSION,
+            Self::VitestPreferToBeDisabled(_) => VitestPreferToBeDisabled::VERSION,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::VERSION,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::VERSION,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::VERSION,
@@ -23781,6 +23805,7 @@ impl RuleEnum {
             }
             Self::VitestPreferStrictEqual(_) => VitestPreferStrictEqual::HAS_CONFIG,
             Self::VitestPreferToBe(_) => VitestPreferToBe::HAS_CONFIG,
+            Self::VitestPreferToBeDisabled(_) => VitestPreferToBeDisabled::HAS_CONFIG,
             Self::VitestPreferToBeFalsy(_) => VitestPreferToBeFalsy::HAS_CONFIG,
             Self::VitestPreferToBeObject(_) => VitestPreferToBeObject::HAS_CONFIG,
             Self::VitestPreferToBeTruthy(_) => VitestPreferToBeTruthy::HAS_CONFIG,
@@ -24619,6 +24644,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.types_info(),
             Self::VitestPreferStrictEqual(rule) => rule.types_info(),
             Self::VitestPreferToBe(rule) => rule.types_info(),
+            Self::VitestPreferToBeDisabled(rule) => rule.types_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.types_info(),
             Self::VitestPreferToBeObject(rule) => rule.types_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.types_info(),
@@ -25445,6 +25471,7 @@ impl RuleEnum {
             Self::VitestPreferStrictBooleanMatchers(rule) => rule.run_info(),
             Self::VitestPreferStrictEqual(rule) => rule.run_info(),
             Self::VitestPreferToBe(rule) => rule.run_info(),
+            Self::VitestPreferToBeDisabled(rule) => rule.run_info(),
             Self::VitestPreferToBeFalsy(rule) => rule.run_info(),
             Self::VitestPreferToBeObject(rule) => rule.run_info(),
             Self::VitestPreferToBeTruthy(rule) => rule.run_info(),
@@ -26399,6 +26426,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferStrictBooleanMatchers(VitestPreferStrictBooleanMatchers::default()),
         RuleEnum::VitestPreferStrictEqual(VitestPreferStrictEqual::default()),
         RuleEnum::VitestPreferToBe(VitestPreferToBe::default()),
+        RuleEnum::VitestPreferToBeDisabled(VitestPreferToBeDisabled::default()),
         RuleEnum::VitestPreferToBeFalsy(VitestPreferToBeFalsy::default()),
         RuleEnum::VitestPreferToBeObject(VitestPreferToBeObject::default()),
         RuleEnum::VitestPreferToBeTruthy(VitestPreferToBeTruthy::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -809,6 +809,7 @@ pub(crate) mod vitest {
     pub mod prefer_strict_boolean_matchers;
     pub mod prefer_strict_equal;
     pub mod prefer_to_be;
+    pub mod prefer_to_be_disabled;
     pub mod prefer_to_be_falsy;
     pub mod prefer_to_be_object;
     pub mod prefer_to_be_truthy;

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_disabled.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_disabled.rs
@@ -1,0 +1,155 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    utils::{PossibleJestNode, parse_expect_jest_fn_call},
+};
+
+fn prefer_to_be_disabled_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer `toBeDisabled()` over checking the `disabled` attribute.")
+        .with_label(span)
+}
+
+fn is_disabled_attribute_name(argument: &Argument) -> bool {
+    match argument {
+        Argument::StringLiteral(string_literal) => string_literal.value.as_str() == "disabled",
+        Argument::TemplateLiteral(template_literal) => {
+            template_literal.single_quasi().is_some_and(|quasi| quasi.as_str() == "disabled")
+        }
+        _ => false,
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferToBeDisabled;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// This rule enforces using `toBeDisabled()` when checking that an element
+    /// is disabled.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `toHaveAttribute('disabled')` only checks for the presence of the
+    /// `disabled` attribute. `toBeDisabled()` expresses the intent more clearly
+    /// and matches Testing Library's disabled-state semantics.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// expect(locator).toHaveAttribute('disabled');
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// expect(locator).toBeDisabled();
+    /// ```
+    PreferToBeDisabled,
+    vitest,
+    style,
+    fix,
+    version = "1.16.0",
+);
+
+impl Rule for PreferToBeDisabled {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        let node = jest_node.node;
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        let Some(expect_call) = parse_expect_jest_fn_call(call_expr, jest_node, ctx) else {
+            return;
+        };
+
+        let Some(matcher) = expect_call.matcher() else {
+            return;
+        };
+
+        if matcher.is_name_unequal("toHaveAttribute")
+            || expect_call.modifiers().iter().any(|modifier| modifier.is_name_equal("not"))
+        {
+            return;
+        }
+
+        let Some([attribute_name]) = expect_call.matcher_arguments.map(|args| args.as_slice())
+        else {
+            return;
+        };
+
+        if !is_disabled_attribute_name(attribute_name) {
+            return;
+        }
+
+        let is_computed = match matcher.parent {
+            Some(Expression::ComputedMemberExpression(_)) => true,
+            Some(Expression::StaticMemberExpression(_) | Expression::PrivateFieldExpression(_)) => {
+                false
+            }
+            _ => return,
+        };
+
+        ctx.diagnostic_with_fix(prefer_to_be_disabled_diagnostic(matcher.span), |fixer| {
+            let replacement = if is_computed { "[\"toBeDisabled\"]()" } else { "toBeDisabled()" };
+            let start = if is_computed { matcher.span.start - 1 } else { matcher.span.start };
+            fixer.replace(Span::new(start, call_expr.span.end), replacement)
+        });
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "expect(locator).toBeDisabled();",
+        "expect(locator).toHaveAttribute();",
+        "expect(locator).toHaveAttribute('aria-disabled');",
+        "expect(locator).toHaveAttribute('disabled', '');",
+        "expect(locator).toHaveAttribute('disabled', true);",
+        "expect(locator).not.toHaveAttribute('disabled');",
+        "expect(locator).toHaveAttribute(attributeName);",
+        "expect(locator).toHaveAttribute(`dis${abled}`);",
+        "expect(locator).toHaveAttribute;",
+        "assert(locator).toHaveAttribute('disabled');",
+    ];
+
+    let fail = vec![
+        "expect(locator).toHaveAttribute('disabled');",
+        "expect(locator).toHaveAttribute(\"disabled\");",
+        "expect(locator).toHaveAttribute(`disabled`);",
+        "expect(locator)[\"toHaveAttribute\"]('disabled');",
+        "expect(locator).resolves.toHaveAttribute('disabled');",
+    ];
+
+    let fix = vec![
+        ("expect(locator).toHaveAttribute('disabled');", "expect(locator).toBeDisabled();"),
+        ("expect(locator).toHaveAttribute(\"disabled\");", "expect(locator).toBeDisabled();"),
+        ("expect(locator).toHaveAttribute(`disabled`);", "expect(locator).toBeDisabled();"),
+        (
+            "expect(locator)[\"toHaveAttribute\"]('disabled');",
+            "expect(locator)[\"toBeDisabled\"]();",
+        ),
+        (
+            "expect(locator).resolves.toHaveAttribute('disabled');",
+            "expect(locator).resolves.toBeDisabled();",
+        ),
+    ];
+
+    Tester::new(PreferToBeDisabled::NAME, PreferToBeDisabled::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_to_be_disabled.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_to_be_disabled.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(prefer-to-be-disabled): Prefer `toBeDisabled()` over checking the `disabled` attribute.
+   ╭─[prefer_to_be_disabled.tsx:1:17]
+ 1 │ expect(locator).toHaveAttribute('disabled');
+   ·                 ───────────────
+   ╰────
+  help: Replace `toHaveAttribute('disabled')` with `toBeDisabled()`.
+
+  ⚠ vitest(prefer-to-be-disabled): Prefer `toBeDisabled()` over checking the `disabled` attribute.
+   ╭─[prefer_to_be_disabled.tsx:1:17]
+ 1 │ expect(locator).toHaveAttribute("disabled");
+   ·                 ───────────────
+   ╰────
+  help: Replace `toHaveAttribute("disabled")` with `toBeDisabled()`.
+
+  ⚠ vitest(prefer-to-be-disabled): Prefer `toBeDisabled()` over checking the `disabled` attribute.
+   ╭─[prefer_to_be_disabled.tsx:1:17]
+ 1 │ expect(locator).toHaveAttribute(`disabled`);
+   ·                 ───────────────
+   ╰────
+  help: Replace `toHaveAttribute(`disabled`)` with `toBeDisabled()`.
+
+  ⚠ vitest(prefer-to-be-disabled): Prefer `toBeDisabled()` over checking the `disabled` attribute.
+   ╭─[prefer_to_be_disabled.tsx:1:17]
+ 1 │ expect(locator)["toHaveAttribute"]('disabled');
+   ·                 ─────────────────
+   ╰────
+  help: Replace `["toHaveAttribute"]('disabled')` with `["toBeDisabled"]()`.
+
+  ⚠ vitest(prefer-to-be-disabled): Prefer `toBeDisabled()` over checking the `disabled` attribute.
+   ╭─[prefer_to_be_disabled.tsx:1:26]
+ 1 │ expect(locator).resolves.toHaveAttribute('disabled');
+   ·                          ───────────────
+   ╰────
+  help: Replace `toHaveAttribute('disabled')` with `toBeDisabled()`.


### PR DESCRIPTION
Dear oxc team, thank you very much for all the effort you put into this project.

Disclaimer: It's been a long while since I wrote Rust code, so AI definitely created this (Codex with GTP-5.5 high). I sadly also only read ["Adding Linter Rules"](https://oxc.rs/docs/contribute/linter/adding-rules.html) after starting. What is a bit unclear for me is if you're open for _any_ new linter rule or if it _must be_ a linter rule from [here](https://github.com/oxc-project/oxc/issues/481).

This PR would add a _new_ rule called `prefer-to-be-disabled`. The idea is to convert  `expect(locator).toHaveAttribute('disabled')` to `expect(locator).toBeDisabled()`.

One alternative I had in mind was adding a rule called `prefer-canonical-usage` (inspired by [better-tailwindcss/enforce-canonical-classes](https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/enforce-canonical-classes.md)) where `expect(locator).toHaveAttribute('disabled')` -> `expect(locator).toBeDisabled()` would simply be the first convention that could then be followed up on (like `expect(locator).not.toBeDisabled()` -> `expect(locator).toBeEnabled()`).

Thanks in any case for the time you invest in reading this MR and responding.

