### PR TITLE
feat(parser): report definite property initializer errors

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
@@ -520,7 +520,7 @@ fn test() {
         (
             "
             class A {
-              a!: number = 1;
+              a: number = 1;
             }
                   ",
             Some(serde_json::json!([ { "ignoreProperties": false, }, ])),
@@ -604,7 +604,7 @@ fn test() {
         (
             "
             class A {
-              a!: number = 1;
+              a: number = 1;
             }
                   ",
             "

--- a/crates/oxc_linter/src/snapshots/typescript_no_inferrable_types.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_inferrable_types.snap
@@ -289,10 +289,10 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ typescript(no-inferrable-types): Type can be trivially inferred from the initializer
-   ╭─[no_inferrable_types.tsx:3:17]
+   ╭─[no_inferrable_types.tsx:3:16]
  2 │             class A {
- 3 │               a!: number = 1;
-   ·                 ────────
+ 3 │               a: number = 1;
+   ·                ────────
  4 │             }
    ╰────
   help: Remove the type annotation

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -709,10 +709,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 initializer.span(),
             ));
         }
-        if definite && (self.ctx.has_ambient() || r#abstract) {
-            self.error(diagnostics::definite_assignment_assertion_not_permitted(
-                self.end_span(span),
-            ));
+        if definite {
+            if initializer.is_some() {
+                self.error(diagnostics::variable_declarator_definite(self.end_span(span)));
+            } else if self.ctx.has_ambient() || r#abstract {
+                self.error(diagnostics::definite_assignment_assertion_not_permitted(
+                    self.end_span(span),
+                ));
+            }
         }
         self.ast.class_element_property_definition(
             self.end_span(span),

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -17821,6 +17821,22 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
   help: Only 'readonly' modifier is allowed here.
 
+  × TS(1263): Declarations with initializers cannot also have definite assignment assertions.
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:20:5]
+ 19 │ class C3 {
+ 20 │     a! = 1;
+    ·     ───────
+ 21 │     b!: number = 1;
+    ╰────
+
+  × TS(1263): Declarations with initializers cannot also have definite assignment assertions.
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:21:5]
+ 20 │     a! = 1;
+ 21 │     b!: number = 1;
+    ·     ───────────────
+ 22 │     static c!: number;
+    ╰────
+
   × TS(1255): A definite assignment assertion '!' is not permitted in this context.
     ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:29:5]
  28 │ declare class C4 {

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 2688fbd1
 
-Passed: 237/395
+Passed: 236/395
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -63,7 +63,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
-# babel-plugin-transform-typescript (24/60)
+# babel-plugin-transform-typescript (23/60)
 * allow-declare-fields-false/input.ts
 Unresolved references mismatch:
 after transform: ["dce"]
@@ -139,6 +139,28 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Phase":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+* declare-and-definite-with-initializer/input.ts
+
+  x TS(1263): Declarations with initializers cannot also have definite
+  | assignment assertions.
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/declare-and-definite-with-initializer/input.ts:8:4]
+ 7 | class DefiniteExample {
+ 8 |    readonly bar! = "test";
+   :    ^^^^^^^^^^^^^^^^^^^^^^^
+ 9 |    readonly foo! = 1;
+   `----
+
+
+  x TS(1263): Declarations with initializers cannot also have definite
+  | assignment assertions.
+    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/declare-and-definite-with-initializer/input.ts:9:4]
+  8 |    readonly bar! = "test";
+  9 |    readonly foo! = 1;
+    :    ^^^^^^^^^^^^^^^^^^
+ 10 | }
+    `----
+
 
 * elimination-declare/input.ts
 Bindings mismatch:


### PR DESCRIPTION
Report TS1263 for TypeScript class properties that combine a definite assignment assertion with an initializer.