### PR TITLE
perf(linter): `jest/no-deprecated-functions` store config version as `usize`

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -2176,9 +2176,9 @@ export interface NoDeprecatedFunctionsConfig {
    * Use please instead { "settings": { "jest": {"version": 29 } } } in `Oxlint config file`.
    * Beware the value from the config have higher priority than the rule config.
    */
-  jest?: JestConfig;
+  jest?: JestConfigJson;
 }
-export interface JestConfig {
+export interface JestConfigJson {
   /**
    * The version of Jest being used.
    */

--- a/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
+++ b/crates/oxc_linter/src/rules/jest/no_deprecated_functions.rs
@@ -15,15 +15,28 @@ fn deprecated_function(deprecated: &str, new: &str, span: Span) -> OxcDiagnostic
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct JestConfig {
     /// The version of Jest being used.
-    version: String,
+    version: usize,
 }
 
 impl Default for JestConfig {
     fn default() -> Self {
-        Self { version: "29".to_string() }
+        Self { version: 29 }
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub struct JestConfigJson {
+    /// The version of Jest being used.
+    version: &'static str,
+}
+
+impl Default for JestConfigJson {
+    fn default() -> Self {
+        Self { version: "29" }
     }
 }
 
@@ -37,6 +50,7 @@ pub struct NoDeprecatedFunctionsConfig {
     /// Deprecated config, it will be removed in future versions.
     /// Use please instead { "settings": { "jest": {"version": 29 } } } in `Oxlint config file`.
     /// Beware the value from the config have higher priority than the rule config.
+    #[schemars(with = "JestConfigJson")]
     jest: JestConfig,
 }
 
@@ -130,7 +144,7 @@ impl Rule for NoDeprecatedFunctions {
         let major: Vec<&str> = version.split('.').collect();
 
         Ok(Self(Box::new(NoDeprecatedFunctionsConfig {
-            jest: JestConfig { version: major[0].to_string() },
+            jest: JestConfig { version: major[0].parse().unwrap_or(29) },
         })))
     }
 
@@ -151,7 +165,7 @@ impl Rule for NoDeprecatedFunctions {
         let jest_version_num: usize = if let Some(jest_version) = ctx.settings().jest.version {
             jest_version
         } else {
-            self.jest.version.parse().unwrap_or(29)
+            self.jest.version
         };
 
         if let Some((base_version, replacement)) = deprecated_functions_map(&node_name)

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -8895,7 +8895,7 @@
       },
       "markdownDescription": "Configure JSX A11y plugin rules.\n\nSee\n[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s\nconfiguration for a full reference."
     },
-    "JestConfig": {
+    "JestConfigJson": {
       "type": "object",
       "properties": {
         "version": {
@@ -9990,7 +9990,7 @@
           "description": "Jest configuration options.\nDeprecated config, it will be removed in future versions.\nUse please instead { \"settings\": { \"jest\": {\"version\": 29 } } } in `Oxlint config file`.\nBeware the value from the config have higher priority than the rule config.",
           "allOf": [
             {
-              "$ref": "#/definitions/JestConfig"
+              "$ref": "#/definitions/JestConfigJson"
             }
           ],
           "markdownDescription": "Jest configuration options.\nDeprecated config, it will be removed in future versions.\nUse please instead { \"settings\": { \"jest\": {\"version\": 29 } } } in `Oxlint config file`.\nBeware the value from the config have higher priority than the rule config."

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -8899,7 +8899,7 @@ expression: json
       },
       "markdownDescription": "Configure JSX A11y plugin rules.\n\nSee\n[eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#configurations)'s\nconfiguration for a full reference."
     },
-    "JestConfig": {
+    "JestConfigJson": {
       "type": "object",
       "properties": {
         "version": {
@@ -9994,7 +9994,7 @@ expression: json
           "description": "Jest configuration options.\nDeprecated config, it will be removed in future versions.\nUse please instead { \"settings\": { \"jest\": {\"version\": 29 } } } in `Oxlint config file`.\nBeware the value from the config have higher priority than the rule config.",
           "allOf": [
             {
-              "$ref": "#/definitions/JestConfig"
+              "$ref": "#/definitions/JestConfigJson"
             }
           ],
           "markdownDescription": "Jest configuration options.\nDeprecated config, it will be removed in future versions.\nUse please instead { \"settings\": { \"jest\": {\"version\": 29 } } } in `Oxlint config file`.\nBeware the value from the config have higher priority than the rule config."


### PR DESCRIPTION
Instead of storing a `String` inside `ConfigStore`, the rule configuration can already transform (and fallback) to its `usize` value.
This transformation was done for every member expression with an identifier as the "object"-part.

Added a new struct to have the same schema generation