### PR TITLE
fix(parser): disallow unerasable `as`/`satisfies` assertions

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1227,6 +1227,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Pratt Parsing Algorithm
         // <https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html>
         let mut lhs = lhs;
+        // Precedence of the operator that produced the running left-hand operand, used to detect
+        // `as`/`satisfies` assertions that cannot be erased. `None` until a binary/logical operator
+        // has been consumed in this loop, matching TypeScript where the initial operand (from unary
+        // parsing) is never a binary expression.
+        let mut last_operand_precedence: Option<Precedence> = None;
         loop {
             // re-lex for `>=` `>>` `>>>`
             // This is needed for jsx `<div>=</div>` case
@@ -1269,6 +1274,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     }
                     self.ast.expression_ts_satisfies(span, lhs, type_annotation)
                 };
+                // When we have `a ## b as T` or `a ## b satisfies T`, where `##` is some binary
+                // operator, stop parsing on any following operator with higher precedence than `##`
+                // because continuing would make it impossible to erase the `as` or `satisfies`
+                // without changing the meaning of the expression.
+                // See <https://github.com/microsoft/TypeScript/issues/63527>.
+                if let Some(last_precedence) = last_operand_precedence
+                    && let Some(next_precedence) = kind_to_precedence(self.re_lex_right_angle())
+                    && next_precedence > last_precedence
+                {
+                    break;
+                }
                 continue;
             }
 
@@ -1315,6 +1331,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             } else {
                 break;
             };
+            last_operand_precedence = Some(left_precedence);
         }
 
         lhs

--- a/tasks/coverage/misc/fail/ts-unerasable-as-chained.ts
+++ b/tasks/coverage/misc/fail/ts-unerasable-as-chained.ts
@@ -1,0 +1,4 @@
+// https://github.com/microsoft/TypeScript/issues/63527
+// A chained `as T as U` keeps referring back to the precedence of the `+` operator,
+// so the trailing `*` still makes the assertion impossible to erase. Syntax error.
+const x = 1 + 1 as any as number * 2;

--- a/tasks/coverage/misc/fail/ts-unerasable-as.ts
+++ b/tasks/coverage/misc/fail/ts-unerasable-as.ts
@@ -1,0 +1,4 @@
+// https://github.com/microsoft/TypeScript/issues/63527
+// `as`/`satisfies` cannot be erased here without changing the meaning, because the
+// trailing `*` binds tighter than the leading `+`. This is a syntax error.
+const x = 1 + 1 as number * 2;

--- a/tasks/coverage/misc/fail/ts-unerasable-satisfies.ts
+++ b/tasks/coverage/misc/fail/ts-unerasable-satisfies.ts
@@ -1,0 +1,4 @@
+// https://github.com/microsoft/TypeScript/issues/63527
+// Same rule as `as`: erasing `satisfies number` would let `*` re-associate, so this
+// is a syntax error.
+const x = 1 + 1 satisfies number * 2;

--- a/tasks/coverage/misc/pass/ts-erasable-as-satisfies.ts
+++ b/tasks/coverage/misc/pass/ts-erasable-as-satisfies.ts
@@ -1,0 +1,54 @@
+// https://github.com/microsoft/TypeScript/issues/63527
+// Expressions of the form `a ## b as T $$ c` are only valid when `as`/`satisfies`
+// can be erased without changing the meaning, i.e. when `$$` does not bind tighter
+// than `##`. The cases below are all erasable and must keep parsing.
+
+const x01 = 1 as number * 2;
+const x02 = 1 as any as number * 2;
+const x05 = 1 as number + 1 * 2;
+const x06 = 1 as any as number + 1 * 2;
+
+const x07 = 1 * 1 as number + 2;
+const x08 = 1 * 1 as any as number + 2;
+const x09 = 1 as number * 1 + 2;
+const x10 = 1 as any as number * 1 + 2;
+
+const x11 = (1 + 1 as number) * 2;
+const x12 = (1 + 1 as any as number) * 2;
+const x13 = (1 as number + 1) * 2;
+const x14 = (1 as any as number + 1) * 2;
+
+const x15 = 1 + 1 as number === 2;
+const x16 = 1 + 1 as any as number === 2;
+const x17 = 1 + 1 as number > 2;
+const x18 = 1 + 1 as any as number > 2;
+const x19 = 1 + 1 as number >= 2;
+const x20 = 1 + 1 as any as number >= 2;
+
+const x21 = 1 + 1 as number >> 2;
+const x22 = 1 + 1 as any as number >> 2;
+
+const y01 = 1 satisfies number * 2;
+const y02 = 1 satisfies any satisfies number * 2;
+const y05 = 1 satisfies number + 1 * 2;
+const y06 = 1 satisfies any satisfies number + 1 * 2;
+
+const y07 = 1 * 1 satisfies number + 2;
+const y08 = 1 * 1 satisfies any satisfies number + 2;
+const y09 = 1 satisfies number * 1 + 2;
+const y10 = 1 satisfies any satisfies number * 1 + 2;
+
+const y11 = (1 + 1 satisfies number) * 2;
+const y12 = (1 + 1 satisfies any satisfies number) * 2;
+const y13 = (1 satisfies number + 1) * 2;
+const y14 = (1 satisfies any satisfies number + 1) * 2;
+
+const y15 = 1 + 1 satisfies number === 2;
+const y16 = 1 + 1 satisfies any satisfies number === 2;
+const y17 = 1 + 1 satisfies number > 2;
+const y18 = 1 + 1 satisfies any satisfies number > 2;
+const y19 = 1 + 1 satisfies number >= 2;
+const y20 = 1 + 1 satisfies any satisfies number >= 2;
+
+const y21 = 1 + 1 satisfies number >> 2;
+const y22 = 1 + 1 satisfies any satisfies number >> 2;

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 67/67 (100.00%)
-Positive Passed: 67/67 (100.00%)
+AST Parsed     : 68/68 (100.00%)
+Positive Passed: 68/68 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 67/67 (100.00%)
-Positive Passed: 67/67 (100.00%)
+AST Parsed     : 68/68 (100.00%)
+Positive Passed: 68/68 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
-AST Parsed     : 67/67 (100.00%)
-Positive Passed: 67/67 (100.00%)
-Negative Passed: 141/141 (100.00%)
+AST Parsed     : 68/68 (100.00%)
+Positive Passed: 68/68 (100.00%)
+Negative Passed: 144/144 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -3866,3 +3866,27 @@ Negative Passed: 141/141 (100.00%)
  3 │ }
    ╰────
   help: If this is intended to be the condition for the switch statement, add `case` before it.
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[misc/fail/ts-unerasable-as-chained.ts:4:33]
+ 3 │ // so the trailing `*` still makes the assertion impossible to erase. Syntax error.
+ 4 │ const x = 1 + 1 as any as number * 2;
+   ·                                 ▲
+   ╰────
+  help: Try inserting a semicolon here
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[misc/fail/ts-unerasable-as.ts:4:26]
+ 3 │ // trailing `*` binds tighter than the leading `+`. This is a syntax error.
+ 4 │ const x = 1 + 1 as number * 2;
+   ·                          ▲
+   ╰────
+  help: Try inserting a semicolon here
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[misc/fail/ts-unerasable-satisfies.ts:4:33]
+ 3 │ // is a syntax error.
+ 4 │ const x = 1 + 1 satisfies number * 2;
+   ·                                 ▲
+   ╰────
+  help: Try inserting a semicolon here

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 67/67 (100.00%)
-Positive Passed: 53/67 (79.10%)
+AST Parsed     : 68/68 (100.00%)
+Positive Passed: 54/68 (79.41%)
 semantic Error: tasks/coverage/misc/pass/conditional-arrow-alternate-return-type.ts
 Unresolved references mismatch:
 after transform: ["Pick", "Record"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 67/67 (100.00%)
-Positive Passed: 67/67 (100.00%)
+AST Parsed     : 68/68 (100.00%)
+Positive Passed: 68/68 (100.00%)


### PR DESCRIPTION
Port of [microsoft/typescript-go#4192](https://github.com/microsoft/typescript-go/pull/4192), which fixes [microsoft/TypeScript#63527](https://github.com/microsoft/TypeScript/issues/63527).

## Problem

`as`/`satisfies` are supposed to be erasable without changing runtime semantics. But for an expression of the form `a ## b as T $$ c`, where `##` has *lower* precedence than `$$`, erasing the assertion silently changes the parse:

```ts
const x = 1 + 1 as number * 2;
```

This parses as `((1 + 1) as number) * 2` (= `4`), but textually erasing `as number` yields `1 + 1 * 2` (= `3`). TypeScript now rejects such constructs as a syntax error, forcing explicit parentheses.

## Change

In `parse_binary_expression_rest`, after parsing an `as`/`satisfies` type, stop parsing if the following operator binds tighter than the operator that produced the running left-hand operand. This leaves the higher-precedence operator dangling and surfaces as a parse error.

A chained `a as T as U` keeps referring back to the original operator's precedence (the tracked precedence is intentionally not updated while consuming `as`/`satisfies`), so `1 + 1 as any as number * 2` is rejected too.

## Behavior

| Expression | Result |
| --- | --- |
| `1 as number * 2` | ok |
| `1 * 1 as number + 2` | ok (`+` does not bind tighter than `*`) |
| `1 + 1 as number * 2` | **error** |
| `1 + 1 as any as number * 2` | **error** |
| `1 >> 1 as number + 2` | **error** |
| `(1 + 1 as number) * 2` | ok |

`satisfies` behaves identically to `as`.

## Tests

Added `misc` coverage fixtures mirroring the upstream test matrix: `pass/ts-erasable-as-satisfies.ts` for the erasable cases and `fail/ts-unerasable-{as,as-chained,satisfies}.ts` for the rejected ones. Full conformance (test262 / babel / typescript) shows zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)