### PR TITLE
fix(parser): report accessor definite assertion on token

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -392,7 +392,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         key: PropertyKey<'a>,
         computed: bool,
-        definite: bool,
+        definite: Option<u32>,
         modifiers: &Modifiers,
         decorators: Vec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
@@ -421,13 +421,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             true,
             diagnostics::accessor_modifier,
         );
-        if definite
+        if let Some(definite_token_start) = definite
             && ((self.ctx.has_ambient() && !modifiers.contains(ModifierKind::Declare))
                 || r#type.is_abstract())
         {
-            self.error(diagnostics::definite_assignment_assertion_not_permitted(
-                self.end_span(span),
-            ));
+            self.error(diagnostics::definite_assignment_assertion_not_permitted(Span::sized(
+                definite_token_start,
+                1,
+            )));
         }
         self.ast.class_element_accessor_property(
             self.end_span(span),
@@ -439,7 +440,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             computed,
             modifiers.contains(ModifierKind::Static),
             modifiers.contains(ModifierKind::Override),
-            definite,
+            definite.is_some(),
             modifiers.accessibility(),
         )
     }
@@ -599,12 +600,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::constructor_accessor(name.span()));
             }
             return self.parse_class_accessor_property(
-                span,
-                name,
-                computed,
-                is_definite,
-                modifiers,
-                decorators,
+                span, name, computed, definite, modifiers, decorators,
             );
         }
 

--- a/tasks/coverage/misc/fail/oxc-23170.ts
+++ b/tasks/coverage/misc/fail/oxc-23170.ts
@@ -1,0 +1,7 @@
+declare class AmbientAccessor {
+  accessor prop!: string;
+}
+
+abstract class AbstractAccessor {
+  abstract accessor prop!: string;
+}

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 68/68 (100.00%)
 Positive Passed: 68/68 (100.00%)
-Negative Passed: 145/145 (100.00%)
+Negative Passed: 146/146 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -3561,6 +3561,22 @@ Negative Passed: 145/145 (100.00%)
     ·       ─────
  10 │ }
     ╰────
+
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+   ╭─[misc/fail/oxc-23170.ts:2:16]
+ 1 │ declare class AmbientAccessor {
+ 2 │   accessor prop!: string;
+   ·                ─
+ 3 │ }
+   ╰────
+
+  × TS(1255): A definite assignment assertion '!' is not permitted in this context.
+   ╭─[misc/fail/oxc-23170.ts:6:25]
+ 5 │ abstract class AbstractAccessor {
+ 6 │   abstract accessor prop!: string;
+   ·                         ─
+ 7 │ }
+   ╰────
 
   × Empty parenthesized expression
    ╭─[misc/fail/oxc-232.js:1:5]


### PR DESCRIPTION
## Summary
- Pass the definite-assignment assertion token offset through the class accessor-property parser path.
- Report invalid ambient and abstract `accessor prop!` diagnostics on the `!` token, matching the span behavior used by variable declarators and normal class properties.
- Add focused misc parser coverage for the accessor-specific invalid cases.

## Rationale
This follows up #23170. That parser change already narrowed definite-assignment diagnostics for variables and normal class properties, but accessor properties still kept only a boolean. That meant `accessor prop!` could only report TS1255 using the full class element span. Carrying the offset into `parse_class_accessor_property` aligns accessor diagnostics with the other definite-assignment diagnostics and keeps the AST shape unchanged by storing only `definite.is_some()`.

The misc fixture is needed because upstream TypeScript coverage exercises invalid definite assertions on normal fields, but not invalid accessor properties. Existing misc coverage only had a valid `accessor y!` pass case, so `just coverage` did not specifically protect the accessor diagnostic span this fixes.