### PR TITLE
fix(linter/double-comparisons): make fixer a suggestion

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
     DoubleComparisons,
     oxc,
     correctness,
-    fix,
+    suggestion,
     version = "0.0.22",
 );
 
@@ -96,7 +96,7 @@ impl Rule for DoubleComparisons {
             _ => return,
         };
 
-        ctx.diagnostic_with_fix(
+        ctx.diagnostic_with_suggestion(
             double_comparisons_diagnostic(logical_expr.span, new_op),
             |fixer| {
                 let modified_code = {
@@ -168,6 +168,7 @@ fn test() {
         ("x > y || x == y", "x >= y"),
         ("x < y || x > y", "x != y"),
         ("x > y || x < y", "x != y"),
+        ("x > 0 || x < 0", "x != 0"),
         ("x <= y && x >= y", "x == y"),
         ("x >= y && x <= y", "x == y"),
         ("x === y || x < y", "x <= y"),


### PR DESCRIPTION
The `oxc/double-comparisons` rule currently exposes its simplification as a safe autofix, so `--fix` can rewrite expressions like `x > 0 || x < 0` to `x != 0`. That rewrite is not always behavior-preserving in JavaScript because relational comparisons and loose equality coerce values differently.

For example, these are not equivalent for values such as `undefined`, `null`, objects, or arrays:

```js
x > 0 || x < 0
x != 0
```

This PR changes the rule from an autofix to a suggestion. The simplification is still available to users who explicitly apply suggestions, but it will no longer be applied by `--fix`.

fixes #22967
