### PR TITLE
fix(linter/react/exhaustive-deps): ignore non `React` namespace hooks

### DIFF
--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -856,7 +856,11 @@ impl ExhaustiveDeps {
 fn get_node_name_without_react_namespace<'a>(expr: &Expression<'a>) -> Option<&'a str> {
     match expr {
         Expression::StaticMemberExpression(member) => {
-            if let Expression::Identifier(_ident) = &member.object {
+            if member
+                .object
+                .get_identifier_reference()
+                .is_some_and(|reference| reference.name == "React")
+            {
                 return Some(member.property.name.as_str());
             }
             None
@@ -2844,6 +2848,15 @@ export const useTest = () => {
   const DATA = 'test' as const;
   const data = useMemo(() => DATA, []);
   return <div>{data}</div>;
+};",
+        "const ReactActual = jest.requireActual('react');
+const Component = ({ filter }) => {
+    const [data, setData] = ReactActual.useState(filter);
+    ReactActual.useEffect(() => {
+        setData(filter);
+    }, [filter]);
+
+    return <div>test</div>;
 };",
     ];
 


### PR DESCRIPTION
upstream ref: https://github.com/facebook/react/blob/8f8b336734d7c807f5aa11b0f31540e63302d789/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts#L136-L149

Fixes #23150
