### PR TITLE
chore(oxfmt): update svelte@5.56 to support declaration tags

### DIFF
--- a/apps/oxfmt/package.json
+++ b/apps/oxfmt/package.json
@@ -34,7 +34,7 @@
     "diff": "^9.0.0",
     "execa": "^9.6.0",
     "json-schema-to-typescript": "catalog:",
-    "svelte": "^5.55.5",
+    "svelte": "^5.56.2",
     "tsdown": "catalog:",
     "vite-plus": "catalog:",
     "vitest": "catalog:",

--- a/apps/oxfmt/test/api/__snapshots__/svelte.test.ts.snap
+++ b/apps/oxfmt/test/api/__snapshots__/svelte.test.ts.snap
@@ -78,3 +78,12 @@ exports[`Svelte support > Template section > should sort Tailwind classes in tem
 {/each}
 "
 `;
+
+exports[`Svelte support > should format Svelte 5 declaration tags 1`] = `
+"{#each boxes as box}
+  {const area = box.width * box.height}
+  {const label = \`\${box.width} x \${box.height} = \${area}\`}
+  <p>{label}</p>
+{/each}
+"
+`;

--- a/apps/oxfmt/test/api/svelte.test.ts
+++ b/apps/oxfmt/test/api/svelte.test.ts
@@ -171,4 +171,16 @@ let n: number = $state(0);
       expect(result.code).toMatchSnapshot();
     });
   });
+
+  it("should format Svelte 5 declaration tags", async () => {
+    const input = `{#each boxes as box}
+{const area = box.width * box.height}
+{const label = \`\${box.width} x \${box.height} = \${area}\`}
+<p>{label}</p>
+{/each}
+`;
+    const result = await format("App.svelte", input, { svelte: {} });
+    expect(result.errors).toStrictEqual([]);
+    expect(result.code).toMatchSnapshot();
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,7 @@ importers:
         specifier: 'catalog:'
         version: 15.0.4
       svelte:
-        specifier: ^5.55.5
+        specifier: ^5.56.2
         version: 5.56.2(@typescript-eslint/types@8.60.1)
       tsdown:
         specifier: 'catalog:'


### PR DESCRIPTION
Follow up on #23087 + #22993, thanks @firatciftci !

NOTE: This is internal updates. If users want it, need to update `svelte` deps by yourself.