### PR TITLE
docs(oxlint, oxfmt): mention migrate skills in npm READMEs

### DIFF
--- a/npm/oxfmt/README.md
+++ b/npm/oxfmt/README.md
@@ -56,3 +56,5 @@ Run
 
 - `npx --yes oxfmt@latest` in your JavaScript / TypeScript codebase and see it complete in milliseconds. No configurations are required.
 - `npx oxfmt@latest --help` for quick usage instructions.
+- `npx skills add https://github.com/oxc-project/oxc --skill migrate-oxfmt` to install the [`migrate-oxfmt`](https://skills.sh/oxc-project/oxc/migrate-oxfmt) skill, then run `/migrate-oxfmt` to migrate from Prettier or Biome.
+- See also [migrate from Prettier](https://oxc.rs/docs/guide/usage/formatter/migrate-from-prettier.html).

--- a/npm/oxlint/README.md
+++ b/npm/oxlint/README.md
@@ -57,3 +57,5 @@ Run
 - `npx --yes oxlint@latest` in your JavaScript / TypeScript codebase and see it complete in milliseconds. No configurations are required.
 - `npx oxlint@latest --help` for quick usage instructions.
 - `npx oxlint@latest --rules` for the list of rules.
+- `npx skills add https://github.com/oxc-project/oxc --skill migrate-oxlint` to install the [`migrate-oxlint`](https://skills.sh/oxc-project/oxc/migrate-oxlint) skill, then run `/migrate-oxlint` to migrate from ESLint.
+- See also [migrate from ESLint](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html).


### PR DESCRIPTION
Adds the migration skills to the `oxlint` and `oxfmt` npm READMEs.

- **oxlint**: install the [`migrate-oxlint`](https://skills.sh/oxc-project/oxc/migrate-oxlint) skill and run `/migrate-oxlint`, plus a [migrate from ESLint](https://oxc.rs/docs/guide/usage/linter/migrate-from-eslint.html) link.
- **oxfmt**: install the [`migrate-oxfmt`](https://skills.sh/oxc-project/oxc/migrate-oxfmt) skill and run `/migrate-oxfmt`, plus a [migrate from Prettier](https://oxc.rs/docs/guide/usage/formatter/migrate-from-prettier.html) link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
