### PR TITLE
feat(linter): add import node protocol alias

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -544,6 +544,7 @@ export interface DummyRuleMap {
   "id-match"?: DummyRule;
   "import/consistent-type-specifier-style"?: DummyRule;
   "import/default"?: DummyRule;
+  "import/enforce-node-protocol-usage"?: DummyRule;
   "import/export"?: DummyRule;
   "import/exports-last"?: DummyRule;
   "import/extensions"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -21,6 +21,17 @@ impl RuleRunner for crate::rules::import::default::Default {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;
 }
 
+impl RuleRunner for crate::rules::import::enforce_node_protocol_usage::EnforceNodeProtocolUsage {
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::ExportNamedDeclaration,
+        AstType::ImportDeclaration,
+        AstType::ImportExpression,
+        AstType::TSImportEqualsDeclaration,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::import::export::Export {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -24,6 +24,7 @@ impl RuleRunner for crate::rules::import::default::Default {
 impl RuleRunner for crate::rules::import::enforce_node_protocol_usage::EnforceNodeProtocolUsage {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::CallExpression,
+        AstType::ExportAllDeclaration,
         AstType::ExportNamedDeclaration,
         AstType::ImportDeclaration,
         AstType::ImportExpression,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -194,6 +194,7 @@ pub use crate::rules::eslint::vars_on_top::VarsOnTop as EslintVarsOnTop;
 pub use crate::rules::eslint::yoda::Yoda as EslintYoda;
 pub use crate::rules::import::consistent_type_specifier_style::ConsistentTypeSpecifierStyle as ImportConsistentTypeSpecifierStyle;
 pub use crate::rules::import::default::Default as ImportDefault;
+pub use crate::rules::import::enforce_node_protocol_usage::EnforceNodeProtocolUsage as ImportEnforceNodeProtocolUsage;
 pub use crate::rules::import::export::Export as ImportExport;
 pub use crate::rules::import::exports_last::ExportsLast as ImportExportsLast;
 pub use crate::rules::import::extensions::Extensions as ImportExtensions;
@@ -844,6 +845,7 @@ use oxc_semantic::AstTypesBitset;
 pub enum RuleEnum {
     ImportConsistentTypeSpecifierStyle(ImportConsistentTypeSpecifierStyle),
     ImportDefault(ImportDefault),
+    ImportEnforceNodeProtocolUsage(ImportEnforceNodeProtocolUsage),
     ImportExport(ImportExport),
     ImportExportsLast(ImportExportsLast),
     ImportExtensions(ImportExtensions),
@@ -1677,7 +1679,8 @@ pub enum RuleEnum {
 }
 const IMPORT_CONSISTENT_TYPE_SPECIFIER_STYLE_ID: usize = 0usize;
 const IMPORT_DEFAULT_ID: usize = IMPORT_CONSISTENT_TYPE_SPECIFIER_STYLE_ID + 1usize;
-const IMPORT_EXPORT_ID: usize = IMPORT_DEFAULT_ID + 1usize;
+const IMPORT_ENFORCE_NODE_PROTOCOL_USAGE_ID: usize = IMPORT_DEFAULT_ID + 1usize;
+const IMPORT_EXPORT_ID: usize = IMPORT_ENFORCE_NODE_PROTOCOL_USAGE_ID + 1usize;
 const IMPORT_EXPORTS_LAST_ID: usize = IMPORT_EXPORT_ID + 1usize;
 const IMPORT_EXTENSIONS_ID: usize = IMPORT_EXPORTS_LAST_ID + 1usize;
 const IMPORT_FIRST_ID: usize = IMPORT_EXTENSIONS_ID + 1usize;
@@ -2610,6 +2613,7 @@ impl RuleEnum {
                 IMPORT_CONSISTENT_TYPE_SPECIFIER_STYLE_ID
             }
             Self::ImportDefault(_) => IMPORT_DEFAULT_ID,
+            Self::ImportEnforceNodeProtocolUsage(_) => IMPORT_ENFORCE_NODE_PROTOCOL_USAGE_ID,
             Self::ImportExport(_) => IMPORT_EXPORT_ID,
             Self::ImportExportsLast(_) => IMPORT_EXPORTS_LAST_ID,
             Self::ImportExtensions(_) => IMPORT_EXTENSIONS_ID,
@@ -3562,6 +3566,7 @@ impl RuleEnum {
         match self {
             Self::ImportConsistentTypeSpecifierStyle(_) => ImportConsistentTypeSpecifierStyle::NAME,
             Self::ImportDefault(_) => ImportDefault::NAME,
+            Self::ImportEnforceNodeProtocolUsage(_) => ImportEnforceNodeProtocolUsage::NAME,
             Self::ImportExport(_) => ImportExport::NAME,
             Self::ImportExportsLast(_) => ImportExportsLast::NAME,
             Self::ImportExtensions(_) => ImportExtensions::NAME,
@@ -4502,6 +4507,7 @@ impl RuleEnum {
                 ImportConsistentTypeSpecifierStyle::CATEGORY
             }
             Self::ImportDefault(_) => ImportDefault::CATEGORY,
+            Self::ImportEnforceNodeProtocolUsage(_) => ImportEnforceNodeProtocolUsage::CATEGORY,
             Self::ImportExport(_) => ImportExport::CATEGORY,
             Self::ImportExportsLast(_) => ImportExportsLast::CATEGORY,
             Self::ImportExtensions(_) => ImportExtensions::CATEGORY,
@@ -5497,6 +5503,7 @@ impl RuleEnum {
         match self {
             Self::ImportConsistentTypeSpecifierStyle(_) => ImportConsistentTypeSpecifierStyle::FIX,
             Self::ImportDefault(_) => ImportDefault::FIX,
+            Self::ImportEnforceNodeProtocolUsage(_) => ImportEnforceNodeProtocolUsage::FIX,
             Self::ImportExport(_) => ImportExport::FIX,
             Self::ImportExportsLast(_) => ImportExportsLast::FIX,
             Self::ImportExtensions(_) => ImportExtensions::FIX,
@@ -6438,6 +6445,9 @@ impl RuleEnum {
                 ImportConsistentTypeSpecifierStyle::documentation()
             }
             Self::ImportDefault(_) => ImportDefault::documentation(),
+            Self::ImportEnforceNodeProtocolUsage(_) => {
+                ImportEnforceNodeProtocolUsage::documentation()
+            }
             Self::ImportExport(_) => ImportExport::documentation(),
             Self::ImportExportsLast(_) => ImportExportsLast::documentation(),
             Self::ImportExtensions(_) => ImportExtensions::documentation(),
@@ -7644,6 +7654,10 @@ impl RuleEnum {
             }
             Self::ImportDefault(_) => {
                 ImportDefault::config_schema(generator).or_else(|| ImportDefault::schema(generator))
+            }
+            Self::ImportEnforceNodeProtocolUsage(_) => {
+                ImportEnforceNodeProtocolUsage::config_schema(generator)
+                    .or_else(|| ImportEnforceNodeProtocolUsage::schema(generator))
             }
             Self::ImportExport(_) => {
                 ImportExport::config_schema(generator).or_else(|| ImportExport::schema(generator))
@@ -10011,6 +10025,7 @@ impl RuleEnum {
         match self {
             Self::ImportConsistentTypeSpecifierStyle(_) => "import",
             Self::ImportDefault(_) => "import",
+            Self::ImportEnforceNodeProtocolUsage(_) => "import",
             Self::ImportExport(_) => "import",
             Self::ImportExportsLast(_) => "import",
             Self::ImportExtensions(_) => "import",
@@ -10848,6 +10863,9 @@ impl RuleEnum {
             Self::ImportDefault(_) => {
                 Ok(Self::ImportDefault(ImportDefault::from_configuration(value)?))
             }
+            Self::ImportEnforceNodeProtocolUsage(_) => Ok(Self::ImportEnforceNodeProtocolUsage(
+                ImportEnforceNodeProtocolUsage::from_configuration(value)?,
+            )),
             Self::ImportExport(_) => {
                 Ok(Self::ImportExport(ImportExport::from_configuration(value)?))
             }
@@ -13500,6 +13518,7 @@ impl RuleEnum {
         match self {
             Self::ImportConsistentTypeSpecifierStyle(rule) => rule.to_configuration(),
             Self::ImportDefault(rule) => rule.to_configuration(),
+            Self::ImportEnforceNodeProtocolUsage(rule) => rule.to_configuration(),
             Self::ImportExport(rule) => rule.to_configuration(),
             Self::ImportExportsLast(rule) => rule.to_configuration(),
             Self::ImportExtensions(rule) => rule.to_configuration(),
@@ -14338,6 +14357,7 @@ impl RuleEnum {
             timing_stat.expect("missing rule timing stat").time(|| match self {
                 Self::ImportConsistentTypeSpecifierStyle(rule) => rule.run(node, ctx),
                 Self::ImportDefault(rule) => rule.run(node, ctx),
+                Self::ImportEnforceNodeProtocolUsage(rule) => rule.run(node, ctx),
                 Self::ImportExport(rule) => rule.run(node, ctx),
                 Self::ImportExportsLast(rule) => rule.run(node, ctx),
                 Self::ImportExtensions(rule) => rule.run(node, ctx),
@@ -15169,6 +15189,7 @@ impl RuleEnum {
             match self {
                 Self::ImportConsistentTypeSpecifierStyle(rule) => rule.run(node, ctx),
                 Self::ImportDefault(rule) => rule.run(node, ctx),
+                Self::ImportEnforceNodeProtocolUsage(rule) => rule.run(node, ctx),
                 Self::ImportExport(rule) => rule.run(node, ctx),
                 Self::ImportExportsLast(rule) => rule.run(node, ctx),
                 Self::ImportExtensions(rule) => rule.run(node, ctx),
@@ -16007,6 +16028,7 @@ impl RuleEnum {
             timing_stat.expect("missing rule timing stat").time(|| match self {
                 Self::ImportConsistentTypeSpecifierStyle(rule) => rule.run_once(ctx),
                 Self::ImportDefault(rule) => rule.run_once(ctx),
+                Self::ImportEnforceNodeProtocolUsage(rule) => rule.run_once(ctx),
                 Self::ImportExport(rule) => rule.run_once(ctx),
                 Self::ImportExportsLast(rule) => rule.run_once(ctx),
                 Self::ImportExtensions(rule) => rule.run_once(ctx),
@@ -16838,6 +16860,7 @@ impl RuleEnum {
             match self {
                 Self::ImportConsistentTypeSpecifierStyle(rule) => rule.run_once(ctx),
                 Self::ImportDefault(rule) => rule.run_once(ctx),
+                Self::ImportEnforceNodeProtocolUsage(rule) => rule.run_once(ctx),
                 Self::ImportExport(rule) => rule.run_once(ctx),
                 Self::ImportExportsLast(rule) => rule.run_once(ctx),
                 Self::ImportExtensions(rule) => rule.run_once(ctx),
@@ -17679,6 +17702,7 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::ImportDefault(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::ImportEnforceNodeProtocolUsage(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportExportsLast(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportExtensions(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18766,6 +18790,7 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::ImportDefault(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::ImportEnforceNodeProtocolUsage(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportExport(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportExportsLast(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::ImportExtensions(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19853,6 +19878,7 @@ impl RuleEnum {
         match self {
             Self::ImportConsistentTypeSpecifierStyle(rule) => rule.should_run(ctx),
             Self::ImportDefault(rule) => rule.should_run(ctx),
+            Self::ImportEnforceNodeProtocolUsage(rule) => rule.should_run(ctx),
             Self::ImportExport(rule) => rule.should_run(ctx),
             Self::ImportExportsLast(rule) => rule.should_run(ctx),
             Self::ImportExtensions(rule) => rule.should_run(ctx),
@@ -20683,6 +20709,9 @@ impl RuleEnum {
                 ImportConsistentTypeSpecifierStyle::IS_TSGOLINT_RULE
             }
             Self::ImportDefault(_) => ImportDefault::IS_TSGOLINT_RULE,
+            Self::ImportEnforceNodeProtocolUsage(_) => {
+                ImportEnforceNodeProtocolUsage::IS_TSGOLINT_RULE
+            }
             Self::ImportExport(_) => ImportExport::IS_TSGOLINT_RULE,
             Self::ImportExportsLast(_) => ImportExportsLast::IS_TSGOLINT_RULE,
             Self::ImportExtensions(_) => ImportExtensions::IS_TSGOLINT_RULE,
@@ -21885,6 +21914,7 @@ impl RuleEnum {
                 ImportConsistentTypeSpecifierStyle::VERSION
             }
             Self::ImportDefault(_) => ImportDefault::VERSION,
+            Self::ImportEnforceNodeProtocolUsage(_) => ImportEnforceNodeProtocolUsage::VERSION,
             Self::ImportExport(_) => ImportExport::VERSION,
             Self::ImportExportsLast(_) => ImportExportsLast::VERSION,
             Self::ImportExtensions(_) => ImportExtensions::VERSION,
@@ -22882,6 +22912,7 @@ impl RuleEnum {
                 ImportConsistentTypeSpecifierStyle::HAS_CONFIG
             }
             Self::ImportDefault(_) => ImportDefault::HAS_CONFIG,
+            Self::ImportEnforceNodeProtocolUsage(_) => ImportEnforceNodeProtocolUsage::HAS_CONFIG,
             Self::ImportExport(_) => ImportExport::HAS_CONFIG,
             Self::ImportExportsLast(_) => ImportExportsLast::HAS_CONFIG,
             Self::ImportExtensions(_) => ImportExtensions::HAS_CONFIG,
@@ -23914,6 +23945,7 @@ impl RuleEnum {
         match self {
             Self::ImportConsistentTypeSpecifierStyle(rule) => rule.types_info(),
             Self::ImportDefault(rule) => rule.types_info(),
+            Self::ImportEnforceNodeProtocolUsage(rule) => rule.types_info(),
             Self::ImportExport(rule) => rule.types_info(),
             Self::ImportExportsLast(rule) => rule.types_info(),
             Self::ImportExtensions(rule) => rule.types_info(),
@@ -24742,6 +24774,7 @@ impl RuleEnum {
         match self {
             Self::ImportConsistentTypeSpecifierStyle(rule) => rule.run_info(),
             Self::ImportDefault(rule) => rule.run_info(),
+            Self::ImportEnforceNodeProtocolUsage(rule) => rule.run_info(),
             Self::ImportExport(rule) => rule.run_info(),
             Self::ImportExportsLast(rule) => rule.run_info(),
             Self::ImportExtensions(rule) => rule.run_info(),
@@ -25592,6 +25625,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
     vec![
         RuleEnum::ImportConsistentTypeSpecifierStyle(ImportConsistentTypeSpecifierStyle::default()),
         RuleEnum::ImportDefault(ImportDefault::default()),
+        RuleEnum::ImportEnforceNodeProtocolUsage(ImportEnforceNodeProtocolUsage::default()),
         RuleEnum::ImportExport(ImportExport::default()),
         RuleEnum::ImportExportsLast(ImportExportsLast::default()),
         RuleEnum::ImportExtensions(ImportExtensions::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -7,6 +7,7 @@
 pub(crate) mod import {
     pub mod consistent_type_specifier_style;
     pub mod default;
+    pub mod enforce_node_protocol_usage;
     pub mod export;
     pub mod exports_last;
     pub mod extensions;

--- a/crates/oxc_linter/src/rules/import/enforce_node_protocol_usage.rs
+++ b/crates/oxc_linter/src/rules/import/enforce_node_protocol_usage.rs
@@ -3,14 +3,38 @@ use oxc_ast::{
     ast::{Expression, TSModuleReference},
 };
 use oxc_macros::declare_oxc_lint;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    AstNode, context::LintContext, rule::Rule,
-    rules::unicorn::prefer_node_protocol::check_node_protocol_path,
+    AstNode,
+    context::LintContext,
+    rule::DefaultRuleConfig,
+    rule::Rule,
+    rules::unicorn::prefer_node_protocol::{NodeProtocolMode, check_node_protocol_path},
 };
 
-#[derive(Debug, Default, Clone)]
-pub struct EnforceNodeProtocolUsage;
+#[derive(Debug, Default, PartialEq, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+enum NodeProtocolUsageMode {
+    /// Require the `node:` protocol for Node.js builtin modules.
+    #[default]
+    Always,
+    /// Disallow the `node:` protocol for Node.js builtin modules.
+    Never,
+}
+
+impl From<NodeProtocolUsageMode> for NodeProtocolMode {
+    fn from(mode: NodeProtocolUsageMode) -> Self {
+        match mode {
+            NodeProtocolUsageMode::Always => Self::Always,
+            NodeProtocolUsageMode::Never => Self::Never,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct EnforceNodeProtocolUsage(NodeProtocolUsageMode);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -32,14 +56,29 @@ declare_oxc_lint!(
     /// ```javascript
     /// import fs from "node:fs";
     /// ```
+    ///
+    /// Examples of **incorrect** code for this rule with the `"never"` option:
+    /// ```javascript
+    /// import fs from "node:fs";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule with the `"never"` option:
+    /// ```javascript
+    /// import fs from "fs";
+    /// ```
     EnforceNodeProtocolUsage,
     import,
     restriction,
     fix,
+    config = NodeProtocolUsageMode,
     version = "next",
 );
 
 impl Rule for EnforceNodeProtocolUsage {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let string_lit_value_with_span = match node.kind() {
             AstKind::ImportExpression(import) => match &import.source {
@@ -59,12 +98,15 @@ impl Rule for EnforceNodeProtocolUsage {
             AstKind::ExportNamedDeclaration(export) => {
                 export.source.as_ref().map(|item| (item.value, item.span))
             }
+            AstKind::ExportAllDeclaration(export) => {
+                Some((export.source.value, export.source.span))
+            }
             _ => return,
         };
         let Some((string_lit_value, span)) = string_lit_value_with_span else {
             return;
         };
-        check_node_protocol_path(string_lit_value, span, ctx);
+        check_node_protocol_path(string_lit_value, span, ctx, self.0.into());
     }
 }
 
@@ -73,22 +115,46 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        r#"import fs from "node:fs";"#,
-        r#"import fs from "./fs";"#,
-        r#"const fs = require("node:fs/promises");"#,
-        r#"const fs = require("unicorn");"#,
+        (r#"import fs from "node:fs";"#, None),
+        (r#"import fs from "./fs";"#, None),
+        (r#"const fs = require("node:fs/promises");"#, None),
+        (r#"const fs = require("unicorn");"#, None),
+        (r#"import fs from "node:fs";"#, Some(serde_json::json!(["always"]))),
+        (r#"export * from "node:fs";"#, Some(serde_json::json!(["always"]))),
+        (r#"import fs from "fs";"#, Some(serde_json::json!(["never"]))),
+        (r#"export * from "fs";"#, Some(serde_json::json!(["never"]))),
     ];
 
     let fail = vec![
-        r#"import fs from "fs";"#,
-        r#"export {promises} from "fs";"#,
-        r#"const fs = require("fs/promises");"#,
-        "async function foo() { const fs = await import('assert/strict'); }",
+        (r#"import fs from "fs";"#, None),
+        (r#"export {promises} from "fs";"#, None),
+        (r#"export * from "fs";"#, None),
+        (r#"const fs = require("fs/promises");"#, None),
+        ("async function foo() { const fs = await import('assert/strict'); }", None),
+        (r#"import fs from "fs";"#, Some(serde_json::json!(["always"]))),
+        (r#"export * as fs from "fs";"#, Some(serde_json::json!(["always"]))),
+        (r#"import fs from "node:fs";"#, Some(serde_json::json!(["never"]))),
+        (r#"export * from "node:fs";"#, Some(serde_json::json!(["never"]))),
     ];
 
     let fix = vec![
-        (r#"import fs from "fs";"#, r#"import fs from "node:fs";"#),
-        (r#"const fs = require("fs/promises");"#, r#"const fs = require("node:fs/promises");"#),
+        (r#"import fs from "fs";"#, r#"import fs from "node:fs";"#, None),
+        (
+            r#"const fs = require("fs/promises");"#,
+            r#"const fs = require("node:fs/promises");"#,
+            None,
+        ),
+        (r#"export * from "fs";"#, r#"export * from "node:fs";"#, None),
+        (
+            r#"import fs from "node:fs";"#,
+            r#"import fs from "fs";"#,
+            Some(serde_json::json!(["never"])),
+        ),
+        (
+            r#"export * from "node:fs";"#,
+            r#"export * from "fs";"#,
+            Some(serde_json::json!(["never"])),
+        ),
     ];
 
     Tester::new(EnforceNodeProtocolUsage::NAME, EnforceNodeProtocolUsage::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/import/enforce_node_protocol_usage.rs
+++ b/crates/oxc_linter/src/rules/import/enforce_node_protocol_usage.rs
@@ -1,0 +1,97 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, TSModuleReference},
+};
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    AstNode, context::LintContext, rule::Rule,
+    rules::unicorn::prefer_node_protocol::check_node_protocol_path,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct EnforceNodeProtocolUsage;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforce using the `node:` protocol when importing Node.js builtin modules.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Node.js builtin modules should be imported using the `node:` protocol to avoid ambiguity with local modules.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// import fs from "fs";
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// import fs from "node:fs";
+    /// ```
+    EnforceNodeProtocolUsage,
+    import,
+    restriction,
+    fix,
+    version = "next",
+);
+
+impl Rule for EnforceNodeProtocolUsage {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let string_lit_value_with_span = match node.kind() {
+            AstKind::ImportExpression(import) => match &import.source {
+                Expression::StringLiteral(str_lit) => Some((str_lit.value, str_lit.span)),
+                _ => None,
+            },
+            AstKind::TSImportEqualsDeclaration(import) => match &import.module_reference {
+                TSModuleReference::ExternalModuleReference(external) => {
+                    Some((external.expression.value, external.expression.span))
+                }
+                _ => None,
+            },
+            AstKind::CallExpression(call) if !call.optional => {
+                call.common_js_require().map(|s| (s.value, s.span))
+            }
+            AstKind::ImportDeclaration(import) => Some((import.source.value, import.source.span)),
+            AstKind::ExportNamedDeclaration(export) => {
+                export.source.as_ref().map(|item| (item.value, item.span))
+            }
+            _ => return,
+        };
+        let Some((string_lit_value, span)) = string_lit_value_with_span else {
+            return;
+        };
+        check_node_protocol_path(string_lit_value, span, ctx);
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"import fs from "node:fs";"#,
+        r#"import fs from "./fs";"#,
+        r#"const fs = require("node:fs/promises");"#,
+        r#"const fs = require("unicorn");"#,
+    ];
+
+    let fail = vec![
+        r#"import fs from "fs";"#,
+        r#"export {promises} from "fs";"#,
+        r#"const fs = require("fs/promises");"#,
+        "async function foo() { const fs = await import('assert/strict'); }",
+    ];
+
+    let fix = vec![
+        (r#"import fs from "fs";"#, r#"import fs from "node:fs";"#),
+        (r#"const fs = require("fs/promises");"#, r#"const fs = require("node:fs/promises");"#),
+    ];
+
+    Tester::new(EnforceNodeProtocolUsage::NAME, EnforceNodeProtocolUsage::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -45,6 +45,30 @@ declare_oxc_lint!(
     version = "0.0.19",
 );
 
+pub(crate) fn check_node_protocol_path(
+    string_lit_value: oxc_str::Str<'_>,
+    span: Span,
+    ctx: &LintContext,
+) {
+    let module_name = if let Some((prefix, postfix)) = string_lit_value.split_once('/') {
+        // `e.g. ignore "assert/"`
+        if postfix.is_empty() { string_lit_value.as_str() } else { prefix }
+    } else {
+        string_lit_value.as_str()
+    };
+    if module_name.starts_with("node:") || !is_nodejs_builtin_module(module_name) {
+        return;
+    }
+
+    ctx.diagnostic_with_fix(prefer_node_protocol_diagnostic(span, &string_lit_value), |fixer| {
+        // Smallest module name is 2 chars, plus 2 for quotes = 4.
+        debug_assert!(span.size() >= 4, "node stdlib module name should be at least 4 chars long");
+        // We're replacing inside the string literal, shift to account for quotes.
+        let span = span.shrink_left(1).shrink_right(1);
+        fixer.replace(span, format!("node:{string_lit_value}"))
+    });
+}
+
 impl Rule for PreferNodeProtocol {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let string_lit_value_with_span = match node.kind() {
@@ -70,29 +94,7 @@ impl Rule for PreferNodeProtocol {
         let Some((string_lit_value, span)) = string_lit_value_with_span else {
             return;
         };
-        let module_name = if let Some((prefix, postfix)) = string_lit_value.split_once('/') {
-            // `e.g. ignore "assert/"`
-            if postfix.is_empty() { string_lit_value.as_str() } else { prefix }
-        } else {
-            string_lit_value.as_str()
-        };
-        if module_name.starts_with("node:") || !is_nodejs_builtin_module(module_name) {
-            return;
-        }
-
-        ctx.diagnostic_with_fix(
-            prefer_node_protocol_diagnostic(span, &string_lit_value),
-            |fixer| {
-                // Smallest module name is 2 chars, plus 2 for quotes = 4.
-                debug_assert!(
-                    span.size() >= 4,
-                    "node stdlib module name should be at least 4 chars long"
-                );
-                // We're replacing inside the string literal, shift to account for quotes.
-                let span = span.shrink_left(1).shrink_right(1);
-                fixer.replace(span, format!("node:{string_lit_value}"))
-            },
-        );
+        check_node_protocol_path(string_lit_value, span, ctx);
     }
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -15,6 +15,20 @@ fn prefer_node_protocol_diagnostic(span: Span, module_name: &str) -> OxcDiagnost
         .with_label(span)
 }
 
+fn disallow_node_protocol_diagnostic(span: Span, module_name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(
+        "Disallow using the `node:` protocol when importing Node.js builtin modules.",
+    )
+    .with_help(format!("Prefer `{module_name}` over `node:{module_name}`."))
+    .with_label(span)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum NodeProtocolMode {
+    Always,
+    Never,
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct PreferNodeProtocol;
 
@@ -49,24 +63,67 @@ pub(crate) fn check_node_protocol_path(
     string_lit_value: oxc_str::Str<'_>,
     span: Span,
     ctx: &LintContext,
+    mode: NodeProtocolMode,
 ) {
-    let module_name = if let Some((prefix, postfix)) = string_lit_value.split_once('/') {
-        // `e.g. ignore "assert/"`
-        if postfix.is_empty() { string_lit_value.as_str() } else { prefix }
-    } else {
-        string_lit_value.as_str()
+    let value = string_lit_value.as_str();
+    let Some(value_without_protocol) = value.strip_prefix("node:") else {
+        if !matches!(mode, NodeProtocolMode::Always) {
+            return;
+        }
+
+        let module_name = if let Some((prefix, postfix)) = string_lit_value.split_once('/') {
+            // `e.g. ignore "assert/"`
+            if postfix.is_empty() { string_lit_value.as_str() } else { prefix }
+        } else {
+            string_lit_value.as_str()
+        };
+        if !is_nodejs_builtin_module(module_name) {
+            return;
+        }
+
+        ctx.diagnostic_with_fix(
+            prefer_node_protocol_diagnostic(span, &string_lit_value),
+            |fixer| {
+                // Smallest module name is 2 chars, plus 2 for quotes = 4.
+                debug_assert!(
+                    span.size() >= 4,
+                    "node stdlib module name should be at least 4 chars long"
+                );
+                // We're replacing inside the string literal, shift to account for quotes.
+                let span = span.shrink_left(1).shrink_right(1);
+                fixer.replace(span, format!("node:{string_lit_value}"))
+            },
+        );
+        return;
     };
-    if module_name.starts_with("node:") || !is_nodejs_builtin_module(module_name) {
+
+    if !matches!(mode, NodeProtocolMode::Never) {
         return;
     }
 
-    ctx.diagnostic_with_fix(prefer_node_protocol_diagnostic(span, &string_lit_value), |fixer| {
-        // Smallest module name is 2 chars, plus 2 for quotes = 4.
-        debug_assert!(span.size() >= 4, "node stdlib module name should be at least 4 chars long");
-        // We're replacing inside the string literal, shift to account for quotes.
-        let span = span.shrink_left(1).shrink_right(1);
-        fixer.replace(span, format!("node:{string_lit_value}"))
-    });
+    let module_name = if let Some((prefix, postfix)) = value_without_protocol.split_once('/') {
+        // `e.g. ignore "assert/"`
+        if postfix.is_empty() { value_without_protocol } else { prefix }
+    } else {
+        value_without_protocol
+    };
+    if !is_nodejs_builtin_module(module_name) {
+        return;
+    }
+
+    ctx.diagnostic_with_fix(
+        disallow_node_protocol_diagnostic(span, value_without_protocol),
+        |fixer| {
+            // Smallest module name is 2 chars, plus 2 for quotes = 4.
+            debug_assert!(
+                span.size() >= 4,
+                "node stdlib module name should be at least 4 chars long"
+            );
+            // We're replacing inside the string literal, shift to account for quotes.
+            let span = span.shrink_left(1).shrink_right(1);
+            fixer.replace(span, value_without_protocol.to_string())
+        },
+    );
 }
 
 impl Rule for PreferNodeProtocol {
@@ -94,7 +151,7 @@ impl Rule for PreferNodeProtocol {
         let Some((string_lit_value, span)) = string_lit_value_with_span else {
             return;
         };
-        check_node_protocol_path(string_lit_value, span, ctx);
+        check_node_protocol_path(string_lit_value, span, ctx, NodeProtocolMode::Always);
     }
 }
 

--- a/crates/oxc_linter/src/snapshots/import_enforce_node_protocol_usage.snap
+++ b/crates/oxc_linter/src/snapshots/import_enforce_node_protocol_usage.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ import(enforce-node-protocol-usage): Prefer using the `node:` protocol when importing Node.js builtin modules.
+   ╭─[enforce_node_protocol_usage.tsx:1:16]
+ 1 │ import fs from "fs";
+   ·                ────
+   ╰────
+  help: Prefer `node:fs` over `fs`.
+
+  ⚠ import(enforce-node-protocol-usage): Prefer using the `node:` protocol when importing Node.js builtin modules.
+   ╭─[enforce_node_protocol_usage.tsx:1:24]
+ 1 │ export {promises} from "fs";
+   ·                        ────
+   ╰────
+  help: Prefer `node:fs` over `fs`.
+
+  ⚠ import(enforce-node-protocol-usage): Prefer using the `node:` protocol when importing Node.js builtin modules.
+   ╭─[enforce_node_protocol_usage.tsx:1:20]
+ 1 │ const fs = require("fs/promises");
+   ·                    ─────────────
+   ╰────
+  help: Prefer `node:fs/promises` over `fs/promises`.
+
+  ⚠ import(enforce-node-protocol-usage): Prefer using the `node:` protocol when importing Node.js builtin modules.
+   ╭─[enforce_node_protocol_usage.tsx:1:48]
+ 1 │ async function foo() { const fs = await import('assert/strict'); }
+   ·                                                ───────────────
+   ╰────
+  help: Prefer `node:assert/strict` over `assert/strict`.

--- a/crates/oxc_linter/src/snapshots/import_enforce_node_protocol_usage.snap
+++ b/crates/oxc_linter/src/snapshots/import_enforce_node_protocol_usage.snap
@@ -18,6 +18,13 @@ assertion_line: 490
   help: Prefer `node:fs` over `fs`.
 
   ⚠ import(enforce-node-protocol-usage): Prefer using the `node:` protocol when importing Node.js builtin modules.
+   ╭─[enforce_node_protocol_usage.tsx:1:15]
+ 1 │ export * from "fs";
+   ·               ────
+   ╰────
+  help: Prefer `node:fs` over `fs`.
+
+  ⚠ import(enforce-node-protocol-usage): Prefer using the `node:` protocol when importing Node.js builtin modules.
    ╭─[enforce_node_protocol_usage.tsx:1:20]
  1 │ const fs = require("fs/promises");
    ·                    ─────────────
@@ -30,3 +37,31 @@ assertion_line: 490
    ·                                                ───────────────
    ╰────
   help: Prefer `node:assert/strict` over `assert/strict`.
+
+  ⚠ import(enforce-node-protocol-usage): Prefer using the `node:` protocol when importing Node.js builtin modules.
+   ╭─[enforce_node_protocol_usage.tsx:1:16]
+ 1 │ import fs from "fs";
+   ·                ────
+   ╰────
+  help: Prefer `node:fs` over `fs`.
+
+  ⚠ import(enforce-node-protocol-usage): Prefer using the `node:` protocol when importing Node.js builtin modules.
+   ╭─[enforce_node_protocol_usage.tsx:1:21]
+ 1 │ export * as fs from "fs";
+   ·                     ────
+   ╰────
+  help: Prefer `node:fs` over `fs`.
+
+  ⚠ import(enforce-node-protocol-usage): Disallow using the `node:` protocol when importing Node.js builtin modules.
+   ╭─[enforce_node_protocol_usage.tsx:1:16]
+ 1 │ import fs from "node:fs";
+   ·                ─────────
+   ╰────
+  help: Prefer `fs` over `node:fs`.
+
+  ⚠ import(enforce-node-protocol-usage): Disallow using the `node:` protocol when importing Node.js builtin modules.
+   ╭─[enforce_node_protocol_usage.tsx:1:15]
+ 1 │ export * from "node:fs";
+   ·               ─────────
+   ╰────
+  help: Prefer `fs` over `node:fs`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -313,6 +313,9 @@
         "import/default": {
           "$ref": "#/definitions/DummyRule"
         },
+        "import/enforce-node-protocol-usage": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "import/export": {
           "$ref": "#/definitions/DummyRule"
         },

--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -35,7 +35,6 @@
     "n/no-process-exit": "No need to implement, already implemented by `unicorn/no-process-exit`.",
     "n/file-extension-in-import": "No need to implement, already implemented by `import/extensions`.",
     "n/no-callback-literal": "Use type-aware linting with `--type-aware --type-check` (or enable `options.typeAware` in config) and TypeScript callback typing (`err: Error | null | undefined`) to catch non-Error literals in error-first callbacks.",
-    "import/enforce-node-protocol-usage": "No need to implement, already implemented by `unicorn/prefer-node-protocol`.",
     "import/no-deprecated": "No need to implement, already implemented by `typescript/no-deprecated` via tsgolint.",
     "n/no-restricted-import": "No need to implement, already implemented by `no-restricted-imports` rule.",
     "n/no-restricted-require": "No need to implement, already implemented by `no-restricted-imports` rule.",


### PR DESCRIPTION
## Summary

Adds `import/enforce-node-protocol-usage` as an import-plugin alias for the existing `unicorn/prefer-node-protocol` behavior.

This lets users enable the import rule directly without enabling the unicorn plugin/categories, while keeping the implementation behavior shared with the existing rule.

Fixes #21013.

## Changes

- Add `import/enforce-node-protocol-usage` with docs, fixer metadata, and snapshot coverage.
- Share the node-protocol path check with `unicorn/prefer-node-protocol`.
- Regenerate linter rule metadata, oxlint schema, and generated TypeScript config types.
- Remove the rule from `unsupported-rules.json`.

## Verification

- `cargo lintgen`
- `cargo test -p oxc_linter node_protocol -- --nocapture`
- `cargo test -p oxc_linter --test rule_configuration_test -- --nocapture`
- `cargo test -p oxc_linter --test rule_configuration_documentation_test -- --nocapture`
- `git diff --check`
- Manual CLI smoke test: `cargo run -p oxlint -- --import-plugin -D import/enforce-node-protocol-usage <fixture>` reported the new rule as expected.

I also regenerated `npm/oxlint/configuration_schema.json` and `apps/oxlint/src-js/package/config.generated.ts`. On my Windows/Node 22.13 setup, `just linter-config-ts` failed because Node tried to execute a `.ts` file directly, so I ran the same generator through `tsx` after producing the schema.

## AI assistance disclosure

I used an AI coding assistant to inspect the existing rule/codegen patterns and prepare this patch. I reviewed the changes, preserved the existing runner node-type detection, regenerated the generated files, and ran the targeted checks listed above.