### PR TITLE
fix(ci): exclude generated oxlint config from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@ pnpm-lock.yaml
 /apps/oxlint @camc314
 /apps/oxlint/conformance @camc314 @overlookmotel
 /apps/oxlint/src-js @camc314 @overlookmotel
+/apps/oxlint/src-js/package/config.generated.ts @camc314
 /apps/oxlint/test @camc314 @overlookmotel
 /apps/oxlint/tsdown_plugins @camc314 @overlookmotel
 


### PR DESCRIPTION
This excludes the generated oxlint config from @overlookmotel ownership because it is updated by linter config changes and creates very noisy review requests.