### PR TITLE
fix(ast): type binding node `typeAnnotation` as `TSTypeAnnotation | null`

### DIFF
--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -82,7 +82,7 @@ export interface BindingIdentifier extends Span {
   decorators?: [];
   name: string;
   optional?: false;
-  typeAnnotation?: null;
+  typeAnnotation?: TSTypeAnnotation | null;
   parent: Node;
 }
 
@@ -613,7 +613,7 @@ export interface ObjectPattern extends Span {
   decorators?: [];
   properties: Array<BindingProperty | BindingRestElement>;
   optional?: false;
-  typeAnnotation?: null;
+  typeAnnotation?: TSTypeAnnotation | null;
   parent: Node;
 }
 
@@ -634,7 +634,7 @@ export interface ArrayPattern extends Span {
   decorators?: [];
   elements: Array<BindingPattern | BindingRestElement | null>;
   optional?: false;
-  typeAnnotation?: null;
+  typeAnnotation?: TSTypeAnnotation | null;
   parent: Node;
 }
 
@@ -643,7 +643,7 @@ export interface BindingRestElement extends Span {
   decorators?: [];
   argument: BindingPattern;
   optional?: false;
-  typeAnnotation?: null;
+  typeAnnotation?: TSTypeAnnotation | null;
   value?: null;
   parent: Node;
 }

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -225,7 +225,7 @@ pub struct IdentifierReference<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree, UnstableAddress)]
 #[estree(
     rename = "Identifier",
-    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsTypeAnnotationOrNull),
     field_order(decorators, name, optional, typeAnnotation, span),
 )]
 pub struct BindingIdentifier<'a> {
@@ -1539,7 +1539,7 @@ pub struct AssignmentPattern<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree, UnstableAddress)]
 #[estree(
-    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsTypeAnnotationOrNull),
     field_order(decorators, properties, optional, typeAnnotation, span),
 )]
 pub struct ObjectPattern<'a> {
@@ -1574,7 +1574,7 @@ pub struct BindingProperty<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree, UnstableAddress)]
 #[estree(
-    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsTypeAnnotationOrNull),
     field_order(decorators, elements, optional, typeAnnotation, span),
 )]
 pub struct ArrayPattern<'a> {
@@ -1599,7 +1599,7 @@ pub struct ArrayPattern<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree, UnstableAddress)]
 #[estree(
     rename = "RestElement",
-    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull, value = TsNull),
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsTypeAnnotationOrNull, value = TsNull),
     field_order(decorators, argument, optional, typeAnnotation, value, span),
 )]
 pub struct BindingRestElement<'a> {

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -102,7 +102,10 @@ impl ESTree for BindingIdentifier<'_> {
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("name", &self.name);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
-        state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_ts_field(
+            "typeAnnotation",
+            &crate::serialize::basic::TsTypeAnnotationOrNull(self),
+        );
         state.serialize_span(self.span);
         state.end();
     }
@@ -1218,7 +1221,10 @@ impl ESTree for ObjectPattern<'_> {
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("properties", &Concat2(&self.properties, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
-        state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_ts_field(
+            "typeAnnotation",
+            &crate::serialize::basic::TsTypeAnnotationOrNull(self),
+        );
         state.serialize_span(self.span);
         state.end();
     }
@@ -1247,7 +1253,10 @@ impl ESTree for ArrayPattern<'_> {
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("elements", &Concat2(&self.elements, &self.rest));
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
-        state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_ts_field(
+            "typeAnnotation",
+            &crate::serialize::basic::TsTypeAnnotationOrNull(self),
+        );
         state.serialize_span(self.span);
         state.end();
     }
@@ -1260,7 +1269,10 @@ impl ESTree for BindingRestElement<'_> {
         state.serialize_ts_field("decorators", &crate::serialize::basic::TsEmptyArray(self));
         state.serialize_field("argument", &self.argument);
         state.serialize_ts_field("optional", &crate::serialize::basic::TsFalse(self));
-        state.serialize_ts_field("typeAnnotation", &crate::serialize::basic::TsNull(self));
+        state.serialize_ts_field(
+            "typeAnnotation",
+            &crate::serialize::basic::TsTypeAnnotationOrNull(self),
+        );
         state.serialize_ts_field("value", &crate::serialize::basic::TsNull(self));
         state.serialize_span(self.span);
         state.end();

--- a/crates/oxc_ast/src/serialize/basic.rs
+++ b/crates/oxc_ast/src/serialize/basic.rs
@@ -24,6 +24,23 @@ impl<T> ESTree for TsNull<T> {
     }
 }
 
+/// Serialized as `null`, but typed as `TSTypeAnnotation | null`. Field only present in TS-ESTree AST.
+///
+/// Used for binding-pattern nodes (e.g. `BindingIdentifier`, `ObjectPattern`) whose `typeAnnotation`
+/// is `null` when the node is serialized standalone, but is populated with a real `TSTypeAnnotation`
+/// by the parent converter (`BindingPatternKindAndTsFields`) when the binding is annotated, as in
+/// `const x: string = ""`.
+#[ast_meta]
+#[estree(ts_type = "TSTypeAnnotation | null", raw_deser = "null", raw_deser_inline)]
+#[ts]
+pub struct TsTypeAnnotationOrNull<T>(pub T);
+
+impl<T> ESTree for TsTypeAnnotationOrNull<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        Null(()).serialize(serializer);
+    }
+}
+
 /// Serialized as `true`.
 #[ast_meta]
 #[estree(ts_type = "true", raw_deser = "true", raw_deser_inline)]

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -75,7 +75,7 @@ export interface BindingIdentifier extends Span {
   decorators?: [];
   name: string;
   optional?: false;
-  typeAnnotation?: null;
+  typeAnnotation?: TSTypeAnnotation | null;
   parent?: Node;
 }
 
@@ -606,7 +606,7 @@ export interface ObjectPattern extends Span {
   decorators?: [];
   properties: Array<BindingProperty | BindingRestElement>;
   optional?: false;
-  typeAnnotation?: null;
+  typeAnnotation?: TSTypeAnnotation | null;
   parent?: Node;
 }
 
@@ -627,7 +627,7 @@ export interface ArrayPattern extends Span {
   decorators?: [];
   elements: Array<BindingPattern | BindingRestElement | null>;
   optional?: false;
-  typeAnnotation?: null;
+  typeAnnotation?: TSTypeAnnotation | null;
   parent?: Node;
 }
 
@@ -636,7 +636,7 @@ export interface BindingRestElement extends Span {
   decorators?: [];
   argument: BindingPattern;
   optional?: false;
-  typeAnnotation?: null;
+  typeAnnotation?: TSTypeAnnotation | null;
   value?: null;
   parent?: Node;
 }


### PR DESCRIPTION
Closes #22134

## Problem

The generated parser TypeScript types declare `typeAnnotation` as `null` for binding nodes, but the parser emits a real `TSTypeAnnotation` at runtime when the binding is annotated:

```ts
const x: string = "foo";
// x.typeAnnotation.typeAnnotation.type === "TSStringKeyword" at runtime,
// but types.d.ts said `typeAnnotation?: null`
```

This is a generated-type gap, not a runtime bug. A `BindingIdentifier` has no `type_annotation` field of its own — the annotation is stored on the parent (`VariableDeclarator`, `FormalParameter`, `CatchParameter`) and hoisted onto the node during serialization by `BindingPatternKindAndTsFields`. The `add_fields(typeAnnotation = TsNull)` placeholder (`ts_type = "null"`) only reflects the standalone case (function/class `id`, import `local`), where `null` is correct.

## Fix

Add a `TsTypeAnnotationOrNull` meta-type that serializes/deserializes exactly like `TsNull` but is typed `TSTypeAnnotation | null`, and use it for the four nodes that can carry a hoisted annotation:

- `BindingIdentifier` — `const x: string`, `function f(a: string)`, `catch (e: unknown)`
- `ObjectPattern` — `const { a }: T = obj`
- `ArrayPattern` — `const [a]: T = arr`
- `BindingRestElement` — `function f(...rest: T[])`

Left as `null` (cannot carry an annotation): `IdentifierReference`, `IdentifierName`, `LabelIdentifier`, `AssignmentPattern` (its own annotation is always `null`; the annotation goes on `left`), and the `AssignmentTarget*` nodes (expression LHS, never annotated).

This lines up with the `typescript-estree` shape the parser targets, where the identifier node declares `typeAnnotation: TSTypeAnnotation | undefined`.

## Notes

- **Type-only change.** `TsTypeAnnotationOrNull::serialize` is byte-identical to `TsNull::serialize`, so runtime serialization and the raw-transfer deserializer are unchanged — no conformance/snapshot movement.
- Generated files (`derive_estree.rs`, `npm/oxc-types/types.d.ts`, `apps/oxlint/src-js/generated/types.d.ts`) regenerated via `just ast`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)