### PR TITLE
fix(linter): allow options for `eslint/capitalized-comments`

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -61,7 +61,7 @@ export type LintPlugins = LintPluginOptionsSchema[];
 export type Mode2 = "as-needed" | "always" | "never";
 export type RuleNoConfig = AllowWarnDeny | [AllowWarnDeny];
 export type AlwaysNever = "always" | "never";
-export type OptionsJsonDoc =
+export type OptionsJsonEnum =
   | CommentConfigJson
   | {
       block?: CommentConfigJson;
@@ -707,7 +707,7 @@ export interface DummyRuleMap {
     | AllowWarnDeny
     | [AllowWarnDeny]
     | [AllowWarnDeny, AlwaysNever]
-    | [AllowWarnDeny, AlwaysNever, OptionsJsonDoc];
+    | [AllowWarnDeny, AlwaysNever, OptionsJsonEnum];
   "class-methods-use-this"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ClassMethodsUseThisConfig];
   complexity?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | ComplexityConfig];
   "constructor-super"?: RuleNoConfig;

--- a/crates/oxc_linter/src/rules/eslint/capitalized_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/capitalized_comments.rs
@@ -67,31 +67,6 @@ impl std::ops::Deref for CapitalizedComments {
     }
 }
 
-#[cfg(feature = "ruledocs")]
-impl CapitalizedComments {
-    #[expect(clippy::unnecessary_wraps, unused)]
-    pub fn config_schema(
-        r#gen: &mut schemars::r#gen::SchemaGenerator,
-    ) -> Option<schemars::schema::Schema> {
-        #[derive(Deserialize, JsonSchema)]
-        #[serde(rename_all = "camelCase", untagged, deny_unknown_fields)]
-        enum OptionsJsonDoc {
-            Base(CommentConfigJson),
-            Difference { line: Option<CommentConfigJson>, block: Option<CommentConfigJson> },
-        }
-
-        /// Configuration for the capitalized-comments rule.
-        ///
-        /// The first element specifies whether comments should `"always"` or `"never"`
-        /// begin with a capital letter. The second element is an optional object
-        /// containing additional options.
-        #[derive(JsonSchema, Deserialize)]
-        struct CapitalizedCommentsOptionsDocs(AlwaysNever, Option<OptionsJsonDoc>);
-
-        Some(r#gen.subschema_for::<CapitalizedCommentsOptionsDocs>())
-    }
-}
-
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 #[expect(clippy::struct_field_names)]
@@ -122,6 +97,14 @@ impl CommentConfigJson {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", untagged, deny_unknown_fields)]
+#[expect(unused)] // Only for schemars docs, not used in actual config parsing
+enum OptionsJsonEnum {
+    Base(CommentConfigJson),
+    Difference { line: Option<CommentConfigJson>, block: Option<CommentConfigJson> },
+}
+
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default)]
 struct OptionsJson {
@@ -132,6 +115,15 @@ struct OptionsJson {
     /// Configuration options specific to block comments.
     block: Option<CommentConfigJson>,
 }
+
+/// Configuration for the capitalized-comments rule.
+///
+/// The first element specifies whether comments should `"always"` or `"never"`
+/// begin with a capital letter. The second element is an optional object
+/// containing additional options.
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[expect(dead_code)]
+struct CapitalizedCommentsOptions(AlwaysNever, Option<OptionsJsonEnum>);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -161,6 +153,7 @@ declare_oxc_lint!(
     eslint,
     style,
     fix,
+    config = CapitalizedCommentsOptions,
     version = "1.34.0",
 );
 

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -677,7 +677,7 @@
       },
       "additionalProperties": false
     },
-    "CapitalizedCommentsOptionsDocs": {
+    "CapitalizedCommentsOptions": {
       "description": "Configuration for the capitalized-comments rule.\n\nThe first element specifies whether comments should `\"always\"` or `\"never\"`\nbegin with a capital letter. The second element is an optional object\ncontaining additional options.",
       "type": "array",
       "items": [
@@ -685,7 +685,7 @@
           "$ref": "#/definitions/AlwaysNever"
         },
         {
-          "$ref": "#/definitions/OptionsJsonDoc"
+          "$ref": "#/definitions/OptionsJsonEnum"
         }
       ],
       "maxItems": 2,
@@ -1416,7 +1416,7 @@
                   "$ref": "#/definitions/AlwaysNever"
                 },
                 {
-                  "$ref": "#/definitions/OptionsJsonDoc"
+                  "$ref": "#/definitions/OptionsJsonEnum"
                 }
               ],
               "maxItems": 3,
@@ -11977,7 +11977,7 @@
       },
       "additionalProperties": false
     },
-    "OptionsJsonDoc": {
+    "OptionsJsonEnum": {
       "anyOf": [
         {
           "$ref": "#/definitions/CommentConfigJson"

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -681,7 +681,7 @@ expression: json
       },
       "additionalProperties": false
     },
-    "CapitalizedCommentsOptionsDocs": {
+    "CapitalizedCommentsOptions": {
       "description": "Configuration for the capitalized-comments rule.\n\nThe first element specifies whether comments should `\"always\"` or `\"never\"`\nbegin with a capital letter. The second element is an optional object\ncontaining additional options.",
       "type": "array",
       "items": [
@@ -689,7 +689,7 @@ expression: json
           "$ref": "#/definitions/AlwaysNever"
         },
         {
-          "$ref": "#/definitions/OptionsJsonDoc"
+          "$ref": "#/definitions/OptionsJsonEnum"
         }
       ],
       "maxItems": 2,
@@ -1420,7 +1420,7 @@ expression: json
                   "$ref": "#/definitions/AlwaysNever"
                 },
                 {
-                  "$ref": "#/definitions/OptionsJsonDoc"
+                  "$ref": "#/definitions/OptionsJsonEnum"
                 }
               ],
               "maxItems": 3,
@@ -11981,7 +11981,7 @@ expression: json
       },
       "additionalProperties": false
     },
-    "OptionsJsonDoc": {
+    "OptionsJsonEnum": {
       "anyOf": [
         {
           "$ref": "#/definitions/CommentConfigJson"


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/23122

was introduced in https://github.com/oxc-project/oxc/pull/22984, where we removed the `config = ` line.