### PR TITLE
fix(codegen): don't over-parenthesize `in` inside an arrow in a for-init

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1757,7 +1757,12 @@ impl Gen for PropertyKey<'_> {
 
 impl GenExpr for ArrowFunctionExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
-        p.wrap(precedence >= Precedence::Assign || self.pife, |p| {
+        let wrap = precedence >= Precedence::Assign || self.pife;
+        // Clear FORBID_IN: always for param defaults (always parenthesized), and for
+        // the concise body only when the arrow is wrapped (which resets the `for` init).
+        let params_ctx = ctx & Context::FORBID_IN.not();
+        let body_ctx = if wrap { params_ctx } else { ctx };
+        p.wrap(wrap, |p| {
             // `pife` wrap: emit leading comments inside the `(`, so the
             // source position `(/* c */ arrow)` is preserved.
             if self.pife {
@@ -1787,7 +1792,7 @@ impl GenExpr for ArrowFunctionExpression<'_> {
                         && !param.optional
                 };
             p.wrap(!remove_params_wrap, |p| {
-                self.params.print(p, ctx);
+                self.params.print(p, params_ctx);
             });
             if let Some(return_type) = &self.return_type {
                 p.print_colon();
@@ -1800,10 +1805,10 @@ impl GenExpr for ArrowFunctionExpression<'_> {
             if self.expression {
                 if let Some(Statement::ExpressionStatement(stmt)) = &self.body.statements.first() {
                     p.start_of_arrow_expr = p.code_len();
-                    stmt.expression.print_expr(p, Precedence::Comma, ctx);
+                    stmt.expression.print_expr(p, Precedence::Comma, body_ctx);
                 }
             } else {
-                self.body.print(p, ctx);
+                self.body.print(p, body_ctx);
             }
         });
     }

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -498,7 +498,8 @@ fn test_for() {
     test("for (x(a in b);;);", "for (x(a in b);;);\n");
     test("for (x[a in b];;);", "for (x[a in b];;);\n");
     test("for (x?.[a in b];;);", "for (x?.[a in b];;);\n");
-    test("for ((x => a in b);;);", "for (((x) => (a in b));;);\n");
+    // `in` is allowed in an arrow body, so no inner parens are needed (matches esbuild).
+    test("for ((x => a in b);;);", "for (((x) => a in b);;);\n");
 
     // Make sure for-of loops with commas are wrapped in parentheses
     test("for (let a in b, c);", "for (let a in b, c);\n");

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -529,6 +529,11 @@ fn in_expr_in_arrow_function_expression() {
     test("() => ('foo' in bar)", "() => \"foo\" in bar;\n");
     test("() => 'foo' in bar", "() => \"foo\" in bar;\n");
     test("() => { ('foo' in bar) }", "() => {\n\t\"foo\" in bar;\n};\n");
+
+    // A parenthesized arrow resets FORBID_IN, so its concise body / param default
+    // does not need extra parentheses around `in` (was `(() => (a in b))`).
+    test("for (x = (() => a in b);;);", "for (x = (() => a in b);;);\n");
+    test("for (x = ((a = b in c) => 1);;);", "for (x = ((a = b in c) => 1);;);\n");
 }
 
 #[test]


### PR DESCRIPTION
## What

A `for` init is printed with `Context::FORBID_IN` (so a top-level `in` gets parenthesized). That flag leaked into arrow functions, adding unnecessary parentheses around `in` in the arrow's param defaults and concise body:

```js
for (x = (() => a in b);;);          // was: for (x = (() => (a in b));;);
for (x = ((a = b in c) => 1);;);     // was: for (x = ((a = (b in c)) => 1);;);
```

## Why the parens aren't needed

- **Param defaults** are always inside the parameter list's `( )`, so `in` is always allowed there — `FORBID_IN` is cleared unconditionally.
- **The concise body** inherits `[?In]` (`ConciseBody[?In]`), so `in` is only allowed unparenthesized when the arrow itself is parenthesized — which resets the restriction. So `FORBID_IN` is cleared for the body only when the arrow is wrapped; an unwrapped arrow at a `for`-init top still propagates it (otherwise the output would be a parse error).

## Validation

All affected outputs pass `node --check` in both normal and minify mode. An existing esbuild-mirrored test (`for ((x => a in b);;)`) is updated to drop the inner parens — matching esbuild's own output.