### PR TITLE
fix(parser): report compound assignment to non-simple target in the parser

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -483,6 +483,11 @@ pub fn invalid_assignment(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn assignment_is_not_simple(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Invalid left-hand side in assignment").with_label(span)
+}
+
+#[cold]
 pub fn invalid_lhs_assignment(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(
         "The left-hand side of an assignment expression must be a variable or a property access.",

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1534,6 +1534,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::invalid_assignment(span));
             }
         }
+        // A destructuring pattern target is only valid with `=`, not a compound operator.
+        if operator != AssignmentOperator::Assign
+            && matches!(lhs, Expression::ObjectExpression(_) | Expression::ArrayExpression(_))
+        {
+            self.error(diagnostics::assignment_is_not_simple(lhs.span()));
+        }
         let left = AssignmentTarget::cover(lhs, self);
         self.bump_any();
         let right =

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -9,7 +9,7 @@ use oxc_str::Ident;
 use oxc_syntax::{
     class::ClassId,
     number::NumberBase,
-    operator::{AssignmentOperator, UnaryOperator},
+    operator::UnaryOperator,
     scope::{ScopeFlags, ScopeId},
     symbol::{SymbolFlags, SymbolId},
 };
@@ -1234,20 +1234,6 @@ fn get_class_details(
     let class = ctx.nodes.kind(node_id).as_class().unwrap();
     let scope_id = class.scope_id();
     (Some(scope_id), class_id)
-}
-
-pub fn check_assignment_expression(assign_expr: &AssignmentExpression, ctx: &SemanticBuilder<'_>) {
-    // AssignmentExpression :
-    //     LeftHandSideExpression AssignmentOperator AssignmentExpression
-    //     LeftHandSideExpression &&= AssignmentExpression
-    //     LeftHandSideExpression ||= AssignmentExpression
-    //     LeftHandSideExpression ??= AssignmentExpression
-    // It is a Syntax Error if AssignmentTargetType of LeftHandSideExpression is not SIMPLE.
-    if assign_expr.operator != AssignmentOperator::Assign
-        && !assign_expr.left.is_simple_assignment_target()
-    {
-        ctx.error(diagnostics::assignment_is_not_simple(assign_expr.left.span()));
-    }
 }
 
 pub fn check_object_expression(obj_expr: &ObjectExpression, ctx: &SemanticBuilder<'_>) {

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -99,7 +99,6 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
             ts::check_formal_parameters(params, ctx);
         }
 
-        AstKind::AssignmentExpression(expr) => js::check_assignment_expression(expr, ctx),
         AstKind::AwaitExpression(expr) => js::check_await_expression(expr, ctx),
         AstKind::ObjectExpression(expr) => js::check_object_expression(expr, ctx),
         AstKind::UnaryExpression(expr) => js::check_unary_expression(expr, ctx),

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -261,11 +261,6 @@ pub fn unexpected_super_reference(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn assignment_is_not_simple(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Invalid left-hand side in assignment").with_label(span)
-}
-
-#[cold]
 pub fn delete_of_unqualified(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Delete of an unqualified identifier in strict mode.").with_label(span)
 }


### PR DESCRIPTION
## What

Moves the "Invalid left-hand side in assignment" check (a compound assignment operator requires a simple target) out of the semantic checker (`check_assignment_expression`) and into the parser's `parse_assignment_expression_recursive`.

## Why / spec simplification

Per [13.15.1](https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors), the only difference between `=` and a compound operator (`+=`, `&&=`, …) is that an object/array literal **destructuring pattern** is allowed *only* with `=`. Every other non-simple left-hand side is already rejected by `AssignmentTarget::cover` (which `fatal_error`s on non-targets).

So the check collapses from `operator != Assign && !left.is_simple_assignment_target()` (run after `cover`, needing a fatal-error guard to avoid double-reporting) to a direct check on the LHS expression — a compound operator with an `ObjectExpression`/`ArrayExpression` target — mirroring the existing parenthesized-LHS check right above it:

```rust
if operator != AssignmentOperator::Assign
    && matches!(lhs, Expression::ObjectExpression(_) | Expression::ArrayExpression(_))
{
    self.error(diagnostics::assignment_is_not_simple(lhs.span()));
}
```

No new parser state; no `is_simple_assignment_target` call or `has_fatal_error` guard.

## Conformance

No snapshot changes in any suite; parser/semantic/linter tests pass. Verified: `[a] += b` / `{a} += b` → error; `({a} = b)`, `a += b` → clean; `a + b += c` → only the existing `cover` error (no double-report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)