### PR TITLE
fix(parser): report `abstract` private class field in the parser

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1204,6 +1204,12 @@ pub fn abstract_property_cannot_have_initializer(name: &str, span: Span) -> OxcD
 }
 
 #[cold]
+pub fn abstract_with_private_identifier(span: Span) -> OxcDiagnostic {
+    ts_error("18019", "'abstract' modifier cannot be used with a private identifier.")
+        .with_label(span)
+}
+
+#[cold]
 pub fn abstract_accessor_cannot_have_implementation(name: &str, span: Span) -> OxcDiagnostic {
     ts_error(
         "1318",

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -684,6 +684,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::static_prototype(span));
             }
         }
+        if r#abstract && name.is_private_identifier() {
+            self.error(diagnostics::abstract_with_private_identifier(name.span()));
+        }
         if r#abstract && initializer.is_some() {
             let (name, span) = name.prop_name().unwrap_or_else(|| {
                 let span = name.span();

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -87,9 +87,6 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
         AstKind::MethodDefinition(method) => {
             ts::check_method_definition(method, ctx);
         }
-        AstKind::PropertyDefinition(prop) => {
-            ts::check_property_definition(prop, ctx);
-        }
         AstKind::ObjectProperty(prop) => {
             ts::check_object_property(prop, ctx);
         }

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -321,13 +321,6 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
     }
 }
 
-pub fn check_property_definition(prop: &PropertyDefinition, ctx: &SemanticBuilder<'_>) {
-    // abstract cannot be used with private identifiers
-    if prop.r#type.is_abstract() && prop.key.is_private_identifier() {
-        ctx.error(diagnostics::abstract_cannot_be_used_with_private_identifier(prop.key.span()));
-    }
-}
-
 pub fn check_object_property(prop: &ObjectProperty, ctx: &SemanticBuilder<'_>) {
     if let Expression::FunctionExpression(func) = &prop.value
         && prop.kind.is_accessor()

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -17020,6 +17020,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  29 │ }
     ╰────
 
+  × TS(18019): 'abstract' modifier cannot be used with a private identifier.
+    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNamesIncompatibleModifiers.ts:32:14]
+ 31 │ abstract class B {
+ 32 │     abstract #quux = 3;      // Error
+    ·              ─────
+ 33 │ }
+    ╰────
+
   × TS(1267): Property '#quux' cannot have an initializer because it is marked abstract.
     ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNamesIncompatibleModifiers.ts:32:14]
  31 │ abstract class B {
@@ -17042,14 +17050,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  26 │     declare set #whatProp(value: number)         // Error
     ·                 ─────────
  27 │     async get #asyncProp() { return 1; }         // Error
-    ╰────
-
-  × TS(18019): 'abstract' modifier cannot be used with a private identifier.
-    ╭─[typescript/tests/cases/conformance/classes/members/privateNames/privateNamesIncompatibleModifiers.ts:32:14]
- 31 │ abstract class B {
- 32 │     abstract #quux = 3;      // Error
-    ·              ─────
- 33 │ }
     ╰────
 
   × Private identifier '#prop' is not allowed outside class bodies


### PR DESCRIPTION
## What

Moves the "'abstract' modifier cannot be used with a private identifier" check (TS18019) for **class fields** out of the semantic checker (`check_property_definition`) into the parser.

## Why it's a clean move

- **Zero state:** the check is `r#abstract && name.is_private_identifier()` — only node fields, evaluated where the class element's modifiers and key are already in hand (next to the existing `abstract_property_cannot_have_initializer` check).
- **Node identity is final at parse time:** a `PropertyDefinition` is a class field; classes are never reinterpreted by cover grammar (unlike object literals → patterns), so there's no value-vs-pattern ambiguity.
- **Negative-only:** `abstract #x` is broken code, confirmed by `cargo coverage` — no positive-suite regressions.

The identical diagnostic for abstract **methods** (`check_method_definition`) stays in the semantic checker, so the shared diagnostic is kept.

## Conformance

No count changes in any suite; the only snapshot delta is the TS18019 error relocating (now emitted during parsing) in `parser_typescript.snap`. Parser/semantic/linter tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)