### PR TITLE
refactor(semantic): don't build the AstNodes store by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_cfg",
+ "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -102,6 +102,16 @@ pub trait CompilerInterface {
         true
     }
 
+    /// Whether to build the full `AstNodes` store during semantic analysis.
+    ///
+    /// Off by default (the compiler pipeline only needs scoping). Override to
+    /// `true` if [`Self::after_semantic`] reads [`Semantic::nodes`].
+    ///
+    /// [`Semantic::nodes`]: oxc_semantic::Semantic::nodes
+    fn build_semantic_nodes(&self) -> bool {
+        false
+    }
+
     fn after_parse(&mut self, _parser_return: &mut ParserReturn) -> ControlFlow<()> {
         ControlFlow::Continue(())
     }
@@ -257,7 +267,10 @@ pub trait CompilerInterface {
             builder = builder.with_excess_capacity(2.0).with_enum_eval(true);
         }
 
-        builder.with_check_syntax_error(self.check_semantic_error()).build(program)
+        builder
+            .with_check_syntax_error(self.check_semantic_error())
+            .with_build_nodes(self.build_semantic_nodes())
+            .build(program)
     }
 
     fn isolated_declaration<'a>(

--- a/crates/oxc_formatter/src/detect_code_removal/mod.rs
+++ b/crates/oxc_formatter/src/detect_code_removal/mod.rs
@@ -35,7 +35,7 @@ fn collect(code: &str, source_type: SourceType) -> StatsCollector {
     }
 
     // Using semantic analysis here only to get parent node
-    let semantic_ret = SemanticBuilder::new().build(&program);
+    let semantic_ret = SemanticBuilder::new().with_build_nodes(true).build(&program);
     collector.collect(&program, &semantic_ret.semantic)
 }
 

--- a/crates/oxc_mangler/src/keep_names.rs
+++ b/crates/oxc_mangler/src/keep_names.rs
@@ -258,7 +258,7 @@ mod test {
         let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
         assert!(!ret.panicked, "{source_text}");
         assert!(ret.errors.is_empty(), "{source_text}");
-        let ret = SemanticBuilder::new().build(&ret.program);
+        let ret = SemanticBuilder::new().with_build_nodes(true).build(&ret.program);
         assert!(ret.errors.is_empty(), "{source_text}");
         let semantic = ret.semantic;
         let symbols = collect_name_symbols(opts, &allocator, semantic.scoping(), semantic.nodes());

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -281,7 +281,11 @@ impl<'t> Mangler<'t> {
     /// Pass the symbol table to oxc_codegen to generate the mangled code.
     #[must_use]
     pub fn build(self, program: &Program<'_>) -> ManglerReturn {
-        let mut semantic = SemanticBuilder::new().with_class_table(true).build(program).semantic;
+        let mut semantic = SemanticBuilder::new()
+            .with_build_nodes(true)
+            .with_class_table(true)
+            .build(program)
+            .semantic;
         let class_private_mappings = self.build_with_semantic(&mut semantic, program);
         ManglerReturn { scoping: semantic.into_scoping(), class_private_mappings }
     }

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -143,6 +143,7 @@ impl<'a> Minifier {
             .mangle
             .map(|options| {
                 let mut semantic = SemanticBuilder::new()
+                    .with_build_nodes(true)
                     .with_stats(stats)
                     .with_class_table(true)
                     .build(program)

--- a/crates/oxc_react_compiler/examples/react_compiler.rs
+++ b/crates/oxc_react_compiler/examples/react_compiler.rs
@@ -38,7 +38,8 @@ fn main() {
 
     let allocator = Allocator::default();
     let program = Parser::new(&allocator, &source_text, source_type).parse().program;
-    let semantic = SemanticBuilder::new().build(&program).semantic;
+    let semantic =
+        SemanticBuilder::new().with_build_nodes(true).with_enum_eval(true).build(&program).semantic;
 
     let result = transform(&program, &semantic, &allocator, default_plugin_options());
 

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -156,8 +156,11 @@ pub fn transform_source<'a>(
 ) -> TransformResult<'a> {
     let parsed = oxc_parser::Parser::new(allocator, source_text, source_type).parse();
 
-    let semantic =
-        oxc_semantic::SemanticBuilder::new().with_enum_eval(true).build(&parsed.program).semantic;
+    let semantic = oxc_semantic::SemanticBuilder::new()
+        .with_build_nodes(true)
+        .with_enum_eval(true)
+        .build(&parsed.program)
+        .semantic;
 
     transform(&parsed.program, &semantic, allocator, options)
 }
@@ -186,8 +189,11 @@ pub fn lint_source(
     let allocator = oxc_allocator::Allocator::default();
     let parsed = oxc_parser::Parser::new(&allocator, source_text, source_type).parse();
 
-    let semantic =
-        oxc_semantic::SemanticBuilder::new().with_enum_eval(true).build(&parsed.program).semantic;
+    let semantic = oxc_semantic::SemanticBuilder::new()
+        .with_build_nodes(true)
+        .with_enum_eval(true)
+        .build(&parsed.program)
+        .semantic;
 
     lint(&parsed.program, &semantic, options)
 }
@@ -205,8 +211,11 @@ pub fn run<'a>(
     // `compiled` lives in `allocator`, not borrowed from `*program`, so the
     // reassignment below is sound.
     let result = {
-        let semantic =
-            oxc_semantic::SemanticBuilder::new().with_enum_eval(true).build(program).semantic;
+        let semantic = oxc_semantic::SemanticBuilder::new()
+            .with_build_nodes(true)
+            .with_enum_eval(true)
+            .build(program)
+            .semantic;
         transform(program, &semantic, allocator, options.clone())
     };
     errors.extend(result.diagnostics);

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -24,6 +24,7 @@ oxc_allocator = { workspace = true, features = ["bitset"] }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_cfg = { workspace = true, optional = true }
+oxc_data_structures = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -75,7 +75,8 @@ fn main() -> std::io::Result<()> {
     std::fs::write(ast_file_path, format!("{:#?}", &program))?;
     println!("Wrote AST to: {}", &ast_file_name);
 
-    let semantic = SemanticBuilder::new_compiler().with_cfg(true).build(&program);
+    let semantic =
+        SemanticBuilder::new_compiler().with_build_nodes(true).with_cfg(true).build(&program);
 
     if !semantic.errors.is_empty() {
         let error_message: String = semantic

--- a/crates/oxc_semantic/examples/semantic.rs
+++ b/crates/oxc_semantic/examples/semantic.rs
@@ -56,8 +56,9 @@ fn main() -> std::io::Result<()> {
 
     let program = parser_ret.program;
 
-    // Build semantic model with the compiler-pipeline defaults (syntax error checking).
-    let semantic = SemanticBuilder::new_compiler().build(&program);
+    // Compiler-pipeline defaults, plus the full `AstNodes` store since this
+    // example reads `semantic.nodes()`.
+    let semantic = SemanticBuilder::new_compiler().with_build_nodes(true).build(&program);
 
     // Report semantic analysis errors
     if !semantic.errors.is_empty() {

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -17,9 +17,10 @@ pub trait Binder<'a> {
 
 impl<'a> Binder<'a> for VariableDeclarator<'a> {
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
-        let is_declare = matches!(builder
-            .nodes
-            .parent_kind(builder.current_node_id), AstKind::VariableDeclaration(decl) if decl.declare);
+        let is_declare = matches!(
+            builder.ancestry().parent_kind(),
+            AstKind::VariableDeclaration(decl) if decl.declare
+        );
 
         let (mut includes, excludes) = match self.kind {
             VariableDeclarationKind::Const
@@ -209,10 +210,7 @@ impl<'a> Binder<'a> for Function<'a> {
         }
 
         // Bind scope flags: GetAccessor | SetAccessor
-        if !is_declaration
-            && let AstKind::ObjectProperty(prop) =
-                builder.nodes.parent_kind(builder.current_node_id)
-        {
+        if !is_declaration && let AstKind::ObjectProperty(prop) = builder.ancestry().parent_kind() {
             // Do not bind scope flags when function is inside of the object property key:
             //
             // { set [function() {}](val) {} }
@@ -233,7 +231,7 @@ impl<'a> Binder<'a> for Function<'a> {
 impl<'a> Binder<'a> for BindingRestElement<'a> {
     // Binds the FormalParameters's rest of a function or method.
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
-        let parent_kind = builder.nodes.parent_kind(builder.current_node_id);
+        let parent_kind = builder.ancestry().parent_kind();
         let AstKind::FormalParameters(_) = parent_kind else {
             return;
         };
@@ -251,7 +249,7 @@ impl<'a> Binder<'a> for BindingRestElement<'a> {
 impl<'a> Binder<'a> for FormalParameter<'a> {
     // Binds the FormalParameter of a function or method.
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
-        let parent_kind = builder.nodes.parent_kind(builder.current_node_id);
+        let parent_kind = builder.ancestry().parent_kind();
         let AstKind::FormalParameters(parameters) = parent_kind else { unreachable!() };
 
         let includes = SymbolFlags::FunctionScopedVariable;
@@ -286,7 +284,7 @@ impl<'a> Binder<'a> for FormalParameter<'a> {
 impl<'a> Binder<'a> for FormalParameterRest<'a> {
     // Binds the FormalParameter of a function or method.
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
-        let parent_kind = builder.nodes.parent_kind(builder.current_node_id);
+        let parent_kind = builder.ancestry().parent_kind();
         let AstKind::FormalParameters(parameters) = parent_kind else { unreachable!() };
 
         let includes = SymbolFlags::FunctionScopedVariable;
@@ -349,7 +347,7 @@ fn declare_symbol_for_import_specifier<'a>(
     builder: &mut SemanticBuilder<'a>,
 ) {
     let includes = if is_type
-        || matches!(builder.nodes.parent_kind(builder.current_node_id), AstKind::ImportDeclaration(decl) if decl.import_kind.is_type(),
+        || matches!(builder.ancestry().parent_kind(), AstKind::ImportDeclaration(decl) if decl.import_kind.is_type(),
         ) {
         SymbolFlags::TypeImport
     } else {
@@ -457,7 +455,8 @@ impl<'a> Binder<'a> for TSModuleDeclaration<'a> {
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let TSModuleDeclarationName::Identifier(id) = &self.id else { return };
         let instantiated =
-            get_module_instance_state(builder, self, builder.current_node_id).is_instantiated();
+            get_module_instance_state(builder, self, builder.node_store.current_node_id)
+                .is_instantiated();
         let (mut includes, excludes) = if instantiated {
             (SymbolFlags::ValueModule, SymbolFlags::ValueModuleExcludes)
         } else {
@@ -705,10 +704,12 @@ fn get_module_instance_state_for_alias_target<'a>(
             }
         }
 
-        let Some((node_id, node)) =
-            builder.nodes.ancestors_enumerated(current_node_id).find(|(_, node)| {
+        // Walk up the ancestry stack (excluding `current_node_id` itself) to the
+        // nearest enclosing block-like node.
+        let Some(kind) =
+            builder.ancestry().ancestor_kinds_from(Some(current_node_id)).skip(1).find(|kind| {
                 matches!(
-                    node.kind(),
+                    kind,
                     AstKind::Program(_) | AstKind::TSModuleBlock(_) | AstKind::BlockStatement(_)
                 )
             })
@@ -716,11 +717,11 @@ fn get_module_instance_state_for_alias_target<'a>(
             break;
         };
 
-        current_node_id = node_id;
+        current_node_id = kind.node_id();
         current_block_stmts.clear();
         // Didn't find the declaration whose name matches export specifier
         // in the current block, so we need to check the parent block.
-        current_block_stmts.extend(match node.kind() {
+        current_block_stmts.extend(match kind {
             AstKind::Program(program) => program.body.iter(),
             AstKind::TSModuleBlock(block) => block.body.iter(),
             AstKind::BlockStatement(block) => block.body.iter(),
@@ -734,10 +735,7 @@ fn get_module_instance_state_for_alias_target<'a>(
 
 impl<'a> Binder<'a> for TSTypeParameter<'a> {
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
-        let scope_id = if matches!(
-            builder.nodes.parent_kind(builder.current_node_id),
-            AstKind::TSInferType(_)
-        ) {
+        let scope_id = if matches!(builder.ancestry().parent_kind(), AstKind::TSInferType(_)) {
             builder
                 .scoping
                 .scope_ancestors(builder.current_scope_id)

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -32,7 +32,7 @@ use crate::{
     class::ClassTableBuilder,
     diagnostics::redeclaration,
     label::UnusedLabels,
-    node::AstNodes,
+    node::{Ancestry, AstNodeStore, AstNodeStoreKind},
     scoping::{Bindings, Scoping},
     stats::Stats,
     unresolved_stack::UnresolvedReferences,
@@ -77,8 +77,6 @@ pub struct SemanticBuilder<'a> {
     pub(crate) errors: RefCell<Vec<OxcDiagnostic>>,
 
     // states
-    pub(crate) current_node_id: NodeId,
-    pub(crate) current_node_flags: NodeFlags,
     pub(crate) current_scope_id: ScopeId,
     /// `NodeId` of current `Function` (not including arrow functions).
     /// When not in a function, is `NodeId` of `Program`.
@@ -92,7 +90,9 @@ pub struct SemanticBuilder<'a> {
     pub(crate) hoisting_variables: FxHashMap<ScopeId, IdentHashMap<'a, SymbolId>>,
 
     // builders
-    pub(crate) nodes: AstNodes<'a>,
+    /// Node-id counter, current-node cursor/flags, and the node storage (full
+    /// store or ancestry stack). See [`AstNodeStore`].
+    pub(crate) node_store: AstNodeStore<'a>,
     pub(crate) scoping: Scoping,
 
     pub(crate) unresolved_references: UnresolvedReferences<'a>,
@@ -150,13 +150,11 @@ impl<'a> SemanticBuilder<'a> {
             source_text: "",
             source_type: SourceType::default(),
             errors: RefCell::new(vec![]),
-            current_node_id: NodeId::new(0),
-            current_node_flags: NodeFlags::empty(),
             current_reference_flags: ReferenceFlags::empty(),
             current_scope_id,
             current_function_node_id: NodeId::ROOT,
             module_instance_state_cache: FxHashMap::default(),
-            nodes: AstNodes::default(),
+            node_store: AstNodeStore::default(),
             hoisting_variables: FxHashMap::default(),
             scoping,
             unresolved_references: UnresolvedReferences::new(),
@@ -181,27 +179,36 @@ impl<'a> SemanticBuilder<'a> {
     /// Create a builder configured for the **compiler pipeline** (the
     /// [`Compiler`], transformer, codegen, minifier, napi bindings, ...).
     ///
-    /// Enables syntax error checking. Leaves linter-only analyses (control flow
-    /// graph, class table) off. This is the single place to tune
-    /// compiler-pipeline defaults; individual options can still be overridden
-    /// with the `with_*` methods.
+    /// Enables syntax error checking. Does **not** build the full [`AstNodes`](crate::AstNodes)
+    /// store — ancestry is served from the lightweight ancestry stack instead.
+    /// Use this whenever you only need [`Scoping`] and diagnostics, not random
+    /// access to [`AstNodes`](crate::AstNodes). Individual options can still be overridden with
+    /// the `with_*` methods.
     ///
     /// [`Compiler`]: https://docs.rs/oxc/latest/oxc/struct.Compiler.html
     #[must_use]
     pub fn new_compiler() -> Self {
-        Self::new().with_check_syntax_error(true)
+        Self::new().with_build_nodes(false).with_check_syntax_error(true)
     }
 
     /// Create a builder configured for the **linter**.
     ///
-    /// Enables everything the linter relies on: syntax error checking, the
-    /// control flow graph, and the class table. JSDoc is built whenever the
-    /// `jsdoc` feature is enabled, which the `linter` feature turns on. This is
-    /// the single place to tune linter defaults; individual options can still be
-    /// overridden with the `with_*` methods.
+    /// Enables everything the linter requires: the full [`AstNodes`](crate::AstNodes) store
+    /// (random access to nodes), the control flow graph, the class table, and
+    /// syntax error checking. JSDoc is built whenever the `jsdoc` feature is
+    /// enabled, which the `linter` feature turns on. Individual options can still
+    /// be overridden with the `with_*` methods.
+    ///
+    /// Tools that need the node store but not the linter analyses or syntax
+    /// checking (e.g. the mangler) should use `new().with_build_nodes(true)`
+    /// instead.
     #[must_use]
     pub fn new_linter() -> Self {
-        Self::new().with_check_syntax_error(true).with_cfg(true).with_class_table(true)
+        Self::new()
+            .with_build_nodes(true)
+            .with_cfg(true)
+            .with_class_table(true)
+            .with_check_syntax_error(true)
     }
 
     /// Enable/disable additional syntax checks.
@@ -214,6 +221,18 @@ impl<'a> SemanticBuilder<'a> {
     #[must_use]
     pub fn with_check_syntax_error(mut self, yes: bool) -> Self {
         self.check_syntax_error = yes;
+        self
+    }
+
+    /// Enable or disable building the full [`AstNodes`](crate::AstNodes) store.
+    ///
+    /// Disabled by default: [`Semantic::nodes`] is empty and only the ancestry
+    /// stack and node-id counter are maintained while traversing — cheaper for
+    /// the compiler pipeline, which does not need random access to nodes. Enable
+    /// it for the linter and mangler, which read [`Semantic::nodes`].
+    #[must_use]
+    pub fn with_build_nodes(mut self, yes: bool) -> Self {
+        self.node_store.set_build_nodes(yes);
         self
     }
 
@@ -315,7 +334,7 @@ impl<'a> SemanticBuilder<'a> {
             let stats_with_excess = stats.increase_by(self.excess_capacity);
             (stats_with_excess, Some(stats))
         };
-        self.nodes.reserve(stats.nodes as usize);
+        self.node_store.reserve(stats.nodes as usize);
         self.scoping.reserve(
             stats.symbols as usize,
             stats.references as usize,
@@ -333,7 +352,9 @@ impl<'a> SemanticBuilder<'a> {
         if let Some(stats) = check_stats {
             #[expect(clippy::cast_possible_truncation)]
             let actual_stats = Stats::new(
-                self.nodes.len() as u32,
+                // `node_count` is the source of truth, valid even when the full
+                // node store is not built.
+                self.node_store.node_count(),
                 self.scoping.scopes_len() as u32,
                 self.scoping.symbols_len() as u32,
                 self.scoping.references.len() as u32,
@@ -358,7 +379,7 @@ impl<'a> SemanticBuilder<'a> {
             source_type: self.source_type,
             comments: &program.comments,
             irregular_whitespaces: [].into(),
-            nodes: self.nodes,
+            nodes: self.node_store.into_nodes(),
             scoping: self.scoping,
             classes: self.class_table_builder.build(),
             #[cfg(feature = "jsdoc")]
@@ -377,6 +398,16 @@ impl<'a> SemanticBuilder<'a> {
         self.errors.borrow_mut().push(error);
     }
 
+    /// Upward-walking view of the current node's ancestors.
+    ///
+    /// This is the only ancestry information the syntax checker and binder read.
+    /// Reads from the full node store when it is built, otherwise from the
+    /// standalone ancestry stack.
+    #[inline]
+    pub(crate) fn ancestry(&self) -> Ancestry<'a, '_> {
+        self.node_store.ancestry()
+    }
+
     pub(crate) fn in_declare_scope(&self) -> bool {
         self.source_type.is_typescript_definition()
             || self
@@ -387,28 +418,54 @@ impl<'a> SemanticBuilder<'a> {
 
     fn create_ast_node(&mut self, kind: AstKind<'a>) {
         #[cfg(not(feature = "jsdoc"))]
-        let flags = self.current_node_flags;
+        let flags = self.node_store.current_node_flags;
         #[cfg(feature = "jsdoc")]
-        let mut flags = self.current_node_flags;
+        let mut flags = self.node_store.current_node_flags;
         #[cfg(feature = "jsdoc")]
         if self.jsdoc.retrieve_attached_jsdoc(&kind) {
             flags |= NodeFlags::JSDoc;
         }
 
-        self.current_node_id = self.nodes.add_node(
-            kind,
-            self.current_scope_id,
-            self.current_node_id,
-            #[cfg(feature = "cfg")]
-            control_flow!(self, |cfg| cfg.current_node_ix),
-            flags,
-        );
+        // 1. Standalone node-id increment.
+        let node_id = self.node_store.alloc_node_id();
+        kind.set_node_id(node_id);
+        let parent_node_id = self.node_store.current_node_id;
+        self.node_store.current_node_id = node_id;
+
+        // 2 & 3. Either the full node store or the ancestry stack — never both.
+        #[cfg(feature = "cfg")]
+        let cfg_id = control_flow!(self, |cfg| cfg.current_node_ix);
+        let scope_id = self.current_scope_id;
+        match &mut self.node_store.kind {
+            AstNodeStoreKind::Full(nodes) => {
+                nodes.add_node(
+                    node_id,
+                    kind,
+                    scope_id,
+                    parent_node_id,
+                    #[cfg(feature = "cfg")]
+                    cfg_id,
+                    flags,
+                );
+            }
+            AstNodeStoreKind::Ancestry(stack) => stack.push(kind),
+        }
         self.record_ast_node();
     }
 
     #[inline]
     fn pop_ast_node(&mut self) {
-        self.current_node_id = self.nodes.parent_id(self.current_node_id);
+        // Restore `current_node_id` to the parent from whichever ancestry source
+        // is in use.
+        match &mut self.node_store.kind {
+            AstNodeStoreKind::Full(nodes) => {
+                self.node_store.current_node_id = nodes.parent_id(self.node_store.current_node_id);
+            }
+            AstNodeStoreKind::Ancestry(stack) => {
+                stack.pop();
+                self.node_store.current_node_id = stack.current_node_id();
+            }
+        }
     }
 
     #[inline]
@@ -439,7 +496,7 @@ impl<'a> SemanticBuilder<'a> {
             && let Some(record) = self.ast_node_records.last_mut()
             && *record == NodeId::DUMMY
         {
-            *record = self.current_node_id;
+            *record = self.node_store.current_node_id;
         }
     }
 
@@ -485,7 +542,7 @@ impl<'a> SemanticBuilder<'a> {
             includes,
             scope_id,
             scope_id,
-            self.current_node_id,
+            self.node_store.current_node_id,
         )
     }
 
@@ -557,7 +614,7 @@ impl<'a> SemanticBuilder<'a> {
             includes,
             self.current_scope_id,
             scope_id,
-            self.current_node_id,
+            self.node_store.current_node_id,
         )
     }
 
@@ -680,7 +737,12 @@ impl<'a> SemanticBuilder<'a> {
         flags: SymbolFlags,
         span: Span,
     ) {
-        self.scoping.add_symbol_redeclaration(symbol_id, flags, self.current_node_id, span);
+        self.scoping.add_symbol_redeclaration(
+            symbol_id,
+            flags,
+            self.node_store.current_node_id,
+            span,
+        );
     }
 
     fn visit_parameter_decorators(&mut self, decorators: &oxc_allocator::Vec<'a, Decorator<'a>>) {
@@ -726,7 +788,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         let parent_scope_id = self.current_scope_id;
         let flags = self.scoping.get_new_scope_flags(flags, parent_scope_id);
         self.current_scope_id =
-            self.scoping.add_scope(Some(parent_scope_id), self.current_node_id, flags);
+            self.scoping.add_scope(Some(parent_scope_id), self.node_store.current_node_id, flags);
         scope_id.set(Some(self.current_scope_id));
     }
 
@@ -782,13 +844,28 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         // This avoids `Nodes::add_node` having to handle the special case.
         // We can also skip calling `self.enter_kind`, `self.record_ast_node`
         // and `self.jsdoc.retrieve_attached_jsdoc`, as they are all no-ops for `Program`.
-        self.current_node_id = self.nodes.add_program_node(
-            kind,
-            self.current_scope_id,
-            #[cfg(feature = "cfg")]
-            control_flow!(self, |cfg| cfg.current_node_ix),
-            self.current_node_flags,
-        );
+        // 1. Standalone node-id increment: `Program` is always `NodeId::ROOT`.
+        let node_id = self.node_store.alloc_node_id();
+        debug_assert_eq!(node_id, NodeId::ROOT);
+        kind.set_node_id(node_id);
+        self.node_store.current_node_id = node_id;
+        // 2 & 3. Either the full node store or the ancestry stack — never both.
+        #[cfg(feature = "cfg")]
+        let cfg_id = control_flow!(self, |cfg| cfg.current_node_ix);
+        let scope_id = self.current_scope_id;
+        let flags = self.node_store.current_node_flags;
+        match &mut self.node_store.kind {
+            AstNodeStoreKind::Full(nodes) => {
+                nodes.add_program_node(
+                    kind,
+                    scope_id,
+                    #[cfg(feature = "cfg")]
+                    cfg_id,
+                    flags,
+                );
+            }
+            AstNodeStoreKind::Ancestry(stack) => stack.push(kind),
+        }
 
         // Don't call `enter_scope` here as `Program` is a special case - scope has no `parent_id`.
         // Inline the specific logic for `Program` here instead.
@@ -797,7 +874,8 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         if self.source_type.is_strict() || program.has_use_strict_directive() {
             flags |= ScopeFlags::StrictMode;
         }
-        self.current_scope_id = self.scoping.add_scope(None, self.current_node_id, flags);
+        self.current_scope_id =
+            self.scoping.add_scope(None, self.node_store.current_node_id, flags);
         program.scope_id.set(Some(self.current_scope_id));
         // NB: Don't call `self.unresolved_references.increment_scope_depth()`
         // as scope depth is initialized as 1 already (the scope depth for `Program`).
@@ -835,7 +913,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         /* cfg */
         #[cfg(feature = "cfg")]
-        let node_id = self.current_node_id;
+        let node_id = self.node_store.current_node_id;
         /* cfg */
 
         if let Some(break_target) = &stmt.label {
@@ -853,7 +931,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_class(&mut self, class: &Class<'a>) {
         let kind = AstKind::Class(self.alloc(class));
         self.enter_node(kind);
-        self.current_node_flags |= NodeFlags::Class;
+        self.node_store.current_node_flags |= NodeFlags::Class;
         if class.is_declaration() {
             class.bind(self);
         }
@@ -884,14 +962,14 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         self.leave_scope();
         self.leave_node(kind);
-        self.current_node_flags -= NodeFlags::Class;
+        self.node_store.current_node_flags -= NodeFlags::Class;
         self.class_table_builder.pop_class();
     }
 
     fn visit_block_statement(&mut self, it: &BlockStatement<'a>) {
         let kind = AstKind::BlockStatement(self.alloc(it));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
 
         let parent_scope_id = self.current_scope_id;
         self.enter_scope(ScopeFlags::empty(), &it.scope_id);
@@ -932,7 +1010,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         /* cfg */
         #[cfg(feature = "cfg")]
-        let node_id = self.current_node_id;
+        let node_id = self.node_store.current_node_id;
         /* cfg */
 
         if let Some(continue_target) = &stmt.label {
@@ -950,7 +1028,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_do_while_statement(&mut self, stmt: &DoWhileStatement<'a>) {
         let kind = AstKind::DoWhileStatement(self.alloc(stmt));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
 
         /* cfg */
         #[cfg(feature = "cfg")]
@@ -1215,7 +1293,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_for_statement(&mut self, stmt: &ForStatement<'a>) {
         let kind = AstKind::ForStatement(self.alloc(stmt));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
         if let Some(init) = &stmt.init {
             self.visit_for_statement_init(init);
@@ -1286,7 +1364,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_for_in_statement(&mut self, stmt: &ForInStatement<'a>) {
         let kind = AstKind::ForInStatement(self.alloc(stmt));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
 
         self.visit_for_statement_left(&stmt.left);
@@ -1350,7 +1428,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_for_of_statement(&mut self, stmt: &ForOfStatement<'a>) {
         let kind = AstKind::ForOfStatement(self.alloc(stmt));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
 
         self.visit_for_statement_left(&stmt.left);
@@ -1413,7 +1491,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_if_statement(&mut self, stmt: &IfStatement<'a>) {
         let kind = AstKind::IfStatement(self.alloc(stmt));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
 
         /* cfg - condition basic block */
         #[cfg(feature = "cfg")]
@@ -1487,8 +1565,8 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_labeled_statement(&mut self, stmt: &LabeledStatement<'a>) {
         let kind = AstKind::LabeledStatement(self.alloc(stmt));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
-        self.unused_labels.add(stmt.label.name, self.current_node_id);
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
+        self.unused_labels.add(stmt.label.name, self.node_store.current_node_id);
 
         /* cfg */
         #[cfg(feature = "cfg")]
@@ -1525,7 +1603,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         /* cfg */
         #[cfg(feature = "cfg")]
-        let node_id = self.current_node_id;
+        let node_id = self.node_store.current_node_id;
         /* cfg */
 
         #[cfg(feature = "cfg")]
@@ -1554,7 +1632,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_switch_statement(&mut self, stmt: &SwitchStatement<'a>) {
         let kind = AstKind::SwitchStatement(self.alloc(stmt));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.visit_expression(&stmt.discriminant);
         self.enter_scope(ScopeFlags::empty(), &stmt.scope_id);
 
@@ -1665,7 +1743,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
 
         /* cfg */
         #[cfg(feature = "cfg")]
-        let node_id = self.current_node_id;
+        let node_id = self.node_store.current_node_id;
         /* cfg */
 
         self.visit_expression(&stmt.argument);
@@ -1680,7 +1758,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_try_statement(&mut self, stmt: &TryStatement<'a>) {
         let kind = AstKind::TryStatement(self.alloc(stmt));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
 
         /* cfg */
 
@@ -1815,7 +1893,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_while_statement(&mut self, stmt: &WhileStatement<'a>) {
         let kind = AstKind::WhileStatement(self.alloc(stmt));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
 
         /* cfg - condition basic block */
         #[cfg(feature = "cfg")]
@@ -1864,7 +1942,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_with_statement(&mut self, stmt: &WithStatement<'a>) {
         let kind = AstKind::WithStatement(self.alloc(stmt));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
 
         /* cfg - condition basic block */
         #[cfg(feature = "cfg")]
@@ -1917,7 +1995,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_node(kind);
 
         let parent_function_node_id = self.current_function_node_id;
-        self.current_function_node_id = self.current_node_id;
+        self.current_function_node_id = self.node_store.current_node_id;
 
         if func.is_declaration() {
             func.bind(self);
@@ -2261,12 +2339,12 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_node(kind);
         self.visit_span(&it.span);
 
-        self.current_node_flags |= NodeFlags::ExportSpecifier;
+        self.node_store.current_node_flags |= NodeFlags::ExportSpecifier;
 
         self.visit_module_export_name(&it.local);
         self.visit_module_export_name(&it.exported);
 
-        self.current_node_flags -= NodeFlags::ExportSpecifier;
+        self.node_store.current_node_flags -= NodeFlags::ExportSpecifier;
 
         self.leave_node(kind);
     }
@@ -2390,7 +2468,8 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_class_body(&mut self, body: &ClassBody<'a>) {
         let kind = AstKind::ClassBody(self.alloc(body));
         self.enter_node(kind);
-        self.class_table_builder.declare_class_body(body, self.current_node_id, &self.nodes);
+        let parent_node_id = self.ancestry().parent_node_id();
+        self.class_table_builder.declare_class_body(body, parent_node_id);
         self.visit_span(&body.span);
         self.visit_class_elements(&body.body);
         self.leave_node(kind);
@@ -2399,10 +2478,11 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_private_identifier(&mut self, ident: &PrivateIdentifier<'a>) {
         let kind = AstKind::PrivateIdentifier(self.alloc(ident));
         self.enter_node(kind);
+        let parent_kind = self.ancestry().parent_kind();
         self.class_table_builder.add_private_identifier_reference(
             ident,
-            self.current_node_id,
-            &self.nodes,
+            self.node_store.current_node_id,
+            parent_kind,
         );
         self.visit_span(&ident.span);
         self.leave_node(kind);
@@ -2573,7 +2653,10 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.enter_node(kind);
         // If not in a function, `current_function_node_id` is `NodeId` of `Program`.
         // But it shouldn't be possible for `yield` to be at top level - that's a parse error.
-        *self.nodes.flags_mut(self.current_function_node_id) |= NodeFlags::HasYield;
+        // `HasYield` is a flag on the full node store, so only set it when that store is built.
+        if let AstNodeStoreKind::Full(nodes) = &mut self.node_store.kind {
+            *nodes.flags_mut(self.current_function_node_id) |= NodeFlags::HasYield;
+        }
         self.visit_span(&expr.span);
         if let Some(argument) = &expr.argument {
             self.visit_expression(argument);
@@ -2658,7 +2741,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_expression_statement(&mut self, it: &ExpressionStatement<'a>) {
         let kind = AstKind::ExpressionStatement(self.alloc(it));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.visit_span(&it.span);
         self.visit_expression(&it.expression);
         self.leave_node(kind);
@@ -2667,7 +2750,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_variable_declaration(&mut self, it: &VariableDeclaration<'a>) {
         let kind = AstKind::VariableDeclaration(self.alloc(it));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.visit_span(&it.span);
         self.visit_variable_declarators(&it.declarations);
         self.leave_node(kind);
@@ -2676,7 +2759,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_empty_statement(&mut self, it: &EmptyStatement) {
         let kind = AstKind::EmptyStatement(self.alloc(it));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.visit_span(&it.span);
         self.leave_node(kind);
     }
@@ -2684,7 +2767,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_debugger_statement(&mut self, it: &DebuggerStatement) {
         let kind = AstKind::DebuggerStatement(self.alloc(it));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.visit_span(&it.span);
         self.leave_node(kind);
     }
@@ -2692,7 +2775,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
     fn visit_export_default_declaration(&mut self, it: &ExportDefaultDeclaration<'a>) {
         let kind = AstKind::ExportDefaultDeclaration(self.alloc(it));
         self.enter_node(kind);
-        control_flow!(self, |cfg| cfg.enter_statement(self.current_node_id));
+        control_flow!(self, |cfg| cfg.enter_statement(self.node_store.current_node_id));
         self.visit_span(&it.span);
         self.visit_export_default_declaration_kind(&it.declaration);
         self.leave_node(kind);
@@ -2703,7 +2786,8 @@ impl<'a> SemanticBuilder<'a> {
     #[inline]
     fn reference_identifier(&mut self, ident: &IdentifierReference<'a>) {
         let flags = self.resolve_reference_usages();
-        let reference = Reference::new(self.current_node_id, self.current_scope_id, flags);
+        let reference =
+            Reference::new(self.node_store.current_node_id, self.current_scope_id, flags);
         let reference_id = self.declare_reference(ident.name, reference);
         ident.reference_id.set(Some(reference_id));
     }

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -201,7 +201,7 @@ fn is_current_node_ambient_binding(symbol_id: Option<SymbolId>, ctx: &SemanticBu
         && ctx.scoping.symbol_flags(symbol_id).contains(SymbolFlags::Ambient)
     {
         true
-    } else if let AstKind::BindingIdentifier(id) = ctx.nodes.kind(ctx.current_node_id)
+    } else if let AstKind::BindingIdentifier(id) = ctx.ancestry().current_kind()
         && let Some(symbol_id) = id.symbol_id.get()
     {
         ctx.scoping.symbol_flags(symbol_id).contains(SymbolFlags::Ambient)
@@ -235,18 +235,17 @@ pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder
                     .is_some_and(|func| matches!(func.r#type, FunctionType::TSDeclareFunction))
             };
 
-            let parent = ctx.nodes.parent_node(ctx.current_node_id);
-            let parent_id = parent.id();
-            let is_ok = match parent.kind() {
+            // Walk up the ancestor stack: `ancestors.next()` yields the parent,
+            // then the grandparent, and so on.
+            let mut ancestors = ctx.ancestry().ancestor_kinds();
+            let parent = ancestors.next().unwrap();
+            let is_ok = match parent {
                 AstKind::Function(func) => matches!(func.r#type, FunctionType::TSDeclareFunction),
                 AstKind::FormalParameter(_) | AstKind::FormalParameterRest(_) => {
-                    is_declare_function(&ctx.nodes.parent_kind(parent_id))
+                    is_declare_function(&ancestors.next().unwrap())
                 }
-                AstKind::BindingRestElement(_) => {
-                    let grand_parent = ctx.nodes.parent_node(parent_id);
-                    let grand_parent_id = grand_parent.id();
-                    is_declare_function(&ctx.nodes.parent_kind(grand_parent_id))
-                }
+                // `nth(1)` skips the `FormalParameter*` grandparent to reach the function.
+                AstKind::BindingRestElement(_) => is_declare_function(&ancestors.nth(1).unwrap()),
                 _ => false,
             };
 
@@ -257,7 +256,7 @@ pub fn check_binding_identifier(ident: &BindingIdentifier, ctx: &SemanticBuilder
         "let" if !ctx.strict_mode() => {
             // LexicalDeclaration : LetOrConst BindingList ;
             // * It is a Syntax Error if the BoundNames of BindingList contains "let".
-            for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
+            for node_kind in ctx.ancestry().ancestor_kinds() {
                 match node_kind {
                     AstKind::VariableDeclarator(decl) => {
                         if decl.kind.is_lexical() {
@@ -286,7 +285,7 @@ pub fn check_identifier_reference(ident: &IdentifierReference, ctx: &SemanticBui
     //  Static Semantics: AssignmentTargetType
     //  1. If this IdentifierReference is contained in strict mode code and StringValue of Identifier is "eval" or "arguments", return invalid.
     if matches!(ident.name.as_str(), "arguments" | "eval") && ctx.strict_mode() {
-        for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
+        for node_kind in ctx.ancestry().ancestor_kinds() {
             match node_kind {
                 // Only check for actual assignment contexts, not member expression access
                 AstKind::ObjectAssignmentTarget(_)
@@ -322,8 +321,8 @@ pub fn check_identifier_reference(ident: &IdentifierReference, ctx: &SemanticBui
     //   It is a Syntax Error if ContainsArguments of ClassStaticBlockStatementList is true.
 
     if ident.name == "arguments" {
-        let mut previous_node_address = ctx.nodes.get_node(ctx.current_node_id).address();
-        for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
+        let mut previous_node_address = ctx.ancestry().current_address();
+        for node_kind in ctx.ancestry().ancestor_kinds() {
             match node_kind {
                 AstKind::Function(_) => break,
                 AstKind::PropertyDefinition(prop)
@@ -501,7 +500,7 @@ pub fn check_directive(directive: &Directive, ctx: &SemanticBuilder<'_>) {
         return;
     }
 
-    if matches!(ctx.nodes.kind(ctx.scoping.get_node_id(ctx.current_scope_id)),
+    if matches!(ctx.ancestry().find_kind_by_node_id(ctx.scoping.get_node_id(ctx.current_scope_id)),
         AstKind::Function(Function { params, .. })
         | AstKind::ArrowFunctionExpression(ArrowFunctionExpression { params, .. })
         if !params.is_simple_parameter_list())
@@ -538,7 +537,7 @@ pub fn check_module_declaration(decl: &ModuleDeclarationKind, ctx: &SemanticBuil
             ctx.error(diagnostics::module_code(text, span));
         }
         ModuleKind::Module => {
-            if matches!(ctx.nodes.parent_kind(ctx.current_node_id), AstKind::Program(_)) {
+            if matches!(ctx.ancestry().parent_kind(), AstKind::Program(_)) {
                 return;
             }
             ctx.error(diagnostics::top_level(text, span));
@@ -590,7 +589,7 @@ pub fn check_function_declaration_in_labeled_statement<'a>(
             ctx.error(diagnostics::function_declaration_strict(decl.span));
         } else {
             // skip(1) for `LabeledStatement`
-            for kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
+            for kind in ctx.ancestry().ancestor_kinds() {
                 match kind {
                     // Nested labeled statement
                     AstKind::LabeledStatement(_) => {}
@@ -658,7 +657,7 @@ pub fn is_function_decl_part_of_if_statement(
     // A function declaration whose parent is an `IfStatement` can only be
     // either that `IfStatement`'s `consequent` or `alternate`
     // (can't be `test` because that's an expression)
-    matches!(builder.nodes.parent_kind(builder.current_node_id), AstKind::IfStatement(_))
+    matches!(builder.ancestry().parent_kind(), AstKind::IfStatement(_))
 }
 
 // It is a Syntax Error if the LexicallyDeclaredNames of StatementList contains any duplicate entries,
@@ -779,7 +778,7 @@ pub fn check_break_statement(stmt: &BreakStatement, ctx: &SemanticBuilder<'_>) {
     // It is a Syntax Error if this BreakStatement is not nested, directly or indirectly (but not crossing function or static initialization block boundaries), within an IterationStatement or a SwitchStatement.
 
     let mut available_labels: Option<Vec<&str>> = None;
-    for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
+    for node_kind in ctx.ancestry().ancestor_kinds() {
         match node_kind {
             AstKind::Program(_) => {
                 return stmt.label.as_ref().map_or_else(
@@ -822,7 +821,7 @@ pub fn check_continue_statement(stmt: &ContinueStatement, ctx: &SemanticBuilder<
     // It is a Syntax Error if this ContinueStatement is not nested, directly or indirectly (but not crossing function or static initialization block boundaries), within an IterationStatement.
 
     let mut available_labels: Option<Vec<&str>> = None;
-    for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
+    for node_kind in ctx.ancestry().ancestor_kinds() {
         match node_kind {
             AstKind::Program(_) => {
                 return stmt.label.as_ref().map_or_else(
@@ -871,7 +870,7 @@ pub fn check_continue_statement(stmt: &ContinueStatement, ctx: &SemanticBuilder<
 
 fn collect_label_names<'a>(ctx: &'_ SemanticBuilder<'a>) -> Vec<&'a str> {
     let mut labels = Vec::new();
-    for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
+    for node_kind in ctx.ancestry().ancestor_kinds() {
         if let AstKind::LabeledStatement(labeled_statement) = node_kind {
             labels.push(labeled_statement.label.name.as_str());
         } else if matches!(node_kind, AstKind::Function(_) | AstKind::StaticBlock(_)) {
@@ -882,7 +881,7 @@ fn collect_label_names<'a>(ctx: &'_ SemanticBuilder<'a>) -> Vec<&'a str> {
 }
 
 pub fn check_labeled_statement(stmt: &LabeledStatement, ctx: &SemanticBuilder<'_>) {
-    for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
+    for node_kind in ctx.ancestry().ancestor_kinds() {
         match node_kind {
             // label cannot cross boundary on function or static block
             AstKind::Function(_)
@@ -945,10 +944,7 @@ pub fn check_class(class: &Class, ctx: &SemanticBuilder<'_>) {
 
     if class.is_declaration()
         && class.id.is_none()
-        && !matches!(
-            ctx.nodes.parent_kind(ctx.current_node_id),
-            AstKind::ExportDefaultDeclaration(_)
-        )
+        && !matches!(ctx.ancestry().parent_kind(), AstKind::ExportDefaultDeclaration(_))
     {
         let start = class.span.start;
         ctx.error(diagnostics::require_class_name(Span::sized(start, 5)));
@@ -977,7 +973,7 @@ pub fn check_class(class: &Class, ctx: &SemanticBuilder<'_>) {
 
 pub fn check_super(sup: &Super, ctx: &SemanticBuilder<'_>) {
     // `Some` for `super()`, `None` for `super.foo` / `super.bar()` etc
-    let super_call_span = match ctx.nodes.parent_kind(ctx.current_node_id) {
+    let super_call_span = match ctx.ancestry().parent_kind() {
         AstKind::CallExpression(expr) => Some(expr.span),
         AstKind::NewExpression(expr) => Some(expr.span),
         _ => None,
@@ -1013,14 +1009,15 @@ pub fn check_super(sup: &Super, ctx: &SemanticBuilder<'_>) {
             // So when visiting `super` in `class Outer { method() { class Inner extends super.foo {} } }`,
             // `ctx.class_table_builder.current_class_id` is `Outer` class, not `Inner`.
 
-            let search_start_node_id = if let Some(previous_scope_id) = previous_scope_id {
-                ctx.scoping.get_node_id(previous_scope_id)
-            } else {
-                ctx.current_node_id
-            };
-            let mut previous_node_address = ctx.nodes.kind(search_start_node_id).address();
+            // Walk up the ancestors, starting either from the previously reached
+            // class's node, or from the current node (`super`) itself.
+            let start = previous_scope_id
+                .map(|previous_scope_id| ctx.scoping.get_node_id(previous_scope_id));
+            let mut kinds_from = ctx.ancestry().ancestor_kinds_from(start);
+            // First kind is the start node itself; remaining kinds are its ancestors.
+            let mut previous_node_address = kinds_from.next().unwrap().address();
 
-            for ancestor_kind in ctx.nodes.ancestor_kinds(search_start_node_id) {
+            for ancestor_kind in kinds_from {
                 match ancestor_kind {
                     AstKind::PropertyDefinition(prop) => {
                         if prop
@@ -1148,9 +1145,11 @@ pub fn check_super(sup: &Super, ctx: &SemanticBuilder<'_>) {
         // `super()` is only legal if in a class constructor.
         // If function is anywhere else, both `super()` and `super.foo` are illegal.
         let func_node_id = ctx.scoping.get_node_id(scope_id);
-        let func_address = ctx.nodes.kind(func_node_id).address();
+        // Walk up from the function node: first is the function, second its parent.
+        let mut func_kinds = ctx.ancestry().ancestor_kinds_from(Some(func_node_id));
+        let func_address = func_kinds.next().unwrap().address();
 
-        match ctx.nodes.parent_kind(func_node_id) {
+        match func_kinds.next().unwrap() {
             AstKind::ObjectProperty(prop) => {
                 // Function's parent is an `ObjectProperty`.
                 // Check the function is a method/getter/setter, not a normal property.
@@ -1201,7 +1200,8 @@ pub fn check_super(sup: &Super, ctx: &SemanticBuilder<'_>) {
                         }
 
                         let class_node_id = ctx.class_table_builder.classes.get_node_id(class_id);
-                        let class = ctx.nodes.kind(class_node_id).as_class().unwrap();
+                        let class =
+                            ctx.ancestry().find_kind_by_node_id(class_node_id).as_class().unwrap();
                         if class.super_class.is_none() {
                             ctx.error(diagnostics::super_without_derived_class(
                                 sup.span, class.span,
@@ -1235,7 +1235,7 @@ fn get_class_details(
         return (None, ClassId::new(0)); // Dummy class ID
     };
     let node_id = ctx.class_table_builder.classes.get_node_id(class_id);
-    let class = ctx.nodes.kind(node_id).as_class().unwrap();
+    let class = ctx.ancestry().find_kind_by_node_id(node_id).as_class().unwrap();
     let scope_id = class.scope_id();
     (Some(scope_id), class_id)
 }
@@ -1294,7 +1294,7 @@ pub fn check_unary_expression(unary_expr: &UnaryExpression, ctx: &SemanticBuilde
 }
 
 fn is_in_formal_parameters(ctx: &SemanticBuilder<'_>) -> bool {
-    for node_kind in ctx.nodes.ancestor_kinds(ctx.current_node_id) {
+    for node_kind in ctx.ancestry().ancestor_kinds() {
         match node_kind {
             AstKind::FormalParameter(_) => return true,
             AstKind::Program(_) | AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -13,8 +13,8 @@ use crate::{builder::SemanticBuilder, diagnostics};
 pub fn check_ts_type_parameter<'a>(param: &TSTypeParameter<'a>, ctx: &SemanticBuilder<'a>) {
     if param.r#in || param.out {
         let is_allowed_node = matches!(
-            // skip parent TSTypeParameterDeclaration
-            ctx.nodes.parent_kind(ctx.nodes.parent_id(ctx.current_node_id)),
+            // skip parent TSTypeParameterDeclaration (grandparent is index 1)
+            ctx.ancestry().ancestor_kinds().nth(1).unwrap(),
             AstKind::TSInterfaceDeclaration(_)
                 | AstKind::Class(_)
                 | AstKind::TSTypeAliasDeclaration(_)
@@ -65,12 +65,11 @@ pub fn check_ts_type_annotation(annotation: &TSTypeAnnotation<'_>, ctx: &Semanti
 }
 
 pub fn check_ts_infer_type<'a>(infer_type: &TSInferType<'a>, ctx: &SemanticBuilder<'a>) {
-    let is_in_conditional_extends_clause =
-        ctx.nodes.ancestor_kinds(ctx.current_node_id).any(|kind| {
-            kind.as_ts_conditional_type().is_some_and(|conditional| {
-                conditional.extends_type.span().contains_inclusive(infer_type.span)
-            })
-        });
+    let is_in_conditional_extends_clause = ctx.ancestry().ancestor_kinds().any(|kind| {
+        kind.as_ts_conditional_type().is_some_and(|conditional| {
+            conditional.extends_type.span().contains_inclusive(infer_type.span)
+        })
+    });
 
     if !is_in_conditional_extends_clause {
         ctx.error(diagnostics::infer_declaration_only_permitted_in_extends_clause(infer_type.span));
@@ -120,8 +119,8 @@ pub fn check_ts_global_declaration<'a>(decl: &TSGlobalDeclaration<'a>, ctx: &Sem
 
 fn check_ts_module_or_global_declaration(span: Span, ctx: &SemanticBuilder<'_>) {
     // skip current node
-    for node in ctx.nodes.ancestors(ctx.current_node_id) {
-        match node.kind() {
+    for kind in ctx.ancestry().ancestor_kinds() {
+        match kind {
             AstKind::Program(_)
             | AstKind::TSModuleBlock(_)
             | AstKind::TSModuleDeclaration(_)
@@ -241,7 +240,7 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
             ctx.source_type.is_typescript_definition(),
             |id| {
                 let node_id = ctx.class_table_builder.classes.declarations[id];
-                let AstKind::Class(class) = ctx.nodes.get_node(node_id).kind() else {
+                let AstKind::Class(class) = ctx.ancestry().find_kind_by_node_id(node_id) else {
                     #[cfg(debug_assertions)]
                     panic!("current_class_id is set, but does not point to a Class node.");
                     #[cfg(not(debug_assertions))]

--- a/crates/oxc_semantic/src/class/builder.rs
+++ b/crates/oxc_semantic/src/class/builder.rs
@@ -8,7 +8,7 @@ use oxc_ast::{
 use oxc_span::GetSpan;
 use oxc_syntax::class::{ClassId, ElementKind};
 
-use crate::{AstNodes, NodeId};
+use crate::NodeId;
 
 use super::{
     ClassTable,
@@ -31,17 +31,12 @@ impl<'a> ClassTableBuilder<'a> {
         self.classes
     }
 
-    pub fn declare_class_body(
-        &mut self,
-        class: &ClassBody<'a>,
-        current_node_id: NodeId,
-        nodes: &AstNodes,
-    ) {
+    pub fn declare_class_body(&mut self, class: &ClassBody<'a>, parent_node_id: NodeId) {
         if !self.enabled {
             return;
         }
-        let parent_id = nodes.parent_id(current_node_id);
-        self.current_class_id = Some(self.classes.declare_class(self.current_class_id, parent_id));
+        self.current_class_id =
+            Some(self.classes.declare_class(self.current_class_id, parent_node_id));
 
         for element in &class.body {
             match element {
@@ -103,13 +98,11 @@ impl<'a> ClassTableBuilder<'a> {
         &mut self,
         ident: &PrivateIdentifier<'a>,
         current_node_id: NodeId,
-        nodes: &AstNodes,
+        parent_kind: AstKind<'a>,
     ) {
         if !self.enabled {
             return;
         }
-        let parent_kind = nodes.parent_kind(current_node_id);
-
         if (matches!(parent_kind, AstKind::PrivateInExpression(_))
             || parent_kind.is_member_expression_kind())
             && let Some(class_id) = self.current_class_id

--- a/crates/oxc_semantic/src/jsdoc.rs
+++ b/crates/oxc_semantic/src/jsdoc.rs
@@ -71,7 +71,7 @@ mod test {
     ) -> Semantic<'a> {
         let source_type = source_type.unwrap_or_default();
         let ret = Parser::new(allocator, source_text, source_type).parse();
-        SemanticBuilder::new().build(allocator.alloc(ret.program)).semantic
+        SemanticBuilder::new().with_build_nodes(true).build(allocator.alloc(ret.program)).semantic
     }
 
     fn get_jsdocs<'a>(

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -49,7 +49,7 @@ pub use builder::{SemanticBuilder, SemanticBuilderReturn};
 pub use is_global_reference::IsGlobalReference;
 #[cfg(feature = "jsdoc")]
 pub use jsdoc::JSDocFinder;
-pub use node::{AstNode, AstNodes};
+pub use node::{Ancestry, AncestryStack, AstNode, AstNodes};
 #[cfg(feature = "jsdoc")]
 pub use oxc_jsdoc::{JSDoc, JSDocTag};
 pub use scoping::Scoping;
@@ -292,7 +292,8 @@ mod tests {
     ) -> Semantic<'s> {
         let parse = oxc_parser::Parser::new(allocator, source, source_type).parse();
         assert!(parse.errors.is_empty());
-        let semantic = SemanticBuilder::new().build(allocator.alloc(parse.program));
+        let semantic =
+            SemanticBuilder::new().with_build_nodes(true).build(allocator.alloc(parse.program));
         assert!(semantic.errors.is_empty(), "Parse error: {}", semantic.errors[0]);
         semantic.semantic
     }

--- a/crates/oxc_semantic/src/node/ancestry.rs
+++ b/crates/oxc_semantic/src/node/ancestry.rs
@@ -1,0 +1,247 @@
+use oxc_allocator::{Address, GetAddress};
+use oxc_ast::AstKind;
+use oxc_data_structures::stack::Stack;
+use oxc_syntax::node::NodeId;
+
+/// Stack of ancestors of the node currently being visited.
+///
+/// This is one of the three independent pieces of state the builder maintains
+/// while traversing (the other two being the standalone `NodeId` counter and
+/// the optional full [`AstNodes`] store). It does **not** depend on the full
+/// node store, so it is available even when that store is not retained.
+///
+/// It is the *only* ancestry information the syntax checker reads, and exposes
+/// an **upward-walk-only** API: you can look at the current node and walk up
+/// towards the root. There is no downward/sideways traversal.
+///
+/// The top of the stack is the node currently being visited. Each frame stores
+/// the node's [`AstKind`] (which also carries its [`NodeId`]).
+///
+/// [`AstNodes`]: super::AstNodes
+pub struct AncestryStack<'a> {
+    /// Path from the root (`Program`) down to the node currently being visited.
+    /// The last element is the current node.
+    stack: Stack<AstKind<'a>>,
+}
+
+/// Iterator walking up the ancestry stack, yielding [`AstKind`]s.
+type AncestorKinds<'s, 'a> = std::iter::Copied<std::iter::Rev<std::slice::Iter<'s, AstKind<'a>>>>;
+
+impl Default for AncestryStack<'_> {
+    fn default() -> Self {
+        // Reserve enough frames for typical AST nesting depth so the stack does not reallocate
+        // while traversing. `Stack`'s own default capacity is only 4 for a 16-byte `AstKind`.
+        Self { stack: Stack::with_capacity(64) }
+    }
+}
+
+impl<'a> AncestryStack<'a> {
+    /// Push the node currently being entered onto the stack.
+    #[inline]
+    pub(crate) fn push(&mut self, kind: AstKind<'a>) {
+        self.stack.push(kind);
+    }
+
+    /// Pop the current node when leaving it.
+    #[inline]
+    pub(crate) fn pop(&mut self) {
+        self.stack.pop();
+    }
+
+    /// [`NodeId`] of the node currently being visited, or [`NodeId::ROOT`] when
+    /// the stack is empty.
+    ///
+    /// Used by the builder to restore `current_node_id` on `leave_node` without
+    /// consulting the full node store.
+    #[inline]
+    pub(crate) fn current_node_id(&self) -> NodeId {
+        self.stack.last().map_or(NodeId::ROOT, AstKind::node_id)
+    }
+
+    /// [`NodeId`] of the parent of the node currently being visited, or
+    /// [`NodeId::ROOT`] when the current node is the root (`Program`).
+    #[inline]
+    pub(crate) fn parent_node_id(&self) -> NodeId {
+        let stack = self.stack.as_slice();
+        // `Program` is its own parent.
+        let parent_index = stack.len().saturating_sub(2);
+        stack.get(parent_index).map_or(NodeId::ROOT, AstKind::node_id)
+    }
+
+    /// [`AstKind`] of the node currently being visited (top of the stack).
+    ///
+    /// # Panics
+    /// Panics if the stack is empty (i.e. not inside a node visit).
+    #[inline]
+    pub fn current_kind(&self) -> AstKind<'a> {
+        *self.stack.last().expect("ancestry stack is empty")
+    }
+
+    /// [`Address`] of the node currently being visited.
+    #[inline]
+    pub fn current_address(&self) -> Address {
+        self.current_kind().address()
+    }
+
+    /// [`AstKind`] of the parent of the node currently being visited.
+    ///
+    /// Returns the current node's own kind when the current node is the root
+    /// (`Program`), as `Program` is its own parent.
+    #[inline]
+    pub fn parent_kind(&self) -> AstKind<'a> {
+        let stack = self.stack.as_slice();
+        // `Program` is its own parent.
+        let parent_index = stack.len().saturating_sub(2);
+        stack[parent_index]
+    }
+
+    /// Walk up the stack, yielding each ancestor's [`AstKind`].
+    ///
+    /// The first kind produced is the parent of the current node; the last is
+    /// `Program`.
+    #[inline]
+    pub fn ancestor_kinds(&self) -> AncestorKinds<'_, 'a> {
+        // Skip the current node (last element), walk towards the root.
+        let stack = self.stack.as_slice();
+        let upto = stack.len().saturating_sub(1);
+        stack[..upto].iter().rev().copied()
+    }
+
+    /// Walk up the stack starting *at* a chosen node (inclusive), yielding each
+    /// [`AstKind`].
+    ///
+    /// `from` selects the start node:
+    /// - `None` starts at the current node (so the first kind is the current
+    ///   node, then its ancestors).
+    /// - `Some(node_id)` starts at `node_id`, which must be on the current path
+    ///   (an ancestor of, or equal to, the node being visited). If not found,
+    ///   the returned iterator is empty.
+    #[inline]
+    pub fn ancestor_kinds_from(&self, from: Option<NodeId>) -> AncestorKinds<'_, 'a> {
+        let stack = self.stack.as_slice();
+        let end = match from {
+            None => stack.len(),
+            Some(node_id) => {
+                stack.iter().rposition(|kind| kind.node_id() == node_id).map_or(0, |i| i + 1)
+            }
+        };
+        stack[..end].iter().rev().copied()
+    }
+
+    /// Find the node with the given [`NodeId`] by walking up the current path,
+    /// returning its [`AstKind`].
+    ///
+    /// Used by checks that resolve `scope -> node` via
+    /// `Scoping::get_node_id(scope)` (and similar `class -> node` lookups). The
+    /// target is always an ancestor of the node being visited.
+    ///
+    /// # Panics
+    /// Panics if no ancestor has the given `node_id`.
+    #[inline]
+    pub fn find_kind_by_node_id(&self, node_id: NodeId) -> AstKind<'a> {
+        self.stack
+            .as_slice()
+            .iter()
+            .rev()
+            .find(|kind| kind.node_id() == node_id)
+            .copied()
+            .expect("node id not found on the ancestry stack")
+    }
+}
+
+/// Upward-walking ancestry view used by the syntax checker and binder.
+///
+/// Dispatches between two backends so the checker/binder code is written once:
+///
+/// - [`Ancestry::Nodes`] — when the full [`AstNodes`] store is built (linter,
+///   mangler), ancestry is read from the store via `current_node_id`. No
+///   separate stack is maintained, so this path has no per-node overhead.
+/// - [`Ancestry::Stack`] — when the store is *not* built (compiler pipeline),
+///   ancestry is read from the [`AncestryStack`] maintained during traversal.
+///
+/// Either way the surface is upward-walk-only and never exposes random access.
+///
+/// [`AstNodes`]: super::AstNodes
+#[derive(Clone, Copy)]
+pub enum Ancestry<'a, 'n> {
+    /// Read ancestry from the full node store.
+    Nodes { nodes: &'n super::AstNodes<'a>, current_node_id: NodeId },
+    /// Read ancestry from the standalone stack.
+    Stack(&'n AncestryStack<'a>),
+}
+
+impl<'a, 'n> Ancestry<'a, 'n> {
+    /// [`AstKind`] of the node currently being visited.
+    #[inline]
+    pub fn current_kind(self) -> AstKind<'a> {
+        match self {
+            Ancestry::Nodes { nodes, current_node_id } => nodes.kind(current_node_id),
+            Ancestry::Stack(stack) => stack.current_kind(),
+        }
+    }
+
+    /// [`Address`] of the node currently being visited.
+    #[inline]
+    pub fn current_address(self) -> Address {
+        self.current_kind().address()
+    }
+
+    /// [`AstKind`] of the parent of the node currently being visited.
+    #[inline]
+    pub fn parent_kind(self) -> AstKind<'a> {
+        match self {
+            Ancestry::Nodes { nodes, current_node_id } => nodes.parent_kind(current_node_id),
+            Ancestry::Stack(stack) => stack.parent_kind(),
+        }
+    }
+
+    /// [`NodeId`] of the parent of the node currently being visited.
+    #[inline]
+    pub fn parent_node_id(self) -> NodeId {
+        match self {
+            Ancestry::Nodes { nodes, current_node_id } => nodes.parent_id(current_node_id),
+            Ancestry::Stack(stack) => stack.parent_node_id(),
+        }
+    }
+
+    /// Walk up, yielding each ancestor's [`AstKind`] (parent first, `Program`
+    /// last).
+    #[inline]
+    pub fn ancestor_kinds(self) -> impl Iterator<Item = AstKind<'a>> + Clone + 'n {
+        match self {
+            Ancestry::Nodes { nodes, current_node_id } => {
+                itertools::Either::Left(nodes.ancestor_kinds(current_node_id))
+            }
+            Ancestry::Stack(stack) => itertools::Either::Right(stack.ancestor_kinds()),
+        }
+    }
+
+    /// Walk up starting *at* a chosen node (inclusive). `None` starts at the
+    /// current node; `Some(node_id)` starts at `node_id` (which must be on the
+    /// current path).
+    #[inline]
+    pub fn ancestor_kinds_from(
+        self,
+        from: Option<NodeId>,
+    ) -> impl Iterator<Item = AstKind<'a>> + Clone + 'n {
+        match self {
+            Ancestry::Nodes { nodes, current_node_id } => {
+                let start = from.unwrap_or(current_node_id);
+                itertools::Either::Left(
+                    std::iter::once(nodes.kind(start)).chain(nodes.ancestor_kinds(start)),
+                )
+            }
+            Ancestry::Stack(stack) => itertools::Either::Right(stack.ancestor_kinds_from(from)),
+        }
+    }
+
+    /// Find the node with the given [`NodeId`] and return its [`AstKind`]. The
+    /// target is always an ancestor of the node being visited.
+    #[inline]
+    pub fn find_kind_by_node_id(self, node_id: NodeId) -> AstKind<'a> {
+        match self {
+            Ancestry::Nodes { nodes, .. } => nodes.kind(node_id),
+            Ancestry::Stack(stack) => stack.find_kind_by_node_id(node_id),
+        }
+    }
+}

--- a/crates/oxc_semantic/src/node/mod.rs
+++ b/crates/oxc_semantic/src/node/mod.rs
@@ -1,6 +1,10 @@
+mod ancestry;
 mod nodes;
+mod store;
 
+pub use ancestry::{Ancestry, AncestryStack};
 pub use nodes::AstNodes;
+pub use store::{AstNodeStore, AstNodeStoreKind};
 
 use oxc_allocator::{Address, GetAddress};
 use oxc_ast::AstKind;

--- a/crates/oxc_semantic/src/node/nodes.rs
+++ b/crates/oxc_semantic/src/node/nodes.rs
@@ -176,14 +176,18 @@ impl<'a> AstNodes<'a> {
     #[inline]
     pub fn add_node(
         &mut self,
+        node_id: NodeId,
         kind: AstKind<'a>,
         scope_id: ScopeId,
         parent_node_id: NodeId,
         #[cfg(feature = "cfg")] cfg_id: BlockNodeId,
         flags: NodeFlags,
-    ) -> NodeId {
-        let node_id = self.parent_ids.push(parent_node_id);
-        kind.set_node_id(node_id);
+    ) {
+        // `node_id` is allocated by the builder's standalone node-id counter; this
+        // store just records the node at the next index, which must equal `node_id`
+        // as nodes are added in id order.
+        debug_assert_eq!(self.parent_ids.len(), node_id.index());
+        self.parent_ids.push(parent_node_id);
         let node = AstNode::new(kind, scope_id);
         self.nodes.push(node);
         self.flags.push(flags);
@@ -191,7 +195,6 @@ impl<'a> AstNodes<'a> {
         self.cfg_ids.push(cfg_id);
         #[cfg(feature = "linter")]
         self.node_kinds_set.set(kind.ty());
-        node_id
     }
 
     /// Create and add an [`AstNode`] to the [`AstNodes`] tree and get its [`NodeId`].
@@ -205,13 +208,13 @@ impl<'a> AstNodes<'a> {
         scope_id: ScopeId,
         #[cfg(feature = "cfg")] cfg_id: BlockNodeId,
         flags: NodeFlags,
-    ) -> NodeId {
+    ) {
         assert!(self.parent_ids.is_empty(), "Program node must be the first node in the AST.");
         debug_assert!(
             matches!(kind, AstKind::Program(_)),
             "Program node must be of kind `AstKind::Program`"
         );
-        kind.set_node_id(NodeId::ROOT);
+        // `Program` always has node id `NodeId::ROOT`, set by the builder.
         self.parent_ids.push(NodeId::ROOT);
         self.nodes.push(AstNode::new(kind, scope_id));
         self.flags.push(flags);
@@ -219,7 +222,6 @@ impl<'a> AstNodes<'a> {
         self.cfg_ids.push(cfg_id);
         #[cfg(feature = "linter")]
         self.node_kinds_set.set(AstType::Program);
-        NodeId::ROOT
     }
 
     /// Reserve space for at least `additional` more nodes.

--- a/crates/oxc_semantic/src/node/store.rs
+++ b/crates/oxc_semantic/src/node/store.rs
@@ -1,0 +1,108 @@
+use oxc_syntax::node::{NodeFlags, NodeId};
+
+use super::{Ancestry, AncestryStack, AstNodes};
+
+/// The node-related state the builder keeps while traversing.
+///
+/// Bundles the three independent pieces of traversal state — the standalone
+/// `NodeId` counter, the cursor/flags of the node currently being visited, and
+/// the actual node storage — so the [`SemanticBuilder`] doesn't have to track
+/// them as separate fields.
+///
+/// [`SemanticBuilder`]: crate::SemanticBuilder
+pub struct AstNodeStore<'a> {
+    /// Standalone `NodeId` counter. The source of truth for node ids, valid even
+    /// when the full node store is not built.
+    node_count: u32,
+    /// `NodeId` of the node currently being visited.
+    pub current_node_id: NodeId,
+    /// Flags for the node currently being visited.
+    pub current_node_flags: NodeFlags,
+    /// The actual node storage. See [`AstNodeStoreKind`].
+    pub kind: AstNodeStoreKind<'a>,
+}
+
+/// The node storage, kept as an enum so the two modes are **mutually exclusive
+/// by construction** — the full [`AstNodes`] store and the ancestry stack can
+/// never both be maintained at the same time:
+///
+/// - [`AstNodeStoreKind::Full`] — linter / mangler. The full node store is built
+///   and ancestry is read from it.
+/// - [`AstNodeStoreKind::Ancestry`] — compiler pipeline. Only the lightweight
+///   ancestry stack is maintained; the full store is never built.
+pub enum AstNodeStoreKind<'a> {
+    /// Full AST node store (linter / mangler).
+    Full(AstNodes<'a>),
+    /// Ancestry stack only (compiler pipeline).
+    Ancestry(AncestryStack<'a>),
+}
+
+impl Default for AstNodeStore<'_> {
+    fn default() -> Self {
+        Self {
+            node_count: 0,
+            current_node_id: NodeId::new(0),
+            current_node_flags: NodeFlags::empty(),
+            // Default to the compiler pipeline (ancestry stack, no full store).
+            kind: AstNodeStoreKind::Ancestry(AncestryStack::default()),
+        }
+    }
+}
+
+impl<'a> AstNodeStore<'a> {
+    /// Switch between the two mutually-exclusive modes. Called at construction
+    /// before traversal starts.
+    pub fn set_build_nodes(&mut self, yes: bool) {
+        self.kind = if yes {
+            AstNodeStoreKind::Full(AstNodes::default())
+        } else {
+            AstNodeStoreKind::Ancestry(AncestryStack::default())
+        };
+    }
+
+    /// Number of nodes allocated so far. Source of truth, valid in both modes.
+    /// Only used by the debug-only stats accuracy check.
+    #[cfg(debug_assertions)]
+    #[inline]
+    pub fn node_count(&self) -> u32 {
+        self.node_count
+    }
+
+    /// Allocate the next [`NodeId`] from the standalone counter.
+    #[inline]
+    pub fn alloc_node_id(&mut self) -> NodeId {
+        let node_id = NodeId::new(self.node_count as usize);
+        self.node_count += 1;
+        node_id
+    }
+
+    /// Reserve capacity in the full node store (no-op in ancestry mode).
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        if let AstNodeStoreKind::Full(nodes) = &mut self.kind {
+            nodes.reserve(additional);
+        }
+    }
+
+    /// Upward-walking view of the current node's ancestors. Reads from the full
+    /// node store when it is built, otherwise from the standalone ancestry stack.
+    #[inline]
+    pub fn ancestry(&self) -> Ancestry<'a, '_> {
+        match &self.kind {
+            AstNodeStoreKind::Full(nodes) => {
+                Ancestry::Nodes { nodes, current_node_id: self.current_node_id }
+            }
+            AstNodeStoreKind::Ancestry(stack) => Ancestry::Stack(stack),
+        }
+    }
+
+    /// Consume into the full [`AstNodes`] store, or an empty store in ancestry
+    /// mode.
+    #[inline]
+    pub fn into_nodes(self) -> AstNodes<'a> {
+        match self.kind {
+            AstNodeStoreKind::Full(nodes) => nodes,
+            AstNodeStoreKind::Ancestry(_) => AstNodes::default(),
+        }
+    }
+}

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -179,6 +179,7 @@ impl<'a> SemanticTester<'a> {
         );
 
         SemanticBuilder::new_compiler()
+            .with_build_nodes(true)
             .with_cfg(self.cfg)
             .build(self.allocator.alloc(parse.program))
     }

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -126,7 +126,9 @@ fn analyze(
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    let semantic = SemanticBuilder::new_compiler().build(&ret.program).semantic;
+    // The conformance checks read `Semantic::nodes()`, so use the linter preset.
+    let semantic =
+        SemanticBuilder::new_compiler().with_build_nodes(true).build(&ret.program).semantic;
     let ctx = TestContext { path, semantic };
     let scope_snapshot = run_scope_snapshot_test(&ctx);
     let conformance_snapshot = conformance_suite.run_on_source(&ctx);

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -236,7 +236,7 @@ impl Oxc {
         parser_options: &OxcParserOptions,
         control_flow_options: &OxcControlFlowOptions,
     ) -> oxc::semantic::Semantic<'a> {
-        let mut semantic_builder = SemanticBuilder::new_compiler();
+        let mut semantic_builder = SemanticBuilder::new_compiler().with_build_nodes(true);
         if run_options.transform {
             // Estimate transformer will triple scopes, symbols, references
             semantic_builder = semantic_builder.with_excess_capacity(2.0).with_enum_eval(true);

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -89,7 +89,8 @@ fn bench_mangler(criterion: &mut Criterion) {
                 allocator.reset();
                 temp_allocator.reset();
                 let program = transform_to_js(&allocator, source_text, source_type, path);
-                let mut semantic = SemanticBuilder::new().build(&program).semantic;
+                let mut semantic =
+                    SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
                 runner.run(|| {
                     Mangler::new_with_temp_allocator(&temp_allocator)
                         .build_with_semantic(&mut semantic, &program);
@@ -112,7 +113,8 @@ fn bench_mangler(criterion: &mut Criterion) {
                 allocator.reset();
                 temp_allocator.reset();
                 let program = transform_to_js(&allocator, source_text, source_type, path);
-                let mut semantic = SemanticBuilder::new().build(&program).semantic;
+                let mut semantic =
+                    SemanticBuilder::new().with_build_nodes(true).build(&program).semantic;
                 runner.run(|| {
                     Mangler::new_with_temp_allocator(&temp_allocator)
                         .with_options(MangleOptions {

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -54,6 +54,11 @@ impl CompilerInterface for Driver {
         self.transform.as_ref()
     }
 
+    fn build_semantic_nodes(&self) -> bool {
+        // The coverage checks read `Semantic::nodes()` (e.g. `nodes().program()`).
+        true
+    }
+
     fn compress_options(&self) -> Option<CompressOptions> {
         self.compress.clone()
     }

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||            166 |              4 ||         152662 |          28244
+checker.ts                 | 2.92 MB        ||            165 |             51 ||         152662 |          28244
 
-App.tsx                    | 415.34 kB      ||            115 |              7 ||          16995 |           2702
+App.tsx                    | 415.34 kB      ||            114 |             48 ||          16995 |           2702
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             24 |              0 ||             31 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             23 |             20 ||             31 |              6
 
-pdf.mjs                    | 567.30 kB      ||           2614 |            203 ||          47465 |           7740
+pdf.mjs                    | 567.30 kB      ||           2613 |            247 ||          47465 |           7740
 
-antd.js                    | 6.69 MB        ||           3084 |             53 ||         336992 |          69349
+antd.js                    | 6.69 MB        ||           3083 |            103 ||         336992 |          69349
 
-binder.ts                  | 193.08 kB      ||             41 |              1 ||           7076 |            824
+binder.ts                  | 193.08 kB      ||             40 |             36 ||           7076 |            824
 
-kitchen-sink.tsx           | 732.90 kB      ||           2918 |            171 ||         100206 |          17853
+kitchen-sink.tsx           | 732.90 kB      ||           2917 |            215 ||         100206 |          17853
 

--- a/tasks/track_memory_allocations/allocs_semantic.snap
+++ b/tasks/track_memory_allocations/allocs_semantic.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             48 |              0 ||              0 |              0
+checker.ts                 | 2.92 MB        ||             46 |              0 ||              0 |              0
 
-App.tsx                    | 415.34 kB      ||             31 |              0 ||              0 |              0
+App.tsx                    | 415.34 kB      ||             29 |              0 ||              0 |              0
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             10 |              0 ||              0 |              0
+RadixUIAdoptionSection.jsx | 2.52 kB        ||              8 |              0 ||              0 |              0
 
-pdf.mjs                    | 567.30 kB      ||             40 |              0 ||              0 |              0
+pdf.mjs                    | 567.30 kB      ||             38 |              0 ||              0 |              0
 
-antd.js                    | 6.69 MB        ||           1072 |              0 ||              0 |              0
+antd.js                    | 6.69 MB        ||           1070 |              0 ||              0 |              0
 
-binder.ts                  | 193.08 kB      ||             19 |              0 ||              0 |              0
+binder.ts                  | 193.08 kB      ||             17 |              0 ||              0 |              0
 
-kitchen-sink.tsx           | 732.90 kB      ||             73 |              0 ||              0 |              0
+kitchen-sink.tsx           | 732.90 kB      ||             71 |              0 ||              0 |              0
 


### PR DESCRIPTION
## What

Make the full `AstNodes` store **opt-in**, so the compiler pipeline (transformer / codegen / minifier) can run semantic analysis without building it at all.

Previously every `SemanticBuilder` run allocated and populated the full `AstNodes` store, even for consumers that only need scoping + the syntax checker. This separates the node-related builder state into three independent pieces:

- a standalone `NodeId` counter — the source of truth for node ids, valid in either mode;
- an **ancestry stack** — an upward-walk-only stack of the current node's ancestors, the only ancestry the syntax checker and binder actually read;
- the full **`AstNodes`** store — random access to every node, needed by the linter and mangler.

## How

- A new `AstNodeStore` (in `crates/oxc_semantic/src/node/store.rs`) bundles the node-id counter, the current-node cursor/flags, and the storage. The storage is an enum (`AstNodeStoreKind`) with two variants — `Full(AstNodes)` and `Ancestry(AncestryStack)` — so the full store and the ancestry stack are **mutually exclusive by construction**; they can never both be maintained at once.
- The checker and binder read ancestry through an `Ancestry` view (`node/ancestry.rs`) that dispatches between the full store (linter / mangler) and the stack (compiler pipeline). They no longer do random `NodeId` access into the store — all ancestry access is upward-walk-only.
- `SemanticBuilder` gains `with_build_nodes(bool)`. The default is **off** (ancestry stack only). `new_linter()` turns it on (the linter needs the full store); `new_compiler()` leaves it off.
- `CompilerInterface::build_semantic_nodes()` lets `oxc::Compiler` consumers opt back in if their `after_semantic` hook reads `Semantic::nodes`.

## Notes

- Behaviour-neutral: semantic conformance snapshots are unchanged.
- Allocation snapshots updated — the default (ancestry) path allocates slightly less (the growing `Stack` trades a couple of fixed allocations for a few reallocs).
- Builds on the already-merged `SymbolFlags`-based redeclaration checks (#23060) and the `new_linter`/`new_compiler` preset adoption (#23057), which removed the last random node reads from the redeclaration path so the checker works without the store.