### PR TITLE
perf(parser): table-driven operator precedence and single-match member expression dispatch

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -832,85 +832,92 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 return lhs;
             }
 
-            let mut question_dot = false;
-            let is_property_access = if allow_optional_chain && self.at(Kind::QuestionDot) {
-                // ?.
-                // Fast check to avoid checkpoint/rewind in common cases
-                let next_kind = self.lexer.peek_token().kind();
-                if next_kind == Kind::LBrack
-                    || next_kind.is_identifier_or_keyword()
-                    || next_kind.is_template_start_of_tagged_template()
-                {
-                    // This is likely a valid optional chain, proceed with normal parsing
-                    self.bump_any(); // consume ?.
-                    let kind = self.cur_kind();
-                    let is_identifier_or_keyword = kind.is_identifier_or_keyword();
-                    // ?.[
-                    // ?.something
-                    // ?.template`...`
-                    *in_optional_chain = true;
-                    question_dot = true;
-                    is_identifier_or_keyword
-                } else {
-                    // This is not a valid optional chain pattern, don't consume ?.
-                    // Should be a cold branch here, as most real-world optional chaining will look like
-                    // `?.something` or `?.[expr]`
-                    false
+            // Dispatch on the current token once. The loop runs after every postfix expression,
+            // and most iterations exit immediately, so a single `match` beats sequential checks.
+            match self.cur_kind() {
+                Kind::Dot => {
+                    self.bump_any();
+                    self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_span);
+                    lhs = self.parse_static_member_expression(lhs_span, lhs, false);
                 }
-            } else {
-                self.eat(Kind::Dot)
-            };
-
-            if is_property_access {
-                self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_span);
-                lhs = self.parse_static_member_expression(lhs_span, lhs, question_dot);
-                continue;
-            }
-
-            if (question_dot || !self.ctx.has_decorator()) && self.at(Kind::LBrack) {
-                self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_span);
-                lhs = self.parse_computed_member_expression(lhs_span, lhs, question_dot);
-                continue;
-            }
-
-            if self.cur_kind().is_template_start_of_tagged_template() {
-                let (expr, type_arguments) =
-                    if let Expression::TSInstantiationExpression(instantiation_expr) = lhs {
-                        let expr = instantiation_expr.unbox();
-                        (expr.expression, Some(expr.type_arguments))
+                Kind::QuestionDot if allow_optional_chain => {
+                    // Fast check to avoid checkpoint/rewind in common cases
+                    let next_kind = self.lexer.peek_token().kind();
+                    if next_kind == Kind::LBrack
+                        || next_kind.is_identifier_or_keyword()
+                        || next_kind.is_template_start_of_tagged_template()
+                    {
+                        // This is likely a valid optional chain, proceed with normal parsing
+                        self.bump_any(); // consume ?.
+                        *in_optional_chain = true;
+                        if self.cur_kind().is_identifier_or_keyword() {
+                            // ?.something
+                            self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_span);
+                            lhs = self.parse_static_member_expression(lhs_span, lhs, true);
+                        } else if self.at(Kind::LBrack) {
+                            // ?.[
+                            self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_span);
+                            lhs = self.parse_computed_member_expression(lhs_span, lhs, true);
+                        } else {
+                            // ?.template`...`
+                            lhs =
+                                self.parse_tagged_template_rest(lhs_span, lhs, *in_optional_chain);
+                        }
                     } else {
-                        (lhs, None)
-                    };
-                lhs =
-                    self.parse_tagged_template(lhs_span, expr, *in_optional_chain, type_arguments);
-                continue;
-            }
-
-            if !question_dot && self.is_ts {
-                if !self.cur_token().is_on_new_line() && self.eat(Kind::Bang) {
-                    lhs = self.ast.expression_ts_non_null(self.end_span(lhs_span), lhs);
-                    continue;
+                        // This is not a valid optional chain pattern, don't consume ?.
+                        // Should be a cold branch here, as most real-world optional chaining will look like
+                        // `?.something` or `?.[expr]`
+                        return lhs;
+                    }
                 }
-
-                if matches!(self.cur_kind(), Kind::LAngle | Kind::ShiftLeft) {
+                Kind::LBrack if !self.ctx.has_decorator() => {
+                    self.error_if_unparenthesized_instantiation_expression(&lhs, lhs_span);
+                    lhs = self.parse_computed_member_expression(lhs_span, lhs, false);
+                }
+                kind if kind.is_template_start_of_tagged_template() => {
+                    lhs = self.parse_tagged_template_rest(lhs_span, lhs, *in_optional_chain);
+                }
+                Kind::Bang if self.is_ts && !self.cur_token().is_on_new_line() => {
+                    self.bump_any();
+                    lhs = self.ast.expression_ts_non_null(self.end_span(lhs_span), lhs);
+                }
+                Kind::LAngle | Kind::ShiftLeft if self.is_ts => {
                     if let Some(arguments) = self.parse_type_arguments_in_expression() {
                         lhs = self.ast.expression_ts_instantiation(
                             self.end_span(lhs_span),
                             lhs,
                             arguments,
                         );
-                        continue;
+                    } else {
+                        // `re_lex_as_typescript_l_angle` may have popped the original token
+                        // (e.g. `<<`) from the collected token stream. Rewind restored the
+                        // parser's current token, so write it back to the stream.
+                        // This is a no-op when tokens are statically disabled (`NoTokensLexerConfig`).
+                        self.lexer.rewrite_last_collected_token(self.token);
+                        return lhs;
                     }
-                    // `re_lex_as_typescript_l_angle` may have popped the original token
-                    // (e.g. `<<`) from the collected token stream. Rewind restored the
-                    // parser's current token, so write it back to the stream.
-                    // This is a no-op when tokens are statically disabled (`NoTokensLexerConfig`).
-                    self.lexer.rewrite_last_collected_token(self.token);
                 }
+                _ => return lhs,
             }
-
-            return lhs;
         }
+    }
+
+    /// Parse the tagged template continuation of a member expression,
+    /// unwrapping a `TSInstantiationExpression` lhs (`` foo<T>`...` ``) into its type arguments.
+    fn parse_tagged_template_rest(
+        &mut self,
+        lhs_span: u32,
+        lhs: Expression<'a>,
+        in_optional_chain: bool,
+    ) -> Expression<'a> {
+        let (expr, type_arguments) =
+            if let Expression::TSInstantiationExpression(instantiation_expr) = lhs {
+                let expr = instantiation_expr.unbox();
+                (expr.expression, Some(expr.type_arguments))
+            } else {
+                (lhs, None)
+            };
+        self.parse_tagged_template(lhs_span, expr, in_optional_chain, type_arguments)
     }
 
     /// Section 13.3 `MemberExpression`

--- a/crates/oxc_parser/src/js/operator.rs
+++ b/crates/oxc_parser/src/js/operator.rs
@@ -7,26 +7,45 @@ use oxc_syntax::{
 
 use crate::lexer::Kind;
 
+/// Lookup table for [`kind_to_precedence`], indexed by `Kind` discriminant.
+///
+/// `kind_to_precedence` is called for every token while parsing binary expressions,
+/// so a single indexed load beats a branchy `match`.
+static PRECEDENCE_TABLE: [Option<Precedence>; 256] = {
+    let mut table = [None; 256];
+    table[Kind::Question2 as usize] = Some(Precedence::NullishCoalescing);
+    table[Kind::Pipe2 as usize] = Some(Precedence::LogicalOr);
+    table[Kind::Amp2 as usize] = Some(Precedence::LogicalAnd);
+    table[Kind::Pipe as usize] = Some(Precedence::BitwiseOr);
+    table[Kind::Caret as usize] = Some(Precedence::BitwiseXor);
+    table[Kind::Amp as usize] = Some(Precedence::BitwiseAnd);
+    table[Kind::Eq2 as usize] = Some(Precedence::Equals);
+    table[Kind::Eq3 as usize] = Some(Precedence::Equals);
+    table[Kind::Neq as usize] = Some(Precedence::Equals);
+    table[Kind::Neq2 as usize] = Some(Precedence::Equals);
+    table[Kind::LAngle as usize] = Some(Precedence::Compare);
+    table[Kind::RAngle as usize] = Some(Precedence::Compare);
+    table[Kind::LtEq as usize] = Some(Precedence::Compare);
+    table[Kind::GtEq as usize] = Some(Precedence::Compare);
+    table[Kind::Instanceof as usize] = Some(Precedence::Compare);
+    table[Kind::In as usize] = Some(Precedence::Compare);
+    table[Kind::ShiftLeft as usize] = Some(Precedence::Shift);
+    table[Kind::ShiftRight as usize] = Some(Precedence::Shift);
+    table[Kind::ShiftRight3 as usize] = Some(Precedence::Shift);
+    table[Kind::Plus as usize] = Some(Precedence::Add);
+    table[Kind::Minus as usize] = Some(Precedence::Add);
+    table[Kind::Star as usize] = Some(Precedence::Multiply);
+    table[Kind::Slash as usize] = Some(Precedence::Multiply);
+    table[Kind::Percent as usize] = Some(Precedence::Multiply);
+    table[Kind::Star2 as usize] = Some(Precedence::Exponentiation);
+    table[Kind::As as usize] = Some(Precedence::Compare);
+    table[Kind::Satisfies as usize] = Some(Precedence::Compare);
+    table
+};
+
 #[inline]
 pub fn kind_to_precedence(kind: Kind) -> Option<Precedence> {
-    match kind {
-        Kind::Question2 => Some(Precedence::NullishCoalescing),
-        Kind::Pipe2 => Some(Precedence::LogicalOr),
-        Kind::Amp2 => Some(Precedence::LogicalAnd),
-        Kind::Pipe => Some(Precedence::BitwiseOr),
-        Kind::Caret => Some(Precedence::BitwiseXor),
-        Kind::Amp => Some(Precedence::BitwiseAnd),
-        Kind::Eq2 | Kind::Eq3 | Kind::Neq | Kind::Neq2 => Some(Precedence::Equals),
-        Kind::LAngle | Kind::RAngle | Kind::LtEq | Kind::GtEq | Kind::Instanceof | Kind::In => {
-            Some(Precedence::Compare)
-        }
-        Kind::ShiftLeft | Kind::ShiftRight | Kind::ShiftRight3 => Some(Precedence::Shift),
-        Kind::Plus | Kind::Minus => Some(Precedence::Add),
-        Kind::Star | Kind::Slash | Kind::Percent => Some(Precedence::Multiply),
-        Kind::Star2 => Some(Precedence::Exponentiation),
-        Kind::As | Kind::Satisfies => Some(Precedence::Compare),
-        _ => None,
-    }
+    PRECEDENCE_TABLE[kind as usize]
 }
 
 #[inline]


### PR DESCRIPTION
Two micro-optimizations in expression parsing hot paths, found by profiling `binder.ts` parsing (flat profile; these were the largest parser-side self-time items after the lexer):

1. **`kind_to_precedence` → lookup table.** It is called for every token while parsing binary expressions, and the `match` compiled to a branch chain. Replaced with a 256-entry `static` table indexed by `Kind` discriminant — a single indexed load.

2. **`parse_member_expression_rest` → single-`match` dispatch.** The loop runs after every postfix expression and tested `?.`, `.`, `[`, template start, `!`, `<` sequentially; most iterations exit with no member access at all. It now dispatches once on the current token kind. Semantics are preserved exactly: the decorator-context `[` restriction, the optional-chain peek fast-path (including returning without consuming `?.` on invalid patterns), and the TS instantiation re-lex fallback with `rewrite_last_collected_token`. The tagged-template continuation is factored into a `parse_tagged_template_rest` helper used by both the plain and `?.`-prefixed paths.

Benchmarks: criterion runs were unstable on my machine that day (a stale baseline plus post-LTO-build thermal throttling produced contradictory numbers), so I measured with an interleaved A/B harness — two prebuilt binaries alternating 12 runs per file, comparing medians, which cancels drift:

| File | Change |
|---|---|
| binder.ts | −3.1% |
| checker.ts (2.9 MB) | −2.3% |
| react.development.js | −2.8% |

Decomposed with a third binary on binder.ts: roughly −1.3% from the precedence table and −1.3% from the member-expression dispatch. Unlike TS-only wins, this helps plain JS too, since member-expression and precedence dispatch are universal.

Conformance pass rates and snapshots are unchanged (test262 100%, TypeScript positive 100%).

Independent of #23191 (different code paths; based directly on main).

> Disclosure: implemented with AI assistance (Claude Code), reviewed and benchmarked locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)