### PR TITLE
feat(linter/eslint): support no-unused-expressions `ignoreDirectives` option

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -3040,6 +3040,10 @@ export interface NoUnusedExpressionsConfig {
    * When set to `true`, enforces the rule for unused JSX expressions also.
    */
   enforceForJSX?: boolean;
+  /**
+   * When set to `true`, allows directive prologues.
+   */
+  ignoreDirectives?: boolean;
 }
 export interface NoUnusedVarsOptions {
   /**

--- a/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
@@ -36,6 +36,8 @@ pub struct NoUnusedExpressionsConfig {
     /// When set to `true`, enforces the rule for unused JSX expressions also.
     #[serde(rename = "enforceForJSX")]
     enforce_for_jsx: bool,
+    /// When set to `true`, allows directive prologues.
+    ignore_directives: bool,
 }
 
 declare_oxc_lint!(
@@ -233,7 +235,20 @@ fn test() {
         ("<></>", None),   // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
         ("var partial = <div />", None), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
         ("var partial = <div />", Some(serde_json::json!([{ "enforceForJSX": true }]))), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
-        ("var partial = <></>", Some(serde_json::json!([{ "enforceForJSX": true }]))), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } }
+        ("var partial = <></>", Some(serde_json::json!([{ "enforceForJSX": true }]))), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        (r#""use strict";"#, Some(serde_json::json!([{ "ignoreDirectives": true }]))),
+        (
+            r#""directive one"; "directive two"; f();"#,
+            Some(serde_json::json!([{ "ignoreDirectives": true }])),
+        ),
+        (
+            r#"function foo() {"use strict"; return true; }"#,
+            Some(serde_json::json!([{ "ignoreDirectives": true }])),
+        ),
+        (
+            r#"function foo() {"directive one"; "directive two"; f(); }"#,
+            Some(serde_json::json!([{ "ignoreDirectives": true }])),
+        ),
         // https://github.com/typescript-eslint/typescript-eslint/blob/32a7a7061abba5bbf1403230526514768d3e2760/packages/eslint-plugin/tests/rules/no-unused-expressions.test.ts#L29
         (
             "
@@ -397,7 +412,8 @@ fn test() {
             'bar'
              } }",
             None,
-        ), // { "ecmaVersion": 2022 }
+        ), // { "ecmaVersion": 2022 },
+        ("foo;", Some(serde_json::json!([{ "ignoreDirectives": true }]))),
         // https://github.com/typescript-eslint/typescript-eslint/blob/32a7a7061abba5bbf1403230526514768d3e2760/packages/eslint-plugin/tests/rules/no-unused-expressions.test.ts#L91
         (
             "
@@ -504,6 +520,13 @@ fn test() {
                   ",
             None,
         ),
+        (
+            "function foo() {
+              const foo = true;
+              ('use strict');
+            }",
+            None,
+        ),
         ("foo && foo?.bar;", Some(serde_json::json!([{ "allowShortCircuit": true }]))),
         ("foo ? foo?.bar : bar.baz;", Some(serde_json::json!([{ "allowTernary": true }]))),
         (
@@ -528,13 +551,6 @@ fn test() {
                   ",
             None,
         ),
-        // (
-        // "
-        // declare const foo: number | undefined;
-        // <any>foo;
-        // ",
-        // None,
-        // ),
         (
             "
             declare const foo: number | undefined;

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_expressions.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_expressions.snap
@@ -259,6 +259,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider using this expression or removing it
 
   ⚠ eslint(no-unused-expressions): Expected expression to be used
+   ╭─[no_unused_expressions.tsx:1:1]
+ 1 │ foo;
+   · ────
+   ╰────
+  help: Consider using this expression or removing it
+
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
    ╭─[no_unused_expressions.tsx:2:20]
  1 │ 
  2 │             if (0) 0;
@@ -392,6 +399,15 @@ source: crates/oxc_linter/src/tester.rs
  5 │               'use strict';
    ·               ─────────────
  6 │             }
+   ╰────
+  help: Consider using this expression or removing it
+
+  ⚠ eslint(no-unused-expressions): Expected expression to be used
+   ╭─[no_unused_expressions.tsx:3:15]
+ 2 │               const foo = true;
+ 3 │               ('use strict');
+   ·               ───────────────
+ 4 │             }
    ╰────
   help: Consider using this expression or removing it
 

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -11540,6 +11540,12 @@
           "default": false,
           "type": "boolean",
           "markdownDescription": "When set to `true`, enforces the rule for unused JSX expressions also."
+        },
+        "ignoreDirectives": {
+          "description": "When set to `true`, allows directive prologues.",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "When set to `true`, allows directive prologues."
         }
       },
       "additionalProperties": false

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -11544,6 +11544,12 @@ expression: json
           "default": false,
           "type": "boolean",
           "markdownDescription": "When set to `true`, enforces the rule for unused JSX expressions also."
+        },
+        "ignoreDirectives": {
+          "description": "When set to `true`, allows directive prologues.",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "When set to `true`, allows directive prologues."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
- Support the `ignoreDirectives` option in `eslint/no-unused-expressions` config parsing.
- Port missing upstream ESLint and TypeScript ESLint cases for directive handling and TypeScript assertion coverage.

Fixes #23051
