### PR TITLE
refactor(semantic): use SemanticBuilder presets at remaining call sites

### DIFF
--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -1424,7 +1424,7 @@ mod tests {
         let source_type = SourceType::default();
         let parser_ret = Parser::new(allocator, source_text, source_type).parse();
         assert!(parser_ret.errors.is_empty());
-        let semantic_ret = SemanticBuilder::new().build(allocator.alloc(parser_ret.program));
+        let semantic_ret = SemanticBuilder::new_linter().build(allocator.alloc(parser_ret.program));
         semantic_ret.semantic
     }
 

--- a/crates/oxc_linter/src/utils/comment.rs
+++ b/crates/oxc_linter/src/utils/comment.rs
@@ -92,7 +92,7 @@ mod test {
             let allocator = Allocator::default();
             let ret = Parser::new(&allocator, source, source_type).parse();
             assert!(ret.errors.is_empty());
-            let semantic = SemanticBuilder::new().build(&ret.program).semantic;
+            let semantic = SemanticBuilder::new_linter().build(&ret.program).semantic;
             let comments = semantic.comments();
 
             assert_eq!(

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -368,7 +368,7 @@ mod test {
             let source_type = SourceType::default();
             let parser_ret = Parser::new(&allocator, "", source_type).parse();
             let program = allocator.alloc(parser_ret.program);
-            let semantic = SemanticBuilder::new().with_cfg(true).build(program).semantic;
+            let semantic = SemanticBuilder::new_linter().build(program).semantic;
             Rc::new(ContextHost::new(
                 path,
                 vec![ContextSubHost::new(

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -1029,7 +1029,7 @@ mod test {
             let parser_ret = Parser::new(&allocator, source, source_type).parse();
             assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
             let semantic =
-                SemanticBuilder::new().build(allocator.alloc(parser_ret.program)).semantic;
+                SemanticBuilder::new_linter().build(allocator.alloc(parser_ret.program)).semantic;
 
             let found = semantic.nodes().iter().any(|node| is_es5_component(node));
             assert_eq!(found, expected, "Failed for: {source}");
@@ -1060,7 +1060,7 @@ mod test {
             assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
 
             let semantic =
-                SemanticBuilder::new().build(allocator.alloc(parser_ret.program)).semantic;
+                SemanticBuilder::new_linter().build(allocator.alloc(parser_ret.program)).semantic;
             let found = semantic.nodes().iter().find_map(|node| {
                 if let super::AstKind::JSXOpeningElement(opening) = node.kind() {
                     Some(get_jsx_element_name(&opening.name).into_owned())
@@ -1124,7 +1124,7 @@ mod test {
             let parser_ret = Parser::new(&allocator, source, source_type).parse();
             assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
             let semantic =
-                SemanticBuilder::new().build(allocator.alloc(parser_ret.program)).semantic;
+                SemanticBuilder::new_linter().build(allocator.alloc(parser_ret.program)).semantic;
 
             let found = semantic.nodes().iter().any(|node| is_es6_component(node));
             assert_eq!(found, expected, "Failed for: {source}");

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -263,7 +263,7 @@ mod test {
         assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
 
         let program = allocator.alloc(parser_ret.program);
-        let semantic = SemanticBuilder::new().with_cfg(true).build(program).semantic;
+        let semantic = SemanticBuilder::new_linter().build(program).semantic;
         let ctx = Rc::new(ContextHost::new(
             "test.js",
             vec![ContextSubHost::new(

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -393,8 +393,7 @@ impl Oxc {
         // Only lint if there are no syntax errors
         if run_options.lint && self.diagnostics.is_empty() {
             let mut external_plugin_store = ExternalPluginStore::default();
-            let semantic_ret =
-                SemanticBuilder::new().with_cfg(true).with_class_table(true).build(program);
+            let semantic_ret = SemanticBuilder::new_linter().build(program);
             let semantic = semantic_ret.semantic;
             let lint_config = if let Some(config) = &linter_options.config {
                 let oxlintrc = Oxlintrc::from_string(config).unwrap_or_default();


### PR DESCRIPTION
Use the `SemanticBuilder::new_linter()` preset at linter call sites that built semantic with ad-hoc `new().with_cfg(true)`-style chains, so they build semantic the same way the linter does instead of replicating its options by hand.

- linter test helpers: `disable_directives`, `utils/{regex,comment,jest,react}`
- playground's lint path

Behaviour-neutral; all linter tests pass.