### PR TITLE
feat(parser): report ambient definite variable assertions

### DIFF
--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -155,6 +155,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::variable_declarator_definite(span));
             } else if decl.type_annotation.is_none() {
                 self.error(diagnostics::variable_declarator_definite_type_assertion(span));
+            } else if self.ctx.has_ambient() {
+                self.error(diagnostics::definite_assignment_assertion_not_permitted(span));
             }
         }
         decl

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -17899,6 +17899,30 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  72 │ }
     ╰────
 
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:76:15]
+ 75 │ 
+ 76 │ declare let v1!: number;
+    ·               ─
+ 77 │ declare var v2!: number;
+    ╰────
+
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:77:15]
+ 76 │ declare let v1!: number;
+ 77 │ declare var v2!: number;
+    ·               ─
+ 78 │ 
+    ╰────
+
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:80:7]
+ 79 │ declare namespace foo {
+ 80 │     var v!: number;
+    ·          ─
+ 81 │ }
+    ╰────
+
   × Expected `,` or `}` but found `!`
    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertionsWithObjectShortHand.ts:2:16]
  1 │ const a: string | undefined = 'ff';


### PR DESCRIPTION
## Summary
- Report TS1255 for definite assignment assertions on ambient variable declarations.
- Preserve TypeScript’s diagnostic precedence for variable declarations: initializer errors first, missing type annotation errors second, then invalid ambient context.

## Details
This covers ambient variable cases from the TypeScript conformance fixture, including:

```ts
declare let v1!: number;
declare var v2!: number;

declare namespace foo {
  var v!: number;
}
```
