### PR TITLE
perf(parser): skip arrow lookahead for a parenthesized literal

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -57,7 +57,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn is_parenthesized_arrow_function_expression(&mut self) -> Tristate {
         match self.cur_kind() {
-            Kind::LParen | Kind::LAngle | Kind::Async => {
+            Kind::LParen => {
+                // `(1 + a)` can never be arrow parameters: the leading literal is not the start of
+                // a `BindingElement`, so the worker would bump past it and return `Tristate::False`
+                // (`!second.is_binding_identifier() && second != This`). Skip the lookahead.
+                if self.lexer.peek_token().kind().is_literal() {
+                    Tristate::False
+                } else {
+                    self.lookahead(Self::is_parenthesized_arrow_function_expression_worker)
+                }
+            }
+            Kind::LAngle | Kind::Async => {
                 self.lookahead(Self::is_parenthesized_arrow_function_expression_worker)
             }
             _ => Tristate::False,


### PR DESCRIPTION
`is_parenthesized_arrow_function_expression` ran a full `lookahead` (checkpoint + speculative sub-parse + rewind) for every `(` in an assignment-expression position — extremely common in expression-dense code.

When the token right after `(` is a literal (`(1 + a)`, `("s")`, `(true && x)`), it can never be arrow parameters: a literal is not the start of a `BindingElement`. The worker bumps past it and returns `Tristate::False` via `!second.is_binding_identifier() && second != This`. So peek that one token and return `Tristate::False` directly, skipping the lookahead.

Notes:
- `is_literal()` = `{Null, True, False, Str, RegExp}` ∪ numbers — none are binding identifiers / `this` / `(` / `[` / `{` / `...` / modifier kinds, so all of them deterministically reach the worker's `False`.
- `/` lexes as `Slash` (not `RegExp`) by default in both `peek_token` and the worker's first bump, so regex literals (`(/re/)`, `(/=/g.test(x))`) stay on the unchanged lookahead path. Verified the full parser output is byte-identical to baseline on a regex/literal/arrow edge-case fixture.

Behavior-preserving:
- `cargo coverage -- parser` — Test262 / Babel / TypeScript / ESTree snapshots byte-identical (no `.snap` changes).
- `just allocs` — allocation snapshot unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)