### PR TITLE
chore(ci): bump codecov action to v7

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload to codecov.io
         if: env.CODECOV_TOKEN
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary

- Bump `codecov/codecov-action` from v6.0.1 to v7.0.0.
- Keep the action pinned to the peeled v7.0.0 commit SHA.
- Fix the uploader bootstrap failure caused by v6 importing the old Codecov Keybase GPG key.

## Testing

- Not run; workflow-only change.

## AI Disclosure

This PR was created with AI assistance. The human contributor is responsible for reviewing and validating the change before merge.