### PR TITLE
feat(parser): report error for `const` modifier on interface type parameter

### DIFF
--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -217,6 +217,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let id = self.parse_binding_identifier();
         self.check_reserved_type_name(&id, "Interface");
         let type_parameters = self.parse_ts_type_parameters();
+        if let Some(type_parameters) = &type_parameters {
+            for param in &type_parameters.params {
+                if param.r#const {
+                    self.error(diagnostics::const_type_parameter(param.span));
+                }
+            }
+        }
         let (extends, implements) = self.parse_heritage_clause();
         let body = self.parse_ts_interface_body();
         let extends = extends.unwrap_or_else(|| self.ast.vec());

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -278,6 +278,46 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts
 
+  × TS(1277): 'const' modifier can only appear on a type parameter of a function, method or class
+    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts:22:13]
+ 21 │ 
+ 22 │ interface I<const T> {}
+    ·             ───────
+ 23 │ interface J<const T extends U> {}
+    ╰────
+
+  × TS(1277): 'const' modifier can only appear on a type parameter of a function, method or class
+    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts:23:13]
+ 22 │ interface I<const T> {}
+ 23 │ interface J<const T extends U> {}
+    ·             ─────────────────
+ 24 │ interface K<T, const U> {}
+    ╰────
+
+  × TS(1277): 'const' modifier can only appear on a type parameter of a function, method or class
+    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts:24:16]
+ 23 │ interface J<const T extends U> {}
+ 24 │ interface K<T, const U> {}
+    ·                ───────
+ 25 │ interface L<in const T> {}
+    ╰────
+
+  × TS(1277): 'const' modifier can only appear on a type parameter of a function, method or class
+    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts:25:13]
+ 24 │ interface K<T, const U> {}
+ 25 │ interface L<in const T> {}
+    ·             ──────────
+ 26 │ interface M<const in T> {}
+    ╰────
+
+  × TS(1277): 'const' modifier can only appear on a type parameter of a function, method or class
+    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts:26:13]
+ 25 │ interface L<in const T> {}
+ 26 │ interface M<const in T> {}
+    ·             ──────────
+ 27 │ 
+    ╰────
+
   × Identifier `method` has already been declared
     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts:29:3]
  28 │ class _ {

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -30535,6 +30535,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ╰────
 
   × TS(1277): 'const' modifier can only appear on a type parameter of a function, method or class
+    ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts:49:14]
+ 48 │ 
+ 49 │ interface I1<const T> { x: T }  // Error
+    ·              ───────
+ 50 │ 
+    ╰────
+
+  × TS(1277): 'const' modifier can only appear on a type parameter of a function, method or class
     ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts:55:9]
  54 │ 
  55 │ type T1<const T> = T;  // Error

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -1311,6 +1311,11 @@ after transform: ScopeId(0): ["a", "b"]
 rebuilt        : ScopeId(0): []
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters/input.ts
+'const' modifier can only appear on a type parameter of a function, method or class
+'const' modifier can only appear on a type parameter of a function, method or class
+'const' modifier can only appear on a type parameter of a function, method or class
+'const' modifier can only appear on a type parameter of a function, method or class
+'const' modifier can only appear on a type parameter of a function, method or class
 Identifier `method` has already been declared
 Identifier `method` has already been declared
 


### PR DESCRIPTION
i think this got lost on Boshen 's stacks, as this appeared to get merged in https://github.com/oxc-project/oxc/pull/22829/changes

