### PR TITLE
perf(diagnostics): adopt u32 SourceSpan from oxc-miette

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,8 +1677,7 @@ dependencies = [
 [[package]]
 name = "oxc-miette"
 version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
+source = "git+https://github.com/oxc-project/oxc-miette.git?branch=perf%2Fu32-source-span#9e28bc040c1dce1f39f82d56847084660a8197fd"
 dependencies = [
  "cfg-if",
  "owo-colors",
@@ -1692,8 +1691,7 @@ dependencies = [
 [[package]]
 name = "oxc-miette-derive"
 version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
+source = "git+https://github.com/oxc-project/oxc-miette.git?branch=perf%2Fu32-source-span#9e28bc040c1dce1f39f82d56847084660a8197fd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,3 +310,7 @@ overflow-checks = true # Catch arithmetic overflow errors
 [profile.dev-no-debug-assertions]
 inherits = "dev"
 debug-assertions = false
+
+# Pending oxc-miette release with u32 SourceSpan: https://github.com/oxc-project/oxc-miette/pull/180
+[patch.crates-io]
+oxc-miette = { git = "https://github.com/oxc-project/oxc-miette.git", branch = "perf/u32-source-span" }

--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -100,8 +100,7 @@ pub fn message_to_lsp_diagnostic(
             .map(|span| {
                 let offset = span.offset();
                 let start_position = offset_to_position(rope, offset, source_text);
-                let end_position =
-                    offset_to_position(rope, offset + span.len(), source_text);
+                let end_position = offset_to_position(rope, offset + span.len(), source_text);
 
                 ls_types::DiagnosticRelatedInformation {
                     location: ls_types::Location {

--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -76,9 +76,6 @@ fn miette_severity_to_lsp_severity(value: Severity) -> DiagnosticSeverity {
         Severity::Advice => DiagnosticSeverity::HINT,
     }
 }
-// clippy: the source field is checked and assumed to be less than 4GB, and
-// we assume that the fix offset will not exceed 2GB in either direction
-#[expect(clippy::cast_possible_truncation)]
 pub fn message_to_lsp_diagnostic(
     message: Message,
     uri: &Uri,
@@ -101,10 +98,10 @@ pub fn message_to_lsp_diagnostic(
         spans
             .iter()
             .map(|span| {
-                let offset = span.offset() as u32;
+                let offset = span.offset();
                 let start_position = offset_to_position(rope, offset, source_text);
                 let end_position =
-                    offset_to_position(rope, offset + span.len() as u32, source_text);
+                    offset_to_position(rope, offset + span.len(), source_text);
 
                 ls_types::DiagnosticRelatedInformation {
                     location: ls_types::Location {

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -273,13 +273,12 @@ pub struct Message {
 }
 
 impl Message {
-    #[expect(clippy::cast_possible_truncation)] // for `as u32`
     pub fn new(error: OxcDiagnostic, fixes: PossibleFixes) -> Self {
         let span = error
             .labels
             .as_ref()
             .and_then(|labels| labels.iter().find(|span| span.primary()).or_else(|| labels.first()))
-            .map(|span| Span::new(span.offset() as u32, (span.offset() + span.len()) as u32))
+            .map(|span| Span::new(span.offset(), span.offset() + span.len()))
             .unwrap_or_default();
 
         Self { error, span, fixes, fixed: false, section_offset: 0, rule: None }
@@ -305,7 +304,7 @@ impl Message {
 
         if let Some(labels) = &mut self.error.labels {
             for label in labels {
-                label.set_span_offset(label.offset().saturating_add(offset as usize));
+                label.set_span_offset(label.offset().saturating_add(offset));
             }
         }
 

--- a/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
@@ -67,10 +67,7 @@ impl Rule for NoSparseArrays {
                     _ => None,
                 })
                 .map(|elision| {
-                    LabeledSpan::at(
-                        elision.span.start..elision.span.start,
-                        "unexpected comma",
-                    )
+                    LabeledSpan::at(elision.span.start..elision.span.start, "unexpected comma")
                 })
                 .collect::<Vec<_>>();
 

--- a/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sparse_arrays.rs
@@ -68,7 +68,7 @@ impl Rule for NoSparseArrays {
                 })
                 .map(|elision| {
                     LabeledSpan::at(
-                        (elision.span.start as usize)..(elision.span.start as usize),
+                        elision.span.start..elision.span.start,
                         "unexpected comma",
                     )
                 })
@@ -86,7 +86,7 @@ impl Rule for NoSparseArrays {
                         LabeledSpan::at(array_expr.span, "the array here")
                     } else {
                         LabeledSpan::at(
-                            (array_expr.span.start as usize)..(array_expr.span.start as usize),
+                            array_expr.span.start..array_expr.span.start,
                             "the array starting here",
                         )
                     };

--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -104,7 +104,7 @@ impl Rule for CheckPropertyNames {
                     .iter()
                     .map(|span| {
                         LabeledSpan::at(
-                            (span.start as usize)..(span.end as usize),
+                            span.start..span.end,
                             "Duplicated property",
                         )
                     })

--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -102,12 +102,7 @@ impl Rule for CheckPropertyNames {
             for (type_name, spans) in seen.iter().filter(|(_, spans)| 1 < spans.len()) {
                 let labels = spans
                     .iter()
-                    .map(|span| {
-                        LabeledSpan::at(
-                            span.start..span.end,
-                            "Duplicated property",
-                        )
-                    })
+                    .map(|span| LabeledSpan::at(span.start..span.end, "Duplicated property"))
                     .collect::<Vec<_>>();
                 ctx.diagnostic(
                     OxcDiagnostic::warn("Duplicate @property found.")

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1095,7 +1095,7 @@ impl Runtime {
                             if let Some(labels) = &mut diagnostic.labels {
                                 for label in labels.iter_mut() {
                                     label.set_span_offset(
-                                        label.offset() + section_source.start as usize,
+                                        label.offset() + section_source.start,
                                     );
                                 }
                             }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1094,9 +1094,7 @@ impl Runtime {
                         .map(|mut diagnostic| {
                             if let Some(labels) = &mut diagnostic.labels {
                                 for label in labels.iter_mut() {
-                                    label.set_span_offset(
-                                        label.offset() + section_source.start,
-                                    );
+                                    label.set_span_offset(label.offset() + section_source.start);
                                 }
                             }
                             diagnostic

--- a/crates/oxc_napi/src/error.rs
+++ b/crates/oxc_napi/src/error.rs
@@ -72,12 +72,11 @@ pub struct ErrorLabel {
 }
 
 impl From<&LabeledSpan> for ErrorLabel {
-    #[expect(clippy::cast_possible_truncation)]
     fn from(label: &LabeledSpan) -> Self {
         Self {
             message: label.label().map(ToString::to_string),
-            start: label.offset() as u32,
-            end: (label.offset() + label.len()) as u32,
+            start: label.offset(),
+            end: label.offset() + label.len(),
         }
     }
 }

--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -563,7 +563,7 @@ impl From<Range<u32>> for Span {
 
 impl From<Span> for SourceSpan {
     fn from(val: Span) -> Self {
-        Self::new(SourceOffset::from(val.start as usize), val.size() as usize)
+        Self::new(SourceOffset::from(val.start), val.size())
     }
 }
 

--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -146,8 +146,7 @@ impl<'a> FromIn<'a, &LabeledSpan> for ErrorLabel<'a> {
     fn from_in(label: &LabeledSpan, allocator: &'a Allocator) -> Self {
         Self {
             message: label.label().map(|message| Str::from_in(message, allocator)),
-            #[expect(clippy::cast_possible_truncation)]
-            span: Span::sized(label.offset() as u32, label.len() as u32),
+            span: Span::sized(label.offset(), label.len()),
         }
     }
 }

--- a/tasks/coverage/src/tools.rs
+++ b/tasks/coverage/src/tools.rs
@@ -150,7 +150,7 @@ fn is_error_suppressed_by_ts_ignore(
     let Some(first_label) = labels.first() else {
         return false;
     };
-    let error_offset = first_label.offset();
+    let error_offset = first_label.offset() as usize;
 
     // Check if any ts-ignore span covers the line before this error
     for ts_ignore_span in ts_ignore_spans {


### PR DESCRIPTION
## What

Adopt the `u32`-based `SourceSpan` API from oxc-miette (oxc-project/oxc-miette#180), which shrinks `LabeledSpan` from **48 → 40 bytes**.

Because the miette API is now `u32`-native (matching oxc's `Span`), this removes the `usize`↔`u32` round-trip casts at every label construction and read site:
- `oxc_span`: `From<Span> for SourceSpan` drops two casts
- `no_sparse_arrays`, `check_property_names`: ranges built directly from `u32`
- `oxc_napi/error.rs`, `napi/parser/raw_transfer_types.rs`, `oxlint` LSP: drop `as u32` casts and two `#[expect(clippy::cast_possible_truncation)]`
- `fixer`, `runtime`, `tasks/coverage`: offset arithmetic now in `u32`

## Blocked on

⚠️ Draft until oxc-project/oxc-miette#180 is merged and released. The `[patch.crates-io]` git pin in `Cargo.toml` must be replaced with a normal `oxc-miette` version bump before merge.

## Verification

- `cargo build --workspace` clean
- `cargo clippy --workspace --all-targets` clean (no new warnings)
- `oxc_linter` (1155), `oxc_diagnostics`, `oxc_napi`, `oxc_span` tests pass