### PR TITLE
refactor(linter): share `"alway" | "never"` option across rules

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -60,7 +60,7 @@ export type LintPluginOptionsSchema =
 export type LintPlugins = LintPluginOptionsSchema[];
 export type Mode2 = "as-needed" | "always" | "never";
 export type RuleNoConfig = AllowWarnDeny | [AllowWarnDeny];
-export type CapitalizeOption = "always" | "never";
+export type AlwaysNever = "always" | "never";
 export type OptionsJsonDoc =
   | CommentConfigJson
   | {
@@ -85,11 +85,8 @@ export type FuncNamesConfigType = "always" | "as-needed" | "never";
 export type Style = "expression" | "declaration";
 export type NamedExports = "ignore" | "expression" | "declaration";
 export type PairOrder = "anyOrder" | "getBeforeSet" | "setBeforeGet";
-export type PropertyKind = "always" | "never";
 export type Target = "single" | "any";
-export type Mode3 = "always" | "never";
 export type JestFnType = "hook" | "describe" | "test" | "expect" | "jest" | "unknown";
-export type LogicalAssignmentOperatorsMode = "always" | "never";
 export type CountThis = "always" | "never" | "except-void";
 export type CheckLoopsConfig = boolean | CheckLoops;
 export type CheckLoops = "all" | "allExceptWhileTrue" | "none";
@@ -671,8 +668,8 @@ export interface DummyRuleMap {
   "capitalized-comments"?:
     | AllowWarnDeny
     | [AllowWarnDeny]
-    | [AllowWarnDeny, CapitalizeOption]
-    | [AllowWarnDeny, CapitalizeOption, OptionsJsonDoc];
+    | [AllowWarnDeny, AlwaysNever]
+    | [AllowWarnDeny, AlwaysNever, OptionsJsonDoc];
   "class-methods-use-this"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ClassMethodsUseThisConfig];
   complexity?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | ComplexityConfig];
   "constructor-super"?: RuleNoConfig;
@@ -737,8 +734,8 @@ export interface DummyRuleMap {
   "init-declarations"?:
     | AllowWarnDeny
     | [AllowWarnDeny]
-    | [AllowWarnDeny, Mode3]
-    | [AllowWarnDeny, Mode3, InitDeclarationsConfig];
+    | [AllowWarnDeny, AlwaysNever]
+    | [AllowWarnDeny, AlwaysNever, InitDeclarationsConfig];
   "jest/consistent-test-it"?: DummyRule;
   "jest/expect-expect"?: DummyRule;
   "jest/max-expects"?: DummyRule;
@@ -872,8 +869,8 @@ export interface DummyRuleMap {
   "logical-assignment-operators"?:
     | AllowWarnDeny
     | [AllowWarnDeny]
-    | [AllowWarnDeny, LogicalAssignmentOperatorsMode]
-    | [AllowWarnDeny, LogicalAssignmentOperatorsMode, LogicalAssignmentOperatorsConfig];
+    | [AllowWarnDeny, AlwaysNever]
+    | [AllowWarnDeny, AlwaysNever, LogicalAssignmentOperatorsConfig];
   "max-classes-per-file"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxClassesPerFileConfig];
   "max-depth"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxDepth];
   "max-lines"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxLinesConfig];
@@ -1831,7 +1828,7 @@ export interface IdLengthConfig {
   /**
    * Whether to check property names for length.
    */
-  properties?: PropertyKind;
+  properties?: AlwaysNever;
 }
 export interface IdMatchOptions {
   /**

--- a/crates/oxc_linter/src/rules/eslint/capitalized_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/capitalized_comments.rs
@@ -7,7 +7,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{context::LintContext, rule::Rule};
+use crate::{context::LintContext, rule::Rule, utils::AlwaysNever};
 
 /// Common directive prefixes that should be ignored (module-level to avoid items-after-statements)
 const DIRECTIVES: &[&str] = &[
@@ -47,18 +47,10 @@ struct CommentConfig {
     ignore_consecutive_comments: bool,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-enum CapitalizeOption {
-    #[default]
-    Always,
-    Never,
-}
-
 /// Internal configuration structure (boxed for size optimization)
 #[derive(Debug, Clone, Default)]
 pub struct CapitalizedCommentsConfig {
-    capitalize: CapitalizeOption,
+    capitalize: AlwaysNever,
     line_config: CommentConfig,
     block_config: CommentConfig,
 }
@@ -94,7 +86,7 @@ impl CapitalizedComments {
         /// begin with a capital letter. The second element is an optional object
         /// containing additional options.
         #[derive(JsonSchema, Deserialize)]
-        struct CapitalizedCommentsOptionsDocs(CapitalizeOption, Option<OptionsJsonDoc>);
+        struct CapitalizedCommentsOptionsDocs(AlwaysNever, Option<OptionsJsonDoc>);
 
         Some(r#gen.subschema_for::<CapitalizedCommentsOptionsDocs>())
     }
@@ -262,8 +254,8 @@ impl Rule for CapitalizedComments {
 
             let is_uppercase = first_letter.is_uppercase();
             let (wrong_case, correct_case, fixed_letter) = match self.capitalize {
-                CapitalizeOption::Always if !is_uppercase => ("lowercase", "uppercase", upper),
-                CapitalizeOption::Never if is_uppercase => ("uppercase", "lowercase", lower),
+                AlwaysNever::Always if !is_uppercase => ("lowercase", "uppercase", upper),
+                AlwaysNever::Never if is_uppercase => ("uppercase", "lowercase", lower),
                 _ => continue,
             };
 

--- a/crates/oxc_linter/src/rules/eslint/id_length.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_length.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 use icu_segmenter::GraphemeClusterSegmenter;
 use lazy_regex::Regex;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::Value;
 
 use oxc_ast::AstKind;
@@ -18,6 +18,7 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
+    utils::AlwaysNever,
 };
 
 fn id_length_is_too_short_diagnostic(span: Span, config_min: u64) -> OxcDiagnostic {
@@ -30,16 +31,6 @@ fn id_length_is_too_long_diagnostic(span: Span, config_max: u64) -> OxcDiagnosti
 
 const DEFAULT_MAX_LENGTH: u64 = u64::MAX;
 const DEFAULT_MIN_LENGTH: u64 = 2;
-
-#[derive(Debug, Default, Clone, PartialEq, JsonSchema, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-enum PropertyKind {
-    /// Property names are checked just like other identifiers
-    #[default]
-    Always,
-    /// Property names are not checked for length.
-    Never,
-}
 
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct IdLength(Box<IdLengthConfig>);
@@ -71,7 +62,7 @@ pub struct IdLengthConfig {
     /// Defaults to `true`.
     check_generic: bool,
     /// Whether to check property names for length.
-    properties: PropertyKind,
+    properties: AlwaysNever,
 }
 
 impl Default for IdLengthConfig {
@@ -82,7 +73,7 @@ impl Default for IdLengthConfig {
             max: DEFAULT_MAX_LENGTH,
             min: DEFAULT_MIN_LENGTH,
             check_generic: true,
-            properties: PropertyKind::default(),
+            properties: AlwaysNever::default(),
         }
     }
 }
@@ -253,7 +244,7 @@ impl IdLength {
                         object_pattern.properties.iter().find(|x| x.span == ident.span);
 
                     if IdLength::is_binding_identifier_or_object_pattern(binding_property_option)
-                        && self.properties == PropertyKind::Never
+                        && self.properties == AlwaysNever::Never
                     {
                         return;
                     }
@@ -309,7 +300,7 @@ impl IdLength {
                 }
             property_key if property_key.is_property_key() => {
                 let property_key = property_key.as_property_key_kind().unwrap();
-                if self.properties == PropertyKind::Never {
+                if self.properties == AlwaysNever::Never {
                     return;
                 }
 
@@ -340,7 +331,7 @@ impl IdLength {
                 }
             }
             AstKind::BindingProperty(binding_prop) => {
-                if self.properties == PropertyKind::Never {
+                if self.properties == AlwaysNever::Never {
                     return;
                 }
                 // If this node is the original identifier in a binding property, we can skip it
@@ -352,7 +343,7 @@ impl IdLength {
                 }
             }
             AstKind::ObjectProperty(_)
-                if self.properties == PropertyKind::Never => {
+                if self.properties == AlwaysNever::Never => {
                     return;
                 }
             AstKind::AssignmentTargetPropertyProperty(assignment_target)
@@ -437,7 +428,7 @@ impl IdLength {
 
     fn should_check_member_expression_property(&self, node: &AstNode, ctx: &LintContext) -> bool {
         // Only check property names in member expressions if properties == Always
-        if self.properties != PropertyKind::Always {
+        if self.properties != AlwaysNever::Always {
             return false;
         }
 

--- a/crates/oxc_linter/src/rules/eslint/init_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/init_declarations.rs
@@ -15,11 +15,15 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::{Rule, TupleRuleConfig},
-    utils::has_ambient_typescript_ancestor,
+    utils::{AlwaysNever, has_ambient_typescript_ancestor},
 };
 
-fn init_declarations_diagnostic(span: Span, mode: &Mode, identifier_name: &str) -> OxcDiagnostic {
-    let msg = if Mode::Always == *mode {
+fn init_declarations_diagnostic(
+    span: Span,
+    mode: &AlwaysNever,
+    identifier_name: &str,
+) -> OxcDiagnostic {
+    let msg = if &AlwaysNever::Always == mode {
         format!("Variable '{identifier_name}' should be initialized on declaration.")
     } else {
         format!("Variable '{identifier_name}' should not be initialized on declaration.")
@@ -29,19 +33,9 @@ fn init_declarations_diagnostic(span: Span, mode: &Mode, identifier_name: &str) 
         .with_label(span)
 }
 
-#[derive(Debug, Default, PartialEq, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-enum Mode {
-    /// Requires that variables be initialized on declaration. This is the default behavior.
-    #[default]
-    Always,
-    /// Disallows initialization during declaration.
-    Never,
-}
-
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
-pub struct InitDeclarations(Mode, InitDeclarationsConfig);
+pub struct InitDeclarations(AlwaysNever, InitDeclarationsConfig);
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
@@ -136,7 +130,7 @@ impl Rule for InitDeclarations {
             let InitDeclarations(mode, config) = &self;
             let parent = ctx.nodes().parent_node(node.id());
             // support for TypeScript's declare variables
-            if mode == &Mode::Always {
+            if mode == &AlwaysNever::Always {
                 if decl.declare {
                     return;
                 }
@@ -163,14 +157,14 @@ impl Rule for InitDeclarations {
                 };
 
                 match mode {
-                    Mode::Always if !is_initialized => {
+                    AlwaysNever::Always if !is_initialized => {
                         ctx.diagnostic(init_declarations_diagnostic(
                             v.span,
                             mode,
                             identifier.name.as_str(),
                         ));
                     }
-                    Mode::Never if is_initialized && !config.ignore_for_loop_init => {
+                    AlwaysNever::Never if is_initialized && !config.ignore_for_loop_init => {
                         if matches!(&v.kind, VariableDeclarationKind::Const) {
                             continue;
                         }

--- a/crates/oxc_linter/src/rules/eslint/logical_assignment_operators.rs
+++ b/crates/oxc_linter/src/rules/eslint/logical_assignment_operators.rs
@@ -19,7 +19,7 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::{Rule, TupleRuleConfig},
-    utils::is_same_member_expression,
+    utils::{AlwaysNever, is_same_member_expression},
 };
 
 fn logical_assignment_operators_diagnostic(
@@ -55,19 +55,6 @@ enum LogicalAssignmentOperatorsDiagnosticKind {
     Unexpected,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "kebab-case")]
-enum LogicalAssignmentOperatorsMode {
-    #[default]
-    /// This option checks for expressions that can be shortened using logical assignment operator.
-    /// For example, `a = a || b` can be shortened to `a ||= b`.
-    /// Expressions with associativity such as `a = a || b || c` are reported as being able to be shortened to `a ||= b || c` unless the evaluation order is explicitly defined using parentheses, such as `a = (a || b) || c`.
-    Always,
-    /// This option disallows logical assignment operator shorthand.
-    /// For example, `a ||= b` should be written as `a = a || b`.
-    Never,
-}
-
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct LogicalAssignmentOperatorsConfig {
@@ -92,10 +79,7 @@ struct LogicalAssignmentOperatorsConfig {
 }
 
 #[derive(Debug, Default, Clone, Serialize, JsonSchema)]
-pub struct LogicalAssignmentOperators(
-    LogicalAssignmentOperatorsMode,
-    LogicalAssignmentOperatorsConfig,
-);
+pub struct LogicalAssignmentOperators(AlwaysNever, LogicalAssignmentOperatorsConfig);
 
 impl<'de> Deserialize<'de> for LogicalAssignmentOperators {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -103,7 +87,7 @@ impl<'de> Deserialize<'de> for LogicalAssignmentOperators {
         D: serde::Deserializer<'de>,
     {
         let values = Vec::<Value>::deserialize(deserializer)?;
-        let mut mode = LogicalAssignmentOperatorsMode::Always;
+        let mut mode = AlwaysNever::Always;
         let mut options = LogicalAssignmentOperatorsConfig::default();
 
         match values.as_slice() {
@@ -113,7 +97,7 @@ impl<'de> Deserialize<'de> for LogicalAssignmentOperators {
             }
             [first, second] if first.is_string() && second.is_object() => {
                 mode = serde_json::from_value(first.clone()).map_err(de::Error::custom)?;
-                if mode == LogicalAssignmentOperatorsMode::Never {
+                if mode == AlwaysNever::Never {
                     return Err(de::Error::custom(r#"options object is only valid with "always""#));
                 }
                 options = serde_json::from_value(second.clone()).map_err(de::Error::custom)?;
@@ -196,17 +180,14 @@ impl Rule for LogicalAssignmentOperators {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::AssignmentExpression(assignment) => match self.0 {
-                LogicalAssignmentOperatorsMode::Never => check_never(assignment, ctx),
-                LogicalAssignmentOperatorsMode::Always => check_assignment(assignment, ctx),
+                AlwaysNever::Never => check_never(assignment, ctx),
+                AlwaysNever::Always => check_assignment(assignment, ctx),
             },
-            AstKind::LogicalExpression(logical)
-                if self.0 == LogicalAssignmentOperatorsMode::Always =>
-            {
+            AstKind::LogicalExpression(logical) if self.0 == AlwaysNever::Always => {
                 check_logical(logical, ctx);
             }
             AstKind::IfStatement(if_statement)
-                if self.0 == LogicalAssignmentOperatorsMode::Always
-                    && self.1.enforce_for_if_statements =>
+                if self.0 == AlwaysNever::Always && self.1.enforce_for_if_statements =>
             {
                 check_if_statement(if_statement, ctx);
             }

--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -9,19 +9,23 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::precedence::GetPrecedence;
-use schemars::JsonSchema;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{AstNode, context::LintContext, rule::Rule, utils::is_same_member_expression};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{AlwaysNever, is_same_member_expression},
+};
 
 fn operator_assignment_diagnostic(
-    mode: Mode,
+    mode: &AlwaysNever,
     span: Span,
     operator: &str,
     can_fix: bool,
 ) -> OxcDiagnostic {
-    let msg = if Mode::Never == mode {
+    let msg = if &AlwaysNever::Never == mode {
         format!("Unexpected operator assignment ({operator}) shorthand.")
     } else {
         format!("Assignment (=) can be replaced with operator assignment ({operator}).")
@@ -29,7 +33,7 @@ fn operator_assignment_diagnostic(
     let mut diagnostic = OxcDiagnostic::warn(msg).with_label(span);
 
     if !can_fix {
-        diagnostic = diagnostic.with_note(if Mode::Never == mode {
+        diagnostic = diagnostic.with_note(if &AlwaysNever::Never == mode {
             format!("Replace '{operator}' with a regular '=' assignment.")
         } else {
             format!("Use '{operator}' shorthand instead of '='.")
@@ -39,26 +43,8 @@ fn operator_assignment_diagnostic(
     diagnostic
 }
 
-#[derive(Debug, Default, PartialEq, Clone, Copy, Serialize, JsonSchema)]
-#[serde(rename_all = "kebab-case")]
-enum Mode {
-    /// Requires assignment operator shorthand where possible.
-    #[default]
-    Always,
-    /// Disallows assignment operator shorthand.
-    Never,
-}
-
-impl Mode {
-    pub fn from(raw: &str) -> Self {
-        if raw == "never" { Self::Never } else { Self::Always }
-    }
-}
-
-#[derive(Debug, Default, Clone, Serialize)]
-pub struct OperatorAssignment {
-    mode: Mode,
-}
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct OperatorAssignment(AlwaysNever);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -109,28 +95,28 @@ declare_oxc_lint!(
     eslint,
     style,
     fix_dangerous,
-    config = Mode,
+    config = AlwaysNever,
     version = "0.15.13",
 );
 
 impl Rule for OperatorAssignment {
     fn from_configuration(value: Value) -> Result<Self, serde_json::error::Error> {
-        Ok(Self { mode: value.get(0).and_then(Value::as_str).map(Mode::from).unwrap_or_default() })
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::AssignmentExpression(assign_expr) = node.kind() else {
             return;
         };
-        if self.mode == Mode::Never {
-            prohibit(assign_expr, self.mode, ctx);
+        if self.0 == AlwaysNever::Never {
+            prohibit(assign_expr, &self.0, ctx);
         } else {
-            verify(assign_expr, self.mode, ctx);
+            verify(assign_expr, &self.0, ctx);
         }
     }
 }
 
-fn verify(expr: &AssignmentExpression, mode: Mode, ctx: &LintContext) {
+fn verify(expr: &AssignmentExpression, mode: &AlwaysNever, ctx: &LintContext) {
     if !expr.operator.is_assign() {
         return;
     }
@@ -188,7 +174,7 @@ fn verify(expr: &AssignmentExpression, mode: Mode, ctx: &LintContext) {
     }
 }
 
-fn prohibit(expr: &AssignmentExpression, mode: Mode, ctx: &LintContext) {
+fn prohibit(expr: &AssignmentExpression, mode: &AlwaysNever, ctx: &LintContext) {
     if !expr.operator.is_assign() && !expr.operator.is_logical() {
         ctx.diagnostic_with_dangerous_fix(
 operator_assignment_diagnostic(mode, expr.span, expr.operator.as_str(), true),

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -2,14 +2,13 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 use crate::{
     AstNode,
     context::{ContextHost, LintContext},
     rule::{DefaultRuleConfig, Rule},
-    utils::{is_es5_component, is_es6_component},
+    utils::{AlwaysNever, is_es5_component, is_es6_component},
 };
 
 fn unexpected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
@@ -22,18 +21,8 @@ fn expected_es6_class_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone, JsonSchema, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-enum PreferES6ClassOptionType {
-    /// Always prefer ES2015 class-style components.
-    #[default]
-    Always,
-    /// Do not allow ES2015 class-style, prefer `createReactClass`.
-    Never,
-}
-
 #[derive(Debug, Default, Clone, Deserialize)]
-pub struct PreferEs6Class(PreferES6ClassOptionType);
+pub struct PreferEs6Class(AlwaysNever);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -61,7 +50,7 @@ declare_oxc_lint!(
     PreferEs6Class,
     react,
     style,
-    config = PreferES6ClassOptionType,
+    config = AlwaysNever,
     version = "0.5.0",
 );
 
@@ -73,13 +62,12 @@ impl Rule for PreferEs6Class {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::CallExpression(call_expr)
-                if matches!(self.0, PreferES6ClassOptionType::Always) && is_es5_component(node) =>
+                if matches!(self.0, AlwaysNever::Always) && is_es5_component(node) =>
             {
                 ctx.diagnostic(expected_es6_class_diagnostic(call_expr.callee.span()));
             }
             AstKind::Class(class_expr)
-                if !matches!(self.0, PreferES6ClassOptionType::Always)
-                    && is_es6_component(node) =>
+                if !matches!(self.0, AlwaysNever::Always) && is_es6_component(node) =>
             {
                 ctx.diagnostic(unexpected_es6_class_diagnostic(
                     class_expr.id.as_ref().map_or(class_expr.span, |id| id.span),

--- a/crates/oxc_linter/src/rules/react/state_in_constructor.rs
+++ b/crates/oxc_linter/src/rules/react/state_in_constructor.rs
@@ -3,7 +3,6 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
-use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::{
@@ -11,7 +10,7 @@ use crate::{
     ast_util::get_outer_member_expression,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
-    utils::{is_es6_component, is_state_member_expression},
+    utils::{AlwaysNever, is_es6_component, is_state_member_expression},
 };
 
 fn state_in_constructor_diagnostic(span: Span, is_state_init_constructor: bool) -> OxcDiagnostic {
@@ -23,37 +22,18 @@ fn state_in_constructor_diagnostic(span: Span, is_state_init_constructor: bool) 
     OxcDiagnostic::warn(message).with_label(span)
 }
 
-#[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-pub enum StateInConstructorConfig {
-    /// Enforce state initialization in the constructor.
-    /// This is the default mode.
-    #[default]
-    Always,
-    /// Enforce state initialization with a class property.
-    Never,
-}
-
-impl StateInConstructorConfig {
+impl StateInConstructor {
     pub const fn is_always(&self) -> bool {
-        matches!(self, Self::Always)
+        matches!(*self.0, AlwaysNever::Always)
     }
 
     pub const fn is_never(&self) -> bool {
-        matches!(self, Self::Never)
+        matches!(*self.0, AlwaysNever::Never)
     }
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
-pub struct StateInConstructor(Box<StateInConstructorConfig>);
-
-impl std::ops::Deref for StateInConstructor {
-    type Target = StateInConstructorConfig;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub struct StateInConstructor(Box<AlwaysNever>);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -123,7 +103,7 @@ declare_oxc_lint!(
     StateInConstructor,
     react,
     style,
-    config = StateInConstructorConfig,
+    config = AlwaysNever,
     version = "1.26.0",
 );
 

--- a/crates/oxc_linter/src/utils/config.rs
+++ b/crates/oxc_linter/src/utils/config.rs
@@ -1,5 +1,6 @@
 use lazy_regex::{Regex, RegexBuilder};
-use serde::Deserialize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 /// Always returns `true`.
 ///
@@ -25,6 +26,14 @@ use serde::Deserialize;
 #[inline]
 pub const fn default_true() -> bool {
     true
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum AlwaysNever {
+    #[default]
+    Always,
+    Never,
 }
 
 pub fn deserialize_regex_option<'de, D>(deserializer: D) -> Result<Option<Regex>, D::Error>

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -447,6 +447,13 @@
         }
       ]
     },
+    "AlwaysNever": {
+      "type": "string",
+      "enum": [
+        "always",
+        "never"
+      ]
+    },
     "AlwaysReturnConfig": {
       "type": "object",
       "properties": {
@@ -670,19 +677,12 @@
       },
       "additionalProperties": false
     },
-    "CapitalizeOption": {
-      "type": "string",
-      "enum": [
-        "always",
-        "never"
-      ]
-    },
     "CapitalizedCommentsOptionsDocs": {
       "description": "Configuration for the capitalized-comments rule.\n\nThe first element specifies whether comments should `\"always\"` or `\"never\"`\nbegin with a capital letter. The second element is an optional object\ncontaining additional options.",
       "type": "array",
       "items": [
         {
-          "$ref": "#/definitions/CapitalizeOption"
+          "$ref": "#/definitions/AlwaysNever"
         },
         {
           "$ref": "#/definitions/OptionsJsonDoc"
@@ -1367,7 +1367,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "$ref": "#/definitions/CapitalizeOption"
+                  "$ref": "#/definitions/AlwaysNever"
                 },
                 {
                   "$ref": "#/definitions/OptionsJsonDoc"
@@ -2050,7 +2050,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "$ref": "#/definitions/Mode3"
+                  "$ref": "#/definitions/AlwaysNever"
                 },
                 {
                   "$ref": "#/definitions/InitDeclarationsConfig"
@@ -2682,7 +2682,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "$ref": "#/definitions/LogicalAssignmentOperatorsMode"
+                  "$ref": "#/definitions/AlwaysNever"
                 },
                 {
                   "$ref": "#/definitions/LogicalAssignmentOperatorsConfig"
@@ -4252,23 +4252,10 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Requires assignment operator shorthand where possible.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Requires assignment operator shorthand where possible."
-                    },
-                    {
-                      "description": "Disallows assignment operator shorthand.",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Disallows assignment operator shorthand."
-                    }
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never"
                   ]
                 }
               ],
@@ -5294,23 +5281,10 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Always prefer ES2015 class-style components.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always prefer ES2015 class-style components."
-                    },
-                    {
-                      "description": "Do not allow ES2015 class-style, prefer `createReactClass`.",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Do not allow ES2015 class-style, prefer `createReactClass`."
-                    }
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never"
                   ]
                 }
               ],
@@ -5380,23 +5354,10 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Enforce state initialization in the constructor.\nThis is the default mode.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Enforce state initialization in the constructor.\nThis is the default mode."
-                    },
-                    {
-                      "description": "Enforce state initialization with a class property.",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Enforce state initialization with a class property."
-                    }
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never"
                   ]
                 }
               ],
@@ -8844,7 +8805,7 @@
           "default": "always",
           "allOf": [
             {
-              "$ref": "#/definitions/PropertyKind"
+              "$ref": "#/definitions/AlwaysNever"
             }
           ],
           "markdownDescription": "Whether to check property names for length."
@@ -8942,7 +8903,7 @@
       "type": "array",
       "items": [
         {
-          "$ref": "#/definitions/Mode3"
+          "$ref": "#/definitions/AlwaysNever"
         },
         {
           "$ref": "#/definitions/InitDeclarationsConfig"
@@ -9318,7 +9279,7 @@
       "type": "array",
       "items": [
         {
-          "$ref": "#/definitions/LogicalAssignmentOperatorsMode"
+          "$ref": "#/definitions/AlwaysNever"
         },
         {
           "$ref": "#/definitions/LogicalAssignmentOperatorsConfig"
@@ -9338,26 +9299,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "LogicalAssignmentOperatorsMode": {
-      "oneOf": [
-        {
-          "description": "This option checks for expressions that can be shortened using logical assignment operator.\nFor example, `a = a || b` can be shortened to `a ||= b`.\nExpressions with associativity such as `a = a || b || c` are reported as being able to be shortened to `a ||= b || c` unless the evaluation order is explicitly defined using parentheses, such as `a = (a || b) || c`.",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "This option checks for expressions that can be shortened using logical assignment operator.\nFor example, `a = a || b` can be shortened to `a ||= b`.\nExpressions with associativity such as `a = a || b || c` are reported as being able to be shortened to `a ||= b || c` unless the evaluation order is explicitly defined using parentheses, such as `a = (a || b) || c`."
-        },
-        {
-          "description": "This option disallows logical assignment operator shorthand.\nFor example, `a ||= b` should be written as `a = a || b`.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "This option disallows logical assignment operator shorthand.\nFor example, `a ||= b` should be written as `a = a || b`."
-        }
-      ]
     },
     "MaxClassesPerFileConfig": {
       "type": "object",
@@ -9606,46 +9547,6 @@
         "as-needed",
         "always",
         "never"
-      ]
-    },
-    "Mode3": {
-      "oneOf": [
-        {
-          "description": "Requires that variables be initialized on declaration. This is the default behavior.",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "Requires that variables be initialized on declaration. This is the default behavior."
-        },
-        {
-          "description": "Disallows initialization during declaration.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "Disallows initialization during declaration."
-        }
-      ]
-    },
-    "Mode4": {
-      "oneOf": [
-        {
-          "description": "Requires assignment operator shorthand where possible.",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "Requires assignment operator shorthand where possible."
-        },
-        {
-          "description": "Disallows assignment operator shorthand.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "Disallows assignment operator shorthand."
-        }
       ]
     },
     "MouseEventsHaveKeyEventsConfig": {
@@ -12532,26 +12433,6 @@
       },
       "additionalProperties": false
     },
-    "PreferES6ClassOptionType": {
-      "oneOf": [
-        {
-          "description": "Always prefer ES2015 class-style components.",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "Always prefer ES2015 class-style components."
-        },
-        {
-          "description": "Do not allow ES2015 class-style, prefer `createReactClass`.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "Do not allow ES2015 class-style, prefer `createReactClass`."
-        }
-      ]
-    },
     "PreferFunctionComponent": {
       "type": "object",
       "properties": {
@@ -12904,26 +12785,6 @@
       },
       "additionalProperties": false,
       "markdownDescription": "A prop with optional `disallowedFor` DOM node list and custom `message`."
-    },
-    "PropertyKind": {
-      "oneOf": [
-        {
-          "description": "Property names are checked just like other identifiers",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "Property names are checked just like other identifiers"
-        },
-        {
-          "description": "Property names are not checked for length.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "Property names are not checked for length."
-        }
-      ]
     },
     "RadixType": {
       "oneOf": [
@@ -13520,26 +13381,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "StateInConstructorConfig": {
-      "oneOf": [
-        {
-          "description": "Enforce state initialization in the constructor.\nThis is the default mode.",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "Enforce state initialization in the constructor.\nThis is the default mode."
-        },
-        {
-          "description": "Enforce state initialization with a class property.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "Enforce state initialization with a class property."
-        }
-      ]
     },
     "StrictBooleanExpressionsConfig": {
       "type": "object",

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -451,6 +451,13 @@ expression: json
         }
       ]
     },
+    "AlwaysNever": {
+      "type": "string",
+      "enum": [
+        "always",
+        "never"
+      ]
+    },
     "AlwaysReturnConfig": {
       "type": "object",
       "properties": {
@@ -674,19 +681,12 @@ expression: json
       },
       "additionalProperties": false
     },
-    "CapitalizeOption": {
-      "type": "string",
-      "enum": [
-        "always",
-        "never"
-      ]
-    },
     "CapitalizedCommentsOptionsDocs": {
       "description": "Configuration for the capitalized-comments rule.\n\nThe first element specifies whether comments should `\"always\"` or `\"never\"`\nbegin with a capital letter. The second element is an optional object\ncontaining additional options.",
       "type": "array",
       "items": [
         {
-          "$ref": "#/definitions/CapitalizeOption"
+          "$ref": "#/definitions/AlwaysNever"
         },
         {
           "$ref": "#/definitions/OptionsJsonDoc"
@@ -1371,7 +1371,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "$ref": "#/definitions/CapitalizeOption"
+                  "$ref": "#/definitions/AlwaysNever"
                 },
                 {
                   "$ref": "#/definitions/OptionsJsonDoc"
@@ -2054,7 +2054,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "$ref": "#/definitions/Mode3"
+                  "$ref": "#/definitions/AlwaysNever"
                 },
                 {
                   "$ref": "#/definitions/InitDeclarationsConfig"
@@ -2686,7 +2686,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "$ref": "#/definitions/LogicalAssignmentOperatorsMode"
+                  "$ref": "#/definitions/AlwaysNever"
                 },
                 {
                   "$ref": "#/definitions/LogicalAssignmentOperatorsConfig"
@@ -4256,23 +4256,10 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Requires assignment operator shorthand where possible.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Requires assignment operator shorthand where possible."
-                    },
-                    {
-                      "description": "Disallows assignment operator shorthand.",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Disallows assignment operator shorthand."
-                    }
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never"
                   ]
                 }
               ],
@@ -5298,23 +5285,10 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Always prefer ES2015 class-style components.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always prefer ES2015 class-style components."
-                    },
-                    {
-                      "description": "Do not allow ES2015 class-style, prefer `createReactClass`.",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Do not allow ES2015 class-style, prefer `createReactClass`."
-                    }
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never"
                   ]
                 }
               ],
@@ -5384,23 +5358,10 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Enforce state initialization in the constructor.\nThis is the default mode.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Enforce state initialization in the constructor.\nThis is the default mode."
-                    },
-                    {
-                      "description": "Enforce state initialization with a class property.",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Enforce state initialization with a class property."
-                    }
+                  "type": "string",
+                  "enum": [
+                    "always",
+                    "never"
                   ]
                 }
               ],
@@ -8848,7 +8809,7 @@ expression: json
           "default": "always",
           "allOf": [
             {
-              "$ref": "#/definitions/PropertyKind"
+              "$ref": "#/definitions/AlwaysNever"
             }
           ],
           "markdownDescription": "Whether to check property names for length."
@@ -8946,7 +8907,7 @@ expression: json
       "type": "array",
       "items": [
         {
-          "$ref": "#/definitions/Mode3"
+          "$ref": "#/definitions/AlwaysNever"
         },
         {
           "$ref": "#/definitions/InitDeclarationsConfig"
@@ -9322,7 +9283,7 @@ expression: json
       "type": "array",
       "items": [
         {
-          "$ref": "#/definitions/LogicalAssignmentOperatorsMode"
+          "$ref": "#/definitions/AlwaysNever"
         },
         {
           "$ref": "#/definitions/LogicalAssignmentOperatorsConfig"
@@ -9342,26 +9303,6 @@ expression: json
         }
       },
       "additionalProperties": false
-    },
-    "LogicalAssignmentOperatorsMode": {
-      "oneOf": [
-        {
-          "description": "This option checks for expressions that can be shortened using logical assignment operator.\nFor example, `a = a || b` can be shortened to `a ||= b`.\nExpressions with associativity such as `a = a || b || c` are reported as being able to be shortened to `a ||= b || c` unless the evaluation order is explicitly defined using parentheses, such as `a = (a || b) || c`.",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "This option checks for expressions that can be shortened using logical assignment operator.\nFor example, `a = a || b` can be shortened to `a ||= b`.\nExpressions with associativity such as `a = a || b || c` are reported as being able to be shortened to `a ||= b || c` unless the evaluation order is explicitly defined using parentheses, such as `a = (a || b) || c`."
-        },
-        {
-          "description": "This option disallows logical assignment operator shorthand.\nFor example, `a ||= b` should be written as `a = a || b`.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "This option disallows logical assignment operator shorthand.\nFor example, `a ||= b` should be written as `a = a || b`."
-        }
-      ]
     },
     "MaxClassesPerFileConfig": {
       "type": "object",
@@ -9610,46 +9551,6 @@ expression: json
         "as-needed",
         "always",
         "never"
-      ]
-    },
-    "Mode3": {
-      "oneOf": [
-        {
-          "description": "Requires that variables be initialized on declaration. This is the default behavior.",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "Requires that variables be initialized on declaration. This is the default behavior."
-        },
-        {
-          "description": "Disallows initialization during declaration.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "Disallows initialization during declaration."
-        }
-      ]
-    },
-    "Mode4": {
-      "oneOf": [
-        {
-          "description": "Requires assignment operator shorthand where possible.",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "Requires assignment operator shorthand where possible."
-        },
-        {
-          "description": "Disallows assignment operator shorthand.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "Disallows assignment operator shorthand."
-        }
       ]
     },
     "MouseEventsHaveKeyEventsConfig": {
@@ -12536,26 +12437,6 @@ expression: json
       },
       "additionalProperties": false
     },
-    "PreferES6ClassOptionType": {
-      "oneOf": [
-        {
-          "description": "Always prefer ES2015 class-style components.",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "Always prefer ES2015 class-style components."
-        },
-        {
-          "description": "Do not allow ES2015 class-style, prefer `createReactClass`.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "Do not allow ES2015 class-style, prefer `createReactClass`."
-        }
-      ]
-    },
     "PreferFunctionComponent": {
       "type": "object",
       "properties": {
@@ -12908,26 +12789,6 @@ expression: json
       },
       "additionalProperties": false,
       "markdownDescription": "A prop with optional `disallowedFor` DOM node list and custom `message`."
-    },
-    "PropertyKind": {
-      "oneOf": [
-        {
-          "description": "Property names are checked just like other identifiers",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "Property names are checked just like other identifiers"
-        },
-        {
-          "description": "Property names are not checked for length.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "Property names are not checked for length."
-        }
-      ]
     },
     "RadixType": {
       "oneOf": [
@@ -13524,26 +13385,6 @@ expression: json
         }
       },
       "additionalProperties": false
-    },
-    "StateInConstructorConfig": {
-      "oneOf": [
-        {
-          "description": "Enforce state initialization in the constructor.\nThis is the default mode.",
-          "type": "string",
-          "enum": [
-            "always"
-          ],
-          "markdownDescription": "Enforce state initialization in the constructor.\nThis is the default mode."
-        },
-        {
-          "description": "Enforce state initialization with a class property.",
-          "type": "string",
-          "enum": [
-            "never"
-          ],
-          "markdownDescription": "Enforce state initialization with a class property."
-        }
-      ]
     },
     "StrictBooleanExpressionsConfig": {
       "type": "object",


### PR DESCRIPTION
Skipped two rules because their defaults are "never".
- `react/jsx-boolean-value`
- `eslint/unicode-bom`

Tried to avoid the `Clone` derive 🤞 and simplified `operator-assignment`.
Sadly some docs are getting removed. Feel free to close the issue if the docs are preferred over a shared option.