### PR TITLE
refactor(linter): reuse non-object references for rules schemas

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -85,9 +85,13 @@ export type FuncNamesConfigType = "always" | "as-needed" | "never";
 export type Style = "expression" | "declaration";
 export type NamedExports = "ignore" | "expression" | "declaration";
 export type PairOrder = "anyOrder" | "getBeforeSet" | "setBeforeGet";
+export type Mode = "prefer-top-level" | "prefer-inline";
+export type AbsoluteFirst = "absolute-first" | "disable-absolute-first";
+export type MaxDependenciesConfigJson = number | MaxDependenciesConfig;
 export type Target = "single" | "any";
 export type JestFnType = "hook" | "describe" | "test" | "expect" | "jest" | "unknown";
 export type CountThis = "always" | "never" | "except-void";
+export type NoCondAssignConfig = "except-parens" | "always";
 export type CheckLoopsConfig = boolean | CheckLoops;
 export type CheckLoops = "all" | "allExceptWhileTrue" | "none";
 /**
@@ -114,18 +118,33 @@ export type AllowKind =
 export type NoInnerDeclarationsConfig = "functions" | "both";
 export type BlockScopedFunctions = "allow" | "disallow";
 export type NoMagicNumbersNumber = number | string;
+export type NoReturnAssignMode = "always" | "except-parens";
 /**
  * Controls how hoisting is handled when checking for shadowing.
  */
 export type HoistOption = "all" | "functions" | "functions-and-types" | "never" | "types";
+export type NoUnusedVarsConfig = VarsOption | NoUnusedVarsOptions;
 export type VarsOption = "all" | "local";
 export type ArgsOption = "after-used" | "all" | "none";
 export type IgnorePatternFor_String = null | string;
 export type CaughtErrorsJson = "all" | "none";
 export type NoUnusedVarsFixMode = "off" | "suggestion" | "fix" | "safe-fix";
 export type Location = "start" | "anywhere";
+/**
+ * The rule takes a single string option: the name of the error parameter.
+ *
+ * This can be either:
+ * - an exact name (e.g. `"err"`, `"error"`)
+ * - a regexp pattern (e.g. `"^(err|error)$"`)
+ *
+ * If the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.
+ *
+ * Default: `"err"`.
+ */
+export type HandleCallbackErrConfig = string;
 export type ShorthandType = "always" | "methods" | "properties" | "consistent" | "consistent-as-needed" | "never";
 export type Destructuring = "any" | "all";
+export type RadixType = "always" | "as-needed";
 /**
  * A forbidden prop, either as a plain prop name string or with options.
  */
@@ -150,13 +169,20 @@ export type ForbidItem2 =
       message?: string;
     };
 export type EnforceBooleanAttribute = "always" | "never";
+export type FragmentMode = "syntax" | "element";
+export type NoDidMountSetStateConfig = "allowed" | "disallow-in-func";
+export type NoWillUpdateSetStateConfig = "allowed" | "disallow-in-func";
 export type RequireFlag = "u" | "v";
 export type ImportKind = "none" | "all" | "multiple" | "single";
 /**
  * Sorting order for keys. Accepts "asc" for ascending or "desc" for descending.
  */
 export type SortOrder = "desc" | "asc";
+export type ClassLiteralPropertyStyleOption = "fields" | "getters";
+export type ConsistentIndexedObjectStyleConfig = "record" | "index-signature";
+export type ConsistentTypeDefinitionsConfig = "interface" | "type";
 export type AccessibilityLevel = "explicit" | "no-public" | "off";
+export type MethodSignatureStyleConfig = "property" | "method";
 /**
  * Type or value specifier for matching specific declarations
  *
@@ -194,6 +220,15 @@ export type FileFrom = "file";
 export type NameSpecifier = string | string[];
 export type LibFrom = "lib";
 export type PackageFrom = "package";
+export type ReturnAwaitOption = "in-try-catch" | "always" | "error-handling-correctness-only" | "never";
+export type BomOptionType = "always" | "never";
+export type PreferTernaryOption = "always" | "only-single-line";
+export type RelativeUrlStyleConfig = "never" | "always";
+export type SwitchCaseBracesConfig = "always" | "avoid";
+export type CaseType = "PascalCase" | "kebab-case";
+export type DeclarationStyle = "type-based" | "type-literal" | "runtime";
+export type DeclarationStyle2 = "type-based" | "runtime";
+export type NextTickOption = "promise" | "callback";
 export type CaseType2 = "camelCase" | "snake_case";
 export type AllowYoda = "never" | "always";
 export type OxlintOverrides = OxlintOverride[];
@@ -695,17 +730,14 @@ export interface DummyRuleMap {
   "guard-for-in"?: RuleNoConfig;
   "id-length"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, IdLengthConfig];
   "id-match"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, string] | [AllowWarnDeny, string, IdMatchOptions];
-  "import/consistent-type-specifier-style"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, "prefer-top-level" | "prefer-inline"];
+  "import/consistent-type-specifier-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, Mode];
   "import/default"?: RuleNoConfig;
   "import/export"?: RuleNoConfig;
   "import/exports-last"?: RuleNoConfig;
   "import/extensions"?: DummyRule;
-  "import/first"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "absolute-first" | "disable-absolute-first"];
+  "import/first"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AbsoluteFirst];
   "import/group-exports"?: RuleNoConfig;
-  "import/max-dependencies"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxDependenciesConfig];
+  "import/max-dependencies"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MaxDependenciesConfigJson];
   "import/named"?: RuleNoConfig;
   "import/namespace"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, Namespace];
   "import/newline-after-import"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NewlineAfterImport];
@@ -909,7 +941,7 @@ export interface DummyRuleMap {
   "no-case-declarations"?: RuleNoConfig;
   "no-class-assign"?: RuleNoConfig;
   "no-compare-neg-zero"?: RuleNoConfig;
-  "no-cond-assign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "except-parens" | "always"];
+  "no-cond-assign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoCondAssignConfig];
   "no-console"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoConsoleConfig];
   "no-const-assign"?: RuleNoConfig;
   "no-constant-binary-expression"?: RuleNoConfig;
@@ -984,7 +1016,7 @@ export interface DummyRuleMap {
   "no-restricted-globals"?: DummyRule;
   "no-restricted-imports"?: DummyRule;
   "no-restricted-properties"?: DummyRule;
-  "no-return-assign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "always" | "except-parens"];
+  "no-return-assign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoReturnAssignMode];
   "no-script-url"?: RuleNoConfig;
   "no-self-assign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoSelfAssign];
   "no-self-compare"?: RuleNoConfig;
@@ -1011,7 +1043,7 @@ export interface DummyRuleMap {
   "no-unused-expressions"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnusedExpressionsConfig];
   "no-unused-labels"?: RuleNoConfig;
   "no-unused-private-class-members"?: RuleNoConfig;
-  "no-unused-vars"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, VarsOption | NoUnusedVarsOptions];
+  "no-unused-vars"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnusedVarsConfig];
   "no-use-before-define"?: DummyRule;
   "no-useless-assignment"?: RuleNoConfig;
   "no-useless-backreference"?: RuleNoConfig;
@@ -1029,7 +1061,7 @@ export interface DummyRuleMap {
   "no-with"?: RuleNoConfig;
   "node/callback-return"?: DummyRule;
   "node/global-require"?: RuleNoConfig;
-  "node/handle-callback-err"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, string];
+  "node/handle-callback-err"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, HandleCallbackErrConfig];
   "node/no-exports-assign"?: RuleNoConfig;
   "node/no-new-require"?: RuleNoConfig;
   "node/no-path-concat"?: RuleNoConfig;
@@ -1039,7 +1071,7 @@ export interface DummyRuleMap {
     | [AllowWarnDeny]
     | [AllowWarnDeny, ShorthandType]
     | [AllowWarnDeny, ShorthandType, ObjectShorthandOptions];
-  "operator-assignment"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "always" | "never"];
+  "operator-assignment"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AlwaysNever];
   "oxc/approx-constant"?: RuleNoConfig;
   "oxc/bad-array-method-on-arguments"?: RuleNoConfig;
   "oxc/bad-bitwise-operator"?: RuleNoConfig;
@@ -1096,7 +1128,7 @@ export interface DummyRuleMap {
   "promise/prefer-catch"?: RuleNoConfig;
   "promise/spec-only"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SpecOnlyConfig];
   "promise/valid-params"?: RuleNoConfig;
-  radix?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "always" | "as-needed"];
+  radix?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RadixType];
   "react-perf/jsx-no-jsx-as-prop"?: RuleNoConfig;
   "react-perf/jsx-no-new-array-as-prop"?: RuleNoConfig;
   "react-perf/jsx-no-new-function-as-prop"?: RuleNoConfig;
@@ -1121,7 +1153,7 @@ export interface DummyRuleMap {
     | [AllowWarnDeny, EnforceBooleanAttribute, JsxBooleanValueOptions];
   "react/jsx-curly-brace-presence"?: DummyRule;
   "react/jsx-filename-extension"?: DummyRule;
-  "react/jsx-fragments"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "syntax" | "element"];
+  "react/jsx-fragments"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, FragmentMode];
   "react/jsx-handler-names"?: DummyRule;
   "react/jsx-key"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxKeyConfig];
   "react/jsx-max-depth"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxMaxDepthConfig];
@@ -1140,7 +1172,7 @@ export interface DummyRuleMap {
   "react/no-clone-element"?: RuleNoConfig;
   "react/no-danger"?: RuleNoConfig;
   "react/no-danger-with-children"?: RuleNoConfig;
-  "react/no-did-mount-set-state"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "allowed" | "disallow-in-func"];
+  "react/no-did-mount-set-state"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoDidMountSetStateConfig];
   "react/no-did-update-set-state"?: DummyRule;
   "react/no-direct-mutation-state"?: RuleNoConfig;
   "react/no-find-dom-node"?: RuleNoConfig;
@@ -1158,15 +1190,15 @@ export interface DummyRuleMap {
   "react/no-unknown-property"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnknownPropertyConfig];
   "react/no-unsafe"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnsafeConfig];
   "react/no-unstable-nested-components"?: DummyRule;
-  "react/no-will-update-set-state"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "allowed" | "disallow-in-func"];
+  "react/no-will-update-set-state"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoWillUpdateSetStateConfig];
   "react/only-export-components"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, OnlyExportComponentsConfig];
-  "react/prefer-es6-class"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "always" | "never"];
+  "react/prefer-es6-class"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AlwaysNever];
   "react/prefer-function-component"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferFunctionComponent];
   "react/react-in-jsx-scope"?: RuleNoConfig;
   "react/require-render-return"?: RuleNoConfig;
   "react/rules-of-hooks"?: RuleNoConfig;
   "react/self-closing-comp"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SelfClosingComp];
-  "react/state-in-constructor"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "always" | "never"];
+  "react/state-in-constructor"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AlwaysNever];
   "react/style-prop-object"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, StylePropObjectConfig];
   "react/void-dom-elements-no-children"?: RuleNoConfig;
   "require-await"?: RuleNoConfig;
@@ -1186,15 +1218,21 @@ export interface DummyRuleMap {
   "typescript/ban-ts-comment"?: DummyRule;
   "typescript/ban-tslint-comment"?: RuleNoConfig;
   "typescript/ban-types"?: RuleNoConfig;
-  "typescript/class-literal-property-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "fields" | "getters"];
+  "typescript/class-literal-property-style"?:
+    | AllowWarnDeny
+    | [AllowWarnDeny]
+    | [AllowWarnDeny, ClassLiteralPropertyStyleOption];
   "typescript/consistent-generic-constructors"?: DummyRule;
   "typescript/consistent-indexed-object-style"?:
     | AllowWarnDeny
     | [AllowWarnDeny]
-    | [AllowWarnDeny, "record" | "index-signature"];
+    | [AllowWarnDeny, ConsistentIndexedObjectStyleConfig];
   "typescript/consistent-return"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentReturnConfig];
   "typescript/consistent-type-assertions"?: DummyRule;
-  "typescript/consistent-type-definitions"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "interface" | "type"];
+  "typescript/consistent-type-definitions"?:
+    | AllowWarnDeny
+    | [AllowWarnDeny]
+    | [AllowWarnDeny, ConsistentTypeDefinitionsConfig];
   "typescript/consistent-type-exports"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentTypeExportsConfig];
   "typescript/consistent-type-imports"?: DummyRule;
   "typescript/dot-notation"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, DotNotationConfig];
@@ -1210,7 +1248,7 @@ export interface DummyRuleMap {
     | AllowWarnDeny
     | [AllowWarnDeny]
     | [AllowWarnDeny, ExplicitModuleBoundaryTypesConfig];
-  "typescript/method-signature-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "property" | "method"];
+  "typescript/method-signature-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MethodSignatureStyleConfig];
   "typescript/no-array-delete"?: RuleNoConfig;
   "typescript/no-base-to-string"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoBaseToStringConfig];
   "typescript/no-confusing-non-null-assertion"?: RuleNoConfig;
@@ -1318,10 +1356,7 @@ export interface DummyRuleMap {
     | AllowWarnDeny
     | [AllowWarnDeny]
     | [AllowWarnDeny, RestrictTemplateExpressionsConfig];
-  "typescript/return-await"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, "in-try-catch" | "always" | "error-handling-correctness-only" | "never"];
+  "typescript/return-await"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ReturnAwaitOption];
   "typescript/strict-boolean-expressions"?:
     | AllowWarnDeny
     | [AllowWarnDeny]
@@ -1335,7 +1370,7 @@ export interface DummyRuleMap {
   "typescript/unbound-method"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, UnboundMethodConfig];
   "typescript/unified-signatures"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, UnifiedSignaturesOptions];
   "typescript/use-unknown-in-catch-callback-variable"?: RuleNoConfig;
-  "unicode-bom"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "always" | "never"];
+  "unicode-bom"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, BomOptionType];
   "unicorn/catch-error-name"?: DummyRule;
   "unicorn/consistent-assert"?: RuleNoConfig;
   "unicorn/consistent-date-clone"?: RuleNoConfig;
@@ -1457,16 +1492,16 @@ export interface DummyRuleMap {
   "unicorn/prefer-string-starts-ends-with"?: RuleNoConfig;
   "unicorn/prefer-string-trim-start-end"?: RuleNoConfig;
   "unicorn/prefer-structured-clone"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferStructuredCloneConfig];
-  "unicorn/prefer-ternary"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "always" | "only-single-line"];
+  "unicorn/prefer-ternary"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferTernaryOption];
   "unicorn/prefer-top-level-await"?: RuleNoConfig;
   "unicorn/prefer-type-error"?: RuleNoConfig;
-  "unicorn/relative-url-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "never" | "always"];
+  "unicorn/relative-url-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RelativeUrlStyleConfig];
   "unicorn/require-array-join-separator"?: RuleNoConfig;
   "unicorn/require-module-attributes"?: RuleNoConfig;
   "unicorn/require-module-specifiers"?: RuleNoConfig;
   "unicorn/require-number-to-fixed-digits-argument"?: RuleNoConfig;
   "unicorn/require-post-message-target-origin"?: RuleNoConfig;
-  "unicorn/switch-case-braces"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "always" | "avoid"];
+  "unicorn/switch-case-braces"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SwitchCaseBracesConfig];
   "unicorn/switch-case-break-position"?: RuleNoConfig;
   "unicorn/text-encoding-identifier-case"?:
     | AllowWarnDeny
@@ -1551,18 +1586,12 @@ export interface DummyRuleMap {
   "vitest/valid-expect-in-promise"?: RuleNoConfig;
   "vitest/valid-title"?: DummyRule;
   "vitest/warn-todo"?: RuleNoConfig;
-  "vue/component-definition-name-casing"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, "PascalCase" | "kebab-case"];
-  "vue/define-emits-declaration"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, "type-based" | "type-literal" | "runtime"];
-  "vue/define-props-declaration"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "type-based" | "runtime"];
+  "vue/component-definition-name-casing"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, CaseType];
+  "vue/define-emits-declaration"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, DeclarationStyle];
+  "vue/define-props-declaration"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, DeclarationStyle2];
   "vue/define-props-destructuring"?: DummyRule;
   "vue/max-props"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MaxProps];
-  "vue/next-tick-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, "promise" | "callback"];
+  "vue/next-tick-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NextTickOption];
   "vue/no-arrow-functions-in-watch"?: RuleNoConfig;
   "vue/no-computed-properties-in-data"?: RuleNoConfig;
   "vue/no-deprecated-data-object-declaration"?: RuleNoConfig;

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -366,13 +366,13 @@ impl JsonSchema for OxlintRules {
                         return current;
                     };
 
-                    // reuse the defined schema if it's already an object schema,
-                    // we really only need to dereference array schemas for rule config
-                    // TODO: for the array config, the reference should be removed from the generator.
-                    if obj.object.is_some() {
+                    // We only need to dereference array schemas for rule config.
+                    // Reuse the schema for other cases.
+                    if obj.array.is_none() {
                         return schema;
                     }
 
+                    // TODO: the reference should be removed from the generator.
                     current
                 }
 

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1653,24 +1653,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Prefer `import type { Foo } from 'foo'` for type imports.",
-                      "type": "string",
-                      "enum": [
-                        "prefer-top-level"
-                      ],
-                      "markdownDescription": "Prefer `import type { Foo } from 'foo'` for type imports."
-                    },
-                    {
-                      "description": "Prefer `import { type Foo } from 'foo'` for type imports.",
-                      "type": "string",
-                      "enum": [
-                        "prefer-inline"
-                      ],
-                      "markdownDescription": "Prefer `import { type Foo } from 'foo'` for type imports."
-                    }
-                  ]
+                  "$ref": "#/definitions/Mode"
                 }
               ],
               "maxItems": 2,
@@ -1702,24 +1685,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Forces absolute imports to be listed before relative imports.\n\nExamples of **incorrect** code for this rule with `\"absolute-first\"`:\n```js\nimport { x } from './foo';\nimport { y } from 'bar'\n```\n\nExamples of **correct** code for this rule with `\"absolute-first\"`:\n```js\nimport { y } from 'bar';\nimport { x } from './foo'\n```",
-                      "type": "string",
-                      "enum": [
-                        "absolute-first"
-                      ],
-                      "markdownDescription": "Forces absolute imports to be listed before relative imports.\n\nExamples of **incorrect** code for this rule with `\"absolute-first\"`:\n```js\nimport { x } from './foo';\nimport { y } from 'bar'\n```\n\nExamples of **correct** code for this rule with `\"absolute-first\"`:\n```js\nimport { y } from 'bar';\nimport { x } from './foo'\n```"
-                    },
-                    {
-                      "description": "Disables the absolute-first behavior.\nThis is the default behavior.",
-                      "type": "string",
-                      "enum": [
-                        "disable-absolute-first"
-                      ],
-                      "markdownDescription": "Disables the absolute-first behavior.\nThis is the default behavior."
-                    }
-                  ]
+                  "$ref": "#/definitions/AbsoluteFirst"
                 }
               ],
               "maxItems": 2,
@@ -1742,16 +1708,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "anyOf": [
-                    {
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    {
-                      "$ref": "#/definitions/MaxDependenciesConfig"
-                    }
-                  ]
+                  "$ref": "#/definitions/MaxDependenciesConfigJson"
                 }
               ],
               "maxItems": 2,
@@ -3021,24 +2978,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Allow assignments in conditional expressions only if they are\nenclosed in parentheses.",
-                      "type": "string",
-                      "enum": [
-                        "except-parens"
-                      ],
-                      "markdownDescription": "Allow assignments in conditional expressions only if they are\nenclosed in parentheses."
-                    },
-                    {
-                      "description": "Disallow all assignments in conditional expressions.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Disallow all assignments in conditional expressions."
-                    }
-                  ]
+                  "$ref": "#/definitions/NoCondAssignConfig"
                 }
               ],
               "maxItems": 2,
@@ -3730,24 +3670,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Disallow all assignments in return statements.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Disallow all assignments in return statements."
-                    },
-                    {
-                      "description": "Allow assignments in return statements only if they are enclosed in parentheses.\nThis is the default mode.",
-                      "type": "string",
-                      "enum": [
-                        "except-parens"
-                      ],
-                      "markdownDescription": "Allow assignments in return statements only if they are enclosed in parentheses.\nThis is the default mode."
-                    }
-                  ]
+                  "$ref": "#/definitions/NoReturnAssignMode"
                 }
               ],
               "maxItems": 2,
@@ -4015,14 +3938,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/VarsOption"
-                    },
-                    {
-                      "$ref": "#/definitions/NoUnusedVarsOptions"
-                    }
-                  ]
+                  "$ref": "#/definitions/NoUnusedVarsConfig"
                 }
               ],
               "maxItems": 2,
@@ -4178,9 +4094,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "description": "The rule takes a single string option: the name of the error parameter.\n\nThis can be either:\n- an exact name (e.g. `\"err\"`, `\"error\"`)\n- a regexp pattern (e.g. `\"^(err|error)$\"`)\n\nIf the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.\n\nDefault: `\"err\"`.",
-                  "type": "string",
-                  "markdownDescription": "The rule takes a single string option: the name of the error parameter.\n\nThis can be either:\n- an exact name (e.g. `\"err\"`, `\"error\"`)\n- a regexp pattern (e.g. `\"^(err|error)$\"`)\n\nIf the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.\n\nDefault: `\"err\"`."
+                  "$ref": "#/definitions/HandleCallbackErrConfig"
                 }
               ],
               "maxItems": 2,
@@ -4252,11 +4166,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "string",
-                  "enum": [
-                    "always",
-                    "never"
-                  ]
+                  "$ref": "#/definitions/AlwaysNever"
                 }
               ],
               "maxItems": 2,
@@ -4682,24 +4592,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Always require the radix parameter when using `parseInt()`.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always require the radix parameter when using `parseInt()`."
-                    },
-                    {
-                      "description": "Only require the radix parameter when necessary.",
-                      "type": "string",
-                      "enum": [
-                        "as-needed"
-                      ],
-                      "markdownDescription": "Only require the radix parameter when necessary."
-                    }
-                  ]
+                  "$ref": "#/definitions/RadixType"
                 }
               ],
               "maxItems": 2,
@@ -4909,24 +4802,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "This is the default mode. It will enforce the shorthand syntax for React fragments, with one exception.\nKeys or attributes are not supported by the shorthand syntax, so the rule will not warn on standard-form fragments that use those.\n\nExamples of **incorrect** code for this rule:\n```jsx\n<React.Fragment><Foo /></React.Fragment>\n```\n\nExamples of **correct** code for this rule:\n```jsx\n<><Foo /></>\n```\n\n```jsx\n<React.Fragment key=\"key\"><Foo /></React.Fragment>\n```",
-                      "type": "string",
-                      "enum": [
-                        "syntax"
-                      ],
-                      "markdownDescription": "This is the default mode. It will enforce the shorthand syntax for React fragments, with one exception.\nKeys or attributes are not supported by the shorthand syntax, so the rule will not warn on standard-form fragments that use those.\n\nExamples of **incorrect** code for this rule:\n```jsx\n<React.Fragment><Foo /></React.Fragment>\n```\n\nExamples of **correct** code for this rule:\n```jsx\n<><Foo /></>\n```\n\n```jsx\n<React.Fragment key=\"key\"><Foo /></React.Fragment>\n```"
-                    },
-                    {
-                      "description": "This mode enforces the standard form for React fragments.\n\nExamples of **incorrect** code for this rule:\n```jsx\n<><Foo /></>\n```\n\nExamples of **correct** code for this rule:\n```jsx\n<React.Fragment><Foo /></React.Fragment>\n```\n\n```jsx\n<React.Fragment key=\"key\"><Foo /></React.Fragment>\n```",
-                      "type": "string",
-                      "enum": [
-                        "element"
-                      ],
-                      "markdownDescription": "This mode enforces the standard form for React fragments.\n\nExamples of **incorrect** code for this rule:\n```jsx\n<><Foo /></>\n```\n\nExamples of **correct** code for this rule:\n```jsx\n<React.Fragment><Foo /></React.Fragment>\n```\n\n```jsx\n<React.Fragment key=\"key\"><Foo /></React.Fragment>\n```"
-                    }
-                  ]
+                  "$ref": "#/definitions/FragmentMode"
                 }
               ],
               "maxItems": 2,
@@ -5068,24 +4944,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Allow `setState` calls in nested functions within `componentDidMount`, the default behavior.",
-                      "type": "string",
-                      "enum": [
-                        "allowed"
-                      ],
-                      "markdownDescription": "Allow `setState` calls in nested functions within `componentDidMount`, the default behavior."
-                    },
-                    {
-                      "description": "When set, also disallows `setState` calls in nested functions within `componentDidMount`.",
-                      "type": "string",
-                      "enum": [
-                        "disallow-in-func"
-                      ],
-                      "markdownDescription": "When set, also disallows `setState` calls in nested functions within `componentDidMount`."
-                    }
-                  ]
+                  "$ref": "#/definitions/NoDidMountSetStateConfig"
                 }
               ],
               "maxItems": 2,
@@ -5224,24 +5083,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Forbids any call to `this.setState` in `componentWillUpdate` outside of functions.",
-                      "type": "string",
-                      "enum": [
-                        "allowed"
-                      ],
-                      "markdownDescription": "Forbids any call to `this.setState` in `componentWillUpdate` outside of functions."
-                    },
-                    {
-                      "description": "Makes this rule more strict by disallowing calls to `this.setState`` even within functions.",
-                      "type": "string",
-                      "enum": [
-                        "disallow-in-func"
-                      ],
-                      "markdownDescription": "Makes this rule more strict by disallowing calls to `this.setState`` even within functions."
-                    }
-                  ]
+                  "$ref": "#/definitions/NoWillUpdateSetStateConfig"
                 }
               ],
               "maxItems": 2,
@@ -5281,11 +5123,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "string",
-                  "enum": [
-                    "always",
-                    "never"
-                  ]
+                  "$ref": "#/definitions/AlwaysNever"
                 }
               ],
               "maxItems": 2,
@@ -5354,11 +5192,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "string",
-                  "enum": [
-                    "always",
-                    "never"
-                  ]
+                  "$ref": "#/definitions/AlwaysNever"
                 }
               ],
               "maxItems": 2,
@@ -5511,24 +5345,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Enforce using readonly fields for literal values.\n\nExamples of **incorrect** code with this option:\n```ts\nclass C {\nget name() {\nreturn \"oxc\";\n}\n}\n```\n\nExamples of **correct** code with this option:\n```ts\nclass C {\nreadonly name = \"oxc\";\n}\n```",
-                      "type": "string",
-                      "enum": [
-                        "fields"
-                      ],
-                      "markdownDescription": "Enforce using readonly fields for literal values.\n\nExamples of **incorrect** code with this option:\n```ts\nclass C {\nget name() {\nreturn \"oxc\";\n}\n}\n```\n\nExamples of **correct** code with this option:\n```ts\nclass C {\nreadonly name = \"oxc\";\n}\n```"
-                    },
-                    {
-                      "description": "Enforce using getters for literal values.\n\nExamples of **incorrect** code with this option:\n```ts\nclass C {\nreadonly name = \"oxc\";\n}\n```\n\nExamples of **correct** code with this option:\n```ts\nclass C {\nget name() {\nreturn \"oxc\";\n}\n}\n```",
-                      "type": "string",
-                      "enum": [
-                        "getters"
-                      ],
-                      "markdownDescription": "Enforce using getters for literal values.\n\nExamples of **incorrect** code with this option:\n```ts\nclass C {\nreadonly name = \"oxc\";\n}\n```\n\nExamples of **correct** code with this option:\n```ts\nclass C {\nget name() {\nreturn \"oxc\";\n}\n}\n```"
-                    }
-                  ]
+                  "$ref": "#/definitions/ClassLiteralPropertyStyleOption"
                 }
               ],
               "maxItems": 2,
@@ -5551,24 +5368,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "When set to `record`, enforces the use of a `Record` for indexed object types, e.g. `Record<string, unknown>`.",
-                      "type": "string",
-                      "enum": [
-                        "record"
-                      ],
-                      "markdownDescription": "When set to `record`, enforces the use of a `Record` for indexed object types, e.g. `Record<string, unknown>`."
-                    },
-                    {
-                      "description": "When set to `index-signature`, enforces the use of indexed signature types, e.g. `{ [key: string]: unknown }`.",
-                      "type": "string",
-                      "enum": [
-                        "index-signature"
-                      ],
-                      "markdownDescription": "When set to `index-signature`, enforces the use of indexed signature types, e.g. `{ [key: string]: unknown }`."
-                    }
-                  ]
+                  "$ref": "#/definitions/ConsistentIndexedObjectStyleConfig"
                 }
               ],
               "maxItems": 2,
@@ -5611,24 +5411,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Prefer `interface` over `type` for object type definitions:\n\n```typescript\ninterface T {\nx: number;\n}\n```",
-                      "type": "string",
-                      "enum": [
-                        "interface"
-                      ],
-                      "markdownDescription": "Prefer `interface` over `type` for object type definitions:\n\n```typescript\ninterface T {\nx: number;\n}\n```"
-                    },
-                    {
-                      "description": "Prefer `type` over `interface` for object type definitions:\n\n```typescript\ntype T = { x: number };\n```",
-                      "type": "string",
-                      "enum": [
-                        "type"
-                      ],
-                      "markdownDescription": "Prefer `type` over `interface` for object type definitions:\n\n```typescript\ntype T = { x: number };\n```"
-                    }
-                  ]
+                  "$ref": "#/definitions/ConsistentTypeDefinitionsConfig"
                 }
               ],
               "maxItems": 2,
@@ -5751,24 +5534,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Enforce using property signature for functions. Use this to enforce maximum correctness together with TypeScript's strict mode.",
-                      "type": "string",
-                      "enum": [
-                        "property"
-                      ],
-                      "markdownDescription": "Enforce using property signature for functions. Use this to enforce maximum correctness together with TypeScript's strict mode."
-                    },
-                    {
-                      "description": "Enforce using method signature for functions. Use this if you aren't using TypeScript's strict mode and prefer this style.",
-                      "type": "string",
-                      "enum": [
-                        "method"
-                      ],
-                      "markdownDescription": "Enforce using method signature for functions. Use this if you aren't using TypeScript's strict mode and prefer this style."
-                    }
-                  ]
+                  "$ref": "#/definitions/MethodSignatureStyleConfig"
                 }
               ],
               "maxItems": 2,
@@ -6479,40 +6245,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Require `await` when returning Promises inside try/catch/finally blocks.\nThis ensures proper error handling and stack traces.",
-                      "type": "string",
-                      "enum": [
-                        "in-try-catch"
-                      ],
-                      "markdownDescription": "Require `await` when returning Promises inside try/catch/finally blocks.\nThis ensures proper error handling and stack traces."
-                    },
-                    {
-                      "description": "Require `await` before returning Promises in all cases.\nExample: `return await Promise.resolve()` is required.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Require `await` before returning Promises in all cases.\nExample: `return await Promise.resolve()` is required."
-                    },
-                    {
-                      "description": "Require `await` only when it affects error handling correctness.\nOnly flags cases where omitting await would change error handling behavior.",
-                      "type": "string",
-                      "enum": [
-                        "error-handling-correctness-only"
-                      ],
-                      "markdownDescription": "Require `await` only when it affects error handling correctness.\nOnly flags cases where omitting await would change error handling behavior."
-                    },
-                    {
-                      "description": "Disallow `await` before returning Promises in all cases.\nExample: `return Promise.resolve()` is required (no await).",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Disallow `await` before returning Promises in all cases.\nExample: `return Promise.resolve()` is required (no await)."
-                    }
-                  ]
+                  "$ref": "#/definitions/ReturnAwaitOption"
                 }
               ],
               "maxItems": 2,
@@ -6638,24 +6371,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Always require a Unicode BOM (Byte Order Mark) at the beginning of the file.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always require a Unicode BOM (Byte Order Mark) at the beginning of the file."
-                    },
-                    {
-                      "description": "Never allow a Unicode BOM (Byte Order Mark) at the beginning of the file.\nThis is the default option.",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Never allow a Unicode BOM (Byte Order Mark) at the beginning of the file.\nThis is the default option."
-                    }
-                  ]
+                  "$ref": "#/definitions/BomOptionType"
                 }
               ],
               "maxItems": 2,
@@ -7199,24 +6915,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Always enforce ternary usage when the branches can be safely merged.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always enforce ternary usage when the branches can be safely merged."
-                    },
-                    {
-                      "description": "Only enforce ternary usage when the condition and both branches are single-line.",
-                      "type": "string",
-                      "enum": [
-                        "only-single-line"
-                      ],
-                      "markdownDescription": "Only enforce ternary usage when the condition and both branches are single-line."
-                    }
-                  ]
+                  "$ref": "#/definitions/PreferTernaryOption"
                 }
               ],
               "maxItems": 2,
@@ -7242,24 +6941,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Never use a `./` prefix.",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Never use a `./` prefix."
-                    },
-                    {
-                      "description": "Always add a `./` prefix to the relative URL when possible.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always add a `./` prefix to the relative URL when possible."
-                    }
-                  ]
+                  "$ref": "#/definitions/RelativeUrlStyleConfig"
                 }
               ],
               "maxItems": 2,
@@ -7294,24 +6976,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Always require braces in case clauses (except empty cases).",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always require braces in case clauses (except empty cases)."
-                    },
-                    {
-                      "description": "Allow braces only when needed for scoping (e.g., variable or function declarations).",
-                      "type": "string",
-                      "enum": [
-                        "avoid"
-                      ],
-                      "markdownDescription": "Allow braces only when needed for scoping (e.g., variable or function declarations)."
-                    }
-                  ]
+                  "$ref": "#/definitions/SwitchCaseBracesConfig"
                 }
               ],
               "maxItems": 2,
@@ -7650,11 +7315,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "string",
-                  "enum": [
-                    "PascalCase",
-                    "kebab-case"
-                  ]
+                  "$ref": "#/definitions/CaseType"
                 }
               ],
               "maxItems": 2,
@@ -7674,32 +7335,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Enforces the use of a named TypeScript type or interface as the\nargument to `defineEmits`, e.g. `defineEmits<MyEmits>()`.",
-                      "type": "string",
-                      "enum": [
-                        "type-based"
-                      ],
-                      "markdownDescription": "Enforces the use of a named TypeScript type or interface as the\nargument to `defineEmits`, e.g. `defineEmits<MyEmits>()`."
-                    },
-                    {
-                      "description": "Enforces the use of an inline type literal as the argument to\n`defineEmits`, e.g. `defineEmits<{ (event: string): void }>()`.",
-                      "type": "string",
-                      "enum": [
-                        "type-literal"
-                      ],
-                      "markdownDescription": "Enforces the use of an inline type literal as the argument to\n`defineEmits`, e.g. `defineEmits<{ (event: string): void }>()`."
-                    },
-                    {
-                      "description": "Enforces the use of runtime declaration, where emits are declared\nusing an array or object, e.g. `defineEmits(['event1', 'event2'])`.",
-                      "type": "string",
-                      "enum": [
-                        "runtime"
-                      ],
-                      "markdownDescription": "Enforces the use of runtime declaration, where emits are declared\nusing an array or object, e.g. `defineEmits(['event1', 'event2'])`."
-                    }
-                  ]
+                  "$ref": "#/definitions/DeclarationStyle"
                 }
               ],
               "maxItems": 2,
@@ -7719,24 +7355,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Enforce type-based declaration.",
-                      "type": "string",
-                      "enum": [
-                        "type-based"
-                      ],
-                      "markdownDescription": "Enforce type-based declaration."
-                    },
-                    {
-                      "description": "Enforce runtime declaration.",
-                      "type": "string",
-                      "enum": [
-                        "runtime"
-                      ],
-                      "markdownDescription": "Enforce runtime declaration."
-                    }
-                  ]
+                  "$ref": "#/definitions/DeclarationStyle2"
                 }
               ],
               "maxItems": 2,
@@ -7779,24 +7398,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Require using the Promise returned by `nextTick`.",
-                      "type": "string",
-                      "enum": [
-                        "promise"
-                      ],
-                      "markdownDescription": "Require using the Promise returned by `nextTick`."
-                    },
-                    {
-                      "description": "Require passing a callback function to `nextTick`.",
-                      "type": "string",
-                      "enum": [
-                        "callback"
-                      ],
-                      "markdownDescription": "Require passing a callback function to `nextTick`."
-                    }
-                  ]
+                  "$ref": "#/definitions/NextTickOption"
                 }
               ],
               "maxItems": 2,

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -1657,24 +1657,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Prefer `import type { Foo } from 'foo'` for type imports.",
-                      "type": "string",
-                      "enum": [
-                        "prefer-top-level"
-                      ],
-                      "markdownDescription": "Prefer `import type { Foo } from 'foo'` for type imports."
-                    },
-                    {
-                      "description": "Prefer `import { type Foo } from 'foo'` for type imports.",
-                      "type": "string",
-                      "enum": [
-                        "prefer-inline"
-                      ],
-                      "markdownDescription": "Prefer `import { type Foo } from 'foo'` for type imports."
-                    }
-                  ]
+                  "$ref": "#/definitions/Mode"
                 }
               ],
               "maxItems": 2,
@@ -1706,24 +1689,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Forces absolute imports to be listed before relative imports.\n\nExamples of **incorrect** code for this rule with `\"absolute-first\"`:\n```js\nimport { x } from './foo';\nimport { y } from 'bar'\n```\n\nExamples of **correct** code for this rule with `\"absolute-first\"`:\n```js\nimport { y } from 'bar';\nimport { x } from './foo'\n```",
-                      "type": "string",
-                      "enum": [
-                        "absolute-first"
-                      ],
-                      "markdownDescription": "Forces absolute imports to be listed before relative imports.\n\nExamples of **incorrect** code for this rule with `\"absolute-first\"`:\n```js\nimport { x } from './foo';\nimport { y } from 'bar'\n```\n\nExamples of **correct** code for this rule with `\"absolute-first\"`:\n```js\nimport { y } from 'bar';\nimport { x } from './foo'\n```"
-                    },
-                    {
-                      "description": "Disables the absolute-first behavior.\nThis is the default behavior.",
-                      "type": "string",
-                      "enum": [
-                        "disable-absolute-first"
-                      ],
-                      "markdownDescription": "Disables the absolute-first behavior.\nThis is the default behavior."
-                    }
-                  ]
+                  "$ref": "#/definitions/AbsoluteFirst"
                 }
               ],
               "maxItems": 2,
@@ -1746,16 +1712,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "anyOf": [
-                    {
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 0.0
-                    },
-                    {
-                      "$ref": "#/definitions/MaxDependenciesConfig"
-                    }
-                  ]
+                  "$ref": "#/definitions/MaxDependenciesConfigJson"
                 }
               ],
               "maxItems": 2,
@@ -3025,24 +2982,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Allow assignments in conditional expressions only if they are\nenclosed in parentheses.",
-                      "type": "string",
-                      "enum": [
-                        "except-parens"
-                      ],
-                      "markdownDescription": "Allow assignments in conditional expressions only if they are\nenclosed in parentheses."
-                    },
-                    {
-                      "description": "Disallow all assignments in conditional expressions.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Disallow all assignments in conditional expressions."
-                    }
-                  ]
+                  "$ref": "#/definitions/NoCondAssignConfig"
                 }
               ],
               "maxItems": 2,
@@ -3734,24 +3674,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Disallow all assignments in return statements.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Disallow all assignments in return statements."
-                    },
-                    {
-                      "description": "Allow assignments in return statements only if they are enclosed in parentheses.\nThis is the default mode.",
-                      "type": "string",
-                      "enum": [
-                        "except-parens"
-                      ],
-                      "markdownDescription": "Allow assignments in return statements only if they are enclosed in parentheses.\nThis is the default mode."
-                    }
-                  ]
+                  "$ref": "#/definitions/NoReturnAssignMode"
                 }
               ],
               "maxItems": 2,
@@ -4019,14 +3942,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/VarsOption"
-                    },
-                    {
-                      "$ref": "#/definitions/NoUnusedVarsOptions"
-                    }
-                  ]
+                  "$ref": "#/definitions/NoUnusedVarsConfig"
                 }
               ],
               "maxItems": 2,
@@ -4182,9 +4098,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "description": "The rule takes a single string option: the name of the error parameter.\n\nThis can be either:\n- an exact name (e.g. `\"err\"`, `\"error\"`)\n- a regexp pattern (e.g. `\"^(err|error)$\"`)\n\nIf the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.\n\nDefault: `\"err\"`.",
-                  "type": "string",
-                  "markdownDescription": "The rule takes a single string option: the name of the error parameter.\n\nThis can be either:\n- an exact name (e.g. `\"err\"`, `\"error\"`)\n- a regexp pattern (e.g. `\"^(err|error)$\"`)\n\nIf the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.\n\nDefault: `\"err\"`."
+                  "$ref": "#/definitions/HandleCallbackErrConfig"
                 }
               ],
               "maxItems": 2,
@@ -4256,11 +4170,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "string",
-                  "enum": [
-                    "always",
-                    "never"
-                  ]
+                  "$ref": "#/definitions/AlwaysNever"
                 }
               ],
               "maxItems": 2,
@@ -4686,24 +4596,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Always require the radix parameter when using `parseInt()`.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always require the radix parameter when using `parseInt()`."
-                    },
-                    {
-                      "description": "Only require the radix parameter when necessary.",
-                      "type": "string",
-                      "enum": [
-                        "as-needed"
-                      ],
-                      "markdownDescription": "Only require the radix parameter when necessary."
-                    }
-                  ]
+                  "$ref": "#/definitions/RadixType"
                 }
               ],
               "maxItems": 2,
@@ -4913,24 +4806,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "This is the default mode. It will enforce the shorthand syntax for React fragments, with one exception.\nKeys or attributes are not supported by the shorthand syntax, so the rule will not warn on standard-form fragments that use those.\n\nExamples of **incorrect** code for this rule:\n```jsx\n<React.Fragment><Foo /></React.Fragment>\n```\n\nExamples of **correct** code for this rule:\n```jsx\n<><Foo /></>\n```\n\n```jsx\n<React.Fragment key=\"key\"><Foo /></React.Fragment>\n```",
-                      "type": "string",
-                      "enum": [
-                        "syntax"
-                      ],
-                      "markdownDescription": "This is the default mode. It will enforce the shorthand syntax for React fragments, with one exception.\nKeys or attributes are not supported by the shorthand syntax, so the rule will not warn on standard-form fragments that use those.\n\nExamples of **incorrect** code for this rule:\n```jsx\n<React.Fragment><Foo /></React.Fragment>\n```\n\nExamples of **correct** code for this rule:\n```jsx\n<><Foo /></>\n```\n\n```jsx\n<React.Fragment key=\"key\"><Foo /></React.Fragment>\n```"
-                    },
-                    {
-                      "description": "This mode enforces the standard form for React fragments.\n\nExamples of **incorrect** code for this rule:\n```jsx\n<><Foo /></>\n```\n\nExamples of **correct** code for this rule:\n```jsx\n<React.Fragment><Foo /></React.Fragment>\n```\n\n```jsx\n<React.Fragment key=\"key\"><Foo /></React.Fragment>\n```",
-                      "type": "string",
-                      "enum": [
-                        "element"
-                      ],
-                      "markdownDescription": "This mode enforces the standard form for React fragments.\n\nExamples of **incorrect** code for this rule:\n```jsx\n<><Foo /></>\n```\n\nExamples of **correct** code for this rule:\n```jsx\n<React.Fragment><Foo /></React.Fragment>\n```\n\n```jsx\n<React.Fragment key=\"key\"><Foo /></React.Fragment>\n```"
-                    }
-                  ]
+                  "$ref": "#/definitions/FragmentMode"
                 }
               ],
               "maxItems": 2,
@@ -5072,24 +4948,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Allow `setState` calls in nested functions within `componentDidMount`, the default behavior.",
-                      "type": "string",
-                      "enum": [
-                        "allowed"
-                      ],
-                      "markdownDescription": "Allow `setState` calls in nested functions within `componentDidMount`, the default behavior."
-                    },
-                    {
-                      "description": "When set, also disallows `setState` calls in nested functions within `componentDidMount`.",
-                      "type": "string",
-                      "enum": [
-                        "disallow-in-func"
-                      ],
-                      "markdownDescription": "When set, also disallows `setState` calls in nested functions within `componentDidMount`."
-                    }
-                  ]
+                  "$ref": "#/definitions/NoDidMountSetStateConfig"
                 }
               ],
               "maxItems": 2,
@@ -5228,24 +5087,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Forbids any call to `this.setState` in `componentWillUpdate` outside of functions.",
-                      "type": "string",
-                      "enum": [
-                        "allowed"
-                      ],
-                      "markdownDescription": "Forbids any call to `this.setState` in `componentWillUpdate` outside of functions."
-                    },
-                    {
-                      "description": "Makes this rule more strict by disallowing calls to `this.setState`` even within functions.",
-                      "type": "string",
-                      "enum": [
-                        "disallow-in-func"
-                      ],
-                      "markdownDescription": "Makes this rule more strict by disallowing calls to `this.setState`` even within functions."
-                    }
-                  ]
+                  "$ref": "#/definitions/NoWillUpdateSetStateConfig"
                 }
               ],
               "maxItems": 2,
@@ -5285,11 +5127,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "string",
-                  "enum": [
-                    "always",
-                    "never"
-                  ]
+                  "$ref": "#/definitions/AlwaysNever"
                 }
               ],
               "maxItems": 2,
@@ -5358,11 +5196,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "string",
-                  "enum": [
-                    "always",
-                    "never"
-                  ]
+                  "$ref": "#/definitions/AlwaysNever"
                 }
               ],
               "maxItems": 2,
@@ -5515,24 +5349,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Enforce using readonly fields for literal values.\n\nExamples of **incorrect** code with this option:\n```ts\nclass C {\nget name() {\nreturn \"oxc\";\n}\n}\n```\n\nExamples of **correct** code with this option:\n```ts\nclass C {\nreadonly name = \"oxc\";\n}\n```",
-                      "type": "string",
-                      "enum": [
-                        "fields"
-                      ],
-                      "markdownDescription": "Enforce using readonly fields for literal values.\n\nExamples of **incorrect** code with this option:\n```ts\nclass C {\nget name() {\nreturn \"oxc\";\n}\n}\n```\n\nExamples of **correct** code with this option:\n```ts\nclass C {\nreadonly name = \"oxc\";\n}\n```"
-                    },
-                    {
-                      "description": "Enforce using getters for literal values.\n\nExamples of **incorrect** code with this option:\n```ts\nclass C {\nreadonly name = \"oxc\";\n}\n```\n\nExamples of **correct** code with this option:\n```ts\nclass C {\nget name() {\nreturn \"oxc\";\n}\n}\n```",
-                      "type": "string",
-                      "enum": [
-                        "getters"
-                      ],
-                      "markdownDescription": "Enforce using getters for literal values.\n\nExamples of **incorrect** code with this option:\n```ts\nclass C {\nreadonly name = \"oxc\";\n}\n```\n\nExamples of **correct** code with this option:\n```ts\nclass C {\nget name() {\nreturn \"oxc\";\n}\n}\n```"
-                    }
-                  ]
+                  "$ref": "#/definitions/ClassLiteralPropertyStyleOption"
                 }
               ],
               "maxItems": 2,
@@ -5555,24 +5372,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "When set to `record`, enforces the use of a `Record` for indexed object types, e.g. `Record<string, unknown>`.",
-                      "type": "string",
-                      "enum": [
-                        "record"
-                      ],
-                      "markdownDescription": "When set to `record`, enforces the use of a `Record` for indexed object types, e.g. `Record<string, unknown>`."
-                    },
-                    {
-                      "description": "When set to `index-signature`, enforces the use of indexed signature types, e.g. `{ [key: string]: unknown }`.",
-                      "type": "string",
-                      "enum": [
-                        "index-signature"
-                      ],
-                      "markdownDescription": "When set to `index-signature`, enforces the use of indexed signature types, e.g. `{ [key: string]: unknown }`."
-                    }
-                  ]
+                  "$ref": "#/definitions/ConsistentIndexedObjectStyleConfig"
                 }
               ],
               "maxItems": 2,
@@ -5615,24 +5415,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Prefer `interface` over `type` for object type definitions:\n\n```typescript\ninterface T {\nx: number;\n}\n```",
-                      "type": "string",
-                      "enum": [
-                        "interface"
-                      ],
-                      "markdownDescription": "Prefer `interface` over `type` for object type definitions:\n\n```typescript\ninterface T {\nx: number;\n}\n```"
-                    },
-                    {
-                      "description": "Prefer `type` over `interface` for object type definitions:\n\n```typescript\ntype T = { x: number };\n```",
-                      "type": "string",
-                      "enum": [
-                        "type"
-                      ],
-                      "markdownDescription": "Prefer `type` over `interface` for object type definitions:\n\n```typescript\ntype T = { x: number };\n```"
-                    }
-                  ]
+                  "$ref": "#/definitions/ConsistentTypeDefinitionsConfig"
                 }
               ],
               "maxItems": 2,
@@ -5755,24 +5538,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Enforce using property signature for functions. Use this to enforce maximum correctness together with TypeScript's strict mode.",
-                      "type": "string",
-                      "enum": [
-                        "property"
-                      ],
-                      "markdownDescription": "Enforce using property signature for functions. Use this to enforce maximum correctness together with TypeScript's strict mode."
-                    },
-                    {
-                      "description": "Enforce using method signature for functions. Use this if you aren't using TypeScript's strict mode and prefer this style.",
-                      "type": "string",
-                      "enum": [
-                        "method"
-                      ],
-                      "markdownDescription": "Enforce using method signature for functions. Use this if you aren't using TypeScript's strict mode and prefer this style."
-                    }
-                  ]
+                  "$ref": "#/definitions/MethodSignatureStyleConfig"
                 }
               ],
               "maxItems": 2,
@@ -6483,40 +6249,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Require `await` when returning Promises inside try/catch/finally blocks.\nThis ensures proper error handling and stack traces.",
-                      "type": "string",
-                      "enum": [
-                        "in-try-catch"
-                      ],
-                      "markdownDescription": "Require `await` when returning Promises inside try/catch/finally blocks.\nThis ensures proper error handling and stack traces."
-                    },
-                    {
-                      "description": "Require `await` before returning Promises in all cases.\nExample: `return await Promise.resolve()` is required.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Require `await` before returning Promises in all cases.\nExample: `return await Promise.resolve()` is required."
-                    },
-                    {
-                      "description": "Require `await` only when it affects error handling correctness.\nOnly flags cases where omitting await would change error handling behavior.",
-                      "type": "string",
-                      "enum": [
-                        "error-handling-correctness-only"
-                      ],
-                      "markdownDescription": "Require `await` only when it affects error handling correctness.\nOnly flags cases where omitting await would change error handling behavior."
-                    },
-                    {
-                      "description": "Disallow `await` before returning Promises in all cases.\nExample: `return Promise.resolve()` is required (no await).",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Disallow `await` before returning Promises in all cases.\nExample: `return Promise.resolve()` is required (no await)."
-                    }
-                  ]
+                  "$ref": "#/definitions/ReturnAwaitOption"
                 }
               ],
               "maxItems": 2,
@@ -6642,24 +6375,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Always require a Unicode BOM (Byte Order Mark) at the beginning of the file.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always require a Unicode BOM (Byte Order Mark) at the beginning of the file."
-                    },
-                    {
-                      "description": "Never allow a Unicode BOM (Byte Order Mark) at the beginning of the file.\nThis is the default option.",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Never allow a Unicode BOM (Byte Order Mark) at the beginning of the file.\nThis is the default option."
-                    }
-                  ]
+                  "$ref": "#/definitions/BomOptionType"
                 }
               ],
               "maxItems": 2,
@@ -7203,24 +6919,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Always enforce ternary usage when the branches can be safely merged.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always enforce ternary usage when the branches can be safely merged."
-                    },
-                    {
-                      "description": "Only enforce ternary usage when the condition and both branches are single-line.",
-                      "type": "string",
-                      "enum": [
-                        "only-single-line"
-                      ],
-                      "markdownDescription": "Only enforce ternary usage when the condition and both branches are single-line."
-                    }
-                  ]
+                  "$ref": "#/definitions/PreferTernaryOption"
                 }
               ],
               "maxItems": 2,
@@ -7246,24 +6945,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Never use a `./` prefix.",
-                      "type": "string",
-                      "enum": [
-                        "never"
-                      ],
-                      "markdownDescription": "Never use a `./` prefix."
-                    },
-                    {
-                      "description": "Always add a `./` prefix to the relative URL when possible.",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always add a `./` prefix to the relative URL when possible."
-                    }
-                  ]
+                  "$ref": "#/definitions/RelativeUrlStyleConfig"
                 }
               ],
               "maxItems": 2,
@@ -7298,24 +6980,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Always require braces in case clauses (except empty cases).",
-                      "type": "string",
-                      "enum": [
-                        "always"
-                      ],
-                      "markdownDescription": "Always require braces in case clauses (except empty cases)."
-                    },
-                    {
-                      "description": "Allow braces only when needed for scoping (e.g., variable or function declarations).",
-                      "type": "string",
-                      "enum": [
-                        "avoid"
-                      ],
-                      "markdownDescription": "Allow braces only when needed for scoping (e.g., variable or function declarations)."
-                    }
-                  ]
+                  "$ref": "#/definitions/SwitchCaseBracesConfig"
                 }
               ],
               "maxItems": 2,
@@ -7654,11 +7319,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "string",
-                  "enum": [
-                    "PascalCase",
-                    "kebab-case"
-                  ]
+                  "$ref": "#/definitions/CaseType"
                 }
               ],
               "maxItems": 2,
@@ -7678,32 +7339,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Enforces the use of a named TypeScript type or interface as the\nargument to `defineEmits`, e.g. `defineEmits<MyEmits>()`.",
-                      "type": "string",
-                      "enum": [
-                        "type-based"
-                      ],
-                      "markdownDescription": "Enforces the use of a named TypeScript type or interface as the\nargument to `defineEmits`, e.g. `defineEmits<MyEmits>()`."
-                    },
-                    {
-                      "description": "Enforces the use of an inline type literal as the argument to\n`defineEmits`, e.g. `defineEmits<{ (event: string): void }>()`.",
-                      "type": "string",
-                      "enum": [
-                        "type-literal"
-                      ],
-                      "markdownDescription": "Enforces the use of an inline type literal as the argument to\n`defineEmits`, e.g. `defineEmits<{ (event: string): void }>()`."
-                    },
-                    {
-                      "description": "Enforces the use of runtime declaration, where emits are declared\nusing an array or object, e.g. `defineEmits(['event1', 'event2'])`.",
-                      "type": "string",
-                      "enum": [
-                        "runtime"
-                      ],
-                      "markdownDescription": "Enforces the use of runtime declaration, where emits are declared\nusing an array or object, e.g. `defineEmits(['event1', 'event2'])`."
-                    }
-                  ]
+                  "$ref": "#/definitions/DeclarationStyle"
                 }
               ],
               "maxItems": 2,
@@ -7723,24 +7359,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Enforce type-based declaration.",
-                      "type": "string",
-                      "enum": [
-                        "type-based"
-                      ],
-                      "markdownDescription": "Enforce type-based declaration."
-                    },
-                    {
-                      "description": "Enforce runtime declaration.",
-                      "type": "string",
-                      "enum": [
-                        "runtime"
-                      ],
-                      "markdownDescription": "Enforce runtime declaration."
-                    }
-                  ]
+                  "$ref": "#/definitions/DeclarationStyle2"
                 }
               ],
               "maxItems": 2,
@@ -7783,24 +7402,7 @@ expression: json
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "oneOf": [
-                    {
-                      "description": "Require using the Promise returned by `nextTick`.",
-                      "type": "string",
-                      "enum": [
-                        "promise"
-                      ],
-                      "markdownDescription": "Require using the Promise returned by `nextTick`."
-                    },
-                    {
-                      "description": "Require passing a callback function to `nextTick`.",
-                      "type": "string",
-                      "enum": [
-                        "callback"
-                      ],
-                      "markdownDescription": "Require passing a callback function to `nextTick`."
-                    }
-                  ]
+                  "$ref": "#/definitions/NextTickOption"
                 }
               ],
               "maxItems": 2,


### PR DESCRIPTION
This reduces the generated JSON schema, but increases the TS config generation. 
I think this is a good trade 🤞 