### PR TITLE
refactor(diagnostics)!: return a Diagnostics type instead of Vec<OxcDiagnostic>

### DIFF
--- a/apps/oxlint/src/js_plugins/parse.rs
+++ b/apps/oxlint/src/js_plugins/parse.rs
@@ -204,16 +204,17 @@ unsafe fn parse_raw_impl(
             })
             .with_config(RuntimeParserConfig::new(true))
             .parse();
-        let ParserReturn { program: parsed_program, errors, mut tokens, panicked, .. } = parser_ret;
+        let ParserReturn { program: parsed_program, diagnostics, mut tokens, panicked, .. } =
+            parser_ret;
         let program = allocator.alloc(parsed_program);
 
-        let mut parsing_failed = panicked || (!errors.is_empty() && !ignore_non_fatal_errors);
+        let mut parsing_failed = panicked || (!diagnostics.is_empty() && !ignore_non_fatal_errors);
 
         // Check for semantic errors.
         // If `ignore_non_fatal_errors` is `true`, skip running semantic, as any errors will be ignored anyway.
         if !parsing_failed && !ignore_non_fatal_errors {
             let semantic_ret = SemanticBuilder::new_compiler().build(program);
-            parsing_failed = !semantic_ret.errors.is_empty();
+            parsing_failed = !semantic_ret.diagnostics.is_empty();
         }
 
         if parsing_failed {

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -3,7 +3,7 @@ use std::{mem, ops::ControlFlow, path::Path};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
 use oxc_codegen::{Codegen, CodegenOptions, CodegenReturn};
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::Diagnostics;
 use oxc_isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions};
 use oxc_mangler::{MangleOptions, Mangler, ManglerReturn};
 use oxc_minifier::{CompressOptions, Compressor};
@@ -19,11 +19,11 @@ use oxc_transformer_plugins::{
 #[derive(Default)]
 pub struct Compiler {
     printed: String,
-    errors: Vec<OxcDiagnostic>,
+    errors: Diagnostics,
 }
 
 impl CompilerInterface for Compiler {
-    fn handle_errors(&mut self, errors: Vec<OxcDiagnostic>) {
+    fn handle_errors(&mut self, errors: Diagnostics) {
         self.errors.extend(errors);
     }
 
@@ -35,13 +35,13 @@ impl CompilerInterface for Compiler {
 impl Compiler {
     /// # Errors
     ///
-    /// * A list of [OxcDiagnostic].
+    /// * The accumulated [Diagnostics].
     pub fn execute(
         &mut self,
         source_text: &str,
         source_type: SourceType,
         source_path: &Path,
-    ) -> Result<String, Vec<OxcDiagnostic>> {
+    ) -> Result<String, Diagnostics> {
         self.compile(source_text, source_type, source_path);
         if self.errors.is_empty() {
             Ok(mem::take(&mut self.printed))
@@ -52,7 +52,7 @@ impl Compiler {
 }
 
 pub trait CompilerInterface {
-    fn handle_errors(&mut self, _errors: Vec<OxcDiagnostic>) {}
+    fn handle_errors(&mut self, _errors: Diagnostics) {}
 
     fn enable_sourcemap(&self) -> bool {
         false
@@ -133,8 +133,8 @@ pub trait CompilerInterface {
         if self.after_parse(&mut parser_return).is_break() {
             return;
         }
-        if !parser_return.errors.is_empty() {
-            self.handle_errors(parser_return.errors);
+        if !parser_return.diagnostics.is_empty() {
+            self.handle_errors(parser_return.diagnostics);
         }
 
         let mut program = parser_return.program;
@@ -147,8 +147,8 @@ pub trait CompilerInterface {
         /* Semantic */
 
         let mut semantic_return = self.semantic(&program);
-        if !semantic_return.errors.is_empty() {
-            self.handle_errors(semantic_return.errors);
+        if !semantic_return.diagnostics.is_empty() {
+            self.handle_errors(semantic_return.diagnostics);
             return;
         }
         if self.after_semantic(&mut semantic_return).is_break() {
@@ -164,8 +164,14 @@ pub trait CompilerInterface {
             let mut transformer_return =
                 self.transform(options, &allocator, &mut program, source_path, scoping);
 
-            // Reported but non-fatal: the transformer always leaves a valid program.
-            self.handle_errors(mem::take(&mut transformer_return.errors));
+            // Errors are fatal (e.g. a React Compiler error); warnings are reported
+            // but codegen still runs.
+            let diagnostics = mem::take(&mut transformer_return.diagnostics);
+            let has_errors = diagnostics.has_errors();
+            self.handle_errors(diagnostics);
+            if has_errors {
+                return;
+            }
 
             if self.after_transform(&mut program, &mut transformer_return).is_break() {
                 return;
@@ -267,7 +273,7 @@ pub trait CompilerInterface {
         source_path: &Path,
     ) {
         let ret = IsolatedDeclarations::new(allocator, options).build(program);
-        self.handle_errors(ret.errors);
+        self.handle_errors(ret.diagnostics);
         let ret = self.codegen(
             &ret.program,
             source_path,

--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -204,7 +204,7 @@ use oxc_data_structures::assert_unchecked;
 ///
 /// let allocator = Allocator::default();
 /// let parsed = Parser::new(&allocator, "let x = 1;", SourceType::default());
-/// assert!(parsed.errors.is_empty());
+/// assert!(parsed.diagnostics.is_empty());
 /// ```
 ///
 /// [`reset`]: Allocator::reset

--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -85,7 +85,7 @@ fn parse<'a>(
             ..ParseOptions::default()
         })
         .parse();
-    for error in ret.errors {
+    for error in ret.diagnostics {
         println!("{:?}", error.with_source_code(source_text.to_string()));
     }
     ret.program

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -75,7 +75,7 @@ pub struct CodegenReturn {
 /// let allocator = Allocator::default();
 /// let source = "const a = 1 + 2;";
 /// let parsed = Parser::new(&allocator, source, SourceType::mjs()).parse();
-/// assert!(parsed.errors.is_empty());
+/// assert!(parsed.diagnostics.is_empty());
 ///
 /// let js = Codegen::new().build(&parsed.program);
 /// assert_eq!(js.code, "const a = 1 + 2;\n");

--- a/crates/oxc_codegen/tests/integration/sourcemap.rs
+++ b/crates/oxc_codegen/tests/integration/sourcemap.rs
@@ -28,7 +28,7 @@ fn pos(line: u32, col: u32) -> Position {
 fn sourcemap_tokens(source_text: &str, source_type: SourceType) -> Vec<Mapping> {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty(), "parse errors: {:?}", ret.errors);
+    assert!(ret.diagnostics.is_empty(), "parse errors: {:?}", ret.diagnostics);
 
     Codegen::new()
         .with_options(default_options())
@@ -92,7 +92,7 @@ fn incorrect_ast() {
     let source_type = SourceType::ts();
     let source_text = "foo\nvar bar = '测试'";
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
 
     let mut program = ret.program;
     program.span = Span::new(0, 0);
@@ -128,7 +128,7 @@ fn no_invalid_tokens_beyond_source() {
         let allocator = Allocator::default();
         let source_type = SourceType::mjs();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
-        assert!(ret.errors.is_empty());
+        assert!(ret.diagnostics.is_empty());
 
         let result = Codegen::new()
             .with_options(CodegenOptions {
@@ -237,7 +237,7 @@ fn synthesized_block_closing_braces_are_mapped() {
     let source_text = "if (foo) {\n  if (bar)\n    baz();\n} else\n  qux();";
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
-    assert!(ret.errors.is_empty(), "parse errors: {:?}", ret.errors);
+    assert!(ret.diagnostics.is_empty(), "parse errors: {:?}", ret.diagnostics);
 
     let mut program = ret.program;
     let Statement::IfStatement(outer_if) = &mut program.body[0] else {
@@ -460,7 +460,7 @@ make().prop",
 fn codegen(code: &str) -> (String, String) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, code, SourceType::mjs()).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     let ret = Codegen::new()
         .with_options(CodegenOptions {
             source_map_path: Some(PathBuf::from("input.js")),

--- a/crates/oxc_codegen/tests/integration/tester.rs
+++ b/crates/oxc_codegen/tests/integration/tester.rs
@@ -13,7 +13,7 @@ pub fn test_with_parse_options(source_text: &str, expected: &str, parse_options:
     let allocator = Allocator::default();
     let ret =
         Parser::new(&allocator, source_text, SourceType::tsx()).with_options(parse_options).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     let result = Codegen::new().with_options(default_options()).build(&ret.program).code;
     assert_eq!(result, expected, "\nfor source: {source_text}");
 }
@@ -47,7 +47,7 @@ pub fn test_options_with_source_type(
 ) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty(), "Parse errors: {:?}", ret.errors);
+    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
     let result = Codegen::new().with_options(options).build(&ret.program).code;
     assert_eq!(result, expected, "\nfor source: {source_text:?}");
 }
@@ -76,7 +76,7 @@ pub fn test_minify(source_text: &str, expected: &str) {
     let source_type = SourceType::jsx();
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty(), "Parse errors: {:?}", ret.errors);
+    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
     let result = Codegen::new()
         .with_options(CodegenOptions { minify: true, ..CodegenOptions::default() })
         .build(&ret.program)
@@ -99,7 +99,7 @@ pub fn codegen_options(source_text: &str, options: &CodegenOptions) -> CodegenRe
     let allocator = Allocator::default();
     let source_type = SourceType::ts();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty(), "Parse errors: {:?}", ret.errors);
+    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
     let mut options = options.clone();
     options.single_quote = true;
     Codegen::new().with_options(options).build(&ret.program)
@@ -115,12 +115,12 @@ pub fn test_idempotency_options(source_text: &str, options: &CodegenOptions) {
     let allocator = Allocator::default();
     let source_type = SourceType::tsx();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty(), "Parse errors: {:?}", ret.errors);
+    assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
     let first = Codegen::new().with_options(options.clone()).build(&ret.program).code;
 
     let allocator2 = Allocator::default();
     let ret2 = Parser::new(&allocator2, &first, source_type).parse();
-    assert!(ret2.errors.is_empty(), "Parse errors on second pass: {:?}", ret2.errors);
+    assert!(ret2.diagnostics.is_empty(), "Parse errors on second pass: {:?}", ret2.diagnostics);
     let second = Codegen::new().with_options(options.clone()).build(&ret2.program).code;
 
     assert_eq!(

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -66,6 +66,107 @@ pub type Result<T> = std::result::Result<T, OxcDiagnostic>;
 use miette::{Diagnostic, SourceCode};
 pub use miette::{GraphicalReportHandler, GraphicalTheme, LabeledSpan, Labels, NamedSource};
 
+/// A collection of [`OxcDiagnostic`]s.
+///
+/// A drop-in replacement for `Vec<OxcDiagnostic>` that can additionally report
+/// whether it holds any [errors](Severity::Error) or [warnings](Severity::Warning).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Diagnostics(Vec<OxcDiagnostic>);
+
+impl Diagnostics {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// `true` if any diagnostic has [error](Severity::Error) severity.
+    pub fn has_errors(&self) -> bool {
+        self.0.iter().any(|diagnostic| diagnostic.severity == Severity::Error)
+    }
+
+    /// `true` if any diagnostic has [warning](Severity::Warning) severity.
+    pub fn has_warnings(&self) -> bool {
+        self.0.iter().any(|diagnostic| diagnostic.severity == Severity::Warning)
+    }
+
+    /// Iterate over the [error](Severity::Error)-severity diagnostics.
+    pub fn errors(&self) -> impl Iterator<Item = &OxcDiagnostic> {
+        self.0.iter().filter(|diagnostic| diagnostic.severity == Severity::Error)
+    }
+
+    /// Iterate over the [warning](Severity::Warning)-severity diagnostics.
+    pub fn warnings(&self) -> impl Iterator<Item = &OxcDiagnostic> {
+        self.0.iter().filter(|diagnostic| diagnostic.severity == Severity::Warning)
+    }
+
+    pub fn into_vec(self) -> Vec<OxcDiagnostic> {
+        self.0
+    }
+
+    pub fn push(&mut self, diagnostic: OxcDiagnostic) {
+        self.0.push(diagnostic);
+    }
+
+    pub fn extend(&mut self, diagnostics: impl IntoIterator<Item = OxcDiagnostic>) {
+        self.0.extend(diagnostics);
+    }
+}
+
+impl Deref for Diagnostics {
+    type Target = Vec<OxcDiagnostic>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Diagnostics {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<Vec<OxcDiagnostic>> for Diagnostics {
+    fn from(diagnostics: Vec<OxcDiagnostic>) -> Self {
+        Self(diagnostics)
+    }
+}
+
+impl From<OxcDiagnostic> for Diagnostics {
+    fn from(diagnostic: OxcDiagnostic) -> Self {
+        Self(vec![diagnostic])
+    }
+}
+
+impl From<Diagnostics> for Vec<OxcDiagnostic> {
+    fn from(diagnostics: Diagnostics) -> Self {
+        diagnostics.0
+    }
+}
+
+impl FromIterator<OxcDiagnostic> for Diagnostics {
+    fn from_iter<T: IntoIterator<Item = OxcDiagnostic>>(iter: T) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl IntoIterator for Diagnostics {
+    type Item = OxcDiagnostic;
+    type IntoIter = std::vec::IntoIter<OxcDiagnostic>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a Diagnostics {
+    type Item = &'a OxcDiagnostic;
+    type IntoIter = std::slice::Iter<'a, OxcDiagnostic>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
 /// Describes an error or warning that occurred.
 ///
 /// Used by all oxc tools.

--- a/crates/oxc_formatter/src/detect_code_removal/mod.rs
+++ b/crates/oxc_formatter/src/detect_code_removal/mod.rs
@@ -23,13 +23,13 @@ pub fn detect_code_removal(
 fn collect(code: &str, source_type: SourceType) -> StatsCollector {
     // Parse the way the formatter does (so the before/after comparison matches the formatter's view).
     let allocator = Allocator::default();
-    let ParserReturn { program, errors, .. } = parse_for_format(&allocator, code, source_type);
+    let ParserReturn { program, diagnostics, .. } = parse_for_format(&allocator, code, source_type);
 
     let mut collector = StatsCollector::default();
 
     // If there are parse errors, skip further analysis.
     // This will be reported in `diff()` later.
-    if !errors.is_empty() {
+    if !diagnostics.is_empty() {
         collector.has_parse_error = true;
         return collector;
     }

--- a/crates/oxc_formatter/src/formatter/jsdoc/embedded.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/embedded.rs
@@ -21,7 +21,7 @@ fn parse_and_build<'a>(
     options: JsFormatOptions,
 ) -> Option<String> {
     let ret = parse_for_format(allocator, source_text, source_type);
-    if ret.panicked || !ret.errors.is_empty() {
+    if ret.panicked || !ret.diagnostics.is_empty() {
         return None;
     }
     let mut code =

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -222,7 +222,7 @@ fn parse<'a>(
     source_type: SourceType,
 ) -> Result<&'a Program<'a>, OxcDiagnostic> {
     let ret = parse_for_format(allocator, source_text, source_type);
-    if let Some(err) = ret.errors.into_iter().next() {
+    if let Some(err) = ret.diagnostics.into_iter().next() {
         return Err(err);
     }
     Ok(allocator.alloc(ret.program))

--- a/crates/oxc_formatter_json/src/parse.rs
+++ b/crates/oxc_formatter_json/src/parse.rs
@@ -61,13 +61,13 @@ pub fn parse_json<'a>(
     // we retry without the wrap and accept the result only when it contains no statements.
     // i.e. `source` is comments / whitespace only.
     // This lets comment-only JSON files round-trip without changing the normal path's cost.
-    if !ret.errors.is_empty() || ret.panicked {
+    if !ret.diagnostics.is_empty() || ret.panicked {
         if let Some(parsed) = try_parse_comments_only(allocator, source, options) {
             validate_comments_for_variant(variant, parsed.comments, false)?;
             return Ok(parsed);
         }
 
-        if let Some(err) = ret.errors.into_iter().next() {
+        if let Some(err) = ret.diagnostics.into_iter().next() {
             return Err(err);
         }
         return Err(OxcDiagnostic::error("Failed to parse JSON source"));
@@ -114,7 +114,7 @@ fn try_parse_comments_only<'a>(
 
     let ret =
         Parser::new(allocator, bare_source, SourceType::default()).with_options(options).parse();
-    if !ret.errors.is_empty() || ret.panicked || !ret.program.body.is_empty() {
+    if !ret.diagnostics.is_empty() || ret.panicked || !ret.program.body.is_empty() {
         return None;
     }
 

--- a/crates/oxc_isolated_declarations/examples/isolated_declarations.rs
+++ b/crates/oxc_isolated_declarations/examples/isolated_declarations.rs
@@ -34,8 +34,8 @@ fn main() -> std::io::Result<()> {
 
     let ret = Parser::new(&allocator, &source_text, source_type).parse();
 
-    if !ret.errors.is_empty() {
-        for error in ret.errors {
+    if !ret.diagnostics.is_empty() {
+        for error in ret.diagnostics {
             let error = error.with_source_code(source_text.clone());
             println!("{error:?}");
         }
@@ -59,9 +59,9 @@ fn main() -> std::io::Result<()> {
     println!("Dts Emit:\n");
     println!("{printed}\n");
 
-    if !id_ret.errors.is_empty() {
+    if !id_ret.diagnostics.is_empty() {
         println!("Transformed dts failed:\n");
-        for error in id_ret.errors {
+        for error in id_ret.diagnostics {
             let error = error.with_source_code(source_text.clone());
             println!("{error:?}");
         }

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -12,7 +12,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use oxc_allocator::{Allocator, CloneIn, Vec as ArenaVec};
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ast_visit::Visit;
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::{GetSpan, SPAN, SourceType};
 use oxc_str::{IdentHashSet, Str};
 
@@ -52,7 +52,7 @@ pub struct IsolatedDeclarationsReturn<'a> {
     /// Generated declaration program (`.d.ts` AST).
     pub program: Program<'a>,
     /// Diagnostics collected while generating declarations.
-    pub errors: Vec<OxcDiagnostic>,
+    pub diagnostics: Diagnostics,
 }
 
 /// Transformer that emits declaration-only AST from TypeScript source AST.
@@ -61,7 +61,7 @@ pub struct IsolatedDeclarations<'a> {
 
     // state
     scope: ScopeTree<'a>,
-    errors: RefCell<Vec<OxcDiagnostic>>,
+    errors: RefCell<Diagnostics>,
 
     // options
     strip_internal: bool,
@@ -79,7 +79,7 @@ impl<'a> IsolatedDeclarations<'a> {
             strip_internal,
             internal_annotations: FxHashSet::default(),
             scope: ScopeTree::new(),
-            errors: RefCell::new(vec![]),
+            errors: RefCell::new(Diagnostics::new()),
         }
     }
 
@@ -104,10 +104,10 @@ impl<'a> IsolatedDeclarations<'a> {
             directives,
             stmts,
         );
-        IsolatedDeclarationsReturn { program, errors: self.take_errors() }
+        IsolatedDeclarationsReturn { program, diagnostics: self.take_errors() }
     }
 
-    fn take_errors(&self) -> Vec<OxcDiagnostic> {
+    fn take_errors(&self) -> Diagnostics {
         mem::take(&mut self.errors.borrow_mut())
     }
 

--- a/crates/oxc_isolated_declarations/tests/deno/mod.rs
+++ b/crates/oxc_isolated_declarations/tests/deno/mod.rs
@@ -13,7 +13,7 @@ mod tests {
         let allocator = Allocator::default();
         let source_type = SourceType::from_path("test.ts").unwrap();
         let ret = Parser::new(&allocator, source, source_type).parse();
-        assert!(ret.errors.is_empty());
+        assert!(ret.diagnostics.is_empty());
         let ret = IsolatedDeclarations::new(
             &allocator,
             IsolatedDeclarationsOptions { strip_internal: true },

--- a/crates/oxc_isolated_declarations/tests/mod.rs
+++ b/crates/oxc_isolated_declarations/tests/mod.rs
@@ -13,10 +13,10 @@ fn transform(path: &Path, source_text: &str) -> String {
     let source_type = SourceType::from_path(path).unwrap();
     let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
     assert!(
-        parser_ret.errors.is_empty(),
+        parser_ret.diagnostics.is_empty(),
         "Parser errors for {}: {:?}",
         path.display(),
-        parser_ret.errors
+        parser_ret.diagnostics
     );
 
     let id_ret =
@@ -26,10 +26,10 @@ fn transform(path: &Path, source_text: &str) -> String {
 
     let mut snapshot =
         format!("```\n==================== .D.TS ====================\n\n{code}\n\n");
-    if !id_ret.errors.is_empty() {
+    if !id_ret.diagnostics.is_empty() {
         let source = Arc::new(source_text.to_string());
         let error_messages = id_ret
-            .errors
+            .diagnostics
             .iter()
             .map(|d| d.clone().with_source_code(Arc::clone(&source)))
             .fold(String::new(), |s, error| s + &format!("{error:?}"));

--- a/crates/oxc_linter/examples/linter.rs
+++ b/crates/oxc_linter/examples/linter.rs
@@ -35,8 +35,8 @@ fn main() -> std::io::Result<()> {
     let ret = Parser::new(&allocator, &source_text, source_type).parse();
 
     // Handle parser errors
-    if !ret.errors.is_empty() {
-        print_errors(&source_text, ret.errors);
+    if !ret.diagnostics.is_empty() {
+        print_errors(&source_text, ret.diagnostics.into());
         return Ok(());
     }
 

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -1423,7 +1423,7 @@ mod tests {
     fn process_source<'a>(allocator: &'a Allocator, source_text: &'a str) -> Semantic<'a> {
         let source_type = SourceType::default();
         let parser_ret = Parser::new(allocator, source_text, source_type).parse();
-        assert!(parser_ret.errors.is_empty());
+        assert!(parser_ret.diagnostics.is_empty());
         let semantic_ret = SemanticBuilder::new_linter().build(allocator.alloc(parser_ret.program));
         semantic_ret.semantic
     }

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -451,9 +451,9 @@ impl<'a> Fixer<'a> {
                 })
                 .parse();
             debug_assert!(
-                parse_result.errors.is_empty() && !parse_result.panicked,
+                parse_result.diagnostics.is_empty() && !parse_result.panicked,
                 "Linter fixer produced invalid syntax.\n\nInput code: \n```\n{source_text}\n```\n\nFixed code: \n```\n{output}\n```\n\nParse errors: {:?}",
-                parse_result.errors
+                parse_result.diagnostics
             );
         }
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -1133,16 +1133,16 @@ impl Runtime {
             .with_config(RuntimeParserConfig::new(collect_tokens))
             .parse();
 
-        if !ret.errors.is_empty() {
-            return Err(if ret.is_flow_language { vec![] } else { ret.errors });
+        if !ret.diagnostics.is_empty() {
+            return Err(if ret.is_flow_language { vec![] } else { ret.diagnostics.into() });
         }
 
         let semantic_ret = SemanticBuilder::new_linter()
             .with_check_syntax_error(check_syntax_errors)
             .build(allocator.alloc(ret.program));
 
-        if !semantic_ret.errors.is_empty() {
-            return Err(semantic_ret.errors);
+        if !semantic_ret.diagnostics.is_empty() {
+            return Err(semantic_ret.diagnostics.into());
         }
 
         let mut semantic = semantic_ret.semantic;

--- a/crates/oxc_linter/src/utils/comment.rs
+++ b/crates/oxc_linter/src/utils/comment.rs
@@ -91,7 +91,7 @@ mod test {
         for (source, source_type, expected_counts) in cases {
             let allocator = Allocator::default();
             let ret = Parser::new(&allocator, source, source_type).parse();
-            assert!(ret.errors.is_empty());
+            assert!(ret.diagnostics.is_empty());
             let semantic = SemanticBuilder::new_linter().build(&ret.program).semantic;
             let comments = semantic.comments();
 

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -1027,7 +1027,7 @@ mod test {
             let allocator = Allocator::default();
             let source_type = SourceType::jsx();
             let parser_ret = Parser::new(&allocator, source, source_type).parse();
-            assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
+            assert!(parser_ret.diagnostics.is_empty(), "Parse error in: {source}");
             let semantic =
                 SemanticBuilder::new_linter().build(allocator.alloc(parser_ret.program)).semantic;
 
@@ -1057,7 +1057,7 @@ mod test {
         for (source, expected) in cases {
             let allocator = Allocator::default();
             let parser_ret = Parser::new(&allocator, source, SourceType::tsx()).parse();
-            assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
+            assert!(parser_ret.diagnostics.is_empty(), "Parse error in: {source}");
 
             let semantic =
                 SemanticBuilder::new_linter().build(allocator.alloc(parser_ret.program)).semantic;
@@ -1122,7 +1122,7 @@ mod test {
             let allocator = Allocator::default();
             let source_type = SourceType::tsx();
             let parser_ret = Parser::new(&allocator, source, source_type).parse();
-            assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
+            assert!(parser_ret.diagnostics.is_empty(), "Parse error in: {source}");
             let semantic =
                 SemanticBuilder::new_linter().build(allocator.alloc(parser_ret.program)).semantic;
 

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -260,7 +260,7 @@ mod test {
     fn is_first_call_or_new_regexp(source: &str) -> Option<bool> {
         let allocator = Allocator::default();
         let parser_ret = Parser::new(&allocator, source, SourceType::default()).parse();
-        assert!(parser_ret.errors.is_empty(), "Parse error in: {source}");
+        assert!(parser_ret.diagnostics.is_empty(), "Parse error in: {source}");
 
         let program = allocator.alloc(parser_ret.program);
         let semantic = SemanticBuilder::new_linter().build(program).semantic;

--- a/crates/oxc_mangler/src/keep_names.rs
+++ b/crates/oxc_mangler/src/keep_names.rs
@@ -257,9 +257,9 @@ mod test {
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
         assert!(!ret.panicked, "{source_text}");
-        assert!(ret.errors.is_empty(), "{source_text}");
+        assert!(ret.diagnostics.is_empty(), "{source_text}");
         let ret = SemanticBuilder::new().with_build_nodes(true).build(&ret.program);
-        assert!(ret.errors.is_empty(), "{source_text}");
+        assert!(ret.diagnostics.is_empty(), "{source_text}");
         let semantic = ret.semantic;
         let symbols = collect_name_symbols(opts, &allocator, semantic.scoping(), semantic.nodes());
         symbols

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -94,7 +94,7 @@ pub struct ManglerReturn {
 /// let allocator = Allocator::default();
 /// let source = "const result = 1 + 2;";
 /// let parsed = Parser::new(&allocator, source, SourceType::mjs()).parse();
-/// assert!(parsed.errors.is_empty());
+/// assert!(parsed.diagnostics.is_empty());
 ///
 /// let mangled_symbols = Mangler::new()
 ///     .with_options(MangleOptions { top_level: true, debug: true })

--- a/crates/oxc_minifier/examples/dce.rs
+++ b/crates/oxc_minifier/examples/dce.rs
@@ -66,7 +66,7 @@ fn dce(
     max_iterations: Option<u8>,
 ) -> String {
     let ret = Parser::new(allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     let mut program = ret.program;
     Compressor::new(allocator).dead_code_elimination(
         &mut program,

--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -62,7 +62,7 @@ fn main() -> std::io::Result<()> {
 fn mangler(source_text: &str, source_type: SourceType, options: MangleOptions) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     let mangler_return = Mangler::new().with_options(options).build(&ret.program);
     Codegen::new()
         .with_scoping(Some(mangler_return.scoping))

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -91,7 +91,7 @@ fn minify(
     max_iterations: Option<u8>,
 ) -> CodegenReturn {
     let ret = Parser::new(allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     let mut program = ret.program;
     let options = MinifierOptions {
         mangle: mangle.then(MangleOptions::default),

--- a/crates/oxc_minifier/tests/ecmascript/is_int32_or_uint32.rs
+++ b/crates/oxc_minifier/tests/ecmascript/is_int32_or_uint32.rs
@@ -8,7 +8,7 @@ fn test(source_text: &str, expected: bool) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
     assert!(!ret.panicked, "{source_text}");
-    assert!(ret.errors.is_empty(), "{source_text}");
+    assert!(ret.diagnostics.is_empty(), "{source_text}");
 
     let Some(Statement::ExpressionStatement(stmt)) = &ret.program.body.first() else {
         panic!("should have a expression statement body: {source_text}");

--- a/crates/oxc_minifier/tests/ecmascript/is_literal_value.rs
+++ b/crates/oxc_minifier/tests/ecmascript/is_literal_value.rs
@@ -69,7 +69,7 @@ fn test_with_ctx_and_functions_option(
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
     assert!(!ret.panicked, "{source_text}");
-    assert!(ret.errors.is_empty(), "{source_text}");
+    assert!(ret.diagnostics.is_empty(), "{source_text}");
 
     let Some(Statement::ExpressionStatement(stmt)) = &ret.program.body.first() else {
         panic!("should have a expression statement body: {source_text}");

--- a/crates/oxc_minifier/tests/ecmascript/is_pure_function.rs
+++ b/crates/oxc_minifier/tests/ecmascript/is_pure_function.rs
@@ -9,7 +9,7 @@ fn test(source: &str, pure_functions: &[&str], expected: bool) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source, SourceType::mjs()).parse();
     assert!(!ret.panicked, "{source}");
-    assert!(ret.errors.is_empty(), "{source}");
+    assert!(ret.diagnostics.is_empty(), "{source}");
 
     let Some(Statement::ExpressionStatement(stmt)) = ret.program.body.first() else {
         panic!("should have an expression statement body: {source}");

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -79,7 +79,7 @@ fn test_ts(source_text: &str, expected: bool) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, SourceType::tsx()).parse();
     assert!(!ret.panicked, "{source_text}");
-    assert!(ret.errors.is_empty(), "{source_text}");
+    assert!(ret.diagnostics.is_empty(), "{source_text}");
 
     let Some(Statement::ExpressionStatement(stmt)) = &ret.program.body.first() else {
         panic!("should have a expression statement body: {source_text}");
@@ -105,7 +105,7 @@ fn test_with_ctx(source_text: &str, ctx: &Ctx, expected: bool) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
     assert!(!ret.panicked, "{source_text}");
-    assert!(ret.errors.is_empty(), "{source_text}");
+    assert!(ret.diagnostics.is_empty(), "{source_text}");
 
     let Some(Statement::ExpressionStatement(stmt)) = &ret.program.body.first() else {
         panic!("should have a expression statement body: {source_text}");
@@ -119,7 +119,7 @@ fn test_in_function(source_text: &str, expected: bool) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
     assert!(!ret.panicked, "{source_text}");
-    assert!(ret.errors.is_empty(), "{source_text}");
+    assert!(ret.diagnostics.is_empty(), "{source_text}");
 
     let Some(Statement::FunctionDeclaration(stmt)) = &ret.program.body.first() else {
         panic!("should have a function declaration: {source_text}");
@@ -151,7 +151,7 @@ fn test_assign_target_with_global_variables(
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
     assert!(!ret.panicked, "{source_text}");
-    assert!(ret.errors.is_empty(), "{source_text}");
+    assert!(ret.diagnostics.is_empty(), "{source_text}");
 
     let Some(Statement::ExpressionStatement(stmt)) = &ret.program.body.first() else {
         panic!("should have a expression statement body: {source_text}");

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects_statements.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects_statements.rs
@@ -55,7 +55,7 @@ fn test(source_text: &str, expected: bool) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
     assert!(!ret.panicked, "{source_text}");
-    assert!(ret.errors.is_empty(), "{source_text}");
+    assert!(ret.diagnostics.is_empty(), "{source_text}");
 
     let stmt = ret.program.body.first().unwrap();
     assert_eq!(stmt.may_have_side_effects(&Ctx::default()), expected, "{source_text}");
@@ -66,7 +66,7 @@ fn test_in_function(source_text: &str, expected: bool) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
     assert!(!ret.panicked, "{source_text}");
-    assert!(ret.errors.is_empty(), "{source_text}");
+    assert!(ret.diagnostics.is_empty(), "{source_text}");
 
     let Some(Statement::FunctionDeclaration(stmt)) = &ret.program.body.first() else {
         panic!("should have a function declaration: {source_text}");

--- a/crates/oxc_minifier/tests/ecmascript/prop_name.rs
+++ b/crates/oxc_minifier/tests/ecmascript/prop_name.rs
@@ -33,7 +33,7 @@ fn test_prop_name() {
         ";
     let ret = Parser::new(&allocator, source, source_type).parse();
     assert!(!ret.program.is_empty());
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
 
     let mut visitor = TestVisitor;
     visitor.visit_program(&ret.program);

--- a/crates/oxc_minifier/tests/ecmascript/value_type.rs
+++ b/crates/oxc_minifier/tests/ecmascript/value_type.rs
@@ -33,7 +33,7 @@ fn test_with_global_variables(
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
     assert!(!ret.panicked, "{source_text}");
-    assert!(ret.errors.is_empty(), "{source_text}");
+    assert!(ret.diagnostics.is_empty(), "{source_text}");
 
     let global_reference_checker = GlobalReferenceChecker { global_variable_names };
 

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -13,7 +13,7 @@ fn mangle_with_source_type(
 ) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty(), "Parser errors: {:?}", ret.errors);
+    assert!(ret.diagnostics.is_empty(), "Parser errors: {:?}", ret.diagnostics);
     let program = ret.program;
     let mangler_return = Mangler::new().with_options(options).build(&program);
     Codegen::new()
@@ -37,7 +37,7 @@ fn test(source_text: &str, expected: &str, options: MangleOptions) {
         let allocator = Allocator::default();
         let source_type = SourceType::mjs().with_unambiguous(true);
         let ret = Parser::new(&allocator, expected, source_type).parse();
-        assert!(ret.errors.is_empty(), "Parser errors: {:?}", ret.errors);
+        assert!(ret.diagnostics.is_empty(), "Parser errors: {:?}", ret.diagnostics);
         Codegen::new().build(&ret.program).code
     };
     assert_eq!(

--- a/crates/oxc_minifier/tests/mod.rs
+++ b/crates/oxc_minifier/tests/mod.rs
@@ -102,7 +102,7 @@ fn run(source_text: &str, source_type: SourceType, options: Option<CompressOptio
         .with_options(ParseOptions { allow_return_outside_function: true, ..Default::default() })
         .parse();
     assert!(!ret.panicked, "{source_text}");
-    assert!(ret.errors.is_empty(), "{source_text}");
+    assert!(ret.diagnostics.is_empty(), "{source_text}");
     let mut program = ret.program;
     if let Some(options) = options {
         Compressor::new(&allocator).build(&mut program, options);

--- a/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
+++ b/crates/oxc_minifier/tests/peephole/dead_code_elimination.rs
@@ -12,7 +12,7 @@ use oxc_span::SourceType;
 fn run(source_text: &str, source_type: SourceType, options: Option<CompressOptions>) -> String {
     let allocator = Allocator::default();
     let mut ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty(), "Parser errors: {:?}", ret.errors);
+    assert!(ret.diagnostics.is_empty(), "Parser errors: {:?}", ret.diagnostics);
     let program = &mut ret.program;
     if let Some(options) = options {
         Compressor::new(&allocator).dead_code_elimination(program, options);

--- a/crates/oxc_napi/src/error.rs
+++ b/crates/oxc_napi/src/error.rs
@@ -27,8 +27,9 @@ impl OxcError {
     pub fn from_diagnostics(
         filename: &str,
         source_text: &str,
-        diagnostics: Vec<OxcDiagnostic>,
+        diagnostics: impl IntoIterator<Item = OxcDiagnostic>,
     ) -> Vec<Self> {
+        let diagnostics = diagnostics.into_iter().collect::<Vec<_>>();
         if diagnostics.is_empty() {
             return vec![];
         }

--- a/crates/oxc_parser/examples/parser.rs
+++ b/crates/oxc_parser/examples/parser.rs
@@ -79,10 +79,10 @@ fn main() -> Result<(), String> {
     }
 
     // Report parsing results
-    if ret.errors.is_empty() {
+    if ret.diagnostics.is_empty() {
         println!("Parsed Successfully.");
     } else {
-        for error in ret.errors {
+        for error in ret.diagnostics {
             let error = error.with_source_code(source_text.clone());
             println!("{error:?}");
         }

--- a/crates/oxc_parser/examples/parser_tsx.rs
+++ b/crates/oxc_parser/examples/parser_tsx.rs
@@ -39,9 +39,9 @@ export const Counter: React.FC = () => {
     let source_type = SourceType::from_path("Counter.tsx").unwrap();
 
     let ParserReturn {
-        program,  // AST
-        errors,   // Syntax errors
-        panicked, // Parser encountered an error it couldn't recover from
+        program,     // AST
+        diagnostics, // Syntax errors
+        panicked,    // Parser encountered an error it couldn't recover from
         ..
     } = Parser::new(&allocator, source_text, source_type).parse();
 
@@ -49,8 +49,8 @@ export const Counter: React.FC = () => {
         return Err("Parser panicked".to_string());
     }
 
-    if !errors.is_empty() {
-        return Err(format!("Parsing errors: {}", errors.len()));
+    if !diagnostics.is_empty() {
+        return Err(format!("Parsing errors: {}", diagnostics.len()));
     }
 
     assert!(!program.body.is_empty());

--- a/crates/oxc_parser/examples/regular_expression.rs
+++ b/crates/oxc_parser/examples/regular_expression.rs
@@ -23,9 +23,9 @@ fn main() {
 
     let parser_ret =
         Parser::new(&allocator, source_text.as_ref(), source_type).with_options(options).parse();
-    if !parser_ret.errors.is_empty() {
+    if !parser_ret.diagnostics.is_empty() {
         println!("Parsing failed:");
-        for error in parser_ret.errors {
+        for error in parser_ret.diagnostics {
             let error = error.with_source_code(Arc::clone(&source_text));
             println!("{error:?}");
         }

--- a/crates/oxc_parser/examples/visitor.rs
+++ b/crates/oxc_parser/examples/visitor.rs
@@ -35,7 +35,7 @@ fn main() -> std::io::Result<()> {
     let ret = Parser::new(&allocator, &source_text, source_type).parse();
 
     // Report any parsing errors
-    for error in ret.errors {
+    for error in ret.diagnostics {
         let error = error.with_source_code(source_text.clone());
         println!("{error:?}");
     }

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -1337,7 +1337,11 @@ mod test {
         let source_type = SourceType::default().with_typescript(false);
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, src, source_type).parse();
-        assert!(ret.errors.is_empty(), "Failed to parse source: {src:?}, error: {:?}", ret.errors);
+        assert!(
+            ret.diagnostics.is_empty(),
+            "Failed to parse source: {src:?}, error: {:?}",
+            ret.diagnostics
+        );
         let declarations = ret.program.body.iter().collect::<Vec<_>>();
         assert_eq!(declarations.len(), 1);
         let Statement::ImportDeclaration(decl) = declarations[0] else {
@@ -1357,7 +1361,11 @@ mod test {
         let source_type = SourceType::default().with_typescript(true);
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, src, source_type).parse();
-        assert!(ret.errors.is_empty(), "Failed to parse source: {src:?}, error: {:?}", ret.errors);
+        assert!(
+            ret.diagnostics.is_empty(),
+            "Failed to parse source: {src:?}, error: {:?}",
+            ret.diagnostics
+        );
         f(ret.program.body.iter().collect::<Vec<_>>());
     }
 
@@ -1370,7 +1378,7 @@ mod test {
         let source_type = SourceType::default().with_typescript(true);
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, src, source_type).parse();
-        assert!(!ret.errors.is_empty(), "Expected a parse error for source: {src:?}");
+        assert!(!ret.diagnostics.is_empty(), "Expected a parse error for source: {src:?}");
         f(ret.program.body.iter().collect::<Vec<_>>());
     }
 
@@ -1382,7 +1390,11 @@ mod test {
         let source_type = SourceType::default().with_typescript(true);
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, src, source_type).parse();
-        assert!(ret.errors.is_empty(), "Failed to parse source: {src:?}, error: {:?}", ret.errors);
+        assert!(
+            ret.diagnostics.is_empty(),
+            "Failed to parse source: {src:?}, error: {:?}",
+            ret.diagnostics
+        );
         let statements =
             ret.program
                 .body

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -406,7 +406,7 @@ mod test {
         let allocator = Allocator::default();
         let source_type = SourceType::default();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
-        assert!(ret.errors.is_empty());
+        assert!(ret.diagnostics.is_empty());
         ret.program.comments.iter().copied().collect::<Vec<_>>()
     }
 

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -92,7 +92,7 @@ use oxc_ast::{
     AstBuilder,
     ast::{Expression, Program},
 };
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::{SourceType, Span};
 use oxc_syntax::module_record::ModuleRecord;
 
@@ -128,14 +128,14 @@ pub(crate) const MAX_LEN: usize = if size_of::<usize>() >= 8 {
 ///
 /// [`program`] will always contain a structurally valid AST, even if there are syntax errors.
 /// However, the AST may be semantically invalid. To ensure a valid AST,
-/// 1. Check that [`errors`] is empty
+/// 1. Check that [`diagnostics`] is empty
 /// 2. Run semantic analysis with [syntax error checking
 ///    enabled](https://docs.rs/oxc_semantic/latest/oxc_semantic/struct.SemanticBuilder.html#method.with_check_syntax_error)
 ///
 /// ## Errors
 /// Oxc's [`Parser`] is able to recover from some syntax errors and continue parsing. When this
 /// happens,
-/// 1. [`errors`] will be non-empty
+/// 1. [`diagnostics`] will be non-empty
 /// 2. [`program`] will contain a full AST
 /// 3. [`panicked`] will be false
 ///
@@ -143,7 +143,7 @@ pub(crate) const MAX_LEN: usize = if size_of::<usize>() >= 8 {
 /// be empty and [`panicked`] will be `true`.
 ///
 /// [`program`]: ParserReturn::program
-/// [`errors`]: ParserReturn::errors
+/// [`diagnostics`]: ParserReturn::diagnostics
 /// [`panicked`]: ParserReturn::panicked
 #[non_exhaustive]
 pub struct ParserReturn<'a> {
@@ -156,7 +156,7 @@ pub struct ParserReturn<'a> {
     /// 1. The [`Parser`] encounters a recoverable syntax error
     /// 2. The logic for checking the violation is in the semantic analyzer
     ///
-    /// To ensure a valid AST, check that [`errors`](ParserReturn::errors) is empty. Then, run
+    /// To ensure a valid AST, check that [`diagnostics`](ParserReturn::diagnostics) is empty. Then, run
     /// semantic analysis with syntax error checking enabled.
     pub program: Program<'a>,
 
@@ -168,7 +168,7 @@ pub struct ParserReturn<'a> {
     /// This list is not comprehensive. Oxc offloads more-expensive checks to [semantic
     /// analysis](https://docs.rs/oxc_semantic), which can be enabled using
     /// [`SemanticBuilder::with_check_syntax_error`](https://docs.rs/oxc_semantic/latest/oxc_semantic/struct.SemanticBuilder.html#method.with_check_syntax_error).
-    pub errors: Vec<OxcDiagnostic>,
+    pub diagnostics: Diagnostics,
 
     /// Irregular whitespaces for `Oxlint`
     pub irregular_whitespaces: Box<[Span]>,
@@ -181,11 +181,11 @@ pub struct ParserReturn<'a> {
     /// Whether the parser panicked and terminated early.
     ///
     /// This will be `false` if parsing was successful, or if parsing was able to recover from a
-    /// syntax error. When `true`, [`program`] will be empty and [`errors`] will contain at least
+    /// syntax error. When `true`, [`program`] will be empty and [`diagnostics`] will contain at least
     /// one error.
     ///
     /// [`program`]: ParserReturn::program
-    /// [`errors`]: ParserReturn::errors
+    /// [`diagnostics`]: ParserReturn::diagnostics
     pub panicked: bool,
 
     /// Whether the file is [flow](https://flow.org).
@@ -404,7 +404,7 @@ mod parser_parse {
         //
         // # Implementation note
         // Dispatches via `Any`, same as `parse` does.
-        pub fn parse_expression(self) -> Result<Expression<'a>, Vec<OxcDiagnostic>> {
+        pub fn parse_expression(self) -> Result<Expression<'a>, Diagnostics> {
             let config: &dyn Any = &self.config;
             if config.is::<NoTokensParserConfig>() {
                 parse_expression_with_no_tokens_config(
@@ -530,7 +530,7 @@ mod parser_parse {
         source_text: &'a str,
         source_type: SourceType,
         options: ParseOptions,
-    ) -> Result<Expression<'a>, Vec<OxcDiagnostic>> {
+    ) -> Result<Expression<'a>, Diagnostics> {
         ParserImpl::<NoTokensParserConfig>::new(
             allocator,
             source_text,
@@ -548,7 +548,7 @@ mod parser_parse {
         source_text: &'a str,
         source_type: SourceType,
         options: ParseOptions,
-    ) -> Result<Expression<'a>, Vec<OxcDiagnostic>> {
+    ) -> Result<Expression<'a>, Diagnostics> {
         ParserImpl::<TokensParserConfig>::new(
             allocator,
             source_text,
@@ -567,7 +567,7 @@ mod parser_parse {
         source_type: SourceType,
         options: ParseOptions,
         config: RuntimeParserConfig,
-    ) -> Result<Expression<'a>, Vec<OxcDiagnostic>> {
+    ) -> Result<Expression<'a>, Diagnostics> {
         ParserImpl::<RuntimeParserConfig>::new(
             allocator,
             source_text,
@@ -696,7 +696,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         }
 
         let mut is_flow_language = false;
-        let mut errors = vec![];
+        let mut errors = Diagnostics::new();
         // only check for `@flow` if the file failed to parse.
         if (!self.lexer.errors.is_empty() || !self.errors.is_empty())
             && let Some(error) = self.flow_error()
@@ -741,7 +741,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         ParserReturn {
             program,
             module_record,
-            errors,
+            diagnostics: errors,
             irregular_whitespaces,
             tokens,
             panicked,
@@ -749,15 +749,15 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         }
     }
 
-    pub fn parse_expression(mut self) -> Result<Expression<'a>, Vec<OxcDiagnostic>> {
+    pub fn parse_expression(mut self) -> Result<Expression<'a>, Diagnostics> {
         // initialize cur_token and prev_token by moving onto the first token
         self.bump_any();
         let expr = self.parse_expr();
         if let Some(FatalError { error, .. }) = self.fatal_error.take() {
-            return Err(vec![error]);
+            return Err(error.into());
         }
         self.check_unfinished_errors();
-        let errors = self.lexer.errors.into_iter().chain(self.errors).collect::<Vec<_>>();
+        let errors = self.lexer.errors.into_iter().chain(self.errors).collect::<Diagnostics>();
         if !errors.is_empty() {
             return Err(errors);
         }
@@ -908,7 +908,7 @@ mod test {
         let source = "";
         let ret = Parser::new(&allocator, source, source_type).parse();
         assert!(ret.program.is_empty());
-        assert!(ret.errors.is_empty());
+        assert!(ret.diagnostics.is_empty());
         assert!(!ret.is_flow_language);
     }
 
@@ -938,8 +938,8 @@ mod test {
         for source in sources {
             let ret = Parser::new(&allocator, source, source_type).parse();
             assert!(ret.is_flow_language);
-            assert_eq!(ret.errors.len(), 1);
-            assert_eq!(ret.errors.first().unwrap().to_string(), "Flow is not supported");
+            assert_eq!(ret.diagnostics.len(), 1);
+            assert_eq!(ret.diagnostics.first().unwrap().to_string(), "Flow is not supported");
         }
     }
 
@@ -949,7 +949,7 @@ mod test {
         let source_type = SourceType::from_path(Path::new("module.ts")).unwrap();
         let source = "declare module 'test'\n";
         let ret = Parser::new(&allocator, source, source_type).parse();
-        assert_eq!(ret.errors.len(), 0);
+        assert_eq!(ret.diagnostics.len(), 0);
     }
 
     #[test]
@@ -976,7 +976,7 @@ mod test {
             let source = "%DebugPrint('Raging against the Dying Light')";
             let opts = ParseOptions { allow_v8_intrinsics: true, ..ParseOptions::default() };
             let ret = Parser::new(&allocator, source, source_type).with_options(opts).parse();
-            assert!(ret.errors.is_empty());
+            assert!(ret.diagnostics.is_empty());
 
             if let Some(Statement::ExpressionStatement(expr_stmt)) = ret.program.body.first() {
                 if let Expression::V8IntrinsicExpression(expr) = &expr_stmt.expression {
@@ -992,17 +992,17 @@ mod test {
             let source = "%DebugPrint(...illegalSpread)";
             let opts = ParseOptions { allow_v8_intrinsics: true, ..ParseOptions::default() };
             let ret = Parser::new(&allocator, source, source_type).with_options(opts).parse();
-            assert_eq!(ret.errors.len(), 1);
+            assert_eq!(ret.diagnostics.len(), 1);
             assert_eq!(
-                ret.errors[0].to_string(),
+                ret.diagnostics[0].to_string(),
                 "V8 runtime calls cannot have spread elements as arguments"
             );
         }
         {
             let source = "%DebugPrint('~~')";
             let ret = Parser::new(&allocator, source, source_type).parse();
-            assert_eq!(ret.errors.len(), 1);
-            assert_eq!(ret.errors[0].to_string(), "Unexpected token");
+            assert_eq!(ret.diagnostics.len(), 1);
+            assert_eq!(ret.diagnostics[0].to_string(), "Unexpected token");
         }
         {
             // https://github.com/oxc-project/oxc/issues/12121
@@ -1011,9 +1011,9 @@ mod test {
             // Should not panic whether `allow_v8_intrinsics` is set or not.
             let opts = ParseOptions { allow_v8_intrinsics: true, ..ParseOptions::default() };
             let ret = Parser::new(&allocator, source, source_type).with_options(opts).parse();
-            assert_eq!(ret.errors.len(), 1);
+            assert_eq!(ret.diagnostics.len(), 1);
             let ret = Parser::new(&allocator, source, source_type).parse();
-            assert_eq!(ret.errors.len(), 1);
+            assert_eq!(ret.diagnostics.len(), 1);
         }
     }
 
@@ -1072,13 +1072,13 @@ mod test {
         // U+FFFD as a standalone token — file appears to be binary
         let ret = Parser::new(&allocator, "\u{FFFD}", source_type).parse();
         assert!(ret.program.is_empty());
-        assert_eq!(ret.errors.len(), 1);
-        assert_eq!(ret.errors[0].to_string(), "File appears to be binary.");
+        assert_eq!(ret.diagnostics.len(), 1);
+        assert_eq!(ret.diagnostics[0].to_string(), "File appears to be binary.");
 
         // U+FFFD inside string literals — should parse fine
         let ret = Parser::new(&allocator, "\"oops \u{FFFD} oops\";", source_type).parse();
         assert!(!ret.program.is_empty());
-        assert!(ret.errors.is_empty());
+        assert!(ret.diagnostics.is_empty());
     }
 
     #[test]
@@ -1158,8 +1158,11 @@ mod test {
         // Parsing should fail
         assert!(ret.program.is_empty());
         assert!(ret.panicked);
-        assert_eq!(ret.errors.len(), 1);
-        assert_eq!(ret.errors.first().unwrap().to_string(), "Source length exceeds 4 GiB limit");
+        assert_eq!(ret.diagnostics.len(), 1);
+        assert_eq!(
+            ret.diagnostics.first().unwrap().to_string(),
+            "Source length exceeds 4 GiB limit"
+        );
     }
 
     // Source with length MAX_LEN parses OK.
@@ -1181,7 +1184,7 @@ mod test {
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, &source, SourceType::default()).parse();
         assert!(!ret.panicked);
-        assert!(ret.errors.is_empty());
+        assert!(ret.diagnostics.is_empty());
         assert_eq!(ret.program.body.len(), 2);
     }
 }

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -411,7 +411,7 @@ mod module_record_tests {
     fn build<'a>(allocator: &'a Allocator, source_text: &'a str) -> ModuleRecord<'a> {
         let source_type = SourceType::ts();
         let ret = Parser::new(allocator, source_text, source_type).parse();
-        assert!(ret.errors.is_empty());
+        assert!(ret.diagnostics.is_empty());
         ret.module_record
     }
 

--- a/crates/oxc_react_compiler/examples/react_compiler.rs
+++ b/crates/oxc_react_compiler/examples/react_compiler.rs
@@ -40,9 +40,9 @@ fn main() {
 
     let result = transform(&program, &allocator, default_plugin_options());
 
-    if !result.errors.is_empty() || !result.warnings.is_empty() {
+    if !result.diagnostics.is_empty() {
         println!("Diagnostics:\n");
-        for diagnostic in result.errors.iter().chain(&result.warnings) {
+        for diagnostic in &result.diagnostics {
             println!("{diagnostic:?}");
         }
         println!();

--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -3,31 +3,15 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use oxc_diagnostics::{OxcDiagnostic, Severity};
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use react_compiler::entrypoint::compile_result::{
     CompileResult, CompilerErrorDetailInfo, LoggerEvent,
 };
 
-/// Errors and warnings produced by a compile, partitioned by severity.
-#[derive(Default)]
-pub struct Diagnostics {
-    pub errors: Vec<OxcDiagnostic>,
-    pub warnings: Vec<OxcDiagnostic>,
-}
-
-impl Diagnostics {
-    fn push(&mut self, diagnostic: OxcDiagnostic) {
-        if diagnostic.severity == Severity::Error {
-            self.errors.push(diagnostic);
-        } else {
-            self.warnings.push(diagnostic);
-        }
-    }
-}
-
-/// Convert a `CompileResult` into OXC diagnostics, split into errors and warnings.
+/// Convert a `CompileResult` into OXC diagnostics. Each diagnostic carries its
+/// own severity (set by [`OxcDiagnostic::error`]/[`OxcDiagnostic::warn`]).
 pub fn compile_result_to_diagnostics(result: &CompileResult) -> Diagnostics {
-    let mut diagnostics = Diagnostics::default();
+    let mut diagnostics = Diagnostics::new();
 
     match result {
         CompileResult::Success { events, .. } => {

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -48,23 +48,19 @@ pub fn default_plugin_options() -> PluginOptions {
 pub struct TransformResult<'a> {
     /// Compiled, ready-to-codegen OXC AST; `None` if the compiler made no changes.
     pub program: Option<oxc_ast::ast::Program<'a>>,
-    /// `Error`-severity diagnostics (e.g. Rules of Hooks violations). These are
-    /// hard problems in the source; the program is still left valid.
-    pub errors: Vec<oxc_diagnostics::OxcDiagnostic>,
-    /// `Warning`/`Hint`-severity diagnostics, including bail-outs where the
-    /// compiler declined to optimize a function (e.g. unsupported syntax).
-    pub warnings: Vec<oxc_diagnostics::OxcDiagnostic>,
+    /// Errors and warnings produced by the compile. Errors (e.g. Rules of Hooks
+    /// violations) are hard problems in the source; the program is still left
+    /// valid. Warnings include bail-outs where the compiler declined to optimize.
+    pub diagnostics: oxc_diagnostics::Diagnostics,
     /// Raw structured logger events from the upstream compiler (compile
     /// success/skip/error with memoization stats), for tooling and profiling.
-    /// Unlike `errors`/`warnings`, these are not meant for user-facing reporting.
+    /// Unlike `diagnostics`, these are not meant for user-facing reporting.
     pub events: Vec<LoggerEvent>,
 }
 
 pub struct LintResult {
-    /// `Error`-severity diagnostics (e.g. Rules of Hooks violations).
-    pub errors: Vec<oxc_diagnostics::OxcDiagnostic>,
-    /// `Warning`/`Hint`-severity diagnostics, including compiler bail-outs.
-    pub warnings: Vec<oxc_diagnostics::OxcDiagnostic>,
+    /// Errors and warnings produced by the compile.
+    pub diagnostics: oxc_diagnostics::Diagnostics,
 }
 
 /// Run the React Compiler on a pre-parsed program, building the semantic model
@@ -102,7 +98,7 @@ pub fn transform<'a>(
     let result =
         react_compiler::entrypoint::program::compile_program(file, scope_info.clone(), options);
 
-    let diagnostics::Diagnostics { errors, warnings } = compile_result_to_diagnostics(&result);
+    let diagnostics = compile_result_to_diagnostics(&result);
     let (program_ast, events, renames) = match result {
         react_compiler::entrypoint::compile_result::CompileResult::Success {
             ast,
@@ -127,7 +123,7 @@ pub fn transform<'a>(
         compiled
     });
 
-    TransformResult { program: compiled_program, errors, warnings, events }
+    TransformResult { program: compiled_program, diagnostics, events }
 }
 
 /// Carry over the comments attached to top-level statements of the compiled
@@ -184,7 +180,7 @@ pub fn lint(program: &oxc_ast::ast::Program, options: PluginOptions) -> LintResu
     // `no_emit` yields `program: None`; a local arena for the conversion suffices.
     let allocator = oxc_allocator::Allocator::default();
     let result = transform(program, &allocator, opts);
-    LintResult { errors: result.errors, warnings: result.warnings }
+    LintResult { diagnostics: result.diagnostics }
 }
 
 /// Convenience wrapper — parses source text, runs semantic analysis, then lints.
@@ -225,8 +221,12 @@ mod tests {
         let allocator = oxc_allocator::Allocator::default();
         let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
 
-        assert!(result.errors.is_empty(), "unexpected errors: {:?}", result.errors);
-        assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
+        assert!(!result.diagnostics.has_errors(), "unexpected errors: {:?}", result.diagnostics);
+        assert!(
+            !result.diagnostics.has_warnings(),
+            "unexpected warnings: {:?}",
+            result.diagnostics
+        );
         let program = result.program.expect("React Compiler should have transformed the component");
 
         let output = oxc_codegen::Codegen::new().build(&program).code;
@@ -267,9 +267,9 @@ export = legacy;\n";
 
         let allocator = oxc_allocator::Allocator::default();
         let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
-        let program = result
-            .program
-            .unwrap_or_else(|| panic!("component should be compiled; errors: {:?}", result.errors));
+        let program = result.program.unwrap_or_else(|| {
+            panic!("component should be compiled; diagnostics: {:?}", result.diagnostics)
+        });
         let output = oxc_codegen::Codegen::new().build(&program).code;
         assert!(
             output.contains("react/compiler-runtime"),
@@ -393,9 +393,9 @@ function Component(props: Props): JSX.Element {\n\
 
         let allocator = oxc_allocator::Allocator::default();
         let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
-        let program = result
-            .program
-            .unwrap_or_else(|| panic!("component should compile; errors: {:?}", result.errors));
+        let program = result.program.unwrap_or_else(|| {
+            panic!("component should compile; diagnostics: {:?}", result.diagnostics)
+        });
         let output = oxc_codegen::Codegen::new().build(&program).code;
 
         assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
@@ -544,10 +544,9 @@ async function Component(props) {\n  await using x = sideEffect();\n  return <di
 
             assert!(result.program.is_none(), "resource management should skip React Compiler");
             assert!(
-                result.errors.is_empty() && result.warnings.is_empty(),
-                "unexpected diagnostics: {:?} {:?}",
-                result.errors,
-                result.warnings
+                result.diagnostics.is_empty(),
+                "unexpected diagnostics: {:?}",
+                result.diagnostics
             );
         }
     }
@@ -637,9 +636,9 @@ function Component(props) {\n  return <div>{props.text}</div>;\n}\n";
         let allocator = oxc_allocator::Allocator::default();
         let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
         assert!(
-            !result.errors.is_empty(),
+            result.diagnostics.has_errors(),
             "Rules of Hooks violation should be reported as an error: {:?}",
-            result.errors
+            result.diagnostics
         );
 
         // A local named `fbt` is an unsupported-syntax bail-out — a warning, not an error.
@@ -647,14 +646,14 @@ function Component(props) {\n  return <div>{props.text}</div>;\n}\n";
         let allocator = oxc_allocator::Allocator::default();
         let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
         assert!(
-            !result.warnings.is_empty(),
+            result.diagnostics.has_warnings(),
             "fbt bail-out should be reported as a warning: {:?}",
-            result.warnings
+            result.diagnostics
         );
         assert!(
-            result.errors.is_empty(),
+            !result.diagnostics.has_errors(),
             "fbt warning must not be reported as an error: {:?}",
-            result.errors
+            result.diagnostics
         );
     }
 

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -60,9 +60,9 @@ fn main() -> std::io::Result<()> {
     let source_type = SourceType::from_path(test_file_path).unwrap();
     let parser_ret = Parser::new(&allocator, &source_text, source_type).parse();
 
-    if !parser_ret.errors.is_empty() {
+    if !parser_ret.diagnostics.is_empty() {
         let error_message: String = parser_ret
-            .errors
+            .diagnostics
             .into_iter()
             .map(|error| error.with_source_code(Arc::clone(&source_text)).to_string())
             .join("\n\n");
@@ -78,9 +78,9 @@ fn main() -> std::io::Result<()> {
     let semantic =
         SemanticBuilder::new_compiler().with_build_nodes(true).with_cfg(true).build(&program);
 
-    if !semantic.errors.is_empty() {
+    if !semantic.diagnostics.is_empty() {
         let error_message: String = semantic
-            .errors
+            .diagnostics
             .into_iter()
             .map(|error| error.with_source_code(Arc::clone(&source_text)).to_string())
             .join("\n\n");

--- a/crates/oxc_semantic/examples/semantic.rs
+++ b/crates/oxc_semantic/examples/semantic.rs
@@ -44,9 +44,9 @@ fn main() -> std::io::Result<()> {
 
     // Parse the source text into an AST
     let parser_ret = Parser::new(&allocator, &source_text, source_type).parse();
-    if !parser_ret.errors.is_empty() {
+    if !parser_ret.diagnostics.is_empty() {
         let error_message: String = parser_ret
-            .errors
+            .diagnostics
             .into_iter()
             .map(|error| format!("{:?}", error.with_source_code(Arc::clone(&source_text))))
             .join("\n");
@@ -61,9 +61,9 @@ fn main() -> std::io::Result<()> {
     let semantic = SemanticBuilder::new_compiler().with_build_nodes(true).build(&program);
 
     // Report semantic analysis errors
-    if !semantic.errors.is_empty() {
+    if !semantic.diagnostics.is_empty() {
         let error_message: String = semantic
-            .errors
+            .diagnostics
             .into_iter()
             .map(|error| format!("{:?}", error.with_source_code(Arc::clone(&source_text))))
             .join("\n");

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -15,7 +15,7 @@ use oxc_cfg::{
     ControlFlowGraphBuilder, CtxCursor, CtxFlags, EdgeType, ErrorEdgeKind, InstructionKind,
     IterationInstructionKind, ReturnInstructionKind,
 };
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::{SourceType, Span};
 use oxc_str::{Ident, IdentHashMap};
 use oxc_syntax::{
@@ -74,7 +74,7 @@ pub struct SemanticBuilder<'a> {
     pub(crate) source_type: SourceType,
 
     /// Semantic early errors such as redeclaration errors.
-    pub(crate) errors: RefCell<Vec<OxcDiagnostic>>,
+    pub(crate) errors: RefCell<Diagnostics>,
 
     // states
     pub(crate) current_scope_id: ScopeId,
@@ -131,7 +131,7 @@ pub struct SemanticBuilderReturn<'a> {
     /// Built semantic model.
     pub semantic: Semantic<'a>,
     /// Diagnostics collected during semantic analysis.
-    pub errors: Vec<OxcDiagnostic>,
+    pub diagnostics: Diagnostics,
 }
 
 impl Default for SemanticBuilder<'_> {
@@ -149,7 +149,7 @@ impl<'a> SemanticBuilder<'a> {
         Self {
             source_text: "",
             source_type: SourceType::default(),
-            errors: RefCell::new(vec![]),
+            errors: RefCell::new(Diagnostics::new()),
             current_reference_flags: ReferenceFlags::empty(),
             current_scope_id,
             current_function_node_id: NodeId::ROOT,
@@ -390,7 +390,7 @@ impl<'a> SemanticBuilder<'a> {
             #[cfg(not(feature = "cfg"))]
             cfg: (),
         };
-        SemanticBuilderReturn { semantic, errors: self.errors.into_inner() }
+        SemanticBuilderReturn { semantic, diagnostics: self.errors.into_inner() }
     }
 
     /// Push a Syntax Error

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -291,10 +291,10 @@ mod tests {
         source_type: SourceType,
     ) -> Semantic<'s> {
         let parse = oxc_parser::Parser::new(allocator, source, source_type).parse();
-        assert!(parse.errors.is_empty());
+        assert!(parse.diagnostics.is_empty());
         let semantic =
             SemanticBuilder::new().with_build_nodes(true).build(allocator.alloc(parse.program));
-        assert!(semantic.errors.is_empty(), "Parse error: {}", semantic.errors[0]);
+        assert!(semantic.diagnostics.is_empty(), "Parse error: {}", semantic.diagnostics[0]);
         semantic.semantic
     }
 
@@ -343,13 +343,13 @@ mod tests {
         let source_type = SourceType::ts();
         let parse = oxc_parser::Parser::new(&allocator, source, source_type).parse();
 
-        assert!(parse.errors.is_empty());
+        assert!(parse.diagnostics.is_empty());
 
         let first = SemanticBuilder::new_compiler().build(&parse.program);
-        assert!(first.errors.is_empty());
+        assert!(first.diagnostics.is_empty());
 
         let second = SemanticBuilder::new_compiler().build(&parse.program);
-        assert!(second.errors.is_empty());
+        assert!(second.diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/oxc_semantic/tests/integration/enum_values.rs
+++ b/crates/oxc_semantic/tests/integration/enum_values.rs
@@ -8,9 +8,9 @@ fn get_enum_member_value(source: &str, member_name: &str) -> Option<ConstantValu
     let allocator = Allocator::default();
     let source_type = SourceType::ts();
     let parser_ret = Parser::new(&allocator, source, source_type).parse();
-    assert!(parser_ret.errors.is_empty(), "Parse errors: {:?}", parser_ret.errors);
+    assert!(parser_ret.diagnostics.is_empty(), "Parse errors: {:?}", parser_ret.diagnostics);
     let semantic_ret = SemanticBuilder::new().with_enum_eval(true).build(&parser_ret.program);
-    assert!(semantic_ret.errors.is_empty(), "Semantic errors: {:?}", semantic_ret.errors);
+    assert!(semantic_ret.diagnostics.is_empty(), "Semantic errors: {:?}", semantic_ret.diagnostics);
     let scoping = semantic_ret.semantic.into_scoping();
 
     for symbol_id in scoping.symbol_ids() {

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -141,13 +141,13 @@ impl<'a> SemanticTester<'a> {
     #[expect(unstable_name_collisions)]
     pub fn build(&self) -> Semantic<'_> {
         let semantic_ret = self.build_with_errors();
-        match (self.expect_errors, semantic_ret.errors.is_empty()) {
+        match (self.expect_errors, semantic_ret.diagnostics.is_empty()) {
             (true, true) => panic!("Expected errors, but none were produced"),
             (false, false) => panic!(
                 "Semantic analysis failed:\n\n{}\n\n{}",
                 self.source_text,
                 semantic_ret
-                    .errors
+                    .diagnostics
                     .iter()
                     .map(ToString::to_string)
                     .intersperse("\n\n".to_owned())
@@ -167,11 +167,11 @@ impl<'a> SemanticTester<'a> {
             oxc_parser::Parser::new(&self.allocator, self.source_text, self.source_type).parse();
 
         assert!(
-            parse.errors.is_empty(),
+            parse.diagnostics.is_empty(),
             "\n Failed to parse source:\n{}\n\n{}",
             self.source_text,
             parse
-                .errors
+                .diagnostics
                 .iter()
                 .map(|e| format!("{e}"))
                 .intersperse("\n\n".to_owned())
@@ -268,18 +268,21 @@ impl<'a> SemanticTester<'a> {
     ///
     /// [`parsing`]: oxc_parser::Parser::parse
     pub fn has_error(&self, message: &str) {
-        let SemanticBuilderReturn { errors, .. } = self.build_with_errors();
+        let SemanticBuilderReturn { diagnostics, .. } = self.build_with_errors();
         assert!(
-            !errors.is_empty(),
+            !diagnostics.is_empty(),
             "Expected an error matching '{message}', but no errors were produced"
         );
-        if errors.iter().any(|e| e.message.contains(message)) {
+        if diagnostics.iter().any(|e| e.message.contains(message)) {
             return;
         }
 
-        let num_errors = errors.len();
-        let rendered_errors =
-            self.wrap_diagnostics(errors).into_iter().map(|e| e.to_string()).join("\n\n");
+        let num_errors = diagnostics.len();
+        let rendered_errors = self
+            .wrap_diagnostics(diagnostics.into())
+            .into_iter()
+            .map(|e| e.to_string())
+            .join("\n\n");
 
         panic!(
             "Expected an error containing '{message}', but none of the {num_errors} matched:\n\n{rendered_errors}",

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -54,9 +54,9 @@ fn main() {
 
     let ret = Parser::new(&allocator, &source_text, source_type).parse();
 
-    if !ret.errors.is_empty() {
+    if !ret.diagnostics.is_empty() {
         println!("Parser Errors:");
-        for error in ret.errors {
+        for error in ret.diagnostics {
             let error = error.with_source_code(source_text.clone());
             println!("{error:?}");
         }
@@ -73,9 +73,9 @@ fn main() {
         .with_enum_eval(true)
         .build(&program);
 
-    if !ret.errors.is_empty() {
+    if !ret.diagnostics.is_empty() {
         println!("Semantic Errors:");
-        for error in ret.errors {
+        for error in ret.diagnostics {
             let error = error.with_source_code(source_text.clone());
             println!("{error:?}");
         }
@@ -103,9 +103,9 @@ fn main() {
     let ret = Transformer::new(&allocator, path, &transform_options)
         .build_with_scoping(scoping, &mut program);
 
-    if !ret.errors.is_empty() {
+    if !ret.diagnostics.is_empty() {
         println!("Transformer Errors:");
-        for error in ret.errors {
+        for error in ret.diagnostics {
             let error = error.with_source_code(source_text.clone());
             println!("{error:?}");
         }

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use oxc_allocator::{Allocator, TakeIn, Vec as ArenaVec};
 use oxc_ast::{AstBuilder, ast::*};
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::Diagnostics;
 #[cfg(feature = "react_compiler")]
 use oxc_react_compiler::{PluginOptions, transform as react_compiler_transform};
 use oxc_semantic::Scoping;
@@ -91,7 +91,7 @@ pub use crate::{
 #[non_exhaustive]
 pub struct TransformerReturn {
     /// Diagnostics produced during transformation.
-    pub errors: std::vec::Vec<OxcDiagnostic>,
+    pub diagnostics: Diagnostics,
     /// Updated semantic scoping after all transforms have run.
     pub scoping: Scoping,
     /// Helpers used by this transform.
@@ -146,7 +146,17 @@ impl<'a> Transformer<'a> {
         #[cfg(feature = "react_compiler")]
         let (scoping, react_compiler_diagnostics) = self.run_react_compiler(scoping, program);
         #[cfg(not(feature = "react_compiler"))]
-        let react_compiler_diagnostics: std::vec::Vec<OxcDiagnostic> = std::vec::Vec::new();
+        let react_compiler_diagnostics = Diagnostics::new();
+
+        // A React Compiler error is fatal: stop before the rest of the transform runs.
+        if react_compiler_diagnostics.has_errors() {
+            #[expect(deprecated)]
+            return TransformerReturn {
+                diagnostics: react_compiler_diagnostics,
+                scoping,
+                helpers_used: FxHashMap::default(),
+            };
+        }
 
         let ast_builder = AstBuilder::new(allocator);
 
@@ -202,10 +212,10 @@ impl<'a> Transformer<'a> {
         traverse_mut_with_ctx(&mut transformer, program, &mut reusable_ctx);
         let (mut state, scoping) = reusable_ctx.into_state_and_scoping();
         let helpers_used = state.helper_loader.used_helpers.drain().collect();
-        let mut errors = react_compiler_diagnostics;
-        errors.extend(state.take_errors());
+        let mut diagnostics = react_compiler_diagnostics;
+        diagnostics.extend(state.take_errors());
         #[expect(deprecated)]
-        TransformerReturn { errors, scoping, helpers_used }
+        TransformerReturn { diagnostics, scoping, helpers_used }
     }
 
     #[cfg(feature = "react_compiler")]
@@ -213,20 +223,18 @@ impl<'a> Transformer<'a> {
         &mut self,
         scoping: Scoping,
         program: &mut Program<'a>,
-    ) -> (Scoping, std::vec::Vec<OxcDiagnostic>) {
+    ) -> (Scoping, Diagnostics) {
         let Some(options) = self.react_compiler.take() else {
-            return (scoping, std::vec::Vec::new());
+            return (scoping, Diagnostics::new());
         };
         let result = react_compiler_transform(program, self.allocator, options);
-        let mut diagnostics = result.errors;
-        diagnostics.extend(result.warnings);
         let Some(compiled) = result.program else {
-            return (scoping, diagnostics);
+            return (scoping, result.diagnostics);
         };
         *program = compiled;
         let scoping =
             SemanticBuilder::new().with_enum_eval(true).build(program).semantic.into_scoping();
-        (scoping, diagnostics)
+        (scoping, result.diagnostics)
     }
 }
 

--- a/crates/oxc_transformer/tests/integrations/helper_call.rs
+++ b/crates/oxc_transformer/tests/integrations/helper_call.rs
@@ -35,7 +35,7 @@ fn helper_call_idempotency() {
         let allocator = Allocator::default();
         let source_type = SourceType::default();
         let ret = Parser::new(&allocator, &first, source_type).parse();
-        assert!(ret.errors.is_empty(), "Parse errors on second pass for: {source}");
+        assert!(ret.diagnostics.is_empty(), "Parse errors on second pass for: {source}");
         let second = Codegen::new().with_options(codegen_options()).build(&ret.program).code;
 
         assert_eq!(

--- a/crates/oxc_transformer/tests/integrations/main.rs
+++ b/crates/oxc_transformer/tests/integrations/main.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use oxc_allocator::Allocator;
 use oxc_codegen::{Codegen, CodegenOptions};
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::Diagnostics;
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
@@ -20,17 +20,14 @@ use oxc_transformer::{TransformOptions, Transformer};
 pub fn codegen(source_text: &str, source_type: SourceType) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     Codegen::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })
         .build(&ret.program)
         .code
 }
 
-pub(crate) fn test(
-    source_text: &str,
-    options: &TransformOptions,
-) -> Result<String, Vec<OxcDiagnostic>> {
+pub(crate) fn test(source_text: &str, options: &TransformOptions) -> Result<String, Diagnostics> {
     let source_type = SourceType::default();
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
@@ -38,8 +35,8 @@ pub(crate) fn test(
     let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
     let ret = Transformer::new(&allocator, Path::new(""), options)
         .build_with_scoping(scoping, &mut program);
-    if !ret.errors.is_empty() {
-        return Err(ret.errors);
+    if !ret.diagnostics.is_empty() {
+        return Err(ret.diagnostics);
     }
     let code = Codegen::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })

--- a/crates/oxc_transformer/tests/integrations/react_compiler.rs
+++ b/crates/oxc_transformer/tests/integrations/react_compiler.rs
@@ -19,7 +19,7 @@ fn memoizes_component_through_transformer() {
         TransformOptions { react_compiler: Some(default_plugin_options()), ..Default::default() };
     let ret = Transformer::new(&allocator, Path::new("greeting.jsx"), &options)
         .build_with_scoping(scoping, &mut program);
-    assert!(ret.errors.is_empty(), "{:?}", ret.errors);
+    assert!(ret.diagnostics.is_empty(), "{:?}", ret.diagnostics);
 
     let code = Codegen::new().build(&program).code;
     assert!(code.contains("react/compiler-runtime"), "missing runtime import:\n{code}");

--- a/crates/oxc_transformer_plugins/examples/define.rs
+++ b/crates/oxc_transformer_plugins/examples/define.rs
@@ -62,7 +62,7 @@ fn parse<'a>(
             ..ParseOptions::default()
         })
         .parse();
-    for error in ret.errors {
+    for error in ret.diagnostics {
         println!("{:?}", error.with_source_code(source_text.to_string()));
     }
     ret.program

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -878,7 +878,7 @@ mod test {
 
     use oxc_allocator::Allocator;
     use oxc_codegen::{Codegen, CodegenOptions, CommentOptions};
-    use oxc_diagnostics::OxcDiagnostic;
+    use oxc_diagnostics::Diagnostics;
     use oxc_parser::Parser;
     use oxc_semantic::SemanticBuilder;
     use oxc_span::SourceType;
@@ -893,7 +893,7 @@ mod test {
         dynamic_deps: FxHashSet<String>,
     }
 
-    fn transform(source_text: &str, is_jsx: bool) -> Result<TransformReturn, Vec<OxcDiagnostic>> {
+    fn transform(source_text: &str, is_jsx: bool) -> Result<TransformReturn, Diagnostics> {
         let source_type = SourceType::default().with_jsx(is_jsx);
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
@@ -909,8 +909,8 @@ mod test {
         let (deps, dynamic_deps) =
             ModuleRunnerTransform::new().transform(&allocator, &mut program, scoping);
 
-        if !ret.errors.is_empty() {
-            return Err(ret.errors);
+        if !ret.diagnostics.is_empty() {
+            return Err(ret.diagnostics);
         }
         let code = Codegen::new()
             .with_options(CodegenOptions {
@@ -928,7 +928,7 @@ mod test {
         let source_type = SourceType::default();
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, source_text, source_type).parse();
-        assert!(ret.errors.is_empty());
+        assert!(ret.diagnostics.is_empty());
 
         Codegen::new()
             .with_options(CodegenOptions {

--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashSet;
 use oxc_allocator::{Address, Allocator, GetAddress, TakeIn, UnstableAddress};
 use oxc_ast::ast::*;
 use oxc_ast_visit::{VisitMut, walk_mut};
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_parser::Parser;
 use oxc_semantic::{IsGlobalReference, ReferenceFlags, ScopeFlags, Scoping};
 use oxc_span::{SPAN, SourceType};
@@ -84,7 +84,7 @@ impl ReplaceGlobalDefinesConfig {
     ///
     /// * key is not an identifier
     /// * value has a syntax error
-    pub fn new<S: AsRef<str>>(defines: &[(S, S)]) -> Result<Self, Vec<OxcDiagnostic>> {
+    pub fn new<S: AsRef<str>>(defines: &[(S, S)]) -> Result<Self, Diagnostics> {
         let allocator = Allocator::default();
         let mut identifier_defines = vec![];
         let mut dot_defines = vec![];
@@ -145,7 +145,7 @@ impl ReplaceGlobalDefinesConfig {
         })))
     }
 
-    fn check_key(key: &str) -> Result<IdentifierType, Vec<OxcDiagnostic>> {
+    fn check_key(key: &str) -> Result<IdentifierType, Diagnostics> {
         let parts: Vec<&str> = key.split('.').collect();
 
         assert!(!parts.is_empty());
@@ -154,7 +154,8 @@ impl ReplaceGlobalDefinesConfig {
             if !is_identifier_name(parts[0]) {
                 return Err(vec![OxcDiagnostic::error(format!(
                     "The define key `{key}` is not an identifier."
-                ))]);
+                ))]
+                .into());
             }
             return Ok(IdentifierType::Identifier);
         }
@@ -167,7 +168,8 @@ impl ReplaceGlobalDefinesConfig {
             if !is_identifier_name(part) {
                 return Err(vec![OxcDiagnostic::error(format!(
                     "The define key `{key}` contains an invalid identifier `{part}`."
-                ))]);
+                ))]
+                .into());
             }
         }
         if is_import_meta {
@@ -187,7 +189,8 @@ impl ReplaceGlobalDefinesConfig {
         } else if normalized_parts_len != parts.len() {
             Err(vec![OxcDiagnostic::error(
                 "The postfix wildcard is only allowed for `import.meta`.".to_string(),
-            )])
+            )]
+            .into())
         } else {
             Ok(IdentifierType::DotDefines {
                 parts: parts
@@ -199,7 +202,7 @@ impl ReplaceGlobalDefinesConfig {
         }
     }
 
-    fn check_value(allocator: &Allocator, source_text: &str) -> Result<(), Vec<OxcDiagnostic>> {
+    fn check_value(allocator: &Allocator, source_text: &str) -> Result<(), Diagnostics> {
         Parser::new(allocator, source_text, SourceType::default()).parse_expression()?;
         Ok(())
     }

--- a/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/inject_global_variables.rs
@@ -16,7 +16,7 @@ fn test(source_text: &str, expected: &str, config: InjectGlobalVariablesConfig) 
     let source_type = SourceType::default();
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     let mut program = ret.program;
     let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
     let ret = InjectGlobalVariables::new(&allocator, config).build(scoping, &mut program);

--- a/crates/oxc_transformer_plugins/tests/integrations/main.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/main.rs
@@ -11,7 +11,7 @@ use oxc_span::SourceType;
 pub fn codegen(source_text: &str, source_type: SourceType) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     Codegen::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })
         .build(&ret.program)

--- a/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
@@ -14,7 +14,7 @@ pub fn test(source_text: &str, expected: &str, config: &ReplaceGlobalDefinesConf
     let source_type = SourceType::ts().with_module(true);
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     let mut program = ret.program;
     let mut scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
     let ret = ReplaceGlobalDefines::new(&allocator, config.clone()).build(scoping, &mut program);
@@ -368,7 +368,7 @@ fn test_define_then_transform_impl(
 
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     let mut program = ret.program;
 
     // Step 1: Run define plugin first (like the playground does)
@@ -385,7 +385,7 @@ fn test_define_then_transform_impl(
     let filename = if source_type.is_typescript() { "test.ts" } else { "test.mjs" };
     let ret = Transformer::new(&allocator, Path::new(filename), &options)
         .build_with_scoping(scoping, &mut program);
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
 
     let result = Codegen::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })

--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -104,7 +104,7 @@ fn minify_impl(filename: &str, source_text: &str, options: Option<MinifyOptions>
     MinifyResult {
         code: ret.code,
         map: ret.map.map(oxc_sourcemap::napi::SourceMap::from),
-        errors: OxcError::from_diagnostics(filename, source_text, parser_ret.errors),
+        errors: OxcError::from_diagnostics(filename, source_text, parser_ret.diagnostics),
         legal_comments,
     }
 }

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -106,11 +106,11 @@ fn parse_with_return(filename: &str, source_text: &str, options: &ParserOptions)
 
     let mut program = ret.program;
     let mut module_record = ret.module_record;
-    let mut diagnostics = ret.errors;
+    let mut diagnostics = ret.diagnostics;
 
     if options.show_semantic_errors == Some(true) {
         let semantic_ret = SemanticBuilder::new_compiler().build(&program);
-        diagnostics.extend(semantic_ret.errors);
+        diagnostics.extend(semantic_ret.diagnostics);
     }
 
     let mut errors = OxcError::from_diagnostics(filename, source_text, diagnostics);

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -276,9 +276,9 @@ unsafe fn parse_raw_impl(
         let mut errors = if options.show_semantic_errors == Some(true) {
             let semantic_ret = SemanticBuilder::new_compiler().build(&program);
 
-            if !ret.errors.is_empty() || !semantic_ret.errors.is_empty() {
+            if !ret.diagnostics.is_empty() || !semantic_ret.diagnostics.is_empty() {
                 Error::from_diagnostics_in(
-                    ret.errors.into_iter().chain(semantic_ret.errors),
+                    ret.diagnostics.into_iter().chain(semantic_ret.diagnostics),
                     source_text,
                     filename,
                     &allocator,
@@ -286,8 +286,8 @@ unsafe fn parse_raw_impl(
             } else {
                 ArenaVec::new_in(&allocator)
             }
-        } else if !ret.errors.is_empty() {
-            Error::from_diagnostics_in(ret.errors, source_text, filename, &allocator)
+        } else if !ret.diagnostics.is_empty() {
+            Error::from_diagnostics_in(ret.diagnostics, source_text, filename, &allocator)
         } else {
             ArenaVec::new_in(&allocator)
         };

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -223,9 +223,9 @@ impl Oxc {
             preserve_parens: parser_options.preserve_parens,
             allow_v8_intrinsics: parser_options.allow_v8_intrinsics,
         };
-        let ParserReturn { program, errors, module_record, .. } =
+        let ParserReturn { program, diagnostics, module_record, .. } =
             Parser::new(allocator, source_text, source_type).with_options(parser_options).parse();
-        self.diagnostics.extend(errors);
+        self.diagnostics.extend(diagnostics);
         (program, module_record)
     }
 
@@ -245,7 +245,7 @@ impl Oxc {
             .with_check_syntax_error(parser_options.semantic_errors)
             .with_cfg(run_options.cfg)
             .build(program);
-        self.diagnostics.extend(semantic_ret.errors);
+        self.diagnostics.extend(semantic_ret.diagnostics);
 
         self.control_flow_graph = semantic_ret.semantic.cfg().map_or_else(String::default, |cfg| {
             cfg.debug_dot(DebugDotContext::new(
@@ -270,10 +270,10 @@ impl Oxc {
             .map(|o| IsolatedDeclarationsOptions { strip_internal: o.strip_internal })
             .unwrap_or_default();
         let ret = IsolatedDeclarations::new(allocator, id_options).build(program);
-        if ret.errors.is_empty() {
+        if ret.diagnostics.is_empty() {
             self.codegen(path, &ret.program, None, run_options, codegen_options);
         } else {
-            self.diagnostics.extend(ret.errors);
+            self.diagnostics.extend(ret.diagnostics);
             self.codegen_text = String::new();
             self.codegen_sourcemap_text = None;
         }
@@ -308,7 +308,7 @@ impl Oxc {
         options.typescript.optimize_const_enums = transform_options.optimize_const_enums;
         let result =
             Transformer::new(allocator, path, &options).build_with_scoping(scoping, program);
-        self.diagnostics.extend(result.errors);
+        self.diagnostics.extend(result.diagnostics);
         result.scoping
     }
 

--- a/napi/transform/src/isolated_declaration.rs
+++ b/napi/transform/src/isolated_declaration.rs
@@ -72,7 +72,8 @@ fn isolated_declaration_impl(
         })
         .build(&transformed_ret.program);
 
-    let diagnostics = ret.errors.into_iter().chain(transformed_ret.errors).collect::<Vec<_>>();
+    let diagnostics =
+        ret.diagnostics.into_iter().chain(transformed_ret.diagnostics).collect::<Vec<_>>();
     let errors = OxcError::from_diagnostics(filename, source_text, diagnostics);
 
     IsolatedDeclarationsResult {

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -14,7 +14,7 @@ use oxc::{
     CompilerInterface,
     allocator::Allocator,
     codegen::{Codegen, CodegenOptions, CodegenReturn},
-    diagnostics::OxcDiagnostic,
+    diagnostics::{Diagnostics, OxcDiagnostic},
     parser::Parser,
     semantic::{SemanticBuilder, SemanticBuilderReturn},
     span::SourceType,
@@ -756,7 +756,7 @@ struct Compiler {
     inject: Option<InjectGlobalVariablesConfig>,
 
     helpers_used: FxHashMap<String, String>,
-    errors: Vec<OxcDiagnostic>,
+    errors: Diagnostics,
 }
 
 impl Compiler {
@@ -823,13 +823,13 @@ impl Compiler {
             define,
             inject,
             helpers_used: FxHashMap::default(),
-            errors: vec![],
+            errors: Diagnostics::new(),
         })
     }
 }
 
 impl CompilerInterface for Compiler {
-    fn handle_errors(&mut self, errors: Vec<OxcDiagnostic>) {
+    fn handle_errors(&mut self, errors: Diagnostics) {
         self.errors.extend(errors);
     }
 
@@ -1069,9 +1069,9 @@ fn module_runner_transform_impl(
     let mut parser_ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = parser_ret.program;
 
-    let SemanticBuilderReturn { semantic, errors } =
+    let SemanticBuilderReturn { semantic, diagnostics } =
         SemanticBuilder::new_compiler().build(&program);
-    parser_ret.errors.extend(errors);
+    parser_ret.diagnostics.extend(diagnostics);
 
     let scoping = semantic.into_scoping();
     let (deps, dynamic_deps) =
@@ -1091,7 +1091,7 @@ fn module_runner_transform_impl(
         map: map.map(Into::into),
         deps: deps.into_iter().collect::<Vec<String>>(),
         dynamic_deps: dynamic_deps.into_iter().collect::<Vec<String>>(),
-        errors: OxcError::from_diagnostics(filename, source_text, parser_ret.errors),
+        errors: OxcError::from_diagnostics(filename, source_text, parser_ret.diagnostics),
     }
 }
 

--- a/napi/transform/test/reactCompiler.test.ts
+++ b/napi/transform/test/reactCompiler.test.ts
@@ -127,7 +127,7 @@ function Component() {
     expect(errors.some((error) => error.severity === "Error")).toBe(false);
   });
 
-  it("reports React Compiler errors at error severity without aborting codegen", () => {
+  it("aborts the transform when React Compiler reports an error", () => {
     const { code, errors } = transformSync(
       "Component.jsx",
       `
@@ -144,13 +144,10 @@ function Component(props) {
       },
     );
 
-    // The Rules of Hooks violation is surfaced at error severity (not flattened
-    // to a warning)...
+    // A React Compiler error (Rules of Hooks violation) is fatal: it is surfaced
+    // at error severity and the transform stops, emitting no code.
     expect(errors.some((error) => error.severity === "Error")).toBe(true);
-    // ...but the React Compiler leaves a valid program, so codegen still runs
-    // and the component is emitted rather than the whole file being dropped.
-    expect(code).not.toBe("");
-    expect(code).toContain("function Component");
+    expect(code).toBe("");
   });
 
   it("keeps enum values available for the downstream TypeScript transform", () => {

--- a/tasks/ast_tools/src/output/javascript.rs
+++ b/tasks/ast_tools/src/output/javascript.rs
@@ -281,7 +281,7 @@ pub(crate) use generate_variants;
 pub fn parse_js<'a>(source_text: &'a str, allocator: &'a Allocator) -> Program<'a> {
     let source_type = SourceType::mjs();
     let parser_ret = Parser::new(allocator, source_text, source_type).parse();
-    assert!(parser_ret.errors.is_empty(), "Parse errors: {:#?}", parser_ret.errors);
+    assert!(parser_ret.diagnostics.is_empty(), "Parse errors: {:#?}", parser_ret.diagnostics);
     parser_ret.program
 }
 

--- a/tasks/benchmark/benches/codegen.rs
+++ b/tasks/benchmark/benches/codegen.rs
@@ -16,7 +16,7 @@ fn bench_codegen(criterion: &mut Criterion) {
         let allocator = Allocator::default();
 
         let parser_ret = Parser::new(&allocator, source_text, source_type).parse();
-        assert!(parser_ret.errors.is_empty());
+        assert!(parser_ret.diagnostics.is_empty());
         let mut program = parser_ret.program;
 
         let scoping =
@@ -26,7 +26,7 @@ fn bench_codegen(criterion: &mut Criterion) {
         let transformer_ret =
             Transformer::new(&allocator, Path::new(&file.file_name), &transform_options)
                 .build_with_scoping(scoping, &mut program);
-        assert!(transformer_ret.errors.is_empty());
+        assert!(transformer_ret.diagnostics.is_empty());
 
         let mut group = criterion.benchmark_group("codegen");
         group.bench_function(id, |b| {

--- a/tasks/benchmark/benches/lexer.rs
+++ b/tasks/benchmark/benches/lexer.rs
@@ -102,7 +102,7 @@ fn lex_whole_file<'a, C: LexerConfig>(
 fn clean<'a>(source_text: &'a str, source_type: SourceType, allocator: &'a Allocator) -> String {
     // Parse
     let parser_ret = Parser::new(allocator, source_text, source_type).parse();
-    assert!(parser_ret.errors.is_empty());
+    assert!(parser_ret.diagnostics.is_empty());
     let program = parser_ret.program;
 
     // Visit AST and compile list of replacements

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -41,7 +41,7 @@ fn bench_minifier(criterion: &mut Criterion) {
                 let transformer_ret =
                     Transformer::new(&allocator, Path::new(&file.file_name), &transform_options)
                         .build_with_scoping(scoping, &mut program);
-                assert!(transformer_ret.errors.is_empty());
+                assert!(transformer_ret.diagnostics.is_empty());
                 let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
 
                 let options = CompressOptions::smallest();
@@ -71,7 +71,7 @@ fn transform_to_js<'a>(
     let transform_options = TransformOptions::from_target("esnext").unwrap();
     let transformer_ret = Transformer::new(allocator, path, &transform_options)
         .build_with_scoping(scoping, &mut program);
-    assert!(transformer_ret.errors.is_empty());
+    assert!(transformer_ret.diagnostics.is_empty());
     program
 }
 

--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -31,7 +31,7 @@ fn bench_semantic(criterion: &mut Criterion) {
                     // we don't want to include it in benchmark time.
                     let ret = SemanticBuilder::new_compiler().build(&program);
                     let ret = black_box(ret);
-                    ret.errors
+                    ret.diagnostics
                 });
             });
         });

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -11,7 +11,7 @@ use oxc::{
     },
     ast_visit::{Visit, walk},
     codegen::{CodegenOptions, CodegenReturn},
-    diagnostics::OxcDiagnostic,
+    diagnostics::{Diagnostics, OxcDiagnostic},
     minifier::CompressOptions,
     parser::{ParseOptions, ParserReturn},
     regular_expression::{LiteralParser, Options},
@@ -36,7 +36,7 @@ pub struct Driver {
     pub allow_return_outside_function: bool,
     // results
     pub panicked: bool,
-    pub errors: Vec<OxcDiagnostic>,
+    pub errors: Diagnostics,
     pub printed: String,
     pub source_type: Option<SourceType>,
 }
@@ -73,19 +73,19 @@ impl CompilerInterface for Driver {
         })
     }
 
-    fn handle_errors(&mut self, errors: Vec<OxcDiagnostic>) {
+    fn handle_errors(&mut self, errors: Diagnostics) {
         self.errors.extend(errors);
     }
 
     fn after_parse(&mut self, parser_return: &mut ParserReturn) -> ControlFlow<()> {
-        let ParserReturn { program, panicked, errors, .. } = parser_return;
+        let ParserReturn { program, panicked, diagnostics, .. } = parser_return;
         self.panicked = *panicked;
         self.source_type = Some(program.source_type);
         self.check_ast_nodes(program);
         if self.check_comments(&program.comments) {
             return ControlFlow::Break(());
         }
-        if (errors.is_empty() || !*panicked) && program.source_type.is_unambiguous() {
+        if (diagnostics.is_empty() || !*panicked) && program.source_type.is_unambiguous() {
             self.errors.push(OxcDiagnostic::error("SourceType must not be unambiguous."));
         }
         // Make sure serialization doesn't crash; also for code coverage.

--- a/tasks/coverage/src/tools.rs
+++ b/tasks/coverage/src/tools.rs
@@ -772,9 +772,11 @@ fn run_estree_test262_impl(
                 .with_config(parser_config)
                 .parse();
 
-            if ret.panicked || !ret.errors.is_empty() {
-                let error =
-                    ret.errors.first().map_or_else(|| "Panicked".to_string(), ToString::to_string);
+            if ret.panicked || !ret.diagnostics.is_empty() {
+                let error = ret
+                    .diagnostics
+                    .first()
+                    .map_or_else(|| "Panicked".to_string(), ToString::to_string);
                 return CoverageResult {
                     path: test_file.path.clone(),
                     should_fail: false,
@@ -844,9 +846,11 @@ fn run_estree_acorn_jsx_impl(
                 .with_config(parser_config)
                 .parse();
 
-            if ret.panicked || !ret.errors.is_empty() {
-                let error =
-                    ret.errors.first().map_or_else(|| "Panicked".to_string(), ToString::to_string);
+            if ret.panicked || !ret.diagnostics.is_empty() {
+                let error = ret
+                    .diagnostics
+                    .first()
+                    .map_or_else(|| "Panicked".to_string(), ToString::to_string);
                 let result = if test_file.should_fail {
                     TestResult::CorrectError(error, ret.panicked)
                 } else {
@@ -982,9 +986,9 @@ fn run_estree_typescript_impl(
                     .with_config(parser_config)
                     .parse();
 
-                if ret.panicked || !ret.errors.is_empty() {
+                if ret.panicked || !ret.diagnostics.is_empty() {
                     let error = ret
-                        .errors
+                        .diagnostics
                         .first()
                         .map_or_else(|| "Panicked".to_string(), ToString::to_string);
                     return CoverageResult {

--- a/tasks/coverage/src/typescript/meta.rs
+++ b/tasks/coverage/src/typescript/meta.rs
@@ -9,7 +9,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use oxc::{
     allocator::Allocator,
     codegen::Codegen,
-    diagnostics::{NamedSource, OxcDiagnostic},
+    diagnostics::{Diagnostics, NamedSource},
     parser::Parser,
     span::{SourceType, Span},
 };
@@ -423,7 +423,7 @@ pub struct Baseline {
     pub original: String,
     pub original_diagnostic: Vec<String>,
     pub oxc_printed: String,
-    pub oxc_diagnostics: Vec<OxcDiagnostic>,
+    pub oxc_diagnostics: Diagnostics,
 }
 
 impl Baseline {

--- a/tasks/coverage/src/typescript/transpile_runner.rs
+++ b/tasks/coverage/src/typescript/transpile_runner.rs
@@ -148,7 +148,7 @@ fn change_extension(name: &str) -> String {
         .to_string()
 }
 
-fn transpile(path: &Path, source_text: &str) -> (String, Vec<oxc::diagnostics::OxcDiagnostic>) {
+fn transpile(path: &Path, source_text: &str) -> (String, oxc::diagnostics::Diagnostics) {
     let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap_or_default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
@@ -162,5 +162,5 @@ fn transpile(path: &Path, source_text: &str) -> (String, Vec<oxc::diagnostics::O
         })
         .build(&ret.program)
         .code;
-    (printed, ret.errors)
+    (printed, ret.diagnostics)
 }

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -158,7 +158,7 @@ fn minify_twice(file: &TestFile, options: Options) -> (String, u8) {
 fn minify(source_text: &str, source_type: SourceType, options: Options) -> (String, u8) {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    assert!(ret.errors.is_empty());
+    assert!(ret.diagnostics.is_empty());
     let mut program = ret.program;
     let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
     let _ = ReplaceGlobalDefines::new(

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -67,7 +67,7 @@ impl SpecParser {
         }
 
         let mut ret = Parser::new(&allocator, &spec_content, source_type).parse();
-        assert!(ret.errors.is_empty());
+        assert!(ret.diagnostics.is_empty());
         self.visit_program(&mut ret.program);
     }
 }

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -1494,14 +1494,14 @@ fn main() {
             let allocator = Allocator::default();
             let source_type = SourceType::from_path(rule_test_path).unwrap();
             let ret = Parser::new(&allocator, &body, source_type).parse();
-            if !ret.errors.is_empty() {
-                let first_error = ret.errors.first().map_or_else(
+            if !ret.diagnostics.is_empty() {
+                let first_error = ret.diagnostics.first().map_or_else(
                     || "unknown parse error".to_string(),
                     std::string::ToString::to_string,
                 );
                 eprintln!(
                     "Warning: {} parse error(s) in test file (possibly due to unsupported or invalid syntax). First error: {}. Attempting to extract test cases anyway.",
-                    ret.errors.len(),
+                    ret.diagnostics.len(),
                     first_error
                 );
             }
@@ -1594,10 +1594,10 @@ fn main() {
             let allocator = Allocator::default();
             let source_type = SourceType::from_path(rule_src_path).unwrap();
             let ret = Parser::new(&allocator, &body, source_type).parse();
-            if !ret.errors.is_empty() {
+            if !ret.diagnostics.is_empty() {
                 eprintln!(
                     "Warning: {} parse error(s) in rule source file (possibly due to Flow types). Attempting to extract rule config anyway.",
-                    ret.errors.len()
+                    ret.diagnostics.len()
                 );
             }
             let debug_mode = false;
@@ -2178,7 +2178,7 @@ mod tests {
         let source_text = "String.raw`new RegExp('([\\\\q])', 'v')`";
         let allocator = Allocator::default();
         let ret = Parser::new(&allocator, source_text, SourceType::default()).parse();
-        assert!(ret.errors.is_empty(), "{:?}", ret.errors);
+        assert!(ret.diagnostics.is_empty(), "{:?}", ret.diagnostics);
 
         let Statement::ExpressionStatement(stmt) = ret.program.body.first().unwrap() else {
             panic!("expected expression statement");

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -149,7 +149,7 @@ pub fn run() -> Result<(), io::Error> {
         let mut parsed = Parser::new(&allocator, &file.source_text, file.source_type)
             .with_options(parse_options)
             .parse();
-        assert!(parsed.errors.is_empty());
+        assert!(parsed.diagnostics.is_empty());
 
         // Transform TypeScript to ESNext before minifying (minifier only works on esnext)
         let scoping = SemanticBuilder::new()
@@ -169,7 +169,7 @@ pub fn run() -> Result<(), io::Error> {
         // so re-parse with the formatter's parse options before formatting
         allocator.reset();
         let parsed = parse_for_format(&allocator, &file.source_text, file.source_type);
-        assert!(parsed.errors.is_empty());
+        assert!(parsed.diagnostics.is_empty());
         let _ = format_program(&allocator, &parsed.program, JsFormatOptions::default(), None)
             .print()
             .unwrap()
@@ -186,7 +186,7 @@ pub fn run() -> Result<(), io::Error> {
             let parsed = Parser::new(&allocator, &file.source_text, file.source_type)
                 .with_options(parse_options)
                 .parse();
-            assert!(parsed.errors.is_empty());
+            assert!(parsed.diagnostics.is_empty());
             parsed
         });
 
@@ -256,7 +256,7 @@ pub fn run() -> Result<(), io::Error> {
         reset_global_allocs();
 
         let parsed = parse_for_format(&allocator, &file.source_text, file.source_type);
-        assert!(parsed.errors.is_empty());
+        assert!(parsed.diagnostics.is_empty());
 
         let (_, formatter_stats) = record_stats_in(&allocator, || {
             format_program(&allocator, &parsed.program, JsFormatOptions::default(), None)

--- a/tasks/transform_conformance/src/driver.rs
+++ b/tasks/transform_conformance/src/driver.rs
@@ -4,7 +4,7 @@ use oxc::{
     CompilerInterface,
     ast::ast::Program,
     codegen::{CodegenOptions, CodegenReturn, CommentOptions, IndentChar},
-    diagnostics::OxcDiagnostic,
+    diagnostics::{Diagnostics, OxcDiagnostic},
     parser::ParseOptions,
     span::SourceType,
     transformer::{TransformOptions, TransformerReturn},
@@ -17,7 +17,7 @@ pub struct Driver {
     print_annotation_comments: bool,
     options: TransformOptions,
     printed: String,
-    errors: Vec<OxcDiagnostic>,
+    errors: Diagnostics,
 }
 
 impl CompilerInterface for Driver {
@@ -48,7 +48,7 @@ impl CompilerInterface for Driver {
         false
     }
 
-    fn handle_errors(&mut self, errors: Vec<OxcDiagnostic>) {
+    fn handle_errors(&mut self, errors: Diagnostics) {
         self.errors.extend(errors);
     }
 
@@ -86,7 +86,7 @@ impl Driver {
             print_annotation_comments,
             options,
             printed: String::new(),
-            errors: vec![],
+            errors: Diagnostics::new(),
         }
     }
 

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -8,7 +8,7 @@ use cow_utils::CowUtils;
 use oxc::{
     allocator::Allocator,
     codegen::{Codegen, CodegenOptions, CommentOptions, IndentChar},
-    diagnostics::{NamedSource, OxcDiagnostic},
+    diagnostics::{Diagnostics, NamedSource, OxcDiagnostic},
     parser::{ParseOptions, Parser},
     span::{SourceType, VALID_EXTENSIONS},
     transformer::{BabelOptions, HelperLoaderMode, TransformOptions},
@@ -29,7 +29,7 @@ pub struct TestCase {
     options: BabelOptions,
     source_type: SourceType,
     transform_options: Result<TransformOptions, Vec<String>>,
-    pub errors: Vec<OxcDiagnostic>,
+    pub errors: Diagnostics,
     pub transformed_code: String,
 }
 
@@ -53,7 +53,7 @@ impl TestCase {
         options.cwd.replace(cwd.to_path_buf());
         let transform_options = TransformOptions::try_from(&options);
         let path = path.to_path_buf();
-        let errors = vec![];
+        let errors = Diagnostics::new();
 
         // in `exec` directory
         let kind = if path
@@ -210,7 +210,7 @@ impl TestCase {
         {
             let allocator = Allocator::default();
             let ret = Parser::new(&allocator, &source, self.source_type).parse();
-            if !ret.errors.is_empty() {
+            if !ret.diagnostics.is_empty() {
                 return true;
             }
         }


### PR DESCRIPTION
## Summary

Introduces `oxc_diagnostics::Diagnostics` — a `Vec<OxcDiagnostic>` newtype that knows the difference between errors and warnings — and makes it the standard diagnostics return value across oxc.

- **New type**: `Diagnostics` with `has_errors()`, `has_warnings()`, `errors()`, `warnings()`, plus `Vec`-like ergonomics (Deref, `IntoIterator`, `Extend`, `From`/`Into<Vec>`) so most call sites are unchanged.
- **Return types**: `ParserReturn`, `SemanticBuilderReturn`, `IsolatedDeclarationsReturn`, the React Compiler `TransformResult`/`LintResult`, and `TransformerReturn` now expose `diagnostics: Diagnostics` instead of `errors: Vec<OxcDiagnostic>` (the React Compiler's separate `errors`/`warnings` are merged into one severity-tagged list).
- **Behaviour**: a React Compiler **error** now stops the transform (no output), while **warnings** flow through and the transform continues. `compile()` aborts codegen only when `diagnostics.has_errors()` — warnings alone no longer abort (previously any diagnostic did).

## Breaking change

Consumers reading `*.errors` on these return values must read `*.diagnostics`. React Compiler consumers that read `.errors`/`.warnings` separately should use `diagnostics.has_errors()` / `diagnostics.errors()` / `diagnostics.warnings()`.

Parser/semantic/isolated-declarations fatality is otherwise unchanged. Builds on the React Compiler transform feature (#23201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)