### PR TITLE
perf(minifier): incremental scoping refresh, delete LiveUsageCollector

### DIFF
--- a/crates/oxc_allocator/src/bitset.rs
+++ b/crates/oxc_allocator/src/bitset.rs
@@ -39,6 +39,29 @@ impl<'alloc> BitSet<'alloc> {
         Self { entries, max_bit_count }
     }
 
+    /// Returns the maximum number of bits this set can hold.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.max_bit_count
+    }
+
+    /// Returns `true` if no bits are set.
+    ///
+    /// Scans the underlying word array; short-circuits at the first non-zero word.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.entries.iter().all(|word| *word == 0)
+    }
+
+    /// Bounds-safe membership test: returns `true` if `bit` is within
+    /// capacity AND set. Positions at or beyond [`Self::capacity`] return
+    /// `false`, whereas [`Self::has_bit`] may panic or read unspecified
+    /// trailing-bit state for such positions.
+    #[inline]
+    pub fn contains(&self, bit: usize) -> bool {
+        bit < self.max_bit_count && self.has_bit(bit)
+    }
+
     /// Returns `true` if the bit at the given position is set.
     #[inline]
     pub fn has_bit(&self, bit: usize) -> bool {
@@ -333,5 +356,30 @@ mod tests {
         bs.set_bit(0);
         bs.set_bit(2);
         assert_eq!(bs.ones().collect::<Vec<_>>(), [0, 2]);
+    }
+
+    #[test]
+    fn capacity_and_is_empty() {
+        let allocator = Allocator::default();
+        let mut bs = BitSet::new_in(128, &allocator);
+        assert_eq!(bs.capacity(), 128);
+        assert!(bs.is_empty());
+        bs.set_bit(100);
+        assert!(!bs.is_empty());
+        bs.unset_bit(100);
+        assert!(bs.is_empty());
+
+        // Zero-capacity bitset is always empty.
+        let bs0 = BitSet::new_in(0, &allocator);
+        assert_eq!(bs0.capacity(), 0);
+        assert!(bs0.is_empty());
+        assert!(!bs0.contains(0));
+
+        // `contains` is bounds-safe: out-of-range is `false`, not a panic.
+        bs.set_bit(100);
+        assert!(bs.contains(100));
+        assert!(!bs.contains(99));
+        assert!(!bs.contains(128));
+        assert!(!bs.contains(usize::MAX));
     }
 }

--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -23,6 +23,22 @@ impl<'a> Compressor<'a> {
     }
 
     /// Returns total number of iterations ran.
+    ///
+    /// # Precondition
+    ///
+    /// `scoping` must be consistent with `program` in the resolved-reference
+    /// domain: every resolved `IdentifierReference` in `program` must be present
+    /// in its symbol's resolved-references list, and no list may contain a
+    /// `ReferenceId` whose node is absent from `program`. The compressor refreshes
+    /// scoping *incrementally* — it only prunes references for nodes it drops, and
+    /// no longer rebuilds liveness from scratch each pass — so a caller that
+    /// mutated `program` after building `scoping` must reflect those edits in
+    /// `scoping`. Stale *extra* references cause missed optimizations (output stays
+    /// correct); an *added* reference that was never recorded can cause incorrect
+    /// output. In-repo callers satisfy this by rebuilding a fresh `Scoping`
+    /// immediately before calling this — e.g. `crates/oxc/src/compiler.rs`
+    /// rebuilds scoping before compress/DCE whenever `ReplaceGlobalDefines`
+    /// reports a change.
     pub fn build_with_scoping(
         self,
         program: &mut Program<'a>,
@@ -30,8 +46,13 @@ impl<'a> Compressor<'a> {
         options: CompressOptions,
     ) -> u8 {
         let max_iterations = options.max_iterations;
-        let state =
-            MinifierState::new(program.source_type, options, /* dce */ false, &scoping);
+        let state = MinifierState::new(
+            program.source_type,
+            options,
+            /* dce */ false,
+            &scoping,
+            self.allocator,
+        );
         let mut ctx = ReusableTraverseCtx::new(state, scoping, self.allocator);
         let normalize_options = NormalizeOptions {
             convert_while_to_fors: true,
@@ -48,6 +69,11 @@ impl<'a> Compressor<'a> {
     }
 
     /// Returns total number of iterations ran.
+    ///
+    /// # Precondition
+    ///
+    /// Same incoming-`scoping` consistency requirement as
+    /// [`Self::build_with_scoping`] — see its docs.
     pub fn dead_code_elimination_with_scoping(
         self,
         program: &mut Program<'a>,
@@ -55,7 +81,13 @@ impl<'a> Compressor<'a> {
         options: CompressOptions,
     ) -> u8 {
         let max_iterations = options.max_iterations;
-        let state = MinifierState::new(program.source_type, options, /* dce */ true, &scoping);
+        let state = MinifierState::new(
+            program.source_type,
+            options,
+            /* dce */ true,
+            &scoping,
+            self.allocator,
+        );
         let mut ctx = ReusableTraverseCtx::new(state, scoping, self.allocator);
         let normalize_options = NormalizeOptions {
             convert_while_to_fors: false,
@@ -73,15 +105,27 @@ impl<'a> Compressor<'a> {
         ctx: &mut ReusableTraverseCtx<'a>,
     ) -> u8 {
         let mut iteration = 0u8;
-        // Defensive: start the fixed-point loop from a clean signal. Nothing records
-        // mutations before the loop today (Normalize uses raw slot writes and does
-        // not consume the signal).
+        // Boundary for the under-prune debug guard: references with indices
+        // beyond this are minted during the loop and legally exempt.
+        #[cfg(debug_assertions)]
+        let initial_references_len = ctx.get_mut().scoping().references_len();
+        // Consume the drops Normalize recorded (`void x` -> `void 0`,
+        // drop_console), so pass 1 already observes the pruned reference
+        // counts and Normalize's drops cost no extra peephole pass.
+        PeepholeOptimizations::flush_pass_dirty(program, ctx.get_mut());
+        // Start the loop from a clean signal: Normalize's drops are flushed
+        // above, so a Normalize-only mutation must not force a pointless
+        // extra iteration.
         ctx.state_mut().take_mutated();
         loop {
             PeepholeOptimizations.run_once(program, ctx);
+            // A pass with no recorded mutation cannot have recorded drops
+            // (every drop helper also records a mutation), so the terminal
+            // iteration skips the flush.
             if !ctx.state_mut().take_mutated() {
                 break;
             }
+            PeepholeOptimizations::flush_pass_dirty(program, ctx.get_mut());
             if let Some(max) = max_iterations {
                 if iteration >= max {
                     break;
@@ -92,6 +136,12 @@ impl<'a> Compressor<'a> {
             }
             iteration += 1;
         }
+        #[cfg(debug_assertions)]
+        PeepholeOptimizations::debug_assert_no_under_prune(
+            program,
+            ctx.get_mut(),
+            initial_references_len,
+        );
         iteration
     }
 }

--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -19,12 +19,11 @@ impl<'a> PeepholeOptimizations {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         // Wrap the fresh conditional in an `Expression` slot so that, if the
-        // fold returns a replacement, it is routed through
-        // `ctx.replace_expression` like every other slot replacement. The
-        // discarded transient `ConditionalExpression` leaves refs in its
-        // untouched slots (e.g. the leftover `b` in `b == null ? c : b` ->
-        // `b ?? c`), which the incremental-scoping follow-up reclaims at this
-        // slot.
+        // fold returns a replacement, `ctx.replace_expression` can walk the
+        // mutated transient conditional and mark its leaked refs dead. Without
+        // the slot wrapping, refs left in untouched slots of the discarded
+        // transient `ConditionalExpression` (e.g. the leftover `b` in
+        // `b == null ? c : b` -> `b ?? c`) would never reach `PassDirty`.
         let mut as_expr = ctx.ast.expression_conditional(span, test, consequent, alternate);
         let Expression::ConditionalExpression(cond_box) = &mut as_expr else { unreachable!() };
         let folded = Self::minimize_conditional_expression(cond_box, ctx);
@@ -460,7 +459,13 @@ impl<'a> PeepholeOptimizations {
         if ctx.expr_eq(&expr.alternate, &expr.consequent) {
             // "/* @__PURE__ */ a() ? b : b" => "b"
             if !expr.test.may_have_side_effects(ctx) {
-                return Some(expr.consequent.take_in(ctx.ast));
+                let result_expr = expr.consequent.take_in(ctx.ast);
+                // "(a ? eval : eval)(x)" => "(0, eval)(x)" — the bare branch
+                // would form a direct eval call / rebind a member call's `this`.
+                if Self::should_keep_indirect_access(&result_expr, ctx) {
+                    return Some(Self::preserve_indirect_access(expr.span, result_expr, ctx));
+                }
+                return Some(result_expr);
             }
 
             // "a ? b : b" => "a, b"

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -19,9 +19,14 @@ use super::PeepholeOptimizations;
 /// with no initializers, which `KeepVar` re-emits unchanged at the end of
 /// the block. Flagging such an identity drop as a real change would
 /// oscillate the peephole fixed-point loop forever.
+///
+/// A TS type annotation disqualifies the identity classification: `KeepVar`'s
+/// re-emit strips annotations, and an annotation can hold resolved references
+/// (computed keys in a type literal) that must go through the drop walk.
 fn dead_drop_mutates_ast(stmt: &Statement<'_>) -> bool {
     !matches!(stmt, Statement::VariableDeclaration(decl)
-        if decl.kind.is_var() && decl.declarations.iter().all(|d| d.init.is_none()))
+        if decl.kind.is_var()
+            && decl.declarations.iter().all(|d| d.init.is_none() && d.type_annotation.is_none()))
 }
 
 impl<'a> PeepholeOptimizations {
@@ -474,13 +479,10 @@ impl<'a> PeepholeOptimizations {
         let VariableDeclaration { span, kind, declarations, declare, .. } = var_decl.unbox();
         for mut decl in declarations {
             if Self::should_remove_unused_declarator(&decl, ctx) {
-                // The whole `VariableDeclarator` is dropped here — including its
-                // `BindingPattern` `id`. There is no typed helper for
-                // `VariableDeclarator` / `BindingPattern` yet, so we keep
-                // `notice_change()` as the drop marker for the declarator.
-                ctx.notice_change();
                 // `init` is `mut` because `remove_unused_expression` rewrites
-                // it in place (peeling pure-call wrappers, etc).
+                // it in place (peeling pure-call wrappers, etc). It is taken
+                // out first because it may survive as an expression statement
+                // — the declarator walk below must not mark its refs dead.
                 if let Some(mut init) = decl.init.take() {
                     if Self::remove_unused_expression(&mut init, ctx) {
                         ctx.drop_expression(&init);
@@ -488,6 +490,10 @@ impl<'a> PeepholeOptimizations {
                         result.push(ctx.ast.statement_expression(init.span(), init));
                     }
                 }
+                // Walk the rest of the dropped declarator (binding pattern +
+                // TS type annotation, which can contain references). Also
+                // records the mutation for the fixed-point loop driver.
+                ctx.drop_variable_declarator(&decl);
             } else {
                 if let Some(Statement::VariableDeclaration(prev_var_decl)) = result.last_mut()
                     && kind == prev_var_decl.kind
@@ -985,11 +991,12 @@ impl<'a> PeepholeOptimizations {
             var_decl.declarations.retain_mut(|decl| {
                 let should_keep = !Self::should_remove_unused_declarator(decl, ctx)
                     || decl.init.as_ref().is_some_and(|init| init.may_have_side_effects(ctx));
-                if !should_keep && let Some(init) = &decl.init {
+                if !should_keep {
                     // Same leak hazard as `remove_unused_variable_declaration`:
-                    // the `retain` silently drops the declarator + init, so
-                    // record the drop of the init explicitly.
-                    ctx.drop_expression(init);
+                    // the `retain` silently drops the declarator, so its refs
+                    // (init and TS type annotation) need an explicit walk to
+                    // reach `PassDirty`.
+                    ctx.drop_variable_declarator(decl);
                 }
                 should_keep
             });
@@ -1256,12 +1263,19 @@ impl<'a> PeepholeOptimizations {
                 ctx,
                 non_scoped_literal_only,
             );
+            // The inlined declarators' inits were already taken out by the
+            // substitution, but the discarded declarators themselves still
+            // need a drop walk — their TS type annotations can hold resolved
+            // references (computed keys in a type literal).
             if new_len == 0 {
                 inlined = true;
-                stmts.pop();
+                let dropped = stmts.pop().unwrap();
+                ctx.drop_statement(&dropped);
             } else if old_len != new_len {
                 inlined = true;
-                prev_var_decl.declarations.truncate(new_len);
+                for decl in prev_var_decl.declarations.drain(new_len..) {
+                    ctx.drop_variable_declarator(&decl);
+                }
                 break;
             } else {
                 break;
@@ -1297,7 +1311,11 @@ impl<'a> PeepholeOptimizations {
             if old_len != new_len {
                 changed = true;
                 let drop_count = old_len - new_len;
-                declarations.drain(i - drop_count..i);
+                // Same drop-walk requirement as the truncate above: the
+                // drained declarators' type annotations can hold references.
+                for decl in declarations.drain(i - drop_count..i) {
+                    ctx.drop_variable_declarator(&decl);
+                }
                 i -= drop_count;
             }
             i += 1;
@@ -1305,7 +1323,14 @@ impl<'a> PeepholeOptimizations {
         changed
     }
 
-    /// Returns new length
+    /// Returns new length.
+    ///
+    /// CONTRACT: the consumed suffix `declarators[new_len..]` is the caller's
+    /// to discard, and the caller must route each discarded declarator through
+    /// `ctx.drop_variable_declarator` (or an enclosing `drop_statement`) — the
+    /// inlined inits are already taken out, but binding patterns and TS type
+    /// annotations can still hold resolved references that would otherwise
+    /// leak past the incremental scoping refresh.
     fn substitute_single_use_symbol_in_expression_from_declarators(
         target_expr: &mut Expression<'a>,
         declarators: &mut [VariableDeclarator<'a>],

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -25,14 +25,18 @@ use oxc_syntax::{
 };
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::{Allocator, BitSet, Vec};
+use oxc_allocator::{BitSet, Vec};
 use oxc_ast::ast::*;
 
-use crate::{ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx};
+use crate::{
+    ReusableTraverseCtx, Traverse, TraverseCtx, minifier_traverse::traverse_mut_with_ctx,
+    traverse_context::as_direct_eval_call,
+};
 
 pub use self::normalize::{Normalize, NormalizeOptions};
 
-/// Stateless peephole optimizer. The `dce` flag and the mutation signal are stored in `MinifierState`.
+/// Stateless peephole optimizer. The `dce` flag, the `mutated` signal, and
+/// the per-pass `PassDirty` accumulator all live on `MinifierState`.
 pub struct PeepholeOptimizations;
 
 impl<'a> PeepholeOptimizations {
@@ -156,32 +160,214 @@ impl<'a> PeepholeOptimizations {
             }
         }
     }
+
+    /// Debug-only guard for the incremental scoping refresh: every reference
+    /// marked dead in `dead_refs` (see [`crate::state::PassDirty::dead_refs`]) must really
+    /// be gone from the live program — pruning a still-live reference is the
+    /// unsafe direction that produces incorrect output.
+    ///
+    /// Walks the live program once per dirty pass in debug builds only, so
+    /// the entire unit-test and `cargo coverage -- minifier` corpus doubles
+    /// as an over-prune detector at zero release cost.
+    #[cfg(debug_assertions)]
+    fn debug_assert_no_over_prune(program: &Program<'a>, dead_refs: &BitSet<'_>) {
+        struct OverPruneCheck<'b, 'c> {
+            dead_refs: &'b BitSet<'c>,
+        }
+        impl<'a> Visit<'a> for OverPruneCheck<'_, '_> {
+            fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+                let Some(reference_id) = it.reference_id.get() else { return };
+                let idx = reference_id.index();
+                // `contains` is false past capacity — the capacity guard
+                // (see `PassDirty::dead_refs`).
+                assert!(
+                    !self.dead_refs.contains(idx),
+                    "incremental scoping over-prune: reference {idx} is marked dead but still \
+                     appears in the live program",
+                );
+            }
+        }
+        OverPruneCheck { dead_refs }.visit_program(program);
+    }
+
+    /// Debug-only converse of [`Self::debug_assert_no_over_prune`], run once
+    /// by the `Compressor` driver after the fixed-point loop: every reference
+    /// that existed when the loop began and is still in a symbol's
+    /// resolved-references list must appear in the live program. A violation
+    /// means a site discarded a subtree without routing it through a
+    /// `drop_*` / `replace_*` helper (the leak direction: stale references
+    /// silently block optimizations), or the caller passed a `scoping`
+    /// already inconsistent with `program` (see the precondition on
+    /// `Compressor::build_with_scoping`).
+    ///
+    /// References minted during the loop (`idx >= initial_references_len`)
+    /// are exempt: the capacity guard deliberately leaves a same-pass
+    /// mint-then-drop unmarked (see `PassDirty::dead_refs`).
+    ///
+    /// Together with the over-prune guard this closes both failure
+    /// directions of the drop-helper convention across the whole unit-test
+    /// and conformance corpus, at zero release cost.
+    #[cfg(debug_assertions)]
+    pub(crate) fn debug_assert_no_under_prune(
+        program: &Program<'a>,
+        ctx: &TraverseCtx<'a>,
+        initial_references_len: usize,
+    ) {
+        struct LiveRefCollector<'b, 'c> {
+            live: &'b mut BitSet<'c>,
+        }
+        impl<'a> Visit<'a> for LiveRefCollector<'_, '_> {
+            fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+                if let Some(reference_id) = it.reference_id.get() {
+                    let idx = reference_id.index();
+                    if idx < self.live.capacity() {
+                        self.live.set_bit(idx);
+                    }
+                }
+            }
+        }
+        let mut live = BitSet::new_in(initial_references_len, ctx.ast.allocator);
+        LiveRefCollector { live: &mut live }.visit_program(program);
+        for reference_ids in ctx.scoping().resolved_references() {
+            for reference_id in reference_ids {
+                let idx = reference_id.index();
+                assert!(
+                    idx >= initial_references_len || live.has_bit(idx),
+                    "incremental scoping under-prune: reference {idx} is still in a symbol's \
+                     resolved-references list but its node is gone from the program — a drop \
+                     site bypassed the `drop_*` / `replace_*` helpers, or the caller passed a \
+                     `scoping` inconsistent with `program`",
+                );
+            }
+        }
+    }
+
+    /// Debug-only guard for the gated direct-eval refresh: every live direct
+    /// `eval(...)` call must already have `ScopeFlags::DirectEval` on its
+    /// reference's recorded scope and every ancestor (the exact postcondition
+    /// of [`Self::refresh_direct_eval_flags`]). The gate
+    /// (`PassDirty::eval_dropped`) only re-derives flags when an eval call is
+    /// *dropped*, so it is sound only while no pass *forms* a new direct eval
+    /// call (e.g. by moving `eval` into callee position). Stale-SET flags are
+    /// merely conservative and not checked; only the missing direction is
+    /// unsafe.
+    ///
+    /// Locally-bound `eval` callees are exempt: `remove_sequence_expression`
+    /// deliberately forms them (`var eval; (0, eval)()` -> `var eval; eval()`
+    /// — `should_keep_indirect_access` only protects the *global* `eval`),
+    /// banking on a local binding named `eval` not holding the real `eval`.
+    /// Under that same assumption the missing flag is inert; a later refresh
+    /// may still set it (the name-based collector), which is the allowed
+    /// conservative direction.
+    ///
+    /// Allocation-free by design: asserts inline per call during the walk so
+    /// the allocation-tracking task (debug assertions on) sees no sys-allocs.
+    /// The walk itself is skipped when the program has no unresolved `eval`
+    /// at all: the check only fires on unresolved (global) callees, and every
+    /// live unresolved reference's name is a key in
+    /// `root_unresolved_references` (populated at build, appended on in-loop
+    /// mints, deliberately never pruned in-loop) — a conservative superset
+    /// that can never skip a checkable call.
+    #[cfg(debug_assertions)]
+    fn debug_assert_no_stale_direct_eval(program: &Program<'a>, scoping: &Scoping) {
+        struct DirectEvalFlagCheck<'s> {
+            scoping: &'s Scoping,
+        }
+        impl<'a> Visit<'a> for DirectEvalFlagCheck<'_> {
+            fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+                if let Some(ident) = as_direct_eval_call(it)
+                    && let Some(reference_id) = ident.reference_id.get()
+                {
+                    let reference = self.scoping.get_reference(reference_id);
+                    // No symbol = unresolved = the global `eval` (see above).
+                    if reference.symbol_id().is_none() {
+                        // Same scope derivation as `LiveDirectEvalCollector` —
+                        // producer, consumer, and this check must agree.
+                        for scope_id in self.scoping.scope_ancestors(reference.scope_id()) {
+                            assert!(
+                                self.scoping.scope_flags(scope_id).contains_direct_eval(),
+                                "stale direct-eval flags: scope {scope_id:?} is missing \
+                                 `ScopeFlags::DirectEval` for a live direct `eval(...)` call — a \
+                                 pass formed a new direct eval call without dropping one — see \
+                                 `PassDirty::eval_dropped`",
+                            );
+                        }
+                    }
+                }
+                walk_call_expression(self, it);
+            }
+        }
+        if !scoping.root_unresolved_references().contains_key("eval") {
+            return;
+        }
+        DirectEvalFlagCheck { scoping }.visit_program(program);
+    }
+
+    /// Consume the `PassDirty` accumulator: batch-prune the dead resolved
+    /// references from scoping, refresh direct-eval flags if an `eval(...)`
+    /// call was dropped, and re-initialize the accumulator.
+    ///
+    /// The `Compressor` driver calls this after `Normalize` (so the
+    /// fixed-point loop starts against already-pruned scoping and
+    /// Normalize's drops cost no extra peephole pass) and after every
+    /// peephole pass.
+    pub(crate) fn flush_pass_dirty(program: &Program<'a>, ctx: &mut TraverseCtx<'a>) {
+        let had_dead = !ctx.state.dirty.dead_refs.is_empty();
+
+        // (1) Resolved references — direct consumption, no walk.
+        //     Dirty data is built by `replace_*` / `drop_*` helpers as
+        //     subtrees are removed and is consumed here in one batch.
+        if had_dead {
+            // Debug-only guard: every reference we are about to prune must
+            // really be gone from the live program (see the helper).
+            #[cfg(debug_assertions)]
+            Self::debug_assert_no_over_prune(program, &ctx.state.dirty.dead_refs);
+
+            // Disjoint-field borrows: `state.dirty` and `scoping` don't overlap.
+            ctx.scoping
+                .scoping_mut()
+                .retain_resolved_references_excluding(&ctx.state.dirty.dead_refs);
+        }
+
+        // (2) Direct-eval — gated full walk only when an eval was dropped.
+        if ctx.state.dirty.eval_dropped {
+            let scoping = ctx.scoping();
+            let mut live = LiveDirectEvalCollector::new(scoping);
+            live.visit_program(program);
+            let scopes = live.scopes;
+            Self::refresh_direct_eval_flags(ctx.scoping_mut(), &scopes);
+        }
+        // Debug-only converse of the gate: no pass may have FORMED a new
+        // direct eval call without dropping one (see the helper).
+        #[cfg(debug_assertions)]
+        Self::debug_assert_no_stale_direct_eval(program, ctx.scoping());
+
+        // (3) Reset the accumulator for the next pass. `references_len` only
+        //     grows (helpers mint, never delete, references), so the bitset
+        //     is re-allocated only when refs were minted this pass; otherwise
+        //     a memset reuses the warm allocation (a bump arena never
+        //     reclaims the old one).
+        let refs_len = ctx.scoping().references_len();
+        if ctx.state.dirty.dead_refs.capacity() == refs_len {
+            if had_dead {
+                ctx.state.dirty.dead_refs.clear();
+            }
+        } else {
+            ctx.state.dirty.dead_refs = BitSet::new_in(refs_len, ctx.ast.allocator);
+        }
+        ctx.state.dirty.eval_dropped = false;
+    }
 }
 
 impl<'a> Traverse<'a> for PeepholeOptimizations {
     fn enter_program(&mut self, _program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         ctx.state.symbol_values.reset();
         ctx.state.proto_write_symbols.clear();
+        // `PassDirty` is managed by the `Compressor` driver via
+        // `flush_pass_dirty`, not reset per traversal.
     }
 
-    fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
-        // Transitional: removed in the incremental-scoping PR together with the collector gate.
-        if ctx.state.was_mutated() {
-            // Walk the live AST to collect data the peephole pass left stale:
-            // - Live `IdentifierReference` IDs, so dead references can be batch-pruned
-            //   from each symbol's reference list (individual deletion via
-            //   `delete_resolved_reference` is O(n) per call, O(n²) over many removals,
-            //   which shows up in bundler output with thousands of unused
-            //   `var import_X = __toESM(require_Y())` declarations).
-            // - Scopes that still contain a direct `eval()` call, needed by
-            //   `refresh_direct_eval_flags`.
-            let mut collector = LiveUsageCollector::new(ctx.scoping(), ctx.ast.allocator);
-            collector.visit_program(program);
-            let LiveUsageCollector { refs, direct_eval_scopes, .. } = collector;
-            let scoping = ctx.scoping_mut();
-            scoping.retain_resolved_references(&refs);
-            Self::refresh_direct_eval_flags(scoping, &direct_eval_scopes);
-        }
+    fn exit_program(&mut self, _program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         // Only check class_symbols_stack in full optimization mode (not DCE mode)
         debug_assert!(ctx.state.dce || ctx.state.class_symbols_stack.is_exhausted());
     }
@@ -563,39 +749,29 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
     }
 }
 
-struct LiveUsageCollector<'a, 's> {
+/// Walks the live program to find scopes containing direct `eval(...)` calls.
+/// Used by `flush_pass_dirty` only when at least one direct eval call was
+/// dropped this pass (gated via `PassDirty::eval_dropped`).
+struct LiveDirectEvalCollector<'s> {
     scoping: &'s Scoping,
-    /// Bitset of live `ReferenceId`s. Sized to `scoping.references_len()` at construction.
-    /// Replaces a `FxHashSet<ReferenceId>`: insert + contains drop from ~25 cycles to ~5,
-    /// and the per-file memory footprint goes from MB-scale to KB-scale.
-    refs: BitSet<'a>,
-    direct_eval_scopes: FxHashSet<ScopeId>,
+    scopes: FxHashSet<ScopeId>,
 }
 
-impl<'a, 's> LiveUsageCollector<'a, 's> {
-    fn new(scoping: &'s Scoping, allocator: &'a Allocator) -> Self {
-        Self {
-            scoping,
-            refs: BitSet::new_in(scoping.references_len(), allocator),
-            direct_eval_scopes: FxHashSet::default(),
-        }
+impl<'s> LiveDirectEvalCollector<'s> {
+    fn new(scoping: &'s Scoping) -> Self {
+        Self { scoping, scopes: FxHashSet::default() }
     }
 }
 
-impl<'a> Visit<'a> for LiveUsageCollector<'_, '_> {
+impl<'a> Visit<'a> for LiveDirectEvalCollector<'_> {
     fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
-        if !it.optional
-            && let Some(ident) = it.callee.get_identifier_reference()
-            && ident.name == "eval"
+        if let Some(ident) = as_direct_eval_call(it)
+            && let Some(reference_id) = ident.reference_id.get()
         {
-            let scope_id = self.scoping.get_reference(ident.reference_id()).scope_id();
-            self.direct_eval_scopes.insert(scope_id);
+            let scope_id = self.scoping.get_reference(reference_id).scope_id();
+            self.scopes.insert(scope_id);
         }
         // Recurse — `eval` may be nested in another call's arguments, e.g. `foo(eval('x'))`.
         walk_call_expression(self, it);
-    }
-
-    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
-        self.refs.set_bit(it.reference_id().index());
     }
 }

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -55,12 +55,11 @@ impl<'a> Traverse<'a> for Normalize {
     }
 
     fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
+        // No console handling here: `exit_expression` has already rewritten
+        // every console call (statement position included) to `void 0`.
         stmts.retain(|stmt| match stmt {
             Statement::EmptyStatement(_) => false,
             Statement::DebuggerStatement(_) if ctx.state.options.drop_debugger => false,
-            Statement::ExpressionStatement(expr) if ctx.state.options.drop_console => {
-                !Self::is_console_expression(&expr.expression)
-            }
             _ => true,
         });
     }
@@ -88,21 +87,22 @@ impl<'a> Traverse<'a> for Normalize {
         if let Expression::ParenthesizedExpression(paren_expr) = expr {
             *expr = paren_expr.expression.take_in(ctx.ast);
         }
+        // Handled outside the match below so the replacement can go through
+        // `ctx.replace_expression`, which walks the dropped call (its
+        // argument subtrees may contain resolved references) into `PassDirty`.
+        if ctx.state.options.drop_console
+            && let Expression::CallExpression(call_expr) = &*expr
+            && Self::is_console_call_expression(call_expr)
+        {
+            let new_expr = ctx.ast.void_0(call_expr.span);
+            ctx.replace_expression(expr, new_expr);
+            return;
+        }
         if let Some(e) = match expr {
             Expression::Identifier(ident) => Self::try_compress_identifier(ident, ctx),
             Expression::UnaryExpression(e) if e.operator.is_void() => {
                 Self::fold_void_ident(e, ctx);
                 None
-            }
-            Expression::ArrowFunctionExpression(e) => {
-                Self::recover_arrow_expression_after_drop_console(e, ctx);
-                None
-            }
-            Expression::CallExpression(call_expr)
-                if ctx.state.options.drop_console
-                    && Self::is_console_call_expression(call_expr) =>
-            {
-                Some(ctx.ast.void_0(call_expr.span))
             }
             Expression::StaticMemberExpression(e) => Self::fold_number_nan_to_nan(e, ctx),
             _ => None,
@@ -129,19 +129,6 @@ impl<'a> Traverse<'a> for Normalize {
 impl<'a> Normalize {
     pub fn new(options: NormalizeOptions) -> Self {
         Self { options }
-    }
-
-    fn recover_arrow_expression_after_drop_console(
-        expr: &mut ArrowFunctionExpression<'a>,
-        ctx: &TraverseCtx<'a>,
-    ) {
-        if ctx.state.options.drop_console && expr.expression && expr.body.is_empty() {
-            expr.expression = false;
-        }
-    }
-
-    fn is_console_expression(expr: &Expression<'_>) -> bool {
-        matches!(expr, Expression::CallExpression(call_expr) if Self::is_console_call_expression(call_expr))
     }
 
     fn is_console_call_expression(call_expr: &CallExpression<'_>) -> bool {
@@ -244,13 +231,19 @@ impl<'a> Normalize {
         false
     }
 
-    fn fold_void_ident(e: &mut UnaryExpression<'a>, ctx: &TraverseCtx<'a>) {
+    fn fold_void_ident(e: &mut UnaryExpression<'a>, ctx: &mut TraverseCtx<'a>) {
         debug_assert!(e.operator.is_void());
         let Expression::Identifier(ident) = &e.argument else { return };
         if ident.is_global_reference(ctx.scoping()) {
             return;
         }
-        e.argument = ctx.ast.expression_numeric_literal(ident.span, 0.0, None, NumberBase::Decimal);
+        // `replace_expression` walks the dropped ident into `PassDirty`, so
+        // its resolved reference is pruned by the driver's pre-loop
+        // `flush_pass_dirty`, before pass 1 — otherwise the symbol would
+        // look referenced forever.
+        let new_arg =
+            ctx.ast.expression_numeric_literal(ident.span, 0.0, None, NumberBase::Decimal);
+        ctx.replace_expression(&mut e.argument, new_arg);
     }
 
     fn fold_number_nan_to_nan(

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -565,6 +565,27 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
+    /// Wrap `expr` as `(0, expr)` so an access that
+    /// [`Self::should_keep_indirect_access`] flagged stays indirect.
+    ///
+    /// The shape is load-bearing: `remove_sequence_expression`'s idempotency
+    /// gate recognizes exactly a 2-element sequence whose head `is_number_0`.
+    /// Sibling fold sites in `fold_constants.rs` / `try_fold_conditional_expression`
+    /// still build it inline; migrating them here is welcome.
+    pub fn preserve_indirect_access(
+        span: Span,
+        expr: Expression<'a>,
+        ctx: &TraverseCtx<'a>,
+    ) -> Expression<'a> {
+        ctx.ast.expression_sequence(
+            span,
+            ctx.ast.vec_from_array([
+                ctx.ast.expression_numeric_literal(span, 0.0, None, NumberBase::Decimal),
+                expr,
+            ]),
+        )
+    }
+
     pub fn remove_dead_code_exit_class_body(body: &mut ClassBody<'a>, _ctx: &mut TraverseCtx<'a>) {
         body.body.retain(|e| !matches!(e, ClassElement::StaticBlock(s) if s.body.is_empty()));
     }

--- a/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_declaration.rs
@@ -65,27 +65,34 @@ impl<'a> PeepholeOptimizations {
         }
     }
 
+    /// Filter unused declarators out of a `KeepVar`-synthesized `var`
+    /// statement. Both callers pass `KeepVar` output: a TRANSIENT statement
+    /// that is not (yet) part of the live tree, whose declarators never
+    /// carry initializers (`KeepVar` hoists names only).
+    ///
+    /// Because the statement is transient and init-less, removing a
+    /// declarator discards no references and must NOT record a mutation or
+    /// route through the `drop_*` helpers: if the caller then skips
+    /// installation (e.g. `try_fold_if`'s already-canonical slot), nothing
+    /// in the live AST changed this pass, and a spurious mutation spins the
+    /// fixed-point loop past its iteration guard (bluebird.js, monitor-oxc).
+    /// Installing — or declining to install — the filtered statement is the
+    /// caller's mutation event.
     pub fn remove_unused_variable_declaration(
         mut stmt: Statement<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Option<Statement<'a>> {
         let Statement::VariableDeclaration(var_decl) = &mut stmt else { return Some(stmt) };
         if !Self::can_remove_unused_declarators(ctx) {
             return Some(stmt);
         }
-        var_decl.declarations.retain_mut(|decl| {
-            if Self::should_remove_unused_declarator(decl, ctx) {
-                // Mark refs in the discarded init as dead so the per-pass
-                // scoping refresh removes them. The `retain_mut` predicate
-                // silently drops the declarator, so we lose the chance to
-                // walk it via `replace_*`.
-                if let Some(init) = &decl.init {
-                    ctx.drop_expression(init);
-                }
-                false
-            } else {
-                true
-            }
+        var_decl.declarations.retain(|decl| {
+            debug_assert!(
+                decl.init.is_none(),
+                "callers must pass KeepVar output (init-less declarators); a declarator \
+                 with an init would need a `drop_*` walk for its references"
+            );
+            !Self::should_remove_unused_declarator(decl, ctx)
         });
         if var_decl.declarations.is_empty() {
             return None;

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -243,8 +243,9 @@ impl<'a> PeepholeOptimizations {
                 if el.may_have_side_effects(ctx) {
                     return true;
                 }
-                // The spread is being elided without a slot-replacement
-                // helper, so record the drop of its argument explicitly.
+                // The spread is being elided — walk its argument so any
+                // identifier refs inside are marked dead in `PassDirty`
+                // and don't leak across passes.
                 let ArrayExpressionElement::SpreadElement(spread) = el else { unreachable!() };
                 ctx.drop_expression(&spread.argument);
                 false
@@ -332,7 +333,12 @@ impl<'a> PeepholeOptimizations {
         for mut e in temp_lit.expressions.drain(..) {
             if e.to_primitive(ctx).is_symbol() != Some(false) {
                 pending_to_string_required_exprs.push(e);
-            } else if !Self::remove_unused_expression(&mut e, ctx) {
+            } else if Self::remove_unused_expression(&mut e, ctx) {
+                // The element collapsed to nothing and is dropped right here
+                // by the `drain` — walk it so refs inside reach `PassDirty`
+                // instead of leaking.
+                ctx.drop_expression(&e);
+            } else {
                 if !pending_to_string_required_exprs.is_empty() {
                     // flush pending to string required expressions
                     let expressions =
@@ -448,7 +454,7 @@ impl<'a> PeepholeOptimizations {
                     if Self::remove_unused_expression(&mut value, ctx) {
                         // Same rationale as the key branch above — the property
                         // value is being dropped without a `replace_*` helper,
-                        // so record the drop explicitly.
+                        // so its references must be walked into `dirty.dead_refs`.
                         ctx.drop_expression(&value);
                     } else {
                         transformed_elements.push(value);

--- a/crates/oxc_minifier/src/peephole/remove_unused_private_members.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_private_members.rs
@@ -52,9 +52,12 @@ impl<'a> PeepholeOptimizations {
                 }
             };
             if !keep {
-                // The element is being silently dropped from the vector
-                // without a slot-replacement helper, so record the drop
-                // explicitly for the fixed-point loop driver.
+                // The element is being silently dropped from the vector. Walk
+                // its subtree so identifier references inside (e.g. a method
+                // body) are recorded in `PassDirty::dead_refs` and pruned by
+                // `flush_pass_dirty`. Without this, refs leak across passes
+                // and break idempotency. `drop_class_element` also records a
+                // mutation for the fixed-point loop driver.
                 ctx.drop_class_element(element);
             }
             keep

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -478,7 +478,7 @@ impl<'a> PeepholeOptimizations {
         left: &Expression<'a>,
         right: &Expression<'a>,
         span: Span,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
         inversed: bool,
     ) -> Option<Expression<'a>> {
         let pair = Self::commutative_pair(
@@ -546,18 +546,42 @@ impl<'a> PeepholeOptimizations {
             return None;
         }
 
-        let mut new_left_expr = typeof_binary_expr.clone_in_with_semantic_ids(ctx.ast.allocator);
+        // The replacement must not alias `ReferenceId`s from the dropped subtree:
+        // `replace_expression` walks the old tree and marks its references dead,
+        // so a reused id would be pruned from scoping while still live in the
+        // program. Mint fresh references (same name, same resolution) instead.
+        let typeof_symbol_id =
+            ctx.scoping().get_reference(typeof_id_ref.reference_id()).symbol_id();
+        let is_null_symbol_id =
+            ctx.scoping().get_reference(is_null_id_ref.reference_id()).symbol_id();
+
+        // Plain `clone_in` resets every `reference_id` to `None`, making id
+        // aliasing structurally impossible; the loop below installs the one
+        // fresh reference the clone needs.
+        let mut new_left_expr = typeof_binary_expr.clone_in(ctx.ast.allocator);
         if let Expression::BinaryExpression(new_left_expr_binary) = &mut new_left_expr {
             new_left_expr_binary.operator =
                 if inversed { BinaryOperator::Inequality } else { BinaryOperator::Equality };
+            let fresh_reference_id =
+                ctx.create_reference(typeof_id_ref.name, typeof_symbol_id, ReferenceFlags::Read);
+            let BinaryExpression { left, right, .. } = &mut **new_left_expr_binary;
+            for operand in [left, right] {
+                if let Expression::UnaryExpression(unary) = operand
+                    && unary.operator == UnaryOperator::Typeof
+                    && let Expression::Identifier(id) = &mut unary.argument
+                {
+                    id.reference_id.set(Some(fresh_reference_id));
+                }
+            }
         } else {
             unreachable!();
         }
 
-        let is_null_id_ref = ctx.ast.expression_identifier_with_reference_id(
+        let is_null_id_ref = ctx.create_ident_expr(
             is_null_id_ref.span,
             is_null_id_ref.name,
-            is_null_id_ref.reference_id(),
+            is_null_symbol_id,
+            ReferenceFlags::Read,
         );
 
         let new_right_expr = if inversed {
@@ -956,14 +980,22 @@ impl<'a> PeepholeOptimizations {
 
             let new_decl =
                 ctx.ast.variable_declarator(SPAN, var_init.kind, r_id_pat, NONE, Some(arr), false);
+            // The old declarators (`e`, `a`, and `r`'s original init) are
+            // replaced wholesale — walk them so refs inside (e.g. `e` in
+            // `Array(e > 1 ? e - 1 : 0)`) reach `PassDirty`. The moved-out
+            // `r` binding and `arguments` ident left id-less dummies behind.
+            for decl in &var_init.declarations {
+                ctx.drop_variable_declarator(decl);
+            }
             var_init.declarations = ctx.ast.vec1(new_decl);
         } else {
             // `for (var; 0;)` with an empty `VariableDeclaration` is invalid JS when printed and
             // makes `try_fold_for` hoist a bogus `var;`. Use `for (; 0;)` instead so dead-code
-            // folding becomes an empty statement.
-            // `for_stmt.init` is `Option<ForStatementInit>` — no typed helper for that
-            // enum slot yet. The `replace_statement` for `for_stmt.body`
-            // below records a mutation, covering this drop's mutation signal.
+            // folding becomes an empty statement. Walk the dropped
+            // declarators so their refs reach `PassDirty`.
+            for decl in &var_init.declarations {
+                ctx.drop_variable_declarator(decl);
+            }
             for_stmt.init = None;
         }
         if let Some(old) = for_stmt.test.take() {

--- a/crates/oxc_minifier/src/state.rs
+++ b/crates/oxc_minifier/src/state.rs
@@ -1,6 +1,7 @@
 use oxc_ecmascript::constant_evaluation::ConstantValue;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use oxc_allocator::{Allocator, BitSet};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_semantic::Scoping;
 use oxc_span::SourceType;
@@ -8,6 +9,41 @@ use oxc_str::Str;
 use oxc_syntax::symbol::SymbolId;
 
 use crate::{CompressOptions, symbol_value::SymbolValues};
+
+/// Dirty data accumulated by the `replace_*` / `drop_*` helper calls between
+/// two consumption points. Live from `MinifierState::new` so the pre-loop
+/// `Normalize` pass records drops through the same typed helpers as the
+/// peephole loop; consumed and re-initialized by `flush_pass_dirty` in the
+/// `Compressor` driver after `Normalize` and after every peephole pass.
+pub struct PassDirty<'a> {
+    /// `ReferenceId`s whose AST node has been removed and not re-installed
+    /// in any later mutation this pass.
+    ///
+    /// Arena-allocated bitset sized to the program's `references_len()` at
+    /// construction / the previous flush. A `BitSet` (rather than an
+    /// `FxHashSet`) keeps the per-ident cost on the `DropDiff` hot path to
+    /// a direct array store instead of a hash + heap insert.
+    ///
+    /// INVARIANT (the "capacity guard", relied on by `DropDiff`,
+    /// `Scoping::retain_resolved_references_excluding`, and the over-prune
+    /// debug assert): references minted MID-pass have indices beyond the
+    /// bitset's capacity and are treated as live everywhere — never marked,
+    /// never excluded. Conservative: such a reference stays in its symbol's
+    /// list until callers rebuild scoping (a missed optimization, never a
+    /// correctness issue). `Normalize` mints no references, so a capacity
+    /// taken at construction is exact for the first pass.
+    pub(crate) dead_refs: BitSet<'a>,
+
+    /// At least one direct `eval(...)` call was dropped this pass. Gates
+    /// the small `LiveDirectEvalCollector` walk at flush time.
+    pub(crate) eval_dropped: bool,
+}
+
+impl<'a> PassDirty<'a> {
+    pub fn new(references_len: usize, allocator: &'a Allocator) -> Self {
+        Self { dead_refs: BitSet::new_in(references_len, allocator), eval_dropped: false }
+    }
+}
 
 pub struct MinifierState<'a> {
     pub source_type: SourceType,
@@ -32,21 +68,27 @@ pub struct MinifierState<'a> {
 
     /// Set when a typed helper mutates the AST. Private by design: the only
     /// writers are the helpers on `MinifierTraverseCtx`; the only reader is
-    /// the fixed-point loop driver via `take_mutated()` (plus the transitional
-    /// `was_mutated()` collector gate).
+    /// the fixed-point loop driver via `take_mutated()`.
     mutated: bool,
+
+    /// Per-pass dirty accumulator populated by `replace_*` / `drop_*` helpers
+    /// as subtrees are removed. Consumed by `flush_pass_dirty` in the
+    /// `Compressor` driver (pre-loop and after each mutated pass) to drive
+    /// the incremental scoping refresh.
+    pub(crate) dirty: PassDirty<'a>,
 
     /// Scratch buffer reused by `try_fold_concat` to build template literal
     /// quasis without allocating a fresh `String` per call.
     pub concat_scratch: String,
 }
 
-impl MinifierState<'_> {
+impl<'a> MinifierState<'a> {
     pub fn new(
         source_type: SourceType,
         options: CompressOptions,
         dce: bool,
         scoping: &Scoping,
+        allocator: &'a Allocator,
     ) -> Self {
         Self {
             source_type,
@@ -57,6 +99,7 @@ impl MinifierState<'_> {
             class_symbols_stack: ClassSymbolsStack::new(),
             proto_write_symbols: FxHashSet::default(),
             mutated: false,
+            dirty: PassDirty::new(scoping.references_len(), allocator),
             concat_scratch: String::new(),
         }
     }
@@ -71,13 +114,6 @@ impl MinifierState<'_> {
     /// Record that a typed helper mutated the AST.
     pub(crate) fn record_mutation(&mut self) {
         self.mutated = true;
-    }
-
-    /// Non-consuming read of the mutation signal.
-    ///
-    /// Transitional: removed in the incremental-scoping PR together with the collector gate.
-    pub(crate) fn was_mutated(&self) -> bool {
-        self.mutated
     }
 }
 

--- a/crates/oxc_minifier/src/traverse_context/drop_diff.rs
+++ b/crates/oxc_minifier/src/traverse_context/drop_diff.rs
@@ -1,0 +1,73 @@
+use oxc_ast::ast::*;
+use oxc_ast_visit::{Visit, walk::walk_call_expression};
+
+use crate::state::PassDirty;
+
+/// Returns the callee `IdentifierReference` if `call` is a direct
+/// `eval(...)` call. Shared by the [`DropDiff`] producer and the
+/// `LiveDirectEvalCollector` consumer — the two must agree on what counts
+/// as a direct eval call for the incremental refresh to be sound.
+pub fn as_direct_eval_call<'a, 'b>(
+    call: &'b CallExpression<'a>,
+) -> Option<&'b IdentifierReference<'a>> {
+    if call.optional {
+        return None;
+    }
+    let ident = call.callee.get_identifier_reference()?;
+    (ident.name == "eval").then_some(ident)
+}
+
+/// Walks AST subtrees being dropped or replaced, collecting
+/// `IdentifierReference`s and direct `eval(...)` calls into the per-pass
+/// `PassDirty` accumulator. Use via the `Visit` entry point matching the
+/// dropped node (`visit_expression`, `visit_variable_declarator`, ...).
+///
+/// Mark-only semantics: every reference found in a dropped subtree is ADDED
+/// to `dirty.dead_refs`; every direct eval call sets
+/// `dirty.eval_dropped = true`. Marks for unresolved references are inert:
+/// the flush only filters per-symbol resolved-reference lists, which never
+/// contain unresolved ids (and `root_unresolved_references` is deliberately
+/// not pruned — no in-loop optimization consumes it and callers rebuild
+/// scoping).
+///
+/// There is deliberately no "resurrect" walk over replacement values: a
+/// `ReferenceId` marked dead can never reappear in a replacement. Subtrees
+/// moved out of the old slot into the new value leave id-less `TakeIn`
+/// dummies behind, so the dead-walk never sees their ids; and replacements
+/// are built with fresh references, never cloned ids (see
+/// `substitute_is_object_and_not_null`).
+pub struct DropDiff<'a, 's> {
+    dirty: &'s mut PassDirty<'a>,
+}
+
+impl<'a, 's> DropDiff<'a, 's> {
+    pub(crate) fn new(dirty: &'s mut PassDirty<'a>) -> Self {
+        Self { dirty }
+    }
+}
+
+impl<'a> Visit<'a> for DropDiff<'a, '_> {
+    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+        // Freshly built `IdentifierReference` nodes (e.g. created via
+        // `ast.identifier_reference(...)` or as a `TakeIn` dummy left in place
+        // by `take_in`) have no `reference_id` yet. Such nodes carry no
+        // semantic state to mark dead, so skip them.
+        let Some(reference_id) = it.reference_id.get() else { return };
+        let idx = reference_id.index();
+        // References minted mid-pass have indices beyond the bitset's
+        // capacity and are treated as live — see `PassDirty::dead_refs`.
+        // This is a legal flow (a fresh ident minted by one optimization can
+        // be dropped later in the same pass by another), so no debug_assert.
+        if idx < self.dirty.dead_refs.capacity() {
+            self.dirty.dead_refs.set_bit(idx);
+        }
+    }
+
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        if as_direct_eval_call(it).is_some() {
+            self.dirty.eval_dropped = true;
+        }
+        // Recurse — eval may be nested inside another call's arguments.
+        walk_call_expression(self, it);
+    }
+}

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -19,7 +19,9 @@ use crate::{
     symbol_value::SymbolValue,
 };
 
-use super::TraverseCtx;
+use oxc_ast_visit::Visit;
+
+use super::{TraverseCtx, drop_diff::DropDiff};
 
 pub fn is_exact_int64(num: f64) -> bool {
     num.fract() == 0.0
@@ -362,6 +364,13 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         (options.class && is_class) || (options.function && !is_class)
     }
 
+    /// Construct a `DropDiff` borrowing the per-pass dirty accumulator.
+    /// Used by the `replace_*` / `drop_*` helpers.
+    #[inline]
+    fn dirty_diff(&mut self) -> DropDiff<'a, '_> {
+        DropDiff::new(&mut self.state.dirty)
+    }
+
     /// Replace an expression slot. Marks the pass as having mutated the AST.
     ///
     /// Prefer this over a direct `*slot = new; ctx.notice_change();` pair —
@@ -369,6 +378,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     /// are the only way to record the mutation (compiler-enforced).
     #[inline]
     pub fn replace_expression(&mut self, slot: &mut Expression<'a>, new: Expression<'a>) {
+        self.dirty_diff().visit_expression(slot);
         *slot = new;
         self.state.record_mutation();
     }
@@ -376,6 +386,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     /// Replace a statement slot. Marks the pass as having mutated the AST.
     #[inline]
     pub fn replace_statement(&mut self, slot: &mut Statement<'a>, new: Statement<'a>) {
+        self.dirty_diff().visit_statement(slot);
         *slot = new;
         self.state.record_mutation();
     }
@@ -387,6 +398,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         slot: &mut AssignmentTargetProperty<'a>,
         new: AssignmentTargetProperty<'a>,
     ) {
+        self.dirty_diff().visit_assignment_target_property(slot);
         *slot = new;
         self.state.record_mutation();
     }
@@ -394,6 +406,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     /// Replace a property-key slot. Marks the pass as having mutated the AST.
     #[inline]
     pub fn replace_property_key(&mut self, slot: &mut PropertyKey<'a>, new: PropertyKey<'a>) {
+        self.dirty_diff().visit_property_key(slot);
         *slot = new;
         self.state.record_mutation();
     }
@@ -406,6 +419,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         slot: &mut ForStatementLeft<'a>,
         new: ForStatementLeft<'a>,
     ) {
+        self.dirty_diff().visit_for_statement_left(slot);
         *slot = new;
         self.state.record_mutation();
     }
@@ -420,30 +434,42 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     }
 
     /// Mark an expression subtree as about to be dropped (popped from a collection,
-    /// taken out of an Option, etc.). Marks the pass as having mutated the AST.
+    /// taken out of an Option, etc.). Walks the subtree to record dead references
+    /// and dropped direct-eval calls into the per-pass `PassDirty` accumulator.
     ///
     /// Use this helper at every site where a subtree is being removed from the AST
     /// without an immediate slot-replacement helper (e.g. inside a `retain_mut`
     /// predicate, before `field = None`, after `vec.pop()`).
-    ///
-    /// The subtree parameter is unused in this PR; the incremental-scoping
-    /// follow-up walks it to record dead references.
     #[inline]
-    pub fn drop_expression(&mut self, _expr: &Expression<'a>) {
+    pub fn drop_expression(&mut self, expr: &Expression<'a>) {
+        self.dirty_diff().visit_expression(expr);
         self.state.record_mutation();
     }
 
     /// Mark a statement subtree as about to be dropped. Same contract as
-    /// `drop_expression`, including the unused subtree parameter.
+    /// `drop_expression`.
     #[inline]
-    pub fn drop_statement(&mut self, _stmt: &Statement<'a>) {
+    pub fn drop_statement(&mut self, stmt: &Statement<'a>) {
+        self.dirty_diff().visit_statement(stmt);
         self.state.record_mutation();
     }
 
     /// Mark a class element subtree as about to be dropped. Same contract as
-    /// `drop_expression`, including the unused subtree parameter.
+    /// `drop_expression`.
     #[inline]
-    pub fn drop_class_element(&mut self, _element: &ClassElement<'a>) {
+    pub fn drop_class_element(&mut self, element: &ClassElement<'a>) {
+        self.dirty_diff().visit_class_element(element);
+        self.state.record_mutation();
+    }
+
+    /// Mark a variable declarator as about to be dropped. Walks the whole
+    /// declarator — binding pattern, TS type annotation (which can contain
+    /// references, e.g. computed keys in a type literal), and init if still
+    /// attached. Same contract as `drop_expression`. If the init is kept
+    /// alive elsewhere, `take()` it out of the declarator before calling this.
+    #[inline]
+    pub fn drop_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
+        self.dirty_diff().visit_variable_declarator(decl);
         self.state.record_mutation();
     }
 }

--- a/crates/oxc_minifier/src/traverse_context/mod.rs
+++ b/crates/oxc_minifier/src/traverse_context/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 
 mod ancestry;
 mod bound_identifier;
+mod drop_diff;
 mod ecma_context;
 mod maybe_bound_identifier;
 mod reusable;
@@ -29,6 +30,7 @@ mod uid;
 use ancestry::PopToken;
 pub use ancestry::TraverseAncestry;
 pub use bound_identifier::BoundIdentifier;
+pub use drop_diff::as_direct_eval_call;
 pub use maybe_bound_identifier::MaybeBoundIdentifier;
 pub use reusable::ReusableTraverseCtx;
 pub use scoping::TraverseScoping;

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -207,9 +207,10 @@ fn dce_var_hoisting() {
 }
 
 // Dropping a dead-after-throw statement (`module.exports = x`) removes the
-// only reference to `x`. Without flagging that as a change, the peephole loop
-// terminates before `LiveUsageCollector` refreshes scoping, leaving the
-// unused-declarator pass to see a stale reference and keep `var x = {}`.
+// only reference to `x`. Without recording that as a mutation, the peephole
+// loop terminates before `flush_pass_dirty` prunes the dropped reference,
+// leaving the unused-declarator pass to see a stale reference and keep
+// `var x = {}`.
 #[test]
 fn dead_after_throw_drop_triggers_unused_declarator_removal() {
     test(
@@ -673,4 +674,15 @@ fn fold_coalesce_on_tracked_non_nullish_binding() {
         "let n = 5n; export function a() { return n ?? other() } export function b() { return n ?? other() }",
         "let n = 5n; export function a() { return n } export function b() { return n }",
     );
+}
+
+// Convergence regression (monitor-oxc, bluebird.js): `try_fold_if` re-extracts
+// the dead branch's `var` names via `KeepVar` on every pass and filters the
+// synthesized statement through the unused-declarator removal. Dropping `x`
+// from that TRANSIENT statement must not record a mutation — when the slot is
+// already in canonical KeepVar shape nothing in the live tree changes, and a
+// spurious mutation spins the fixed-point loop past its iteration guard.
+#[test]
+fn test_fold_if_keep_var_filter_converges() {
+    test_same("function f() {\n\tif (0) var x, y;\n\ty = 1;\n\treturn y;\n}\nf();");
 }

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1279,6 +1279,37 @@ fn test_inline_values_in_template_literal() {
     fold_same("foo`foo${1}bar`");
 }
 
+// Regression: when `fold_object_exp` drops or folds a spread, the dropped
+// subtree must be walked through `drop_expression` so identifier references
+// inside don't leak across passes. The discriminating signal is an
+// otherwise-inlineable symbol that stays uninlined because a stale
+// write-ref hangs around in `Scoping` (#22736).
+//
+// Test options keep unused declarations (`CompressOptionsUnused::Keep`), so
+// `let x` survives — but with `write_references_count == 0` the inline pass
+// replaces `return x` with the constant value. Without the drop walk, the
+// dropped subtree's stale write-ref leaves the count at 1 and inline is
+// blocked.
+#[test]
+fn test_fold_object_spread_drop_walks_argument_refs() {
+    // Path 2: spread argument is a side-effect-free function expression,
+    // folded away entirely. The write to `x` inside the function body must
+    // be cleared from `Scoping`, otherwise the constant inline of `x`
+    // below is blocked by a stale write-reference.
+    test(
+        "function f() { let x = 'a'; ({...function(){ x = 'b' }}); return x; }",
+        "function f() { let x = 'a'; return 'a'; }",
+    );
+    // Path 3: non-computed `__proto__` from an inlined object literal is
+    // elided because it would set the prototype rather than become a
+    // regular property. The dropped property's value subtree must be
+    // walked for the same reason.
+    test(
+        "function f() { let x = 'a'; ({...{__proto__: function(){ x = 'b' }}}); return x; }",
+        "function f() { let x = 'a'; return 'a'; }",
+    );
+}
+
 mod bigint {
     use super::{
         MAX_SAFE_FLOAT, MAX_SAFE_INT, NEG_MAX_SAFE_FLOAT, NEG_MAX_SAFE_INT, fold, fold_same,

--- a/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/tests/peephole/minimize_conditions.rs
@@ -1191,3 +1191,18 @@ fn try_minimize_binary() {
     test("f(!a === true)", "f(!a)");
     test("f(!a === false)", "f(!!a)");
 }
+
+#[test]
+fn test_fold_equal_branches_keeps_indirect_access() {
+    // `(c ? eval : eval)(x)` is an indirect eval (runs in global scope);
+    // folding the equal branches must not form a direct eval call.
+    test("var c; (c ? eval : eval)('x')", "var c; (0, eval)('x')");
+    // Member-expression callees have the same hazard: the fold must not
+    // rebind `this` from undefined to the member object.
+    test("var c; (c ? o.f : o.f)('y')", "var c; (0, o.f)('y')");
+    test("var c; (c ? o.f : o.f)`y`", "var c; (0, o.f)`y`");
+    // No hazard: a plain identifier callee still folds.
+    test("var c; (c ? foo : foo)('x')", "var c; foo('x')");
+    // A side-effectful test folds to a sequence, which stays indirect.
+    test("(c() ? eval : eval)('x')", "(c(), eval)('x')");
+}

--- a/crates/oxc_minifier/tests/peephole/normalize.rs
+++ b/crates/oxc_minifier/tests/peephole/normalize.rs
@@ -34,6 +34,17 @@ fn test_void_ident() {
     test("void x", "x"); // reference error
 }
 
+// Leak regression: Normalize runs before the peephole fixed-point loop, but
+// `PassDirty` is live from `MinifierState::new`, so Normalize's typed-helper
+// drops are recorded like any pass's and consumed by the driver's pre-loop
+// `flush_pass_dirty`. A leaked read makes `x` look referenced, blocking
+// unused-declaration removal.
+#[test]
+fn test_void_ident_does_not_leak_reference() {
+    let options = CompressOptions::smallest();
+    test_options("let x = 1; void x; console.log(2);", "console.log(2);", &options);
+}
+
 #[test]
 fn parens() {
     test("(((x)))", "x");
@@ -50,6 +61,18 @@ fn drop_console() {
         "(() => { try { return } catch {} })()",
         &options,
     );
+}
+
+// Same leak class as `test_void_ident_does_not_leak_reference`: dropped
+// `console.*` calls (statement position and expression position) contain
+// argument subtrees whose resolved references must be deleted from scoping.
+#[test]
+fn drop_console_does_not_leak_references() {
+    let options = CompressOptions { drop_console: true, ..CompressOptions::smallest() };
+    // Statement position.
+    test_options("let x = 1; console.log(x); foo(2);", "foo(2);", &options);
+    // Expression position: the call is replaced with `void 0`.
+    test_options("let x = 1; foo(console.log(x));", "foo(void 0);", &options);
 }
 
 #[test]

--- a/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
@@ -118,6 +118,16 @@ fn test_fold_try_statement() {
     test("try {} catch (e) { } finally {}", "");
     test("try { foo() } catch (e) { bar() } finally {}", "try { foo() } catch { bar() }");
     test_same("try { foo() } catch { bar() } finally { baz() }");
+
+    // Leak regression: when the empty `try` drops, the catch arm's write-ref
+    // to `x` must be walked into `PassDirty`, else the stale write blocks
+    // constant inlining of `x`.
+    let options = CompressOptions::smallest();
+    test_options(
+        "let x = 'initial'; try {} catch (e) { x = 'unexpected'; } console.log(x);",
+        "console.log('initial');",
+        &options,
+    );
 }
 
 #[test]
@@ -189,6 +199,13 @@ fn remove_unused_expressions_in_sequence() {
     test("(true, true, foo.bar)();", "(0, foo.bar)();");
     test("var foo; (true, foo.bar)();", "var foo; (0, foo.bar)();");
     test("var foo; (true, true, foo.bar)();", "var foo; (0, foo.bar)();");
+
+    // Regression: a >=3 element sequence in indirect-access position whose
+    // second-to-last element is already `0` must converge. Re-wrapping the
+    // already-`0` element re-records a mutation every iteration, spinning
+    // the fixed-point loop into the 10-iteration debug_assert.
+    test_same("(sideEffect(), 0, foo.bar)();");
+    test_same("delete (sideEffect(), 0, foo.bar);");
 
     test("typeof (0, foo);", "foo");
     test_same("v = typeof (0, foo);");

--- a/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_declaration.rs
@@ -5,6 +5,93 @@ use crate::{
     test_same_options_source_type, test_same_smallest, test_smallest,
 };
 
+// Leak regression: dropping an unused declarator must walk the whole
+// declarator, not just the init — references can also live in the binding's
+// TS type annotation (e.g. computed keys in a type literal). A leaked type
+// ref makes the symbol look used, blocking its own removal.
+#[test]
+fn remove_unused_declarator_walks_type_annotation_refs() {
+    let options = CompressOptions::smallest();
+    test_options_source_type(
+        "function f() { const a = Symbol('a'); const b = Symbol('b'); const reg: { [a]: string; [b]: string } = { foo: 1, bar: 2 }; return 1; } g(f());",
+        "function f() { return 1; } g(f());",
+        SourceType::ts(),
+        &options,
+    );
+}
+
+// Leak regression (single-use inlining, `stmts.pop()` site): after the lone
+// declarator's init is inlined into the next statement, the whole declaration
+// statement is popped — the discarded declarator's type annotation still holds
+// a ref to `a`.
+#[test]
+fn single_use_inline_pop_walks_type_annotation_refs() {
+    let options = CompressOptions::smallest();
+    test_options_source_type(
+        "function f() { const a = Symbol('a'); const x: { [a]: string } = g(); return x; } h(f());",
+        "function f() { return g(); } h(f());",
+        SourceType::ts(),
+        &options,
+    );
+}
+
+// Leak regression (single-use inlining, `declarations.truncate()` site): only
+// the tail declarator `x` is inlined; the truncate discards it while `keep`
+// survives — `x`'s type annotation still holds a ref to `a`.
+#[test]
+fn single_use_inline_truncate_walks_type_annotation_refs() {
+    let options = CompressOptions::smallest();
+    test_options_source_type(
+        "function f() { const a = Symbol('a'); const keep = g(), x: { [a]: string } = h(); return [keep, keep, x]; } j(f());",
+        "function f() { let keep = g(); return [keep, keep, h()]; } j(f());",
+        SourceType::ts(),
+        &options,
+    );
+}
+
+// Leak regression (single-use inlining, `declarations.drain()` site): `x` is
+// inlined into the sibling declarator `y`'s init within the same declaration;
+// the drain discards `x`'s declarator — its type annotation still holds a ref
+// to `a`.
+#[test]
+fn single_use_inline_drain_walks_type_annotation_refs() {
+    let options = CompressOptions::smallest();
+    test_options_source_type(
+        "function f() { const a = Symbol('a'); const x: { [a]: string } = g(), y = [x]; return y; } j(f());",
+        "function f() { return [g()]; } j(f());",
+        SourceType::ts(),
+        &options,
+    );
+}
+
+// Leak regression (dead-code identity-drop site): an init-less `var` after
+// `return` is classified as an identity drop (KeepVar re-emits it), skipping
+// the drop walk — but KeepVar's re-emit strips the type annotation, so the
+// annotation's ref to `b` leaks.
+#[test]
+fn dead_code_identity_drop_checks_type_annotation() {
+    let options = CompressOptions::smallest();
+    test_options_source_type(
+        "function f() { const b = Symbol('b'); return 1; var a: { [b]: string }; } g(f());",
+        "function f() { return 1; } g(f());",
+        SourceType::ts(),
+        &options,
+    );
+}
+
+// Near-miss: dropping the annotated declarator must only kill the annotation's
+// own ref — `a`'s other (value) uses keep `const a = Symbol('a')` alive.
+#[test]
+fn type_annotation_drop_keeps_symbol_used_elsewhere() {
+    let options = CompressOptions::smallest();
+    test_options_source_type(
+        "function f() { const a = Symbol('a'); const x: { [a]: string } = g(); return [x, a, a]; } h(f());",
+        "function f() { let a = Symbol('a'); return [g(), a, a]; } h(f());",
+        SourceType::ts(),
+        &options,
+    );
+}
+
 #[test]
 fn remove_unused_variable_declaration() {
     let options = CompressOptions::smallest();

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -155,6 +155,44 @@ fn test_array_literal_containing_spread() {
     test_same("([...b, ...c])"); // It would also be fine if the spreads were split apart.
 }
 
+// Leak regression: `remove_unused_template_literal` drains the template's
+// elements; an element that `remove_unused_expression` reports removable was
+// silently discarded without a `drop_expression` walk, leaking its refs.
+// Two computed keys keep `p` multi-use so single-use inlining can't paper
+// over the leak; the stale reads then block unused-declaration removal.
+#[test]
+fn test_template_literal_drop_walks_removed_element_refs() {
+    let options = CompressOptions::smallest();
+    test_options(
+        "function f() { let p = 'metric'; let t = { [`${p}_x`]: 0, [`${p}_y`]: 0 }; void t; return 1; } g(f());",
+        "function f() { return 1; } g(f());",
+        &options,
+    );
+}
+
+// Regression: when `remove_unused_array_expr` elides a side-effect-free
+// `SpreadElement`, the argument subtree must be walked through
+// `drop_expression` so identifier references inside don't leak across
+// passes (#22736).
+//
+// The spread argument is an array literal with two holes, so
+// `try_flatten_array_expression_elements` (gated at < 2 holes) does not
+// flatten it and the spread reaches the elision branch with `p`'s
+// references still inside; `p` is multi-use so single-use inlining can't
+// paper over the leak. Without the drop walk the stale reads keep `let p`
+// alive and panic the under-prune debug guard.
+#[test]
+fn test_array_spread_drop_walks_argument_refs() {
+    test("([...[function(){}]])", "");
+    test("([4, ...[function(){}], a])", "a");
+    let options = CompressOptions::smallest();
+    test_options(
+        "function f() { let p = 'metric'; [...[p, , , p]]; return 1; } g(f());",
+        "function f() { return 1; } g(f());",
+        &options,
+    );
+}
+
 #[test]
 fn test_fold_unary_expression_statement() {
     test("typeof x", "");

--- a/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/tests/peephole/substitute_alternate_syntax.rs
@@ -532,6 +532,21 @@ fn test_fold_is_object_and_not_null() {
 }
 
 #[test]
+fn test_fold_is_object_and_not_null_minted_then_dropped() {
+    // Exercises the same-pass mint-then-drop flow through `DropDiff`'s
+    // capacity guard: `substitute_is_object_and_not_null` mints fresh
+    // references (indices beyond the pass bitset's capacity) at
+    // `exit_expression`, then the unreachable statement containing them is
+    // dropped at `exit_statements` in the same pass. The guard must treat
+    // the minted refs as live (conservative — callers rebuild scoping), not
+    // panic.
+    test(
+        "function f(a) { return 1; if (typeof a === 'object' && a !== null) b(a); } f();",
+        "function f(a) { return 1; }",
+    );
+}
+
+#[test]
 fn test_swap_binary_expressions() {
     test_same("v = a === 0");
     test("v = 0 === a", "v = a === 0");

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -599,18 +599,21 @@ impl Scoping {
         });
     }
 
-    /// Retain only resolved references that are in the given set.
+    /// Remove every `ReferenceId` whose bit is set in `excluded` from each
+    /// symbol's resolved-references list. O(total_references) in the worst
+    /// case; short-circuits when `excluded` has no bits set.
     ///
-    /// This is an O(n) batch operation across all symbols, much more efficient than
-    /// calling `delete_resolved_reference` repeatedly when many references from the
-    /// same symbol need to be removed (which would be O(n²) due to the linear scan
-    /// in each deletion).
-    ///
-    /// `live_references` should be sized to [`Self::references_len`] at construction time.
-    pub fn retain_resolved_references(&mut self, live_references: &BitSet<'_>) {
+    /// `excluded` should be sized to at least [`Self::references_len`] at the
+    /// time it was constructed. References created after the bitset was
+    /// constructed have indices beyond `excluded.capacity()` and are treated
+    /// as live (never excluded) — `BitSet::contains` is `false` past capacity.
+    pub fn retain_resolved_references_excluding(&mut self, excluded: &BitSet<'_>) {
+        if excluded.is_empty() {
+            return;
+        }
         self.cell.with_dependent_mut(|_allocator, cell| {
             for reference_ids in &mut cell.resolved_references {
-                reference_ids.retain(|id| live_references.has_bit(id.index()));
+                reference_ids.retain(|id| !excluded.contains(id.index()));
             }
         });
     }

--- a/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
@@ -19,8 +19,15 @@ pub fn test(source_text: &str, expected: &str, config: &ReplaceGlobalDefinesConf
     let mut scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
     let ret = ReplaceGlobalDefines::new(&allocator, config.clone()).build(scoping, &mut program);
     assert_eq!(ret.changed, source_text != expected);
-    // Use the updated scoping, instead of recreating one.
-    scoping = ret.scoping;
+    // Mirror the pipeline in crates/oxc/src/compiler.rs: it treats scoping as
+    // dirty whenever ReplaceGlobalDefines changed the AST (`scoping_dirty |=
+    // ret.changed`) and rebuilds it before DCE. Reuse RGD's scoping only on
+    // the unchanged path.
+    scoping = if ret.changed {
+        SemanticBuilder::new().build(&program).semantic.into_scoping()
+    } else {
+        ret.scoping
+    };
     AssertAst.visit_program(&program);
     // Run DCE, to align pipeline in crates/oxc/src/compiler.rs
     Compressor::new(&allocator).dead_code_elimination_with_scoping(
@@ -299,6 +306,20 @@ fn replace_with_undefined() {
 fn declare_const() {
     let config = config(&[("IS_PROD", "true")]);
     test("declare const IS_PROD: boolean; if (IS_PROD) {} foo(IS_PROD)", "foo(true)", &config);
+}
+
+#[test]
+fn declare_const_assignment_target_bailout() {
+    // `IS_PROD = 0` cannot be rewritten to `true = 0` (literals are not valid
+    // assignment targets), so the LHS replacement bails out and the original
+    // identifier stays in the AST, its reference intact — downstream DCE must
+    // not treat IS_PROD as unused and drop the `declare const`.
+    let config = config(&[("IS_PROD", "true")]);
+    test(
+        "declare const IS_PROD: boolean; IS_PROD = 0;",
+        "declare const IS_PROD: boolean; IS_PROD = 0;",
+        &config,
+    );
 }
 
 #[test]

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||            165 |             51 ||         152743 |          28244
+checker.ts                 | 2.92 MB        ||            165 |             51 ||         152742 |          28244
 
 App.tsx                    | 415.34 kB      ||            114 |             48 ||          17012 |           2702
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             23 |             20 ||             31 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             23 |             20 ||             32 |              6
 
-pdf.mjs                    | 567.30 kB      ||           2613 |            247 ||          47484 |           7740
+pdf.mjs                    | 567.30 kB      ||           2613 |            248 ||          47485 |           7740
 
-antd.js                    | 6.69 MB        ||           3083 |            103 ||         337252 |          69349
+antd.js                    | 6.69 MB        ||           3083 |            104 ||         337251 |          69349
 
-binder.ts                  | 193.08 kB      ||             40 |             36 ||           7082 |            824
+binder.ts                  | 193.08 kB      ||             40 |             36 ||           7083 |            824
 
-kitchen-sink.tsx           | 732.90 kB      ||           2917 |            215 ||         100230 |          17853
+kitchen-sink.tsx           | 732.90 kB      ||           2639 |            216 ||          90554 |          15823
 


### PR DESCRIPTION
> Developed with AI assistance (Claude Code); reviewed, tested, and benchmarked by the contributor.

## Summary

Deletes the per-pass `LiveUsageCollector` walk over the entire live program. The typed mutation helpers (previous PR in this stack) now walk only the dropped/replaced subtrees in place, accumulating dead `ReferenceId`s into a per-pass `PassDirty` arena `BitSet` that the `Compressor` driver consumes in one batch (after `Normalize` and after each peephole pass) via the new `Scoping::retain_resolved_references_excluding`. Direct-eval flag refresh runs only when an `eval(...)` call was actually dropped.

Cross-crate support riding in this PR: `Scoping::retain_resolved_references_excluding` (oxc_semantic) and `BitSet::capacity()` / `is_empty()` / `contains()` (oxc_allocator).

## Breaking

Removes `oxc_semantic::Scoping::retain_resolved_references` — its only consumer was `LiveUsageCollector`, deleted here. No other in-repo or known downstream callers.

## Benchmarks (CodSpeed, this PR vs stack base)

| Benchmark | Base → Head | Efficiency |
|---|---|---|
| `minifier[kitchen-sink.tsx]` | 63.6 ms → 52.5 ms | **+21.2%** |
| `pipeline[kitchen-sink.tsx]` | 122.3 ms → 110.7 ms | +10.5% |
| `minifier[App.tsx]` | 12.5 ms → 12.1 ms | +3.3% |
| everything else | — | unchanged |

> **Why earlier runs showed ~2× on kitchen-sink:** the initial cut of this branch had a reference-leak bug — dropped subtrees weren't always marked dead, leaked references made symbols look used, and the minifier silently skipped most of kitchen-sink's DCE, producing output **22% larger than main** (invisible to minsize, which doesn't include that file). Those runs measured a minifier doing less work, not a faster minifier. The leak is fixed (see below); the numbers above are measured at byte-identical output to main.

Memory: kitchen-sink.tsx arena allocs 100230 → 90553, sys allocs 2917 → 2639; all other tracked files at or slightly below base.

## Relation to #22736

This re-cuts the approach prototyped and discussed in #22736 (kept open during development as the design record), with three deviations from the POC:

1. **Mark-only `DropDiff`** — the POC's "Resurrect" mode existed for one call site (`substitute_is_object_and_not_null`) that reused `ReferenceId`s in replacement values. That site now mints fresh references (same symbol/resolution, new id), so the resurrect walk and its cross-call aliasing invariant are gone entirely.
2. **`mutated: bool` instead of a `mutations: u64` snapshot counter** — after this PR the signal's only reader is the fixed-point loop, so a private bool with read-and-reset `take_mutated()` suffices.
3. **Bounds-checked mark path** — references minted mid-pass and dropped in the same pass are skipped (treated live → conservative output) instead of the POC's debug-assert + potential release panic.

Safety net: `debug_assert_no_over_prune` walks the live program in debug builds after each dirty pass, so the whole test + conformance corpus doubles as an over-prune detector at zero release cost.

## Reference-leak fix + simplification follow-ups

The initial cut leaked references at three classes of drop sites. The leak direction is safe (stale extra references block optimizations, never corrupt output), but it cost real output size on `void ident`-heavy inputs — kitchen-sink.tsx minified 22% larger than main:

1. **`Normalize` raw drops** (`void x` → `void 0`, `drop_console`) never reached `PassDirty`. `Normalize` now records drops through the same typed helpers, and the driver flushes once before the fixed-point loop so pass 1 already observes pruned reference counts (no extra peephole pass).
2. **`remove_unused_template_literal`** silently drained elements that `remove_unused_expression` collapsed to nothing, without a drop walk.
3. **Dropped variable declarators** walked only `init`; references in the binding's TS type annotation (e.g. computed keys in a type literal) leaked. New `drop_variable_declarator` helper walks the whole declarator.

Each class has a leak-regression test; kitchen-sink.tsx output is verified **byte-identical to main**.

Two simplification passes followed: flush hoisted into the `Compressor` driver (no cross-traversal coupling), `DropDiff` reduced to a thin `Visit` over `&mut PassDirty` (no scoping lookup on the mark hot path; marks for unresolved refs are inert), `BitSet::clear()` reuse instead of a per-pass arena realloc, a shared `as_direct_eval_call` predicate for producer and consumer, plain `clone_in` (id-less) at the one site that cloned semantic ids, and removal of dead `drop_console` repair code.

## Verification

- `cargo test -p oxc_minifier -p oxc_mangler -p oxc_semantic -p oxc_allocator` — all pass, incl. the new leak-regression tests
- `just minsize` — **bit-identical output**; kitchen-sink.tsx (not in minsize) separately verified byte-identical to main
- `cargo coverage -- minifier` — test262 44825/44829, babel 1785/1785, snapshots unchanged
- clippy (all features/targets), fmt clean


## Test alignment in oxc_transformer_plugins

The `replace_global_defines` integration-test helper previously reused RGD's returned scoping directly for DCE — a path production does not take: `crates/oxc/src/compiler.rs` marks scoping dirty whenever RGD changed the AST (`scoping_dirty |= ret.changed`) and rebuilds before compress/DCE, and rolldown minifies freshly-parsed chunks. With the full-walk `LiveUsageCollector` gone, that test-only path surfaced stale ambient-`declare` references. The helper now mirrors the production pipeline (rebuild when `ret.changed`, reuse otherwise). No `ReplaceGlobalDefines` source changes. Two `declare`-define contract tests added.

## Known trade-off: defines-heavy DCE pays O(dropped) drop-walks

Profiling `pipeline[react.development.js]` (with `process.env.NODE_ENV` defines) shows the worst case of walk-what-you-drop: DCE drops one `if` subtree covering ~90% of the program's nodes, so the drop-walk approaches a full-program traversal where the old per-pass live walk only covered the small remainder (−3% CodSpeed / +7% local wall on that bench; attribution: ~72% drop-walks, 0% double-marking, ~0% bitset cost). A bounded-walk + live-walk-fallback mitigation was prototyped and validated (recovers to +1.4%, all other wins preserved), but we decided the added mechanism wasn't worth the maintenance cost for a one-bench regression — the same file's plain minification *improves* 12%, and kitchen-sink-class inputs (the load-bearing case) improve ~2×. Revisit if real-world defines-heavy workloads surface it.


