### PR TITLE
perf(parser): consume already-peeked digit bytes unchecked in decimal loop

### DIFF
--- a/crates/oxc_parser/src/lexer/numeric.rs
+++ b/crates/oxc_parser/src/lexer/numeric.rs
@@ -152,21 +152,26 @@ impl<C: Config> Lexer<'_, C> {
         while let Some(b) = self.peek_byte() {
             match b {
                 b'_' => {
-                    self.consume_char();
+                    // SAFETY: `b` (`_`) was just peeked, so a byte exists, and it is ASCII, so
+                    // consuming exactly 1 byte leaves `source` on a UTF-8 character boundary.
+                    // (`consume_char` would re-peek + unwrap the same byte we already have.)
+                    unsafe { self.source.next_byte_unchecked() };
                     // NOTE: it looks invalid numeric tokens are still parsed.
                     // This seems to be a waste. It also requires us to put this
                     // call here instead of after we ensure the next character
                     // is an ASCII digit
                     self.token.set_has_separator(true);
                     if self.peek_byte().is_some_and(|b| b.is_ascii_digit()) {
-                        self.consume_char();
+                        // SAFETY: an ASCII digit was just peeked (exists, ASCII).
+                        unsafe { self.source.next_byte_unchecked() };
                     } else {
                         self.unexpected_err();
                         return;
                     }
                 }
                 b'0'..=b'9' => {
-                    self.consume_char();
+                    // SAFETY: `b` (an ASCII digit) was just peeked (exists, ASCII).
+                    unsafe { self.source.next_byte_unchecked() };
                 }
                 _ => break,
             }


### PR DESCRIPTION
## Finding (Pattern B from assembly audit — lowest priority / lowest confidence)

`read_decimal_digits_after_first_digit` loops with `while let Some(b) = peek_byte()` then `consume_char()`. `consume_char` = `next_char().unwrap()`, which **re-peeks** the byte the loop already has and unwraps it — leaving a redundant EOF check and a cold `Option::unwrap_failed` stub (visible in the `DIG` byte-handler). Since `b` is already peeked and ASCII, consume it directly via `next_byte_unchecked`.

## ⚠️ Ambiguous result — likely close unless CodSpeed says otherwise

Effect on `DIG` (ARM64, release codegen):
- cold `unwrap_failed` panic stub **removed** (1 → 0 panic sites) ✓
- but static size **grew 87 → 117 instr** — LLVM unrolls the digit loop further.

This trades static size for *potentially* fewer dynamic loop-overhead instructions per digit, but it's genuinely ambiguous, and it adds `unsafe` to previously-safe clean code. It was the audit's lowest-confidence finding. **Only land it if CodSpeed (dynamic instruction count) shows a real, repeatable win; otherwise close.** Filed as a draft for exactly that decision.

## Verification
- Conformance: **byte-identical** to `main` across all 31 snapshot suites.
- The `next_byte_unchecked` SAFETY invariant (byte just peeked → exists + ASCII) is documented at each site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
