### PR TITLE
refactor(semantic): track function kind in SymbolFlags for redeclaration checks

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -138,11 +138,20 @@ impl<'a> Binder<'a> for Function<'a> {
         let is_declaration = self.is_declaration();
 
         if let Some(ident) = &self.id {
-            let includes = if self.declare {
-                SymbolFlags::Function | SymbolFlags::Ambient
-            } else {
-                SymbolFlags::Function
-            };
+            let mut includes = SymbolFlags::Function;
+            if self.declare {
+                includes |= SymbolFlags::Ambient;
+            }
+            // A named function expression, so `check_redeclaration` can recognise its name binding
+            // (e.g. `(function n(n) {})` - the parameter `n` is not a redeclaration of the name).
+            if self.is_expression() {
+                includes |= SymbolFlags::FunctionExpression;
+            }
+            // An `async`/generator function, so the Annex B.3.3 redeclaration check can tell plain
+            // (relaxable) function declarations apart from these.
+            if self.r#async || self.generator {
+                includes |= SymbolFlags::AsyncOrGeneratorFunction;
+            }
 
             let excludes = if builder.source_type.is_typescript() {
                 SymbolFlags::FunctionExcludes
@@ -159,20 +168,6 @@ impl<'a> Binder<'a> for Function<'a> {
             ident.symbol_id.set(Some(symbol_id));
 
             let scope_flags = builder.current_scope_flags();
-
-            // Record `async`/generator function declarations in sloppy-mode block scopes,
-            // so the redeclaration check `check_function_redeclaration` (Annex B.3.3) can later identify
-            // an offending previous declaration without reading its AST node (which may not be retained).
-            // The check only consults this for function declarations in a sloppy-mode JS block,
-            // so record nothing in any other case.
-            if is_declaration
-                && (self.r#async || self.generator)
-                && !builder.source_type.is_typescript()
-                && !scope_flags.is_strict_mode()
-                && !scope_flags.is_var()
-            {
-                builder.async_or_generator_function_node_ids.push(builder.current_node_id);
-            }
 
             // Annex B.3.2.1: In sloppy mode, plain function declarations inside block
             // scopes also create an implicit var-like binding in the enclosing function

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -91,13 +91,6 @@ pub struct SemanticBuilder<'a> {
     /// in that scope can still detect redeclarations via `check_redeclaration`.
     pub(crate) hoisting_variables: FxHashMap<ScopeId, IdentHashMap<'a, SymbolId>>,
 
-    /// `NodeId`s of `async`/generator function declarations in sloppy-mode block scopes in JS files.
-    /// Read by `check_function_redeclaration` (Annex B.3.3) to identify an offending previous declaration
-    /// without reading its AST node, which may not be retained.
-    /// These conditions are extremely rarely met, so this `Vec` is practically always empty.
-    /// Build-only scratch (discarded after the build).
-    pub(crate) async_or_generator_function_node_ids: Vec<NodeId>,
-
     // builders
     pub(crate) nodes: AstNodes<'a>,
     pub(crate) scoping: Scoping,
@@ -165,7 +158,6 @@ impl<'a> SemanticBuilder<'a> {
             module_instance_state_cache: FxHashMap::default(),
             nodes: AstNodes::default(),
             hoisting_variables: FxHashMap::default(),
-            async_or_generator_function_node_ids: Vec::new(),
             scoping,
             unresolved_references: UnresolvedReferences::new(),
             unresolved_references_checkpoint: 0,
@@ -521,23 +513,14 @@ impl<'a> SemanticBuilder<'a> {
             self.hoisting_variables.get(&scope_id).and_then(|symbols| symbols.get(&name).copied())
         })?;
 
-        // `(function n(n) {})()`
-        //              ^ is not a redeclaration
-        // Since we put the function expression binding 'n' Symbol into the function itself scope,
-        // then defining a variable with the same name as the function name will be considered
-        // a redeclaration, but it's actually not a redeclaration, so if the symbol declaration
-        // is a function expression, then return None to tell the caller that it's not a redeclaration.
-        if self.scoping.symbol_flags(symbol_id).is_function()
-            && self
-                .nodes
-                .kind(self.scoping.symbol_declaration(symbol_id))
-                .as_function()
-                .is_some_and(Function::is_expression)
-        {
+        let flags = self.scoping.symbol_flags(symbol_id);
+
+        // A named function expression binds its own name in the function's scope, so a same-named
+        // parameter is not a redeclaration: `(function n(n) {})` - param `n` is fine.
+        if flags.contains(SymbolFlags::FunctionExpression) {
             return None;
         }
 
-        let flags = self.scoping.symbol_flags(symbol_id);
         if flags.intersects(excludes) {
             let symbol_span = self.scoping.symbol_span(symbol_id);
             self.error(redeclaration(&name, symbol_span, span));

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -734,10 +734,14 @@ fn check_redeclared_function(
             // (A clash with a `var`/`let`/`class` of the same name is a separate rule, reported elsewhere.)
             // This branch is only reached for function redeclarations in a sloppy-mode block,
             // which are extremely rare, so the linear scan's high cost does not really matter.
+            // Annex B.3.3 is JavaScript-only; TypeScript allows these (overloads/merging).
+            if ctx.source_type.is_typescript() {
+                return;
+            }
             let previous_declarations = &redeclarations[..redeclarations.len() - 1];
             let Some(culprit) = previous_declarations
                 .iter()
-                .find(|decl| ctx.async_or_generator_function_node_ids.contains(&decl.declaration))
+                .find(|decl| decl.flags.contains(SymbolFlags::AsyncOrGeneratorFunction))
             else {
                 // No `async`/generator function among the previous declarations - allowed by B.3.3.
                 return;

--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -440,7 +440,7 @@ fn test_class_merging() {
 fn test_redeclaration() {
     SemanticTester::js("(function n(n) { console.log (n) }) ()")
         .has_symbol("n") // the first `n` is the function expression
-        .equal_flags(SymbolFlags::Function) // param `n` is a SymbolFlags::FunctionScopedVariable
+        .equal_flags(SymbolFlags::Function | SymbolFlags::FunctionExpression) // param `n` is a SymbolFlags::FunctionScopedVariable
         .has_number_of_references(0) // no references to the function
         .test();
 }

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -73,6 +73,16 @@ bitflags! {
         // https://github.com/microsoft/TypeScript/blob/15392346d05045742e653eab5c87538ff2a3c863/src/compiler/types.ts#L819-L820
         const Ambient                 = 1 << 16;
 
+        // The following are not part of TypeScript's `SymbolFlags`. They record the syntactic kind
+        // of a function binding so the semantic builder's redeclaration checks can consult them
+        // (on `symbol_flags`, and per-declaration via `Redeclaration::flags`) instead of reading the
+        // declaration's AST node. The transformer keeps them in sync when it rewrites functions.
+
+        /// A named function expression, e.g. `n` in `(function n() {})`.
+        const FunctionExpression       = 1 << 17;
+        /// An `async` and/or generator function.
+        const AsyncOrGeneratorFunction = 1 << 18;
+
         const Enum = Self::ConstEnum.bits() | Self::RegularEnum.bits();
         const Variable = Self::FunctionScopedVariable.bits() | Self::BlockScopedVariable.bits();
 

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -69,6 +69,7 @@ use crate::{
     common::helper_loader::{Helper, helper_call_expr},
     context::TraverseCtx,
     state::TransformState,
+    utils::sync_function_symbol_flags,
 };
 
 pub struct AsyncToGenerator<'a> {
@@ -294,6 +295,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         func.generator = false;
         func.body = Some(ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), ctx.ast.vec1(statement)));
         func.scope_id.set(Some(wrapper_scope_id));
+        sync_function_symbol_flags(func, ctx);
     }
 
     /// Transforms [`Function`] whose type is [`FunctionType::FunctionExpression`] to a generator function
@@ -438,6 +440,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         {
             wrapper_function.r#async = false;
             wrapper_function.generator = false;
+            sync_function_symbol_flags(wrapper_function, ctx);
             let statements = ctx.ast.vec1(Self::create_apply_call_statement(&bound_ident, ctx));
             debug_assert!(wrapper_function.body.is_none());
             wrapper_function.body.replace(ctx.ast.alloc_function_body(
@@ -654,9 +657,9 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         params: ArenaBox<'a, FormalParameters<'a>>,
         body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> ArenaBox<'a, Function<'a>> {
-        ctx.ast.alloc_function_with_scope_id(
+        let function = ctx.ast.alloc_function_with_scope_id(
             SPAN,
             r#type,
             id,
@@ -669,7 +672,9 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             NONE,
             Some(body),
             scope_id,
-        )
+        );
+        sync_function_symbol_flags(&function, ctx);
+        function
     }
 
     /// Creates a [`Statement`] that calls the `apply` method on the bound identifier.

--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -10,7 +10,10 @@ use oxc_semantic::{ScopeFlags, ScopeId};
 use oxc_span::SPAN;
 use oxc_traverse::Ancestor;
 
-use crate::{Helper, common::helper_loader::helper_call_expr, context::TraverseCtx};
+use crate::{
+    Helper, common::helper_loader::helper_call_expr, context::TraverseCtx,
+    utils::sync_function_symbol_flags,
+};
 
 use super::{
     ClassProperties,
@@ -61,6 +64,7 @@ impl<'a> ClassProperties<'a> {
         function.span = *span;
         function.id = Some(temp_binding.create_binding_identifier(ctx));
         function.r#type = FunctionType::FunctionDeclaration;
+        sync_function_symbol_flags(&function, ctx);
 
         // Change parent scope of function to current scope id and remove
         // strict mode flag if parent scope is not strict mode.

--- a/crates/oxc_transformer/src/utils/mod.rs
+++ b/crates/oxc_transformer/src/utils/mod.rs
@@ -1,1 +1,25 @@
 pub mod ast_builder;
+
+use oxc_ast::ast::Function;
+use oxc_syntax::symbol::SymbolFlags;
+
+use crate::context::TraverseCtx;
+
+/// Keep the `SymbolFlags` that record a function's syntactic kind in sync with the function's
+/// current shape, after a transform has rewritten it.
+///
+/// The semantic builder sets [`SymbolFlags::AsyncOrGeneratorFunction`] and
+/// [`SymbolFlags::FunctionExpression`] from the original source. When a transform changes a
+/// function's shape — downleveling `async`/generator to a plain function, or turning a declaration
+/// into a named function expression (or vice versa) — it must call this so the semantic data stays
+/// consistent with the rewritten AST.
+///
+/// No-op for anonymous functions (no symbol to update).
+pub fn sync_function_symbol_flags<'a>(func: &Function<'a>, ctx: &mut TraverseCtx<'a>) {
+    let Some(symbol_id) = func.id.as_ref().and_then(|id| id.symbol_id.get()) else {
+        return;
+    };
+    let flags = ctx.scoping_mut().symbol_flags_mut(symbol_id);
+    flags.set(SymbolFlags::AsyncOrGeneratorFunction, func.r#async || func.generator);
+    flags.set(SymbolFlags::FunctionExpression, func.is_expression());
+}


### PR DESCRIPTION
Encode whether a function binding is a named function expression or an `async`/generator function as two internal `SymbolFlags` bits (`FunctionExpression`, `AsyncOrGeneratorFunction`), set at bind time.

The redeclaration checks now read these flags instead of the AST node:

- `check_redeclaration` checks `FunctionExpression` rather than fetching the declaration node to ask `Function::is_expression`.
- `check_redeclared_function` (Annex B.3.3) checks `AsyncOrGeneratorFunction` on each previous declaration, replacing the build-only `async_or_generator_function_node_ids` Vec and its linear scan.

The transformer keeps the flags accurate when it rewrites functions, via a new `sync_function_symbol_flags` helper applied at the function-rewriting sites in `async_to_generator` and class private-method extraction.

Behaviour-neutral: semantic conformance snapshots are unchanged.