### PR TITLE
feat(transformer)!: disable styled-components transpileTemplateLiterals by default

### DIFF
--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -110,13 +110,17 @@ pub struct StyledComponentsOptions {
     pub ssr: bool,
 
     /// Transpiles styled-components tagged template literals to a smaller representation
-    /// than what Babel normally creates, helping to reduce bundle size.
+    /// than what Babel normally creates.
     ///
-    /// Converts `` styled.div`width: 100%;` `` to `styled.div(['width: 100%;'])`, which is
-    /// more compact than the standard Babel template literal transformation.
+    /// Converts `` styled.div`width: 100%;` `` to `styled.div(['width: 100%;'])`.
     ///
-    /// Default: `true`
-    #[serde(default = "default_as_true")]
+    /// This is only beneficial when template literals are down-levelled to ES5 (as Babel
+    /// does), where the array form is more compact than the transpiled tagged template.
+    /// Oxc does not down-level template literals, so this transform only makes the output
+    /// larger than leaving the template literal as-is. It is therefore disabled by default.
+    ///
+    /// Default: `false`
+    #[serde(default)]
     pub transpile_template_literals: bool,
 
     /// Minifies CSS content by removing all whitespace and comments from your CSS,
@@ -209,13 +213,15 @@ impl Default for StyledComponentsOptions {
     /// are set but not yet implemented.
     ///
     /// The `pure` option is disabled by default to avoid potential issues with
-    /// tree-shaking in some bundlers.
+    /// tree-shaking in some bundlers. `transpileTemplateLiterals` is disabled by default
+    /// because Oxc does not down-level template literals, so transpiling them to the array
+    /// form only increases output size.
     fn default() -> Self {
         Self {
             display_name: true,
             file_name: true,
             ssr: true,
-            transpile_template_literals: true,
+            transpile_template_literals: false,
             pure: false,
             minify: true,
             namespace: None,

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -467,7 +467,10 @@ export interface StyledComponentsOptions {
    * Transpiles styled-components tagged template literals to a smaller representation
    * than what Babel normally creates, helping to reduce bundle size.
    *
-   * @default true
+   * Disabled by default because Oxc does not down-level template literals, so this
+   * transform only increases output size.
+   *
+   * @default false
    */
   transpileTemplateLiterals?: boolean
   /**

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -472,7 +472,10 @@ pub struct StyledComponentsOptions {
     /// Transpiles styled-components tagged template literals to a smaller representation
     /// than what Babel normally creates, helping to reduce bundle size.
     ///
-    /// @default true
+    /// Disabled by default because Oxc does not down-level template literals, so this
+    /// transform only increases output size.
+    ///
+    /// @default false
     pub transpile_template_literals: Option<bool>,
 
     /// Minifies CSS content by removing all whitespace and comments from your CSS,

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -547,7 +547,7 @@ describe("styled-components", () => {
 			styled.div.withConfig({
 				displayName: "test",
 				componentId: "sc-3q0sbi-0"
-			})(["color:red;"]);
+			})\`color:red;\`;
 			const v = /* @__PURE__ */ css(["color: red;"]);
 			"
 		`);

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/annotate-create-global-style-with-pure-comments/options.json
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/annotate-create-global-style-with-pure-comments/options.json
@@ -1,7 +1,8 @@
 {
   "plugins": [
     ["styled-components", {
-      "pure": true
+      "pure": true,
+      "transpileTemplateLiterals": true
     }]
   ]
 }

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/annotate-styled-calls-with-pure-comments/options.json
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/annotate-styled-calls-with-pure-comments/options.json
@@ -1,7 +1,8 @@
 {
   "plugins": [
     ["styled-components", {
-      "pure": true
+      "pure": true,
+      "transpileTemplateLiterals": true
     }]
   ]
 }

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/css-declared-after-component/options.json
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/css-declared-after-component/options.json
@@ -1,5 +1,7 @@
 {
   "plugins": [
-    ["styled-components"]
+    ["styled-components", {
+      "transpileTemplateLiterals": true
+    }]
   ]
 }

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/does-not-replace-native-with-no-tags/options.json
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/does-not-replace-native-with-no-tags/options.json
@@ -1,5 +1,7 @@
 {
   "plugins": [
-    ["styled-components"]
+    ["styled-components", {
+      "transpileTemplateLiterals": true
+    }]
   ]
 }

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/ignore-external-styled-import/options.json
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/ignore-external-styled-import/options.json
@@ -1,5 +1,7 @@
 {
   "plugins": [
-    ["styled-components"]
+    ["styled-components", {
+      "transpileTemplateLiterals": true
+    }]
   ]
 }

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/minify-single-line-comments-with-interpolations/options.json
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/minify-single-line-comments-with-interpolations/options.json
@@ -1,7 +1,8 @@
 {
   "plugins": [
     ["styled-components", {
-      "minify": true
+      "minify": true,
+      "transpileTemplateLiterals": true
     }]
   ]
 }

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/transformed-imports-with-jsx-member-expressions/options.json
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/transformed-imports-with-jsx-member-expressions/options.json
@@ -1,5 +1,7 @@
 {
   "plugins": [
-    ["styled-components"]
+    ["styled-components", {
+      "transpileTemplateLiterals": true
+    }]
   ]
 }

--- a/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/transpile-require-default/options.json
+++ b/tasks/transform_conformance/tests/plugin-styled-components/test/fixtures/styled-components/transpile-require-default/options.json
@@ -1,5 +1,7 @@
 {
   "plugins": [
-    ["styled-components"]
+    ["styled-components", {
+      "transpileTemplateLiterals": true
+    }]
   ]
 }


### PR DESCRIPTION
## Summary

Closes #13398.

The styled-components transform's `transpileTemplateLiterals` option rewrites tagged template literals into the array-call form:

```js
// in
styled.div`width: 100%;`
// out — transpileTemplateLiterals: true
styled.div(["width: 100%;"])
```

This form is only more compact when template literals are *also* down-levelled to ES5 — which is why `babel-plugin-styled-components` enables it by default, to pre-empt Babel's verbose `_taggedTemplateLiteral` output. Oxc does not down-level template literals below ES6, so the array-call form is strictly *larger* than leaving the tagged template untouched.

This PR flips the default to `false`, as agreed with @Dunqing in #13398.

## Changes

- `StyledComponentsOptions::transpile_template_literals` now defaults to `false` (both the `serde` field default and the `Default` impl), with docs explaining why.
- napi: `transpileTemplateLiterals` is documented `@default false` (`transformer.rs` + `index.d.ts`), and the styled-components napi test snapshot now reflects the non-transpiled default output.
- Conformance fixtures that relied on the old default and whose reference output is transpiled now pin `transpileTemplateLiterals: true`, so they keep matching `babel-plugin-styled-components`' reference output. The conformance snapshot is unchanged — `plugin-styled-components` stays at 25/40.

## Breaking change

`transpileTemplateLiterals` now defaults to `false`. Pass `transpileTemplateLiterals: true` to restore the previous behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
