### PR TITLE
perf(mangler): POC: reuse slots for disjoint-lifetime var bindings

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -4,10 +4,11 @@ use itertools::Itertools;
 use keep_names::collect_name_symbols;
 use oxc_index::IndexVec;
 use oxc_syntax::class::ClassId;
+use oxc_syntax::scope::ScopeId;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use base54::base54;
-use oxc_allocator::{Allocator, BitSet, HashSet, Vec};
+use oxc_allocator::{Allocator, BitSet, HashMap, HashSet, Vec};
 use oxc_ast::ast::{Declaration, Program, Statement};
 use oxc_data_structures::inline_string::InlineString;
 use oxc_semantic::{AstNodes, Reference, Scoping, Semantic, SemanticBuilder, SymbolId};
@@ -429,6 +430,68 @@ impl<'t> Mangler<'t> {
     }
 }
 
+/// If `symbol_id` is a hoisted function-scoped binding (a `var`/function declared inside a
+/// descendant block) whose declaration and every reference are confined to a single immediate
+/// child scope of `binding_scope`, and it is neither captured by a nested function nor reachable
+/// from a direct-`eval` scope, returns that child scope. Such a binding's live range is limited
+/// to the child's subtree, so it can safely share a mangled name with a binding confined to a
+/// *different* child scope.
+///
+/// Returns `None` for body-proper bindings, `let`/`const` (block-scoped; bound where declared and
+/// illegal to co-name), bindings spanning multiple child branches, captured bindings, or
+/// eval-adjacent bindings.
+fn confined_child_branch(
+    scoping: &Scoping,
+    ast_nodes: &AstNodes,
+    symbol_id: SymbolId,
+    binding_scope: ScopeId,
+) -> Option<ScopeId> {
+    // Only hoisted bindings have a declaration node in a *descendant* scope. `let`/`const` are
+    // bound where declared (declaration scope == binding scope), so this rejects them.
+    let declared_scope = ast_nodes.get_node(scoping.symbol_declaration(symbol_id)).scope_id();
+    if declared_scope == binding_scope {
+        return None;
+    }
+    let mut branch: Option<ScopeId> = None;
+    let use_scopes = iter::once(declared_scope)
+        .chain(scoping.get_resolved_references(symbol_id).map(Reference::scope_id))
+        .chain(
+            scoping
+                .symbol_redeclarations(symbol_id)
+                .iter()
+                .map(|r| ast_nodes.get_node(r.declaration).scope_id()),
+        );
+    for use_scope in use_scopes {
+        // Walk from the use up to `binding_scope`; `child` ends as the immediate child of
+        // `binding_scope` on that path. A function or direct-eval scope in between makes the
+        // binding observable outside its child subtree, so bail.
+        let mut child: Option<ScopeId> = None;
+        let mut reached = false;
+        for ancestor in scoping.scope_ancestors(use_scope) {
+            if ancestor == binding_scope {
+                reached = true;
+                break;
+            }
+            let flags = scoping.scope_flags(ancestor);
+            if flags.is_function() || flags.contains_direct_eval() {
+                return None;
+            }
+            child = Some(ancestor);
+        }
+        // `child == None` means the use is in `binding_scope` itself (body-proper).
+        if !reached {
+            return None;
+        }
+        let child = child?;
+        match branch {
+            None => branch = Some(child),
+            Some(existing) if existing == child => {}
+            Some(_) => return None,
+        }
+    }
+    branch
+}
+
 fn is_special_name(name: &str) -> bool {
     matches!(name, "arguments")
 }
@@ -536,6 +599,12 @@ impl<'a, 's> SlotAssignment<'a, 's> {
         let mut reusable_slots = Vec::new_in(allocator);
         // Pre-computed BitSet for ancestor membership tests - reused across iterations
         let mut ancestor_set = BitSet::new_in(scoping.scopes_len(), allocator);
+        // Scratch for intra-scope `var` slot merging (see `confined_child_branch`).
+        // `group_of[i]` is the slot-group of `tmp_bindings[i]`; bindings in one group share a slot.
+        let root_scope_id = scoping.root_scope_id();
+        let mut group_of: Vec<usize> = Vec::with_capacity_in(scoping.symbols_len(), allocator);
+        let mut branch_col: HashMap<ScopeId, usize> = HashMap::new_in(allocator);
+        let mut col_group: HashMap<usize, usize> = HashMap::new_in(allocator);
 
         // Walk down the scope tree and assign a slot number for each symbol. Doing it as a scope
         // walk (rather than a flat symbol loop) generates better code.
@@ -562,6 +631,43 @@ impl<'a, 's> SlotAssignment<'a, 's> {
             }
             tmp_bindings.sort_unstable();
 
+            // Assign each binding to a slot *group*. Normally identity (one group per binding),
+            // but a function-scoped `var` confined to a single child scope and not captured may
+            // share a group — hence a slot and name — with such a `var` in a *different* child
+            // scope: their live ranges are disjoint, so co-naming them is a legal `var`/`var`
+            // redeclaration. The k-th confined binding of each child scope shares a column/group.
+            // Done in this pass (not post-hoc) so slot count, liveness union, and numbering stay
+            // identical on re-minification, keeping mangling idempotent. `let`/`const` are bound
+            // where declared and never qualify.
+            group_of.clear();
+            let mut num_groups = 0usize;
+            if scope_id == root_scope_id {
+                group_of.extend(0..tmp_bindings.len());
+                num_groups = tmp_bindings.len();
+            } else {
+                branch_col.clear();
+                col_group.clear();
+                for &symbol_id in &tmp_bindings {
+                    let group = if let Some(branch) =
+                        confined_child_branch(scoping, ast_nodes, symbol_id, scope_id)
+                    {
+                        let col = branch_col.entry(branch).or_insert(0);
+                        let c = *col;
+                        *col += 1;
+                        *col_group.entry(c).or_insert_with(|| {
+                            let g = num_groups;
+                            num_groups += 1;
+                            g
+                        })
+                    } else {
+                        let g = num_groups;
+                        num_groups += 1;
+                        g
+                    };
+                    group_of.push(group);
+                }
+            }
+
             let mut slot = slot_liveness.len();
 
             reusable_slots.clear();
@@ -576,11 +682,11 @@ impl<'a, 's> SlotAssignment<'a, 's> {
                         #[expect(clippy::cast_possible_truncation)]
                         |(slot, _)| slot as Slot,
                     )
-                    .take(tmp_bindings.len()),
+                    .take(num_groups),
             );
 
             // The number of new slots that needs to be allocated.
-            let remaining_count = tmp_bindings.len() - reusable_slots.len();
+            let remaining_count = num_groups - reusable_slots.len();
             // There cannot be more slots than there are symbols, and `SymbolId` is a `u32`,
             // so truncation is not possible here
             #[expect(clippy::cast_possible_truncation)]
@@ -601,7 +707,10 @@ impl<'a, 's> SlotAssignment<'a, 's> {
             }
 
             let scope_id_index = scope_id.index();
-            for (&symbol_id, &assigned_slot) in tmp_bindings.iter().zip(&reusable_slots) {
+            for (pos, &symbol_id) in tmp_bindings.iter().enumerate() {
+                // Bindings in the same group resolve to the same slot; the liveness walks below
+                // then union into that slot's bitset.
+                let assigned_slot = reusable_slots[group_of[pos]];
                 slots[symbol_id.index()] = assigned_slot;
 
                 // `var` is hoisted, so include the scope where it is declared

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -4,10 +4,11 @@ use itertools::Itertools;
 use keep_names::collect_name_symbols;
 use oxc_index::IndexVec;
 use oxc_syntax::class::ClassId;
+use oxc_syntax::scope::ScopeId;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use base54::base54;
-use oxc_allocator::{Allocator, ArenaHashSet, ArenaVec, BitSet};
+use oxc_allocator::{Allocator, ArenaHashSet, ArenaVec, BitSet, HashMap};
 use oxc_ast::ast::{Declaration, Program, Statement};
 use oxc_data_structures::inline_string::InlineString;
 use oxc_ecmascript::BoundNames;
@@ -462,6 +463,68 @@ impl<'t> Mangler<'t> {
     }
 }
 
+/// If `symbol_id` is a hoisted function-scoped binding (a `var`/function declared inside a
+/// descendant block) whose declaration and every reference are confined to a single immediate
+/// child scope of `binding_scope`, and it is neither captured by a nested function nor reachable
+/// from a direct-`eval` scope, returns that child scope. Such a binding's live range is limited
+/// to the child's subtree, so it can safely share a mangled name with a binding confined to a
+/// *different* child scope.
+///
+/// Returns `None` for body-proper bindings, `let`/`const` (block-scoped; bound where declared and
+/// illegal to co-name), bindings spanning multiple child branches, captured bindings, or
+/// eval-adjacent bindings.
+fn confined_child_branch(
+    scoping: &Scoping,
+    ast_nodes: &AstNodes,
+    symbol_id: SymbolId,
+    binding_scope: ScopeId,
+) -> Option<ScopeId> {
+    // Only hoisted bindings have a declaration node in a *descendant* scope. `let`/`const` are
+    // bound where declared (declaration scope == binding scope), so this rejects them.
+    let declared_scope = ast_nodes.get_node(scoping.symbol_declaration(symbol_id)).scope_id();
+    if declared_scope == binding_scope {
+        return None;
+    }
+    let mut branch: Option<ScopeId> = None;
+    let use_scopes = iter::once(declared_scope)
+        .chain(scoping.get_resolved_references(symbol_id).map(Reference::scope_id))
+        .chain(
+            scoping
+                .symbol_redeclarations(symbol_id)
+                .iter()
+                .map(|r| ast_nodes.get_node(r.declaration).scope_id()),
+        );
+    for use_scope in use_scopes {
+        // Walk from the use up to `binding_scope`; `child` ends as the immediate child of
+        // `binding_scope` on that path. A function or direct-eval scope in between makes the
+        // binding observable outside its child subtree, so bail.
+        let mut child: Option<ScopeId> = None;
+        let mut reached = false;
+        for ancestor in scoping.scope_ancestors(use_scope) {
+            if ancestor == binding_scope {
+                reached = true;
+                break;
+            }
+            let flags = scoping.scope_flags(ancestor);
+            if flags.is_function() || flags.contains_direct_eval() {
+                return None;
+            }
+            child = Some(ancestor);
+        }
+        // `child == None` means the use is in `binding_scope` itself (body-proper).
+        if !reached {
+            return None;
+        }
+        let child = child?;
+        match branch {
+            None => branch = Some(child),
+            Some(existing) if existing == child => {}
+            Some(_) => return None,
+        }
+    }
+    branch
+}
+
 fn is_special_name(name: &str) -> bool {
     matches!(name, "arguments")
 }
@@ -592,6 +655,12 @@ impl<'a, 's> SlotAssignment<'a, 's> {
         let mut reusable_slots = ArenaVec::new_in(&allocator);
         // Pre-computed BitSet for ancestor membership tests - reused across iterations
         let mut ancestor_set = BitSet::new_in(scoping.scopes_len(), allocator);
+        // Scratch for intra-scope `var` slot merging (see `confined_child_branch`).
+        // `group_of[i]` is the slot-group of `tmp_bindings[i]`; bindings in one group share a slot.
+        let root_scope_id = scoping.root_scope_id();
+        let mut group_of: ArenaVec<usize> = ArenaVec::with_capacity_in(scoping.symbols_len(), &allocator);
+        let mut branch_col: HashMap<ScopeId, usize> = HashMap::new_in(allocator);
+        let mut col_group: HashMap<usize, usize> = HashMap::new_in(allocator);
 
         // Walk down the scope tree and assign a slot number for each symbol. Doing it as a scope
         // walk (rather than a flat symbol loop) generates better code.
@@ -618,6 +687,43 @@ impl<'a, 's> SlotAssignment<'a, 's> {
             }
             tmp_bindings.sort_unstable();
 
+            // Assign each binding to a slot *group*. Normally identity (one group per binding),
+            // but a function-scoped `var` confined to a single child scope and not captured may
+            // share a group — hence a slot and name — with such a `var` in a *different* child
+            // scope: their live ranges are disjoint, so co-naming them is a legal `var`/`var`
+            // redeclaration. The k-th confined binding of each child scope shares a column/group.
+            // Done in this pass (not post-hoc) so slot count, liveness union, and numbering stay
+            // identical on re-minification, keeping mangling idempotent. `let`/`const` are bound
+            // where declared and never qualify.
+            group_of.clear();
+            let mut num_groups = 0usize;
+            if scope_id == root_scope_id {
+                group_of.extend(0..tmp_bindings.len());
+                num_groups = tmp_bindings.len();
+            } else {
+                branch_col.clear();
+                col_group.clear();
+                for &symbol_id in &tmp_bindings {
+                    let group = if let Some(branch) =
+                        confined_child_branch(scoping, ast_nodes, symbol_id, scope_id)
+                    {
+                        let col = branch_col.entry(branch).or_insert(0);
+                        let c = *col;
+                        *col += 1;
+                        *col_group.entry(c).or_insert_with(|| {
+                            let g = num_groups;
+                            num_groups += 1;
+                            g
+                        })
+                    } else {
+                        let g = num_groups;
+                        num_groups += 1;
+                        g
+                    };
+                    group_of.push(group);
+                }
+            }
+
             let mut slot = slot_liveness.len();
 
             reusable_slots.clear();
@@ -632,11 +738,11 @@ impl<'a, 's> SlotAssignment<'a, 's> {
                         #[expect(clippy::cast_possible_truncation)]
                         |(slot, _)| slot as Slot,
                     )
-                    .take(tmp_bindings.len()),
+                    .take(num_groups),
             );
 
             // The number of new slots that needs to be allocated.
-            let remaining_count = tmp_bindings.len() - reusable_slots.len();
+            let remaining_count = num_groups - reusable_slots.len();
             // There cannot be more slots than there are symbols, and `SymbolId` is a `u32`,
             // so truncation is not possible here
             #[expect(clippy::cast_possible_truncation)]
@@ -657,7 +763,10 @@ impl<'a, 's> SlotAssignment<'a, 's> {
             }
 
             let scope_id_index = scope_id.index();
-            for (&symbol_id, &assigned_slot) in tmp_bindings.iter().zip(&reusable_slots) {
+            for (pos, &symbol_id) in tmp_bindings.iter().enumerate() {
+                // Bindings in the same group resolve to the same slot; the liveness walks below
+                // then union into that slot's bitset.
+                let assigned_slot = reusable_slots[group_of[pos]];
                 slots[symbol_id.index()] = assigned_slot;
 
                 // `var` is hoisted, so include the scope where it is declared

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -658,7 +658,8 @@ impl<'a, 's> SlotAssignment<'a, 's> {
         // Scratch for intra-scope `var` slot merging (see `confined_child_branch`).
         // `group_of[i]` is the slot-group of `tmp_bindings[i]`; bindings in one group share a slot.
         let root_scope_id = scoping.root_scope_id();
-        let mut group_of: ArenaVec<usize> = ArenaVec::with_capacity_in(scoping.symbols_len(), &allocator);
+        let mut group_of: ArenaVec<usize> =
+            ArenaVec::with_capacity_in(scoping.symbols_len(), &allocator);
         let mut branch_col: HashMap<ScopeId, usize> = HashMap::new_in(allocator);
         let mut col_group: HashMap<usize, usize> = HashMap::new_in(allocator);
 

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -151,6 +151,7 @@ fn mangler() {
         "function _() { for (var i = 0; i < 9; i++) for (var j = 0; j < 9; j++) g(i, j); }", // nested: must NOT reuse (i live during inner)
         "function _() { for (var i = 0; i < 9; i++) h(() => i); for (var j = 0; j < 9; j++) g(j); }", // captured by closure: must NOT reuse
         "function _() { for (var i = 0; i < 9; i++) {} g(i); for (var j = 0; j < 9; j++) {} }", // used after loop: must NOT reuse
+        "function _() { for (var i = 0; i < 9; i++) { g(i) } for (var j; j === undefined; j++) { g(j) } }", // should NOT reuse (j is declared but used before init and must be undefined)
     ];
     let top_level_cases = [
         "function foo(a) {a}",

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -146,6 +146,11 @@ fn mangler() {
             var a = 1;
           }
         }", // a and b should have different names
+        "function _() { for (var i = 0; i < 9; i++) g(i); for (var j = 0; j < 9; j++) g(j); }", // disjoint `var` loop counters reuse one name
+        "function _() { if (c) for (var i = 0; i < 9; i++) g(i); else for (var j = 0; j < 9; j++) g(j); }", // if/else branches reuse
+        "function _() { for (var i = 0; i < 9; i++) for (var j = 0; j < 9; j++) g(i, j); }", // nested: must NOT reuse (i live during inner)
+        "function _() { for (var i = 0; i < 9; i++) h(() => i); for (var j = 0; j < 9; j++) g(j); }", // captured by closure: must NOT reuse
+        "function _() { for (var i = 0; i < 9; i++) {} g(i); for (var j = 0; j < 9; j++) {} }", // used after loop: must NOT reuse
     ];
     let top_level_cases = [
         "function foo(a) {a}",

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -152,6 +152,11 @@ fn mangler() {
         "function _() { for (var i = 0; i < 9; i++) h(() => i); for (var j = 0; j < 9; j++) g(j); }", // captured by closure: must NOT reuse
         "function _() { for (var i = 0; i < 9; i++) {} g(i); for (var j = 0; j < 9; j++) {} }", // used after loop: must NOT reuse
         "function _() { for (var i = 0; i < 9; i++) { g(i) } for (var j; j === undefined; j++) { g(j) } }", // should NOT reuse (j is declared but used before init and must be undefined)
+        "function _() { { var i = 1; g(i); } { var j; g(j); } }", // sequential child scopes with an uninitialized var: must NOT reuse
+        "function _() { if (c) { var i = 1; g(i); } if (d) { var j; g(j); } }", // overlapping child scopes with an uninitialized var: must NOT reuse
+        "function _() { if (c) { var i = 1; g(i); } if (d) { var j = j; g(j); } }", // self-initialization in a child scope: must NOT reuse
+        "function _() { { var i = 1; g(i); } try { var j; g(j); } catch {} }", // try block with an uninitialized var: must NOT reuse
+        "function _() { { var i = 1; g(i); } switch (c) { case 0: var j = 2; case 1: g(j); } }", // switch can enter after the initializer: must NOT reuse
     ];
     let top_level_cases = [
         "function foo(a) {a}",

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -239,6 +239,36 @@ function _() {
 	}
 }
 
+function _() { for (var i = 0; i < 9; i++) g(i); for (var j = 0; j < 9; j++) g(j); }
+function _() {
+	for (var e = 0; e < 9; e++) g(e);
+	for (var e = 0; e < 9; e++) g(e);
+}
+
+function _() { if (c) for (var i = 0; i < 9; i++) g(i); else for (var j = 0; j < 9; j++) g(j); }
+function _() {
+	if (c) for (var e = 0; e < 9; e++) g(e);
+	else for (var e = 0; e < 9; e++) g(e);
+}
+
+function _() { for (var i = 0; i < 9; i++) for (var j = 0; j < 9; j++) g(i, j); }
+function _() {
+	for (var e = 0; e < 9; e++) for (var t = 0; t < 9; t++) g(e, t);
+}
+
+function _() { for (var i = 0; i < 9; i++) h(() => i); for (var j = 0; j < 9; j++) g(j); }
+function _() {
+	for (var e = 0; e < 9; e++) h(() => e);
+	for (var t = 0; t < 9; t++) g(t);
+}
+
+function _() { for (var i = 0; i < 9; i++) {} g(i); for (var j = 0; j < 9; j++) {} }
+function _() {
+	for (var e = 0; e < 9; e++) {}
+	g(e);
+	for (var t = 0; t < 9; t++) {}
+}
+
 function foo(a) {a}
 function e(e) {
 	e;

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -269,6 +269,16 @@ function _() {
 	for (var t = 0; t < 9; t++) {}
 }
 
+function _() { for (var i = 0; i < 9; i++) { g(i) } for (var j; j === undefined; j++) { g(j) } }
+function _() {
+	for (var e = 0; e < 9; e++) {
+		g(e);
+	}
+	for (var t; t === undefined; t++) {
+		g(t);
+	}
+}
+
 function foo(a) {a}
 function e(e) {
 	e;

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,7 +1,7 @@
            | Oxc        | ESBuild    | Oxc        | ESBuild    |
 Original   | minified   | minified   | gzip       | gzip       | Iterations | File      
 -------------------------------------------------------------------------------------
-72.14 kB   | 23.18 kB   | 23.70 kB   | 8.38 kB    | 8.54 kB    |          2 | react.development.js 
+72.14 kB   | 23.17 kB   | 23.70 kB   | 8.38 kB    | 8.54 kB    |          2 | react.development.js 
 
 173.90 kB  | 59.40 kB   | 59.82 kB   | 19.15 kB   | 19.33 kB   |          2 | moment.js  
 
@@ -9,19 +9,19 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 342.15 kB  | 116.97 kB  | 118.14 kB  | 43.18 kB   | 44.37 kB   |          2 | vue.js     
 
-544.10 kB  | 71.04 kB   | 72.48 kB   | 25.77 kB   | 26.20 kB   |          2 | lodash.js  
+544.10 kB  | 71.04 kB   | 72.48 kB   | 25.79 kB   | 26.20 kB   |          2 | lodash.js  
 
-555.77 kB  | 267.40 kB  | 270.13 kB  | 88.01 kB   | 90.80 kB   |          2 | d3.js      
+555.77 kB  | 267.40 kB  | 270.13 kB  | 88.00 kB   | 90.80 kB   |          2 | d3.js      
 
-1.01 MB    | 439.35 kB  | 458.89 kB  | 122.05 kB  | 126.71 kB  |          2 | bundle.min.js 
+1.01 MB    | 439.32 kB  | 458.89 kB  | 121.93 kB  | 126.71 kB  |          2 | bundle.min.js 
 
-1.25 MB    | 642.65 kB  | 646.76 kB  | 159.41 kB  | 163.73 kB  |          2 | three.js   
+1.25 MB    | 642.48 kB  | 646.76 kB  | 158.23 kB  | 163.73 kB  |          2 | three.js   
 
-2.14 MB    | 711.10 kB  | 724.14 kB  | 160.44 kB  | 181.07 kB  |          2 | victory.js 
+2.14 MB    | 711.01 kB  | 724.14 kB  | 160.30 kB  | 181.07 kB  |          2 | victory.js 
 
-3.20 MB    | 1.00 MB    | 1.01 MB    | 322.61 kB  | 331.56 kB  |          2 | echarts.js 
+3.20 MB    | 1.00 MB    | 1.01 MB    | 322.24 kB  | 331.56 kB  |          2 | echarts.js 
 
-6.69 MB    | 2.22 MB    | 2.31 MB    | 458.45 kB  | 488.28 kB  |          4 | antd.js    
+6.69 MB    | 2.22 MB    | 2.31 MB    | 458.33 kB  | 488.28 kB  |          4 | antd.js    
 
-10.95 MB   | 3.33 MB    | 3.49 MB    | 853.35 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.33 MB    | 3.49 MB    | 851.71 kB  | 915.50 kB  |          4 | typescript.js 
 

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,7 +1,7 @@
            | Oxc        | ESBuild    | Oxc        | ESBuild    |
 Original   | minified   | minified   | gzip       | gzip       | Iterations | File      
 -------------------------------------------------------------------------------------
-72.14 kB   | 23.11 kB   | 23.70 kB   | 8.34 kB    | 8.54 kB    |          2 | react.development.js 
+72.14 kB   | 23.11 kB   | 23.70 kB   | 8.33 kB    | 8.54 kB    |          2 | react.development.js 
 
 173.90 kB  | 59.34 kB   | 59.82 kB   | 19.15 kB   | 19.33 kB   |          2 | moment.js  
 
@@ -9,19 +9,19 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 342.15 kB  | 116.94 kB  | 118.14 kB  | 43.18 kB   | 44.37 kB   |          2 | vue.js     
 
-544.10 kB  | 70.89 kB   | 72.48 kB   | 25.71 kB   | 26.20 kB   |          2 | lodash.js  
+544.10 kB  | 70.88 kB   | 72.48 kB   | 25.73 kB   | 26.20 kB   |          2 | lodash.js  
 
-555.77 kB  | 267.20 kB  | 270.13 kB  | 87.99 kB   | 90.80 kB   |          2 | d3.js      
+555.77 kB  | 267.20 kB  | 270.13 kB  | 87.98 kB   | 90.80 kB   |          2 | d3.js      
 
-1.01 MB    | 439.21 kB  | 458.89 kB  | 122.01 kB  | 126.71 kB  |          2 | bundle.min.js 
+1.01 MB    | 439.18 kB  | 458.89 kB  | 121.89 kB  | 126.71 kB  |          2 | bundle.min.js 
 
-1.25 MB    | 642.43 kB  | 646.76 kB  | 159.35 kB  | 163.73 kB  |          2 | three.js   
+1.25 MB    | 642.26 kB  | 646.76 kB  | 158.17 kB  | 163.73 kB  |          2 | three.js   
 
-2.14 MB    | 710.75 kB  | 724.14 kB  | 160.33 kB  | 181.07 kB  |          2 | victory.js 
+2.14 MB    | 710.66 kB  | 724.14 kB  | 160.22 kB  | 181.07 kB  |          2 | victory.js 
 
-3.20 MB    | 1.00 MB    | 1.01 MB    | 322.54 kB  | 331.56 kB  |          2 | echarts.js 
+3.20 MB    | 1.00 MB    | 1.01 MB    | 322.21 kB  | 331.56 kB  |          2 | echarts.js 
 
-6.69 MB    | 2.12 MB    | 2.31 MB    | 453.79 kB  | 488.28 kB  |          5 | antd.js    
+6.69 MB    | 2.12 MB    | 2.31 MB    | 453.70 kB  | 488.28 kB  |          5 | antd.js    
 
-10.95 MB   | 3.33 MB    | 3.49 MB    | 852.64 kB  | 915.50 kB  |          4 | typescript.js 
+10.95 MB   | 3.33 MB    | 3.49 MB    | 851.13 kB  | 915.50 kB  |          4 | typescript.js 
 


### PR DESCRIPTION
> **Stacked on #23066** (the typed-stage pipeline refactor) — review/merge that first. This PR is the change that refactor was setting up for.

## What

A function-scoped `var` whose declaration and every reference are confined to a single child scope (e.g. a `for` head/body) and that isn't captured by a nested function has a live range limited to that child's subtree. Two such `var`s in **different** child scopes never overlap, so they can share one slot and mangled name — a legal `var`/`var` redeclaration.

That's what sequential `for (var i…)` / `for (var j…)` loops do. Previously only the `let` form reused (block scoping put the counters in sibling scopes the existing cross-scope reuse already handled):

```js
// before                              // after
for (var t = 0; …) …;                  for (var t = 0; …) …;
for (var n = 0; …) …;                  for (var t = 0; …) …;   // reuse `t`
```

## How

The merge happens **inside the slot-assignment pass** (`SlotAssignment::compute`): bindings are grouped before slot acquisition, and confined `var`s in disjoint sibling child-scopes share a slot group (their liveness walks then union into the shared slot). Doing it in-pass — rather than post-hoc — keeps the slot count, liveness union, and numbering identical on re-minification, so **mangling stays idempotent**.

Excluded (verified by the new snapshot cases): nested loops (outer counter live during the inner loop), closure-captured counters (escape the loop), and counters used after the loop.

## Result

Net **~−3.5 kB gzip** across the `minsize` fixtures — three.js −1.18 kB (−0.74%), typescript.js −1.64 kB, echarts/victory/bundle/antd down; raw minified output also shrinks. One tiny lodash +20 B from name-frequency reshuffle.

## Behaviour & validation

- minifier conformance (Test262 + Babel idempotency): no new failures.
- new `mangler.snap` cases pin the merge + the three no-merge guards.
- mangler/minifier unit tests pass; `minsize` `minify_twice` idempotency assert holds; allocation snapshot unchanged (scratch is arena-allocated); clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
