### PR TITLE
fix(oxfmt): avoid JS promise rejects for all TSFN call sites

### DIFF
--- a/apps/oxfmt/src-js/bindings.d.ts
+++ b/apps/oxfmt/src-js/bindings.d.ts
@@ -34,7 +34,7 @@ export declare const enum Severity {
  * # Panics
  * Panics if the current working directory cannot be determined.
  */
-export declare function format(filename: string, sourceText: string, options: any | undefined | null, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<FormatResult>
+export declare function format(filename: string, sourceText: string, options: any | undefined | null, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<FormatResult>
 
 export interface FormatResult {
   /** The formatted code. */
@@ -49,7 +49,7 @@ export interface FormatResult {
  * This API is specialized for JS/TS snippets embedded in non-JS files.
  * Unlike `format()`, it is called only for js-in-xxx `textToDoc()` flow.
  */
-export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<string | null>
+export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmtPluginOptionsJson: string, parentContext: string, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<string | null>
 
 /**
  * NAPI based JS CLI entry point.
@@ -67,4 +67,4 @@ export declare function jsTextToDoc(sourceExt: string, sourceText: string, oxfmt
  * - `mode`: If main logic will run in JS side, use this to indicate which mode
  * - `exitCode`: If main logic already ran in Rust side, return the exit code
  */
-export declare function runCli(args: Array<string>, loadJsConfigCb: (path: string) => Promise<any>, initExternalFormatterCb: (numThreads: number) => Promise<void>, formatFileCb: (options: Record<string, any>, code: string) => Promise<string>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<[string, number | undefined | null]>
+export declare function runCli(args: Array<string>, loadJsConfigCb: (path: string) => Promise<any>, initExternalFormatterCb: (numThreads: number) => Promise<void>, formatFileCb: (options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>, formatEmbeddedCb: (options: Record<string, any>, code: string) => Promise<string | null>, formatEmbeddedDocCb: (options: Record<string, any>, texts: string[]) => Promise<string[] | null>, sortTailwindcssClassesCb: (options: Record<string, any>, classes: string[]) => Promise<string[] | null>): Promise<[string, number | undefined | null]>

--- a/apps/oxfmt/src-js/cli/worker-proxy.ts
+++ b/apps/oxfmt/src-js/cli/worker-proxy.ts
@@ -1,4 +1,6 @@
 import Tinypool from "tinypool";
+import { toFormatFileResult, toNullable } from "../libs/napi-callbacks";
+import type { FormatFileResult } from "../libs/napi-callbacks";
 import type {
   FormatFileParam,
   FormatEmbeddedCodeParam,
@@ -31,65 +33,42 @@ export async function disposeExternalFormatter(): Promise<void> {
 
 // ---
 
-// Used for non-JS files formatting
-export async function formatFile(
+export function formatFile(
   options: FormatFileParam["options"],
   code: string,
-): Promise<string> {
-  return (
-    pool!
-      .run({ options, code } satisfies FormatFileParam, { name: "formatFile" })
-      // `tinypool` with `runtime: "child_process"` serializes Error as plain objects via IPC.
-      // (e.g. `{ name, message, stack, ... }`)
-      // And napi-rs converts unknown JS values to Rust Error by calling `String()` on them,
-      // which yields `"[object Object]"` for plain objects...
-      // So, this function reconstructs a proper `Error` instance so napi-rs can extract the message.
-      .catch((err) => {
-        if (err instanceof Error) throw err;
-        if (err !== null && typeof err === "object") {
-          const obj = err as { name: string; message: string };
-          const newErr = new Error(obj.message);
-          newErr.name = obj.name;
-          throw newErr;
-        }
-        throw new Error(String(err));
-      })
+): Promise<FormatFileResult> {
+  return toFormatFileResult(
+    pool!.run({ options, code } satisfies FormatFileParam, { name: "formatFile" }),
   );
 }
 
 // ---
 
-// All functions below are used for JS files with embedded code
-//
-// NOTE: These functions return `null` on error instead of throwing.
-// When errors were propagated as rejected JS promises, which become `napi::Error` values in Rust TSFN await paths.
-// In heavily concurrent runs, dropping those error values could reach `napi_reference_unref` during teardown and trigger V8 fatal checks.
-
-export async function formatEmbeddedCode(
+export function formatEmbeddedCode(
   options: FormatEmbeddedCodeParam["options"],
   code: string,
 ): Promise<string | null> {
-  return pool!
-    .run({ options, code } satisfies FormatEmbeddedCodeParam, { name: "formatEmbeddedCode" })
-    .catch(() => null);
+  return toNullable(
+    pool!.run({ options, code } satisfies FormatEmbeddedCodeParam, { name: "formatEmbeddedCode" }),
+  );
 }
 
-export async function formatEmbeddedDoc(
+export function formatEmbeddedDoc(
   options: FormatEmbeddedDocParam["options"],
   texts: string[],
 ): Promise<string[] | null> {
-  return pool!
-    .run({ options, texts } satisfies FormatEmbeddedDocParam, {
-      name: "formatEmbeddedDoc",
-    })
-    .catch(() => null);
+  return toNullable(
+    pool!.run({ options, texts } satisfies FormatEmbeddedDocParam, { name: "formatEmbeddedDoc" }),
+  );
 }
 
-export async function sortTailwindClasses(
+export function sortTailwindClasses(
   options: SortTailwindClassesArgs["options"],
   classes: string[],
 ): Promise<string[] | null> {
-  return pool!
-    .run({ classes, options } satisfies SortTailwindClassesArgs, { name: "sortTailwindClasses" })
-    .catch(() => null);
+  return toNullable(
+    pool!.run({ classes, options } satisfies SortTailwindClassesArgs, {
+      name: "sortTailwindClasses",
+    }),
+  );
 }

--- a/apps/oxfmt/src-js/index.ts
+++ b/apps/oxfmt/src-js/index.ts
@@ -7,6 +7,7 @@ import {
   formatEmbeddedDoc,
   sortTailwindClasses,
 } from "./libs/apis";
+import { toFormatFileResult, toNullable } from "./libs/napi-callbacks";
 // Types are auto-generated from the JSON Schema.
 import type {
   Oxfmtrc,
@@ -73,10 +74,10 @@ export async function format(fileName: string, sourceText: string, options?: For
     fileName,
     sourceText,
     options ?? {},
-    (options, code) => formatFile({ options, code }),
-    (options, code) => formatEmbeddedCode({ options, code }),
-    (options, texts) => formatEmbeddedDoc({ options, texts }),
-    (options, classes) => sortTailwindClasses({ options, classes }),
+    (options, code) => toFormatFileResult(formatFile({ options, code })),
+    (options, code) => toNullable(formatEmbeddedCode({ options, code })),
+    (options, texts) => toNullable(formatEmbeddedDoc({ options, texts })),
+    (options, classes) => toNullable(sortTailwindClasses({ options, classes })),
   );
 }
 
@@ -94,9 +95,9 @@ export async function jsTextToDoc(
     sourceText,
     oxfmtPluginOptionsJson,
     parentContext,
-    (_options, _code) => Promise.reject(/* Unreachable */),
-    (options, code) => formatEmbeddedCode({ options, code }),
-    (options, texts) => formatEmbeddedDoc({ options, texts }),
-    (options, classes) => sortTailwindClasses({ options, classes }),
+    () => toFormatFileResult(Promise.reject("formatFile is unavailable for jsTextToDoc")),
+    (options, code) => toNullable(formatEmbeddedCode({ options, code })),
+    (options, texts) => toNullable(formatEmbeddedDoc({ options, texts })),
+    (options, classes) => toNullable(sortTailwindClasses({ options, classes })),
   );
 }

--- a/apps/oxfmt/src-js/libs/napi-callbacks.ts
+++ b/apps/oxfmt/src-js/libs/napi-callbacks.ts
@@ -1,0 +1,44 @@
+/**
+ * Adapters that turn the throwing `apis.ts` functions into never-rejecting NAPI callbacks.
+ *
+ * Rust awaits these callbacks as Promises.
+ * A rejected Promise becomes a `napi::Error` whose drop can reach `napi_reference_unref`
+ * during ThreadsafeFunction teardown and trigger a V8 fatal crash sometimes.
+ *
+ * To avoid that, every callback handed to Rust must always resolve,
+ * carrying recoverable failures as data instead of rejecting.
+ */
+
+export type FormatFileResult = { ok: true; code: string } | { ok: false; error: string };
+
+/**
+ * Wrap a `formatFile`-shaped `Promise<string>` so it never rejects, preserving the error message.
+ */
+export async function toFormatFileResult(run: Promise<string>): Promise<FormatFileResult> {
+  return run
+    .then((code) => ({ ok: true as const, code }))
+    .catch((err) => ({ ok: false as const, error: errorToMessage(err) }));
+}
+
+/**
+ * Wrap a best-effort formatter `Promise<T>` so it never rejects, discarding the error as `null`.
+ * Used for embedded code / tailwind sorting, where Rust falls back to the original code on failure.
+ */
+export async function toNullable<T>(run: Promise<T>): Promise<T | null> {
+  return run.catch(() => null);
+}
+
+// Reproduces the `name: message` form (e.g. `SyntaxError: ...`) that Rust previously
+// received when these errors crossed the NAPI boundary as rejected Promises.
+function errorToMessage(err: unknown): string {
+  if (err instanceof Error) return String(err);
+  // `tinypool` with `runtime: "child_process"` serializes Error as a plain object
+  // via IPC (e.g. `{ name, message, stack, ... }`), so rebuild the form from it.
+  if (err !== null && typeof err === "object") {
+    const { name, message } = err as { name?: unknown; message?: unknown };
+    if (typeof message === "string") {
+      return typeof name === "string" && name.length > 0 ? `${name}: ${message}` : message;
+    }
+  }
+  return String(err);
+}

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -32,13 +32,13 @@ pub type JsInitExternalFormatterCb = ThreadsafeFunction<
 >;
 
 /// Type alias for the callback function signature.
-/// Takes (options, code) as arguments and returns formatted code.
+/// Takes (options, code) as arguments and returns a wrapped formatter result.
 /// The `options` object includes `parser` and `filepath` fields set by Rust side.
 pub type JsFormatFileCb = ThreadsafeFunction<
     // Input arguments
     FnArgs<(Value, String)>, // (options, code)
     // Return type (what JS function returns)
-    Promise<String>,
+    Promise<Value>,
     // Arguments (repeated)
     FnArgs<(Value, String)>,
     // Error status
@@ -442,7 +442,7 @@ fn wrap_format_file(
             let status = cb.call_async(FnArgs::from((options, code.to_string()))).await;
             match status {
                 Ok(promise) => match promise.await {
-                    Ok(formatted_code) => Ok(formatted_code),
+                    Ok(result) => parse_format_file_result(result),
                     Err(err) => Err(err.reason.clone()),
                 },
                 Err(err) => Err(err.reason.clone()),
@@ -451,6 +451,30 @@ fn wrap_format_file(
         drop(guard);
         result
     })
+}
+
+/// The `{ ok, code?, error? }` payload returned by the JS `formatFile` callback.
+/// Recoverable formatter errors are passed as data instead of a rejected Promise,
+/// so dropping a `napi::Error` never reaches `napi_reference_unref` during TSFN teardown.
+#[derive(serde::Deserialize)]
+struct FormatFileResult {
+    ok: bool,
+    code: Option<String>,
+    error: Option<String>,
+}
+
+fn parse_format_file_result(result: Value) -> Result<String, String> {
+    let result: FormatFileResult = serde_json::from_value(result)
+        .map_err(|_| "File formatting returned an unexpected result".to_string())?;
+
+    if result.ok {
+        result.code.ok_or_else(|| "File formatting result missing `code`".to_string())
+    } else {
+        Err(result
+            .error
+            .filter(|error| !error.is_empty())
+            .unwrap_or_else(|| "File formatting failed".to_string()))
+    }
 }
 
 /// Wrap JS `formatEmbeddedCode` callback as a normal Rust function.
@@ -535,4 +559,35 @@ fn wrap_sort_tailwind_classes(
         drop(guard);
         result
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::parse_format_file_result;
+
+    #[test]
+    fn parse_format_file_result_accepts_success_object() {
+        let result = parse_format_file_result(json!({ "ok": true, "code": "formatted" }));
+        assert_eq!(result, Ok("formatted".to_string()));
+    }
+
+    #[test]
+    fn parse_format_file_result_preserves_error_message() {
+        let result = parse_format_file_result(json!({ "ok": false, "error": "Unexpected token" }));
+        assert_eq!(result, Err("Unexpected token".to_string()));
+    }
+
+    #[test]
+    fn parse_format_file_result_falls_back_for_empty_error() {
+        let result = parse_format_file_result(json!({ "ok": false, "error": "" }));
+        assert_eq!(result, Err("File formatting failed".to_string()));
+    }
+
+    #[test]
+    fn parse_format_file_result_rejects_unexpected_shape() {
+        let result = parse_format_file_result(json!("formatted"));
+        assert_eq!(result, Err("File formatting returned an unexpected result".to_string()));
+    }
 }

--- a/apps/oxfmt/src/main_napi.rs
+++ b/apps/oxfmt/src/main_napi.rs
@@ -39,7 +39,9 @@ pub async fn run_cli(
     #[napi(ts_arg_type = "(path: string) => Promise<any>")] load_js_config_cb: JsLoadJsConfigCb,
     #[napi(ts_arg_type = "(numThreads: number) => Promise<void>")]
     init_external_formatter_cb: JsInitExternalFormatterCb,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    #[napi(
+        ts_arg_type = "(options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>"
+    )]
     format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,
@@ -155,7 +157,9 @@ pub async fn format(
     filename: String,
     source_text: String,
     options: Option<Value>,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    #[napi(
+        ts_arg_type = "(options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>"
+    )]
     format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,
@@ -195,7 +199,9 @@ pub async fn js_text_to_doc(
     source_text: String,
     oxfmt_plugin_options_json: String,
     parent_context: String,
-    #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string>")]
+    #[napi(
+        ts_arg_type = "(options: Record<string, any>, code: string) => Promise<{ ok: true; code: string; } | { ok: false; error: string }>"
+    )]
     format_file_cb: JsFormatFileCb,
     #[napi(ts_arg_type = "(options: Record<string, any>, code: string) => Promise<string | null>")]
     format_embedded_cb: JsFormatEmbeddedCb,

--- a/apps/oxfmt/test/api/basic.test.ts
+++ b/apps/oxfmt/test/api/basic.test.ts
@@ -38,6 +38,14 @@ describe("Format non-js", () => {
     );
     expect(result.errors).toStrictEqual([]);
   });
+
+  it("should surface Prettier parse errors as-is", async () => {
+    const brokenVue = `<template><div></template>`;
+    const result = await format("broken.vue", brokenVue, {});
+
+    expect(result.code).toBe(brokenVue);
+    expect(result.errors[0]?.message).toMatch(/Unexpected closing tag/);
+  });
 });
 
 describe("Format empty", () => {


### PR DESCRIPTION
Fixes #20525, (thanks @oxura !)

```sh
# Many files that route to the Prettier `formatFile` callback and fail to parse
mkdir -p /tmp/repro
for i in $(seq 1 500); do printf '<template><div></template>' > /tmp/repro/broken$i.vue; done

# Run repeatedly with default concurrency
for run in $(seq 1 10); do node apps/oxfmt/dist/cli.js --write /tmp/repro; done
```

Within a few runs it crashes non-deterministically (exit codes varied: 133 / 138 / 139, and sometimes 2 = clean error report), with the same fatal as #20525:

```
# Fatal error in , line 0
# Check failed: object_ != kGlobalHandleZapValue.   (or: node->IsInUse())
...
napi_reference_unref
<napi::error::Error as ...Drop>::drop
core::ptr::drop_in_place<napi::error::Error>
oxfmt::core::external_formatter::wrap_format_file::{{closure}}
```

Each broken file makes the `formatFile` callback reject; the resulting `napi::Error` is dropped on the TSFN await path and reaches `napi_reference_unref` during teardown → V8 fatal check.

After this fix (callback resolves errors as data), the same workload runs clean.


