### PR TITLE
fix(codegen): preserve new tagged template callee parens

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2300,6 +2300,18 @@ impl GenExpr for ChainExpression<'_> {
     }
 }
 
+fn should_wrap_new_callee_tagged_template(callee: &Expression) -> bool {
+    let Expression::ParenthesizedExpression(expr) = callee else {
+        return false;
+    };
+    let Expression::TaggedTemplateExpression(tagged) = expr.expression.without_parentheses() else {
+        return false;
+    };
+    // Keep `new (foo()`bar`)()` distinct from `new foo()`bar`()`, while preserving
+    // existing `new tag`bar`` output.
+    matches!(tagged.tag.without_parentheses(), Expression::CallExpression(_))
+}
+
 impl GenExpr for NewExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         let mut wrap = precedence >= self.precedence();
@@ -2315,7 +2327,9 @@ impl GenExpr for NewExpression<'_> {
             p.add_source_mapping(self.span);
             p.print_str("new");
             p.print_soft_space();
-            self.callee.print_expr(p, Precedence::New, Context::FORBID_CALL);
+            p.wrap(should_wrap_new_callee_tagged_template(&self.callee), |p| {
+                self.callee.print_expr(p, Precedence::New, Context::FORBID_CALL);
+            });
             if let Some(type_parameters) = &self.type_arguments {
                 type_parameters.print(p, ctx);
             }

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -57,6 +57,11 @@ fn export_type() {
 #[test]
 fn expr() {
     test("new (foo()).bar();", "new (foo()).bar();\n");
+    test_same("const foo = () => (args) => class A {};\nnew (foo()`bar`)();\n");
+    test_minify(
+        "const foo = () => (args) => class A {};\nnew (foo()`bar`)();",
+        "const foo=()=>args=>class A{};new(foo()`bar`);",
+    );
     test_minify("x in new Error()", "x in new Error;");
     test(
         "new function() { let a = foo?.bar().baz; return a; }();",


### PR DESCRIPTION
## Summary

- preserve parentheses for `new (foo()`bar`)()` so codegen does not emit `new foo()`bar`()`, which changes how the expression is parsed
- keep existing `new tag`bar`` output behavior unchanged for the simpler tagged-template callee form
- add normal and minified regression coverage for the reported case

Fixes #22961

## Testing

- `cargo test -p oxc_codegen expr -- --nocapture`
- `cargo test -p oxc_codegen esbuild::test_template -- --nocapture`
- `cargo fmt --all`
- `git diff --check`

AI assistance disclosure: I used AI assistance to inspect the codegen behavior, draft the patch, and run verification commands; I reviewed the changes before pushing.