### PR TITLE
perf(parser): shrink-wrap cold diagnostic tails out of hot frames

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -8,7 +8,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{
     Context, ParserConfig as Config, ParserImpl, diagnostics,
     error_handler::FatalError,
-    lexer::{Kind, LexerCheckpoint, Token},
+    lexer::{Kind, LexerCheckpoint, Token, cold_branch},
 };
 
 #[derive(Clone)]
@@ -143,9 +143,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.eat(Kind::Semicolon) || self.can_insert_semicolon() {
             /* no op */
         } else {
-            let span = Span::empty(self.prev_token_end);
-            let error = diagnostics::auto_semicolon_insertion(span);
-            self.set_fatal_error(error);
+            // ASI failure is a syntax error (cold). Build the diagnostic out of line so the
+            // ~232-byte `OxcDiagnostic` buffer does not inflate `asi`'s stack frame on the
+            // common (valid) path.
+            cold_branch(|| {
+                let span = Span::empty(self.prev_token_end);
+                let error = diagnostics::auto_semicolon_insertion(span);
+                self.set_fatal_error(error);
+            });
         }
     }
 

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -91,6 +91,10 @@ impl<'a, C: Config> CoverGrammar<'a, Expression<'a>, C> for SimpleAssignmentTarg
 }
 
 impl<'a, C: Config> CoverGrammar<'a, ArrayExpression<'a>, C> for ArrayAssignmentTarget<'a> {
+    // Destructuring-target conversion is comparatively rare and large. Keeping it out of line
+    // stops it being inlined into `AssignmentTarget::cover`, whose common arm (simple targets)
+    // would otherwise carry this body's large stack frame + callee-saved spills on every call.
+    #[inline(never)]
     fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
         let mut elements = p.ast.vec();
         let mut rest = None;
@@ -165,6 +169,9 @@ impl<'a, C: Config> CoverGrammar<'a, AssignmentExpression<'a>, C>
 }
 
 impl<'a, C: Config> CoverGrammar<'a, ObjectExpression<'a>, C> for ObjectAssignmentTarget<'a> {
+    // Kept out of line for the same reason as `ArrayAssignmentTarget::cover` above: avoid
+    // inlining this large body into the hot `AssignmentTarget::cover` dispatcher.
+    #[inline(never)]
     fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
         let mut properties = p.ast.vec();
         let mut rest = None;

--- a/crates/oxc_parser/src/lexer/numeric.rs
+++ b/crates/oxc_parser/src/lexer/numeric.rs
@@ -2,7 +2,7 @@ use oxc_syntax::identifier::{is_identifier_part_ascii, is_identifier_start};
 
 use crate::{config::LexerConfig as Config, diagnostics};
 
-use super::{Kind, Lexer, Span};
+use super::{Kind, Lexer, Span, cold_branch};
 
 impl<C: Config> Lexer<'_, C> {
     /// 12.9.3 Numeric Literals with `0` prefix
@@ -222,18 +222,22 @@ impl<C: Config> Lexer<'_, C> {
             None => return kind,
         }
 
-        // Invalid next char
-        let offset = self.offset();
-        self.consume_char();
-        while let Some(c) = self.peek_char() {
-            if is_identifier_start(c) {
-                self.consume_char();
-            } else {
-                break;
+        // Invalid next char (identifier/digit immediately after a number). This is invalid JS,
+        // so a cold path: building the diagnostic out-of-line keeps the `OxcDiagnostic` return
+        // buffer out of this function's stack frame, so the common (valid) return is near-leaf.
+        cold_branch(|| {
+            let offset = self.offset();
+            self.consume_char();
+            while let Some(c) = self.peek_char() {
+                if is_identifier_start(c) {
+                    self.consume_char();
+                } else {
+                    break;
+                }
             }
-        }
-        self.error(diagnostics::invalid_number_end(Span::new(offset, self.offset())));
-        self.advance_to_end();
-        Kind::Eof
+            self.error(diagnostics::invalid_number_end(Span::new(offset, self.offset())));
+            self.advance_to_end();
+            Kind::Eof
+        })
     }
 }

--- a/crates/oxc_parser/src/lexer/punctuation.rs
+++ b/crates/oxc_parser/src/lexer/punctuation.rs
@@ -2,7 +2,7 @@ use oxc_span::Span;
 
 use crate::{config::LexerConfig as Config, diagnostics};
 
-use super::{Kind, Lexer, Token};
+use super::{Kind, Lexer, Token, cold_branch};
 
 impl<C: Config> Lexer<'_, C> {
     /// Section 12.8 Punctuators
@@ -33,8 +33,10 @@ impl<C: Config> Lexer<'_, C> {
                 self.consume_char();
                 Some(Kind::LtEq)
             }
-            // `<!--` HTML comment (Annex B.1.1)
-            Some(b'!') if self.remaining().starts_with("!--") => {
+            // `<!--` HTML comment (Annex B.1.1). Rare legacy syntax, so handle out of line:
+            // it builds/pushes a diagnostic, whose `OxcDiagnostic` buffer would otherwise inflate
+            // the `<` byte-handler's stack frame on the common `<`/`<<`/`<=` path.
+            Some(b'!') if self.remaining().starts_with("!--") => cold_branch(|| {
                 if self.source_type.is_module() {
                     if self.token.is_on_new_line() {
                         let span = Span::sized(self.token.start(), 4);
@@ -48,7 +50,7 @@ impl<C: Config> Lexer<'_, C> {
                     self.defer_html_comment_error(4);
                     None
                 }
-            }
+            }),
             _ => Some(Kind::LAngle),
         }
     }

--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -62,8 +62,13 @@ macro_rules! handle_string_literal {
             table: $table,
             start: after_opening_quote,
             handle_eof: {
-                $lexer.error(diagnostics::unterminated_string($lexer.unterminated_range()));
-                return Kind::Undetermined;
+                // Unterminated string is invalid JS, so a cold path. Building the diagnostic
+                // out-of-line keeps the `OxcDiagnostic` return buffer out of this handler's
+                // stack frame (matching the sibling `\\` and line-break arms below).
+                return cold_branch(|| {
+                    $lexer.error(diagnostics::unterminated_string($lexer.unterminated_range()));
+                    Kind::Undetermined
+                });
             },
         };
 


### PR DESCRIPTION
## Finding (Pattern A from assembly audit — highest-leverage)

An assembly audit found several hot lexer/parser functions carrying a large stack frame + callee-saved register spills **unconditionally**, purely to construct a ~232-byte `OxcDiagnostic` buffer on a cold error arm that almost never runs. Classic missed shrink-wrapping: the rare path's frame is paid on every hot return.

## Change

Move each cold diagnostic arm out of line — `cold_branch(...)` (already the idiom for the sibling string-escape / line-break arms), or `#[inline(never)]` for the destructuring `cover` impls.

| Function | frame before → after | notes |
|---|---|---|
| `QOD` / `QOS` (string handlers) | 288 B → **0 B** | now frameless leaves |
| `LSS` (the `<` byte handler) | 288 B → **32 B** | `<!--` HTML-comment arm outlined |
| `cursor::asi` | 288 B → **64 B** | ASI-failure diagnostic → closure |
| `check_after_numeric_literal` | 336 B frame → **fully inlined** | invalid-number tail outlined |
| `AssignmentTarget::cover` | 3066 instr / 448 B / 3 panic-sites → **225 / 176 B / 0** | `#[inline(never)]` on `Array`/`ObjectAssignmentTarget::cover` |

These are the hottest-frame offenders the audit surfaced; the underlying pattern recurs elsewhere and could be pushed into the byte-handler macros as a follow-up.

## Verification
- **Pure codegen change, no behavior change.** Conformance: **byte-identical** to `main` across all 31 snapshot suites (test262/babel/typescript × parser/semantic/codegen/estree/transformer/minifier/formatter).
- Each frame shrink re-verified by disassembling before/after (ARM64, release codegen).

## Caveat
Frame-size wins are instruction-count-scale; net effect on the per-token path must be confirmed on **CodSpeed** before merge. The `AssignmentTarget::cover` change moves the (rare) destructuring-target conversion out of line — confirm that path doesn't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
