### PR TITLE
refactor(linter/no-confusing-non-null-assertion): improve diagnostic snippets formatting

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -49,25 +49,27 @@ declare_oxc_lint!(
 
 fn not_need_no_confusing_non_null_assertion_diagnostic(op_str: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-            "Confusing combinations of non-null assertion and equal test like \"a! {op_str} b\", which looks very similar to not equal \"a !{op_str} b\"."
+        r"Confusing combinations of non-null assertion and equal test like `a! {op_str} b`, which looks very similar to not equal `a !{op_str} b`."
     ))
-    .with_help("Remove the \"!\", or prefix the \"=\" with it.")
+    .with_help(r"Remove the `!`, or prefix the `=` with it.")
     .with_label(span)
 }
 
 fn wrap_up_no_confusing_non_null_assertion_diagnostic(op_str: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Confusing combinations of non-null assertion and equal test like \"a! {op_str} b\", which looks very similar to not equal \"a !{op_str} b\"."
+        r"Confusing combinations of non-null assertion and equal test like `a! {op_str} b`, which looks very similar to not equal `a !{op_str} b`."
     ))
-    .with_help("Wrap left-hand side in parentheses to avoid putting non-null assertion \"!\" and \"=\" together.")
+    .with_help(
+        r"Wrap left-hand side in parentheses to avoid putting non-null assertion `!` and `=` together.",
+    )
     .with_label(span)
 }
 
 fn confusing_non_null_assignment_assertion_diagnostic(op_str: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-            "Confusing combinations of non-null assertion and assignment like \"a! {op_str} b\", which looks very similar to not equal \"a !{op_str} b\"."
+        r"Confusing combinations of non-null assertion and assignment like `a! {op_str} b`, which looks very similar to not equal `a !{op_str} b`."
     ))
-    .with_help("Remove the \"!\", or wrap the left-hand side in parentheses.")
+    .with_help(r"Remove the `!`, or wrap the left-hand side in parentheses.")
     .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/typescript_no_confusing_non_null_assertion.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_confusing_non_null_assertion.snap
@@ -2,51 +2,51 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
-  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like "a! == b", which looks very similar to not equal "a !== b".
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like `a! == b`, which looks very similar to not equal `a !== b`.
    ╭─[no_confusing_non_null_assertion.tsx:1:1]
  1 │ a! == b;
    · ───────
    ╰────
-  help: Remove the "!", or prefix the "=" with it.
+  help: Remove the `!`, or prefix the `=` with it.
 
-  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like "a! === b", which looks very similar to not equal "a !=== b".
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like `a! === b`, which looks very similar to not equal `a !=== b`.
    ╭─[no_confusing_non_null_assertion.tsx:1:1]
  1 │ a! === b;
    · ────────
    ╰────
-  help: Remove the "!", or prefix the "=" with it.
+  help: Remove the `!`, or prefix the `=` with it.
 
-  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like "a! == b", which looks very similar to not equal "a !== b".
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like `a! == b`, which looks very similar to not equal `a !== b`.
    ╭─[no_confusing_non_null_assertion.tsx:1:1]
  1 │ a + b! == c;
    · ───────────
    ╰────
-  help: Wrap left-hand side in parentheses to avoid putting non-null assertion "!" and "=" together.
+  help: Wrap left-hand side in parentheses to avoid putting non-null assertion `!` and `=` together.
 
-  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like "a! == b", which looks very similar to not equal "a !== b".
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like `a! == b`, which looks very similar to not equal `a !== b`.
    ╭─[no_confusing_non_null_assertion.tsx:1:1]
  1 │ (obj = new new OuterObj().InnerObj).Name! == c;
    · ──────────────────────────────────────────────
    ╰────
-  help: Remove the "!", or prefix the "=" with it.
+  help: Remove the `!`, or prefix the `=` with it.
 
-  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like "a! == b", which looks very similar to not equal "a !== b".
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and equal test like `a! == b`, which looks very similar to not equal `a !== b`.
    ╭─[no_confusing_non_null_assertion.tsx:1:1]
  1 │ (a==b)! ==c;
    · ───────────
    ╰────
-  help: Remove the "!", or prefix the "=" with it.
+  help: Remove the `!`, or prefix the `=` with it.
 
-  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and assignment like "a! = b", which looks very similar to not equal "a != b".
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and assignment like `a! = b`, which looks very similar to not equal `a != b`.
    ╭─[no_confusing_non_null_assertion.tsx:1:1]
  1 │ a! = b;
    · ──────
    ╰────
-  help: Remove the "!", or wrap the left-hand side in parentheses.
+  help: Remove the `!`, or wrap the left-hand side in parentheses.
 
-  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and assignment like "a! = b", which looks very similar to not equal "a != b".
+  ⚠ typescript(no-confusing-non-null-assertion): Confusing combinations of non-null assertion and assignment like `a! = b`, which looks very similar to not equal `a != b`.
    ╭─[no_confusing_non_null_assertion.tsx:1:1]
  1 │ (obj = new new OuterObj().InnerObj).Name! = c;
    · ─────────────────────────────────────────────
    ╰────
-  help: Remove the "!", or wrap the left-hand side in parentheses.
+  help: Remove the `!`, or wrap the left-hand side in parentheses.


### PR DESCRIPTION
Use raw string literals and code spans in the no-confusing-non-null-assertion diagnostics so snippets and operators are easier to read.