### PR TITLE
fix(parser): report duplicate `__proto__` in the parser

### DIFF
--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -166,6 +166,9 @@ impl<'a, C: Config> CoverGrammar<'a, AssignmentExpression<'a>, C>
 
 impl<'a, C: Config> CoverGrammar<'a, ObjectExpression<'a>, C> for ObjectAssignmentTarget<'a> {
     fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
+        // A duplicate `__proto__` is allowed in a destructuring pattern.
+        p.state.duplicate_proto.remove(&expr.span.start);
+
         let mut properties = p.ast.vec();
         let mut rest = None;
 

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -1,5 +1,7 @@
 use oxc_allocator::Box;
 use oxc_ast::ast::*;
+use oxc_ecmascript::PropName;
+use oxc_span::Span;
 use oxc_syntax::operator::AssignmentOperator;
 
 use crate::{
@@ -32,7 +34,35 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.state.trailing_commas.insert(span, self.end_span(comma_span));
         }
         self.expect(Kind::RCurly);
+        self.record_duplicate_proto(span, &object_expression_properties);
         self.ast.alloc_object_expression(self.end_span(span), object_expression_properties)
+    }
+
+    /// Record a duplicate `__proto__` data property keyed by the object's `span` start.
+    /// The error is emitted later (in `check_unfinished_errors`) unless the object is
+    /// covered into a destructuring assignment target, in which case it is removed.
+    /// Computed keys, shorthands, methods and accessors don't count (`prop_name` returns
+    /// `None` for computed/shorthand; the `kind`/`method` checks skip methods and accessors).
+    fn record_duplicate_proto(&mut self, span: u32, properties: &[ObjectPropertyKind<'a>]) {
+        // A duplicate requires ≥2 entries. JSX/TSX call sites emit huge numbers of
+        // single-property object literals, so the early-exit skips the loop for those.
+        if properties.len() < 2 {
+            return;
+        }
+        let mut prev_proto: Option<Span> = None;
+        for prop in properties {
+            let ObjectPropertyKind::ObjectProperty(obj_prop) = prop else { continue };
+            if obj_prop.kind != PropertyKind::Init || obj_prop.method {
+                continue;
+            }
+            if let Some(("__proto__", proto_span)) = prop.prop_name() {
+                if let Some(prev_span) = prev_proto {
+                    self.state.duplicate_proto.insert(span, (prev_span, proto_span));
+                    break;
+                }
+                prev_proto = Some(proto_span);
+            }
+        }
     }
 
     fn parse_object_expression_property(&mut self) -> ObjectPropertyKind<'a> {

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -874,6 +874,11 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         for expr in self.state.cover_initialized_name.values() {
             self.errors.push(diagnostics::cover_initialized_name(expr.span()));
         }
+        // It is a Syntax Error if an object literal (not a destructuring pattern) has
+        // more than one `__proto__` data property.
+        for &(prev_span, span) in self.state.duplicate_proto.values() {
+            self.errors.push(diagnostics::redeclaration("__proto__", prev_span, span));
+        }
     }
 
     /// Check if source length exceeds MAX_LEN, if the file cannot be parsed.

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -12,6 +12,13 @@ pub struct ParserState<'a> {
     /// Keyed by `ObjectProperty`'s span.start.
     pub cover_initialized_name: FxHashMap<u32, AssignmentExpression<'a>>,
 
+    /// A duplicate `__proto__` data property in an object literal, e.g.
+    /// `({ __proto__: 1, __proto__: 2 })`. This is only an error when the object
+    /// is a value; it is removed when the object is covered into a destructuring
+    /// assignment target. Keyed by `ObjectExpression`'s span.start, valued by the
+    /// spans of the first and the duplicate `__proto__` key.
+    pub duplicate_proto: FxHashMap<u32, (Span, Span)>,
+
     /// Trailing comma spans for `ArrayExpression` and `ObjectExpression`.
     /// Used for error reporting.
     /// Keyed by start span of `ArrayExpression` / `ObjectExpression`.
@@ -38,6 +45,7 @@ impl ParserState<'_> {
         Self {
             not_parenthesized_arrow: FxHashSet::default(),
             cover_initialized_name: FxHashMap::default(),
+            duplicate_proto: FxHashMap::default(),
             trailing_commas: FxHashMap::default(),
             potential_await_reparse: Vec::new(),
             encountered_await_identifier: false,

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -1236,39 +1236,6 @@ fn get_class_details(
     (Some(scope_id), class_id)
 }
 
-pub fn check_object_expression(obj_expr: &ObjectExpression, ctx: &SemanticBuilder<'_>) {
-    // ObjectLiteral : { PropertyDefinitionList }
-    // It is a Syntax Error if PropertyNameList of PropertyDefinitionList contains any duplicate entries for "__proto__"
-    // and at least two of those entries were obtained from productions of the form PropertyDefinition : PropertyName : AssignmentExpression
-
-    // A duplicate requires ≥2 entries. JSX/TSX call sites emit huge numbers
-    // of single-property object literals (`<Foo prop={x}>` → `{prop: x}`), so
-    // the early-exit skips the loop setup and `prop_name()` call for those
-    // very common cases.
-    if obj_expr.properties.len() < 2 {
-        return;
-    }
-
-    let mut prev_proto: Option<Span> = None;
-    for prop in &obj_expr.properties {
-        if let ObjectPropertyKind::ObjectProperty(obj_prop) = prop {
-            // Skip if not a property definition production:
-            // PropertyDefinition : PropertyName : AssignmentExpression
-            if obj_prop.kind != PropertyKind::Init || obj_prop.method {
-                continue;
-            }
-            if let Some((prop_name, span)) = prop.prop_name()
-                && prop_name == "__proto__"
-            {
-                if let Some(prev_span) = prev_proto {
-                    ctx.error(diagnostics::redeclaration("__proto__", prev_span, span));
-                }
-                prev_proto = Some(span);
-            }
-        }
-    }
-}
-
 pub fn check_unary_expression(unary_expr: &UnaryExpression, ctx: &SemanticBuilder<'_>) {
     // https://tc39.es/ecma262/#sec-delete-operator-static-semantics-early-errors
     if unary_expr.operator == UnaryOperator::Delete {

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -100,7 +100,6 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
         }
 
         AstKind::AwaitExpression(expr) => js::check_await_expression(expr, ctx),
-        AstKind::ObjectExpression(expr) => js::check_object_expression(expr, ctx),
         AstKind::UnaryExpression(expr) => js::check_unary_expression(expr, ctx),
         AstKind::YieldExpression(expr) => js::check_yield_expression(expr, ctx),
         AstKind::VariableDeclaration(decl) => {


### PR DESCRIPTION
## What

Moves the duplicate `__proto__` data-property check (`{ __proto__: 1, __proto__: 2 }`) out of the semantic checker (`check_object_expression`) into the parser.

## Why it needs deferred state (not a plain parse-time check)

A duplicate `__proto__` is an early error only in an object literal **value**. In an object **pattern** it is valid:

```js
({ __proto__: a, __proto__: b } = x);   // OK — destructuring assignment
let { __proto__: a, __proto__: b } = x; // OK — binding
```

The semantic checker handled this for free: those patterns become `ObjectAssignmentTarget` / `ObjectPattern` nodes before it runs, so it only ever saw real `ObjectExpression` values. A naive check in `parse_object_expression` runs *before* the cover-grammar decision and would wrongly flag valid destructuring.

## How

Mirror the existing `CoverInitializedName` (`{ foo = bar }`) mechanism — the parser's established solution to the same value-vs-pattern problem:

1. `parse_object_expression` records a duplicate `__proto__` as deferred state keyed by the object's `span.start` (`ParserState::duplicate_proto`).
2. `ObjectAssignmentTarget::cover` **removes** the entry when the object is reinterpreted as a destructuring target.
3. `check_unfinished_errors` emits any leftovers (true value-context literals) at the end of parsing.

Arrow params and binding declarations are parsed as binding patterns directly and never reach `parse_object_expression`, so they never record. Computed keys, shorthands, methods and accessors are excluded (`prop_name` returns `None` for computed/shorthand; the `kind`/`method` checks skip the rest).

## Verification

- Errors: `{__proto__:1, __proto__:2}` as a value (incl. nested, 3+ entries → one error).
- Clean: assignment/arrow/binding patterns, computed/shorthand/method, single `__proto__`.
- No conformance snapshot changes, no allocation snapshot changes; parser/semantic/linter tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)