### PR TITLE
fix(codegen): remove stray space before mapped type value colon

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3345,7 +3345,6 @@ impl Gen for TSMappedType<'_> {
             Some(TSMappedTypeModifierOperator::Minus) => p.print_str("-?"),
             None => {}
         }
-        p.print_soft_space();
         if let Some(type_annotation) = &self.type_annotation {
             p.print_colon();
             p.print_soft_space();

--- a/crates/oxc_codegen/tests/integration/snapshots/ts.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/ts.snap
@@ -99,7 +99,7 @@ export { Foo, type Bar } from 'foo';
 ########## 15
 type A<T> = { [K in keyof T as K extends string ? B<K> : K ]: T[K] }
 ----------
-type A<T> = { [K in keyof T as K extends string ? B<K> : K] : T[K] };
+type A<T> = { [K in keyof T as K extends string ? B<K> : K]: T[K] };
 
 ########## 16
 class A {readonly type = 'frame'}

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -26,6 +26,9 @@ fn cases() {
     test_same("type T = (keyof A)[K];\n");
     test_same("type T = (A extends B ? C : D)[K];\n");
     test_same("type T = A extends (B extends C ? D : E) ? F : G;\n");
+    test_same("type T = { [K in U]: V };\n");
+    test_same("type T = { [K in U]?: V };\n");
+    test_same("type T = { -readonly [K in U]-?: V };\n");
     test_same("type T = (A extends B ? C : D) extends E ? F : G;\n");
     test_same("type T = A & (B extends C ? D : E);\n");
     test_same("type T = (A | B) & C;\n");
@@ -269,7 +272,7 @@ fn type_codegen_with_preserve_parens_off() {
     );
     test_with_parse_options(
         "type T = ({ [K in keyof Obj]: Obj[K] } & { a: 1 }) & { b: 2 };",
-        "type T = ({ [K in keyof Obj] : Obj[K] } & {\n\ta: 1;\n}) & {\n\tb: 2;\n};\n",
+        "type T = ({ [K in keyof Obj]: Obj[K] } & {\n\ta: 1;\n}) & {\n\tb: 2;\n};\n",
         parse_options,
     );
 }

--- a/crates/oxc_isolated_declarations/tests/snapshots/mapped-types.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/mapped-types.snap
@@ -8,5 +8,5 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/mapped-types.ts
 import { K } from "foo";
 import { T } from "bar";
 export interface I {
-	prop: { [key in K] : T };
+	prop: { [key in K]: T };
 }


### PR DESCRIPTION
## What

`TSMappedType` printed a `soft_space` immediately before the value colon, so the colon was spaced off from the key:

| Input | Before | After |
| --- | --- | --- |
| `{ [K in U]: V }` | `{ [K in U] : V }` | `{ [K in U]: V }` |
| `{ [K in U]?: V }` | `{ [K in U]? : V }` | `{ [K in U]?: V }` |
| `{ -readonly [K in U]-?: V }` | `{ -readonly [K in U]-? : V }` | `{ -readonly [K in U]-?: V }` |

Every other member colon (object types, interfaces) is printed as `key: value`; mapped types now match. Minified output was already correct (`[K in U]?:V`).

The stray `print_soft_space()` before `print_colon()` is removed.