### PR TITLE
docs(linter/react-perf): use autogenerated docs

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -3856,8 +3856,9 @@ export interface SpecOnlyConfig {
 export interface ReactPerfConfig {
   /**
    * Controls whether native elements (lowercase-first-letter tags such as `div`)
-   * are ignored by the rule. Either `"all"` to ignore the rule entirely on native
-   * elements, or an array of attribute names to ignore on native elements.
+   * are ignored by the rule. Set to `"all"` to ignore every attribute on native
+   * elements, or to an array of attribute names to ignore only those attributes
+   * on native elements.
    */
   nativeAllowList?: NativeAllowList;
 }

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_jsx_as_prop.rs
@@ -45,19 +45,6 @@ declare_oxc_lint!(
     /// ```jsx
     /// <Item callback={this.props.jsx} />
     /// ```
-    ///
-    /// ### Configuration
-    ///
-    /// This rule accepts a `nativeAllowList` option controlling whether native
-    /// elements (lowercase-first-letter tags) are ignored. Set it to `"all"` to
-    /// ignore the rule for all attributes on native elements, or to an array of
-    /// attribute names to ignore only those attributes on native elements.
-    ///
-    /// ```json
-    /// {
-    ///     "react-perf/jsx-no-jsx-as-prop": ["error", { "nativeAllowList": ["icon"] }]
-    /// }
-    /// ```
     JsxNoJsxAsProp,
     react_perf,
     perf,

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_array_as_prop.rs
@@ -53,19 +53,6 @@ declare_oxc_lint!(
     /// ```jsx
     /// <Item list={this.props.list} />
     /// ```
-    ///
-    /// ### Configuration
-    ///
-    /// This rule accepts a `nativeAllowList` option controlling whether native
-    /// elements (lowercase-first-letter tags) are ignored. Set it to `"all"` to
-    /// ignore the rule for all attributes on native elements, or to an array of
-    /// attribute names to ignore only those attributes on native elements.
-    ///
-    /// ```json
-    /// {
-    ///     "react-perf/jsx-no-new-array-as-prop": ["error", { "nativeAllowList": ["style"] }]
-    /// }
-    /// ```
     JsxNoNewArrayAsProp,
     react_perf,
     perf,

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_function_as_prop.rs
@@ -47,19 +47,6 @@ declare_oxc_lint!(
     /// ```jsx
     /// <Item callback={this.props.callback} />
     /// ```
-    ///
-    /// ### Configuration
-    ///
-    /// This rule accepts a `nativeAllowList` option controlling whether native
-    /// elements (lowercase-first-letter tags) are ignored. Set it to `"all"` to
-    /// ignore the rule for all attributes on native elements, or to an array of
-    /// attribute names to ignore only those attributes on native elements.
-    ///
-    /// ```json
-    /// {
-    ///     "react-perf/jsx-no-new-function-as-prop": ["error", { "nativeAllowList": ["onClick"] }]
-    /// }
-    /// ```
     JsxNoNewFunctionAsProp,
     react_perf,
     perf,

--- a/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
+++ b/crates/oxc_linter/src/rules/react_perf/jsx_no_new_object_as_prop.rs
@@ -54,19 +54,6 @@ declare_oxc_lint!(
     /// ```jsx
     /// <Item config={staticConfig} />
     /// ```
-    ///
-    /// ### Configuration
-    ///
-    /// This rule accepts a `nativeAllowList` option controlling whether native
-    /// elements (lowercase-first-letter tags) are ignored. Set it to `"all"` to
-    /// ignore the rule for all attributes on native elements, or to an array of
-    /// attribute names to ignore only those attributes on native elements.
-    ///
-    /// ```json
-    /// {
-    ///     "react-perf/jsx-no-new-object-as-prop": ["error", { "nativeAllowList": ["style"] }]
-    /// }
-    /// ```
     JsxNoNewObjectAsProp,
     react_perf,
     perf,

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -22,8 +22,9 @@ use crate::{
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ReactPerfConfig {
     /// Controls whether native elements (lowercase-first-letter tags such as `div`)
-    /// are ignored by the rule. Either `"all"` to ignore the rule entirely on native
-    /// elements, or an array of attribute names to ignore on native elements.
+    /// are ignored by the rule. Set to `"all"` to ignore every attribute on native
+    /// elements, or to an array of attribute names to ignore only those attributes
+    /// on native elements.
     native_allow_list: NativeAllowList,
 }
 

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -13311,13 +13311,13 @@
       "type": "object",
       "properties": {
         "nativeAllowList": {
-          "description": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Either `\"all\"` to ignore the rule entirely on native\nelements, or an array of attribute names to ignore on native elements.",
+          "description": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Set to `\"all\"` to ignore every attribute on native\nelements, or to an array of attribute names to ignore only those attributes\non native elements.",
           "allOf": [
             {
               "$ref": "#/definitions/NativeAllowList"
             }
           ],
-          "markdownDescription": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Either `\"all\"` to ignore the rule entirely on native\nelements, or an array of attribute names to ignore on native elements."
+          "markdownDescription": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Set to `\"all\"` to ignore every attribute on native\nelements, or to an array of attribute names to ignore only those attributes\non native elements."
         }
       },
       "additionalProperties": false

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -13315,13 +13315,13 @@ expression: json
       "type": "object",
       "properties": {
         "nativeAllowList": {
-          "description": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Either `\"all\"` to ignore the rule entirely on native\nelements, or an array of attribute names to ignore on native elements.",
+          "description": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Set to `\"all\"` to ignore every attribute on native\nelements, or to an array of attribute names to ignore only those attributes\non native elements.",
           "allOf": [
             {
               "$ref": "#/definitions/NativeAllowList"
             }
           ],
-          "markdownDescription": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Either `\"all\"` to ignore the rule entirely on native\nelements, or an array of attribute names to ignore on native elements."
+          "markdownDescription": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Set to `\"all\"` to ignore every attribute on native\nelements, or to an array of attribute names to ignore only those attributes\non native elements."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
these will be autogenerated, so docs in the rule documentation is unnecessary.