### PR TITLE
feat(linter/promise/catch-or-return): add support for `allowThenStrict` option

### DIFF
--- a/crates/oxc_linter/src/rules/promise/catch_or_return.rs
+++ b/crates/oxc_linter/src/rules/promise/catch_or_return.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{CallExpression, Expression},
+    ast::{Argument, CallExpression, Expression},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -33,6 +33,8 @@ pub struct CatchOrReturnConfig {
     allow_finally: bool,
     /// Whether to allow `then()` with two arguments as a termination method.
     allow_then: bool,
+    /// Whether to allow `then(null, handler)` as a termination method.
+    allow_then_strict: bool,
     /// List of allowed termination methods (e.g., `catch`, `done`).
     #[serde(
         default = "default_termination_method",
@@ -46,6 +48,7 @@ impl Default for CatchOrReturnConfig {
         Self {
             allow_finally: false,
             allow_then: false,
+            allow_then_strict: false,
             termination_method: default_termination_method(),
         }
     }
@@ -160,7 +163,12 @@ impl CatchOrReturn {
         };
 
         // somePromise.then(a, b)
-        if self.allow_then && prop_name == "then" && call_expr.arguments.len() == 2 {
+        if prop_name == "then"
+            && call_expr.arguments.len() == 2
+            && (self.allow_then
+                || (self.allow_then_strict
+                    && matches!(call_expr.arguments.first(), Some(Argument::NullLiteral(_)))))
+        {
             return true;
         }
 
@@ -300,6 +308,34 @@ fn test() {
             Some(serde_json::json!([{ "allowThen": true }])),
         ),
         (
+            "frank().then(go).then(null, doIt)",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
+            "frank().then(go).then().then().then().then(null, doIt)",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
+            "frank().then(go).then().then(null, function() { /* why bother */ })",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
+            "frank.then(go).then(to).then(null, jail)",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
+            "frank().then(a).then(b).then(null, c)",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
+            "frank().then(a).then(b).then().then().then(null, doIt)",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
+            "frank().then(a).then(b).then(null, function() { /* why bother */ })",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
             "frank().then(go).catch(doIt).finally(fn)",
             Some(serde_json::json!([{ "allowFinally": true }])),
         ),
@@ -371,6 +407,36 @@ fn test() {
         ("frank().catch(go)", Some(serde_json::json!([{ "terminationMethod": "done" }]))),
         ("frank().catch(go).someOtherMethod()", None),
         ("frank()['catch'](go).someOtherMethod()", None),
+        ("frank().then(a).then(b).then(null, c)", None),
+        ("frank().then(a).then(b).then().then().then(null, doIt)", None),
+        ("frank().then(a).then(b).then(null, function() { /* why bother */ })", None),
+        ("frank().then(a, b)", None),
+        ("frank().then(go).then(zam, doIt)", None),
+        ("frank().then(a).then(b).then(c, d)", None),
+        ("frank().then(go).then().then().then().then(wham, doIt)", None),
+        ("frank().then(go).then().then(function() {}, function() { /* why bother */ })", None),
+        ("frank.then(go).then(to).then(pewPew, jail)", None),
+        ("frank().then(a, b)", Some(serde_json::json!([{ "allowThenStrict": true }]))),
+        (
+            "frank().then(go).then(zam, doIt)",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
+            "frank().then(a).then(b).then(c, d)",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
+            "frank().then(go).then().then().then().then(wham, doIt)",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
+            "frank().then(go).then().then(function() {}, function() { /* why bother */ })",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
+        (
+            "frank.then(go).then(to).then(pewPew, jail)",
+            Some(serde_json::json!([{ "allowThenStrict": true }])),
+        ),
         ("const a = () => { Promise.resolve(null); }", None),
         ("function a() { const b = () => { Promise.resolve(null); }; return b; }", None),
     ];

--- a/crates/oxc_linter/src/snapshots/promise_catch_or_return.snap
+++ b/crates/oxc_linter/src/snapshots/promise_catch_or_return.snap
@@ -171,6 +171,111 @@ source: crates/oxc_linter/src/tester.rs
   help: Return the promise or chain a `catch()`.
 
   ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(a).then(b).then(null, c)
+   · ─────────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(a).then(b).then().then().then(null, doIt)
+   · ──────────────────────────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(a).then(b).then(null, function() { /* why bother */ })
+   · ───────────────────────────────────────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(a, b)
+   · ──────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(go).then(zam, doIt)
+   · ────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(a).then(b).then(c, d)
+   · ──────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(go).then().then().then().then(wham, doIt)
+   · ──────────────────────────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(go).then().then(function() {}, function() { /* why bother */ })
+   · ────────────────────────────────────────────────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank.then(go).then(to).then(pewPew, jail)
+   · ──────────────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(a, b)
+   · ──────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(go).then(zam, doIt)
+   · ────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(a).then(b).then(c, d)
+   · ──────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(go).then().then().then().then(wham, doIt)
+   · ──────────────────────────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank().then(go).then().then(function() {}, function() { /* why bother */ })
+   · ────────────────────────────────────────────────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
+   ╭─[catch_or_return.mjs:1:1]
+ 1 │ frank.then(go).then(to).then(pewPew, jail)
+   · ──────────────────────────────────────────
+   ╰────
+  help: Return the promise or chain a `catch()`.
+
+  ⚠ promise(catch-or-return): Expected `catch` or `return`.
    ╭─[catch_or_return.mjs:1:19]
  1 │ const a = () => { Promise.resolve(null); }
    ·                   ─────────────────────


### PR DESCRIPTION
## Summary
- Adds `allowThenStrict` support to `promise/catch-or-return`, matching the upstream `eslint-plugin-promise` option.
- Re-ports the upstream `catch-or-return` tests for default `.then(...)` handling and strict `.then(null, handler)` behavior.

## Before/After
Before, `{ allowThenStrict: true }` produced a configuration error by Oxlint.

After, strict mode accepts only the null-first-argument form as a promise termination, while `.then(onFulfilled, onRejected)` still reports under `allowThenStrict`.

```js
// allowed with { allowThenStrict: true }
promise.then(work).then(null, handleError)

// still reported with { allowThenStrict: true }
promise.then(work).then(onFulfilled, handleError)
```

Fixes #23188