### PR TITLE
fix(codegen): keep legal comments when minifying

### DIFF
--- a/crates/oxc_codegen/src/options.rs
+++ b/crates/oxc_codegen/src/options.rs
@@ -60,12 +60,12 @@ impl Default for CodegenOptions {
 }
 
 impl CodegenOptions {
-    /// Minify whitespace and remove comments.
+    /// Minify whitespace and remove comments, but keep legal comments.
     pub fn minify() -> Self {
         Self {
             single_quote: false,
             minify: true,
-            comments: CommentOptions::disabled(),
+            comments: CommentOptions::minify(),
             source_map_path: None,
             indent_char: IndentChar::default(),
             indent_width: DEFAULT_INDENT_WIDTH,
@@ -140,6 +140,13 @@ impl CommentOptions {
     /// Disable Comments.
     pub fn disabled() -> Self {
         Self { normal: false, jsdoc: false, annotation: false, legal: LegalComment::None }
+    }
+
+    /// Comments to keep when minifying: drop normal/jsdoc/annotation comments but
+    /// move legal comments (`/*! */`, `@license`, `@preserve`) to the end of the
+    /// file, matching other minifiers.
+    pub fn minify() -> Self {
+        Self { normal: false, jsdoc: false, annotation: false, legal: LegalComment::Eof }
     }
 }
 

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -351,6 +351,12 @@ pub mod legal {
     }
 
     #[test]
+    fn minify_preset_keeps_legal_comment() {
+        // The `minify()` preset drops normal comments but keeps legal ones (at eof).
+        snapshot_options("minify_preset_legal_comments", &cases(), &CodegenOptions::minify());
+    }
+
+    #[test]
     fn legal_linked_comment() {
         let options = CodegenOptions {
             comments: CommentOptions {

--- a/crates/oxc_codegen/tests/integration/snapshots/minify_preset_legal_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/minify_preset_legal_comments.snap
@@ -1,0 +1,111 @@
+---
+source: crates/oxc_codegen/tests/integration/tester.rs
+---
+########## 0
+/* @license */
+/* @license */
+foo;bar;
+----------
+foo;bar;
+/* @license */
+
+########## 1
+/* @license */
+/* @preserve */
+foo;bar;
+----------
+foo;bar;
+/* @license */
+/* @preserve */
+
+########## 2
+/* @license */
+//! KEEP
+foo;bar;
+----------
+foo;bar;
+/* @license */
+//! KEEP
+
+########## 3
+/* @license */
+/*! KEEP */
+foo;bar;
+----------
+foo;bar;
+/* @license */
+/*! KEEP */
+
+########## 4
+/* @license *//*! KEEP */
+foo;bar;
+----------
+foo;bar;
+/* @license */
+/*! KEEP */
+
+########## 5
+function test() {
+    /*
+    * @license
+    * Copyright notice 2
+    */
+    bar;
+}
+----------
+function test(){bar}
+/*
+* @license
+* Copyright notice 2
+*/
+
+########## 6
+function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function baz() { } }
+----------
+function bar(){var foo;function baz(){}}
+/*! #__NO_SIDE_EFFECTS__ */
+
+########## 7
+function foo() {
+	(() => {
+		/**
+		 * @preserve
+		 */
+	})();
+	/**
+	 * @preserve
+	 */
+}
+/**
+ * @preserve
+ */
+----------
+function foo(){(()=>{})()}
+/**
+* @preserve
+*/
+
+########## 8
+/**
+* @preserve
+*/
+
+----------
+
+/**
+* @preserve
+*/
+
+########## 9
+/*!
+ * legal comment
+ */
+
+"use strict";
+
+export const foo = 'foo';
+----------
+'use strict';export const foo=`foo`;
+/*!
+* legal comment
+*/


### PR DESCRIPTION
## What

Found while comparing oxc's whitespace-minify against esbuild's `--minify-whitespace` over ~3500 real-world files: oxc **drops legal/license comments** when minifying, while esbuild (and terser) preserve them.

`CodegenOptions::minify()` used `CommentOptions::disabled()`, which sets `legal: LegalComment::None`. Minified bundles are expected to retain `/*! … */`, `@license`, and `@preserve` banners for license compliance.

## Change

`minify()` now keeps **legal** comments (moved to end-of-file, like terser/esbuild's `--minify`) while still dropping normal, jsdoc, and annotation comments:

```ts
/*! @license MIT */
const x = 1;
```
```js
// before:  const x=1;
// after:   const x=1;
//          /*! @license MIT */
```

oxc already had full legal-comment support (default `LegalComment::Inline`); only the minify preset had it off. Codegen (116) and minifier (506) suites pass.