### PR TITLE
perf(parser): remove duploicate check inside `parse_literal_boolean

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -344,13 +344,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
     }
 
-    #[inline(always)]
     pub fn parse_literal_boolean(&mut self) -> BooleanLiteral {
         let span = self.start_span();
         let value = match self.cur_kind() {
             Kind::True => true,
             Kind::False => false,
-            _ => return self.unexpected(),
+            _ => unsafe { std::hint::unreachable_unchecked() },
         };
         self.bump_any();
         self.ast.boolean_literal(self.end_span(span), value)

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -344,7 +344,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
     }
 
-    pub(crate) fn parse_literal_boolean(&mut self) -> BooleanLiteral {
+    #[inline(always)]
+    pub fn parse_literal_boolean(&mut self) -> BooleanLiteral {
         let span = self.start_span();
         let value = match self.cur_kind() {
             Kind::True => true,


### PR DESCRIPTION
my theory is that the `match` inside `parse_literal_boolean` is unnecessary, as we already know that `self.cur_kind()` must be `Kind::True` or `Kind::false`, so by adding `#[inline(always)]` , it will get collapsed and optimized away