### PR TITLE
fix(linter/react/jsx-curly-brace-presence): avoid false positive with comment within braces

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -461,6 +461,10 @@ impl JsxCurlyBracePresence {
         parent_is_attribute: bool,
     ) {
         let Some(inner) = container.expression.as_expression() else { return };
+        if ctx.has_comments_between(container.span) {
+            return;
+        }
+
         let allowed = if parent_is_attribute { self.props } else { self.children };
         match inner {
             Expression::JSXFragment(_)
@@ -1072,6 +1076,19 @@ fn test() {
         ("<App>{`${label}`}</App>", Some(json!(["never"]))),
         (r#"<div>{`Nobody's "here"`}</div>"#, None),
         (r#"<Foo bar={`a "x" 'y'`} />;"#, Some(json!(["never"]))),
+        ("<App>{<Component>{/* keep */}</Component>}</App>", None),
+        (r"<Component name={/* This is a comment */ 'test'} />", None),
+        (
+            r"
+                    <ComponentA>
+                        {
+                            // This is another comment
+                            <ComponentB />
+                        }
+                    </ComponentA>;
+                  ",
+            None,
+        ),
     ];
 
     let fail = vec![


### PR DESCRIPTION
## Summary

`react/jsx-curly-brace-presence` now preserves JSX expression containers that include comments. Removing the braces in these cases would drop the comment, so Oxlint now treats the container as necessary, matching `eslint-plugin-react` behavior.

## Examples

These are now accepted without an unnecessary-braces diagnostic:

```tsx
<Component name={/* This is a comment */ 'test'} />;
```

```tsx
<ComponentA>
  {
    // This is an another comment
    <ComponentB />
  }
</ComponentA>;
```

Fixes #23233