### PR TITLE
perf(parser): peek before the unparenthesized async arrow lookahead

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -200,6 +200,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     fn is_un_parenthesized_async_arrow_function_worker(&mut self) -> bool {
+        // An unparenthesized async arrow is `async <BindingIdentifier> =>`, so the token right after
+        // `async` (the caller guarantees `cur` is `async`) must be a same-line binding identifier.
+        // Peek it before the lookahead, which is still needed to look past the identifier for `=>`.
+        let peeked = self.lexer.peek_token();
+        if peeked.is_on_new_line() || !peeked.kind().is_binding_identifier() {
+            return false;
+        }
         // Use lookahead to avoid checkpoint/rewind
         self.lookahead(|parser| {
             parser.bump(Kind::Async);


### PR DESCRIPTION
`is_un_parenthesized_async_arrow_function_worker` is called with `cur` at `async`, and an unparenthesized async arrow is `async <BindingIdentifier> =>`. So the token right after `async` must be a same-line binding identifier; otherwise (`async function`, `async (`, `async.foo`, `async + 1`, `async` then newline) it cannot be one.

Peek that one token and bail before the `lookahead` — the lookahead is still used past the identifier to confirm the trailing `=>`.

Behavior-preserving:
- `cargo coverage -- parser` — snapshots byte-identical (no `.snap` changes).
- `just allocs` — unchanged.
- Full parser output byte-identical to baseline on an async-arrow edge fixture in `.ts` and `.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)