### PR TITLE
feat(linter/vitest): implement `prefer-vi-mocked` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1704,6 +1704,7 @@ export interface DummyRuleMap {
   "vitest/prefer-to-have-been-called-times"?: RuleNoConfig;
   "vitest/prefer-to-have-length"?: RuleNoConfig;
   "vitest/prefer-todo"?: RuleNoConfig;
+  "vitest/prefer-vi-mocked"?: RuleNoConfig;
   "vitest/require-awaited-expect-poll"?: RuleNoConfig;
   "vitest/require-hook"?: RuleNoConfig | [AllowWarnDeny, RequireHookConfig];
   "vitest/require-local-test-context-for-concurrent-snapshots"?: RuleNoConfig;

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1737,6 +1737,7 @@ export interface DummyRuleMap {
   "vitest/prefer-to-have-been-called-times"?: RuleNoConfig;
   "vitest/prefer-to-have-length"?: RuleNoConfig;
   "vitest/prefer-todo"?: RuleNoConfig;
+  "vitest/prefer-vi-mocked"?: RuleNoConfig;
   "vitest/require-awaited-expect-poll"?: RuleNoConfig;
   "vitest/require-hook"?: RuleNoConfig | [AllowWarnDeny, RequireHookConfig];
   "vitest/require-local-test-context-for-concurrent-snapshots"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4954,6 +4954,12 @@ impl RuleRunner for crate::rules::vitest::prefer_todo::PreferTodo {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::prefer_vi_mocked::PreferViMocked {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSAsExpression, AstType::TSTypeAssertion]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vitest::require_awaited_expect_poll::RequireAwaitedExpectPoll {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5108,6 +5108,12 @@ impl RuleRunner for crate::rules::vitest::prefer_todo::PreferTodo {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::vitest::prefer_vi_mocked::PreferViMocked {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::TSAsExpression, AstType::TSTypeAssertion]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vitest::require_awaited_expect_poll::RequireAwaitedExpectPoll {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -793,6 +793,7 @@ pub use crate::rules::vitest::prefer_to_contain::PreferToContain as VitestPrefer
 pub use crate::rules::vitest::prefer_to_have_been_called_times::PreferToHaveBeenCalledTimes as VitestPreferToHaveBeenCalledTimes;
 pub use crate::rules::vitest::prefer_to_have_length::PreferToHaveLength as VitestPreferToHaveLength;
 pub use crate::rules::vitest::prefer_todo::PreferTodo as VitestPreferTodo;
+pub use crate::rules::vitest::prefer_vi_mocked::PreferViMocked as VitestPreferViMocked;
 pub use crate::rules::vitest::require_awaited_expect_poll::RequireAwaitedExpectPoll as VitestRequireAwaitedExpectPoll;
 pub use crate::rules::vitest::require_hook::RequireHook as VitestRequireHook;
 pub use crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots as VitestRequireLocalTestContextForConcurrentSnapshots;
@@ -1641,6 +1642,7 @@ pub enum RuleEnum {
     VitestPreferToHaveBeenCalledTimes(VitestPreferToHaveBeenCalledTimes),
     VitestPreferToHaveLength(VitestPreferToHaveLength),
     VitestPreferTodo(VitestPreferTodo),
+    VitestPreferViMocked(VitestPreferViMocked),
     VitestRequireAwaitedExpectPoll(VitestRequireAwaitedExpectPoll),
     VitestRequireHook(VitestRequireHook),
     VitestRequireLocalTestContextForConcurrentSnapshots(
@@ -2584,7 +2586,8 @@ const VITEST_PREFER_TO_CONTAIN_ID: usize = VITEST_PREFER_TO_BE_TRUTHY_ID + 1usiz
 const VITEST_PREFER_TO_HAVE_BEEN_CALLED_TIMES_ID: usize = VITEST_PREFER_TO_CONTAIN_ID + 1usize;
 const VITEST_PREFER_TO_HAVE_LENGTH_ID: usize = VITEST_PREFER_TO_HAVE_BEEN_CALLED_TIMES_ID + 1usize;
 const VITEST_PREFER_TODO_ID: usize = VITEST_PREFER_TO_HAVE_LENGTH_ID + 1usize;
-const VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID: usize = VITEST_PREFER_TODO_ID + 1usize;
+const VITEST_PREFER_VI_MOCKED_ID: usize = VITEST_PREFER_TODO_ID + 1usize;
+const VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID: usize = VITEST_PREFER_VI_MOCKED_ID + 1usize;
 const VITEST_REQUIRE_HOOK_ID: usize = VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID + 1usize;
 const VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID: usize =
     VITEST_REQUIRE_HOOK_ID + 1usize;
@@ -3561,6 +3564,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VITEST_PREFER_TO_HAVE_LENGTH_ID,
             Self::VitestPreferTodo(_) => VITEST_PREFER_TODO_ID,
+            Self::VitestPreferViMocked(_) => VITEST_PREFER_VI_MOCKED_ID,
             Self::VitestRequireAwaitedExpectPoll(_) => VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID,
             Self::VitestRequireHook(_) => VITEST_REQUIRE_HOOK_ID,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -4520,6 +4524,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(_) => VitestPreferToHaveBeenCalledTimes::NAME,
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::NAME,
             Self::VitestPreferTodo(_) => VitestPreferTodo::NAME,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::NAME,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::NAME,
             Self::VitestRequireHook(_) => VitestRequireHook::NAME,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -5535,6 +5540,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::CATEGORY,
             Self::VitestPreferTodo(_) => VitestPreferTodo::CATEGORY,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::CATEGORY,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::CATEGORY,
             Self::VitestRequireHook(_) => VitestRequireHook::CATEGORY,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -6497,6 +6503,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(_) => VitestPreferToHaveBeenCalledTimes::FIX,
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::FIX,
             Self::VitestPreferTodo(_) => VitestPreferTodo::FIX,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::FIX,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::FIX,
             Self::VitestRequireHook(_) => VitestRequireHook::FIX,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -7699,6 +7706,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::documentation(),
             Self::VitestPreferTodo(_) => VitestPreferTodo::documentation(),
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::documentation(),
             Self::VitestRequireAwaitedExpectPoll(_) => {
                 VitestRequireAwaitedExpectPoll::documentation()
             }
@@ -10022,6 +10030,8 @@ impl RuleEnum {
                 .or_else(|| VitestPreferToHaveLength::schema(generator)),
             Self::VitestPreferTodo(_) => VitestPreferTodo::config_schema(generator)
                 .or_else(|| VitestPreferTodo::schema(generator)),
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::config_schema(generator)
+                .or_else(|| VitestPreferViMocked::schema(generator)),
             Self::VitestRequireAwaitedExpectPoll(_) => {
                 VitestRequireAwaitedExpectPoll::config_schema(generator)
                     .or_else(|| VitestRequireAwaitedExpectPoll::schema(generator))
@@ -10995,6 +11005,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(_) => "vitest",
             Self::VitestPreferToHaveLength(_) => "vitest",
             Self::VitestPreferTodo(_) => "vitest",
+            Self::VitestPreferViMocked(_) => "vitest",
             Self::VitestRequireAwaitedExpectPoll(_) => "vitest",
             Self::VitestRequireHook(_) => "vitest",
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => "vitest",
@@ -13567,6 +13578,9 @@ impl RuleEnum {
             Self::VitestPreferTodo(_) => {
                 Ok(Self::VitestPreferTodo(VitestPreferTodo::from_configuration(value)?))
             }
+            Self::VitestPreferViMocked(_) => {
+                Ok(Self::VitestPreferViMocked(VitestPreferViMocked::from_configuration(value)?))
+            }
             Self::VitestRequireAwaitedExpectPoll(_) => Ok(Self::VitestRequireAwaitedExpectPoll(
                 VitestRequireAwaitedExpectPoll::from_configuration(value)?,
             )),
@@ -14556,6 +14570,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.to_configuration(),
             Self::VitestPreferToHaveLength(rule) => rule.to_configuration(),
             Self::VitestPreferTodo(rule) => rule.to_configuration(),
+            Self::VitestPreferViMocked(rule) => rule.to_configuration(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.to_configuration(),
             Self::VitestRequireHook(rule) => rule.to_configuration(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
@@ -15404,6 +15419,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.run(node, ctx),
             Self::VitestPreferToHaveLength(rule) => rule.run(node, ctx),
             Self::VitestPreferTodo(rule) => rule.run(node, ctx),
+            Self::VitestPreferViMocked(rule) => rule.run(node, ctx),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.run(node, ctx),
             Self::VitestRequireHook(rule) => rule.run(node, ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run(node, ctx),
@@ -16262,6 +16278,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.run_once(ctx),
             Self::VitestPreferToHaveLength(rule) => rule.run_once(ctx),
             Self::VitestPreferTodo(rule) => rule.run_once(ctx),
+            Self::VitestPreferViMocked(rule) => rule.run_once(ctx),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_once(ctx),
             Self::VitestRequireHook(rule) => rule.run_once(ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_once(ctx),
@@ -17231,6 +17248,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToHaveLength(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPreferViMocked(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestRequireHook(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
@@ -18096,6 +18114,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.should_run(ctx),
             Self::VitestPreferToHaveLength(rule) => rule.should_run(ctx),
             Self::VitestPreferTodo(rule) => rule.should_run(ctx),
+            Self::VitestPreferViMocked(rule) => rule.should_run(ctx),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.should_run(ctx),
             Self::VitestRequireHook(rule) => rule.should_run(ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.should_run(ctx),
@@ -19291,6 +19310,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::IS_TSGOLINT_RULE,
             Self::VitestPreferTodo(_) => VitestPreferTodo::IS_TSGOLINT_RULE,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::IS_TSGOLINT_RULE,
             Self::VitestRequireAwaitedExpectPoll(_) => {
                 VitestRequireAwaitedExpectPoll::IS_TSGOLINT_RULE
             }
@@ -20330,6 +20350,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::VERSION,
             Self::VitestPreferTodo(_) => VitestPreferTodo::VERSION,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::VERSION,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::VERSION,
             Self::VitestRequireHook(_) => VitestRequireHook::VERSION,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -21382,6 +21403,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::HAS_CONFIG,
             Self::VitestPreferTodo(_) => VitestPreferTodo::HAS_CONFIG,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::HAS_CONFIG,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::HAS_CONFIG,
             Self::VitestRequireHook(_) => VitestRequireHook::HAS_CONFIG,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -22349,6 +22371,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(_) => VitestPreferToHaveBeenCalledTimes::INFO,
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::INFO,
             Self::VitestPreferTodo(_) => VitestPreferTodo::INFO,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::INFO,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::INFO,
             Self::VitestRequireHook(_) => VitestRequireHook::INFO,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -23205,6 +23228,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.types_info(),
             Self::VitestPreferToHaveLength(rule) => rule.types_info(),
             Self::VitestPreferTodo(rule) => rule.types_info(),
+            Self::VitestPreferViMocked(rule) => rule.types_info(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.types_info(),
             Self::VitestRequireHook(rule) => rule.types_info(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.types_info(),
@@ -24050,6 +24074,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.run_info(),
             Self::VitestPreferToHaveLength(rule) => rule.run_info(),
             Self::VitestPreferTodo(rule) => rule.run_info(),
+            Self::VitestPreferViMocked(rule) => rule.run_info(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_info(),
             Self::VitestRequireHook(rule) => rule.run_info(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_info(),
@@ -25025,6 +25050,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferToHaveBeenCalledTimes(VitestPreferToHaveBeenCalledTimes::default()),
         RuleEnum::VitestPreferToHaveLength(VitestPreferToHaveLength::default()),
         RuleEnum::VitestPreferTodo(VitestPreferTodo::default()),
+        RuleEnum::VitestPreferViMocked(VitestPreferViMocked::default()),
         RuleEnum::VitestRequireAwaitedExpectPoll(VitestRequireAwaitedExpectPoll::default()),
         RuleEnum::VitestRequireHook(VitestRequireHook::default()),
         RuleEnum::VitestRequireLocalTestContextForConcurrentSnapshots(

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -822,6 +822,7 @@ pub use crate::rules::vitest::prefer_to_contain::PreferToContain as VitestPrefer
 pub use crate::rules::vitest::prefer_to_have_been_called_times::PreferToHaveBeenCalledTimes as VitestPreferToHaveBeenCalledTimes;
 pub use crate::rules::vitest::prefer_to_have_length::PreferToHaveLength as VitestPreferToHaveLength;
 pub use crate::rules::vitest::prefer_todo::PreferTodo as VitestPreferTodo;
+pub use crate::rules::vitest::prefer_vi_mocked::PreferViMocked as VitestPreferViMocked;
 pub use crate::rules::vitest::require_awaited_expect_poll::RequireAwaitedExpectPoll as VitestRequireAwaitedExpectPoll;
 pub use crate::rules::vitest::require_hook::RequireHook as VitestRequireHook;
 pub use crate::rules::vitest::require_local_test_context_for_concurrent_snapshots::RequireLocalTestContextForConcurrentSnapshots as VitestRequireLocalTestContextForConcurrentSnapshots;
@@ -1697,6 +1698,7 @@ pub enum RuleEnum {
     VitestPreferToHaveBeenCalledTimes(VitestPreferToHaveBeenCalledTimes),
     VitestPreferToHaveLength(VitestPreferToHaveLength),
     VitestPreferTodo(VitestPreferTodo),
+    VitestPreferViMocked(VitestPreferViMocked),
     VitestRequireAwaitedExpectPoll(VitestRequireAwaitedExpectPoll),
     VitestRequireHook(VitestRequireHook),
     VitestRequireLocalTestContextForConcurrentSnapshots(
@@ -2670,7 +2672,8 @@ const VITEST_PREFER_TO_CONTAIN_ID: usize = VITEST_PREFER_TO_BE_TRUTHY_ID + 1usiz
 const VITEST_PREFER_TO_HAVE_BEEN_CALLED_TIMES_ID: usize = VITEST_PREFER_TO_CONTAIN_ID + 1usize;
 const VITEST_PREFER_TO_HAVE_LENGTH_ID: usize = VITEST_PREFER_TO_HAVE_BEEN_CALLED_TIMES_ID + 1usize;
 const VITEST_PREFER_TODO_ID: usize = VITEST_PREFER_TO_HAVE_LENGTH_ID + 1usize;
-const VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID: usize = VITEST_PREFER_TODO_ID + 1usize;
+const VITEST_PREFER_VI_MOCKED_ID: usize = VITEST_PREFER_TODO_ID + 1usize;
+const VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID: usize = VITEST_PREFER_VI_MOCKED_ID + 1usize;
 const VITEST_REQUIRE_HOOK_ID: usize = VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID + 1usize;
 const VITEST_REQUIRE_LOCAL_TEST_CONTEXT_FOR_CONCURRENT_SNAPSHOTS_ID: usize =
     VITEST_REQUIRE_HOOK_ID + 1usize;
@@ -2748,7 +2751,7 @@ const VUE_VALID_DEFINE_EMITS_ID: usize = VUE_RETURN_IN_EMITS_VALIDATOR_ID + 1usi
 const VUE_VALID_DEFINE_OPTIONS_ID: usize = VUE_VALID_DEFINE_EMITS_ID + 1usize;
 const VUE_VALID_DEFINE_PROPS_ID: usize = VUE_VALID_DEFINE_OPTIONS_ID + 1usize;
 const VUE_VALID_NEXT_TICK_ID: usize = VUE_VALID_DEFINE_PROPS_ID + 1usize;
-static RULE_NAMES: [&str; 870usize] = [
+static RULE_NAMES: [&str; 871usize] = [
     ImportConsistentTypeSpecifierStyle::NAME,
     ImportDefault::NAME,
     ImportExport::NAME,
@@ -3550,6 +3553,7 @@ static RULE_NAMES: [&str; 870usize] = [
     VitestPreferToHaveBeenCalledTimes::NAME,
     VitestPreferToHaveLength::NAME,
     VitestPreferTodo::NAME,
+    VitestPreferViMocked::NAME,
     VitestRequireAwaitedExpectPoll::NAME,
     VitestRequireHook::NAME,
     VitestRequireLocalTestContextForConcurrentSnapshots::NAME,
@@ -4548,6 +4552,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VITEST_PREFER_TO_HAVE_LENGTH_ID,
             Self::VitestPreferTodo(_) => VITEST_PREFER_TODO_ID,
+            Self::VitestPreferViMocked(_) => VITEST_PREFER_VI_MOCKED_ID,
             Self::VitestRequireAwaitedExpectPoll(_) => VITEST_REQUIRE_AWAITED_EXPECT_POLL_ID,
             Self::VitestRequireHook(_) => VITEST_REQUIRE_HOOK_ID,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -5597,6 +5602,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::CATEGORY,
             Self::VitestPreferTodo(_) => VitestPreferTodo::CATEGORY,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::CATEGORY,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::CATEGORY,
             Self::VitestRequireHook(_) => VitestRequireHook::CATEGORY,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -6588,6 +6594,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(_) => VitestPreferToHaveBeenCalledTimes::FIX,
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::FIX,
             Self::VitestPreferTodo(_) => VitestPreferTodo::FIX,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::FIX,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::FIX,
             Self::VitestRequireHook(_) => VitestRequireHook::FIX,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -7829,6 +7836,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::documentation(),
             Self::VitestPreferTodo(_) => VitestPreferTodo::documentation(),
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::documentation(),
             Self::VitestRequireAwaitedExpectPoll(_) => {
                 VitestRequireAwaitedExpectPoll::documentation()
             }
@@ -10226,6 +10234,8 @@ impl RuleEnum {
                 .or_else(|| VitestPreferToHaveLength::schema(generator)),
             Self::VitestPreferTodo(_) => VitestPreferTodo::config_schema(generator)
                 .or_else(|| VitestPreferTodo::schema(generator)),
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::config_schema(generator)
+                .or_else(|| VitestPreferViMocked::schema(generator)),
             Self::VitestRequireAwaitedExpectPoll(_) => {
                 VitestRequireAwaitedExpectPoll::config_schema(generator)
                     .or_else(|| VitestRequireAwaitedExpectPoll::schema(generator))
@@ -11230,6 +11240,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(_) => "vitest",
             Self::VitestPreferToHaveLength(_) => "vitest",
             Self::VitestPreferTodo(_) => "vitest",
+            Self::VitestPreferViMocked(_) => "vitest",
             Self::VitestRequireAwaitedExpectPoll(_) => "vitest",
             Self::VitestRequireHook(_) => "vitest",
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => "vitest",
@@ -13238,6 +13249,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.run(node, ctx),
             Self::VitestPreferToHaveLength(rule) => rule.run(node, ctx),
             Self::VitestPreferTodo(rule) => rule.run(node, ctx),
+            Self::VitestPreferViMocked(rule) => rule.run(node, ctx),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.run(node, ctx),
             Self::VitestRequireHook(rule) => rule.run(node, ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run(node, ctx),
@@ -14125,6 +14137,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.run_once(ctx),
             Self::VitestPreferToHaveLength(rule) => rule.run_once(ctx),
             Self::VitestPreferTodo(rule) => rule.run_once(ctx),
+            Self::VitestPreferViMocked(rule) => rule.run_once(ctx),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_once(ctx),
             Self::VitestRequireHook(rule) => rule.run_once(ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_once(ctx),
@@ -15123,6 +15136,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferToHaveLength(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestPreferTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VitestPreferViMocked(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestRequireHook(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
@@ -16017,6 +16031,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.should_run(ctx),
             Self::VitestPreferToHaveLength(rule) => rule.should_run(ctx),
             Self::VitestPreferTodo(rule) => rule.should_run(ctx),
+            Self::VitestPreferViMocked(rule) => rule.should_run(ctx),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.should_run(ctx),
             Self::VitestRequireHook(rule) => rule.should_run(ctx),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.should_run(ctx),
@@ -17251,6 +17266,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::IS_TSGOLINT_RULE,
             Self::VitestPreferTodo(_) => VitestPreferTodo::IS_TSGOLINT_RULE,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::IS_TSGOLINT_RULE,
             Self::VitestRequireAwaitedExpectPoll(_) => {
                 VitestRequireAwaitedExpectPoll::IS_TSGOLINT_RULE
             }
@@ -18321,6 +18337,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::VERSION,
             Self::VitestPreferTodo(_) => VitestPreferTodo::VERSION,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::VERSION,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::VERSION,
             Self::VitestRequireHook(_) => VitestRequireHook::VERSION,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -19406,6 +19423,7 @@ impl RuleEnum {
             }
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::HAS_CONFIG,
             Self::VitestPreferTodo(_) => VitestPreferTodo::HAS_CONFIG,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::HAS_CONFIG,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::HAS_CONFIG,
             Self::VitestRequireHook(_) => VitestRequireHook::HAS_CONFIG,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -20402,6 +20420,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(_) => VitestPreferToHaveBeenCalledTimes::INFO,
             Self::VitestPreferToHaveLength(_) => VitestPreferToHaveLength::INFO,
             Self::VitestPreferTodo(_) => VitestPreferTodo::INFO,
+            Self::VitestPreferViMocked(_) => VitestPreferViMocked::INFO,
             Self::VitestRequireAwaitedExpectPoll(_) => VitestRequireAwaitedExpectPoll::INFO,
             Self::VitestRequireHook(_) => VitestRequireHook::INFO,
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(_) => {
@@ -21287,6 +21306,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.types_info(),
             Self::VitestPreferToHaveLength(rule) => rule.types_info(),
             Self::VitestPreferTodo(rule) => rule.types_info(),
+            Self::VitestPreferViMocked(rule) => rule.types_info(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.types_info(),
             Self::VitestRequireHook(rule) => rule.types_info(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.types_info(),
@@ -22161,6 +22181,7 @@ impl RuleEnum {
             Self::VitestPreferToHaveBeenCalledTimes(rule) => rule.run_info(),
             Self::VitestPreferToHaveLength(rule) => rule.run_info(),
             Self::VitestPreferTodo(rule) => rule.run_info(),
+            Self::VitestPreferViMocked(rule) => rule.run_info(),
             Self::VitestRequireAwaitedExpectPoll(rule) => rule.run_info(),
             Self::VitestRequireHook(rule) => rule.run_info(),
             Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => rule.run_info(),
@@ -23165,6 +23186,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestPreferToHaveBeenCalledTimes(VitestPreferToHaveBeenCalledTimes::default()),
         RuleEnum::VitestPreferToHaveLength(VitestPreferToHaveLength::default()),
         RuleEnum::VitestPreferTodo(VitestPreferTodo::default()),
+        RuleEnum::VitestPreferViMocked(VitestPreferViMocked::default()),
         RuleEnum::VitestRequireAwaitedExpectPoll(VitestRequireAwaitedExpectPoll::default()),
         RuleEnum::VitestRequireHook(VitestRequireHook::default()),
         RuleEnum::VitestRequireLocalTestContextForConcurrentSnapshots(

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -826,6 +826,7 @@ pub(crate) mod vitest {
     pub mod prefer_to_have_been_called_times;
     pub mod prefer_to_have_length;
     pub mod prefer_todo;
+    pub mod prefer_vi_mocked;
     pub mod require_awaited_expect_poll;
     pub mod require_hook;
     pub mod require_local_test_context_for_concurrent_snapshots;

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -904,6 +904,7 @@ pub(crate) mod vitest {
     pub mod prefer_to_have_been_called_times;
     pub mod prefer_to_have_length;
     pub mod prefer_todo;
+    pub mod prefer_vi_mocked;
     pub mod require_awaited_expect_poll;
     pub mod require_hook;
     pub mod require_local_test_context_for_concurrent_snapshots;

--- a/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
-    /// ```js
+    /// ```ts
     /// ;(foo as Mock).mockReturnValue(1)
     /// const mock = (foo as Mock).mockReturnValue(1)
     /// ;(foo as unknown as Mock).mockReturnValue(1)
@@ -43,7 +43,7 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    /// ```js
+    /// ```ts
     /// vi.mocked(foo).mockReturnValue(1)
     /// const mock = vi.mocked(foo).mockReturnValue(1)
     /// vi.mocked(Obj.foo).mockReturnValue(1)

--- a/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
@@ -1,0 +1,238 @@
+use oxc_ast::{
+    AstKind,
+    ast::{TSAsExpression, TSType, TSTypeAssertion, TSTypeName, TSTypeReference},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn prefer_vi_mocked_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Prefer `vi.mocked()` over `fn as Mock`").with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferViMocked;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Require `vi.mocked()` over `fn as Mock`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// When working with mocks of functions using Vitest, it's recommended to use the `vi.mocked()` helper function to properly type the mocked functions.
+    /// This rule enforces the use of `vi.mocked()` for better type safety and readability.
+    ///
+    /// Restricted types:
+    /// - `Mock`
+    /// - `MockedFunction`
+    /// - `MockedClass`
+    /// - `MockedObject`
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// ;(foo as Mock).mockReturnValue(1)
+    /// const mock = (foo as Mock).mockReturnValue(1)
+    /// ;(foo as unknown as Mock).mockReturnValue(1)
+    /// ;(Obj.foo as Mock).mockReturnValue(1)
+    /// ;([].foo as Mock).mockReturnValue(1)
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// vi.mocked(foo).mockReturnValue(1)
+    /// const mock = vi.mocked(foo).mockReturnValue(1)
+    /// vi.mocked(Obj.foo).mockReturnValue(1)
+    /// vi.mocked([].foo).mockReturnValue(1)
+    /// ```
+    PreferViMocked,
+    vitest,
+    style,
+    fix,
+    version = "next",
+);
+
+impl Rule for PreferViMocked {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if let AstKind::TSAsExpression(ts_expr) = node.kind() {
+            if !matches!(ctx.nodes().parent_kind(node.id()), AstKind::TSAsExpression(_)) {
+                check_ts_as_expression(ts_expr, ctx);
+            }
+        } else if let AstKind::TSTypeAssertion(assert_type) = node.kind() {
+            check_assert_type(assert_type, ctx);
+        }
+    }
+}
+
+const MOCK_TYPES: [&str; 4] = ["Mock", "MockedFunction", "MockedClass", "MockedObject"];
+
+fn check_ts_as_expression(as_expr: &TSAsExpression, ctx: &LintContext<'_>) {
+    let TSType::TSTypeReference(ts_reference) = &as_expr.type_annotation else {
+        return;
+    };
+    let arg_span = as_expr.expression.get_inner_expression().span();
+    check(ts_reference, arg_span, as_expr.span, ctx);
+}
+
+fn check_assert_type(assert_type: &TSTypeAssertion, ctx: &LintContext<'_>) {
+    let TSType::TSTypeReference(ts_reference) = &assert_type.type_annotation else {
+        return;
+    };
+    let arg_span = assert_type.expression.get_inner_expression().span();
+    check(ts_reference, arg_span, assert_type.span, ctx);
+}
+
+fn check(ts_reference: &TSTypeReference, arg_span: Span, span: Span, ctx: &LintContext<'_>) {
+    let TSTypeName::IdentifierReference(ident_ref) = &ts_reference.type_name else {
+        return;
+    };
+
+    if !MOCK_TYPES.contains(&ident_ref.name.as_str()) {
+        return;
+    }
+
+    ctx.diagnostic_with_fix(prefer_vi_mocked_diagnostic(span), |fixer| {
+        let span_source_code = fixer.source_range(arg_span);
+        fixer.replace(span, format!("vi.mocked({span_source_code})"))
+    });
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "foo();",
+        "vi.mocked(foo).mockReturnValue(1);",
+        "bar.mockReturnValue(1);",
+        "sinon.stub(foo).returns(1);",
+        "foo.mockImplementation(() => 1);",
+        "obj.foo();",
+        "mockFn.mockReturnValue(1);",
+        "arr[0]();",
+        "obj.foo.mockReturnValue(1);",
+        r#"vi.spyOn(obj, "foo").mockReturnValue(1);"#,
+        "(foo as Mock.vi).mockReturnValue(1);",
+        "type MockType = Mock;
+            const mockFn = vi.fn();
+            (mockFn as MockType).mockReturnValue(1);",
+    ];
+
+    let fail = vec![
+        "(foo as Mock).mockReturnValue(1);",
+        "(foo as unknown as string as unknown as Mock).mockReturnValue(1);",
+        "(foo as unknown as Mock as unknown as Mock).mockReturnValue(1);",
+        "(<Mock>foo).mockReturnValue(1);",
+        "(foo as Mock).mockImplementation(1);",
+        "(foo as unknown as Mock).mockReturnValue(1);",
+        "(<Mock>foo as unknown).mockReturnValue(1);",
+        "(Obj.foo as Mock).mockReturnValue(1);",
+        "([].foo as Mock).mockReturnValue(1);",
+        "(foo as MockedFunction).mockReturnValue(1);",
+        "(foo as MockedFunction).mockImplementation(1);",
+        "(foo as unknown as MockedFunction).mockReturnValue(1);",
+        "(Obj.foo as MockedFunction).mockReturnValue(1);",
+        "(new Array(0).fill(null).foo as MockedFunction).mockReturnValue(1);",
+        "(vi.fn(() => foo) as MockedFunction).mockReturnValue(1);",
+        "const mockedUseFocused = useFocused as MockedFunction<typeof useFocused>;",
+        "const filter = (MessageService.getMessage as Mock).mock.calls[0][0];",
+        "class A {}
+            (foo as MockedClass<A>)",
+        "(foo as MockedObject<{method: () => void}>)",
+        r#"(Obj["foo"] as MockedFunction).mockReturnValue(1);"#,
+        "(
+            new Array(100)
+              .fill(undefined)
+              .map(x => x.value)
+              .filter(v => !!v).myProperty as MockedFunction<{
+              method: () => void;
+            }>
+            ).mockReturnValue(1);",
+    ];
+
+    let fix = vec![
+        ("(foo as Mock).mockReturnValue(1);", "(vi.mocked(foo)).mockReturnValue(1);"),
+        (
+            "(foo as unknown as string as unknown as Mock).mockReturnValue(1);",
+            "(vi.mocked(foo)).mockReturnValue(1);",
+        ),
+        (
+            "(foo as unknown as Mock as unknown as Mock).mockReturnValue(1);",
+            "(vi.mocked(foo)).mockReturnValue(1);",
+        ),
+        ("(<Mock>foo).mockReturnValue(1);", "(vi.mocked(foo)).mockReturnValue(1);"),
+        ("(foo as Mock).mockImplementation(1);", "(vi.mocked(foo)).mockImplementation(1);"),
+        ("(foo as unknown as Mock).mockReturnValue(1);", "(vi.mocked(foo)).mockReturnValue(1);"),
+        (
+            "(<Mock>foo as unknown).mockReturnValue(1);",
+            "(vi.mocked(foo) as unknown).mockReturnValue(1);",
+        ),
+        ("(Obj.foo as Mock).mockReturnValue(1);", "(vi.mocked(Obj.foo)).mockReturnValue(1);"),
+        ("([].foo as Mock).mockReturnValue(1);", "(vi.mocked([].foo)).mockReturnValue(1);"),
+        ("(foo as MockedFunction).mockReturnValue(1);", "(vi.mocked(foo)).mockReturnValue(1);"),
+        (
+            "(foo as MockedFunction).mockImplementation(1);",
+            "(vi.mocked(foo)).mockImplementation(1);",
+        ),
+        (
+            "(foo as unknown as MockedFunction).mockReturnValue(1);",
+            "(vi.mocked(foo)).mockReturnValue(1);",
+        ),
+        (
+            "(Obj.foo as MockedFunction).mockReturnValue(1);",
+            "(vi.mocked(Obj.foo)).mockReturnValue(1);",
+        ),
+        (
+            "(new Array(0).fill(null).foo as MockedFunction).mockReturnValue(1);",
+            "(vi.mocked(new Array(0).fill(null).foo)).mockReturnValue(1);",
+        ),
+        (
+            "(vi.fn(() => foo) as MockedFunction).mockReturnValue(1);",
+            "(vi.mocked(vi.fn(() => foo))).mockReturnValue(1);",
+        ),
+        (
+            "const mockedUseFocused = useFocused as MockedFunction<typeof useFocused>;",
+            "const mockedUseFocused = vi.mocked(useFocused);",
+        ),
+        (
+            "const filter = (MessageService.getMessage as Mock).mock.calls[0][0];",
+            "const filter = (vi.mocked(MessageService.getMessage)).mock.calls[0][0];",
+        ),
+        (
+            "class A {}
+            (foo as MockedClass<A>)",
+            "class A {}
+            (vi.mocked(foo))",
+        ),
+        ("(foo as MockedObject<{method: () => void}>)", "(vi.mocked(foo))"),
+        (
+            r#"(Obj["foo"] as MockedFunction).mockReturnValue(1);"#,
+            r#"(vi.mocked(Obj["foo"])).mockReturnValue(1);"#,
+        ),
+        (
+            "(
+            new Array(100)
+              .fill(undefined)
+              .map(x => x.value)
+              .filter(v => !!v).myProperty as MockedFunction<{
+              method: () => void;
+            }>
+            ).mockReturnValue(1);",
+            "(
+            vi.mocked(new Array(100)
+              .fill(undefined)
+              .map(x => x.value)
+              .filter(v => !!v).myProperty)
+            ).mockReturnValue(1);",
+        ),
+    ];
+
+    Tester::new(PreferViMocked::NAME, PreferViMocked::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
@@ -10,6 +10,7 @@ use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn prefer_vi_mocked_diagnostic(span: Span, mock_type: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Prefer `vi.mocked()` over type assertions using `{mock_type}`"))
+        .with_help("Use `vi.mocked()` instead.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     style,
     fix,
     version = "next",
+    short_description = "Require `vi.mocked()` over Vitest mock type assertions."
 );
 
 impl Rule for PreferViMocked {

--- a/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
@@ -61,12 +61,14 @@ declare_oxc_lint!(
 
 impl Rule for PreferViMocked {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if let AstKind::TSAsExpression(ts_expr) = node.kind() {
-            if !matches!(ctx.nodes().parent_kind(node.id()), AstKind::TSAsExpression(_)) {
+        match node.kind() {
+            AstKind::TSAsExpression(ts_expr)
+                if !matches!(ctx.nodes().parent_kind(node.id()), AstKind::TSAsExpression(_)) =>
+            {
                 check_ts_as_expression(ts_expr, ctx);
             }
-        } else if let AstKind::TSTypeAssertion(assert_type) = node.kind() {
-            check_assert_type(assert_type, ctx);
+            AstKind::TSTypeAssertion(assert_type) => check_assert_type(assert_type, ctx),
+            _ => {}
         }
     }
 }

--- a/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_vi_mocked.rs
@@ -8,8 +8,9 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
-fn prefer_vi_mocked_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Prefer `vi.mocked()` over `fn as Mock`").with_label(span)
+fn prefer_vi_mocked_diagnostic(span: Span, mock_type: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `vi.mocked()` over type assertions using `{mock_type}`"))
+        .with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -18,7 +19,7 @@ pub struct PreferViMocked;
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Require `vi.mocked()` over `fn as Mock`.
+    /// Require `vi.mocked()` over Vitest mock type assertions.
     ///
     /// ### Why is this bad?
     ///
@@ -91,11 +92,12 @@ fn check(ts_reference: &TSTypeReference, arg_span: Span, span: Span, ctx: &LintC
         return;
     };
 
-    if !MOCK_TYPES.contains(&ident_ref.name.as_str()) {
+    let mock_type = ident_ref.name.as_str();
+    if !MOCK_TYPES.contains(&mock_type) {
         return;
     }
 
-    ctx.diagnostic_with_fix(prefer_vi_mocked_diagnostic(span), |fixer| {
+    ctx.diagnostic_with_fix(prefer_vi_mocked_diagnostic(span, mock_type), |fixer| {
         let span_source_code = fixer.source_range(arg_span);
         fixer.replace(span, format!("vi.mocked({span_source_code})"))
     });

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_vi_mocked.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_vi_mocked.snap
@@ -2,126 +2,126 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as Mock).mockReturnValue(1);
    ·  ───────────
    ╰────
   help: Replace `foo as Mock` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as unknown as string as unknown as Mock).mockReturnValue(1);
    ·  ───────────────────────────────────────────
    ╰────
   help: Replace `foo as unknown as string as unknown as Mock` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as unknown as Mock as unknown as Mock).mockReturnValue(1);
    ·  ─────────────────────────────────────────
    ╰────
   help: Replace `foo as unknown as Mock as unknown as Mock` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (<Mock>foo).mockReturnValue(1);
    ·  ─────────
    ╰────
   help: Replace `<Mock>foo` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as Mock).mockImplementation(1);
    ·  ───────────
    ╰────
   help: Replace `foo as Mock` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as unknown as Mock).mockReturnValue(1);
    ·  ──────────────────────
    ╰────
   help: Replace `foo as unknown as Mock` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (<Mock>foo as unknown).mockReturnValue(1);
    ·  ─────────
    ╰────
   help: Replace `<Mock>foo` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (Obj.foo as Mock).mockReturnValue(1);
    ·  ───────────────
    ╰────
   help: Replace `Obj.foo as Mock` with `vi.mocked(Obj.foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ ([].foo as Mock).mockReturnValue(1);
    ·  ──────────────
    ╰────
   help: Replace `[].foo as Mock` with `vi.mocked([].foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as MockedFunction).mockReturnValue(1);
    ·  ─────────────────────
    ╰────
   help: Replace `foo as MockedFunction` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as MockedFunction).mockImplementation(1);
    ·  ─────────────────────
    ╰────
   help: Replace `foo as MockedFunction` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as unknown as MockedFunction).mockReturnValue(1);
    ·  ────────────────────────────────
    ╰────
   help: Replace `foo as unknown as MockedFunction` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (Obj.foo as MockedFunction).mockReturnValue(1);
    ·  ─────────────────────────
    ╰────
   help: Replace `Obj.foo as MockedFunction` with `vi.mocked(Obj.foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (new Array(0).fill(null).foo as MockedFunction).mockReturnValue(1);
    ·  ─────────────────────────────────────────────
    ╰────
   help: Replace `new Array(0).fill(null).foo as MockedFunction` with `vi.mocked(new Array(0).fill(null).foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (vi.fn(() => foo) as MockedFunction).mockReturnValue(1);
    ·  ──────────────────────────────────
    ╰────
   help: Replace `vi.fn(() => foo) as MockedFunction` with `vi.mocked(vi.fn(() => foo))`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:26]
  1 │ const mockedUseFocused = useFocused as MockedFunction<typeof useFocused>;
    ·                          ───────────────────────────────────────────────
    ╰────
   help: Replace `useFocused as MockedFunction<typeof useFocused>` with `vi.mocked(useFocused)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:17]
  1 │ const filter = (MessageService.getMessage as Mock).mock.calls[0][0];
    ·                 ─────────────────────────────────
    ╰────
   help: Replace `MessageService.getMessage as Mock` with `vi.mocked(MessageService.getMessage)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedClass`
    ╭─[prefer_vi_mocked.ts:2:14]
  1 │ class A {}
  2 │             (foo as MockedClass<A>)
@@ -129,21 +129,21 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `foo as MockedClass<A>` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedObject`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as MockedObject<{method: () => void}>)
    ·  ─────────────────────────────────────────
    ╰────
   help: Replace `foo as MockedObject<{method: () => void}>` with `vi.mocked(foo)`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (Obj["foo"] as MockedFunction).mockReturnValue(1);
    ·  ────────────────────────────
    ╰────
   help: Replace `Obj["foo"] as MockedFunction` with `vi.mocked(Obj["foo"])`.
 
-  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:2:13]
  1 │     (
  2 │ ╭─▶             new Array(100)

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_vi_mocked.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_vi_mocked.snap
@@ -7,119 +7,119 @@ source: crates/oxc_linter/src/tester.rs
  1 │ (foo as Mock).mockReturnValue(1);
    ·  ───────────
    ╰────
-  help: Replace `foo as Mock` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as unknown as string as unknown as Mock).mockReturnValue(1);
    ·  ───────────────────────────────────────────
    ╰────
-  help: Replace `foo as unknown as string as unknown as Mock` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as unknown as Mock as unknown as Mock).mockReturnValue(1);
    ·  ─────────────────────────────────────────
    ╰────
-  help: Replace `foo as unknown as Mock as unknown as Mock` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (<Mock>foo).mockReturnValue(1);
    ·  ─────────
    ╰────
-  help: Replace `<Mock>foo` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as Mock).mockImplementation(1);
    ·  ───────────
    ╰────
-  help: Replace `foo as Mock` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as unknown as Mock).mockReturnValue(1);
    ·  ──────────────────────
    ╰────
-  help: Replace `foo as unknown as Mock` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (<Mock>foo as unknown).mockReturnValue(1);
    ·  ─────────
    ╰────
-  help: Replace `<Mock>foo` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (Obj.foo as Mock).mockReturnValue(1);
    ·  ───────────────
    ╰────
-  help: Replace `Obj.foo as Mock` with `vi.mocked(Obj.foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ ([].foo as Mock).mockReturnValue(1);
    ·  ──────────────
    ╰────
-  help: Replace `[].foo as Mock` with `vi.mocked([].foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as MockedFunction).mockReturnValue(1);
    ·  ─────────────────────
    ╰────
-  help: Replace `foo as MockedFunction` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as MockedFunction).mockImplementation(1);
    ·  ─────────────────────
    ╰────
-  help: Replace `foo as MockedFunction` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as unknown as MockedFunction).mockReturnValue(1);
    ·  ────────────────────────────────
    ╰────
-  help: Replace `foo as unknown as MockedFunction` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (Obj.foo as MockedFunction).mockReturnValue(1);
    ·  ─────────────────────────
    ╰────
-  help: Replace `Obj.foo as MockedFunction` with `vi.mocked(Obj.foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (new Array(0).fill(null).foo as MockedFunction).mockReturnValue(1);
    ·  ─────────────────────────────────────────────
    ╰────
-  help: Replace `new Array(0).fill(null).foo as MockedFunction` with `vi.mocked(new Array(0).fill(null).foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (vi.fn(() => foo) as MockedFunction).mockReturnValue(1);
    ·  ──────────────────────────────────
    ╰────
-  help: Replace `vi.fn(() => foo) as MockedFunction` with `vi.mocked(vi.fn(() => foo))`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:26]
  1 │ const mockedUseFocused = useFocused as MockedFunction<typeof useFocused>;
    ·                          ───────────────────────────────────────────────
    ╰────
-  help: Replace `useFocused as MockedFunction<typeof useFocused>` with `vi.mocked(useFocused)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `Mock`
    ╭─[prefer_vi_mocked.ts:1:17]
  1 │ const filter = (MessageService.getMessage as Mock).mock.calls[0][0];
    ·                 ─────────────────────────────────
    ╰────
-  help: Replace `MessageService.getMessage as Mock` with `vi.mocked(MessageService.getMessage)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedClass`
    ╭─[prefer_vi_mocked.ts:2:14]
@@ -127,21 +127,21 @@ source: crates/oxc_linter/src/tester.rs
  2 │             (foo as MockedClass<A>)
    ·              ─────────────────────
    ╰────
-  help: Replace `foo as MockedClass<A>` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedObject`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (foo as MockedObject<{method: () => void}>)
    ·  ─────────────────────────────────────────
    ╰────
-  help: Replace `foo as MockedObject<{method: () => void}>` with `vi.mocked(foo)`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:1:2]
  1 │ (Obj["foo"] as MockedFunction).mockReturnValue(1);
    ·  ────────────────────────────
    ╰────
-  help: Replace `Obj["foo"] as MockedFunction` with `vi.mocked(Obj["foo"])`.
+  help: Use `vi.mocked()` instead.
 
   ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over type assertions using `MockedFunction`
    ╭─[prefer_vi_mocked.ts:2:13]
@@ -154,12 +154,4 @@ source: crates/oxc_linter/src/tester.rs
  7 │ ╰─▶             }>
  8 │                 ).mockReturnValue(1);
    ╰────
-  help: Replace `new Array(100)
-                      .fill(undefined)
-                      .map(x => x.value)
-                      .filter(v => !!v).myProperty as MockedFunction<{
-                      method: () => void;
-                    }>` with `vi.mocked(new Array(100)
-                      .fill(undefined)
-                      .map(x => x.value)
-                      .filter(v => !!v).myProperty)`.
+  help: Use `vi.mocked()` instead.

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_vi_mocked.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_vi_mocked.snap
@@ -1,0 +1,165 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (foo as Mock).mockReturnValue(1);
+   ·  ───────────
+   ╰────
+  help: Replace `foo as Mock` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (foo as unknown as string as unknown as Mock).mockReturnValue(1);
+   ·  ───────────────────────────────────────────
+   ╰────
+  help: Replace `foo as unknown as string as unknown as Mock` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (foo as unknown as Mock as unknown as Mock).mockReturnValue(1);
+   ·  ─────────────────────────────────────────
+   ╰────
+  help: Replace `foo as unknown as Mock as unknown as Mock` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (<Mock>foo).mockReturnValue(1);
+   ·  ─────────
+   ╰────
+  help: Replace `<Mock>foo` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (foo as Mock).mockImplementation(1);
+   ·  ───────────
+   ╰────
+  help: Replace `foo as Mock` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (foo as unknown as Mock).mockReturnValue(1);
+   ·  ──────────────────────
+   ╰────
+  help: Replace `foo as unknown as Mock` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (<Mock>foo as unknown).mockReturnValue(1);
+   ·  ─────────
+   ╰────
+  help: Replace `<Mock>foo` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (Obj.foo as Mock).mockReturnValue(1);
+   ·  ───────────────
+   ╰────
+  help: Replace `Obj.foo as Mock` with `vi.mocked(Obj.foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ ([].foo as Mock).mockReturnValue(1);
+   ·  ──────────────
+   ╰────
+  help: Replace `[].foo as Mock` with `vi.mocked([].foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (foo as MockedFunction).mockReturnValue(1);
+   ·  ─────────────────────
+   ╰────
+  help: Replace `foo as MockedFunction` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (foo as MockedFunction).mockImplementation(1);
+   ·  ─────────────────────
+   ╰────
+  help: Replace `foo as MockedFunction` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (foo as unknown as MockedFunction).mockReturnValue(1);
+   ·  ────────────────────────────────
+   ╰────
+  help: Replace `foo as unknown as MockedFunction` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (Obj.foo as MockedFunction).mockReturnValue(1);
+   ·  ─────────────────────────
+   ╰────
+  help: Replace `Obj.foo as MockedFunction` with `vi.mocked(Obj.foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (new Array(0).fill(null).foo as MockedFunction).mockReturnValue(1);
+   ·  ─────────────────────────────────────────────
+   ╰────
+  help: Replace `new Array(0).fill(null).foo as MockedFunction` with `vi.mocked(new Array(0).fill(null).foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (vi.fn(() => foo) as MockedFunction).mockReturnValue(1);
+   ·  ──────────────────────────────────
+   ╰────
+  help: Replace `vi.fn(() => foo) as MockedFunction` with `vi.mocked(vi.fn(() => foo))`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:26]
+ 1 │ const mockedUseFocused = useFocused as MockedFunction<typeof useFocused>;
+   ·                          ───────────────────────────────────────────────
+   ╰────
+  help: Replace `useFocused as MockedFunction<typeof useFocused>` with `vi.mocked(useFocused)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:17]
+ 1 │ const filter = (MessageService.getMessage as Mock).mock.calls[0][0];
+   ·                 ─────────────────────────────────
+   ╰────
+  help: Replace `MessageService.getMessage as Mock` with `vi.mocked(MessageService.getMessage)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:2:14]
+ 1 │ class A {}
+ 2 │             (foo as MockedClass<A>)
+   ·              ─────────────────────
+   ╰────
+  help: Replace `foo as MockedClass<A>` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (foo as MockedObject<{method: () => void}>)
+   ·  ─────────────────────────────────────────
+   ╰────
+  help: Replace `foo as MockedObject<{method: () => void}>` with `vi.mocked(foo)`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:1:2]
+ 1 │ (Obj["foo"] as MockedFunction).mockReturnValue(1);
+   ·  ────────────────────────────
+   ╰────
+  help: Replace `Obj["foo"] as MockedFunction` with `vi.mocked(Obj["foo"])`.
+
+  ⚠ vitest(prefer-vi-mocked): Prefer `vi.mocked()` over `fn as Mock`
+   ╭─[prefer_vi_mocked.ts:2:13]
+ 1 │     (
+ 2 │ ╭─▶             new Array(100)
+ 3 │ │                 .fill(undefined)
+ 4 │ │                 .map(x => x.value)
+ 5 │ │                 .filter(v => !!v).myProperty as MockedFunction<{
+ 6 │ │                 method: () => void;
+ 7 │ ╰─▶             }>
+ 8 │                 ).mockReturnValue(1);
+   ╰────
+  help: Replace `new Array(100)
+                      .fill(undefined)
+                      .map(x => x.value)
+                      .filter(v => !!v).myProperty as MockedFunction<{
+                      method: () => void;
+                    }>` with `vi.mocked(new Array(100)
+                      .fill(undefined)
+                      .map(x => x.value)
+                      .filter(v => !!v).myProperty)`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9901,6 +9901,9 @@
         "vitest/prefer-todo": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "vitest/prefer-vi-mocked": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "vitest/require-awaited-expect-poll": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10188,6 +10188,9 @@
         "vitest/prefer-todo": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "vitest/prefer-vi-mocked": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "vitest/require-awaited-expect-poll": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -717,6 +717,7 @@ vitest/prefer-to-contain                                   |      0
 vitest/prefer-to-have-been-called-times                    |      0
 vitest/prefer-to-have-length                               |      0
 vitest/prefer-todo                                         |      0
+vitest/prefer-vi-mocked                                    |   2576
 vitest/require-awaited-expect-poll                         |      0
 vitest/require-hook                                        |  62613
 vitest/require-local-test-context-for-concurrent-snapshots |      0

--- a/tasks/track_linter_timings/linter_timings.snap
+++ b/tasks/track_linter_timings/linter_timings.snap
@@ -745,6 +745,7 @@ vitest/prefer-to-contain                                   |      0
 vitest/prefer-to-have-been-called-times                    |      0
 vitest/prefer-to-have-length                               |      0
 vitest/prefer-todo                                         |      0
+vitest/prefer-vi-mocked                                    |   2576
 vitest/require-awaited-expect-poll                         |      0
 vitest/require-hook                                        |  62613
 vitest/require-local-test-context-for-concurrent-snapshots |      0


### PR DESCRIPTION
This PR implements the `vitest/prefer-vi-mocked` rule. There is already a `jest/prefer-jest-mocked` rule, but the vitest version differs in some cases and fixes, so I didnt move the logic into a shared implementation, i think its cleaner to keep this rule separate.

issue #4656 