### PR TITLE
fix(codegen): preserve tagged template new callee parens

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2257,30 +2257,20 @@ impl Gen for TemplateLiteral<'_> {
     }
 }
 
-fn tagged_template_tag_needs_wrap_for_new_callee(tag: &Expression<'_>) -> bool {
-    match tag {
-        Expression::CallExpression(_)
-        | Expression::ImportExpression(_)
-        | Expression::V8IntrinsicExpression(_) => true,
-        Expression::StaticMemberExpression(expr) => {
-            tagged_template_tag_needs_wrap_for_new_callee(&expr.object)
+fn tagged_template_tag_needs_wrap_for_new_callee(mut tag: &Expression<'_>) -> bool {
+    loop {
+        match tag {
+            Expression::CallExpression(_)
+            | Expression::ImportExpression(_)
+            | Expression::V8IntrinsicExpression(_) => return true,
+            Expression::StaticMemberExpression(expr) => tag = &expr.object,
+            Expression::ComputedMemberExpression(expr) => tag = &expr.object,
+            Expression::PrivateFieldExpression(expr) => tag = &expr.object,
+            Expression::ParenthesizedExpression(expr) => tag = &expr.expression,
+            Expression::TSNonNullExpression(expr) => tag = &expr.expression,
+            Expression::TSInstantiationExpression(expr) => tag = &expr.expression,
+            _ => return false,
         }
-        Expression::ComputedMemberExpression(expr) => {
-            tagged_template_tag_needs_wrap_for_new_callee(&expr.object)
-        }
-        Expression::PrivateFieldExpression(expr) => {
-            tagged_template_tag_needs_wrap_for_new_callee(&expr.object)
-        }
-        Expression::ParenthesizedExpression(expr) => {
-            tagged_template_tag_needs_wrap_for_new_callee(&expr.expression)
-        }
-        Expression::TSNonNullExpression(expr) => {
-            tagged_template_tag_needs_wrap_for_new_callee(&expr.expression)
-        }
-        Expression::TSInstantiationExpression(expr) => {
-            tagged_template_tag_needs_wrap_for_new_callee(&expr.expression)
-        }
-        _ => false,
     }
 }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1257,7 +1257,7 @@ impl GenExpr for Expression<'_> {
             Self::NewExpression(expr) => expr.print_expr(p, precedence, ctx),
             // Template literals
             Self::TemplateLiteral(literal) => literal.print(p, ctx),
-            Self::TaggedTemplateExpression(expr) => expr.print(p, ctx),
+            Self::TaggedTemplateExpression(expr) => expr.print_expr(p, precedence, ctx),
             // Other literals
             Self::RegExpLiteral(lit) => lit.print(p, ctx),
             Self::BigIntLiteral(lit) => lit.print_expr(p, precedence, ctx),
@@ -2257,14 +2257,51 @@ impl Gen for TemplateLiteral<'_> {
     }
 }
 
+fn tagged_template_tag_needs_wrap_for_new_callee(tag: &Expression<'_>) -> bool {
+    match tag {
+        Expression::CallExpression(_)
+        | Expression::ImportExpression(_)
+        | Expression::V8IntrinsicExpression(_) => true,
+        Expression::StaticMemberExpression(expr) => {
+            tagged_template_tag_needs_wrap_for_new_callee(&expr.object)
+        }
+        Expression::ComputedMemberExpression(expr) => {
+            tagged_template_tag_needs_wrap_for_new_callee(&expr.object)
+        }
+        Expression::PrivateFieldExpression(expr) => {
+            tagged_template_tag_needs_wrap_for_new_callee(&expr.object)
+        }
+        Expression::ParenthesizedExpression(expr) => {
+            tagged_template_tag_needs_wrap_for_new_callee(&expr.expression)
+        }
+        Expression::TSNonNullExpression(expr) => {
+            tagged_template_tag_needs_wrap_for_new_callee(&expr.expression)
+        }
+        Expression::TSInstantiationExpression(expr) => {
+            tagged_template_tag_needs_wrap_for_new_callee(&expr.expression)
+        }
+        _ => false,
+    }
+}
+
 impl Gen for TaggedTemplateExpression<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
-        p.add_source_mapping(self.span);
-        self.tag.print_expr(p, Precedence::Postfix, Context::empty());
-        if let Some(type_parameters) = &self.type_arguments {
-            type_parameters.print(p, ctx);
-        }
-        self.quasi.print(p, ctx);
+        self.print_expr(p, Precedence::Lowest, ctx);
+    }
+}
+
+impl GenExpr for TaggedTemplateExpression<'_> {
+    fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
+        let wrap = ctx.forbid_call() && tagged_template_tag_needs_wrap_for_new_callee(&self.tag);
+
+        p.wrap(wrap, |p| {
+            p.add_source_mapping(self.span);
+            self.tag.print_expr(p, Precedence::Postfix, Context::empty());
+            if let Some(type_parameters) = &self.type_arguments {
+                type_parameters.print(p, ctx);
+            }
+            self.quasi.print(p, ctx);
+        });
     }
 }
 

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -418,19 +418,25 @@ fn test_template() {
 
     test("new tag`x`", "new tag`x`();\n");
     test("new (tag`x`)", "new tag`x`();\n");
+    test("new (foo()`x`)()", "new (foo()`x`)();\n");
+    test("new (foo().bar`x`)()", "new (foo().bar`x`)();\n");
     test("new tag()`x`", "new tag()`x`;\n");
     test("(new tag)`x`", "new tag()`x`;\n");
     test_minify("new tag`x`", "new tag`x`;");
     test_minify("new (tag`x`)", "new tag`x`;");
+    test_minify("new (foo()`x`)()", "new(foo()`x`);");
+    test_minify("new (foo().bar`x`)()", "new(foo().bar`x`);");
     test_minify("new tag()`x`", "new tag()`x`;");
     test_minify("(new tag)`x`", "new tag()`x`;");
 
     test("new tag`${x}`", "new tag`${x}`();\n");
     test("new (tag`${x}`)", "new tag`${x}`();\n");
+    test("new (foo()`${x}`)()", "new (foo()`${x}`)();\n");
     test("new tag()`${x}`", "new tag()`${x}`;\n");
     test("(new tag)`${x}`", "new tag()`${x}`;\n");
     test_minify("new tag`${x}`", "new tag`${x}`;");
     test_minify("new (tag`${x}`)", "new tag`${x}`;");
+    test_minify("new (foo()`${x}`)()", "new(foo()`${x}`);");
     test_minify("new tag()`${x}`", "new tag()`${x}`;");
     test_minify("(new tag)`${x}`", "new tag()`${x}`;");
 }

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -178,12 +178,23 @@ fn test_new() {
     test("new (import('foo')[bar])", "new (import(\"foo\"))[bar]();\n");
     test("new (import('foo'))[bar]", "new (import(\"foo\"))[bar]();\n");
 
+    test("new (foo?.bar)()", "new (foo?.bar)();\n");
+    test("new (foo()?.bar)()", "new ((foo())?.bar)();\n");
+    test("new (foo.bar()?.baz)()", "new ((foo.bar())?.baz)();\n");
+    test("new ((foo?.bar).baz)()", "new (foo?.bar).baz();\n");
+    test("new ((foo?.bar)[baz])()", "new (foo?.bar)[baz]();\n");
+
     test_minify("new x", "new x;");
     test_minify("new x.y", "new x.y;");
     test_minify("(new x).y", "new x().y;");
     test_minify("new x().y", "new x().y;");
     test_minify("new x() + y", "new x+y;");
     test_minify("new x() ** 2", "new x**2;");
+    test_minify("new (foo?.bar)()", "new(foo?.bar);");
+    test_minify("new (foo()?.bar)()", "new((foo())?.bar);");
+    test_minify("new (foo.bar()?.baz)()", "new((foo.bar())?.baz);");
+    test_minify("new ((foo?.bar).baz)()", "new(foo?.bar).baz;");
+    test_minify("new ((foo?.bar)[baz])()", "new(foo?.bar)[baz];");
 
     // Test preservation of Webpack-specific comments
     test(
@@ -438,11 +449,17 @@ fn test_template() {
     test("new tag`${x}`", "new tag`${x}`();\n");
     test("new (tag`${x}`)", "new tag`${x}`();\n");
     test("new (foo()`${x}`)()", "new (foo()`${x}`)();\n");
+    test("new ((foo?.bar)`x`)()", "new (foo?.bar)`x`();\n");
+    test("new ((foo?.bar)`x`.baz)()", "new (foo?.bar)`x`.baz();\n");
+    test("new ((foo?.bar())`x`)()", "new (foo?.bar())`x`();\n");
     test("new tag()`${x}`", "new tag()`${x}`;\n");
     test("(new tag)`${x}`", "new tag()`${x}`;\n");
     test_minify("new tag`${x}`", "new tag`${x}`;");
     test_minify("new (tag`${x}`)", "new tag`${x}`;");
     test_minify("new (foo()`${x}`)()", "new(foo()`${x}`);");
+    test_minify("new ((foo?.bar)`x`)()", "new(foo?.bar)`x`;");
+    test_minify("new ((foo?.bar)`x`.baz)()", "new(foo?.bar)`x`.baz;");
+    test_minify("new ((foo?.bar())`x`)()", "new(foo?.bar())`x`;");
     test_minify("new tag()`${x}`", "new tag()`${x}`;");
     test_minify("(new tag)`${x}`", "new tag()`${x}`;");
 }

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -173,6 +173,11 @@ fn test_new() {
     test("new (foo()[bar])", "new (foo())[bar]();\n");
     test("new (foo())[bar]", "new (foo())[bar]();\n");
 
+    test(
+        "new (import('foo'))()",
+        r#"new (import("foo"))();
+"#,
+    );
     test("new (import('foo').bar)", "new (import(\"foo\")).bar();\n");
     test("new (import('foo')).bar", "new (import(\"foo\")).bar();\n");
     test("new (import('foo')[bar])", "new (import(\"foo\"))[bar]();\n");
@@ -190,6 +195,7 @@ fn test_new() {
     test_minify("new x().y", "new x().y;");
     test_minify("new x() + y", "new x+y;");
     test_minify("new x() ** 2", "new x**2;");
+    test_minify("new (import('foo'))()", "new(import(`foo`));");
     test_minify("new (foo?.bar)()", "new(foo?.bar);");
     test_minify("new (foo()?.bar)()", "new((foo())?.bar);");
     test_minify("new (foo.bar()?.baz)()", "new((foo.bar())?.baz);");

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -420,12 +420,18 @@ fn test_template() {
     test("new (tag`x`)", "new tag`x`();\n");
     test("new (foo()`x`)()", "new (foo()`x`)();\n");
     test("new (foo().bar`x`)()", "new (foo().bar`x`)();\n");
+    test("new (import('foo')`x`)()", "new (import(\"foo\")`x`)();\n");
+    test("new (super()`x`)()", "new (super()`x`)();\n");
+    test("new (foo!()`x`)()", "new (foo!()`x`)();\n");
+    test("new (import('foo')!`x`)()", "new (import(\"foo\")!`x`)();\n");
     test("new tag()`x`", "new tag()`x`;\n");
     test("(new tag)`x`", "new tag()`x`;\n");
     test_minify("new tag`x`", "new tag`x`;");
     test_minify("new (tag`x`)", "new tag`x`;");
     test_minify("new (foo()`x`)()", "new(foo()`x`);");
     test_minify("new (foo().bar`x`)()", "new(foo().bar`x`);");
+    test_minify("new (import('foo')`x`)()", "new(import(`foo`)`x`);");
+    test_minify("new (super()`x`)()", "new(super()`x`);");
     test_minify("new tag()`x`", "new tag()`x`;");
     test_minify("(new tag)`x`", "new tag()`x`;");
 


### PR DESCRIPTION
This fixes a codegen precedence issue where a tagged template callee inside a `NewExpression` could be printed without the parentheses needed to preserve the original constructor target. In particular, 
```ts
new (foo()`bar`)()
```
was emitted as
```ts
new foo()`bar`()
```
 which reparses as a different AST.

The change makes tagged template expressions participate in precedence-aware expression printing and wraps call-rooted tagged template callees when `new` forbids call ambiguity. Regression coverage was added for direct call tags and member tags rooted in calls, including minified output.


fixes #22961