### PR TITLE
feat(linter/unicorn): support no-null `checkArguments` option

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -4783,6 +4783,10 @@ export interface NoArraySort {
 }
 export interface NoNull {
   /**
+   * When set to `true`, disallow the use of `null` as a direct function call or constructor argument.
+   */
+  checkArguments?: boolean;
+  /**
    * When set to `true`, the rule will also check strict equality/inequality comparisons (`===` and `!==`) against `null`.
    */
   checkStrictEquality?: boolean;

--- a/crates/oxc_linter/src/rules/unicorn/no_null.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_null.rs
@@ -25,11 +25,19 @@ fn no_null_diagnostic(null: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use `null` literals").with_label(null)
 }
 
-#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoNull {
     /// When set to `true`, the rule will also check strict equality/inequality comparisons (`===` and `!==`) against `null`.
     check_strict_equality: bool,
+    /// When set to `true`, disallow the use of `null` as a direct function call or constructor argument.
+    check_arguments: bool,
+}
+
+impl Default for NoNull {
+    fn default() -> Self {
+        Self { check_strict_equality: false, check_arguments: true }
+    }
 }
 
 declare_oxc_lint!(
@@ -73,6 +81,13 @@ fn match_null_arg(call_expr: &CallExpression, index: usize, span: Span) -> bool 
         Some(Expression::NullLiteral(null_lit)) => span.contains_inclusive(null_lit.span),
         _ => false,
     }
+}
+
+fn match_direct_null_arg(arguments: &[Argument], span: Span) -> bool {
+    arguments
+        .iter()
+        .filter_map(Argument::as_expression)
+        .any(|expr| matches!(expr.get_inner_expression(), Expression::NullLiteral(null_lit) if span.contains_inclusive(null_lit.span)))
 }
 
 impl NoNull {
@@ -198,6 +213,18 @@ impl Rule for NoNull {
             {
                 // no violation
             }
+            (AstKind::CallExpression(call_expr), _)
+                if !self.check_arguments
+                    && match_direct_null_arg(&call_expr.arguments, null_literal.span) =>
+            {
+                // no violation
+            }
+            (AstKind::NewExpression(new_expr), _)
+                if !self.check_arguments
+                    && match_direct_null_arg(&new_expr.arguments, null_literal.span) =>
+            {
+                // no violation
+            }
             (AstKind::BinaryExpression(binary_expr), _) => {
                 self.diagnose_binary_expression(ctx, null_literal, binary_expr);
             }
@@ -264,6 +291,17 @@ fn test() {
             "checkStrictEquality": option,
         }])
     }
+    fn check_arguments(option: bool) -> serde_json::Value {
+        serde_json::json!([{
+            "checkArguments": option,
+        }])
+    }
+    fn check_arguments_and_strict_equality() -> serde_json::Value {
+        serde_json::json!([{
+            "checkArguments": false,
+            "checkStrictEquality": true,
+        }])
+    }
 
     let pass = vec![
         ("let foo", None),
@@ -290,6 +328,14 @@ fn test() {
         ("if (foo !== null) {}", Some(check_strict_equality(false))),
         ("if (null !== foo) {}", Some(check_strict_equality(false))),
         ("if (foo === null || foo === undefined) {}", None),
+        ("foo(null)", Some(check_arguments(false))),
+        ("foo(bar, null)", Some(check_arguments(false))),
+        ("drawingManager.setMap(null)", Some(check_arguments(false))),
+        ("markers[index].setMap(null)", Some(check_arguments(false))),
+        ("object?.method?.(null)", Some(check_arguments(false))),
+        ("foo?.(null)", Some(check_arguments(false))),
+        ("new HttpResponse(null)", Some(check_arguments(false))),
+        ("new HttpResponse(body, null)", Some(check_arguments(false))),
     ];
 
     let fail = vec![
@@ -312,6 +358,18 @@ fn test() {
         ("var foo = null;", None),
         ("var foo = 1, bar = null, baz = 2;", None),
         ("const foo = null;", None),
+        ("const foo = null;", Some(check_arguments(false))),
+        (
+            "function foo() {
+            return null;
+            }",
+            Some(check_arguments(false)),
+        ),
+        ("if (foo === null) {}", Some(check_arguments_and_strict_equality())),
+        ("foo([null])", Some(check_arguments(false))),
+        ("foo(bar ?? null)", Some(check_arguments(false))),
+        ("foo(...[null])", Some(check_arguments(false))),
+        ("new HttpResponse([null])", Some(check_arguments(false))),
         // `checkStrictEquality`
         ("if (foo === null) {}", Some(check_strict_equality(true))),
         ("if (null === foo) {}", Some(check_strict_equality(true))),

--- a/crates/oxc_linter/src/snapshots/unicorn_no_null.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_null.snap
@@ -91,6 +91,57 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ unicorn(no-null): Do not use `null` literals
    ╭─[no_null.tsx:1:13]
+ 1 │ const foo = null;
+   ·             ────
+   ╰────
+  help: Replace `null` with `undefined`.
+
+  ⚠ unicorn(no-null): Do not use `null` literals
+   ╭─[no_null.tsx:2:20]
+ 1 │ function foo() {
+ 2 │             return null;
+   ·                    ────
+ 3 │             }
+   ╰────
+  help: Delete this code.
+
+  ⚠ unicorn(no-null): Do not use `null` literals
+   ╭─[no_null.tsx:1:13]
+ 1 │ if (foo === null) {}
+   ·             ────
+   ╰────
+  help: Replace `null` with `undefined`.
+
+  ⚠ unicorn(no-null): Do not use `null` literals
+   ╭─[no_null.tsx:1:6]
+ 1 │ foo([null])
+   ·      ────
+   ╰────
+  help: Replace `null` with `undefined`.
+
+  ⚠ unicorn(no-null): Do not use `null` literals
+   ╭─[no_null.tsx:1:12]
+ 1 │ foo(bar ?? null)
+   ·            ────
+   ╰────
+  help: Replace `null` with `undefined`.
+
+  ⚠ unicorn(no-null): Do not use `null` literals
+   ╭─[no_null.tsx:1:9]
+ 1 │ foo(...[null])
+   ·         ────
+   ╰────
+  help: Replace `null` with `undefined`.
+
+  ⚠ unicorn(no-null): Do not use `null` literals
+   ╭─[no_null.tsx:1:19]
+ 1 │ new HttpResponse([null])
+   ·                   ────
+   ╰────
+  help: Replace `null` with `undefined`.
+
+  ⚠ unicorn(no-null): Do not use `null` literals
+   ╭─[no_null.tsx:1:13]
  1 │ if (foo === null) {}
    ·             ────
    ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10913,6 +10913,12 @@
     "NoNull": {
       "type": "object",
       "properties": {
+        "checkArguments": {
+          "description": "When set to `true`, disallow the use of `null` as a direct function call or constructor argument.",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "When set to `true`, disallow the use of `null` as a direct function call or constructor argument."
+        },
         "checkStrictEquality": {
           "description": "When set to `true`, the rule will also check strict equality/inequality comparisons (`===` and `!==`) against `null`.",
           "default": false,

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -10917,6 +10917,12 @@ expression: json
     "NoNull": {
       "type": "object",
       "properties": {
+        "checkArguments": {
+          "description": "When set to `true`, disallow the use of `null` as a direct function call or constructor argument.",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "When set to `true`, disallow the use of `null` as a direct function call or constructor argument."
+        },
         "checkStrictEquality": {
           "description": "When set to `true`, the rule will also check strict equality/inequality comparisons (`===` and `!==`) against `null`.",
           "default": false,


### PR DESCRIPTION
- Support `checkArguments` in `unicorn/no-null`, defaulting to upstream behavior of checking direct call and constructor arguments.
- Allow direct `null` call/constructor arguments when `checkArguments: false`, while still reporting nested `null` values.
- Port the missing upstream Unicorn cases and update generated config artifacts.

Fixes #23048