### PR TITLE
perf(parser): store definite assertion offset

### DIFF
--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::Box;
 use oxc_ast::ast::*;
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Span};
 
 use super::VariableDeclarationParent;
 use crate::{ParserConfig as Config, ParserImpl, StatementContext, diagnostics, lexer::Kind};
@@ -114,9 +114,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 && !self.cur_token().is_on_new_line()
                 && self.at(Kind::Bang)
             {
-                let span = self.cur_token().span();
+                let span_start = self.cur_token().start();
                 self.bump_any();
-                Some(span)
+                Some(span_start)
             } else {
                 None
             };
@@ -150,7 +150,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if decl_parent == VariableDeclarationParent::Statement {
             self.check_missing_initializer(&decl);
         }
-        if let Some(span) = definite {
+        if let Some(definite_token_start) = definite {
+            let span = Span::sized(definite_token_start, 1);
             if decl.init.is_some() {
                 self.error(diagnostics::variable_declarator_definite(span));
             } else if decl.type_annotation.is_none() {


### PR DESCRIPTION
- Store the definite assignment assertion token position as a `u32` offset instead of a full `Span`.
- Reconstruct the one-character diagnostic span only when emitting definite-assignment diagnostics.