### PR TITLE
fix(codegen): don't over-parenthesize `TSTypeAssertion` operand

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2394,7 +2394,9 @@ impl GenExpr for TSTypeAssertion<'_> {
             }
             self.type_annotation.print(p, ctx);
             p.print_ascii_byte(b'>');
-            self.expression.print_expr(p, Precedence::Member, ctx);
+            // The operand is a `UnaryExpression`, so print it like a unary argument
+            // (`<T>-x`, not `<T>(-x)`) while still wrapping looser operands.
+            self.expression.print_expr(p, Precedence::Exponentiation, ctx);
         });
     }
 }

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -211,6 +211,15 @@ fn ts_type_assertion() {
         SourceType::ts(),
         CodegenOptions::minify(),
     );
+    // The assertion operand is a UnaryExpression and must not be over-parenthesized.
+    test_ts("a = <T>-x;\n");
+    test_ts("b = <T>typeof x;\n");
+    test_ts("c = <T><U>x;\n");
+    test_ts("d = <T>x();\n");
+    // Looser operands still need parentheses.
+    test_ts("e = <T>(b + c);\n");
+    test_ts("f = <T>(d ** e);\n");
+    test_ts("g = <T>(h ? i : j);\n");
 }
 
 #[test]


### PR DESCRIPTION
## What

The operand of an angle-bracket assertion `<T>x` is a `UnaryExpression` (TS grammar: `< Type > UnaryExpression`), but codegen printed it at `Precedence::Member`. That wrapped **every** unary operand in redundant parentheses.

It now prints the operand at `Precedence::Exponentiation` — exactly what `UnaryExpression::gen_expr` uses for its own argument — so a `UnaryExpression` operand stays bare while looser operands (binary, conditional, `**`) are still wrapped.

## Examples

| Input | Before | After |
| --- | --- | --- |
| `<T>-x` | `<T>(-x)` | `<T>-x` |
| `<T>typeof x` | `<T>(typeof x)` | `<T>typeof x` |
| `<T><U>x` | `<T>(<U>x)` | `<T><U>x` |
| `<T>x()` | `<T>(x())` | `<T>x()` |

Operands that genuinely require parentheses keep them:

| Input | Output |
| --- | --- |
| `<T>(b + c)` | `<T>(b + c)` |
| `<T>(d ** e)` | `<T>(d ** e)` |
| `<T>(h ? i : j)` | `<T>(h ? i : j)` |

Follow-up to #23002.