### PR TITLE
fix(linter/jsx-a11y): no-redundant-roles attribute-aware implicit roles for `<input>`, skip ancestor-conditional elements

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -1,3 +1,7 @@
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::{
     AstKind,
     ast::{Expression, JSXAttributeItem, JSXAttributeValue, JSXOpeningElement},
@@ -6,9 +10,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_str::CompactStr;
-use rustc_hash::FxHashMap;
-use schemars::JsonSchema;
-use serde::Deserialize;
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -1,7 +1,3 @@
-use rustc_hash::FxHashMap;
-use schemars::JsonSchema;
-use serde::Deserialize;
-
 use oxc_ast::{
     AstKind,
     ast::{Expression, JSXAttributeItem, JSXAttributeValue, JSXOpeningElement},
@@ -10,6 +6,9 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_str::CompactStr;
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -62,18 +62,15 @@ declare_oxc_lint!(
     /// This rule applies for the following elements and their implicit roles:
     ///
     /// - `<button>`: `button`
-    /// - `<main>`: `main`
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```jsx
     /// <button role="button"></button>
-    /// <main role="main"></main>
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```jsx
     /// <button></button>
-    /// <main></main>
     /// ```
     ///
     /// ### Options
@@ -145,9 +142,19 @@ fn get_redundant_implicit_role(
     explicit_role: &str,
 ) -> Option<&'static str> {
     match element {
+        // Skip elements whose implicit role depends on ancestors and cannot
+        // be determined from a single `JSXOpeningElement`. Per ARIA in HTML
+        // (https://www.w3.org/TR/html-aria/), `<header>`/`<footer>` map to
+        // `banner`/`contentinfo` only when not nested in `article`, `aside`,
+        // `main`, `nav`, or `section`; otherwise their role is `generic`.
+        // `<main>` and `<address>` are similarly ancestor- or context-
+        // dependent. eslint-plugin-jsx-a11y omits these elements from its
+        // implicit-role lookup for the same reason. See #22743.
+        "header" | "footer" | "main" | "address" => None,
         "body" => explicit_role.eq_ignore_ascii_case("document").then_some("document"),
         "img" => get_img_implicit_role(jsx_el)
             .filter(|implicit_role| explicit_role.eq_ignore_ascii_case(implicit_role)),
+        "input" => get_input_implicit_role(jsx_el, explicit_role),
         "select" => {
             let implicit_role = get_select_implicit_role(jsx_el);
             explicit_role.eq_ignore_ascii_case(implicit_role).then_some(implicit_role)
@@ -221,6 +228,54 @@ fn jsx_prop_value_is_truthy(item: &JSXAttributeItem) -> bool {
     }
 }
 
+/// Returns the implicit ARIA role matched by the explicit role on an `<input>`.
+///
+/// Mirrors the HTML-AAM table for `input` and matches
+/// `eslint-plugin-jsx-a11y`'s behavior of returning `combobox` only when a
+/// `list` attribute is present.
+fn get_input_implicit_role(
+    jsx_el: &JSXOpeningElement<'_>,
+    explicit_role: &str,
+) -> Option<&'static str> {
+    let input_type = has_jsx_prop_ignore_case(jsx_el, "type")
+        .and_then(get_string_literal_prop_value)
+        .unwrap_or("text");
+    let has_list = has_jsx_prop_ignore_case(jsx_el, "list").is_some();
+
+    if input_type.eq_ignore_ascii_case("checkbox") {
+        explicit_role.eq_ignore_ascii_case("checkbox").then_some("checkbox")
+    } else if input_type.eq_ignore_ascii_case("radio") {
+        explicit_role.eq_ignore_ascii_case("radio").then_some("radio")
+    } else if input_type.eq_ignore_ascii_case("range") {
+        explicit_role.eq_ignore_ascii_case("slider").then_some("slider")
+    } else if input_type.eq_ignore_ascii_case("number") {
+        explicit_role.eq_ignore_ascii_case("spinbutton").then_some("spinbutton")
+    } else if input_type.eq_ignore_ascii_case("search") {
+        if explicit_role.eq_ignore_ascii_case("searchbox") {
+            Some("searchbox")
+        } else if has_list && explicit_role.eq_ignore_ascii_case("combobox") {
+            Some("combobox")
+        } else {
+            None
+        }
+    } else if input_type.eq_ignore_ascii_case("email")
+        || input_type.eq_ignore_ascii_case("tel")
+        || input_type.eq_ignore_ascii_case("url")
+        || input_type.eq_ignore_ascii_case("text")
+        || input_type.is_empty()
+    {
+        if explicit_role.eq_ignore_ascii_case("textbox") {
+            Some("textbox")
+        } else if has_list && explicit_role.eq_ignore_ascii_case("combobox") {
+            Some("combobox")
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
 #[test]
 fn test() {
     use crate::tester::Tester;
@@ -289,6 +344,24 @@ fn test() {
             None,
         ),
         (r#"<li role="listitem" />"#, Some(serde_json::json!([{ "li": ["listitem"] }])), None),
+        // Ancestor-dependent elements: implicit role cannot be determined
+        // from a single opening element, so do not flag. See #22743.
+        (r#"<header role="banner" />"#, None, None),
+        (r#"<header role="banner" aria-label="Editor topbar">Topbar</header>"#, None, None),
+        (r#"<footer role="contentinfo" />"#, None, None),
+        (r#"<main role="main" />"#, None, None),
+        (r#"<main role="main"><p>Content</p></main>"#, None, None),
+        (r#"<address role="group" />"#, None, None),
+        // <input>: combobox is implicit only when a `list` attribute is
+        // set; otherwise the implicit role is `textbox` (HTML-AAM §3.5.76).
+        (r#"<input role="combobox" />"#, None, None),
+        (r#"<input type="text" role="combobox" />"#, None, None),
+        (r#"<input type="search" role="combobox" />"#, None, None),
+        // type=checkbox: implicit role is `checkbox`, not `radio` etc.
+        (r#"<input type="checkbox" role="radio" />"#, None, None),
+        (r#"<input type="checkbox" role="textbox" />"#, None, None),
+        // unknown / non-listed input types should not be flagged.
+        (r#"<input type="password" role="textbox" />"#, None, None),
     ];
 
     let fail = vec![
@@ -304,15 +377,12 @@ fn test() {
         ("<Button role='button' />", None, Some(settings())),
         (r#"<article role="article" />"#, None, None),
         (r#"<aside role="complementary" />"#, None, None),
-        (r#"<footer role="contentinfo" />"#, None, None),
         (r#"<form role="form" />"#, None, None),
         (r#"<h1 role="heading" />"#, None, None),
         (r#"<h2 role="heading" />"#, None, None),
-        (r#"<header role="banner" />"#, None, None),
         (r#"<hr role="separator" />"#, None, None),
         (r#"<img role="img" />"#, None, None),
         (r#"<li role="listitem" />"#, None, None),
-        (r#"<main role="main" />"#, None, None),
         (r#"<ol role="list" />"#, None, None),
         (r#"<ul role="list" />"#, None, None),
         (r#"<select role="combobox" />"#, None, None),
@@ -349,6 +419,16 @@ fn test() {
         (r#"<ul role="list" />"#, Some(serde_json::json!([{ "li": ["listitem"] }])), None),
         // A user-provided option overrides the default exception for that element.
         (r#"<nav role="navigation" />"#, Some(serde_json::json!([{ "nav": [] }])), None),
+        // Attribute-narrowed implicit roles for <input>:
+        (r#"<input list="opts" role="combobox" />"#, None, None),
+        (r#"<input type="search" list="opts" role="combobox" />"#, None, None),
+        (r#"<input type="checkbox" role="checkbox" />"#, None, None),
+        (r#"<input type="radio" role="radio" />"#, None, None),
+        (r#"<input type="range" role="slider" />"#, None, None),
+        (r#"<input type="number" role="spinbutton" />"#, None, None),
+        (r#"<input type="search" role="searchbox" />"#, None, None),
+        (r#"<input type="text" role="textbox" />"#, None, None),
+        (r#"<input role="textbox" />"#, None, None),
     ];
 
     let fix = vec![
@@ -364,11 +444,11 @@ fn test() {
               Foo
              </button>",
         ),
-        ("<main role='main' />", "<main  />"),
-        (
-            "<main role='main'><p>Foobarbaz!!  main role</p></main>",
-            "<main ><p>Foobarbaz!!  main role</p></main>",
-        ),
+        // Note: prior fixtures for `<main role='main' />` and
+        // `<header role='banner' />` were removed because those roles are
+        // ancestor-dependent and no longer flagged. See #22743.
+        (r#"<input type="checkbox" role="checkbox" />"#, r#"<input type="checkbox"  />"#),
+        (r#"<input list="opts" role="combobox" />"#, r#"<input list="opts"  />"#),
     ];
 
     Tester::new(NoRedundantRoles::NAME, NoRedundantRoles::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -238,11 +238,17 @@ fn get_input_implicit_role(
     explicit_role: &str,
 ) -> Option<&'static str> {
     let input_type = has_jsx_prop_ignore_case(jsx_el, "type")
-        .and_then(get_string_literal_prop_value)
+        .and_then(get_static_string_prop_value)
         .unwrap_or("text");
     let has_list = has_jsx_prop_ignore_case(jsx_el, "list").is_some();
 
-    if input_type.eq_ignore_ascii_case("checkbox") {
+    if input_type.eq_ignore_ascii_case("button")
+        || input_type.eq_ignore_ascii_case("image")
+        || input_type.eq_ignore_ascii_case("reset")
+        || input_type.eq_ignore_ascii_case("submit")
+    {
+        explicit_role.eq_ignore_ascii_case("button").then_some("button")
+    } else if input_type.eq_ignore_ascii_case("checkbox") {
         explicit_role.eq_ignore_ascii_case("checkbox").then_some("checkbox")
     } else if input_type.eq_ignore_ascii_case("radio") {
         explicit_role.eq_ignore_ascii_case("radio").then_some("radio")
@@ -423,12 +429,18 @@ fn test() {
         (r#"<input list="opts" role="combobox" />"#, None, None),
         (r#"<input type="search" list="opts" role="combobox" />"#, None, None),
         (r#"<input type="checkbox" role="checkbox" />"#, None, None),
+        (r#"<input type={"checkbox"} role="checkbox" />"#, None, None),
         (r#"<input type="radio" role="radio" />"#, None, None),
         (r#"<input type="range" role="slider" />"#, None, None),
         (r#"<input type="number" role="spinbutton" />"#, None, None),
         (r#"<input type="search" role="searchbox" />"#, None, None),
         (r#"<input type="text" role="textbox" />"#, None, None),
         (r#"<input role="textbox" />"#, None, None),
+        (r#"<input type="email" list="opts" role="combobox" />"#, None, None),
+        (r#"<input type="button" role="button" />"#, None, None),
+        (r#"<input type="image" role="button" />"#, None, None),
+        (r#"<input type="reset" role="button" />"#, None, None),
+        (r#"<input type="submit" role="button" />"#, None, None),
     ];
 
     let fix = vec![
@@ -449,6 +461,7 @@ fn test() {
         // ancestor-dependent and no longer flagged. See #22743.
         (r#"<input type="checkbox" role="checkbox" />"#, r#"<input type="checkbox"  />"#),
         (r#"<input list="opts" role="combobox" />"#, r#"<input list="opts"  />"#),
+        (r#"<input type="submit" role="button" />"#, r#"<input type="submit"  />"#),
     ];
 
     Tester::new(NoRedundantRoles::NAME, NoRedundantRoles::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
@@ -359,6 +359,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the redundant role `checkbox` from the element `input`.
 
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `checkbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:26]
+ 1 │ <input type={"checkbox"} role="checkbox" />
+   ·                          ───────────────
+   ╰────
+  help: Remove the redundant role `checkbox` from the element `input`.
+
   ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `radio`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:21]
  1 │ <input type="radio" role="radio" />
@@ -400,3 +407,38 @@ source: crates/oxc_linter/src/tester.rs
    ·        ──────────────
    ╰────
   help: Remove the redundant role `textbox` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:33]
+ 1 │ <input type="email" list="opts" role="combobox" />
+   ·                                 ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:22]
+ 1 │ <input type="button" role="button" />
+   ·                      ─────────────
+   ╰────
+  help: Remove the redundant role `button` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:21]
+ 1 │ <input type="image" role="button" />
+   ·                     ─────────────
+   ╰────
+  help: Remove the redundant role `button` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:21]
+ 1 │ <input type="reset" role="button" />
+   ·                     ─────────────
+   ╰────
+  help: Remove the redundant role `button` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `button`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:22]
+ 1 │ <input type="submit" role="button" />
+   ·                      ─────────────
+   ╰────
+  help: Remove the redundant role `button` from the element `input`.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_redundant_roles.snap
@@ -86,13 +86,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the redundant role `complementary` from the element `aside`.
 
-  ⚠ jsx-a11y(no-redundant-roles): The `footer` element has an implicit role of `contentinfo`. Defining this explicitly is redundant and should be avoided.
-   ╭─[no_redundant_roles.tsx:1:9]
- 1 │ <footer role="contentinfo" />
-   ·         ──────────────────
-   ╰────
-  help: Remove the redundant role `contentinfo` from the element `footer`.
-
   ⚠ jsx-a11y(no-redundant-roles): The `form` element has an implicit role of `form`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:7]
  1 │ <form role="form" />
@@ -114,13 +107,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the redundant role `heading` from the element `h2`.
 
-  ⚠ jsx-a11y(no-redundant-roles): The `header` element has an implicit role of `banner`. Defining this explicitly is redundant and should be avoided.
-   ╭─[no_redundant_roles.tsx:1:9]
- 1 │ <header role="banner" />
-   ·         ─────────────
-   ╰────
-  help: Remove the redundant role `banner` from the element `header`.
-
   ⚠ jsx-a11y(no-redundant-roles): The `hr` element has an implicit role of `separator`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:5]
  1 │ <hr role="separator" />
@@ -141,13 +127,6 @@ source: crates/oxc_linter/src/tester.rs
    ·     ───────────────
    ╰────
   help: Remove the redundant role `listitem` from the element `li`.
-
-  ⚠ jsx-a11y(no-redundant-roles): The `main` element has an implicit role of `main`. Defining this explicitly is redundant and should be avoided.
-   ╭─[no_redundant_roles.tsx:1:7]
- 1 │ <main role="main" />
-   ·       ───────────
-   ╰────
-  help: Remove the redundant role `main` from the element `main`.
 
   ⚠ jsx-a11y(no-redundant-roles): The `ol` element has an implicit role of `list`. Defining this explicitly is redundant and should be avoided.
    ╭─[no_redundant_roles.tsx:1:5]
@@ -358,3 +337,66 @@ source: crates/oxc_linter/src/tester.rs
    ·      ─────────────────
    ╰────
   help: Remove the redundant role `navigation` from the element `nav`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:20]
+ 1 │ <input list="opts" role="combobox" />
+   ·                    ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `combobox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:34]
+ 1 │ <input type="search" list="opts" role="combobox" />
+   ·                                  ───────────────
+   ╰────
+  help: Remove the redundant role `combobox` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `checkbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:24]
+ 1 │ <input type="checkbox" role="checkbox" />
+   ·                        ───────────────
+   ╰────
+  help: Remove the redundant role `checkbox` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `radio`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:21]
+ 1 │ <input type="radio" role="radio" />
+   ·                     ────────────
+   ╰────
+  help: Remove the redundant role `radio` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `slider`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:21]
+ 1 │ <input type="range" role="slider" />
+   ·                     ─────────────
+   ╰────
+  help: Remove the redundant role `slider` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `spinbutton`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:22]
+ 1 │ <input type="number" role="spinbutton" />
+   ·                      ─────────────────
+   ╰────
+  help: Remove the redundant role `spinbutton` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `searchbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:22]
+ 1 │ <input type="search" role="searchbox" />
+   ·                      ────────────────
+   ╰────
+  help: Remove the redundant role `searchbox` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `textbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:20]
+ 1 │ <input type="text" role="textbox" />
+   ·                    ──────────────
+   ╰────
+  help: Remove the redundant role `textbox` from the element `input`.
+
+  ⚠ jsx-a11y(no-redundant-roles): The `input` element has an implicit role of `textbox`. Defining this explicitly is redundant and should be avoided.
+   ╭─[no_redundant_roles.tsx:1:8]
+ 1 │ <input role="textbox" />
+   ·        ──────────────
+   ╰────
+  help: Remove the redundant role `textbox` from the element `input`.


### PR DESCRIPTION
## Summary

Fixes #22743.

`jsx-a11y/no-redundant-roles` was checking an element's explicit `role` against every possible implicit role in the shared tag-to-role map. That produced false positives for roles that depend on attributes or ancestor context.

This PR narrows the rule at the call site:

- Skip ancestor-dependent elements (`header`, `footer`, `main`, `address`) because a single `JSXOpeningElement` cannot determine whether their landmark role applies.
- Resolve `<input>` implicit roles from `type` and `list` before reporting a redundant role.
- Keep the shared `get_element_implicit_roles` helper unchanged, since other callers still need the full set of possible roles for a tag.

## Details

The input handling now covers the HTML-AAM cases this rule can determine locally:

- `list` on text-like input types maps to `combobox`.
- text-like inputs without `list` map to `textbox`, except `type="search"` maps to `searchbox`.
- `checkbox`, `radio`, `range`, and `number` map to their specific widget roles.
- `button`, `image`, `reset`, and `submit` map to `button`.
- static JSX string expression values such as `type={"checkbox"}` are handled the same as string literal attributes.

`allowedRedundantRoles`, `img`, and `select` behavior from the existing rule are preserved.

## AI disclosure

This PR was prepared with AI assistance. The change set, tests, and HTML-AAM mapping were reviewed against the issue details and upstream `eslint-plugin-jsx-a11y` behavior before submission.
