### PR TITLE
refactor(react_compiler): split diagnostics into errors/warnings and simplify transform API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,9 +780,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "forked_react_compiler"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34495a9926779b57310fd72e031fafdabc90f7c62e188aa5317ca08a115cce21"
+checksum = "41fb1da782c6cf52c2fc1ee4bf3f3865cbbbb965db5ddd5162d81dd2cdae29e7"
 dependencies = [
  "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
@@ -802,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_ast"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ed273c27b68afe5b5f3bec2cd0215d6507f93921bf93a63b77f4362699c67e"
+checksum = "98195aab233f221d598c9a716fb9735e14c11e7640cc2fcf5eeeee43a0e7b77b"
 dependencies = [
  "indexmap",
  "serde",
@@ -813,18 +813,18 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_diagnostics"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0c5c845634ca8381a4dba94fc53f757c85de2e1e29711ef8fd7b5a4ca1fe9f"
+checksum = "65de210598cc723ff47ecc9eb2ca7e5bd5e9bf62b879a124656cc43359b6d749"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "forked_react_compiler_hir"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bbec4ac046d8eac451b16c75d51d7709b10cbfdc8a52e7c580e1e45239491b"
+checksum = "343ee2d47156f2241d124fc43c4461156382f3fc88295de062468b16f7dc79c3"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "indexmap",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_inference"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c910dd22822ab23c29d2e969f3e3ca9302fb10c065fcf48b83344dab715e798"
+checksum = "9f73e9cd19d109c5ace30108d969e3c6a4e463a7b6908b67cfce9c1d10042a90"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
@@ -849,9 +849,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_lowering"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d891d2ea5d43aa948c56a036960059f405489c60089e57c261be4f35f05d815"
+checksum = "554beea54a83743dfbfd434d16254f6ddd43e82dcf1ace8c2f8724b92a6c57c3"
 dependencies = [
  "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_optimization"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8611f21629cf6333c1b634e1bca816c863d4cba48d4ac1f42d61203835797de9"
+checksum = "0c44a963cf05002e692860604451484dfeae7927dbd8c64b47669be5ef1e1cd3"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
@@ -875,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_reactive_scopes"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294a00391f2051dec90669fdff54397a464b16bb568117b48a959bed56d2798b"
+checksum = "ff8b376595fc7b9fb459977fa71c323b24fc9ddb760b17fb93cb532f0c8aeaf3"
 dependencies = [
  "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
@@ -890,9 +890,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_ssa"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4782ac57df264c71abaabf68e90b9e3a96f3d607e772bc9ee6e9d26654614aa"
+checksum = "bc9de54e28b1a714726464585341e3e2aeb1a107adbce66566d9cba538dbe686"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
@@ -902,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_typeinference"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d9379f0f48a565d82ed03de02946571af209057cfdc81fe09355518e587a54"
+checksum = "db89b2dec4518fb42fc9c6a6991e95f449df567aa16ff8b0ebc4fed8a0b2f855"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
@@ -913,18 +913,18 @@ dependencies = [
 
 [[package]]
 name = "forked_react_compiler_utils"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531d2adbbfa861f9669f70e49eb1cc27e8817a7f1d000bee3e2c71a2d82217ec"
+checksum = "f337a7f0f69ff71a4a662deb9946aa673ce28c572c886f956ac79f433c191c0a"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "forked_react_compiler_validation"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f8b2c12e00b41dc87bc2c63656b473047dcdf75b1f5dc545ca93a308d53a89"
+checksum = "6887d3cbe37dad95dbaa213f5ce3cf276c9a6a54505e72963eade959fcae32c2"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -171,8 +171,20 @@ pub trait CompilerInterface {
         // Runs first, on the pristine AST, before every other transform.
         let mut errors = Vec::new();
         if let Some(options) = self.react_compiler_options() {
-            scoping =
-                oxc_react_compiler::run(&mut program, &allocator, scoping, &options, &mut errors);
+            // `compiled` lives in `allocator`, not borrowed from `program`, so the
+            // reassignment below is sound.
+            let result = oxc_react_compiler::transform(&program, &allocator, options);
+            errors.extend(result.errors);
+            errors.extend(result.warnings);
+            if let Some(compiled) = result.program {
+                program = compiled;
+                // Rebuild scoping for downstream transforms.
+                scoping = SemanticBuilder::new()
+                    .with_enum_eval(true)
+                    .build(&program)
+                    .semantic
+                    .into_scoping();
+            }
         }
 
         /* Transform */

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -38,9 +38,9 @@ oxc_syntax = { workspace = true }
 
 # React Compiler core crates — frontend-agnostic (no oxc deps). Published fork of
 # facebook/react#36173 (MIT). `package` keeps the in-code name `react_compiler*`.
-react_compiler = { package = "forked_react_compiler", version = "0.1.3" }
-react_compiler_ast = { package = "forked_react_compiler_ast", version = "0.1.3" }
-react_compiler_hir = { package = "forked_react_compiler_hir", version = "0.1.3" }
+react_compiler = { package = "forked_react_compiler", version = "0.1.4" }
+react_compiler_ast = { package = "forked_react_compiler_ast", version = "0.1.4" }
+react_compiler_hir = { package = "forked_react_compiler_hir", version = "0.1.4" }
 
 indexmap = { workspace = true, features = ["serde"] }
 rustc-hash = { workspace = true }

--- a/crates/oxc_react_compiler/examples/react_compiler.rs
+++ b/crates/oxc_react_compiler/examples/react_compiler.rs
@@ -17,7 +17,6 @@ use std::path::Path;
 use oxc_allocator::Allocator;
 use oxc_codegen::Codegen;
 use oxc_parser::Parser;
-use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 
 use oxc_react_compiler::{default_plugin_options, transform};
@@ -38,14 +37,12 @@ fn main() {
 
     let allocator = Allocator::default();
     let program = Parser::new(&allocator, &source_text, source_type).parse().program;
-    let semantic =
-        SemanticBuilder::new().with_build_nodes(true).with_enum_eval(true).build(&program).semantic;
 
-    let result = transform(&program, &semantic, &allocator, default_plugin_options());
+    let result = transform(&program, &allocator, default_plugin_options());
 
-    if !result.diagnostics.is_empty() {
+    if !result.errors.is_empty() || !result.warnings.is_empty() {
         println!("Diagnostics:\n");
-        for diagnostic in &result.diagnostics {
+        for diagnostic in result.errors.iter().chain(&result.warnings) {
             println!("{diagnostic:?}");
         }
         println!();

--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -3,14 +3,31 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::{OxcDiagnostic, Severity};
 use react_compiler::entrypoint::compile_result::{
     CompileResult, CompilerErrorDetailInfo, LoggerEvent,
 };
 
-/// Convert a `CompileResult` into OXC diagnostics.
-pub fn compile_result_to_diagnostics(result: &CompileResult) -> Vec<OxcDiagnostic> {
-    let mut diagnostics = Vec::new();
+/// Errors and warnings produced by a compile, partitioned by severity.
+#[derive(Default)]
+pub struct Diagnostics {
+    pub errors: Vec<OxcDiagnostic>,
+    pub warnings: Vec<OxcDiagnostic>,
+}
+
+impl Diagnostics {
+    fn push(&mut self, diagnostic: OxcDiagnostic) {
+        if diagnostic.severity == Severity::Error {
+            self.errors.push(diagnostic);
+        } else {
+            self.warnings.push(diagnostic);
+        }
+    }
+}
+
+/// Convert a `CompileResult` into OXC diagnostics, split into errors and warnings.
+pub fn compile_result_to_diagnostics(result: &CompileResult) -> Diagnostics {
+    let mut diagnostics = Diagnostics::default();
 
     match result {
         CompileResult::Success { events, .. } => {

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -44,21 +44,36 @@ pub fn default_plugin_options() -> PluginOptions {
     }
 }
 
+#[derive(Default)]
 pub struct TransformResult<'a> {
     /// Compiled, ready-to-codegen OXC AST; `None` if the compiler made no changes.
     pub program: Option<oxc_ast::ast::Program<'a>>,
-    pub diagnostics: Vec<oxc_diagnostics::OxcDiagnostic>,
+    /// `Error`-severity diagnostics (e.g. Rules of Hooks violations). These are
+    /// hard problems in the source; the program is still left valid.
+    pub errors: Vec<oxc_diagnostics::OxcDiagnostic>,
+    /// `Warning`/`Hint`-severity diagnostics, including bail-outs where the
+    /// compiler declined to optimize a function (e.g. unsupported syntax).
+    pub warnings: Vec<oxc_diagnostics::OxcDiagnostic>,
+    /// Raw structured logger events from the upstream compiler (compile
+    /// success/skip/error with memoization stats), for tooling and profiling.
+    /// Unlike `errors`/`warnings`, these are not meant for user-facing reporting.
     pub events: Vec<LoggerEvent>,
 }
 
 pub struct LintResult {
-    pub diagnostics: Vec<oxc_diagnostics::OxcDiagnostic>,
+    /// `Error`-severity diagnostics (e.g. Rules of Hooks violations).
+    pub errors: Vec<oxc_diagnostics::OxcDiagnostic>,
+    /// `Warning`/`Hint`-severity diagnostics, including compiler bail-outs.
+    pub warnings: Vec<oxc_diagnostics::OxcDiagnostic>,
 }
 
-/// Transform a pre-parsed program. `program` is `None` when nothing was compiled.
+/// Run the React Compiler on a pre-parsed program, building the semantic model
+/// internally and returning the result. `program` in the result is `None` when
+/// nothing was compiled (no React-like functions, a bail-out, or no changes).
+///
+/// Must run **first**, on the pristine AST, before any other transform.
 pub fn transform<'a>(
     program: &oxc_ast::ast::Program<'a>,
-    semantic: &oxc_semantic::Semantic,
     allocator: &'a oxc_allocator::Allocator,
     options: PluginOptions,
 ) -> TransformResult<'a> {
@@ -68,20 +83,26 @@ pub fn transform<'a>(
     if !matches!(options.compilation_mode.as_str(), "all" | "annotation")
         && !has_react_like_functions(program)
     {
-        return TransformResult { program: None, diagnostics: vec![], events: vec![] };
+        return TransformResult::default();
     }
 
     // `using`/`await using` disposal semantics aren't preserved yet — skip the file.
     if has_resource_management_declarations(program) {
-        return TransformResult { program: None, diagnostics: vec![], events: vec![] };
+        return TransformResult::default();
     }
 
+    let semantic = oxc_semantic::SemanticBuilder::new()
+        .with_build_nodes(true)
+        .with_enum_eval(true)
+        .build(program)
+        .semantic;
+
     let file = convert_program(program, source_text);
-    let scope_info = convert_scope_info(semantic, program);
+    let scope_info = convert_scope_info(&semantic, program);
     let result =
         react_compiler::entrypoint::program::compile_program(file, scope_info.clone(), options);
 
-    let diagnostics = compile_result_to_diagnostics(&result);
+    let diagnostics::Diagnostics { errors, warnings } = compile_result_to_diagnostics(&result);
     let (program_ast, events, renames) = match result {
         react_compiler::entrypoint::compile_result::CompileResult::Success {
             ast,
@@ -106,7 +127,7 @@ pub fn transform<'a>(
         compiled
     });
 
-    TransformResult { program: compiled_program, diagnostics, events }
+    TransformResult { program: compiled_program, errors, warnings, events }
 }
 
 /// Re-parse the source for comments and keep those attached to top-level
@@ -155,29 +176,18 @@ pub fn transform_source<'a>(
     options: PluginOptions,
 ) -> TransformResult<'a> {
     let parsed = oxc_parser::Parser::new(allocator, source_text, source_type).parse();
-
-    let semantic = oxc_semantic::SemanticBuilder::new()
-        .with_build_nodes(true)
-        .with_enum_eval(true)
-        .build(&parsed.program)
-        .semantic;
-
-    transform(&parsed.program, &semantic, allocator, options)
+    transform(&parsed.program, allocator, options)
 }
 
 /// Lint a pre-parsed program — like [`transform`] but only collects diagnostics.
-pub fn lint(
-    program: &oxc_ast::ast::Program,
-    semantic: &oxc_semantic::Semantic,
-    options: PluginOptions,
-) -> LintResult {
+pub fn lint(program: &oxc_ast::ast::Program, options: PluginOptions) -> LintResult {
     let mut opts = options;
     opts.no_emit = true;
 
     // `no_emit` yields `program: None`; a local arena for the conversion suffices.
     let allocator = oxc_allocator::Allocator::default();
-    let result = transform(program, semantic, &allocator, opts);
-    LintResult { diagnostics: result.diagnostics }
+    let result = transform(program, &allocator, opts);
+    LintResult { errors: result.errors, warnings: result.warnings }
 }
 
 /// Convenience wrapper — parses source text, runs semantic analysis, then lints.
@@ -188,45 +198,7 @@ pub fn lint_source(
 ) -> LintResult {
     let allocator = oxc_allocator::Allocator::default();
     let parsed = oxc_parser::Parser::new(&allocator, source_text, source_type).parse();
-
-    let semantic = oxc_semantic::SemanticBuilder::new()
-        .with_build_nodes(true)
-        .with_enum_eval(true)
-        .build(&parsed.program)
-        .semantic;
-
-    lint(&parsed.program, &semantic, options)
-}
-
-/// Run the React Compiler as a standalone pass, returning the `Scoping` for the
-/// rest of the pipeline (rebuilt if the program changed). Must run **first**, on
-/// the pristine AST, before any other transform.
-pub fn run<'a>(
-    program: &mut oxc_ast::ast::Program<'a>,
-    allocator: &'a oxc_allocator::Allocator,
-    scoping: oxc_semantic::Scoping,
-    options: &PluginOptions,
-    errors: &mut std::vec::Vec<oxc_diagnostics::OxcDiagnostic>,
-) -> oxc_semantic::Scoping {
-    // `compiled` lives in `allocator`, not borrowed from `*program`, so the
-    // reassignment below is sound.
-    let result = {
-        let semantic = oxc_semantic::SemanticBuilder::new()
-            .with_build_nodes(true)
-            .with_enum_eval(true)
-            .build(program)
-            .semantic;
-        transform(program, &semantic, allocator, options.clone())
-    };
-    errors.extend(result.diagnostics);
-
-    let Some(compiled) = result.program else {
-        return scoping;
-    };
-    *program = compiled;
-
-    // Rebuild scoping for downstream transforms.
-    oxc_semantic::SemanticBuilder::new().with_enum_eval(true).build(program).semantic.into_scoping()
+    lint(&parsed.program, options)
 }
 
 // End-to-end smoke tests: oxc parse + semantic -> convert -> compile -> convert
@@ -256,7 +228,8 @@ mod tests {
         let allocator = oxc_allocator::Allocator::default();
         let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
 
-        assert!(result.diagnostics.is_empty(), "unexpected diagnostics: {:?}", result.diagnostics);
+        assert!(result.errors.is_empty(), "unexpected errors: {:?}", result.errors);
+        assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
         let program = result.program.expect("React Compiler should have transformed the component");
 
         let output = oxc_codegen::Codegen::new().build(&program).code;
@@ -297,9 +270,9 @@ export = legacy;\n";
 
         let allocator = oxc_allocator::Allocator::default();
         let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
-        let program = result.program.unwrap_or_else(|| {
-            panic!("component should be compiled; diagnostics: {:?}", result.diagnostics)
-        });
+        let program = result
+            .program
+            .unwrap_or_else(|| panic!("component should be compiled; errors: {:?}", result.errors));
         let output = oxc_codegen::Codegen::new().build(&program).code;
         assert!(
             output.contains("react/compiler-runtime"),
@@ -423,9 +396,9 @@ function Component(props: Props): JSX.Element {\n\
 
         let allocator = oxc_allocator::Allocator::default();
         let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
-        let program = result.program.unwrap_or_else(|| {
-            panic!("component should compile; diagnostics: {:?}", result.diagnostics)
-        });
+        let program = result
+            .program
+            .unwrap_or_else(|| panic!("component should compile; errors: {:?}", result.errors));
         let output = oxc_codegen::Codegen::new().build(&program).code;
 
         assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
@@ -574,9 +547,10 @@ async function Component(props) {\n  await using x = sideEffect();\n  return <di
 
             assert!(result.program.is_none(), "resource management should skip React Compiler");
             assert!(
-                result.diagnostics.is_empty(),
-                "unexpected diagnostics: {:?}",
-                result.diagnostics
+                result.errors.is_empty() && result.warnings.is_empty(),
+                "unexpected diagnostics: {:?} {:?}",
+                result.errors,
+                result.warnings
             );
         }
     }
@@ -617,16 +591,14 @@ function Component(props) {\n  return <div>{E.A}{N.value}{props.text}</div>;\n}\
     /// Diagnostics are surfaced at the compiler's own severity, not flattened.
     #[test]
     fn diagnostics_preserve_compiler_severity() {
-        use oxc_diagnostics::Severity;
-
         // A Rules of Hooks violation is an `Error`-severity diagnostic.
         let source = "function Component(props) {\n  if (props.cond) {\n    useState(0);\n  }\n  return <div>{props.text}</div>;\n}\n";
         let allocator = oxc_allocator::Allocator::default();
         let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
         assert!(
-            result.diagnostics.iter().any(|d| d.severity == Severity::Error),
+            !result.errors.is_empty(),
             "Rules of Hooks violation should be reported as an error: {:?}",
-            result.diagnostics
+            result.errors
         );
 
         // A local named `fbt` is an unsupported-syntax bail-out — a warning, not an error.
@@ -634,14 +606,14 @@ function Component(props) {\n  return <div>{E.A}{N.value}{props.text}</div>;\n}\
         let allocator = oxc_allocator::Allocator::default();
         let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
         assert!(
-            result.diagnostics.iter().any(|d| d.severity == Severity::Warning),
+            !result.warnings.is_empty(),
             "fbt bail-out should be reported as a warning: {:?}",
-            result.diagnostics
+            result.warnings
         );
         assert!(
-            result.diagnostics.iter().all(|d| d.severity != Severity::Error),
+            result.errors.is_empty(),
             "fbt warning must not be reported as an error: {:?}",
-            result.diagnostics
+            result.errors
         );
     }
 }

--- a/tasks/benchmark/benches/react_compiler.rs
+++ b/tasks/benchmark/benches/react_compiler.rs
@@ -2,7 +2,6 @@ use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_parser::{Parser, ParserReturn};
 use oxc_react_compiler::{default_plugin_options, transform};
-use oxc_semantic::SemanticBuilder;
 use oxc_tasks_common::TestFiles;
 
 fn bench_react_compiler(criterion: &mut Criterion) {
@@ -24,17 +23,12 @@ fn bench_react_compiler(criterion: &mut Criterion) {
                 // Reset allocator at start of each iteration.
                 allocator.reset();
 
-                // Create fresh AST + semantic data for each iteration. The compiler
-                // reads them and allocates the compiled program in the same arena.
+                // Create a fresh AST for each iteration. The compiler builds
+                // semantic data and allocates the compiled program in the same arena.
                 let ParserReturn { program, .. } =
                     Parser::new(&allocator, source_text, source_type).parse();
-                let semantic = SemanticBuilder::new()
-                    .with_build_nodes(true)
-                    .with_enum_eval(true)
-                    .build(&program)
-                    .semantic;
 
-                runner.run(|| transform(&program, &semantic, &allocator, options.clone()));
+                runner.run(|| transform(&program, &allocator, options.clone()));
             });
         });
     }


### PR DESCRIPTION
## What

Reworks the `oxc_react_compiler` public API:

- Renames the standalone `run` entrypoint to `transform`. It now returns a `TransformResult` instead of taking a `&mut errors` vec and rebuilding `Scoping` internally. Callers use `result.program` (`Some`/`None`) to decide whether to rebuild scoping — the `oxc::Compiler` callsite does exactly this.
- Splits `TransformResult`/`LintResult` diagnostics into separate `errors` and `warnings` (partitioned by `Severity`), and documents `errors` / `warnings` / `events`.
- Adds `#[derive(Default)]` to `TransformResult` for the bail-out paths.
- Inlines the former `transform_impl`; semantic is now built internally, after the cheap prefilter bail-outs (so non-React files skip semantic construction).
- Bumps the `forked_react_compiler` family `0.1.3` → `0.1.4`.

Example and benchmark updated to the new `transform(&program, &allocator, options)` signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)