### PR TITLE
perf(parser): force-inline read_non_decimal to fold per-digit number dispatch

### DIFF
--- a/crates/oxc_parser/src/lexer/numeric.rs
+++ b/crates/oxc_parser/src/lexer/numeric.rs
@@ -43,7 +43,12 @@ impl<C: Config> Lexer<'_, C> {
     // Inline into the 3 calls from `read_zero` so that value of `kind` is known
     // and `kind.matches_number_byte` can be statically reduced to just the match arm
     // that applies for this specific kind. `matches_number_byte` is also marked `#[inline]`.
-    #[inline]
+    // `#[inline(always)]` (not just `#[inline]`) is required: with plain `#[inline]` the
+    // function stayed a single shared out-of-line copy taking `kind` as a runtime argument,
+    // so the per-digit `kind.matches_number_byte(b)` was never folded to the single applicable
+    // arm. Forcing inlining monomorphizes each `0x`/`0o`/`0b` call site on its constant `kind`.
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
     fn read_non_decimal(&mut self, kind: Kind) -> Kind {
         self.consume_char();
 


### PR DESCRIPTION
## Finding (F2 from assembly audit)

`read_non_decimal` (numeric.rs) has a comment stating it must inline into its 3 `read_zero` call sites so the constant `kind` lets `kind.matches_number_byte(b)` reduce to one match arm. **Assembly shows plain `#[inline]` did not achieve this** — it stayed a single out-of-line symbol taking `kind` as a runtime arg, re-masking + re-comparing `kind` on every digit of a `0x`/`0o`/`0b` literal.

## Change

`#[inline]` → `#[inline(always)]`. The standalone `read_non_decimal` symbol disappears; each radix call site monomorphizes on its constant kind and the per-digit dispatch folds.

## ⚠️ Tradeoff — needs CodSpeed before merge

The `ZER` byte-handler grows **~68 → 293 instructions** (read_zero + read_non_decimal now inline for all 3 radices). `ZER` handles *all* `0`-prefixed tokens (`0`, `0.5`, `0n`, legacy octal), so this is a static-size/icache cost on those common paths in exchange for fewer dynamic instructions per non-decimal digit. **This is only a win if CodSpeed (instruction count) confirms it net-positive** on representative input; non-decimal literals are rare in typical JS/TS, so it may be neutral-to-negative. Draft pending that signal.

## Verification
- Conformance: **byte-identical** to `main` across all 31 snapshot suites (test262/babel/typescript × parser/semantic/codegen/estree/transformer/minifier/formatter).
- Assembly re-checked: `read_non_decimal` standalone symbol removed; folded dispatch confirmed in `ZER`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)