### PR TITLE
fix(transformer/class): parent generated constructors to class scope

### DIFF
--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -213,7 +213,8 @@ impl<'a> TypeScript<'a> {
             // If there is no constructor, we need to create a default constructor
             // that initializes the public fields
             // TODO: should use `ctx.insert_scope_below_statements`, but it only accept an `ArenaVec` rather than std `Vec`.
-            let scope_id = ctx.create_child_scope_of_current(
+            let scope_id = ctx.create_child_scope(
+                class_scope_id,
                 ScopeFlags::StrictMode | ScopeFlags::Function | ScopeFlags::Constructor,
             );
             let ctor = create_class_constructor(

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 2688fbd1
 
-Passed: 236/395
+Passed: 237/395
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -659,12 +659,6 @@ after transform: ["dce"]
 rebuilt        : []
 
 * use-define-for-class-fields-without-class-properties/input.ts
-Scope parent mismatch:
-after transform: ScopeId(12): Some(ScopeId(0))
-rebuilt        : ScopeId(2): Some(ScopeId(1))
-Scope parent mismatch:
-after transform: ScopeId(17): Some(ScopeId(0))
-rebuilt        : ScopeId(12): Some(ScopeId(11))
 Unresolved reference IDs mismatch for "dce":
 after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(9), ReferenceId(12), ReferenceId(14), ReferenceId(17)]
 rebuilt        : [ReferenceId(5)]
@@ -685,7 +679,7 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (9/105)
+# legacy-decorators (10/105)
 * oxc/accessor/input.ts
 x Output mismatch
 
@@ -708,11 +702,6 @@ rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["PropertyDescriptor", "babelHelpers"]
 rebuilt        : ["babelHelpers", "property"]
-
-* oxc/accessor-use-define-for-class-fields/input.ts
-Scope parent mismatch:
-after transform: ScopeId(5): Some(ScopeId(0))
-rebuilt        : ScopeId(2): Some(ScopeId(1))
 
 * oxc/accessor-with-class-properties/input.ts
 Bindings mismatch:


### PR DESCRIPTION
## Summary
- Parent synthesized constructors for TypeScript class field lowering under the transformed class body scope instead of the current traversal scope.
- Update the transform conformance snapshot now that the generated constructor scope matches the rebuilt semantic scope.

## Details
When `useDefineForClassFields` lowering needs to synthesize a constructor, the traversal is still positioned in the scope that encloses the class. Static blocks created in the same transform already use `class_scope_id`, but generated constructors used `create_child_scope_of_current`, so their semantic parent could point outside the class.

This changes the generated constructor scope creation to use `create_child_scope(class_scope_id, ...)`, matching where the constructor actually lives in the class body.

## Example
```ts
class Cls {
  y = 1;
  [key] = 2;
}
```

Conceptually this transform creates a constructor for the hoisted field initializers:

```ts
class Cls {
  constructor() {
    this.y = 1;
    this[key] = 2;
  }
}
```

Before this change, the constructor AST was nested in `Cls`, but its semantic scope was parented to the enclosing scope:

```mermaid
flowchart TD
  Program["Program scope"] --> Class["Class body scope: Cls"]
  Program --> GeneratedCtor["Generated constructor scope"]
  Class --> StaticBlocks["Generated static blocks"]
```

After this change, the generated constructor scope is parented to the class body scope, matching the rebuilt semantic tree:

```mermaid
flowchart TD
  Program["Program scope"] --> Class["Class body scope: Cls"]
  Class --> GeneratedCtor["Generated constructor scope"]
  Class --> StaticBlocks["Generated static blocks"]
```

The same mismatch showed up in the accessor backing field fixture:

```ts
class Hello {
  private input = { foo };
  accessor util = this.input.foo();
}
```

AI assistance: OpenAI Codex was used to prepare this change.