### PR TITLE
feat(parser): report invalid class definite assertions

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -712,7 +712,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if definite {
             if initializer.is_some() {
                 self.error(diagnostics::variable_declarator_definite(self.end_span(span)));
-            } else if self.ctx.has_ambient() || r#abstract {
+            } else if type_annotation.is_none() {
+                self.error(diagnostics::variable_declarator_definite_type_assertion(
+                    self.end_span(span),
+                ));
+            } else if self.ctx.has_ambient() || r#static || r#abstract {
                 self.error(diagnostics::definite_assignment_assertion_not_permitted(
                     self.end_span(span),
                 ));

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -2,7 +2,7 @@ commit: 2688fbd1
 
 parser_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
-Positive Passed: 2222/2236 (99.37%)
+Positive Passed: 2221/2236 (99.33%)
 Negative Passed: 1709/1723 (99.19%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/cast/unparenthesized-assert-and-assign/input.ts
 
@@ -178,7 +178,25 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  8 │         // Also works on AssignmentPattern
    ╰────
 
+Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/private-fields/input.ts
+
+  × TS(1264): Declarations with definite assignment assertions must also have type annotations.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/private-fields/input.ts:5:3]
+ 4 │   #c?: number;
+ 5 │   #d!;
+   ·   ────
+ 6 │   #e!: boolean;
+   ╰────
+
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/properties/input.ts
+
+  × TS(1264): Declarations with definite assignment assertions must also have type annotations.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/properties/input.ts:6:5]
+ 5 │     x: number = 1;
+ 6 │     x!;
+   ·     ───
+ 7 │     x!: number;
+   ╰────
 
   × Identifier `x` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/properties/input.ts:2:5]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 7539c04d
 parser_typescript Summary:
 AST Parsed     : 9779/9779 (100.00%)
 Positive Passed: 9779/9779 (100.00%)
-Negative Passed: 1636/2640 (61.97%)
+Negative Passed: 1637/2640 (62.01%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -217,8 +217,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/defaultValue
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/defaultValueInFunctionOverload1.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/defaultValueInFunctionTypes.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/definiteAssignmentWithErrorStillStripped.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/deleteOperator1.ts
 
@@ -5928,6 +5926,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  1 │ default function () {
    · ───────
  2 │ 
+   ╰────
+
+  × TS(1264): Declarations with definite assignment assertions must also have type annotations.
+   ╭─[typescript/tests/cases/compiler/definiteAssignmentWithErrorStillStripped.ts:2:5]
+ 1 │ class C {
+ 2 │     p!;
+   ·     ───
+ 3 │ }
    ╰────
 
   × Delete of an unqualified identifier in strict mode.
@@ -17835,6 +17841,22 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  21 │     b!: number = 1;
     ·     ───────────────
  22 │     static c!: number;
+    ╰────
+
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:22:5]
+ 21 │     b!: number = 1;
+ 22 │     static c!: number;
+    ·     ──────────────────
+ 23 │     d!;
+    ╰────
+
+  × TS(1264): Declarations with definite assignment assertions must also have type annotations.
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:23:5]
+ 22 │     static c!: number;
+ 23 │     d!;
+    ·     ───
+ 24 │ }
     ╰────
 
   × TS(1255): A definite assignment assertion '!' is not permitted in this context.

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 2688fbd1
 
 semantic_babel Summary:
 AST Parsed     : 2236/2236 (100.00%)
-Positive Passed: 2037/2236 (91.10%)
+Positive Passed: 2036/2236 (91.06%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/comments/decorators/decorators-after-export/input.js
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 65, end: 66 }
@@ -309,7 +309,11 @@ semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescr
 A parameter cannot have a question mark and an initializer.
 A required parameter cannot follow an optional parameter.
 
+semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/private-fields/input.ts
+Declarations with definite assignment assertions must also have type annotations.
+
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/properties/input.ts
+Declarations with definite assignment assertions must also have type annotations.
 Identifier `x` has already been declared
 Identifier `x` has already been declared
 Identifier `x` has already been declared

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
 commit: 2688fbd1
 
-Passed: 703/1165
+Passed: 702/1165
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -1095,7 +1095,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (55/157)
+# babel-plugin-transform-typescript (54/157)
 * cast/as-expression/input.ts
 Unresolved references mismatch:
 after transform: ["T", "x"]
@@ -1166,6 +1166,18 @@ x Output mismatch
 
 * class/private-method-override-transform-private/input.ts
 x Output mismatch
+
+* class/uninitialized-definite/input.ts
+
+  x TS(1264): Declarations with definite assignment assertions must also have
+  | type annotations.
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/class/uninitialized-definite/input.ts:2:3]
+ 1 | class A {
+ 2 |   x!;
+   :   ^^^
+ 3 | }
+   `----
+
 
 * declarations/const-enum/input.ts
 Bindings mismatch:


### PR DESCRIPTION
 - Match TypeScript’s diagnostic precedence for class property definite assignment assertions.
 - Report TS1264 when a class property uses ! without a type annotation.
 - Report TS1255 when a definite assignment assertion is used in disallowed class property contexts, including static.