### PR TITLE
test(linter): add tests for missing rule `config`

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -241,9 +241,11 @@ fn test() {
 			
 			          }
 			      ",
-            Some(
-                serde_json::json!([        {          "setDefaultDestructuredRootDescription": true,        },      ]),
-            ),
+            // TODO: support configurations for this rule
+            // Some(
+            //     serde_json::json!([        {          "setDefaultDestructuredRootDescription": true,        },      ]),
+            // ),
+            None,
             None,
         ),
         (
@@ -257,9 +259,11 @@ fn test() {
 			
 			          }
 			      ",
-            Some(
-                serde_json::json!([        {          "defaultDestructuredRootDescription": "Root description",          "setDefaultDestructuredRootDescription": true,        },      ]),
-            ),
+            // TODO: support configurations for this rule
+            // Some(
+            //     serde_json::json!([        {          "defaultDestructuredRootDescription": "Root description",          "setDefaultDestructuredRootDescription": true,        },      ]),
+            // ),
+            None,
             None,
         ),
         (
@@ -273,9 +277,11 @@ fn test() {
 			
 			          }
 			      ",
-            Some(
-                serde_json::json!([        {          "setDefaultDestructuredRootDescription": false,        },      ]),
-            ),
+            // TODO: support configurations for this rule
+            // Some(
+            //     serde_json::json!([        {          "setDefaultDestructuredRootDescription": false,        },      ]),
+            // ),
+            None,
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
@@ -237,7 +237,9 @@ fn test() {
 
 			          }
 			      ",
-            Some(serde_json::json!([ { "setDefaultDestructuredRootType": true } ])),
+            // TODO: support configurations for this rule
+            // Some(serde_json::json!([ { "setDefaultDestructuredRootType": true } ])),
+            None,
             None,
         ),
         (
@@ -251,7 +253,9 @@ fn test() {
 
 			          }
 			      ",
-            Some(serde_json::json!([ { "setDefaultDestructuredRootType": false } ])),
+            // TODO: support configurations for this rule
+            // Some(serde_json::json!([ { "setDefaultDestructuredRootType": false } ])),
+            None,
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns_description.rs
@@ -136,13 +136,14 @@ fn test() {
 			
 			          }
 			      ",
-            Some(serde_json::json!([
-              {
-                "contexts": [
-                  "any",
-                ],
-              },
-            ])),
+            // Some(serde_json::json!([
+            //   {
+            //     "contexts": [
+            //       "any",
+            //     ],
+            //   },
+            // ])),
+            None,
             None,
         ),
         (

--- a/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
+++ b/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
@@ -700,7 +700,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -719,7 +719,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -738,7 +738,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -758,7 +758,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -776,7 +776,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -795,7 +795,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -814,7 +814,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -833,7 +833,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -852,7 +852,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -871,7 +871,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -891,7 +891,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -911,7 +911,7 @@ fn test() {
                       );
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -928,7 +928,7 @@ fn test() {
                     }
                     </script>
                   ",
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ),
@@ -945,7 +945,7 @@ fn test() {
                     }
                     </script>
                   ",
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ),
@@ -963,7 +963,7 @@ fn test() {
                     })
                     </script>
                   ",
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ),
@@ -981,7 +981,7 @@ fn test() {
                     })
                     </script>
                   ",
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ),
@@ -1014,7 +1014,7 @@ fn test() {
                       })
                     </script>
                   ",
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ),
@@ -1027,7 +1027,7 @@ fn test() {
                       const {name="World"} = defineProps<TestPropType>();
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -1039,7 +1039,7 @@ fn test() {
                       }>();
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ), // {        "parserOptions": {          "parser": require.resolve("@typescript-eslint/parser")        }      },
@@ -1053,7 +1053,7 @@ fn test() {
                       });
                     </script>
                   "#,
-            Some(serde_json::json!([{ "autofix": true }])),
+            None, // Some(serde_json::json!([{ "autofix": true }])),
             None,
             Some(PathBuf::from("test.vue")),
         ),

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -499,7 +499,17 @@ impl Tester {
         // but we only want to show the diagnostic for this test case
         let mut output_index = 0;
         let mut failed = vec![];
+
+        let rule: &RuleEnum = self.find_rule();
+        let rule_has_config = rule.has_config();
+        let rule_name = format!("{}/{}", rule.plugin_name(), rule.name());
+
         for TestCase { source, rule_config, eslint_config, path } in self.expect_pass.clone() {
+            assert!(
+                rule_config.is_none() || rule_has_config,
+                "Rule {rule_name} has no config schema, but a rule config was provided in the test case.\n{rule_config:?}"
+            );
+
             let result =
                 self.run(&source, rule_config.clone(), eslint_config, path, ExpectFixKind::None, 0);
             let passed = result == TestResult::Passed;
@@ -516,8 +526,16 @@ impl Tester {
     }
 
     fn test_fail(&mut self) -> Vec<TestFailure> {
+        let rule: &RuleEnum = self.find_rule();
+        let rule_has_config = rule.has_config();
+        let rule_name = format!("{}/{}", rule.plugin_name(), rule.name());
+
         let mut passed = vec![];
         for TestCase { source, rule_config, eslint_config, path } in self.expect_fail.clone() {
+            assert!(
+                rule_config.is_none() || rule_has_config,
+                "Rule {rule_name} has no config schema, but a rule config was provided in the test case.\n{rule_config:?}"
+            );
             let result =
                 self.run(&source, rule_config.clone(), eslint_config, path, ExpectFixKind::None, 0);
             let failed = result == TestResult::Failed;
@@ -534,6 +552,8 @@ impl Tester {
 
         // If auto-fixes are reported, make sure some fix test cases are provided
         let rule: &RuleEnum = self.find_rule();
+        let rule_has_config = rule.has_config();
+        let rule_name = format!("{}/{}", rule.plugin_name(), rule.name());
         let Some(fix_test_cases) = self.expect_fix.clone() else {
             assert!(
                 !rule.fix().has_fix(),
@@ -547,6 +567,12 @@ impl Tester {
         for fix in fix_test_cases {
             let ExpectFixTestCase { source, expected, rule_config: config, path, eslint_config } =
                 fix;
+
+            assert!(
+                config.is_none() || rule_has_config,
+                "Rule {rule_name} has no config schema, but a rule config was provided in the test case.\n{config:?}"
+            );
+
             for (index, expect) in expected.iter().enumerate() {
                 let result = self.run(
                     &source,


### PR DESCRIPTION
follow up from https://github.com/oxc-project/oxc/pull/23139

Added tests when a test-case has an option but the `rule.has_config()`, making sure this code path will never hit for rules which should have a config:
https://github.com/oxc-project/oxc/blob/01b74c4e84696950add4b813b0dfa2600c459f09/crates/oxc_linter/src/config/rules.rs#L158-L165

On the way I found some rules where the test-cases shown us options for rules, which we do not support atm.