### PR TITLE
fix(oxfmt): return format file errors as data

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -34,7 +34,7 @@ export declare const enum Severity {
  * # Panics
  * Panics if the current working directory cannot be determined.
  */
-export declare function format(filename: string, sourceText: string, options: any | undefined | null, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<FormatResult>
+export declare function format(filename: string, sourceText: string, options: any | undefined | null, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<FormatResult>
 
 export interface FormatResult {
   /** The formatted code. */
@@ -49,7 +49,7 @@ export interface FormatResult {
  * This API is specialized for JS/TS snippets embedded in non-JS files.
  * Unlike `format()`, it is called only for js-in-xxx `textToDoc()` flow.
  */
-export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<string | null>
+export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<string | null>
 
 /**
  * NAPI based JS CLI entry point.
@@ -67,4 +67,4 @@ export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmt
  * - `mode`: If main logic will run in JS side, use this to indicate which mode
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
-export declare function runCli(args: Array<string>, loadJsConfigCb: (path: string) => Promise<any>, initExternalFormatterCb: (numThreads: number) => Promise<void>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<[string, number | undefined | null]>
+export declare function runCli(args: Array<string>, loadJsConfigCb: (path: string) => Promise<any>, initExternalFormatterCb: (numThreads: number) => Promise<void>, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -1,6 +1,7 @@
 import Tinypool from "tinypool";
 import type {
   FormatFileParam,
+  FormatFileResult,
   FormatEmbeddedCodeParam,
   FormatEmbeddedDocParam,
   SortTailwindClassesArgs,
@@ -35,31 +36,16 @@ export async function disposeExternalFormatter(): Promise<void> {
 export async function formatFile(
   options: FormatFileParam["options"],
   code: string,
-): Promise<string> {
-  return (
-    pool!
-      .run({ options, code } satisfies FormatFileParam, { name: "formatFile" })
-      // `tinypool` with `runtime: "child_process"` serializes Error as plain objects via IPC.
-      // (e.g. `{ name, message, stack, ... }`)
-      // And napi-rs converts unknown JS values to Rust Error by calling `String()` on them,
-      // which yields `"[object Object]"` for plain objects...
-      // So, this function reconstructs a proper `Error` instance so napi-rs can extract the message.
-      .catch((err) => {
-        if (err instanceof Error) throw err;
-        if (err !== null && typeof err === "object") {
-          const obj = err as { name: string; message: string };
-          const newErr = new Error(obj.message);
-          newErr.name = obj.name;
-          throw newErr;
-        }
-        throw new Error(String(err));
-      })
-  );
+): Promise<FormatFileResult> {
+  return pool!
+    .run({ options, code } satisfies FormatFileParam, { name: "formatFile" })
+    .then((formattedCode: string) => ({ ok: true as const, code: formattedCode }))
+    .catch((err) => ({ ok: false, error: errorToMessage(err) }));
 }
 
 // ---
 
-// All functions below are used for JS files with embedded code
+// These functions call JS formatters from Rust via NAPI ThreadsafeFunction.
 //
 // NOTE: These functions return `null` on error instead of throwing.
 // When errors were propagated as rejected JS promises, which become `napi::Error` values in Rust TSFN await paths.
@@ -92,4 +78,13 @@ export async function sortTailwindClasses(
   return pool!
     .run({ classes, options } satisfies SortTailwindClassesArgs, { name: "sortTailwindClasses" })
     .catch(() => null);
+}
+
+function errorToMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err !== null && typeof err === "object") {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return String(err);
 }

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -2,7 +2,7 @@
 
 import { format as napiFormat, jsTextToDoc as napiJsTextToDoc } from "./bindings";
 import {
-  formatFile,
+  formatFileSafe,
   formatEmbeddedCode,
   formatEmbeddedDoc,
   sortTailwindClasses,
@@ -73,7 +73,7 @@ export async function format(fileName: string, sourceText: string, options?: For
     fileName,
     sourceText,
     options ?? {},
-    (options, code) => formatFile({ options, code }),
+    (options, code) => formatFileSafe({ options, code }),
     (options, code) => formatEmbeddedCode({ options, code }),
     (options, texts) => formatEmbeddedDoc({ options, texts }),
     (options, classes) => sortTailwindClasses({ options, classes }),
@@ -94,7 +94,7 @@ export async function jsTextToDoc(
     sourceText,
     oxfmtPluginOptionsJson,
     parentContext,
-    (_options, _code) => Promise.reject(/* Unreachable */),
+    () => Promise.resolve({ ok: false, error: "formatFile is unavailable for jsTextToDoc" }),
     (options, code) => formatEmbeddedCode({ options, code }),
     (options, texts) => formatEmbeddedDoc({ options, texts }),
     (options, classes) => sortTailwindClasses({ options, classes }),

--- a/apps/oxfmt/src-js/libs/apis.ts
+++ b/apps/oxfmt/src-js/libs/apis.ts
@@ -76,6 +76,10 @@ export type FormatFileParam = {
   options: Options;
 };
 
+export type FormatFileResult =
+  | { ok: true; code: string }
+  | { ok: false; error: string };
+
 /**
  * Format non-js file
  *
@@ -93,6 +97,21 @@ export async function formatFile({ code, options }: FormatFileParam): Promise<st
   if ("_oxfmtPluginOptionsJson" in options) await setupOxfmtPlugin(options);
 
   return prettier.format(code, options);
+}
+
+/**
+ * `formatFile()` wrapper that never rejects.
+ * Rust receives recoverable formatter errors as data to avoid rejected Promise cleanup on the NAPI path.
+ */
+export async function formatFileSafe(
+  args: FormatFileParam,
+): Promise<FormatFileResult> {
+  try {
+    const code = await formatFile(args);
+    return { ok: true, code };
+  } catch (err) {
+    return { ok: false, error: errorToMessage(err) };
+  }
 }
 
 // ---
@@ -281,4 +300,13 @@ async function setupOxfmtPlugin(options: Options): Promise<void> {
   );
   options.plugins ??= [];
   options.plugins.push(CACHES.oxfmtPlugin);
+}
+
+function errorToMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err !== null && typeof err === "object") {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return String(err);
 }

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -32,13 +32,13 @@ pub type JsInitExternalFormatterCb = ThreadsafeFunction<
 >;
 
 /// Type alias for the callback function signature.
-/// Takes (options, code) as arguments and returns formatted code.
+/// Takes (options, code) as arguments and returns a wrapped formatter result.
 /// The `options` object includes `parser` and `filepath` fields set by Rust side.
 pub type JsFormatFileCb = ThreadsafeFunction<
     // Input arguments
     FnArgs<(Value, String)>, // (options, code)
     // Return type (what JS function returns)
-    Promise<String>,
+    Promise<Value>,
     // Arguments (repeated)
     FnArgs<(Value, String)>,
     // Error status
@@ -442,7 +442,7 @@ fn wrap_format_file(
             let status = cb.call_async(FnArgs::from((options, code.to_string()))).await;
             match status {
                 Ok(promise) => match promise.await {
-                    Ok(formatted_code) => Ok(formatted_code),
+                    Ok(result) => parse_format_file_result(result),
                     Err(err) => Err(err.reason.clone()),
                 },
                 Err(err) => Err(err.reason.clone()),
@@ -451,6 +451,33 @@ fn wrap_format_file(
         drop(guard);
         result
     })
+}
+
+fn parse_format_file_result(result: Value) -> Result<String, String> {
+    if let Some(code) = result.as_str() {
+        return Ok(code.to_string());
+    }
+
+    let Some(obj) = result.as_object() else {
+        return Err("File formatting failed".to_string());
+    };
+
+    match obj.get("ok").and_then(Value::as_bool) {
+        Some(true) => obj
+            .get("code")
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+            .ok_or_else(|| "File formatting result missing `code`".to_string()),
+        Some(false) => {
+            let error = obj
+                .get("error")
+                .and_then(Value::as_str)
+                .filter(|error| !error.is_empty())
+                .unwrap_or("File formatting failed");
+            Err(error.to_string())
+        }
+        None => Err("File formatting result missing `ok`".to_string()),
+    }
 }
 
 /// Wrap JS `formatEmbeddedCode` callback as a normal Rust function.
@@ -535,4 +562,35 @@ fn wrap_sort_tailwind_classes(
         drop(guard);
         result
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::parse_format_file_result;
+
+    #[test]
+    fn parse_format_file_result_accepts_success_object() {
+        let result = parse_format_file_result(json!({ "ok": true, "code": "formatted" }));
+        assert_eq!(result, Ok("formatted".to_string()));
+    }
+
+    #[test]
+    fn parse_format_file_result_preserves_error_message() {
+        let result = parse_format_file_result(json!({ "ok": false, "error": "Unexpected token" }));
+        assert_eq!(result, Err("Unexpected token".to_string()));
+    }
+
+    #[test]
+    fn parse_format_file_result_falls_back_for_empty_error() {
+        let result = parse_format_file_result(json!({ "ok": false, "error": "" }));
+        assert_eq!(result, Err("File formatting failed".to_string()));
+    }
+
+    #[test]
+    fn parse_format_file_result_accepts_legacy_string() {
+        let result = parse_format_file_result(json!("formatted"));
+        assert_eq!(result, Ok("formatted".to_string()));
+    }
 }

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -39,7 +39,9 @@ pub async fn run_cli(
     #[napi(ts_arg_type = "(path: string) => Promise<any>")] load_js_config_cb: JsLoadJsConfigCb,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<void>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    #[napi(
+        ts_arg_type = "(options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>"
+    )]
     format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,
@@ -155,7 +157,9 @@ pub async fn format(
     filename: String,
     source_text: String,
     options: Option<Value>,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    #[napi(
+        ts_arg_type = "(options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>"
+    )]
     format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,
@@ -195,7 +199,9 @@ pub async fn js_text_to_doc(
     source_text: String,
     oxfmt_plugin_options_json: String,
     parent_context: String,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    #[napi(
+        ts_arg_type = "(options: Record<string, any>, code: string) => Promise<{ ok: boolean; code?: string; error?: string }>"
+    )]
     format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,

--- a/apps/oxfmt/test/api/basic.test.ts
+++ b/apps/oxfmt/test/api/basic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { format } from "../../dist/index.js";
+import { formatFileSafe } from "../../src-js/libs/apis";
 
 describe("Format non-js", () => {
   it("should format json with options", async () => {
@@ -37,6 +38,17 @@ describe("Format non-js", () => {
 `.trimStart(),
     );
     expect(result.errors).toStrictEqual([]);
+  });
+  it("should return Prettier formatFile errors as data", async () => {
+    const result = await formatFileSafe({
+      code: `{`,
+      options: { parser: "jsonc", filepath: "broken.jsonc" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).not.toBe("File formatting failed");
+      expect(result.error).toMatch(/Unexpected|JSON|end/i);
+    }
   });
 });
 

--- a/apps/oxfmt/test/api/basic.test.ts
+++ b/apps/oxfmt/test/api/basic.test.ts
@@ -42,13 +42,22 @@ describe("Format non-js", () => {
   it("should return Prettier formatFile errors as data", async () => {
     const result = await formatFileSafe({
       code: `{`,
-      options: { parser: "jsonc", filepath: "broken.jsonc" },
+      options: { parser: "json5", filepath: "broken.json5" },
     });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).not.toBe("File formatting failed");
       expect(result.error).toMatch(/Unexpected|JSON|end/i);
     }
+  });
+
+  it("should surface Prettier parse errors from format API", async () => {
+    const result = await format("broken.json5", `{`, {});
+
+    expect(result.code).toBe(`{`);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.message).not.toBe("File formatting failed");
+    expect(result.errors[0]?.message).toMatch(/Unexpected|JSON|end/i);
   });
 });
 


### PR DESCRIPTION
Fixes #20525

## Summary
- Change the `formatFile` NAPI callback contract to resolve formatter results as data: `{ ok, code?, error? }`.
- Preserve Prettier/worker error messages without sending normal formatter failures through a rejected Promise.
- Parse the wrapped result on the Rust side, with a legacy string success fallback and regression coverage.
- Add JS regression coverage for both `formatFileSafe()` and the public `format()` API on a Prettier-routed parse error.

## Reproduction before fix
The nondeterministic V8 fatal crash in #20525 was reported on macOS and I cannot reproduce that crash on my Windows machine. The deterministic pre-fix condition is still visible locally: `formatFile` was the remaining external formatter callback that sent recoverable formatter failures through a rejected NAPI `Promise`.

On the parent commit, forcing the `formatFileCb` to reject with a plain object, matching the shape Tinypool can produce across the `child_process` boundary, makes Rust receive the rejected Promise and report the lossy message:

```text
[object Object]
[broken.json5]
```

That matches the `[object Object]` formatter failures in #20525. #19806 fixed the same rejected-Promise/TSFN teardown class for embedded formatter callbacks by returning errors as data; this PR applies that pattern to the remaining `formatFile` callback.

## Validation
- `cargo test -p oxfmt parse_format_file_result`
- `pnpm -C apps/oxfmt run build-napi-test`
- `pnpm -C apps/oxfmt exec vitest run test/api/basic.test.ts`
- `git diff --check`

Disclosure: I prepared this PR with AI assistance, reviewed the patch, and ran the validation above locally.