### PR TITLE
fix(formatter,formatter_json): handle PS/LS as line terminator

### DIFF
--- a/crates/oxc_formatter/src/print/arrow_function_expression.rs
+++ b/crates/oxc_formatter/src/print/arrow_function_expression.rs
@@ -362,7 +362,7 @@ pub fn is_multiline_template_starting_on_same_line(
     };
 
     template.quasis.iter().any(|quasi| source_text.contains_newline(quasi.span))
-        && !source_text.has_newline_before(start)
+        && !source_text.has_line_terminator_before(start)
 }
 
 /// Returns `true` if the expression is an HTML embed template that should be hugged.

--- a/crates/oxc_formatter/src/print/decorators.rs
+++ b/crates/oxc_formatter/src/print/decorators.rs
@@ -101,5 +101,7 @@ fn should_expand_decorators<'a>(
     decorators: &AstNode<'a, Vec<'a, Decorator<'a>>>,
     f: &JsFormatter<'_, 'a>,
 ) -> bool {
-    decorators.iter().any(|decorator| f.source_text().has_newline_after(decorator.span().end))
+    decorators
+        .iter()
+        .any(|decorator| f.source_text().has_line_terminator_after(decorator.span().end))
 }

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -264,7 +264,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, ImportAttribute
         write!(
             f,
             group(&format_inner)
-                .should_expand(f.source_text().has_newline_before(first.span.start))
+                .should_expand(f.source_text().has_line_terminator_before(first.span.start))
         );
     }
 }

--- a/crates/oxc_formatter/src/print/mapped_type.rs
+++ b/crates/oxc_formatter/src/print/mapped_type.rs
@@ -29,7 +29,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSMappedType<'a>> {
         // Because the break is not immediately after `{`.
         // `+ 1` skips the opening `{`.
         let should_expand =
-            f.source_text().has_newline_after_skipping_comments(self.span.start + 1);
+            f.source_text().has_line_terminator_after_skipping_comments(self.span.start + 1);
 
         let format_inner = format_with(|f| {
             if should_expand {

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -114,8 +114,9 @@ pub(super) fn format_css_doc<'a>(
                             // - the original source has newlines in the interpolation
                             // - AND the expression is a comment-bearing node or Identifier/etc
                             // For CSS embed, the relevant case is comments inside `${...}`.
-                            let has_newline = f.source_text().has_newline_before(expr.span().start)
-                                || f.source_text().has_newline_after(expr.span().end);
+                            let has_newline =
+                                f.source_text().has_line_terminator_before(expr.span().start)
+                                    || f.source_text().has_line_terminator_after(expr.span().end);
                             let has_comment = has_newline && {
                                 let comments = f.context().comments();
                                 let leading = comments.comments_before(expr.span().start);

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -208,8 +208,11 @@ pub(super) fn format_html_doc<'a>(
                                 // preserving hard line breaks (from comments).
                                 // Otherwise let it break naturally based on line width.
                                 let has_newline = has_trailing
-                                    && (f.source_text().has_newline_before(expr.span().start)
-                                        || f.source_text().has_newline_after(expr.span().end));
+                                    && (f
+                                        .source_text()
+                                        .has_line_terminator_before(expr.span().start)
+                                        || f.source_text()
+                                            .has_line_terminator_after(expr.span().end));
 
                                 let format_expr = format_with(|f| {
                                     let Some(element) = &interned else { return };

--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -469,8 +469,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatTemplateExpression<'a, '_> {
 impl<'a> TemplateExpression<'a, '_> {
     fn has_new_line_in_range(&self, f: &JsFormatter<'_, 'a>) -> bool {
         let span = self.span();
-        f.source_text().has_newline_before(span.start)
-            || f.source_text().has_newline_after(span.end)
+        f.source_text().has_line_terminator_before(span.start)
+            || f.source_text().has_line_terminator_after(span.end)
             || f.source_text().contains_newline(span)
     }
 }

--- a/crates/oxc_formatter/src/source_text.rs
+++ b/crates/oxc_formatter/src/source_text.rs
@@ -32,6 +32,19 @@ pub trait SourceTextExt {
     /// `first_unprinted_comment` is the span of the first not-yet-printed comment, or `None`.
     /// When that comment ends before `span.start`, its leading trivia is included in the count.
     fn get_lines_before(&self, span: Span, first_unprinted_comment: Option<Span>) -> usize;
+
+    /// Is there a line terminator immediately before `position` (skipping only horizontal whitespace, space / tab)?
+    ///
+    /// Recognizes the full ECMAScript line-terminator set, scanning by `char` so a multi-byte terminator is never split.
+    /// Matches Prettier's `skipSpaces` + `isLineTerminator`.
+    fn has_line_terminator_before(&self, position: u32) -> bool;
+
+    /// Is there a line terminator immediately after `position`? The forward counterpart of [`Self::has_line_terminator_before`].
+    fn has_line_terminator_after(&self, position: u32) -> bool;
+
+    /// Is there a line terminator after `position`,
+    /// treating an intervening comment as transparent (matches Prettier detecting the newline in `{ /* comment */\n`)?
+    fn has_line_terminator_after_skipping_comments(&self, position: u32) -> bool;
 }
 
 impl SourceTextExt for SourceText<'_> {
@@ -126,6 +139,64 @@ impl SourceTextExt for SourceText<'_> {
 
         0
     }
+
+    fn has_line_terminator_before(&self, position: u32) -> bool {
+        let text: &str = self;
+        for c in text[..position as usize].chars().rev() {
+            match c {
+                ' ' | '\t' => {}
+                _ if is_line_terminator(c) => return true,
+                _ => return false,
+            }
+        }
+        false
+    }
+
+    fn has_line_terminator_after(&self, position: u32) -> bool {
+        let text: &str = self;
+        for c in text[position as usize..].chars() {
+            match c {
+                ' ' | '\t' => {}
+                _ if is_line_terminator(c) => return true,
+                _ => return false,
+            }
+        }
+        false
+    }
+
+    fn has_line_terminator_after_skipping_comments(&self, position: u32) -> bool {
+        let text: &str = self;
+        let mut chars = text[position as usize..].chars().peekable();
+        while let Some(c) = chars.next() {
+            match c {
+                ' ' | '\t' => {}
+                _ if is_line_terminator(c) => return true,
+                '/' => match chars.peek() {
+                    Some(&'/') => {
+                        chars.next();
+                        // Line comment: scan until line terminator or EOF.
+                        return chars.any(is_line_terminator);
+                    }
+                    Some(&'*') => {
+                        chars.next();
+                        // Block comment: scan for `*/`, returning early on any inner terminator.
+                        while let Some(c) = chars.next() {
+                            if is_line_terminator(c) {
+                                return true;
+                            }
+                            if c == '*' && chars.peek() == Some(&'/') {
+                                chars.next();
+                                break;
+                            }
+                        }
+                    }
+                    _ => return false,
+                },
+                _ => return false,
+            }
+        }
+        false
+    }
 }
 
 // NOTE: Our test fixtures are managed under `.gitattributes` to enforce LF line endings.
@@ -199,5 +270,43 @@ const z = 3;
 
         assert_eq!(source_text.lines_after(span_x.end), 2);
         assert_eq!(source_text.lines_after(span_y.end), 2);
+    }
+
+    #[test]
+    fn has_line_terminator_recognizes_ls_ps_and_crlf() {
+        // Each case is `a` + gap + `b`. `has_*_after` scans from byte 1 (right after `a`);
+        // `has_*_before` scans back from the start of `b` (byte `1 + gap.len()`).
+        for gap in ["\n", "\r", "\r\n", "\u{2028}", "\u{2029}", "  \u{2028}"] {
+            let src = format!("a{gap}b");
+            let st = SourceText::new(&src);
+            let before_b = u32::try_from(1 + gap.len()).unwrap();
+            assert!(st.has_line_terminator_after(1), "after: {src:?}");
+            assert!(st.has_line_terminator_before(before_b), "before: {src:?}");
+        }
+
+        // No terminator (incl. other 0xE2-led chars: em dash U+2014, bullet U+2022).
+        for gap in [" ", "\u{2014}", " \u{2022} "] {
+            let src = format!("a{gap}b");
+            let st = SourceText::new(&src);
+            let before_b = u32::try_from(1 + gap.len()).unwrap();
+            assert!(!st.has_line_terminator_after(1), "after: {src:?}");
+            assert!(!st.has_line_terminator_before(before_b), "before: {src:?}");
+        }
+    }
+
+    #[test]
+    fn has_line_terminator_after_skipping_comments_is_ls_ps_aware() {
+        // Terminator hidden behind a comment is still detected.
+        let st = SourceText::new("{ /* c */\u{2028}x }");
+        assert!(st.has_line_terminator_after_skipping_comments(1));
+        // Terminator inside the block comment itself counts.
+        let st = SourceText::new("{ /* c\u{2029} */ x }");
+        assert!(st.has_line_terminator_after_skipping_comments(1));
+        // Line comment then terminator.
+        let st = SourceText::new("{ // c\u{2028}x }");
+        assert!(st.has_line_terminator_after_skipping_comments(1));
+        // No terminator before the next token.
+        let st = SourceText::new("{ /* c */ x }");
+        assert!(!st.has_line_terminator_after_skipping_comments(1));
     }
 }

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -60,8 +60,9 @@ Parameterizing language differences (sharpened gate 2), when a shared helper nee
   - e.g. `normalize_string` takes a raw quote byte, `SourceText` takes byte offsets
 - a parameter that would have to encode the language's grammar / logic structure is the language smuggled in disguise → it belongs in the consumer
 
-`SourceText` follows this line. Core owns mechanical, offset-keyed access only (slicing, raw-byte newline checks).
+`SourceText` follows this line. Core owns mechanical, offset-keyed access only (slicing, raw-byte lookups).
 Lexical-semantic scanning whose answer is language-defined, what counts as a newline (U+2028/U+2029), a comment, or ASI/parens trivia lives in the consumer (`oxc_formatter`'s `SourceTextExt`), not here.
+Even raw newline detection proved to be consumer-owned (every consumer needs the LS/PS-aware variant in addition to `\r|\n`), so core keeps no newline helpers.
 Quote-style options, comment rules, and the like are likewise consumer-owned.
 
 ## Cargo features

--- a/crates/oxc_formatter_core/src/source_text.rs
+++ b/crates/oxc_formatter_core/src/source_text.rs
@@ -4,7 +4,7 @@ use oxc_span::{GetSpan, Span};
 
 /// Source text wrapper providing mechanical byte/offset access for the formatter.
 ///
-/// This owns only language-agnostic, offset-keyed access (slicing, raw-byte newline checks).
+/// This owns only language-agnostic, offset-keyed access (slicing, raw-byte lookups).
 /// Lexical-semantic scanning whose answer is language-defined
 /// ("what counts as a newline / comment / trivia") lives in each consumer. (e.g. `oxc_formatter`'s `SourceTextExt`)
 ///
@@ -60,73 +60,6 @@ impl<'a> SourceText<'a> {
         self.bytes_from(position)
             .find(|byte| !byte.is_ascii_whitespace())
             .is_some_and(|b| b == expected_byte)
-    }
-
-    // Newline detection
-    /// Check for newlines before position, stopping at first non-whitespace
-    pub fn has_newline_before(&self, position: u32) -> bool {
-        for byte in self.bytes_to(position) {
-            match byte {
-                b'\n' | b'\r' => return true,
-                b' ' | b'\t' => {}
-                _ => return false,
-            }
-        }
-        false
-    }
-
-    /// Check for newlines after position, stopping at first non-whitespace
-    pub fn has_newline_after(&self, position: u32) -> bool {
-        for byte in self.bytes_from(position) {
-            match byte {
-                b'\n' | b'\r' => return true,
-                b' ' | b'\t' => {}
-                _ => return false,
-            }
-        }
-        false
-    }
-
-    /// Check for a newline starting at `position`, scanning through comments.
-    /// Unlike [`Self::has_newline_after`], a comment between `position` and the newline is
-    /// transparent (matches Prettier detecting the newline in `{ /* comment */\n`).
-    ///
-    /// NOTE: comment scanning assumes C-family comment syntax (`//`, `/* */`),
-    /// shared by all current consumers (JS/TS and JSON, a JS subset).
-    /// A future non-C-family consumer must supply its own comment-aware scan,
-    /// or make this more generic. (e.g. pass comments ranges to skip)
-    pub fn has_newline_after_skipping_comments(&self, position: u32) -> bool {
-        let mut iter = self.bytes_from(position).peekable();
-
-        while let Some(byte) = iter.next() {
-            match byte {
-                b'\n' | b'\r' => return true,
-                b' ' | b'\t' => {}
-                b'/' => match iter.peek() {
-                    Some(&b'/') => {
-                        iter.next();
-                        // Line comment: scan until newline or EOF
-                        return iter.any(|b| b == b'\n' || b == b'\r');
-                    }
-                    Some(&b'*') => {
-                        iter.next();
-                        // Block comment: scan for */ and check for newlines
-                        while let Some(b) = iter.next() {
-                            if matches!(b, b'\n' | b'\r') {
-                                return true;
-                            }
-                            if b == b'*' && matches!(iter.peek(), Some(&b'/')) {
-                                iter.next();
-                                break;
-                            }
-                        }
-                    }
-                    _ => return false,
-                },
-                _ => return false,
-            }
-        }
-        false
     }
 
     // Byte range operations

--- a/crates/oxc_formatter_json/AGENTS.md
+++ b/crates/oxc_formatter_json/AGENTS.md
@@ -25,6 +25,13 @@ Prettier compatible JSON/JSONC/JSON5 formatter (`oxfmt`'s Tier 1 backend), using
 All variants share lenient parsing (comments, trailing commas, single quotes, unquoted keys all parse regardless of variant).
 What differs is the output formatting.
 
+Parsing always uses `SourceType::default()` (JS); `variant` only gates comment validation (see `parse.rs`), never the lexis.
+
+- So JS lexer rules including line terminators U+2028 / U+2029 apply to every variant's input, not just JSON5
+- Consequence: downstream source scans (newline / blank-line detection) must be LS/PS-aware for all variants
+  - Strictly LS/PS are line terminators only in JSON5, but a `json` / `jsonc` input can still carry them in inter-token gaps
+  - Because the lenient JS parse accepts them (also matching Prettier, which routes every variant through its JS printer)
+
 See the doc comments on `JsonVariant` in `src/options.rs` for the per-variant rules.
 
 ## Verification

--- a/crates/oxc_formatter_json/src/comments.rs
+++ b/crates/oxc_formatter_json/src/comments.rs
@@ -11,6 +11,7 @@ use oxc_formatter_core::{
 use oxc_span::Span;
 use oxc_syntax::line_terminator::{
     LS_LAST_2_BYTES, LS_OR_PS_FIRST_BYTE, LineTerminatorSplitter, PS_LAST_2_BYTES,
+    is_line_terminator,
 };
 
 use crate::{
@@ -129,16 +130,13 @@ pub fn write_leading_comments(
     }
 }
 
-/// Counts ECMAScript line terminators in `slice`, treating `\r\n` as a single break.
+/// Recognizes `\n`, lone `\r`, `\r\n`, and LS(U+2028) / PS(U+2029), the full ECMAScript line-terminator set.
 ///
-/// Recognizes `\n`, lone `\r`, `\r\n`, and U+2028 / U+2029 — the full ECMAScript line-terminator
-/// set. CR/LF cover every JSON variant; U+2028 / U+2029 are line terminators only in JSON5 (ES5 lexis).
-///
-/// Recognizing U+2028 / U+2029 unconditionally is observably a no-op for `json` / `jsonc`: in valid
-/// input they can only appear inside string literals, never in the inter-entry gaps this scans, so
-/// they reach this function only for JSON5 (or already-invalid input, where Prettier — which routes
-/// every variant through its JS printer — also treats them as breaks). This keeps `count_newlines`
-/// a pure `&[u8]` helper with no variant threading, and aligns with core's raw-byte newline checks.
+/// LS/PS recognition is unconditional (no `JsonVariant` threading), keeping this a pure `&[u8]` helper.
+/// It is required for JSON5 (ES5 lexis), and is not a no-op for `json` / `jsonc` either:
+/// this crate parses every variant leniently as JS, so the lexer accepts a bare LS/PS in an inter-entry gap regardless of variant.
+/// A spec-strict JSON document keeps them inside string literals, so the branch rarely fires for `json` / `jsonc`.
+/// But when it does, treating it as a break matches Prettier (every variant goes through its JS printer).
 pub fn count_newlines(slice: &[u8]) -> usize {
     let mut count = 0;
     let mut i = 0;
@@ -167,6 +165,43 @@ pub fn count_newlines(slice: &[u8]) -> usize {
         i += 1;
     }
     count
+}
+
+/// Does a line terminator precede the first property / `}`, treating a comment as transparent?
+///
+/// `text` is the source slice starting just after the opening `{` (up to the container's end).
+/// Recognizes the full ECMAScript line-terminator set unconditionally, for the same reason as [`count_newlines`].
+pub fn has_line_terminator_after_skipping_comments(text: &str) -> bool {
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            ' ' | '\t' => {}
+            _ if is_line_terminator(c) => return true,
+            '/' => match chars.peek() {
+                Some(&'/') => {
+                    chars.next();
+                    // Line comment: a terminator anywhere up to its end counts.
+                    return chars.any(is_line_terminator);
+                }
+                Some(&'*') => {
+                    chars.next();
+                    // Block comment: scan for `*/`, returning early on any inner terminator.
+                    while let Some(c) = chars.next() {
+                        if is_line_terminator(c) {
+                            return true;
+                        }
+                        if c == '*' && chars.peek() == Some(&'/') {
+                            chars.next();
+                            break;
+                        }
+                    }
+                }
+                _ => return false,
+            },
+            _ => return false,
+        }
+    }
+    false
 }
 
 /// Emits the formatter element that reproduces the vertical spacing implied by `gap`:
@@ -284,7 +319,7 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FormatSuppressedNode {
 
 #[cfg(test)]
 mod tests {
-    use super::count_newlines;
+    use super::{count_newlines, has_line_terminator_after_skipping_comments};
 
     // NOTE: source fixtures are LF-only (enforced via `.gitattributes`),
     // so CR / CRLF / mixed / Unicode endings are exercised here instead.
@@ -317,5 +352,21 @@ mod tests {
         assert_eq!(count_newlines("a\r\n\u{2029}b".as_bytes()), 2);
         // Other `0xE2`-led characters must NOT be counted (em dash U+2014, bullet U+2022).
         assert_eq!(count_newlines("a\u{2014}b\u{2022}c".as_bytes()), 0);
+    }
+
+    #[test]
+    fn has_line_terminator_after_skipping_comments_is_ls_ps_aware() {
+        // `text` is the slice just after `{`. A bare terminator before the first token → true.
+        for src in ["\nx", "\rx", "\r\nx", "\u{2028}x", "\u{2029}x", "  \u{2028}x"] {
+            assert!(has_line_terminator_after_skipping_comments(src), "{src:?}");
+        }
+        // Terminator hidden behind a comment is still detected.
+        assert!(has_line_terminator_after_skipping_comments(" /* c */\u{2028}x"));
+        assert!(has_line_terminator_after_skipping_comments(" /* c\u{2029} */ x"));
+        assert!(has_line_terminator_after_skipping_comments(" // c\u{2028}x"));
+        // No terminator before the next token (incl. other 0xE2-led chars).
+        for src in [" x", " /* c */ x", "\u{2014}x"] {
+            assert!(!has_line_terminator_after_skipping_comments(src), "{src:?}");
+        }
     }
 }

--- a/crates/oxc_formatter_json/src/parse.rs
+++ b/crates/oxc_formatter_json/src/parse.rs
@@ -49,6 +49,10 @@ pub fn parse_json<'a>(
     // from being swallowed by a trailing line comment in `source`.
     let wrapped_source: &'a str = allocator.alloc_concat_strs_array(["(", source, "\n)"]);
 
+    // NOTE: We use `oxc_parser` which parses according to JavaScript rules, not JSON.
+    // So the JS lexer rules apply uniformly regardless of `variant`.
+    // e.g. line terminators (incl. U+2028 / U+2029), trailing commas, single quotes
+    // Downstream newline scans must therefore be LS/PS-aware for all variants, not just JSON5.
     let options = ParseOptions { preserve_parens: false, ..ParseOptions::default() };
     let ret =
         Parser::new(allocator, wrapped_source, SourceType::default()).with_options(options).parse();

--- a/crates/oxc_formatter_json/src/print/object.rs
+++ b/crates/oxc_formatter_json/src/print/object.rs
@@ -11,7 +11,7 @@ use oxc_syntax::number::ToJsString;
 use crate::{
     comments::{
         FormatLeadingComments, FormatSuppressedNode, FormatTrailingInsideComments,
-        is_suppressed_before, write_dangling_comments,
+        has_line_terminator_after_skipping_comments, is_suppressed_before, write_dangling_comments,
     },
     context::JsonFormatContext,
     options::Expand,
@@ -92,8 +92,10 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FmtJsonObject<'a, '_> {
         let expand = match options.expand {
             Expand::Auto => {
                 // `+ 1` skips the opening `{`.
+                // Scan only within the object so the slice ends at the closing `}` at the latest.
                 let after_brace = self.object.span.start + 1;
-                f.context().source_text().has_newline_after_skipping_comments(after_brace)
+                let rest = f.context().source_text().slice_range(after_brace, self.object.span.end);
+                has_line_terminator_after_skipping_comments(rest)
             }
             Expand::Never => false,
         };


### PR DESCRIPTION
I know this is also a rare, but it's better to be precise.

This also makes that the core no longer needs to be aware of line terminators, which can vary from language to language.