### PR TITLE
fix(codegen): drop space after `:` in function return type when minifying

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -788,7 +788,8 @@ impl Gen for Function<'_> {
             self.params.print(p, ctx);
             p.print_ascii_byte(b')');
             if let Some(return_type) = &self.return_type {
-                p.print_str(": ");
+                p.print_colon();
+                p.print_soft_space();
                 return_type.print(p, ctx);
             }
             if let Some(body) = &self.body {
@@ -3588,7 +3589,8 @@ impl Gen for TSThisParameter<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("this");
         if let Some(type_annotation) = &self.type_annotation {
-            p.print_str(": ");
+            p.print_colon();
+            p.print_soft_space();
             type_annotation.print(p, ctx);
         }
     }

--- a/crates/oxc_codegen/tests/integration/snapshots/minify.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/minify.snap
@@ -10,7 +10,7 @@ function foo<T extends string>(x: T, y: string, ...restOfParams: Omit<T, 'x'>): 
 	return x;
 }
 ----------
-function foo<T extends string>(x:T,y:string,...restOfParams:Omit<T,`x`>): T{return x}
+function foo<T extends string>(x:T,y:string,...restOfParams:Omit<T,`x`>):T{return x}
 ########## 2
 let x: string[] = ['abc', 'def', 'ghi'];
 ----------
@@ -54,7 +54,7 @@ function isString(value: unknown): asserts value is string {
             }
         }
 ----------
-function isString(value:unknown): asserts value is string{if(typeof value!==`string`){throw new Error(`Not a string`)}}
+function isString(value:unknown):asserts value is string{if(typeof value!==`string`){throw new Error(`Not a string`)}}
 ########## 12
 import type { Foo } from 'foo';
 ----------

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -193,6 +193,21 @@ fn minify_export_default() {
 }
 
 #[test]
+fn minify_return_type_colon() {
+    let min = |src: &str, expected: &str| {
+        test_options_with_source_type(src, expected, SourceType::ts(), CodegenOptions::minify());
+    };
+    // No space after `:` in a function return type / `this` param annotation,
+    // matching method/arrow return types.
+    min("function f(): Promise<void> {}", "function f():Promise<void>{}");
+    min(
+        "function g(a: string): boolean { return true; }",
+        "function g(a:string):boolean{return true}",
+    );
+    min("function h(this: Foo): void {}", "function h(this:Foo):void{}");
+}
+
+#[test]
 fn ts_as_expression_in_binary_expr() {
     test_idempotency("key in (that as object)");
     test_idempotency("'foo' in (x as Record<string, unknown>)");


### PR DESCRIPTION
## What

Found with the whitespace analyzer run over TypeScript sources. `Function` return-type annotations and `TSThisParameter` printed a hardcoded `": "`, so minified TS had a stray space — and inconsistent with methods/arrows which were already tight:

| Input | Before | After |
| --- | --- | --- |
| `function f(): Promise<void> {}` | `function f(): Promise<void>{}` | `function f():Promise<void>{}` |
| `function h(this: Foo): void {}` | `function h(this: Foo): void{}` | `function h(this:Foo):void{}` |
| `class C { m(): void {} }` | `m():void{}` (already tight) | `m():void{}` |

## Fix

Replace `print_str(": ")` with `print_colon()` + `print_soft_space()` (the soft space is dropped when minifying, kept when pretty-printing) — the same form methods, arrows, and parameter annotations already use. Pretty-print output is unchanged; the `ts` minify snapshot is updated.