### PR TITLE
fix(codegen): give `TSTypeAssertion` unary precedence

### DIFF
--- a/crates/oxc_ast/src/precedence.rs
+++ b/crates/oxc_ast/src/precedence.rs
@@ -133,6 +133,7 @@ impl GetPrecedence for PrivateFieldExpression<'_> {
 
 impl GetPrecedence for TSTypeAssertion<'_> {
     fn precedence(&self) -> Precedence {
-        Precedence::Lowest
+        // `<T>x` is a unary expression, so it binds like one (e.g. `(<T>x).foo`).
+        Precedence::Prefix
     }
 }

--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -206,6 +206,7 @@ impl<'a> BinaryExpressionVisitor<'a> {
                     e.left(),
                     Expression::UnaryExpression(_)
                         | Expression::AwaitExpression(_)
+                        | Expression::TSTypeAssertion(_)
                         | Expression::NumericLiteral(_)
                 ) {
                     self.left_precedence = Precedence::Call;

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2381,6 +2381,11 @@ impl GenExpr for TSInstantiationExpression<'_> {
 impl GenExpr for TSTypeAssertion<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         p.wrap(precedence >= self.precedence(), |p| {
+            // Avoid merging into `<<` when this assertion follows a `<` operator,
+            // e.g. minified `a < <T>x` must not become `a<<T>x` (a shift token).
+            if p.last_byte() == Some(b'<') {
+                p.print_hard_space();
+            }
             p.print_ascii_byte(b'<');
             // var r = < <T>(x: T) => T > ((x) => { return null; });
             //          ^ make sure space is printed here.

--- a/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
@@ -461,12 +461,12 @@ const Foo = /* @__PURE__ */ (() => {})()<X>;
 ########## 29
 const Foo = /* @__PURE__ */ <Foo>(() => {})()!
 ----------
-const Foo = (<Foo>(/* @__PURE__ */ (() => {})())!);
+const Foo = <Foo>(/* @__PURE__ */ (() => {})())!;
 
 ########## 30
 const Foo = /* @__PURE__ */ <Foo>(() => {})()! as X satisfies Y
 ----------
-const Foo = ((<Foo>(/* @__PURE__ */ (() => {})())!) as X) satisfies Y;
+const Foo = (<Foo>(/* @__PURE__ */ (() => {})())! as X) satisfies Y;
 
 ########## 31
 /* @__NO_SIDE_EFFECTS__ */ ((options, extraOptions) => {

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -1,9 +1,13 @@
 use oxc_codegen::CodegenOptions;
 use oxc_parser::ParseOptions;
+use oxc_span::SourceType;
 
 use crate::{
     snapshot, snapshot_options,
-    tester::{test_idempotency, test_same, test_tsx, test_with_parse_options},
+    tester::{
+        default_options, test_idempotency, test_options_with_source_type, test_same, test_tsx,
+        test_with_parse_options,
+    },
 };
 
 #[test]
@@ -182,6 +186,30 @@ fn ts_as_expression_in_binary_expr() {
     test_idempotency("'foo' in ((x as object) as Record<string, unknown>)");
     test_idempotency(
         "!(typeof that === 'object' && 'keys' in that && typeof (that as object & { keys: unknown }).keys === 'function')",
+    );
+}
+
+#[test]
+fn ts_type_assertion() {
+    // `<T>x` (TS angle-bracket assertion) is only valid in non-tsx source.
+    let test_ts =
+        |src: &str| test_options_with_source_type(src, src, SourceType::ts(), default_options());
+    // `<T>x` is a unary expression; it should not be over-parenthesized.
+    test_ts("y = <T>x;\n");
+    test_ts("z = <T>x + 1;\n");
+    test_ts("foo(<T>x);\n");
+    test_ts("c = -<T>x;\n");
+    // Parentheses are required where a unary expression would re-associate.
+    test_ts("m = (<T>x).foo;\n");
+    test_ts("o = (<T>x)();\n");
+    // The base of `**` must be an UpdateExpression, so a type assertion is wrapped.
+    test_ts("n = (<T>x) ** 2;\n");
+    // Minified `a < <T>x` must keep a space so `<` + `<` isn't tokenized as `<<`.
+    test_options_with_source_type(
+        "a < <T>x;",
+        "a< <T>x;",
+        SourceType::ts(),
+        CodegenOptions::minify(),
     );
 }
 


### PR DESCRIPTION
## What

A TS angle-bracket assertion `<T>x` is a unary expression (ECMA/TS grammar: `< Type > UnaryExpression`), but `TSTypeAssertion::precedence()` returned `Precedence::Lowest`. The wrap condition `precedence >= self.precedence()` is therefore always true, so the assertion was parenthesized in **every** position.

It now reports `Precedence::Prefix` like other unary expressions, and joins the `**`-base special case (a unary expression can't be a `**` base, so it must stay wrapped there).

## Examples

| Input | Before | After |
| --- | --- | --- |
| `y = <T>x` | `y = (<T>x)` | `y = <T>x` |
| `foo(<T>x)` | `foo((<T>x))` | `foo(<T>x)` |
| `z = <T>x + 1` | `z = (<T>x) + 1` | `z = <T>x + 1` |
| `c = -<T>x` | `c = -(<T>x)` | `c = -<T>x` |

Positions that genuinely require parentheses still keep them, because they print the assertion at a higher precedence than `Prefix`:

| Input | Output |
| --- | --- |
| `(<T>x).foo` | `(<T>x).foo` |
| `(<T>x)()` | `(<T>x)()` |
| `(<T>x) ** 2` | `(<T>x) ** 2` |