### PR TITLE
refactor(benchmark): drive pipeline benchmark through oxc Compiler interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,6 +1979,7 @@ version = "0.0.0"
 dependencies = [
  "cow-utils",
  "criterion2",
+ "oxc",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -68,6 +68,7 @@ bench = false
 # All `oxc_*` dependencies optional as on CI we build each benchmark separately
 # with only the crates it needs, to speed up the builds
 [dependencies]
+oxc = { workspace = true, optional = true, features = ["full"] }
 oxc_allocator = { workspace = true, optional = true }
 oxc_ast = { workspace = true, optional = true, features = ["serialize"] }
 oxc_ast_visit = { workspace = true, optional = true, features = ["serialize"] }
@@ -106,6 +107,7 @@ codspeed_napi = ["criterion2/codspeed", "dep:serde", "dep:serde_json"]
 # "compiler" feature includes: lexer, parser, transformer, semantic, minifier, codegen, formatter
 # "linter" feature includes: linter
 compiler = [
+  "dep:oxc",
   "dep:oxc_allocator",
   "dep:oxc_ast",
   "dep:oxc_ast_visit",
@@ -145,6 +147,7 @@ rustc-hash = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = [
+  "oxc",
   "oxc_allocator",
   "oxc_ast",
   "oxc_ast_visit",

--- a/tasks/benchmark/benches/pipeline.rs
+++ b/tasks/benchmark/benches/pipeline.rs
@@ -8,12 +8,16 @@ use oxc::{
     parser::Parser,
     semantic::SemanticBuilder,
     transformer::{TransformOptions, Transformer},
+    transformer_plugins::{
+        InjectGlobalVariables, InjectGlobalVariablesConfig, InjectImport, ReplaceGlobalDefines,
+        ReplaceGlobalDefinesConfig,
+    },
 };
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_tasks_common::TestFiles;
 
 /// Benchmark the complete compilation pipeline:
-/// allocate -> parse -> semantic -> transform -> minify -> mangle -> codegen -> drop
+/// allocate -> parse -> semantic -> transform -> define -> inject -> minify -> mangle -> codegen -> drop
 fn bench_pipeline(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("pipeline");
 
@@ -36,6 +40,14 @@ fn bench_pipeline(criterion: &mut Criterion) {
                 let compress_options = CompressOptions::smallest();
                 let mangle_options = MangleOptions::default();
                 let codegen_options = CodegenOptions::default();
+                let define_config = ReplaceGlobalDefinesConfig::new(&[(
+                    "process.env.NODE_ENV",
+                    "'production'",
+                )])
+                .unwrap();
+                let inject_config = InjectGlobalVariablesConfig::new(vec![
+                    InjectImport::named_specifier("node:buffer", Some("Buffer"), "Buffer"),
+                ]);
 
                 runner.run(|| {
                     // Parse
@@ -57,7 +69,17 @@ fn bench_pipeline(criterion: &mut Criterion) {
                         &transform_options,
                     )
                     .build_with_scoping(scoping, &mut program);
-                    let _scoping = transformer_ret.scoping;
+                    let scoping = transformer_ret.scoping;
+
+                    // Define - replace global constants
+                    let define_ret = ReplaceGlobalDefines::new(&allocator, define_config)
+                        .build(scoping, &mut program);
+                    let scoping = define_ret.scoping;
+
+                    // Inject - inject global variable imports
+                    let inject_ret = InjectGlobalVariables::new(&allocator, inject_config)
+                        .build(scoping, &mut program);
+                    let _scoping = inject_ret.scoping;
 
                     // Compress (minify) - rebuilds semantic internally
                     Compressor::new(&allocator).build(&mut program, compress_options);

--- a/tasks/benchmark/benches/pipeline.rs
+++ b/tasks/benchmark/benches/pipeline.rs
@@ -14,37 +14,37 @@ use oxc_tasks_common::TestFiles;
 /// A [`CompilerInterface`] that runs the complete compilation pipeline:
 /// parse -> semantic -> transform -> define -> inject -> minify -> mangle -> codegen.
 struct PipelineCompiler {
-    transform_options: TransformOptions,
-    define_options: ReplaceGlobalDefinesConfig,
-    inject_options: InjectGlobalVariablesConfig,
-    compress_options: CompressOptions,
-    mangle_options: MangleOptions,
-    codegen_options: CodegenOptions,
+    transform: TransformOptions,
+    define: ReplaceGlobalDefinesConfig,
+    inject: InjectGlobalVariablesConfig,
+    compress: CompressOptions,
+    mangle: MangleOptions,
+    codegen: CodegenOptions,
 }
 
 impl CompilerInterface for PipelineCompiler {
     fn transform_options(&self) -> Option<&TransformOptions> {
-        Some(&self.transform_options)
+        Some(&self.transform)
     }
 
     fn define_options(&self) -> Option<ReplaceGlobalDefinesConfig> {
-        Some(self.define_options.clone())
+        Some(self.define.clone())
     }
 
     fn inject_options(&self) -> Option<InjectGlobalVariablesConfig> {
-        Some(self.inject_options.clone())
+        Some(self.inject.clone())
     }
 
     fn compress_options(&self) -> Option<CompressOptions> {
-        Some(self.compress_options.clone())
+        Some(self.compress.clone())
     }
 
     fn mangle_options(&self) -> Option<MangleOptions> {
-        Some(self.mangle_options)
+        Some(self.mangle)
     }
 
     fn codegen_options(&self) -> Option<CodegenOptions> {
-        Some(self.codegen_options.clone())
+        Some(self.codegen.clone())
     }
 
     fn check_semantic_error(&self) -> bool {
@@ -63,21 +63,19 @@ fn bench_pipeline(criterion: &mut Criterion) {
 
         // `compile` creates its own `Allocator` and keeps no state between runs,
         // so the compiler and its options can be built once and reused.
-        let mut compiler =
-            PipelineCompiler {
-                transform_options: TransformOptions::from_target("esnext").unwrap(),
-                define_options: ReplaceGlobalDefinesConfig::new(&[(
-                    "process.env.NODE_ENV",
-                    "'production'",
-                )])
+        let mut compiler = PipelineCompiler {
+            transform: TransformOptions::from_target("esnext").unwrap(),
+            define: ReplaceGlobalDefinesConfig::new(&[("process.env.NODE_ENV", "'production'")])
                 .unwrap(),
-                inject_options: InjectGlobalVariablesConfig::new(vec![
-                    InjectImport::named_specifier("node:buffer", Some("Buffer"), "Buffer"),
-                ]),
-                compress_options: CompressOptions::smallest(),
-                mangle_options: MangleOptions::default(),
-                codegen_options: CodegenOptions::default(),
-            };
+            inject: InjectGlobalVariablesConfig::new(vec![InjectImport::named_specifier(
+                "node:buffer",
+                Some("Buffer"),
+                "Buffer",
+            )]),
+            compress: CompressOptions::smallest(),
+            mangle: MangleOptions::default(),
+            codegen: CodegenOptions::default(),
+        };
 
         group.bench_function(id, |b| {
             b.iter(|| {

--- a/tasks/benchmark/benches/pipeline.rs
+++ b/tasks/benchmark/benches/pipeline.rs
@@ -63,22 +63,21 @@ fn bench_pipeline(criterion: &mut Criterion) {
 
         // `compile` creates its own `Allocator` and keeps no state between runs,
         // so the compiler and its options can be built once and reused.
-        let mut compiler = PipelineCompiler {
-            transform_options: TransformOptions::from_target("esnext").unwrap(),
-            define_options: ReplaceGlobalDefinesConfig::new(&[(
-                "process.env.NODE_ENV",
-                "'production'",
-            )])
-            .unwrap(),
-            inject_options: InjectGlobalVariablesConfig::new(vec![InjectImport::named_specifier(
-                "node:buffer",
-                Some("Buffer"),
-                "Buffer",
-            )]),
-            compress_options: CompressOptions::smallest(),
-            mangle_options: MangleOptions::default(),
-            codegen_options: CodegenOptions::default(),
-        };
+        let mut compiler =
+            PipelineCompiler {
+                transform_options: TransformOptions::from_target("esnext").unwrap(),
+                define_options: ReplaceGlobalDefinesConfig::new(&[(
+                    "process.env.NODE_ENV",
+                    "'production'",
+                )])
+                .unwrap(),
+                inject_options: InjectGlobalVariablesConfig::new(vec![
+                    InjectImport::named_specifier("node:buffer", Some("Buffer"), "Buffer"),
+                ]),
+                compress_options: CompressOptions::smallest(),
+                mangle_options: MangleOptions::default(),
+                codegen_options: CodegenOptions::default(),
+            };
 
         group.bench_function(id, |b| {
             b.iter(|| {

--- a/tasks/benchmark/benches/pipeline.rs
+++ b/tasks/benchmark/benches/pipeline.rs
@@ -1,14 +1,16 @@
 use std::path::Path;
 
-use oxc_allocator::Allocator;
+use oxc::{
+    allocator::Allocator,
+    codegen::{Codegen, CodegenOptions},
+    mangler::{MangleOptions, Mangler},
+    minifier::{CompressOptions, Compressor},
+    parser::Parser,
+    semantic::SemanticBuilder,
+    transformer::{TransformOptions, Transformer},
+};
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use oxc_codegen::{Codegen, CodegenOptions};
-use oxc_mangler::{MangleOptions, Mangler};
-use oxc_minifier::{CompressOptions, Compressor};
-use oxc_parser::Parser;
-use oxc_semantic::SemanticBuilder;
 use oxc_tasks_common::TestFiles;
-use oxc_transformer::{TransformOptions, Transformer};
 
 /// Benchmark the complete compilation pipeline:
 /// allocate -> parse -> semantic -> transform -> minify -> mangle -> codegen -> drop

--- a/tasks/benchmark/benches/pipeline.rs
+++ b/tasks/benchmark/benches/pipeline.rs
@@ -40,14 +40,15 @@ fn bench_pipeline(criterion: &mut Criterion) {
                 let compress_options = CompressOptions::smallest();
                 let mangle_options = MangleOptions::default();
                 let codegen_options = CodegenOptions::default();
-                let define_config = ReplaceGlobalDefinesConfig::new(&[(
-                    "process.env.NODE_ENV",
-                    "'production'",
-                )])
-                .unwrap();
-                let inject_config = InjectGlobalVariablesConfig::new(vec![
-                    InjectImport::named_specifier("node:buffer", Some("Buffer"), "Buffer"),
-                ]);
+                let define_config =
+                    ReplaceGlobalDefinesConfig::new(&[("process.env.NODE_ENV", "'production'")])
+                        .unwrap();
+                let inject_config =
+                    InjectGlobalVariablesConfig::new(vec![InjectImport::named_specifier(
+                        "node:buffer",
+                        Some("Buffer"),
+                        "Buffer",
+                    )]);
 
                 runner.run(|| {
                     // Parse

--- a/tasks/benchmark/benches/pipeline.rs
+++ b/tasks/benchmark/benches/pipeline.rs
@@ -61,27 +61,28 @@ fn bench_pipeline(criterion: &mut Criterion) {
         let source_type = file.source_type;
         let source_path = Path::new(&file.file_name);
 
-        group.bench_function(id, |b| {
-            b.iter_with_setup_wrapper(|runner| {
-                // Create options inside the closure to avoid move issues
-                let mut compiler = PipelineCompiler {
-                    transform_options: TransformOptions::from_target("esnext").unwrap(),
-                    define_options: ReplaceGlobalDefinesConfig::new(&[(
-                        "process.env.NODE_ENV",
-                        "'production'",
-                    )])
-                    .unwrap(),
-                    inject_options: InjectGlobalVariablesConfig::new(vec![
-                        InjectImport::named_specifier("node:buffer", Some("Buffer"), "Buffer"),
-                    ]),
-                    compress_options: CompressOptions::smallest(),
-                    mangle_options: MangleOptions::default(),
-                    codegen_options: CodegenOptions::default(),
-                };
+        // `compile` creates its own `Allocator` and keeps no state between runs,
+        // so the compiler and its options can be built once and reused.
+        let mut compiler = PipelineCompiler {
+            transform_options: TransformOptions::from_target("esnext").unwrap(),
+            define_options: ReplaceGlobalDefinesConfig::new(&[(
+                "process.env.NODE_ENV",
+                "'production'",
+            )])
+            .unwrap(),
+            inject_options: InjectGlobalVariablesConfig::new(vec![InjectImport::named_specifier(
+                "node:buffer",
+                Some("Buffer"),
+                "Buffer",
+            )]),
+            compress_options: CompressOptions::smallest(),
+            mangle_options: MangleOptions::default(),
+            codegen_options: CodegenOptions::default(),
+        };
 
-                runner.run(|| {
-                    compiler.compile(source_text, source_type, source_path);
-                });
+        group.bench_function(id, |b| {
+            b.iter(|| {
+                compiler.compile(source_text, source_type, source_path);
             });
         });
     }

--- a/tasks/benchmark/benches/pipeline.rs
+++ b/tasks/benchmark/benches/pipeline.rs
@@ -1,23 +1,57 @@
 use std::path::Path;
 
 use oxc::{
-    allocator::Allocator,
-    codegen::{Codegen, CodegenOptions},
-    mangler::{MangleOptions, Mangler},
-    minifier::{CompressOptions, Compressor},
-    parser::Parser,
-    semantic::SemanticBuilder,
-    transformer::{TransformOptions, Transformer},
-    transformer_plugins::{
-        InjectGlobalVariables, InjectGlobalVariablesConfig, InjectImport, ReplaceGlobalDefines,
-        ReplaceGlobalDefinesConfig,
-    },
+    CompilerInterface,
+    codegen::CodegenOptions,
+    mangler::MangleOptions,
+    minifier::CompressOptions,
+    transformer::TransformOptions,
+    transformer_plugins::{InjectGlobalVariablesConfig, InjectImport, ReplaceGlobalDefinesConfig},
 };
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_tasks_common::TestFiles;
 
-/// Benchmark the complete compilation pipeline:
-/// allocate -> parse -> semantic -> transform -> define -> inject -> minify -> mangle -> codegen -> drop
+/// A [`CompilerInterface`] that runs the complete compilation pipeline:
+/// parse -> semantic -> transform -> define -> inject -> minify -> mangle -> codegen.
+struct PipelineCompiler {
+    transform_options: TransformOptions,
+    define_options: ReplaceGlobalDefinesConfig,
+    inject_options: InjectGlobalVariablesConfig,
+    compress_options: CompressOptions,
+    mangle_options: MangleOptions,
+    codegen_options: CodegenOptions,
+}
+
+impl CompilerInterface for PipelineCompiler {
+    fn transform_options(&self) -> Option<&TransformOptions> {
+        Some(&self.transform_options)
+    }
+
+    fn define_options(&self) -> Option<ReplaceGlobalDefinesConfig> {
+        Some(self.define_options.clone())
+    }
+
+    fn inject_options(&self) -> Option<InjectGlobalVariablesConfig> {
+        Some(self.inject_options.clone())
+    }
+
+    fn compress_options(&self) -> Option<CompressOptions> {
+        Some(self.compress_options.clone())
+    }
+
+    fn mangle_options(&self) -> Option<MangleOptions> {
+        Some(self.mangle_options)
+    }
+
+    fn codegen_options(&self) -> Option<CodegenOptions> {
+        Some(self.codegen_options.clone())
+    }
+
+    fn check_semantic_error(&self) -> bool {
+        false
+    }
+}
+
 fn bench_pipeline(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("pipeline");
 
@@ -25,75 +59,28 @@ fn bench_pipeline(criterion: &mut Criterion) {
         let id = BenchmarkId::from_parameter(&file.file_name);
         let source_text = &file.source_text;
         let source_type = file.source_type;
-
-        // Create `Allocator` outside of `bench_function`, so same allocator is used for
-        // both the warmup and measurement phases
-        let mut allocator = Allocator::default();
+        let source_path = Path::new(&file.file_name);
 
         group.bench_function(id, |b| {
             b.iter_with_setup_wrapper(|runner| {
-                // Reset allocator at start of each iteration
-                allocator.reset();
-
                 // Create options inside the closure to avoid move issues
-                let transform_options = TransformOptions::from_target("esnext").unwrap();
-                let compress_options = CompressOptions::smallest();
-                let mangle_options = MangleOptions::default();
-                let codegen_options = CodegenOptions::default();
-                let define_config =
-                    ReplaceGlobalDefinesConfig::new(&[("process.env.NODE_ENV", "'production'")])
-                        .unwrap();
-                let inject_config =
-                    InjectGlobalVariablesConfig::new(vec![InjectImport::named_specifier(
-                        "node:buffer",
-                        Some("Buffer"),
-                        "Buffer",
-                    )]);
+                let mut compiler = PipelineCompiler {
+                    transform_options: TransformOptions::from_target("esnext").unwrap(),
+                    define_options: ReplaceGlobalDefinesConfig::new(&[(
+                        "process.env.NODE_ENV",
+                        "'production'",
+                    )])
+                    .unwrap(),
+                    inject_options: InjectGlobalVariablesConfig::new(vec![
+                        InjectImport::named_specifier("node:buffer", Some("Buffer"), "Buffer"),
+                    ]),
+                    compress_options: CompressOptions::smallest(),
+                    mangle_options: MangleOptions::default(),
+                    codegen_options: CodegenOptions::default(),
+                };
 
                 runner.run(|| {
-                    // Parse
-                    let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
-                    let mut program = parser_ret.program;
-
-                    // Semantic
-                    let scoping = SemanticBuilder::new()
-                        .with_excess_capacity(2.0)
-                        .with_enum_eval(true)
-                        .build(&program)
-                        .semantic
-                        .into_scoping();
-
-                    // Transform
-                    let transformer_ret = Transformer::new(
-                        &allocator,
-                        Path::new(&file.file_name),
-                        &transform_options,
-                    )
-                    .build_with_scoping(scoping, &mut program);
-                    let scoping = transformer_ret.scoping;
-
-                    // Define - replace global constants
-                    let define_ret = ReplaceGlobalDefines::new(&allocator, define_config)
-                        .build(scoping, &mut program);
-                    let scoping = define_ret.scoping;
-
-                    // Inject - inject global variable imports
-                    let inject_ret = InjectGlobalVariables::new(&allocator, inject_config)
-                        .build(scoping, &mut program);
-                    let _scoping = inject_ret.scoping;
-
-                    // Compress (minify) - rebuilds semantic internally
-                    Compressor::new(&allocator).build(&mut program, compress_options);
-
-                    // Mangle - rebuilds semantic internally
-                    let mangler_ret = Mangler::new().with_options(mangle_options).build(&program);
-
-                    // Codegen
-                    Codegen::new()
-                        .with_options(codegen_options)
-                        .with_scoping(Some(mangler_ret.scoping))
-                        .with_private_member_mappings(Some(mangler_ret.class_private_mappings))
-                        .build(&program)
+                    compiler.compile(source_text, source_type, source_path);
                 });
             });
         });


### PR DESCRIPTION
Rework the pipeline benchmark to run the full compilation through the `oxc` root crate's `Compiler`/`CompilerInterface` instead of hand-wiring each `oxc_*` stage.

- A `PipelineCompiler` implements `CompilerInterface`, overriding the option hooks with common options:
  - **transform**: `esnext` target
  - **define**: `process.env.NODE_ENV` → `'production'`
  - **inject**: `Buffer` from `node:buffer`
  - **compress**: `CompressOptions::smallest()`, plus default mangle and codegen
- The bench body just calls `compiler.compile(...)`, so parse → semantic → transform → define → inject → minify → mangle → codegen is driven by the interface.
- `Cargo.toml`: added `oxc` (with `full` feature) to the `compiler` feature and to `cargo-shear` ignored list.

The CI matrix maps the `pipeline` component to the `compiler` feature, which now includes `oxc`, so no workflow changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)