### PR TITLE
feat(linter/react-perf): support `nativeAllowList` config

### DIFF
--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -2,11 +2,20 @@ use oxc_ast::{AstKind, ast::Expression};
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
+use serde::Deserialize;
 
-use crate::utils::ReactPerfRule;
+use crate::utils::{NativeAllowList, ReactPerfConfig, ReactPerfRule};
 
-#[derive(Debug, Default, Clone)]
-pub struct JsxNoJsxAsProp;
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct JsxNoJsxAsProp(Box<ReactPerfConfig>);
+
+impl std::ops::Deref for JsxNoJsxAsProp {
+    type Target = ReactPerfConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -35,14 +44,32 @@ declare_oxc_lint!(
     /// ```jsx
     /// <Item callback={this.props.jsx} />
     /// ```
+    ///
+    /// ### Configuration
+    ///
+    /// This rule accepts a `nativeAllowList` option controlling whether native
+    /// elements (lowercase-first-letter tags) are ignored. Set it to `"all"` to
+    /// ignore the rule for all attributes on native elements, or to an array of
+    /// attribute names to ignore only those attributes on native elements.
+    ///
+    /// ```json
+    /// {
+    ///     "react-perf/jsx-no-jsx-as-prop": ["error", { "nativeAllowList": ["icon"] }]
+    /// }
+    /// ```
     JsxNoJsxAsProp,
     react_perf,
     perf,
+    config = ReactPerfConfig,
     version = "0.2.3",
 );
 
 impl ReactPerfRule for JsxNoJsxAsProp {
     const MESSAGE: &'static str = "JSX attribute values should not contain other JSX.";
+
+    fn native_allow_list(&self) -> &NativeAllowList {
+        self.0.native_allow_list()
+    }
 
     fn check_for_violation_on_expr(&self, expr: &Expression<'_>) -> Option<Span> {
         check_expression(expr)
@@ -74,24 +101,49 @@ fn check_expression(expr: &Expression) -> Option<Span> {
 
 #[test]
 fn test() {
+    use serde_json::json;
+
     use crate::tester::Tester;
 
     let pass = vec![
-        r"<Item callback={this.props.jsx} />",
-        r"const Foo = () => <Item callback={this.props.jsx} />",
-        r"<Item jsx={<SubItem />} />",
-        r"<Item jsx={this.props.jsx || <SubItem />} />",
-        r"<Item jsx={this.props.jsx ? this.props.jsx : <SubItem />} />",
-        r"<Item jsx={this.props.jsx || (this.props.component ? this.props.component : <SubItem />)} />",
-        r"const Icon = <svg />; const Foo = () => (<IconButton icon={Icon} />)",
+        (r"<Item callback={this.props.jsx} />", None),
+        (r"const Foo = () => <Item callback={this.props.jsx} />", None),
+        (r"<Item jsx={<SubItem />} />", None),
+        (r"<Item jsx={this.props.jsx || <SubItem />} />", None),
+        (r"<Item jsx={this.props.jsx ? this.props.jsx : <SubItem />} />", None),
+        (
+            r"<Item jsx={this.props.jsx || (this.props.component ? this.props.component : <SubItem />)} />",
+            None,
+        ),
+        (r"const Icon = <svg />; const Foo = () => (<IconButton icon={Icon} />)", None),
+        (
+            r"const Foo = () => <div jsx={<SubItem />} />",
+            Some(json!([{ "nativeAllowList": "all" }])),
+        ),
+        (
+            r"const Foo = () => <div jsx={<SubItem />} />",
+            Some(json!([{ "nativeAllowList": ["jsx"] }])),
+        ),
     ];
 
     let fail = vec![
-        r"const Foo = () => (<Item jsx={<SubItem />} />)",
-        r"const Foo = () => (<Item jsx={this.props.jsx || <SubItem />} />)",
-        r"const Foo = () => (<Item jsx={this.props.jsx ? this.props.jsx : <SubItem />} />)",
-        r"const Foo = () => (<Item jsx={this.props.jsx || (this.props.component ? this.props.component : <SubItem />)} />)",
-        r"const Foo = () => { const Icon = <svg />; return (<IconButton icon={Icon} />) }",
+        (r"const Foo = () => (<Item jsx={<SubItem />} />)", None),
+        (r"const Foo = () => (<Item jsx={this.props.jsx || <SubItem />} />)", None),
+        (r"const Foo = () => (<Item jsx={this.props.jsx ? this.props.jsx : <SubItem />} />)", None),
+        (
+            r"const Foo = () => (<Item jsx={this.props.jsx || (this.props.component ? this.props.component : <SubItem />)} />)",
+            None,
+        ),
+        (r"const Foo = () => { const Icon = <svg />; return (<IconButton icon={Icon} />) }", None),
+        (
+            r"const Foo = () => <div jsx={<SubItem />} />",
+            Some(json!([{ "nativeAllowList": ["icon"] }])),
+        ),
+        // components are never exempt, even with `"all"`
+        (
+            r"const Foo = () => <Item jsx={<SubItem />} />",
+            Some(json!([{ "nativeAllowList": "all" }])),
+        ),
     ];
 
     Tester::new(JsxNoJsxAsProp::NAME, JsxNoJsxAsProp::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -2,14 +2,26 @@ use oxc_ast::{AstKind, ast::Expression};
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
+use serde::Deserialize;
 
 use crate::{
     ast_util::is_method_call,
-    utils::{ReactPerfRule, find_initialized_binding, is_constructor_matching_name},
+    utils::{
+        NativeAllowList, ReactPerfConfig, ReactPerfRule, find_initialized_binding,
+        is_constructor_matching_name,
+    },
 };
 
-#[derive(Debug, Default, Clone)]
-pub struct JsxNoNewArrayAsProp;
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct JsxNoNewArrayAsProp(Box<ReactPerfConfig>);
+
+impl std::ops::Deref for JsxNoNewArrayAsProp {
+    type Target = ReactPerfConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -40,15 +52,33 @@ declare_oxc_lint!(
     /// ```jsx
     /// <Item list={this.props.list} />
     /// ```
+    ///
+    /// ### Configuration
+    ///
+    /// This rule accepts a `nativeAllowList` option controlling whether native
+    /// elements (lowercase-first-letter tags) are ignored. Set it to `"all"` to
+    /// ignore the rule for all attributes on native elements, or to an array of
+    /// attribute names to ignore only those attributes on native elements.
+    ///
+    /// ```json
+    /// {
+    ///     "react-perf/jsx-no-new-array-as-prop": ["error", { "nativeAllowList": ["style"] }]
+    /// }
+    /// ```
     JsxNoNewArrayAsProp,
     react_perf,
     perf,
+    config = ReactPerfConfig,
     version = "0.2.3",
 );
 
 impl ReactPerfRule for JsxNoNewArrayAsProp {
     const MESSAGE: &'static str =
         "JSX attribute values should not contain Arrays created in the same scope.";
+
+    fn native_allow_list(&self) -> &NativeAllowList {
+        self.0.native_allow_list()
+    }
 
     fn check_for_violation_on_expr(&self, expr: &Expression<'_>) -> Option<Span> {
         check_expression(expr)
@@ -113,33 +143,43 @@ fn check_expression(expr: &Expression) -> Option<Span> {
 
 #[test]
 fn test() {
+    use serde_json::json;
+
     use crate::tester::Tester;
 
     let pass = vec![
-        r"<Item list={this.props.list} />",
-        r"<Item list={[]} />",
-        r"<Item list={new Array()} />",
-        r"<Item list={Array()} />",
-        r"<Item list={this.props.list || []} />",
-        r"<Item list={this.props.list ? this.props.list : []} />",
-        r"<Item list={this.props.list || (this.props.arr ? this.props.arr : [])} />",
-        r"const Foo = () => <Item list={this.props.list} />",
-        r"const x = []; const Foo = () => <Item list={x} />",
-        r"const DEFAULT_X = []; const Foo = ({ x = DEFAULT_X }) => <Item list={x} />",
+        (r"<Item list={this.props.list} />", None),
+        (r"<Item list={[]} />", None),
+        (r"<Item list={new Array()} />", None),
+        (r"<Item list={Array()} />", None),
+        (r"<Item list={this.props.list || []} />", None),
+        (r"<Item list={this.props.list ? this.props.list : []} />", None),
+        (r"<Item list={this.props.list || (this.props.arr ? this.props.arr : [])} />", None),
+        (r"const Foo = () => <Item list={this.props.list} />", None),
+        (r"const x = []; const Foo = () => <Item list={x} />", None),
+        (r"const DEFAULT_X = []; const Foo = ({ x = DEFAULT_X }) => <Item list={x} />", None),
+        (r"const Foo = () => <div list={[]} />", Some(json!([{ "nativeAllowList": "all" }]))),
+        (r"const Foo = () => <div list={[]} />", Some(json!([{ "nativeAllowList": ["list"] }]))),
     ];
 
     let fail = vec![
-        r"const Foo = () => (<Item list={[]} />)",
-        r"const Foo = () => (<Item list={new Array()} />)",
-        r"const Foo = () => (<Item list={Array()} />)",
-        r"const Foo = () => (<Item list={arr1.concat(arr2)} />)",
-        r"const Foo = () => (<Item list={arr1.filter(x => x > 0)} />)",
-        r"const Foo = () => (<Item list={arr1.map(x => x * x)} />)",
-        r"const Foo = () => (<Item list={this.props.list || []} />)",
-        r"const Foo = () => (<Item list={this.props.list ? this.props.list : []} />)",
-        r"const Foo = () => (<Item list={this.props.list || (this.props.arr ? this.props.arr : [])} />)",
-        r"const Foo = () => { let x = []; return <Item list={x} /> }",
-        r"const Foo = ({ x = [] }) => <Item list={x} />",
+        (r"const Foo = () => (<Item list={[]} />)", None),
+        (r"const Foo = () => (<Item list={new Array()} />)", None),
+        (r"const Foo = () => (<Item list={Array()} />)", None),
+        (r"const Foo = () => (<Item list={arr1.concat(arr2)} />)", None),
+        (r"const Foo = () => (<Item list={arr1.filter(x => x > 0)} />)", None),
+        (r"const Foo = () => (<Item list={arr1.map(x => x * x)} />)", None),
+        (r"const Foo = () => (<Item list={this.props.list || []} />)", None),
+        (r"const Foo = () => (<Item list={this.props.list ? this.props.list : []} />)", None),
+        (
+            r"const Foo = () => (<Item list={this.props.list || (this.props.arr ? this.props.arr : [])} />)",
+            None,
+        ),
+        (r"const Foo = () => { let x = []; return <Item list={x} /> }", None),
+        (r"const Foo = ({ x = [] }) => <Item list={x} />", None),
+        (r"const Foo = () => <div list={[]} />", Some(json!([{ "nativeAllowList": ["style"] }]))),
+        // components are never exempt, even with `"all"`
+        (r"const Foo = () => <Item list={[]} />", Some(json!([{ "nativeAllowList": "all" }]))),
     ];
 
     Tester::new(JsxNoNewArrayAsProp::NAME, JsxNoNewArrayAsProp::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -5,11 +5,20 @@ use oxc_ast::{
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
+use serde::Deserialize;
 
-use crate::utils::{ReactPerfRule, is_constructor_matching_name};
+use crate::utils::{NativeAllowList, ReactPerfConfig, ReactPerfRule, is_constructor_matching_name};
 
-#[derive(Debug, Default, Clone)]
-pub struct JsxNoNewFunctionAsProp;
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct JsxNoNewFunctionAsProp(Box<ReactPerfConfig>);
+
+impl std::ops::Deref for JsxNoNewFunctionAsProp {
+    type Target = ReactPerfConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -37,15 +46,33 @@ declare_oxc_lint!(
     /// ```jsx
     /// <Item callback={this.props.callback} />
     /// ```
+    ///
+    /// ### Configuration
+    ///
+    /// This rule accepts a `nativeAllowList` option controlling whether native
+    /// elements (lowercase-first-letter tags) are ignored. Set it to `"all"` to
+    /// ignore the rule for all attributes on native elements, or to an array of
+    /// attribute names to ignore only those attributes on native elements.
+    ///
+    /// ```json
+    /// {
+    ///     "react-perf/jsx-no-new-function-as-prop": ["error", { "nativeAllowList": ["onClick"] }]
+    /// }
+    /// ```
     JsxNoNewFunctionAsProp,
     react_perf,
     perf,
+    config = ReactPerfConfig,
     version = "0.2.3",
 );
 
 impl ReactPerfRule for JsxNoNewFunctionAsProp {
     const MESSAGE: &'static str =
         "JSX attribute values should not contain functions created in the same scope.";
+
+    fn native_allow_list(&self) -> &NativeAllowList {
+        self.0.native_allow_list()
+    }
 
     fn check_for_violation_on_expr(&self, expr: &Expression<'_>) -> Option<Span> {
         check_expression(expr)
@@ -103,32 +130,47 @@ fn check_expression(expr: &Expression) -> Option<Span> {
 
 #[test]
 fn test() {
+    use serde_json::json;
+
     use crate::tester::Tester;
 
     let pass = vec![
-        r"const Foo = () => <Item callback={this.props.callback} />",
-        r"const Foo = () => (<Item promise={new Promise()} />)",
-        r"const Foo = () => (<Item onClick={bind(foo)} />)",
-        r"const Foo = () => (<Item prop={0} />)",
-        r"const Foo = () => { var a; return <Item prop={a} /> }",
-        r"const Foo = () => { var a;a = 1; return <Item prop={a} /> }",
-        r"const Foo = () => { var a;<Item prop={a} /> }",
-        r"function foo ({prop1 = function(){}, prop2}) {
+        (r"const Foo = () => <Item callback={this.props.callback} />", None),
+        (r"const Foo = () => (<Item promise={new Promise()} />)", None),
+        (r"const Foo = () => (<Item onClick={bind(foo)} />)", None),
+        (r"const Foo = () => (<Item prop={0} />)", None),
+        (r"const Foo = () => { var a; return <Item prop={a} /> }", None),
+        (r"const Foo = () => { var a;a = 1; return <Item prop={a} /> }", None),
+        (r"const Foo = () => { var a;<Item prop={a} /> }", None),
+        (
+            r"function foo ({prop1 = function(){}, prop2}) {
             return <Comp prop={prop2} />
           }",
-        r"function foo ({prop1, prop2 = function(){}}) {
+            None,
+        ),
+        (
+            r"function foo ({prop1, prop2 = function(){}}) {
             return <Comp prop={prop1} />
           }",
-        r"<Item prop={function(){return true}} />",
-        r"<Item prop={() => true} />",
-        r"<Item prop={new Function('a', 'alert(a)')}/>",
-        r"<Item prop={Function()}/>",
-        r"<Item onClick={this.clickHandler.bind(this)} />",
-        r"<Item callback={this.props.callback || function() {}} />",
-        r"<Item callback={this.props.callback ? this.props.callback : function() {}} />",
-        r"<Item prop={this.props.callback || this.props.callback ? this.props.callback : function(){}} />",
-        r"<Item prop={this.props.callback || (this.props.cb ? this.props.cb : function(){})} />",
-        r"
+            None,
+        ),
+        (r"<Item prop={function(){return true}} />", None),
+        (r"<Item prop={() => true} />", None),
+        (r"<Item prop={new Function('a', 'alert(a)')}/>", None),
+        (r"<Item prop={Function()}/>", None),
+        (r"<Item onClick={this.clickHandler.bind(this)} />", None),
+        (r"<Item callback={this.props.callback || function() {}} />", None),
+        (r"<Item callback={this.props.callback ? this.props.callback : function() {}} />", None),
+        (
+            r"<Item prop={this.props.callback || this.props.callback ? this.props.callback : function(){}} />",
+            None,
+        ),
+        (
+            r"<Item prop={this.props.callback || (this.props.cb ? this.props.cb : function(){})} />",
+            None,
+        ),
+        (
+            r"
         import { FC, useCallback } from 'react';
         export const Foo: FC = props => {
             const onClick = useCallback(
@@ -137,7 +179,10 @@ fn test() {
             );
             return <button onClick={onClick} />
         }",
-        r"
+            None,
+        ),
+        (
+            r"
         import React from 'react'
         function onClick(e: React.MouseEvent) {
             window.location.navigate(e.target.href)
@@ -146,24 +191,47 @@ fn test() {
             return <a onClick={onClick} />
         }
         ",
+            None,
+        ),
+        (
+            r"const Foo = () => <button onClick={() => true} />",
+            Some(json!([{ "nativeAllowList": "all" }])),
+        ),
+        (
+            r"const Foo = () => <button onClick={() => true} />",
+            Some(json!([{ "nativeAllowList": ["onClick"] }])),
+        ),
     ];
 
     let fail = vec![
-        r"const Foo = () => (<Item prop={function(){return true}} />)",
-        r"const Foo = () => (<Item prop={() => true} />)",
-        r"const Foo = () => (<Item prop={new Function('a', 'alert(a)')}/>)",
-        r"const Foo = () => (<Item prop={Function()}/>)",
-        r"const Foo = () => (<Item onClick={this.clickHandler.bind(this)} />)",
-        r"const Foo = () => (<Item callback={this.props.callback || function() {}} />)",
-        r"const Foo = () => (<Item callback={this.props.callback ? this.props.callback : function() {}} />)",
-        r"const Foo = () => (<Item prop={this.props.callback || this.props.callback ? this.props.callback : function(){}} />)",
-        r"const Foo = () => (<Item prop={this.props.callback || (this.props.cb ? this.props.cb : function(){})} />)",
-        r"
+        (r"const Foo = () => (<Item prop={function(){return true}} />)", None),
+        (r"const Foo = () => (<Item prop={() => true} />)", None),
+        (r"const Foo = () => (<Item prop={new Function('a', 'alert(a)')}/>)", None),
+        (r"const Foo = () => (<Item prop={Function()}/>)", None),
+        (r"const Foo = () => (<Item onClick={this.clickHandler.bind(this)} />)", None),
+        (r"const Foo = () => (<Item callback={this.props.callback || function() {}} />)", None),
+        (
+            r"const Foo = () => (<Item callback={this.props.callback ? this.props.callback : function() {}} />)",
+            None,
+        ),
+        (
+            r"const Foo = () => (<Item prop={this.props.callback || this.props.callback ? this.props.callback : function(){}} />)",
+            None,
+        ),
+        (
+            r"const Foo = () => (<Item prop={this.props.callback || (this.props.cb ? this.props.cb : function(){})} />)",
+            None,
+        ),
+        (
+            r"
         const Foo = ({ onClick }) => {
             const _onClick = onClick.bind(this)
             return <button onClick={_onClick} />
         }",
-        r"
+            None,
+        ),
+        (
+            r"
         const Foo = () => {
             function onClick(e) {
                 window.location.navigate(e.target.href)
@@ -171,7 +239,10 @@ fn test() {
             return <a onClick={onClick} />
         }
         ",
-        r"
+            None,
+        ),
+        (
+            r"
         const Foo = () => {
             const onClick = (e) => {
                 window.location.navigate(e.target.href)
@@ -179,7 +250,10 @@ fn test() {
             return <a onClick={onClick} />
         }
         ",
-        r"
+            None,
+        ),
+        (
+            r"
         const Foo = () => {
             const onClick = function (e) {
                 window.location.navigate(e.target.href)
@@ -187,6 +261,17 @@ fn test() {
             return <a onClick={onClick} />
         }
         ",
+            None,
+        ),
+        (
+            r"const Foo = () => <button onClick={() => true} />",
+            Some(json!([{ "nativeAllowList": ["onChange"] }])),
+        ),
+        // components are never exempt, even with `"all"`
+        (
+            r"const Foo = () => <Item onClick={() => true} />",
+            Some(json!([{ "nativeAllowList": "all" }])),
+        ),
     ];
 
     Tester::new(JsxNoNewFunctionAsProp::NAME, JsxNoNewFunctionAsProp::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -2,14 +2,26 @@ use oxc_ast::{AstKind, ast::Expression};
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
+use serde::Deserialize;
 
 use crate::{
     ast_util::is_method_call,
-    utils::{ReactPerfRule, find_initialized_binding, is_constructor_matching_name},
+    utils::{
+        NativeAllowList, ReactPerfConfig, ReactPerfRule, find_initialized_binding,
+        is_constructor_matching_name,
+    },
 };
 
-#[derive(Debug, Default, Clone)]
-pub struct JsxNoNewObjectAsProp;
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct JsxNoNewObjectAsProp(Box<ReactPerfConfig>);
+
+impl std::ops::Deref for JsxNoNewObjectAsProp {
+    type Target = ReactPerfConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 declare_oxc_lint!(
     /// ### What it does
@@ -41,15 +53,33 @@ declare_oxc_lint!(
     /// ```jsx
     /// <Item config={staticConfig} />
     /// ```
+    ///
+    /// ### Configuration
+    ///
+    /// This rule accepts a `nativeAllowList` option controlling whether native
+    /// elements (lowercase-first-letter tags) are ignored. Set it to `"all"` to
+    /// ignore the rule for all attributes on native elements, or to an array of
+    /// attribute names to ignore only those attributes on native elements.
+    ///
+    /// ```json
+    /// {
+    ///     "react-perf/jsx-no-new-object-as-prop": ["error", { "nativeAllowList": ["style"] }]
+    /// }
+    /// ```
     JsxNoNewObjectAsProp,
     react_perf,
     perf,
+    config = ReactPerfConfig,
     version = "0.2.3",
 );
 
 impl ReactPerfRule for JsxNoNewObjectAsProp {
     const MESSAGE: &'static str =
         "JSX attribute values should not contain objects created in the same scope.";
+
+    fn native_allow_list(&self) -> &NativeAllowList {
+        self.0.native_allow_list()
+    }
 
     fn check_for_violation_on_expr(&self, expr: &Expression<'_>) -> Option<Span> {
         check_expression(expr)
@@ -114,19 +144,22 @@ fn check_expression(expr: &Expression) -> Option<Span> {
 
 #[test]
 fn test() {
+    use serde_json::json;
+
     use crate::tester::Tester;
 
     let pass = vec![
-        r"<Item config={staticConfig} />",
-        r"<Item config={{}} />",
-        r"<Item config={'foo'} />",
-        r"const Foo = () => <Item config={staticConfig} />",
-        r"const Foo = (props) => <Item {...props} />",
-        r"const Foo = (props) => <Item x={props.x} />",
-        r"const Foo = ({ x = 5 }) => <Item x={x} />",
-        r"const x = {}; const Foo = () => <Bar x={x} />",
-        r"const DEFAULT_X = {}; const Foo = ({ x = DEFAULT_X }) => <Bar x={x} />",
-        r"
+        (r"<Item config={staticConfig} />", None),
+        (r"<Item config={{}} />", None),
+        (r"<Item config={'foo'} />", None),
+        (r"const Foo = () => <Item config={staticConfig} />", None),
+        (r"const Foo = (props) => <Item {...props} />", None),
+        (r"const Foo = (props) => <Item x={props.x} />", None),
+        (r"const Foo = ({ x = 5 }) => <Item x={x} />", None),
+        (r"const x = {}; const Foo = () => <Bar x={x} />", None),
+        (r"const DEFAULT_X = {}; const Foo = ({ x = DEFAULT_X }) => <Bar x={x} />", None),
+        (
+            r"
         import { FC, useMemo } from 'react';
         import { Bar } from './bar';
         export const Foo: FC = () => {
@@ -134,7 +167,10 @@ fn test() {
             return <Bar prop={x} />
         }
         ",
-        r"
+            None,
+        ),
+        (
+            r"
         import { FC, useMemo } from 'react';
         import { Bar } from './bar';
         export const Foo: FC = () => {
@@ -143,26 +179,36 @@ fn test() {
             return <Bar prop={y} />
         }
         ",
+            None,
+        ),
         // new arr, not an obj
-        r"const Foo = () => <Item arr={[]} />",
+        (r"const Foo = () => <Item arr={[]} />", None),
+        (r"const Foo = () => <div style={{}} />", Some(json!([{ "nativeAllowList": "all" }]))),
+        (r"const Foo = () => <div style={{}} />", Some(json!([{ "nativeAllowList": ["style"] }]))),
     ];
 
     let fail = vec![
-        r"const Foo = () => <Item config={{}} />",
-        r"const Foo = () => <Item config={Object.create(null)} />",
-        r"const Foo = ({ x }) => <Item config={Object.assign({}, x)} />",
-        r"const Foo = () => (<Item config={new Object()} />)",
-        r"const Foo = () => (<Item config={Object()} />)",
-        r"const Foo = () => (<div style={{display: 'none'}} />)",
-        r"const Foo = () => (<Item config={this.props.config || {}} />)",
-        r"const Foo = () => (<Item config={this.props.config ? this.props.config : {}} />)",
-        r"const Foo = () => (<Item config={this.props.config || (this.props.default ? this.props.default : {})} />)",
-        r"const Foo = () => { const x = {}; return <Bar x={x} /> }",
-        r"const Foo = ({ x = {} }) => <Item x={x} />",
-        r"const Foo = () => { const x: Foo = {}; return <Bar x={x} /> }",
-        r"const Foo = () => { const x: Foo = {} as Foo; return <Bar x={x} /> }",
-        r"const Foo = () => { const x: Foo = {} satisfies Foo; return <Bar x={x} /> }",
-        r"const Foo = () => { const x: Foo = {} as const; return <Bar x={x} /> }",
+        (r"const Foo = () => <Item config={{}} />", None),
+        (r"const Foo = () => <Item config={Object.create(null)} />", None),
+        (r"const Foo = ({ x }) => <Item config={Object.assign({}, x)} />", None),
+        (r"const Foo = () => (<Item config={new Object()} />)", None),
+        (r"const Foo = () => (<Item config={Object()} />)", None),
+        (r"const Foo = () => (<div style={{display: 'none'}} />)", None),
+        (r"const Foo = () => (<Item config={this.props.config || {}} />)", None),
+        (r"const Foo = () => (<Item config={this.props.config ? this.props.config : {}} />)", None),
+        (
+            r"const Foo = () => (<Item config={this.props.config || (this.props.default ? this.props.default : {})} />)",
+            None,
+        ),
+        (r"const Foo = () => { const x = {}; return <Bar x={x} /> }", None),
+        (r"const Foo = ({ x = {} }) => <Item x={x} />", None),
+        (r"const Foo = () => { const x: Foo = {}; return <Bar x={x} /> }", None),
+        (r"const Foo = () => { const x: Foo = {} as Foo; return <Bar x={x} /> }", None),
+        (r"const Foo = () => { const x: Foo = {} satisfies Foo; return <Bar x={x} /> }", None),
+        (r"const Foo = () => { const x: Foo = {} as const; return <Bar x={x} /> }", None),
+        (r"const Foo = () => <div config={{}} />", Some(json!([{ "nativeAllowList": ["style"] }]))),
+        // components are never exempt, even with `"all"`
+        (r"const Foo = () => <Item style={{}} />", Some(json!([{ "nativeAllowList": "all" }]))),
     ];
 
     Tester::new(JsxNoNewObjectAsProp::NAME, JsxNoNewObjectAsProp::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/react_perf_jsx_no_jsx_as_prop.snap
+++ b/crates/oxc_linter/src/snapshots/react_perf_jsx_no_jsx_as_prop.snap
@@ -39,3 +39,17 @@ source: crates/oxc_linter/src/tester.rs
    ·                             ╰── The prop was declared here
    ╰────
   help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ react-perf(jsx-no-jsx-as-prop): JSX attribute values should not contain other JSX.
+   ╭─[jsx_no_jsx_as_prop.tsx:1:29]
+ 1 │ const Foo = () => <div jsx={<SubItem />} />
+   ·                             ───────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ react-perf(jsx-no-jsx-as-prop): JSX attribute values should not contain other JSX.
+   ╭─[jsx_no_jsx_as_prop.tsx:1:30]
+ 1 │ const Foo = () => <Item jsx={<SubItem />} />
+   ·                              ───────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).

--- a/crates/oxc_linter/src/snapshots/react_perf_jsx_no_new_array_as_prop.snap
+++ b/crates/oxc_linter/src/snapshots/react_perf_jsx_no_new_array_as_prop.snap
@@ -84,3 +84,17 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── The prop was declared here
    ╰────
   help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ react-perf(jsx-no-new-array-as-prop): JSX attribute values should not contain Arrays created in the same scope.
+   ╭─[jsx_no_new_array_as_prop.tsx:1:30]
+ 1 │ const Foo = () => <div list={[]} />
+   ·                              ──
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ react-perf(jsx-no-new-array-as-prop): JSX attribute values should not contain Arrays created in the same scope.
+   ╭─[jsx_no_new_array_as_prop.tsx:1:31]
+ 1 │ const Foo = () => <Item list={[]} />
+   ·                               ──
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).

--- a/crates/oxc_linter/src/snapshots/react_perf_jsx_no_new_function_as_prop.snap
+++ b/crates/oxc_linter/src/snapshots/react_perf_jsx_no_new_function_as_prop.snap
@@ -122,3 +122,17 @@ source: crates/oxc_linter/src/tester.rs
  7 │         }
    ╰────
   help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:36]
+ 1 │ const Foo = () => <button onClick={() => true} />
+   ·                                    ──────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ react-perf(jsx-no-new-function-as-prop): JSX attribute values should not contain functions created in the same scope.
+   ╭─[jsx_no_new_function_as_prop.tsx:1:34]
+ 1 │ const Foo = () => <Item onClick={() => true} />
+   ·                                  ──────────
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).

--- a/crates/oxc_linter/src/snapshots/react_perf_jsx_no_new_object_as_prop.snap
+++ b/crates/oxc_linter/src/snapshots/react_perf_jsx_no_new_object_as_prop.snap
@@ -124,3 +124,17 @@ source: crates/oxc_linter/src/tester.rs
    ·                           ╰── The prop was declared here
    ╰────
   help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.
+   ╭─[jsx_no_new_object_as_prop.tsx:1:32]
+ 1 │ const Foo = () => <div config={{}} />
+   ·                                ──
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).
+
+  ⚠ react-perf(jsx-no-new-object-as-prop): JSX attribute values should not contain objects created in the same scope.
+   ╭─[jsx_no_new_object_as_prop.tsx:1:32]
+ 1 │ const Foo = () => <Item style={{}} />
+   ·                                ──
+   ╰────
+  help: simplify props or memoize props in the parent component (https://react.dev/reference/react/memo#my-component-rerenders-when-a-prop-is-an-object-or-array).

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -7,8 +7,58 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
+use oxc_str::CompactStr;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
-use crate::{AstNode, LintContext, context::ContextHost, rule::Rule};
+use crate::{
+    AstNode, LintContext,
+    context::ContextHost,
+    rule::{DefaultRuleConfig, Rule},
+    utils::is_react_component_name,
+};
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct ReactPerfConfig {
+    /// Controls whether native elements (lowercase-first-letter tags such as `div`)
+    /// are ignored by the rule. Either `"all"` to ignore the rule entirely on native
+    /// elements, or an array of attribute names to ignore on native elements.
+    native_allow_list: NativeAllowList,
+}
+
+impl ReactPerfConfig {
+    pub fn native_allow_list(&self) -> &NativeAllowList {
+        &self.native_allow_list
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum NativeAllowList {
+    All(AllKeyword),
+    List(Vec<CompactStr>),
+    #[default]
+    #[serde(skip)]
+    None,
+}
+
+#[derive(Debug, Clone, Copy, JsonSchema)]
+pub struct AllKeyword;
+
+impl<'de> Deserialize<'de> for AllKeyword {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        if value == "all" {
+            Ok(AllKeyword)
+        } else {
+            Err(serde::de::Error::custom(r#"expected the string "all""#))
+        }
+    }
+}
 
 fn react_perf_inline_diagnostic(message: &'static str, attr_span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(message)
@@ -37,6 +87,9 @@ fn react_perf_reference_diagnostic(
 pub trait ReactPerfRule: Sized + Default + fmt::Debug {
     const MESSAGE: &'static str;
 
+    /// The `nativeAllowList` configuration for this rule.
+    fn native_allow_list(&self) -> &NativeAllowList;
+
     /// Check if an [`Expression`] violates a react perf rule. If it does,
     /// report the [`OxcDiagnostic`] and return `true`.
     ///
@@ -55,8 +108,12 @@ pub trait ReactPerfRule: Sized + Default + fmt::Debug {
 
 impl<R> Rule for R
 where
-    R: ReactPerfRule,
+    R: ReactPerfRule + serde::de::DeserializeOwned,
 {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         // new objects/arrays/etc created at the root scope do not get
         // re-created on each render and thus do not affect performance.
@@ -75,6 +132,26 @@ where
         let Some(expr) = container.expression.as_expression() else {
             return;
         };
+
+        // skip native elements (lowercase-first-letter tags like `div`) that are
+        // exempted by the `nativeAllowList` configuration.
+        if !matches!(self.native_allow_list(), NativeAllowList::None)
+            && let AstKind::JSXOpeningElement(opening) = ctx.nodes().parent_kind(node.id())
+            && let Some(tag_name) = opening.name.get_identifier_name()
+            && !is_react_component_name(&tag_name)
+        {
+            match self.native_allow_list() {
+                NativeAllowList::All(_) => return,
+                NativeAllowList::List(names) => {
+                    if let Some(attr_name) = attr.name.as_identifier()
+                        && names.iter().any(|n| n.as_str().eq_ignore_ascii_case(&attr_name.name))
+                    {
+                        return;
+                    }
+                }
+                NativeAllowList::None => {}
+            }
+        }
 
         // strip parenthesis and TS type casting expressions
         let expr = expr.get_inner_expression();


### PR DESCRIPTION
## Summary

Adds nativeAllowList configuration support to the four react_perf rules, matching eslint-plugin-react-perf v3.3.0+ behavior. This allows users to disable this rule specifically for native elements (see below)

> With this configuration, all native elements are ignored for this rule:
> ```json
> {
>   "react-perf/jsx-no-new-object-as-prop": [
>     "error",
>     {
>       "nativeAllowList": "all"
>     }
>   ]
> }
> ```
> With this configuration, the "style" attribute is ignored for native elements for this rule:
> ```json
> {
>   "react-perf/jsx-no-new-object-as-prop": [
>     "error",
>     {
>       "nativeAllowList": ["style"]
>     }
>   ]
> }
> ```
>
> from https://github.com/cvazac/eslint-plugin-react-perf/tree/master#configuration

It's worth noting that native elements are defined as "lower case first letter React components" for this rule in the eslint variant. This approach is maintained.

The bulk of changes are in `crates/oxc_linter/src/utils/react_perf.rs`, which adds support for and handling of the `nativeAllowList` configuration. 

This PR was generated with AI assistance & manually reviewed/validated for correctness and quality.

## Verification

- updated & added new tests for relevant rules