### PR TITLE
refactor(semantic): identify illegal function declarations without using AST nodes

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -158,10 +158,25 @@ impl<'a> Binder<'a> for Function<'a> {
             let symbol_id = builder.declare_symbol(ident.span, ident.name, includes, excludes);
             ident.symbol_id.set(Some(symbol_id));
 
+            let scope_flags = builder.current_scope_flags();
+
+            // Record `async`/generator function declarations in sloppy-mode block scopes,
+            // so the redeclaration check `check_function_redeclaration` (Annex B.3.3) can later identify
+            // an offending previous declaration without reading its AST node (which may not be retained).
+            // The check only consults this for function declarations in a sloppy-mode JS block,
+            // so record nothing in any other case.
+            if is_declaration
+                && (self.r#async || self.generator)
+                && !builder.source_type.is_typescript()
+                && !scope_flags.is_strict_mode()
+                && !scope_flags.is_var()
+            {
+                builder.async_or_generator_function_node_ids.push(builder.current_node_id);
+            }
+
             // Annex B.3.2.1: In sloppy mode, plain function declarations inside block
             // scopes also create an implicit var-like binding in the enclosing function
             // scope. Hoist to the var scope — same pattern as var hoisting (line 46).
-            let scope_flags = builder.current_scope_flags();
             if is_declaration // function expressions are bound in their own (var) scope
                 && !self.r#async // Annex B only applies to plain functions
                 && !self.generator // not generators or async generators

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -91,6 +91,13 @@ pub struct SemanticBuilder<'a> {
     /// in that scope can still detect redeclarations via `check_redeclaration`.
     pub(crate) hoisting_variables: FxHashMap<ScopeId, IdentHashMap<'a, SymbolId>>,
 
+    /// `NodeId`s of `async`/generator function declarations in sloppy-mode block scopes in JS files.
+    /// Read by `check_function_redeclaration` (Annex B.3.3) to identify an offending previous declaration
+    /// without reading its AST node, which may not be retained.
+    /// These conditions are extremely rarely met, so this `Vec` is practically always empty.
+    /// Build-only scratch (discarded after the build).
+    pub(crate) async_or_generator_function_node_ids: Vec<NodeId>,
+
     // builders
     pub(crate) nodes: AstNodes<'a>,
     pub(crate) scoping: Scoping,
@@ -158,6 +165,7 @@ impl<'a> SemanticBuilder<'a> {
             module_instance_state_cache: FxHashMap::default(),
             nodes: AstNodes::default(),
             hoisting_variables: FxHashMap::default(),
+            async_or_generator_function_node_ids: Vec::new(),
             scoping,
             unresolved_references: UnresolvedReferences::new(),
             unresolved_references_checkpoint: 0,

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -764,10 +764,25 @@ pub fn check_function_redeclaration(func: &Function, ctx: &SemanticBuilder<'_>) 
         // `function a() { var b; function b() { } }` valid in any mode.
         return;
     } else if !(current_scope_flags.is_strict_mode() || func.r#async || func.generator) {
-        // `class a {}; function a() {}` and `async function a() {} function a () {}` are
-        // invalid in both strict and non-strict mode.
-        let prev_function = ctx.nodes.kind(prev.declaration).as_function();
-        if prev_function.is_some_and(|func| !(func.r#async || func.generator)) {
+        // Current declaration is a plain function in a sloppy-mode block. Annex B.3.3 permits
+        // duplicate *plain* function declarations here, but the relaxation does not extend to
+        // `async`/generator functions, nor to non-function declarations like `class a {}`.
+        if prev.flags.contains(SymbolFlags::Function) {
+            // `prev` is a function, so the function-duplicate rule (Annex B.3.3) is violated
+            // only if an earlier declaration is an `async`/generator function.
+            // Search for a declaration that makes it illegal, so the error can point at it.
+            // (A clash with a `var`/`let`/`class` of the same name is a separate rule, reported elsewhere.)
+            // This branch is only reached for function redeclarations in a sloppy-mode block,
+            // which are extremely rare, so the linear scan's high cost does not really matter.
+            let previous_declarations = &redeclarations[..redeclarations.len() - 1];
+            let Some(culprit) = previous_declarations
+                .iter()
+                .find(|decl| ctx.async_or_generator_function_node_ids.contains(&decl.declaration))
+            else {
+                // No `async`/generator function among the previous declarations - allowed by B.3.3.
+                return;
+            };
+            ctx.error(diagnostics::redeclaration(&id.name, culprit.span, id.span));
             return;
         }
     }


### PR DESCRIPTION
Closes: #22934 

Alternative to #22934.

### The problem

`check_function_redeclaration` (the Annex B.3.3 legacy duplicate-function rule) distinguished a plain `FunctionDeclaration` from an `async`/generator one by reading the _previous_ declaration's AST node through its stored `NodeId`:

```rust
let prev_function = ctx.nodes.kind(prev.declaration).as_function();
if prev_function.is_some_and(|f| !(f.r#async || f.generator)) { return; }
```

That node is a popped sibling (not an ancestor of the current node), so it's the last build-time read that would prevent making AST node storage optional.

### Starting point

In real-world code, no-one uses function redeclarations. They are completely pointless. We only need to handle this case to be conformant with the spec, just to be able to say we're conformant with the spec.

Further, the specific circumstances in which this Annex B rule applies are even more rare. All the following must be satisfied:

- Sloppy-mode code.
- Function redeclarations in a nested block (not top-level or nested in another function).
- JS not TS.

Therefore, we can assume the code which handles this case is unreachable in practice. The priority is to make recording the data required for the check as cheap as possible - in terms of perf, and memory usage.

### How

Record the one bit of information we need at bind time, while the node is still in hand. When binding an `async`/generator function declaration in a sloppy-mode block, push its `NodeId` into a `Vec` on
`SemanticBuilder`. The check then answers "was the previous declaration async/generator?" by searching this `Vec`.

The check only applies in the specific circumstances listed above. So don't push values to the `Vec` in modules, strict mode, top-level code, or TypeScript. In practice, the `Vec` will always remain empty.

The checking code in `check_redeclared_function` does a linear scan of the `Vec`, which is expensive, but as function redeclarations in nested blocks in sloppy mode JS are vanishingly rare in real-world code, this doesn't matter.

Additionally, improve the errors when a violation _is_ found - the error points to the offending `async`/generator function, rather than stopping at the immediately preceding declaration. That only adds diagnostics on code that was already invalid - conformance is unchanged.