### PR TITLE
fix(codegen): print space before `const`/`declare` enum modifier

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3967,13 +3967,13 @@ impl Gen for TSInterfaceHeritage<'_> {
 
 impl Gen for TSEnumDeclaration<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
+        p.print_space_before_identifier();
         if self.declare {
             p.print_str("declare ");
         }
         if self.r#const {
             p.print_str("const ");
         }
-        p.print_space_before_identifier();
         p.print_str("enum ");
         self.id.print(p, ctx);
         p.print_space_before_identifier();


### PR DESCRIPTION
## What

`TSEnumDeclaration::gen` printed the `declare ` / `const ` modifiers *before* its `print_space_before_identifier()` guard (which sat just before `enum`). A leading modifier could therefore merge with a preceding identifier-char token.

Most visible when minified, where the soft newline between a `do` and its body collapses:

```ts
do const enum C {} while (0);
```

- Before: `do const enum C {}while(0);` → `doconst enum C {}while(0);`
- After: `do const enum C {}while(0);`

The guard is moved to the start of the declaration so it covers the `declare`/`const` prefixes.