### PR TITLE
perf(parser): unchecked slicing on proven-invariant number/comment paths

### DIFF
--- a/crates/oxc_parser/src/lexer/identifier.rs
+++ b/crates/oxc_parser/src/lexer/identifier.rs
@@ -128,8 +128,11 @@ impl<'a, C: Config> Lexer<'a, C> {
             }
         }
 
-        // Return identifier
-        self.source.str_from_pos_to_current(start_pos)
+        // Return identifier.
+        // SAFETY: `start_pos` is the identifier start; only forward `consume_char`s have happened
+        // since (no `set_position`, `start_pos` not advanced), so it is not after the current
+        // position, satisfying `str_from_pos_to_current_unchecked`.
+        unsafe { self.source.str_from_pos_to_current_unchecked(start_pos) }
     }
 
     /// Handle identifier starting with `\` escape.

--- a/crates/oxc_parser/src/lexer/number.rs
+++ b/crates/oxc_parser/src/lexer/number.rs
@@ -20,23 +20,31 @@ pub fn parse_int(s: &str, kind: Kind, has_sep: bool) -> Result<f64, &'static str
             Ok(if has_sep { parse_decimal_with_underscores(s) } else { parse_decimal(s) })
         }
         Kind::Binary => {
-            let s = &s[2..];
+            // SAFETY: a `Binary` token always begins with the 2-byte ASCII prefix `0b`/`0B`, so
+            // slicing off 2 bytes is in bounds and on a UTF-8 character boundary — the same
+            // invariant the `Octal` arm below already relies on with `get_unchecked`.
+            let s = unsafe { s.get_unchecked(2..) };
             Ok(if has_sep { parse_binary_with_underscores(s) } else { parse_binary(s) })
         }
         Kind::Octal => {
-            // Octals always begin with `0`. Trim off leading `0`, `0o` or `0O`.
-            let second_byte = s.as_bytes()[1];
+            // Octals always begin with `0` and are at least 2 chars (`0o<digit>` or legacy
+            // `0<digit>`), so byte index 1 and slicing off 1 byte are always in bounds.
+            // SAFETY: an `Octal` token is guaranteed >= 2 ASCII bytes.
+            let second_byte = unsafe { *s.as_bytes().get_unchecked(1) };
             let s = if second_byte == b'o' || second_byte == b'O' {
-                // SAFETY: We just checked that 2nd byte is ASCII, so slicing off 2 bytes
-                // must be in bounds and on a UTF-8 character boundary.
+                // SAFETY: 2nd byte is ASCII, so slicing off 2 bytes is in bounds and on a
+                // UTF-8 character boundary.
                 unsafe { s.get_unchecked(2..) }
             } else {
-                &s[1..] // legacy octal
+                // SAFETY: legacy octal is >= 2 ASCII bytes, so slicing off 1 byte is in bounds.
+                unsafe { s.get_unchecked(1..) } // legacy octal
             };
             Ok(if has_sep { parse_octal_with_underscores(s) } else { parse_octal(s) })
         }
         Kind::Hex => {
-            let s = &s[2..];
+            // SAFETY: a `Hex` token always begins with the 2-byte ASCII prefix `0x`/`0X`, so
+            // slicing off 2 bytes is in bounds and on a UTF-8 character boundary (see `Octal`).
+            let s = unsafe { s.get_unchecked(2..) };
             Ok(if has_sep { parse_hex_with_underscores(s) } else { parse_hex(s) })
         }
         _ => unreachable!(),

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -340,7 +340,9 @@ impl<'a> TriviaBuilder<'a> {
 
         // Check for __PURE__ or __NO_SIDE_EFFECTS__ after @ or #
         if start < bytes.len() && bytes[start..].starts_with(b"__") {
-            let rest = &bytes[start + 2..];
+            // SAFETY: `starts_with(b"__")` guarantees `bytes[start..]` has at least 2 bytes,
+            // so `start + 2 <= bytes.len()` and the slice is in bounds.
+            let rest = unsafe { bytes.get_unchecked(start + 2..) };
             if rest.starts_with(b"PURE__") {
                 comment.content = CommentContent::Pure;
                 return;


### PR DESCRIPTION
## Finding (Pattern C from assembly audit)

Several slice/index operations leave bounds-check panic stubs because their invariant is guaranteed by the calling context but opaque to LLVM. In each case the unchecked sibling is already used nearby for the identical invariant.

## Changes (each with a documented SAFETY note)

- **`number::parse_int`** — a `Binary`/`Hex` token always starts with a 2-byte ASCII prefix (`0b`/`0x`), and an `Octal` token is always ≥ 2 bytes. Switch `&s[2..]`, `s.as_bytes()[1]`, `&s[1..]` to `get_unchecked`, matching the `0o` arm that already did. **339 → 292 instr.**
- **`trivia_builder::add_comment`** — `starts_with(b"__")` guarantees ≥ 2 bytes, so `&bytes[start + 2..]` is in bounds. **1 → 0 panic sites.**
- **`identifier_tail_after_unicode`** — `start_pos` (identifier start) is reached only via forward `consume_char`, so it's never after the current position → `str_from_pos_to_current_unchecked`.

## Verification
- Conformance: **byte-identical** to `main` across all 31 snapshot suites.
- Assembly re-checked: bounds-check panic stubs removed at each site.
- Every replaced checked access asserted the same invariant the SAFETY comment now documents (and the checked variants' asserts still run in debug/test builds, including all conformance suites).

## Caveat
Micro-scale (removes cold panic stubs + a few compares; mainly icache). Confirm net effect on **CodSpeed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
