### PR TITLE
perf(parser): peek instead of checkpoint/rewind for `export default` modifier

### DIFF
--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -697,34 +697,33 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let function_span = self.start_span();
 
-        let checkpoint = self.checkpoint();
-        let mut is_abstract = false;
-        let mut is_async = false;
-        let mut is_interface = false;
-
-        match self.cur_kind() {
-            Kind::Abstract => is_abstract = true,
-            Kind::Async => is_async = true,
-            Kind::Interface => is_interface = true,
-            _ => {}
-        }
-
-        if is_abstract || is_async || is_interface {
+        // ExportDeclaration :
+        //   export default HoistableDeclaration
+        //   export default ClassDeclaration
+        //   export default [lookahead ∉ { function, async [no LineTerminator here] function, class }]
+        //                  AssignmentExpression ;
+        // <https://tc39.es/ecma262/#prod-ExportDeclaration>
+        //
+        // `abstract`/`interface` (TS) and `async` are contextual keywords, so each can be the start
+        // of the `AssignmentExpression` (`export default async;`). Peek the token after the keyword
+        // to apply the lookahead restriction without consuming it, committing only when it confirms
+        // a declaration. `[no LineTerminator here]` maps to `!next.is_on_new_line()`.
+        let kind = self.cur_kind();
+        if matches!(kind, Kind::Abstract | Kind::Async | Kind::Interface) {
             let modifier_span = self.start_span();
-            self.bump_any();
-            let cur_token = self.cur_token();
-            let kind = cur_token.kind();
-            if !cur_token.is_on_new_line() {
-                // export default abstract class ...
-                if is_abstract && kind == Kind::Class {
+            let next = self.lexer.peek_token();
+            if !next.is_on_new_line() {
+                // export default abstract class C {}
+                if kind == Kind::Abstract && next.kind() == Kind::Class {
+                    self.bump_any();
                     let modifiers = Modifiers::new_single(ModifierKind::Abstract, modifier_span);
                     return ExportDefaultDeclarationKind::ClassDeclaration(
                         self.parse_class_declaration(decl_span, &modifiers, decorators),
                     );
                 }
-
-                // export default async function ...
-                if is_async && kind == Kind::Function {
+                // export default async function f() {}
+                if kind == Kind::Async && next.kind() == Kind::Function {
+                    self.bump_any();
                     for decorator in &decorators {
                         self.error(diagnostics::decorators_are_not_valid_here(decorator.span));
                     }
@@ -738,9 +737,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     }
                     return ExportDefaultDeclarationKind::FunctionDeclaration(func);
                 }
-
-                // export default interface ...
-                if is_interface {
+                // export default interface I {}
+                if kind == Kind::Interface {
+                    self.bump_any();
                     for decorator in &decorators {
                         self.error(diagnostics::decorators_are_not_valid_here(decorator.span));
                     }
@@ -751,11 +750,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     }
                 }
             }
-            self.rewind(checkpoint);
+            // Used as an identifier (`export default async;`); nothing consumed, so fall through.
         }
 
         let kind = self.cur_kind();
-        // export default class ...
+        // export default class C {}
         if kind == Kind::Class {
             return ExportDefaultDeclarationKind::ClassDeclaration(self.parse_class_declaration(
                 decl_span,
@@ -768,7 +767,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::decorators_are_not_valid_here(decorator.span));
         }
 
-        // export default function ...
+        // export default function f() {}
         if kind == Kind::Function {
             let mut func = self.parse_function_impl(
                 function_span,
@@ -781,7 +780,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return ExportDefaultDeclarationKind::FunctionDeclaration(func);
         }
 
-        // export default expr
+        // export default 1 + 1;
         let decl = ExportDefaultDeclarationKind::from(self.parse_assignment_expression_or_higher());
         self.asi();
         decl


### PR DESCRIPTION
## What

`parse_export_default_declaration_kind` took a parser-level `checkpoint()` and consumed the contextual keyword (`abstract`/`async`/`interface`) with `bump_any()` *before* knowing whether it begins a declaration, then `rewind`-ed to un-consume it when the keyword turned out to be an identifier expression (`export default async;`, `export default abstract + 1`).

## Why it's removable

- The disambiguation is single-token lookahead, so `self.lexer.peek_token()` answers it without consuming the modifier.
- No diagnostics were ever discarded by the rewind: the only `self.error(...)` calls on the speculative span live in the `async function` and `interface` branches, both of which `return` (commit) and never reach the rewind. `parse_ts_interface_declaration` always returns `Declaration::TSInterfaceDeclaration`, so its `if let` never fails. The rewind only ever un-consumed a single token.

## Change

Peek the following token, consume the modifier only on the commit branches, and fall through to the expression parse otherwise. This drops the parser-level `checkpoint()`/`rewind()` — including the fragile `fatal_error.take()` that was dropped on the commit paths — and only pays a lexer-level peek when the token actually is a contextual keyword.

Behavior-preserving:
- `cargo coverage -- parser` — test262 100%, snapshots unchanged.
- `just allocs` — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)