### PR TITLE
fix(linter/react-perf): re-generate stale snapshots

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -149,6 +149,8 @@ export type HandleCallbackErrConfig = string;
 export type ShorthandType = "always" | "methods" | "properties" | "consistent" | "consistent-as-needed" | "never";
 export type Destructuring = "any" | "all";
 export type RadixType = "always" | "as-needed";
+export type NativeAllowList = AllKeyword | string[];
+export type AllKeyword = null;
 /**
  * A forbidden prop, either as a plain prop name string or with options.
  */
@@ -1137,9 +1139,9 @@ export interface DummyRuleMap {
   "promise/spec-only"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SpecOnlyConfig];
   "promise/valid-params"?: RuleNoConfig;
   radix?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RadixType];
-  "react-perf/jsx-no-jsx-as-prop"?: RuleNoConfig;
-  "react-perf/jsx-no-new-array-as-prop"?: RuleNoConfig;
-  "react-perf/jsx-no-new-function-as-prop"?: RuleNoConfig;
+  "react-perf/jsx-no-jsx-as-prop"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ReactPerfConfig];
+  "react-perf/jsx-no-new-array-as-prop"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ReactPerfConfig];
+  "react-perf/jsx-no-new-function-as-prop"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ReactPerfConfig];
   "react-perf/jsx-no-new-object-as-prop"?: DummyRule;
   "react/button-has-type"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ButtonHasType];
   "react/checked-requires-onchange-or-readonly"?:
@@ -3850,6 +3852,14 @@ export interface SpecOnlyConfig {
    * List of Promise static methods that are allowed to be used.
    */
   allowedMethods?: string[];
+}
+export interface ReactPerfConfig {
+  /**
+   * Controls whether native elements (lowercase-first-letter tags such as `div`)
+   * are ignored by the rule. Either `"all"` to ignore the rule entirely on native
+   * elements, or an array of attribute names to ignore on native elements.
+   */
+  nativeAllowList?: NativeAllowList;
 }
 export interface ButtonHasType {
   /**

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -285,6 +285,9 @@
       },
       "additionalProperties": false
     },
+    "AllKeyword": {
+      "type": "null"
+    },
     "AllowKind": {
       "description": "Kinds of functions that can be allowed to be empty.",
       "oneOf": [
@@ -4902,13 +4905,64 @@
           ]
         },
         "react-perf/jsx-no-jsx-as-prop": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/ReactPerfConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 1
+            }
+          ]
         },
         "react-perf/jsx-no-new-array-as-prop": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/ReactPerfConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 1
+            }
+          ]
         },
         "react-perf/jsx-no-new-function-as-prop": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/ReactPerfConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 1
+            }
+          ]
         },
         "react-perf/jsx-no-new-object-as-prop": {
           "$ref": "#/definitions/DummyRule"
@@ -9822,6 +9876,19 @@
       },
       "additionalProperties": false
     },
+    "NativeAllowList": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/AllKeyword"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "NewCapConfig": {
       "type": "object",
       "properties": {
@@ -13239,6 +13306,21 @@
           "markdownDescription": "Only require the radix parameter when necessary."
         }
       ]
+    },
+    "ReactPerfConfig": {
+      "type": "object",
+      "properties": {
+        "nativeAllowList": {
+          "description": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Either `\"all\"` to ignore the rule entirely on native\nelements, or an array of attribute names to ignore on native elements.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NativeAllowList"
+            }
+          ],
+          "markdownDescription": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Either `\"all\"` to ignore the rule entirely on native\nelements, or an array of attribute names to ignore on native elements."
+        }
+      },
+      "additionalProperties": false
     },
     "ReactPluginSettings": {
       "description": "Configure React plugin rules.\n\nDerived from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc-)",

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -289,6 +289,9 @@ expression: json
       },
       "additionalProperties": false
     },
+    "AllKeyword": {
+      "type": "null"
+    },
     "AllowKind": {
       "description": "Kinds of functions that can be allowed to be empty.",
       "oneOf": [
@@ -4906,13 +4909,64 @@ expression: json
           ]
         },
         "react-perf/jsx-no-jsx-as-prop": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/ReactPerfConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 1
+            }
+          ]
         },
         "react-perf/jsx-no-new-array-as-prop": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/ReactPerfConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 1
+            }
+          ]
         },
         "react-perf/jsx-no-new-function-as-prop": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/ReactPerfConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 1
+            }
+          ]
         },
         "react-perf/jsx-no-new-object-as-prop": {
           "$ref": "#/definitions/DummyRule"
@@ -9826,6 +9880,19 @@ expression: json
       },
       "additionalProperties": false
     },
+    "NativeAllowList": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/AllKeyword"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "NewCapConfig": {
       "type": "object",
       "properties": {
@@ -13243,6 +13310,21 @@ expression: json
           "markdownDescription": "Only require the radix parameter when necessary."
         }
       ]
+    },
+    "ReactPerfConfig": {
+      "type": "object",
+      "properties": {
+        "nativeAllowList": {
+          "description": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Either `\"all\"` to ignore the rule entirely on native\nelements, or an array of attribute names to ignore on native elements.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NativeAllowList"
+            }
+          ],
+          "markdownDescription": "Controls whether native elements (lowercase-first-letter tags such as `div`)\nare ignored by the rule. Either `\"all\"` to ignore the rule entirely on native\nelements, or an array of attribute names to ignore on native elements."
+        }
+      },
+      "additionalProperties": false
     },
     "ReactPluginSettings": {
       "description": "Configure React plugin rules.\n\nDerived from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react#configuration-legacy-eslintrc-)",


### PR DESCRIPTION
this one is my bad, I merged #22996 , but it wasn't up to date with `main`.