### PR TITLE
perf(parser): peek once for the static modifier disambiguation

### DIFF
--- a/crates/oxc_parser/src/modifiers.rs
+++ b/crates/oxc_parser/src/modifiers.rs
@@ -568,16 +568,23 @@ impl<C: Config> ParserImpl<'_, C> {
                 return None;
             }
             self.bump_any();
-        } else if
-        // we're at the start of a static block
-        (stop_on_start_of_class_static_block
-            && kind == Kind::Static
-            && self.lexer.peek_token().kind() == Kind::LCurly)
-            // we may be at the start of a static block
-            || (kind == Kind::Static && seen_modifier_kinds.contains(ModifierKind::Static))
+        } else if kind == Kind::Static {
+            // ClassStaticBlock : `static { ClassStaticBlockBody }`   e.g. `static { x = 1; }`
+            // member named `static`                                  e.g. `static() {}`, `static = 1`, `static;`
+            // repeated `static`                                      e.g. `static static x`
+            //
+            // Peek once and reuse it — `peek_token` is not cached, so checking `== LCurly` separately
+            // from the peek inside `next_token_can_follow_modifier` re-lexed this token twice.
+            let next_kind = self.lexer.peek_token().kind();
+            if (stop_on_start_of_class_static_block && next_kind == Kind::LCurly)
+                || seen_modifier_kinds.contains(ModifierKind::Static)
+                || !Self::can_follow_modifier(next_kind)
+            {
+                return None;
+            }
+            self.bump_any();
+        } else if !self.parse_any_contextual_modifier() {
             // next token is not a modifier
-            || (!self.parse_any_contextual_modifier())
-        {
             return None;
         }
         Some(self.modifier(kind, span_start))


### PR DESCRIPTION
In `try_parse_modifier`, a `static` token was peeked twice at the same offset: once for `peek_token().kind() == LCurly` (the `static {}` block check) and again inside `next_token_can_follow_modifier` (reached via `parse_any_contextual_modifier`). `peek_token` is not cached, so this re-lexed the token after `static` twice for every `static` class member.

Pull `static` into its own branch, peek the next token once, and reuse it for all three checks (static block / repeated `static` / `static` used as a property name). The non-`static` modifier path still goes through `parse_any_contextual_modifier` unchanged.

Behavior-preserving:
- `cargo coverage -- parser` — snapshots byte-identical (no `.snap` changes).
- `just allocs` — unchanged.
- Full parser output byte-identical to baseline on a `static` class fixture (static block, fields, methods, `static` as name, repeated `static`, TS modifier combos) in `.ts` and `.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)