### PR TITLE
refactor(semantic): remove dead check_object_property accessor check

### DIFF
--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -87,9 +87,6 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
         AstKind::MethodDefinition(method) => {
             ts::check_method_definition(method, ctx);
         }
-        AstKind::ObjectProperty(prop) => {
-            ts::check_object_property(prop, ctx);
-        }
         AstKind::Super(sup) => js::check_super(sup, ctx),
 
         AstKind::FormalParameters(params) => {

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -255,15 +255,6 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
     }
 }
 
-pub fn check_object_property(prop: &ObjectProperty, ctx: &SemanticBuilder<'_>) {
-    if let Expression::FunctionExpression(func) = &prop.value
-        && prop.kind.is_accessor()
-        && matches!(func.r#type, FunctionType::TSEmptyBodyFunctionExpression)
-    {
-        ctx.error(diagnostics::accessor_without_body(prop.key.span()));
-    }
-}
-
 pub fn check_for_statement_left(left: &ForStatementLeft, is_for_in: bool, ctx: &SemanticBuilder) {
     let ForStatementLeft::VariableDeclaration(decls) = left else {
         return;


### PR DESCRIPTION
## What

Removes `check_object_property`, which reported *"Getters and setters must have an implementation"* for an object-literal accessor whose value is a `TSEmptyBodyFunctionExpression`. **That condition is unreachable.**

## Why it's dead

Object getters/setters are parsed via `parse_method(FunctionKind::ObjectMethod)`. In `parse_function`:

- A missing body for an `ObjectMethod` is a **fatal error** (`expect_function_body`) that returns *before* the function type is ever set to `TSEmptyBodyFunctionExpression`.
- On the fatal-error recovery path, the dummy `Function` is created with `FunctionType::FunctionDeclaration` (see `derive_dummy.rs`), which also fails the `matches!(func.r#type, TSEmptyBodyFunctionExpression)` guard.

So an object accessor without a body only ever produces *"Expected function body"* — verified both by reading the code and by running the `oxc_semantic` example on `const o = { get x() , set y(v) }`, which emits only that diagnostic.

Class accessors are a separate path handled by `check_method_definition`, which still uses the `accessor_without_body` diagnostic — so the diagnostic itself is retained.

## Verification

- Parser and semantic conformance unchanged (100%), no snapshot diff.
- `oxc_semantic` test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)