### PR TITLE
perf(parser): cache peek_token by source offset

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -103,6 +103,12 @@ pub struct Lexer<'a, C: Config> {
     /// Collected tokens in source order.
     tokens: ArenaVec<'a, Token>,
 
+    /// One-token lookahead cache for [`Self::peek_token`], keyed by the source offset the peek was
+    /// taken at. The default-goal next token is a pure function of the source offset, so the cache
+    /// is self-validating: a peek at a different offset misses and re-lexes, and returning to a
+    /// previously-peeked offset (e.g. after a rewind) yields the same token.
+    peeked_token: Option<(u32, Token)>,
+
     /// Config
     pub(crate) config: C,
 }
@@ -152,6 +158,7 @@ impl<'a, C: Config> Lexer<'a, C> {
             escaped_templates: FxHashMap::default(),
             multi_line_comment_end_finder: None,
             tokens,
+            peeked_token: None,
             config,
         }
     }
@@ -232,9 +239,20 @@ impl<'a, C: Config> Lexer<'a, C> {
     }
 
     pub fn peek_token(&mut self) -> Token {
+        // The default-goal next token is a pure function of the current source offset, so a repeated
+        // peek at the same offset returns the cached token without re-lexing. On any offset change
+        // the cache misses and we re-lex (always correct). The checkpoint/rewind below leaves lexer
+        // state exactly as it was, so this is side-effect-neutral.
+        let offset = self.offset();
+        if let Some((cached_offset, token)) = self.peeked_token
+            && cached_offset == offset
+        {
+            return token;
+        }
         let checkpoint = self.checkpoint();
         let token = self.next_token();
         self.rewind(checkpoint);
+        self.peeked_token = Some((offset, token));
         token
     }
 


### PR DESCRIPTION
## What

`Lexer::peek_token` previously did a full `checkpoint` + re-lex + `rewind` on **every** call. Add a one-entry cache keyed by the source offset the peek was taken at, so a repeated peek at the same offset returns the cached token with no re-lex.

```rust
let offset = self.offset();
if let Some((cached_offset, token)) = self.peeked_token
    && cached_offset == offset
{
    return token;
}
let checkpoint = self.checkpoint();
let token = self.next_token();
self.rewind(checkpoint);
self.peeked_token = Some((offset, token));
token
```

## Why

Several paths peek the same offset more than once:

- **`await <expr>`** (very common): the `await using` check peeks the token after `await`, returns false, then expression parsing's `is_unambiguous_await` peeks the same offset again.
- **`static` class members**: `try_parse_modifier` peeks for `static {` and then `parse_any_contextual_modifier` → `next_token_can_follow_modifier` peeks the same offset again.

`peek_token` now has ~25 call sites after the recent migration off `lookahead`, so removing the redundant re-lex helps broadly.

## Correctness

The default-goal `next_token` is a pure function of the source offset (context-sensitive tokens — regex/template/JSX/angle — are produced by separate explicit methods, never by `next_token`). So the cache is self-validating: a peek at a different offset misses and re-lexes; returning to a previously-peeked offset (e.g. after a `rewind`) yields the same token. `peek_token` remains side-effect-neutral (a cache hit records no trivia/errors; a miss rolls them back via `rewind` as before).

## Conformance

No AST change — estree (full AST + spans + token streams) byte-identical to `main`.