### PR TITLE
perf(parser): peek before the async arrow lookahead

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -57,7 +57,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn is_parenthesized_arrow_function_expression(&mut self) -> Tristate {
         match self.cur_kind() {
-            Kind::LParen | Kind::LAngle | Kind::Async => {
+            Kind::LParen => {
+                // `( <literal>` can never be arrow parameters: a literal is not the start of a
+                // `BindingElement`, so the worker would bump past it and return `Tristate::False`
+                // (`!second.is_binding_identifier() && second != This`). Skip the lookahead.
+                if self.lexer.peek_token().kind().is_literal() {
+                    Tristate::False
+                } else {
+                    self.lookahead(Self::is_parenthesized_arrow_function_expression_worker)
+                }
+            }
+            Kind::LAngle | Kind::Async => {
                 self.lookahead(Self::is_parenthesized_arrow_function_expression_worker)
             }
             _ => Tristate::False,

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -67,15 +67,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     self.lookahead(Self::is_parenthesized_arrow_function_expression_worker)
                 }
             }
-            Kind::LAngle => {
-                self.lookahead(Self::is_parenthesized_arrow_function_expression_worker)
-            }
+            Kind::LAngle => self.lookahead(Self::is_parenthesized_arrow_function_expression_worker),
             Kind::Async => {
                 // `async` only begins a parenthesized/angle arrow when the next token (same line) is
                 // `(` or `<`; the worker's leading `eat(Async)` block returns `Tristate::False`
                 // otherwise. Peek that one token before paying for the speculative lookahead.
                 let peeked = self.lexer.peek_token();
-                if peeked.is_on_new_line() || !matches!(peeked.kind(), Kind::LParen | Kind::LAngle) {
+                if peeked.is_on_new_line() || !matches!(peeked.kind(), Kind::LParen | Kind::LAngle)
+                {
                     Tristate::False
                 } else {
                     self.lookahead(Self::is_parenthesized_arrow_function_expression_worker)

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -67,8 +67,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     self.lookahead(Self::is_parenthesized_arrow_function_expression_worker)
                 }
             }
-            Kind::LAngle | Kind::Async => {
+            Kind::LAngle => {
                 self.lookahead(Self::is_parenthesized_arrow_function_expression_worker)
+            }
+            Kind::Async => {
+                // `async` only begins a parenthesized/angle arrow when the next token (same line) is
+                // `(` or `<`; the worker's leading `eat(Async)` block returns `Tristate::False`
+                // otherwise. Peek that one token before paying for the speculative lookahead.
+                let peeked = self.lexer.peek_token();
+                if peeked.is_on_new_line() || !matches!(peeked.kind(), Kind::LParen | Kind::LAngle) {
+                    Tristate::False
+                } else {
+                    self.lookahead(Self::is_parenthesized_arrow_function_expression_worker)
+                }
             }
             _ => Tristate::False,
         }


### PR DESCRIPTION
Stacked on #23070 (extends the same `match` in `is_parenthesized_arrow_function_expression`).

`is_parenthesized_arrow_function_expression` ran a full `lookahead` for a leading `async`. But `async` only begins a parenthesized/angle arrow when the next token (same line) is `(` or `<` — the worker's leading `eat(Async)` block returns `Tristate::False` for everything else (`async x => …`, `async function`, `async.foo`, `async + 1`, `async` then newline).

Peek that one token first and return `Tristate::False` directly, falling through to the unchanged lookahead only for `async (` / `async <`.

Behavior-preserving:
- `cargo coverage -- parser` — snapshots byte-identical (no `.snap` changes).
- `just allocs` — unchanged.
- Full parser output byte-identical to baseline on an async-arrow edge fixture (paren/angle/unparenthesized/`async function`/member/binary/newline) in `.ts` and `.js`.

> Base will retarget to `main` once #23070 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)