### PR TITLE
fix(ci): exclude generated oxlint config from plugin label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,8 +39,9 @@ A-linter:
 
 A-linter-plugins:
   - changed-files:
-      - any-glob-to-any-file:
-          ["apps/oxlint/src-js/**", "apps/oxlint/test/**", "apps/oxlint/conformance/**"]
+      - all-globs-to-any-file:
+          ["apps/oxlint/src-js/**", "!apps/oxlint/src-js/package/config.generated.ts"]
+      - any-glob-to-any-file: ["apps/oxlint/test/**", "apps/oxlint/conformance/**"]
 
 A-minifier:
   - changed-files:


### PR DESCRIPTION
This updates the `A-linter-plugins` label rule so changes to the generated oxlint package config no longer trigger the plugin-area label.

The old matcher used `apps/oxlint/src-js/**`, which also caught `apps/oxlint/src-js/package/config.generated.ts`. This splits that coverage into root `src-js` files, non-package subdirectories, and package files except `config.generated.ts`, keeping the rest of the existing plugin/test/conformance coverage intact.

