### PR TITLE
fix(parser): avoid TS1477 for parenthesized instantiation expressions

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -304,6 +304,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.options.preserve_parens {
             self.ast.expression_parenthesized(self.end_span(span), expression)
         } else {
+            // `ParenthesizedExpression` wrapper is dropped here; record the parenthesization so
+            // the TS1477 check (`is_unparenthesized_instantiation_expression`) can still tell
+            // `(Foo<Bar>).baz` (valid) apart from `Foo<Bar>.baz` (invalid).
+            if let Expression::TSInstantiationExpression(expr) = &expression {
+                self.state.parenthesized_instantiation_expr.insert(expr.span.start);
+            }
             expression
         }
     }
@@ -796,6 +802,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ast.expression_super(span)
     }
 
+    /// Whether `lhs` is an instantiation expression not wrapped in parentheses, which cannot be
+    /// followed by a property access (TS1477). The parenthesized case `(Foo<Bar>)` is allowed;
+    /// with `preserve_parens: false` it has no wrapper node, so consult the record left by
+    /// `parse_paren_expression`.
+    fn is_unparenthesized_instantiation_expression(&self, lhs: &Expression<'a>) -> bool {
+        let Expression::TSInstantiationExpression(expr) = lhs else { return false };
+        !self.state.parenthesized_instantiation_expr.contains(&expr.span.start)
+    }
+
     /// parse rhs of a member expression, starting from lhs
     fn parse_member_expression_rest(
         &mut self,
@@ -840,7 +855,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             };
 
             if is_property_access {
-                if matches!(lhs, Expression::TSInstantiationExpression(_)) {
+                if self.is_unparenthesized_instantiation_expression(&lhs) {
                     self.error(
                         diagnostics::ts_instantiation_expression_cannot_be_followed_by_property_access(
                             self.end_span(lhs_span),
@@ -852,7 +867,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
 
             if (question_dot || !self.ctx.has_decorator()) && self.at(Kind::LBrack) {
-                if matches!(lhs, Expression::TSInstantiationExpression(_)) {
+                if self.is_unparenthesized_instantiation_expression(&lhs) {
                     self.error(
                         diagnostics::ts_instantiation_expression_cannot_be_followed_by_property_access(
                             self.end_span(lhs_span),

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -1038,6 +1038,57 @@ mod test {
     }
 
     #[test]
+    fn parenthesized_instantiation_expression_member_access() {
+        // A parenthesized instantiation expression may be followed by a property access
+        // (`(Foo<Bar>).baz`), unlike a bare one (`Foo<Bar>.baz`, TS1477). This must hold even
+        // with `preserve_parens: false`, which drops the `ParenthesizedExpression` wrapper.
+        let allocator = Allocator::default();
+        let source_type = SourceType::default().with_typescript(true);
+        let opts = ParseOptions { preserve_parens: false, ..ParseOptions::default() };
+
+        for source in [
+            "(Foo<Bar>).findOne()",
+            "(Foo<Bar>)[\"findOne\"]",
+            "(Foo<Bar>)?.findOne",
+            "(Foo<Bar>)?.[\"findOne\"]",
+            // Chained access: only the innermost expr is exempt, but after `.a` the lhs is no
+            // longer an instantiation expression, so `.b` is fine too.
+            "(Foo<Bar>).a.b",
+            // Redundant parens collapse to the same inner expr under `preserve_parens: false`.
+            "((Foo<Bar>)).findOne()",
+            // Call/`new` callees unwrap the instantiation expr instead of hitting the TS1477
+            // check, so these are valid with or without parens.
+            "(Foo<Bar>)()",
+            "new (Foo<Bar>)()",
+            // Tagged templates are intentionally not a TS1477 site.
+            "(Foo<Bar>)`tpl`",
+        ] {
+            let ret = Parser::new(&allocator, source, source_type).parse();
+            assert!(ret.errors.is_empty(), "preserve_parens: true should accept `{source}`");
+            let ret = Parser::new(&allocator, source, source_type).with_options(opts).parse();
+            assert!(ret.errors.is_empty(), "preserve_parens: false should accept `{source}`");
+        }
+
+        // The exemption is keyed by source position, not a single flag: a parenthesized
+        // instantiation expression must not mask a later unparenthesized one. Exactly one error.
+        for source in ["(Foo<Bar>).a; Foo<Bar>.b;", "Foo<Bar>.a; (Foo<Bar>).b;"] {
+            let ret = Parser::new(&allocator, source, source_type).parse();
+            assert_eq!(ret.errors.len(), 1, "only the unparenthesized form errors in `{source}`");
+            let ret = Parser::new(&allocator, source, source_type).with_options(opts).parse();
+            assert_eq!(ret.errors.len(), 1, "only the unparenthesized form errors in `{source}`");
+        }
+
+        // Unparenthesized forms remain TS1477 errors. (Plain `Foo<Bar>[x]` is not an instantiation
+        // expression - the `[` makes `<` parse as less-than - but `Foo<Bar>?.[x]` is.)
+        for source in ["Foo<Bar>.findOne()", "Foo<Bar>?.findOne", "Foo<Bar>?.[\"findOne\"]"] {
+            let ret = Parser::new(&allocator, source, source_type).parse();
+            assert_eq!(ret.errors.len(), 1, "`{source}` should be TS1477");
+            let ret = Parser::new(&allocator, source, source_type).with_options(opts).parse();
+            assert_eq!(ret.errors.len(), 1, "`{source}` should be TS1477 (no parens)");
+        }
+    }
+
+    #[test]
     fn hashbang() {
         let allocator = Allocator::default();
         let source_type = SourceType::default();

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -8,6 +8,14 @@ use crate::cursor::ParserCheckpoint;
 pub struct ParserState<'a> {
     pub not_parenthesized_arrow: FxHashSet<u32>,
 
+    /// `span.start` of each `TSInstantiationExpression` that was parenthesized, e.g. the `Foo`
+    /// in `(Foo<Bar>)`. Used so the TS1477 check ("instantiation expression cannot be followed
+    /// by a property access") allows `(Foo<Bar>).baz` while still rejecting `Foo<Bar>.baz`.
+    /// Needed because `preserve_parens: false` drops the `ParenthesizedExpression` wrapper that
+    /// would otherwise distinguish the two. Keying on `span.start` is sound because at most one
+    /// `TSInstantiationExpression` can begin at any given offset.
+    pub parenthesized_instantiation_expr: FxHashSet<u32>,
+
     /// Temporary storage for `CoverInitializedName` `({ foo = bar })`.
     /// Keyed by `ObjectProperty`'s span.start.
     pub cover_initialized_name: FxHashMap<u32, AssignmentExpression<'a>>,
@@ -37,6 +45,7 @@ impl ParserState<'_> {
     pub fn new() -> Self {
         Self {
             not_parenthesized_arrow: FxHashSet::default(),
+            parenthesized_instantiation_expr: FxHashSet::default(),
             cover_initialized_name: FxHashMap::default(),
             trailing_commas: FxHashMap::default(),
             potential_await_reparse: Vec::new(),


### PR DESCRIPTION
`(Foo<Bar>).baz` is valid TypeScript but got rejected as TS1477, and oxc-parser's behavior diverges from tsc. The check for TS1477 keyed off AST node shape, which only tells it apart from the invalid `Foo<Bar>.baz` when the parens are preserved as a wrapper node. oxfmt parses with `preserve_parens: false`, so it hits the false positive.

Fix: Track whether an instantiation expression was parenthesized in parse state instead, mirroring the existing `not_parenthesized_arrow`.

Fixes https://github.com/oxc-project/oxc/issues/23133

AI usage disclosure: developed with Claude Code, reviewed and tested by me.