### PR TITLE
fix(codegen): parenthesize lower-precedence `TSInstantiationExpression` operand

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2369,8 +2369,9 @@ impl GenExpr for TSNonNullExpression<'_> {
 }
 
 impl GenExpr for TSInstantiationExpression<'_> {
-    fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
-        self.expression.print_expr(p, precedence, ctx);
+    fn gen_expr(&self, p: &mut Codegen, _precedence: Precedence, ctx: Context) {
+        // Wrap a lower-precedence operand so `(a ?? b)<T>` isn't emitted as `a ?? b<T>`.
+        self.expression.print_expr(p, Precedence::Prefix, ctx);
         self.type_arguments.print(p, ctx);
         if p.options.minify {
             p.print_hard_space();

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -223,6 +223,18 @@ fn ts_type_assertion() {
 }
 
 #[test]
+fn ts_instantiation_expression() {
+    test_same("v = (a ?? b)<T>;\n");
+    test_same("w = (a + b)<T>;\n");
+    test_same("x = (a, b)<T>;\n");
+    test_same("q = (a as B)<T>;\n");
+    test_same("r = (-a)<T>;\n");
+    test_same("y = a.b<T>;\n");
+    test_same("z = f<T>;\n");
+    test_same("p = a()<T>;\n");
+}
+
+#[test]
 fn ts_satisfies_expression() {
     test_idempotency("d = x satisfies y");
     test_idempotency("const Foo = (() => {})() satisfies X");


### PR DESCRIPTION
## What

A type-instantiation expression `expr<T>` forwarded the incoming precedence to its operand, so a lower-precedence operand wasn't parenthesized. `(a ?? b)<T>` was emitted as `a ?? b<T>`, which re-parses as `a ?? (b<T>)` — the `<T>` binds to `b` instead of the whole `a ?? b`, a **different AST**.

The operand of `expr<T>` is a member/LHS expression, so it's now printed at `Precedence::Prefix`, wrapping lower-precedence operands while leaving member/call operands bare.

## Examples

| Input | Before | After |
| --- | --- | --- |
| `(a ?? b)<T>` | `a ?? b<T>` ❌ | `(a ?? b)<T>` ✅ |
| `(a + b)<T>` | `a + b<T>` ❌ | `(a + b)<T>` ✅ |
| `(a as B)<T>` | `a as B<T>` ❌ | `(a as B)<T>` ✅ |
| `(-a)<T>` | `-a<T>` ❌ | `(-a)<T>` ✅ |

Member/call operands keep needing no parentheses: `a.b<T>`, `f<T>`, `a()<T>`.

`Prefix` (not `Postfix`) is used so the pure-annotated-call wrap rule isn't triggered — `(() => {})()<X>` stays as-is rather than gaining redundant parens.