### PR TITLE
fix(codegen): parenthesize TS-cast assignment targets

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2054,11 +2054,12 @@ impl Gen for AssignmentTarget<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         match self {
             match_simple_assignment_target!(Self) => {
-                self.to_simple_assignment_target().print_expr(
-                    p,
-                    Precedence::Comma,
-                    Context::empty(),
-                );
+                let precedence = match self {
+                    Self::TSAsExpression(_) | Self::TSSatisfiesExpression(_) => Precedence::Compare,
+                    Self::TSTypeAssertion(_) => Precedence::Prefix,
+                    _ => Precedence::Comma,
+                };
+                self.to_simple_assignment_target().print_expr(p, precedence, Context::empty());
             }
             match_assignment_target_pattern!(Self) => {
                 self.to_assignment_target_pattern().print(p, ctx);

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -441,3 +441,19 @@ fn type_codegen_with_preserve_parens_off() {
         parse_options,
     );
 }
+
+#[test]
+fn ts_cast_assignment_target_is_parenthesized() {
+    test_same("(foo as Bar) = baz;\n");
+    test_same("(foo satisfies Bar) = baz;\n");
+    test_same("(foo.bar as Bar) = baz;\n");
+    test_same("(foo[key] as Bar) = baz;\n");
+    test_options_with_source_type(
+        "(<Bar>foo) = baz;\n",
+        "(<Bar>foo) = baz;\n",
+        SourceType::ts(),
+        default_options(),
+    );
+    test_idempotency("(foo as Bar) = baz");
+    test_idempotency("(foo satisfies Bar) = baz");
+}


### PR DESCRIPTION
A TypeScript wrapper used as an assignment target — `(x as T) = v`, `(x satisfies T) = v`, `(<T>x) = v` — must keep its parentheses, otherwise codegen emits invalid output such as `x as T = v`.

`AssignmentTarget`'s codegen printed the simple target at `Precedence::Comma` (1), too low to make the wrapper parenthesize itself: `TSAsExpression` / `TSSatisfiesExpression` wrap at `>= Compare` (13) and `TSTypeAssertion` at `>= Prefix` (18). So the parentheses were dropped and the output no longer re-parsed.

It now passes the minimal precedence that forces each wrapper to wrap — `Compare` for `as` / `satisfies`, `Prefix` for the angle-bracket type assertion.

Surfaced while round-tripping code through `oxc_react_compiler`, but it is a general codegen bug affecting any TS-cast assignment target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
