### PR TITLE
fix(benchmark): build AstNodes store for react_compiler bench

### DIFF
--- a/tasks/benchmark/benches/react_compiler.rs
+++ b/tasks/benchmark/benches/react_compiler.rs
@@ -28,7 +28,11 @@ fn bench_react_compiler(criterion: &mut Criterion) {
                 // reads them and allocates the compiled program in the same arena.
                 let ParserReturn { program, .. } =
                     Parser::new(&allocator, source_text, source_type).parse();
-                let semantic = SemanticBuilder::new().build(&program).semantic;
+                let semantic = SemanticBuilder::new()
+                    .with_build_nodes(true)
+                    .with_enum_eval(true)
+                    .build(&program)
+                    .semantic;
 
                 runner.run(|| transform(&program, &semantic, &allocator, options.clone()));
             });


### PR DESCRIPTION
## What

The `Bench react_compiler` job on `main` panics:

```
thread 'main' panicked at oxc_index-5.0.0/src/indexing.rs:38:10:
index out of bounds: the len is 0 but the index is 2
```

[Failing run.](https://github.com/oxc-project/oxc/actions/runs/27154333851/job/80153249638)

## Why

#23005 made the full `AstNodes` store opt-in via `SemanticBuilder::with_build_nodes(true)` (default now off). The react compiler reads `semantic.nodes()` in `convert_scope.rs`, so it needs the store.

That PR updated every call site that feeds `transform` — `transform_source`, `lint_source`, `run`, and the example — to enable `with_build_nodes(true)` and `with_enum_eval(true)`, but missed this benchmark. With nodes off, `semantic.nodes()` is an empty `IndexVec` and the first `NodeId` access panics. PR CI didn't catch it because the benchmark only runs on `main`.

## How

Match the other call sites: enable `with_build_nodes(true)` and `with_enum_eval(true)` in the benchmark's `SemanticBuilder`.

Verified locally by building with `--features react_compiler` and running the bench across all 5 inputs (RadixUIAdoptionSection.jsx, react.development.js, App.tsx, binder.ts, kitchen-sink.tsx) — all complete, no panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)