### PR TITLE
perf(parser): store class definite assertion offset

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -584,9 +584,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             );
         }
 
-        let definite = self.eat(Kind::Bang);
+        let is_definite = self.eat(Kind::Bang);
+        let definite = is_definite.then_some(self.prev_token_end - 1);
 
-        if definite && let Some(optional_span) = optional_span {
+        if is_definite && let Some(optional_span) = optional_span {
             self.error(diagnostics::optional_definite_property(optional_span.expand_right(1)));
         }
 
@@ -598,7 +599,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::constructor_accessor(name.span()));
             }
             return self.parse_class_accessor_property(
-                span, name, computed, definite, modifiers, decorators,
+                span,
+                name,
+                computed,
+                is_definite,
+                modifiers,
+                decorators,
             );
         }
 
@@ -652,7 +658,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         name: PropertyKey<'a>,
         computed: bool,
         optional_span: Option<Span>,
-        definite: bool,
+        definite: Option<u32>,
         modifiers: &Modifiers,
         decorators: Vec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
@@ -709,17 +715,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 initializer.span(),
             ));
         }
-        if definite {
+        if let Some(definite_token_start) = definite {
+            let definite_span = Span::sized(definite_token_start, 1);
             if initializer.is_some() {
-                self.error(diagnostics::variable_declarator_definite(self.end_span(span)));
+                self.error(diagnostics::variable_declarator_definite(definite_span));
             } else if type_annotation.is_none() {
-                self.error(diagnostics::variable_declarator_definite_type_assertion(
-                    self.end_span(span),
-                ));
+                self.error(diagnostics::variable_declarator_definite_type_assertion(definite_span));
             } else if self.ctx.has_ambient() || r#static || r#abstract {
-                self.error(diagnostics::definite_assignment_assertion_not_permitted(
-                    self.end_span(span),
-                ));
+                self.error(diagnostics::definite_assignment_assertion_not_permitted(definite_span));
             }
         }
         self.ast.class_element_property_definition(
@@ -734,7 +737,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             modifiers.contains(ModifierKind::Declare),
             modifiers.contains(ModifierKind::Override),
             optional_span.is_some(),
-            definite,
+            definite.is_some(),
             modifiers.contains(ModifierKind::Readonly),
             modifiers.accessibility(),
         )

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -181,20 +181,20 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/private-fields/input.ts
 
   × TS(1264): Declarations with definite assignment assertions must also have type annotations.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/private-fields/input.ts:5:3]
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/private-fields/input.ts:5:5]
  4 │   #c?: number;
  5 │   #d!;
-   ·   ────
+   ·     ─
  6 │   #e!: boolean;
    ╰────
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/properties/input.ts
 
   × TS(1264): Declarations with definite assignment assertions must also have type annotations.
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/properties/input.ts:6:5]
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/properties/input.ts:6:6]
  5 │     x: number = 1;
  6 │     x!;
-   ·     ───
+   ·      ─
  7 │     x!: number;
    ╰────
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -5929,10 +5929,10 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
    ╰────
 
   × TS(1264): Declarations with definite assignment assertions must also have type annotations.
-   ╭─[typescript/tests/cases/compiler/definiteAssignmentWithErrorStillStripped.ts:2:5]
+   ╭─[typescript/tests/cases/compiler/definiteAssignmentWithErrorStillStripped.ts:2:6]
  1 │ class C {
  2 │     p!;
-   ·     ───
+   ·      ─
  3 │ }
    ╰────
 
@@ -17475,10 +17475,10 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ╰────
 
   × TS(1255): A definite assignment assertion '!' is not permitted in this context.
-    ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/derivedUninitializedPropertyDeclaration.ts:12:5]
+    ╭─[typescript/tests/cases/conformance/classes/propertyMemberDeclarations/derivedUninitializedPropertyDeclaration.ts:12:21]
  11 │ class BDBang extends A {
  12 │     declare property!: any; // ! is not allowed, this is an ambient declaration
-    ·     ───────────────────────
+    ·                     ─
  13 │ }
     ╰────
 
@@ -17828,50 +17828,50 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
   help: Only 'readonly' modifier is allowed here.
 
   × TS(1263): Declarations with initializers cannot also have definite assignment assertions.
-    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:20:5]
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:20:6]
  19 │ class C3 {
  20 │     a! = 1;
-    ·     ───────
+    ·      ─
  21 │     b!: number = 1;
     ╰────
 
   × TS(1263): Declarations with initializers cannot also have definite assignment assertions.
-    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:21:5]
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:21:6]
  20 │     a! = 1;
  21 │     b!: number = 1;
-    ·     ───────────────
+    ·      ─
  22 │     static c!: number;
     ╰────
 
   × TS(1255): A definite assignment assertion '!' is not permitted in this context.
-    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:22:5]
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:22:13]
  21 │     b!: number = 1;
  22 │     static c!: number;
-    ·     ──────────────────
+    ·             ─
  23 │     d!;
     ╰────
 
   × TS(1264): Declarations with definite assignment assertions must also have type annotations.
-    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:23:5]
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:23:6]
  22 │     static c!: number;
  23 │     d!;
-    ·     ───
+    ·      ─
  24 │ }
     ╰────
 
   × TS(1255): A definite assignment assertion '!' is not permitted in this context.
-    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:29:5]
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:29:6]
  28 │ declare class C4 {
  29 │     a!: number;
-    ·     ───────────
+    ·      ─
  30 │ }
     ╰────
 
   × TS(1255): A definite assignment assertion '!' is not permitted in this context.
-    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:35:5]
+    ╭─[typescript/tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts:35:15]
  34 │ abstract class C5 {
  35 │     abstract a!: number;
-    ·     ────────────────────
+    ·               ─
  36 │ }
     ╰────
 

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1171,10 +1171,10 @@ x Output mismatch
 
   x TS(1264): Declarations with definite assignment assertions must also have
   | type annotations.
-   ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/class/uninitialized-definite/input.ts:2:3]
+   ,-[tasks/coverage/babel/packages/babel-plugin-transform-typescript/test/fixtures/class/uninitialized-definite/input.ts:2:4]
  1 | class A {
  2 |   x!;
-   :   ^^^
+   :    ^
  3 | }
    `----
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -144,20 +144,20 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
   x TS(1263): Declarations with initializers cannot also have definite
   | assignment assertions.
-   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/declare-and-definite-with-initializer/input.ts:8:4]
+   ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/declare-and-definite-with-initializer/input.ts:8:16]
  7 | class DefiniteExample {
  8 |    readonly bar! = "test";
-   :    ^^^^^^^^^^^^^^^^^^^^^^^
+   :                ^
  9 |    readonly foo! = 1;
    `----
 
 
   x TS(1263): Declarations with initializers cannot also have definite
   | assignment assertions.
-    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/declare-and-definite-with-initializer/input.ts:9:4]
+    ,-[tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/declare-and-definite-with-initializer/input.ts:9:16]
   8 |    readonly bar! = "test";
   9 |    readonly foo! = 1;
-    :    ^^^^^^^^^^^^^^^^^^
+    :                ^
  10 | }
     `----
 


### PR DESCRIPTION
- Store class property definite assignment assertion positions as `u32` offsets instead of carrying a full `Span`.
- Reconstruct the one-character diagnostic span only when emitting class definite-assignment diagnostics.
- aligns the behaviour for definite assertion errors with variables by reporting on the definite assertion rather than on the whole class member
