### PR TITLE
chore(deps): update mimalloc-safe to 0.1.62

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,7 @@ memchr = "2.7.6" # Fast byte searching
 miette = { package = "oxc-miette", version = "2.7.1", features = [
   "fancy-no-syscall",
 ] } # Error reporting
-mimalloc-safe = "0.1.61" # Fast allocator
+mimalloc-safe = "0.1.62" # Fast allocator
 nodejs-built-in-modules = "1.0.0" # Node.js built-in modules
 nonmax = "0.5.5" # Non-maximum numbers
 num-bigint = "0.4.6" # Big integers


### PR DESCRIPTION
See napi-rs/mimalloc-safe#71. This prepares us for mimalloc v3.

Although the version has already been updated in `Cargo.lock`, we should also update the version declared in `Cargo.toml`.