### PR TITLE
refactor(semantic): use new_linter/new_compiler presets at callsites

### DIFF
--- a/crates/oxc_linter/examples/linter.rs
+++ b/crates/oxc_linter/examples/linter.rs
@@ -41,7 +41,7 @@ fn main() -> std::io::Result<()> {
     }
 
     // Build semantic model for AST analysis
-    let semantic_ret = SemanticBuilder::new().build(&ret.program);
+    let semantic_ret = SemanticBuilder::new_linter().build(&ret.program);
 
     let mut errors: Vec<OxcDiagnostic> = vec![];
 

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -75,8 +75,7 @@ fn main() -> std::io::Result<()> {
     std::fs::write(ast_file_path, format!("{:#?}", &program))?;
     println!("Wrote AST to: {}", &ast_file_name);
 
-    let semantic =
-        SemanticBuilder::new().with_check_syntax_error(true).with_cfg(true).build(&program);
+    let semantic = SemanticBuilder::new_compiler().with_cfg(true).build(&program);
 
     if !semantic.errors.is_empty() {
         let error_message: String = semantic

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -203,9 +203,10 @@ impl<'a> SemanticBuilder<'a> {
     /// Create a builder configured for the **linter**.
     ///
     /// Enables everything the linter relies on: syntax error checking, the
-    /// control flow graph, and the class table. This is the single place to tune
-    /// linter defaults; individual options can still be overridden with the
-    /// `with_*` methods.
+    /// control flow graph, and the class table. JSDoc is built whenever the
+    /// `jsdoc` feature is enabled, which the `linter` feature turns on. This is
+    /// the single place to tune linter defaults; individual options can still be
+    /// overridden with the `with_*` methods.
     #[must_use]
     pub fn new_linter() -> Self {
         Self::new().with_check_syntax_error(true).with_cfg(true).with_class_table(true)

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -178,8 +178,7 @@ impl<'a> SemanticTester<'a> {
                 .collect::<String>()
         );
 
-        SemanticBuilder::new()
-            .with_check_syntax_error(true)
+        SemanticBuilder::new_compiler()
             .with_cfg(self.cfg)
             .build(self.allocator.alloc(parse.program))
     }

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -236,7 +236,7 @@ impl Oxc {
         parser_options: &OxcParserOptions,
         control_flow_options: &OxcControlFlowOptions,
     ) -> oxc::semantic::Semantic<'a> {
-        let mut semantic_builder = SemanticBuilder::new();
+        let mut semantic_builder = SemanticBuilder::new_compiler();
         if run_options.transform {
             // Estimate transformer will triple scopes, symbols, references
             semantic_builder = semantic_builder.with_excess_capacity(2.0).with_enum_eval(true);

--- a/tasks/benchmark/benches/linter.rs
+++ b/tasks/benchmark/benches/linter.rs
@@ -31,10 +31,7 @@ fn bench_linter(criterion: &mut Criterion) {
 
                 let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
                 let path = Path::new("");
-                let semantic_ret = SemanticBuilder::new()
-                    .with_cfg(true)
-                    .with_class_table(true)
-                    .build(&parser_ret.program);
+                let semantic_ret = SemanticBuilder::new_linter().build(&parser_ret.program);
                 let semantic = semantic_ret.semantic;
                 let module_record =
                     Arc::new(ModuleRecord::new(path, &parser_ret.module_record, &semantic));

--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -29,10 +29,7 @@ fn bench_semantic(criterion: &mut Criterion) {
                     // We return `errors` to be dropped outside of the measured section, as usually
                     // real-world code has no errors, so allocating and dropping them is atypical and
                     // we don't want to include it in benchmark time.
-                    let ret = SemanticBuilder::new()
-                        .with_check_syntax_error(true)
-                        .with_class_table(true)
-                        .build(&program);
+                    let ret = SemanticBuilder::new_compiler().build(&program);
                     let ret = black_box(ret);
                     ret.errors
                 });


### PR DESCRIPTION
Replaces ad-hoc `SemanticBuilder::new().with_*()` chains with the `new_linter()` / `new_compiler()` presets where the preset already expands to the exact same option set, so the config lives in one place.

- linter example + linter benchmark → `new_linter()` (cfg + class table + syntax)
- semantic benchmark, cfg example, integration test util → `new_compiler()` (syntax)

Behavior-neutral — each preset matches the options the callsite set by hand. Carved out of the larger store-optional refactor so it can land independently on `main` first.