### PR TITLE
fix(linter/website): render u32 max defaults as infinity

### DIFF
--- a/tasks/website_common/src/schema_markdown.rs
+++ b/tasks/website_common/src/schema_markdown.rs
@@ -539,7 +539,10 @@ impl Renderer {
         let m = schema.metadata.as_ref()?;
         let default = m.default.as_ref()?;
 
-        if default.as_u64().is_some_and(|value| value == usize::MAX as u64) {
+        if default
+            .as_u64()
+            .is_some_and(|value| value == usize::MAX as u64 || value == u64::from(u32::MAX))
+        {
             return Some("Infinity".to_string());
         }
 

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -2070,7 +2070,7 @@ This rule accepts a configuration object with the following properties:
 
 type: `integer`
 
-default: `4294967295`
+default: `Infinity`
 
 The maximum number of top-level `describe` blocks allowed in a test file.
 


### PR DESCRIPTION
- Render `u32::MAX` defaults as `Infinity` in generated markdown docs.
- Keeps the `require-top-level-describe` docs stable on 32-bit targets, where `u32::MAX` also equals `usize::MAX`.


This should fix the faiking 32 bit tests