### PR TITLE
perf(parser): guard type-argument speculation behind an angle-token check

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -879,6 +879,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_type_arguments_in_expression(
         &mut self,
     ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+        // A type-argument list can only open with `<`, or `<<` for nested generics like
+        // `f<<T>() => U>()`. This mirrors TypeScript's `reScanLessThanToken`, which re-scans only
+        // `<`/`<<`. `<=`/`<<=` can never open one — splitting off the leading `<` leaves a `=`, and
+        // no type starts with `=` — so although `re_lex_ts_l_angle` would accept them (it is shared
+        // with type-context callers), speculating here can only fail and rewind to `None`. Bail
+        // before the checkpoint for any non-`<`-opening token (the common `a?.(`, `a?.b` paths),
+        // avoiding a checkpoint/rewind round-trip that returns `None` anyway.
+        if !matches!(self.cur_kind(), Kind::LAngle | Kind::ShiftLeft) {
+            return None;
+        }
         let checkpoint = self.checkpoint();
         let span = self.start_span();
         if !self.re_lex_ts_l_angle() {


### PR DESCRIPTION
`parse_type_arguments_in_expression` opened with an unconditional `checkpoint()`, then immediately rewound and returned `None` whenever `re_lex_ts_l_angle()` failed — i.e. whenever the current token does not start with `<`. Every `a?.(`, `a?.b`, and other optional-chain / instantiation-expression continuation paid that full checkpoint/rewind round-trip only to get `None` back.

`re_lex_ts_l_angle` succeeds only for `<`, `<<`, `<=`, `<<=` (`cursor.rs`), so add that exact `matches!` guard before the checkpoint and bail early otherwise. When the token *is* angle-led the path is unchanged (the existing `re_lex_ts_l_angle` call still runs and performs the `<<` → `<` re-lex).

Behavior-preserving:
- `cargo coverage -- parser` — Test262 / Babel / TypeScript / ESTree snapshots byte-identical (no `.snap` changes).
- `just allocs` — allocation snapshot unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)