### PR TITLE
fix(parser): report `super.#field` private access in the parser

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -732,6 +732,11 @@ pub fn unexpected_super(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn super_private(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Private fields cannot be accessed on super").with_label(span)
+}
+
+#[cold]
 pub fn expect_function_name(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Expected function name")
         .with_help("Function name is required in function declaration or named export")

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -914,12 +914,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> Expression<'a> {
         Expression::from(if self.cur_kind() == Kind::PrivateIdentifier {
             let private_ident = self.parse_private_identifier();
-            self.ast.member_expression_private_field_expression(
-                self.end_span(lhs_span),
-                lhs,
-                private_ident,
-                optional,
-            )
+            let span = self.end_span(lhs_span);
+            // `super.#field` is not allowed.
+            if lhs.is_super() {
+                self.error(diagnostics::super_private(span));
+            }
+            self.ast.member_expression_private_field_expression(span, lhs, private_ident, optional)
         } else {
             let ident = self.parse_identifier_name();
             self.ast.member_expression_static(self.end_span(lhs_span), lhs, ident, optional)

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -1283,16 +1283,6 @@ pub fn check_object_expression(obj_expr: &ObjectExpression, ctx: &SemanticBuilde
     }
 }
 
-pub fn check_private_field_expression(
-    private_expr: &PrivateFieldExpression,
-    ctx: &SemanticBuilder<'_>,
-) {
-    // `super.#m`
-    if private_expr.object.is_super() {
-        ctx.error(diagnostics::super_private(private_expr.span));
-    }
-}
-
 pub fn check_unary_expression(unary_expr: &UnaryExpression, ctx: &SemanticBuilder<'_>) {
     // https://tc39.es/ecma262/#sec-delete-operator-static-semantics-early-errors
     if unary_expr.operator == UnaryOperator::Delete {

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -101,7 +101,6 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
 
         AstKind::AssignmentExpression(expr) => js::check_assignment_expression(expr, ctx),
         AstKind::AwaitExpression(expr) => js::check_await_expression(expr, ctx),
-        AstKind::PrivateFieldExpression(expr) => js::check_private_field_expression(expr, ctx),
         AstKind::ObjectExpression(expr) => js::check_object_expression(expr, ctx),
         AstKind::UnaryExpression(expr) => js::check_unary_expression(expr, ctx),
         AstKind::YieldExpression(expr) => js::check_yield_expression(expr, ctx),

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -266,11 +266,6 @@ pub fn assignment_is_not_simple(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn super_private(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Private fields cannot be accessed on super").with_label(span)
-}
-
-#[cold]
 pub fn delete_of_unqualified(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Delete of an unqualified identifier in strict mode.").with_label(span)
 }


### PR DESCRIPTION
## What

Moves the "Private fields cannot be accessed on super" check out of the semantic checker (`check_private_field_expression`) and into the parser's `parse_static_member_expression`.

## Why

The check only reads whether the member expression's object is `super` — it needs no scope, symbol, or strict-mode information, so it can move to the parser without introducing any new parser state. The object expression and span are already in hand at the parse site:

```rust
let private_ident = self.parse_private_identifier();
let span = self.end_span(lhs_span);
if lhs.is_super() {
    self.error(diagnostics::super_private(span));
}
self.ast.member_expression_private_field_expression(span, lhs, private_ident, optional)
```

## Conformance

No snapshot changes in any suite; all parser/semantic/linter tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)