### PR TITLE
fix(codegen): don't leak space after comment-only JSX expression container

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2561,6 +2561,8 @@ impl Gen for JSXAttribute<'_> {
 impl Gen for JSXEmptyExpression {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
         p.print_comments_at(self.span.end);
+        // Clear the flag so the comment doesn't leak a space onto the next indent.
+        p.print_next_indent_as_space = false;
     }
 }
 

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -44,6 +44,9 @@ fn test_comment_at_top_of_file() {
 #[test]
 fn unit() {
     test_same("<div>{/* Hello */}</div>;\n");
+    // A comment-only JSX expression container must not leak a leading space onto
+    // the following statement's indent.
+    test_same("x = <div>{/* Hello */}</div>;\ny = 1;\n");
     // https://github.com/oxc-project/oxc/issues/17266
     test("console.log(<div x={/*before*/ x} />)", "console.log(<div x={/*before*/ x} />);\n");
     test(


### PR DESCRIPTION
## What

A comment-only JSX expression container such as `{/* Hello */}` prints its comment via `print_comments`, which sets `print_next_indent_as_space = true` (the mechanism that turns the next indent into a single space for inline comments like `/* c */ code`).

But the container's closing `}` is printed directly with `print_ascii_byte`, not through `print_indent`, so the flag is never consumed there. It leaks until the **next statement's** `print_indent`, producing a stray leading space.

```jsx
x = <div>{/* Hello */}</div>;
y = 1;
```

Before:
```jsx
x = <div>{/* Hello */}</div>;
 y = 1;
```

After:
```jsx
x = <div>{/* Hello */}</div>;
y = 1;
```

## Fix

Clear `print_next_indent_as_space` after printing the empty expression's comments — the comment is the entire content of `{...}` and is always immediately followed by `}`, so the flag should never carry past it. This is the same class of leak already handled for orphaned legal comments.