### PR TITLE
feat(parser): add TS2398 parameter property diagnostic

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -1085,6 +1085,11 @@ pub fn parameter_property_cannot_be_binding_pattern(span: Span) -> OxcDiagnostic
         .with_label(span)
 }
 
+#[cold]
+pub fn constructor_cannot_be_parameter_property_name(span: Span) -> OxcDiagnostic {
+    ts_error("2398", "'constructor' cannot be used as a parameter property name.").with_label(span)
+}
+
 pub fn cannot_appear_on_an_index_signature(
     modifier: &Modifier,
     allowed: Option<ModifierKinds>,

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -202,15 +202,22 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             None
         };
 
-        if (modifiers.contains_accessibility()
+        let is_parameter_property = modifiers.contains_accessibility()
             || modifiers.contains_readonly()
-            || modifiers.contains_override())
-            && !pattern.is_binding_identifier()
-        {
-            self.error(diagnostics::parameter_property_cannot_be_binding_pattern(Span::new(
-                span,
-                self.prev_token_end,
-            )));
+            || modifiers.contains_override();
+        if is_parameter_property {
+            if let Some(ident) = pattern.get_binding_identifier() {
+                if func_kind == FunctionKind::Constructor && ident.name == "constructor" {
+                    self.error(diagnostics::constructor_cannot_be_parameter_property_name(
+                        ident.span,
+                    ));
+                }
+            } else {
+                self.error(diagnostics::parameter_property_cannot_be_binding_pattern(Span::new(
+                    span,
+                    self.prev_token_end,
+                )));
+            }
         }
 
         let are_decorators_allowed =

--- a/tasks/coverage/misc/fail/oxc-ts-2398.ts
+++ b/tasks/coverage/misc/fail/oxc-ts-2398.ts
@@ -1,0 +1,2 @@
+class A {constructor(public constructor){}}
+class B {constructor(readonly constructor){}}

--- a/tasks/coverage/misc/pass/oxc-ts-2398.ts
+++ b/tasks/coverage/misc/pass/oxc-ts-2398.ts
@@ -1,0 +1,2 @@
+class A {constructor(constructor){}}
+class B {method(constructor){}}

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 68/68 (100.00%)
-Positive Passed: 68/68 (100.00%)
+AST Parsed     : 69/69 (100.00%)
+Positive Passed: 69/69 (100.00%)

--- a/tasks/coverage/snapshots/formatter_misc.snap
+++ b/tasks/coverage/snapshots/formatter_misc.snap
@@ -1,3 +1,3 @@
 formatter_misc Summary:
-AST Parsed     : 68/68 (100.00%)
-Positive Passed: 68/68 (100.00%)
+AST Parsed     : 69/69 (100.00%)
+Positive Passed: 69/69 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
-AST Parsed     : 68/68 (100.00%)
-Positive Passed: 68/68 (100.00%)
-Negative Passed: 146/146 (100.00%)
+AST Parsed     : 69/69 (100.00%)
+Positive Passed: 69/69 (100.00%)
+Negative Passed: 147/147 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -3849,6 +3849,20 @@ Negative Passed: 146/146 (100.00%)
  3 │ }
    ╰────
   help: Add an identifier after '?.'
+
+  × TS(2398): 'constructor' cannot be used as a parameter property name.
+   ╭─[misc/fail/oxc-ts-2398.ts:1:29]
+ 1 │ class A {constructor(public constructor){}}
+   ·                             ───────────
+ 2 │ class B {constructor(readonly constructor){}}
+   ╰────
+
+  × TS(2398): 'constructor' cannot be used as a parameter property name.
+   ╭─[misc/fail/oxc-ts-2398.ts:2:31]
+ 1 │ class A {constructor(public constructor){}}
+ 2 │ class B {constructor(readonly constructor){}}
+   ·                               ───────────
+   ╰────
 
   × Invalid rest element target in destructuring assignment
    ╭─[misc/fail/rest-assignment-target.js:1:6]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 7539c04d
 parser_typescript Summary:
 AST Parsed     : 9779/9779 (100.00%)
 Positive Passed: 9779/9779 (100.00%)
-Negative Passed: 1637/2640 (62.01%)
+Negative Passed: 1638/2640 (62.05%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
@@ -737,8 +737,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overloadsInD
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/overshifts.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parameterDecoratorsEmitCrash.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyInConstructor3.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot_realRootFile.ts
 
@@ -10335,6 +10333,14 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  3 │     constructor(public names: string);
    ·                 ────────────────────
  4 │     constructor(public names: string, public ages: number) {
+   ╰────
+
+  × TS(2398): 'constructor' cannot be used as a parameter property name.
+   ╭─[typescript/tests/cases/compiler/parameterPropertyInConstructor3.ts:2:22]
+ 1 │ class Foo {
+ 2 │   constructor(public constructor: string) {}
+   ·                      ───────────
+ 3 │ }
    ╰────
 
   × TS(1090): 'public' modifier cannot appear on a parameter.

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 68/68 (100.00%)
-Positive Passed: 54/68 (79.41%)
+AST Parsed     : 69/69 (100.00%)
+Positive Passed: 55/69 (79.71%)
 semantic Error: tasks/coverage/misc/pass/conditional-arrow-alternate-return-type.ts
 Unresolved references mismatch:
 after transform: ["Pick", "Record"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 68/68 (100.00%)
-Positive Passed: 68/68 (100.00%)
+AST Parsed     : 69/69 (100.00%)
+Positive Passed: 69/69 (100.00%)


### PR DESCRIPTION
## Summary

- Report TS2398 when a TypeScript constructor parameter property is named `constructor`.
- Add coverage for the upstream TypeScript fixture plus dedicated misc pass/fail cases for ordinary `constructor` parameters versus invalid parameter properties.

```
  × TS(2398): 'constructor' cannot be used as a parameter property name.
   ╭─[misc/fail/oxc-ts-2398.ts:2:31]
 1 │ class A {constructor(public constructor){}}
 2 │ class B {constructor(readonly constructor){}}
   ·                               ───────────
   ╰────
```
