### PR TITLE
perf(parser): unchecked Source::back for TS angle-bracket re-lexers

### DIFF
--- a/crates/oxc_parser/src/lexer/source.rs
+++ b/crates/oxc_parser/src/lexer/source.rs
@@ -326,40 +326,27 @@ impl<'a> Source<'a> {
         unsafe { pos.offset_from(self.start()) }
     }
 
-    /// Move current position back by `n` bytes.
+    /// Move current position back by `n` bytes, without bounds / boundary checks.
     ///
-    /// # Panic
-    /// Panics if:
-    /// * `n` is 0.
-    /// * `n` is greater than current offset in source.
-    /// * Moving back `n` bytes would not place current position on a UTF-8 character boundary.
+    /// A previous safe `back` asserted `n > 0`, `n <= bytes_consumed`, and that the destination is
+    /// on a UTF-8 character boundary. The only callers (the TS `<`/`>` re-lexers) statically know
+    /// all three hold, so those asserts were dead — but the compiler could not prove it (the
+    /// argument is derived by wrapping `u32` arithmetic), leaving cold panic stubs + a stack frame
+    /// on the call site. This unchecked variant elides them.
+    ///
+    /// # SAFETY
+    /// * `n` must be `> 0`.
+    /// * `n` must be `<=` the number of bytes consumed so far (`self.offset()`).
+    /// * Moving back `n` bytes must place the position on a UTF-8 character boundary.
     #[inline]
-    pub(super) fn back(&mut self, n: usize) {
-        // This assertion is essential to ensure safety of `new_pos.read()` call below.
-        // Without this check, calling `back(0)` on an empty `Source` would cause reading
-        // out of bounds.
-        // Compiler should remove this assertion when inlining this function,
-        // as long as it can deduce from calling code that `n` is non-zero.
-        assert!(n > 0, "Cannot call `Source::back` with 0");
-
-        // Ensure not attempting to go back to before start of source
-        let offset = self.offset_usize();
-        assert!(n <= offset, "Cannot go back {n} bytes - only {offset} bytes consumed");
-
-        // SAFETY: We have checked that `n` is less than distance between `start` and `ptr`,
-        // so `new_ptr` cannot be outside of allocation of original `&str`
+    pub(super) unsafe fn back_unchecked(&mut self, n: usize) {
+        debug_assert!(n > 0, "Cannot call `Source::back_unchecked` with 0");
+        debug_assert!(n <= self.offset_usize(), "`back_unchecked` went before start of source");
+        // SAFETY: Caller guarantees `n <= bytes consumed`, so `new_pos` is in bounds of the source.
         let new_pos = unsafe { self.position().sub(n) };
-
-        // Enforce invariant that `ptr` must be positioned on a UTF-8 character boundary.
-        // SAFETY: `new_ptr` is in bounds of original `&str`, and `n > 0` assertion ensures
-        // not at the end, so valid to read a byte.
-        // `Source`'s invariants guarantee that `self.start` - `self.end` contains allocated memory.
-        // `Source::new` takes an immutable ref `&str`, guaranteeing that the memory `new_ptr`
-        // addresses cannot be aliased by a `&mut` ref as long as `Source` exists.
-        let byte = unsafe { new_pos.read() };
-        assert!(!is_utf8_cont_byte(byte), "Offset is not on a UTF-8 character boundary");
-
-        // Move current position. The checks above satisfy `Source`'s invariants.
+        // SAFETY: `n > 0` (caller guarantee) means `new_pos` is not at the end, so a byte is
+        // readable; caller guarantees it is a UTF-8 character boundary.
+        debug_assert!(unsafe { !is_utf8_cont_byte(new_pos.read()) });
         self.ptr = new_pos.ptr;
     }
 

--- a/crates/oxc_parser/src/lexer/typescript.rs
+++ b/crates/oxc_parser/src/lexer/typescript.rs
@@ -22,7 +22,11 @@ impl<C: Config> Lexer<'_, C> {
     /// will be lexed as separate tokens on subsequent `next_token` calls.
     pub(crate) fn re_lex_as_typescript_l_angle(&mut self, offset: u32) -> Token {
         self.token.set_start(self.offset() - offset);
-        self.source.back(offset as usize - 1);
+        // `offset` is the length of the compound token being split (`<<`=2, `<=`=2, `<<=`=3),
+        // so `n = offset - 1` is 1 or 2: `n > 0`, `n <= offset <= bytes consumed`, and the byte
+        // landed on is the ASCII `<` (or second `<`/`=`), always a UTF-8 boundary.
+        // SAFETY: the invariants above satisfy `back_unchecked`'s contract.
+        unsafe { self.source.back_unchecked(offset as usize - 1) };
         if self.config.tokens() {
             let popped = self.tokens.pop();
             debug_assert!(popped.is_some());
@@ -46,7 +50,11 @@ impl<C: Config> Lexer<'_, C> {
     /// position, `truncate(checkpoint.tokens_len)` on rewind removes it automatically.
     pub(crate) fn re_lex_as_typescript_r_angle(&mut self, offset: u32) -> Token {
         self.token.set_start(self.offset() - offset);
-        self.source.back(offset as usize - 1);
+        // `offset` is the length of the compound token being split (`>>`=2, `>>>`=3), so
+        // `n = offset - 1` is 1 or 2: `n > 0`, `n <= offset <= bytes consumed`, and the byte
+        // landed on is an ASCII `>`, always a UTF-8 boundary.
+        // SAFETY: the invariants above satisfy `back_unchecked`'s contract.
+        unsafe { self.source.back_unchecked(offset as usize - 1) };
         self.finish_re_lex(Kind::RAngle)
     }
 }


### PR DESCRIPTION
## Finding (F1 from assembly audit)

The TS angle-bracket re-lexers `re_lex_as_typescript_l_angle` / `_r_angle` split a compound token (`<<`, `<=`, `<<=`, `>>`, `>>>`) back into a single `<`/`>` via `Source::back(offset - 1)`. `offset` is the compound token's length (2 or 3), so `n = offset - 1` ∈ {1, 2}. That means all three of `Source::back`'s asserts are **provably dead**:

- `n > 0` — n ≥ 1
- `n <= bytes_consumed` — the cursor is `offset` bytes past the token start
- destination on a UTF-8 boundary — it's the ASCII `<`/`>` the token began on

But the compiler can't deduce it (`n` is derived via wrapping `u32` arithmetic), so it kept cold `panic_fmt` stubs and forced a stack frame. The assembly audit measured `re_lex_ts_l_angle` as a **245-instr / 64 B-frame / 6-panic-site** standalone function.

## Change

Add `Source::back_unchecked` (debug-assert-guarded) and call it from the two re-lexers with SAFETY notes establishing the invariants. `re_lex_ts_l_angle` drops to **fully inlined, 0 panic sites**. The safe `Source::back` had no other callers, so it's removed.

## Verification
- Conformance: **byte-identical** to `main` across all 31 snapshot suites.
- Assembly re-checked: both re-lexers lose their panic stubs and inline away.
- `debug_assert!`s preserve the old `back` invariant checks in debug/test builds (which all conformance suites run under).

## Caveat
This is the TS-only speculative type-argument path (`<`/`<<` in generics-possible positions) — frequent in generic-heavy TS, absent from plain JS. Instruction-count-scale; confirm on **CodSpeed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
