### PR TITLE
refactor(semantic): add SemanticBuilder::new_compiler / new_linter presets

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -212,7 +212,7 @@ unsafe fn parse_raw_impl(
         // Check for semantic errors.
         // If `ignore_non_fatal_errors` is `true`, skip running semantic, as any errors will be ignored anyway.
         if !parsing_failed && !ignore_non_fatal_errors {
-            let semantic_ret = SemanticBuilder::new().with_check_syntax_error(true).build(program);
+            let semantic_ret = SemanticBuilder::new_compiler().build(program);
             parsing_failed = !semantic_ret.errors.is_empty();
         }
 

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -221,7 +221,7 @@ pub trait CompilerInterface {
     }
 
     fn semantic<'a>(&self, program: &'a Program<'a>) -> SemanticBuilderReturn<'a> {
-        let mut builder = SemanticBuilder::new();
+        let mut builder = SemanticBuilder::new_compiler();
 
         if self.transform_options().is_some() {
             // Estimate transformer will triple scopes, symbols, references

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1141,9 +1141,7 @@ impl Runtime {
             return Err(if ret.is_flow_language { vec![] } else { ret.errors });
         }
 
-        let semantic_ret = SemanticBuilder::new()
-            .with_cfg(true)
-            .with_class_table(true)
+        let semantic_ret = SemanticBuilder::new_linter()
             .with_check_syntax_error(check_syntax_errors)
             .build(allocator.alloc(ret.program));
 

--- a/crates/oxc_semantic/examples/semantic.rs
+++ b/crates/oxc_semantic/examples/semantic.rs
@@ -56,11 +56,8 @@ fn main() -> std::io::Result<()> {
 
     let program = parser_ret.program;
 
-    // Build semantic model with syntax error checking
-    let semantic = SemanticBuilder::new()
-        // Enable additional syntax checks not performed by the parser
-        .with_check_syntax_error(true)
-        .build(&program);
+    // Build semantic model with the compiler-pipeline defaults (syntax error checking).
+    let semantic = SemanticBuilder::new_compiler().build(&program);
 
     // Report semantic analysis errors
     if !semantic.errors.is_empty() {

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -186,6 +186,31 @@ impl<'a> SemanticBuilder<'a> {
         }
     }
 
+    /// Create a builder configured for the **compiler pipeline** (the
+    /// [`Compiler`], transformer, codegen, minifier, napi bindings, ...).
+    ///
+    /// Enables syntax error checking. Leaves linter-only analyses (control flow
+    /// graph, class table) off. This is the single place to tune
+    /// compiler-pipeline defaults; individual options can still be overridden
+    /// with the `with_*` methods.
+    ///
+    /// [`Compiler`]: https://docs.rs/oxc/latest/oxc/struct.Compiler.html
+    #[must_use]
+    pub fn new_compiler() -> Self {
+        Self::new().with_check_syntax_error(true)
+    }
+
+    /// Create a builder configured for the **linter**.
+    ///
+    /// Enables everything the linter relies on: syntax error checking, the
+    /// control flow graph, and the class table. This is the single place to tune
+    /// linter defaults; individual options can still be overridden with the
+    /// `with_*` methods.
+    #[must_use]
+    pub fn new_linter() -> Self {
+        Self::new().with_check_syntax_error(true).with_cfg(true).with_class_table(true)
+    }
+
     /// Enable/disable additional syntax checks.
     ///
     /// Set this to `true` to enable additional syntax checks. Without these,

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -344,10 +344,10 @@ mod tests {
 
         assert!(parse.errors.is_empty());
 
-        let first = SemanticBuilder::new().with_check_syntax_error(true).build(&parse.program);
+        let first = SemanticBuilder::new_compiler().build(&parse.program);
         assert!(first.errors.is_empty());
 
-        let second = SemanticBuilder::new().with_check_syntax_error(true).build(&parse.program);
+        let second = SemanticBuilder::new_compiler().build(&parse.program);
         assert!(second.errors.is_empty());
     }
 

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -126,8 +126,7 @@ fn analyze(
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    let semantic =
-        SemanticBuilder::new().with_check_syntax_error(true).build(&ret.program).semantic;
+    let semantic = SemanticBuilder::new_compiler().build(&ret.program).semantic;
     let ctx = TestContext { path, semantic };
     let scope_snapshot = run_scope_snapshot_test(&ctx);
     let conformance_snapshot = conformance_suite.run_on_source(&ctx);

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -109,7 +109,7 @@ fn parse_with_return(filename: &str, source_text: &str, options: &ParserOptions)
     let mut diagnostics = ret.errors;
 
     if options.show_semantic_errors == Some(true) {
-        let semantic_ret = SemanticBuilder::new().with_check_syntax_error(true).build(&program);
+        let semantic_ret = SemanticBuilder::new_compiler().build(&program);
         diagnostics.extend(semantic_ret.errors);
     }
 

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -274,7 +274,7 @@ unsafe fn parse_raw_impl(
         // Note: Avoid calling `Error::from_diagnostics_in` unless there are some errors,
         // because it's fairly expensive (it copies whole of source text into a `String`).
         let mut errors = if options.show_semantic_errors == Some(true) {
-            let semantic_ret = SemanticBuilder::new().with_check_syntax_error(true).build(&program);
+            let semantic_ret = SemanticBuilder::new_compiler().build(&program);
 
             if !ret.errors.is_empty() || !semantic_ret.errors.is_empty() {
                 Error::from_diagnostics_in(

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -1058,7 +1058,7 @@ fn module_runner_transform_impl(
     let mut program = parser_ret.program;
 
     let SemanticBuilderReturn { semantic, errors } =
-        SemanticBuilder::new().with_check_syntax_error(true).build(&program);
+        SemanticBuilder::new_compiler().build(&program);
     parser_ret.errors.extend(errors);
 
     let scoping = semantic.into_scoping();


### PR DESCRIPTION
## Summary

Adds two named constructor presets to `SemanticBuilder` that bake in the options each use case needs, so the configuration lives in one place instead of being repeated at call sites:

- **`SemanticBuilder::new_compiler()`** — compiler pipeline. Enables syntax-error checking; leaves linter-only analyses (control flow graph, class table) off.
- **`SemanticBuilder::new_linter()`** — linter. Enables syntax-error checking, the control flow graph, and the class table.

The presets are applied at the real pipeline entry points:
- `new_linter()` → the linter service build.
- `new_compiler()` → `oxc::Compiler`, and the napi parser/transform bindings.

Everywhere else keeps `SemanticBuilder::new()` and turns on only the features it needs (mangler, minifier, formatter, transformer plugins, examples, tests, ...). Individual options can still be overridden after a preset (e.g. the linter service overrides `check_syntax_error` with its runtime flag).

Behavior is preserved at every migrated site. Node-store access is intentionally untouched in this PR.

## Verified

- Builds across the affected crates + napi; clippy clean; `oxc_linter` tests pass; full `cargo coverage` with no snapshot changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
