### PR TITLE
fix(codegen): don't emit space before a postfix update operand when minifying

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1882,9 +1882,9 @@ impl GenExpr for UpdateExpression<'_> {
                 p.prev_op_end = p.code().len();
                 self.argument.print_expr(p, Precedence::Prefix, ctx);
             } else {
-                p.print_space_before_operator(self.operator.into());
                 p.add_source_mapping(self.span);
                 self.argument.print_expr(p, Precedence::Postfix, ctx);
+                p.print_space_before_operator(self.operator.into());
                 p.print_str(operator);
                 p.prev_op = Some(self.operator.into());
                 p.prev_op_end = p.code().len();

--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -794,6 +794,11 @@ fn test_whitespace() {
     test_minify("x - ++y", "x-++y;");
     test_minify("x + ++y", "x+ ++y;");
 
+    // Postfix update operand: no space, the trailing `++`/`--` doesn't follow the `+`.
+    test_minify("x + y++", "x+y++;");
+    test_minify("x + y--", "x+y--;");
+    test_minify("x - y--", "x-y--;");
+
     test_minify("x-- > y", "x-- >y;");
     test_minify("x < !--y", "x<! --y;");
     test_minify("x > !--y", "x>!--y;");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -5,7 +5,7 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 173.90 kB  | 59.40 kB   | 59.82 kB   | 19.15 kB   | 19.33 kB   |          2 | moment.js  
 
-287.63 kB  | 89.26 kB   | 90.07 kB   | 30.91 kB   | 31.95 kB   |          2 | jquery.js  
+287.63 kB  | 89.25 kB   | 90.07 kB   | 30.91 kB   | 31.95 kB   |          2 | jquery.js  
 
 342.15 kB  | 116.97 kB  | 118.14 kB  | 43.18 kB   | 44.37 kB   |          2 | vue.js     
 


### PR DESCRIPTION
## What

Found with the whitespace analyzer. The postfix branch of `UpdateExpression::gen_expr` called `print_space_before_operator(operator)` **before** printing the operand. For a postfix `x++` the `++` comes *after* the operand, so this treated the trailing `++` as if it immediately followed a preceding `+` (the `+`/`++` guard exists to avoid `+++` in prefix `x + ++y`).

Result, when minifying:

| Input | Before | After |
| --- | --- | --- |
| `x + y++` | `x+ y++` | `x+y++` |
| ``a + `-` + i[1]++`` | ``a+`-`+ i[1]++`` | ``a+`-`+i[1]++`` |

## Fix

Matches esbuild's `EUnary` printer: for postfix, print the operand first, then call `printSpaceBeforeOperator` immediately before the operator text. The guard `prev_op_end == code.len()` then makes it a no-op (the operand was printed since the last operator), so `x+y++` stays tight. Required spaces from the prefix/binary guard are unaffected:

- `x + ++y` → `x+ ++y`, `x - --y` → `x- --y`, `b + +c` → `b+ +c`

Output matches esbuild exactly. Codegen (116) + minifier (506) pass; minsize updated.