### PR TITLE
feat(linter/unicorn): implement prefer-single-call rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1500,6 +1500,7 @@ export interface DummyRuleMap {
   "unicorn/prefer-response-static-json"?: RuleNoConfig;
   "unicorn/prefer-set-has"?: RuleNoConfig;
   "unicorn/prefer-set-size"?: RuleNoConfig;
+  "unicorn/prefer-single-call"?: DummyRule;
   "unicorn/prefer-spread"?: RuleNoConfig;
   "unicorn/prefer-string-raw"?: RuleNoConfig;
   "unicorn/prefer-string-replace-all"?: RuleNoConfig;

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1500,7 +1500,7 @@ export interface DummyRuleMap {
   "unicorn/prefer-response-static-json"?: RuleNoConfig;
   "unicorn/prefer-set-has"?: RuleNoConfig;
   "unicorn/prefer-set-size"?: RuleNoConfig;
-  "unicorn/prefer-single-call"?: DummyRule;
+  "unicorn/prefer-single-call"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferSingleCallConfig];
   "unicorn/prefer-spread"?: RuleNoConfig;
   "unicorn/prefer-string-raw"?: RuleNoConfig;
   "unicorn/prefer-string-replace-all"?: RuleNoConfig;
@@ -5132,6 +5132,12 @@ export interface PreferObjectFromEntriesConfig {
    * Additional functions to treat as equivalents to `Object.fromEntries`.
    */
   functions?: string[];
+}
+export interface PreferSingleCallConfig {
+  /**
+   * Methods to ignore.
+   */
+  ignore?: string[];
 }
 export interface PreferStructuredCloneConfig {
   /**

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3664,6 +3664,12 @@ impl RuleRunner for crate::rules::unicorn::prefer_set_size::PreferSetSize {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::prefer_single_call::PreferSingleCall {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ExpressionStatement]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::prefer_spread::PreferSpread {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -24644,6 +24644,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(_) => UnicornPreferResponseStaticJson::INFO,
             Self::UnicornPreferSetHas(_) => UnicornPreferSetHas::INFO,
             Self::UnicornPreferSetSize(_) => UnicornPreferSetSize::INFO,
+            Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::INFO,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::INFO,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::INFO,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::INFO,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -701,6 +701,7 @@ pub use crate::rules::unicorn::prefer_regexp_test::PreferRegexpTest as UnicornPr
 pub use crate::rules::unicorn::prefer_response_static_json::PreferResponseStaticJson as UnicornPreferResponseStaticJson;
 pub use crate::rules::unicorn::prefer_set_has::PreferSetHas as UnicornPreferSetHas;
 pub use crate::rules::unicorn::prefer_set_size::PreferSetSize as UnicornPreferSetSize;
+pub use crate::rules::unicorn::prefer_single_call::PreferSingleCall as UnicornPreferSingleCall;
 pub use crate::rules::unicorn::prefer_spread::PreferSpread as UnicornPreferSpread;
 pub use crate::rules::unicorn::prefer_string_raw::PreferStringRaw as UnicornPreferStringRaw;
 pub use crate::rules::unicorn::prefer_string_replace_all::PreferStringReplaceAll as UnicornPreferStringReplaceAll;
@@ -1411,6 +1412,7 @@ pub enum RuleEnum {
     UnicornPreferResponseStaticJson(UnicornPreferResponseStaticJson),
     UnicornPreferSetHas(UnicornPreferSetHas),
     UnicornPreferSetSize(UnicornPreferSetSize),
+    UnicornPreferSingleCall(UnicornPreferSingleCall),
     UnicornPreferSpread(UnicornPreferSpread),
     UnicornPreferStringRaw(UnicornPreferStringRaw),
     UnicornPreferStringReplaceAll(UnicornPreferStringReplaceAll),
@@ -2317,7 +2319,8 @@ const UNICORN_PREFER_REGEXP_TEST_ID: usize = UNICORN_PREFER_REFLECT_APPLY_ID + 1
 const UNICORN_PREFER_RESPONSE_STATIC_JSON_ID: usize = UNICORN_PREFER_REGEXP_TEST_ID + 1usize;
 const UNICORN_PREFER_SET_HAS_ID: usize = UNICORN_PREFER_RESPONSE_STATIC_JSON_ID + 1usize;
 const UNICORN_PREFER_SET_SIZE_ID: usize = UNICORN_PREFER_SET_HAS_ID + 1usize;
-const UNICORN_PREFER_SPREAD_ID: usize = UNICORN_PREFER_SET_SIZE_ID + 1usize;
+const UNICORN_PREFER_SINGLE_CALL_ID: usize = UNICORN_PREFER_SET_SIZE_ID + 1usize;
+const UNICORN_PREFER_SPREAD_ID: usize = UNICORN_PREFER_SINGLE_CALL_ID + 1usize;
 const UNICORN_PREFER_STRING_RAW_ID: usize = UNICORN_PREFER_SPREAD_ID + 1usize;
 const UNICORN_PREFER_STRING_REPLACE_ALL_ID: usize = UNICORN_PREFER_STRING_RAW_ID + 1usize;
 const UNICORN_PREFER_STRING_SLICE_ID: usize = UNICORN_PREFER_STRING_REPLACE_ALL_ID + 1usize;
@@ -3277,6 +3280,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(_) => UNICORN_PREFER_RESPONSE_STATIC_JSON_ID,
             Self::UnicornPreferSetHas(_) => UNICORN_PREFER_SET_HAS_ID,
             Self::UnicornPreferSetSize(_) => UNICORN_PREFER_SET_SIZE_ID,
+            Self::UnicornPreferSingleCall(_) => UNICORN_PREFER_SINGLE_CALL_ID,
             Self::UnicornPreferSpread(_) => UNICORN_PREFER_SPREAD_ID,
             Self::UnicornPreferStringRaw(_) => UNICORN_PREFER_STRING_RAW_ID,
             Self::UnicornPreferStringReplaceAll(_) => UNICORN_PREFER_STRING_REPLACE_ALL_ID,
@@ -4223,6 +4227,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(_) => UnicornPreferResponseStaticJson::NAME,
             Self::UnicornPreferSetHas(_) => UnicornPreferSetHas::NAME,
             Self::UnicornPreferSetSize(_) => UnicornPreferSetSize::NAME,
+            Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::NAME,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::NAME,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::NAME,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::NAME,
@@ -5201,6 +5206,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(_) => UnicornPreferResponseStaticJson::CATEGORY,
             Self::UnicornPreferSetHas(_) => UnicornPreferSetHas::CATEGORY,
             Self::UnicornPreferSetSize(_) => UnicornPreferSetSize::CATEGORY,
+            Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::CATEGORY,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::CATEGORY,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::CATEGORY,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::CATEGORY,
@@ -6162,6 +6168,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(_) => UnicornPreferResponseStaticJson::FIX,
             Self::UnicornPreferSetHas(_) => UnicornPreferSetHas::FIX,
             Self::UnicornPreferSetSize(_) => UnicornPreferSetSize::FIX,
+            Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::FIX,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::FIX,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::FIX,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::FIX,
@@ -7273,6 +7280,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferSetHas(_) => UnicornPreferSetHas::documentation(),
             Self::UnicornPreferSetSize(_) => UnicornPreferSetSize::documentation(),
+            Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::documentation(),
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::documentation(),
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::documentation(),
             Self::UnicornPreferStringReplaceAll(_) => {
@@ -9285,6 +9293,8 @@ impl RuleEnum {
                 .or_else(|| UnicornPreferSetHas::schema(generator)),
             Self::UnicornPreferSetSize(_) => UnicornPreferSetSize::config_schema(generator)
                 .or_else(|| UnicornPreferSetSize::schema(generator)),
+            Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::config_schema(generator)
+                .or_else(|| UnicornPreferSingleCall::schema(generator)),
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::config_schema(generator)
                 .or_else(|| UnicornPreferSpread::schema(generator)),
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::config_schema(generator)
@@ -10594,6 +10604,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(_) => "unicorn",
             Self::UnicornPreferSetHas(_) => "unicorn",
             Self::UnicornPreferSetSize(_) => "unicorn",
+            Self::UnicornPreferSingleCall(_) => "unicorn",
             Self::UnicornPreferSpread(_) => "unicorn",
             Self::UnicornPreferStringRaw(_) => "unicorn",
             Self::UnicornPreferStringReplaceAll(_) => "unicorn",
@@ -12685,6 +12696,9 @@ impl RuleEnum {
             Self::UnicornPreferSetSize(_) => {
                 Ok(Self::UnicornPreferSetSize(UnicornPreferSetSize::from_configuration(value)?))
             }
+            Self::UnicornPreferSingleCall(_) => Ok(Self::UnicornPreferSingleCall(
+                UnicornPreferSingleCall::from_configuration(value)?,
+            )),
             Self::UnicornPreferSpread(_) => {
                 Ok(Self::UnicornPreferSpread(UnicornPreferSpread::from_configuration(value)?))
             }
@@ -14093,6 +14107,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(rule) => rule.to_configuration(),
             Self::UnicornPreferSetHas(rule) => rule.to_configuration(),
             Self::UnicornPreferSetSize(rule) => rule.to_configuration(),
+            Self::UnicornPreferSingleCall(rule) => rule.to_configuration(),
             Self::UnicornPreferSpread(rule) => rule.to_configuration(),
             Self::UnicornPreferStringRaw(rule) => rule.to_configuration(),
             Self::UnicornPreferStringReplaceAll(rule) => rule.to_configuration(),
@@ -14933,6 +14948,7 @@ impl RuleEnum {
                 Self::UnicornPreferResponseStaticJson(rule) => rule.run(node, ctx),
                 Self::UnicornPreferSetHas(rule) => rule.run(node, ctx),
                 Self::UnicornPreferSetSize(rule) => rule.run(node, ctx),
+                Self::UnicornPreferSingleCall(rule) => rule.run(node, ctx),
                 Self::UnicornPreferSpread(rule) => rule.run(node, ctx),
                 Self::UnicornPreferStringRaw(rule) => rule.run(node, ctx),
                 Self::UnicornPreferStringReplaceAll(rule) => rule.run(node, ctx),
@@ -15766,6 +15782,7 @@ impl RuleEnum {
                 Self::UnicornPreferResponseStaticJson(rule) => rule.run(node, ctx),
                 Self::UnicornPreferSetHas(rule) => rule.run(node, ctx),
                 Self::UnicornPreferSetSize(rule) => rule.run(node, ctx),
+                Self::UnicornPreferSingleCall(rule) => rule.run(node, ctx),
                 Self::UnicornPreferSpread(rule) => rule.run(node, ctx),
                 Self::UnicornPreferStringRaw(rule) => rule.run(node, ctx),
                 Self::UnicornPreferStringReplaceAll(rule) => rule.run(node, ctx),
@@ -16606,6 +16623,7 @@ impl RuleEnum {
                 Self::UnicornPreferResponseStaticJson(rule) => rule.run_once(ctx),
                 Self::UnicornPreferSetHas(rule) => rule.run_once(ctx),
                 Self::UnicornPreferSetSize(rule) => rule.run_once(ctx),
+                Self::UnicornPreferSingleCall(rule) => rule.run_once(ctx),
                 Self::UnicornPreferSpread(rule) => rule.run_once(ctx),
                 Self::UnicornPreferStringRaw(rule) => rule.run_once(ctx),
                 Self::UnicornPreferStringReplaceAll(rule) => rule.run_once(ctx),
@@ -17439,6 +17457,7 @@ impl RuleEnum {
                 Self::UnicornPreferResponseStaticJson(rule) => rule.run_once(ctx),
                 Self::UnicornPreferSetHas(rule) => rule.run_once(ctx),
                 Self::UnicornPreferSetSize(rule) => rule.run_once(ctx),
+                Self::UnicornPreferSingleCall(rule) => rule.run_once(ctx),
                 Self::UnicornPreferSpread(rule) => rule.run_once(ctx),
                 Self::UnicornPreferStringRaw(rule) => rule.run_once(ctx),
                 Self::UnicornPreferStringReplaceAll(rule) => rule.run_once(ctx),
@@ -18464,6 +18483,7 @@ impl RuleEnum {
                 }
                 Self::UnicornPreferSetHas(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferSetSize(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::UnicornPreferSingleCall(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferSpread(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferStringRaw(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferStringReplaceAll(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19553,6 +19573,7 @@ impl RuleEnum {
                 }
                 Self::UnicornPreferSetHas(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferSetSize(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::UnicornPreferSingleCall(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferSpread(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferStringRaw(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferStringReplaceAll(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20458,6 +20479,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(rule) => rule.should_run(ctx),
             Self::UnicornPreferSetHas(rule) => rule.should_run(ctx),
             Self::UnicornPreferSetSize(rule) => rule.should_run(ctx),
+            Self::UnicornPreferSingleCall(rule) => rule.should_run(ctx),
             Self::UnicornPreferSpread(rule) => rule.should_run(ctx),
             Self::UnicornPreferStringRaw(rule) => rule.should_run(ctx),
             Self::UnicornPreferStringReplaceAll(rule) => rule.should_run(ctx),
@@ -21548,6 +21570,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferSetHas(_) => UnicornPreferSetHas::IS_TSGOLINT_RULE,
             Self::UnicornPreferSetSize(_) => UnicornPreferSetSize::IS_TSGOLINT_RULE,
+            Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::IS_TSGOLINT_RULE,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::IS_TSGOLINT_RULE,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::IS_TSGOLINT_RULE,
             Self::UnicornPreferStringReplaceAll(_) => {
@@ -22620,6 +22643,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(_) => UnicornPreferResponseStaticJson::VERSION,
             Self::UnicornPreferSetHas(_) => UnicornPreferSetHas::VERSION,
             Self::UnicornPreferSetSize(_) => UnicornPreferSetSize::VERSION,
+            Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::VERSION,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::VERSION,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::VERSION,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::VERSION,
@@ -23643,6 +23667,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(_) => UnicornPreferResponseStaticJson::HAS_CONFIG,
             Self::UnicornPreferSetHas(_) => UnicornPreferSetHas::HAS_CONFIG,
             Self::UnicornPreferSetSize(_) => UnicornPreferSetSize::HAS_CONFIG,
+            Self::UnicornPreferSingleCall(_) => UnicornPreferSingleCall::HAS_CONFIG,
             Self::UnicornPreferSpread(_) => UnicornPreferSpread::HAS_CONFIG,
             Self::UnicornPreferStringRaw(_) => UnicornPreferStringRaw::HAS_CONFIG,
             Self::UnicornPreferStringReplaceAll(_) => UnicornPreferStringReplaceAll::HAS_CONFIG,
@@ -25474,6 +25499,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(rule) => rule.types_info(),
             Self::UnicornPreferSetHas(rule) => rule.types_info(),
             Self::UnicornPreferSetSize(rule) => rule.types_info(),
+            Self::UnicornPreferSingleCall(rule) => rule.types_info(),
             Self::UnicornPreferSpread(rule) => rule.types_info(),
             Self::UnicornPreferStringRaw(rule) => rule.types_info(),
             Self::UnicornPreferStringReplaceAll(rule) => rule.types_info(),
@@ -26304,6 +26330,7 @@ impl RuleEnum {
             Self::UnicornPreferResponseStaticJson(rule) => rule.run_info(),
             Self::UnicornPreferSetHas(rule) => rule.run_info(),
             Self::UnicornPreferSetSize(rule) => rule.run_info(),
+            Self::UnicornPreferSingleCall(rule) => rule.run_info(),
             Self::UnicornPreferSpread(rule) => rule.run_info(),
             Self::UnicornPreferStringRaw(rule) => rule.run_info(),
             Self::UnicornPreferStringReplaceAll(rule) => rule.run_info(),
@@ -27246,6 +27273,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornPreferResponseStaticJson(UnicornPreferResponseStaticJson::default()),
         RuleEnum::UnicornPreferSetHas(UnicornPreferSetHas::default()),
         RuleEnum::UnicornPreferSetSize(UnicornPreferSetSize::default()),
+        RuleEnum::UnicornPreferSingleCall(UnicornPreferSingleCall::default()),
         RuleEnum::UnicornPreferSpread(UnicornPreferSpread::default()),
         RuleEnum::UnicornPreferStringRaw(UnicornPreferStringRaw::default()),
         RuleEnum::UnicornPreferStringReplaceAll(UnicornPreferStringReplaceAll::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -592,6 +592,7 @@ pub(crate) mod unicorn {
     pub mod prefer_response_static_json;
     pub mod prefer_set_has;
     pub mod prefer_set_size;
+    pub mod prefer_single_call;
     pub mod prefer_spread;
     pub mod prefer_string_raw;
     pub mod prefer_string_replace_all;

--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -175,6 +175,40 @@ fn same_call<'a>(a: &CallInfo<'a>, b: &CallInfo<'a>) -> bool {
     a.description == b.description && a.receiver_text == b.receiver_text
 }
 
+/// Returns `true` if `receiver` appears as a standalone identifier (or
+/// member-access chain) within `arg_src` — i.e. it is not a substring of a
+/// longer identifier.
+///
+/// Used to detect arguments like `arr.length` in `arr.push(arr.length)`,
+/// where merging two consecutive pushes would change the evaluation order of
+/// the argument (the receiver is mutated by the first call).
+fn arg_references_receiver(arg_src: &str, receiver: &str) -> bool {
+    if receiver.is_empty() {
+        return false;
+    }
+    let rbytes = receiver.as_bytes();
+    let abytes = arg_src.as_bytes();
+    let mut i = 0;
+    while i + rbytes.len() <= abytes.len() {
+        if abytes[i..].starts_with(rbytes) {
+            let before_ok =
+                i == 0 || !is_js_ident_continue(abytes[i - 1] as char);
+            let after_ok = i + rbytes.len() >= abytes.len()
+                || !is_js_ident_continue(abytes[i + rbytes.len()] as char);
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+#[inline]
+fn is_js_ident_continue(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '$'
+}
+
 impl Rule for PreferSingleCall {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         // Run on block-level containers so we can iterate statement pairs in
@@ -212,6 +246,25 @@ impl Rule for PreferSingleCall {
             let second_args = &curr_call.arguments;
             let description = curr_info.description;
             let diag_span = curr_info.diagnostic_span;
+            let receiver = prev_info.receiver_text;
+
+            // P1: Skip autofix when a second-call argument references the
+            // receiver — merging would change the evaluation order because the
+            // first call mutates the receiver before those args are read.
+            // e.g. `arr.push(1); arr.push(arr.length);`
+            let has_state_dep_args = second_args.iter().any(|a| {
+                arg_references_receiver(a.span().source_text(src), receiver)
+            });
+
+            // P2: Skip autofix when there are comments in the gap between the
+            // two statements — deleting the gap would silently drop them.
+            let has_gap_comments =
+                ctx.comments_range(first_stmt_end..second_stmt_end).count() > 0;
+
+            if has_state_dep_args || has_gap_comments {
+                ctx.diagnostic(prefer_single_call_diagnostic(diag_span, description));
+                continue;
+            }
 
             ctx.diagnostic_with_fix(
                 prefer_single_call_diagnostic(diag_span, description),
@@ -346,6 +399,12 @@ mod tests {
             // Parenthesized receiver — normalised to same identity.
             "(foo).push(1); foo.push(2);",
             "foo.push(1); (foo).push(2);",
+            // P1: second-call arg reads the receiver — merging would change
+            // evaluation order (diagnostic fires, but no autofix offered).
+            "arr.push(1); arr.push(arr.length);",
+            "arr.push(1); arr.push(arr[0]);",
+            // P2: comment in the gap — autofix would silently drop it.
+            "foo.push(1); // keep this\nfoo.push(2);",
         ];
 
         let fix = vec![

--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -79,8 +79,150 @@ declare_oxc_lint!(
     pending,
     fix,
     config = PreferSingleCallConfig,
-    version = "0.0.0",
+    version = "next"
 );
+
+
+impl Rule for PreferSingleCall {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // Match only expression statements, then look at the parent statement
+        // list to find the immediate previous sibling. This keeps the rule off
+        // non-expression-statement nodes in the generated runner.
+        let AstKind::ExpressionStatement(curr_es) = node.kind() else {
+            return;
+        };
+        let Expression::CallExpression(curr_call) = &curr_es.expression else {
+            return;
+        };
+
+        let src = ctx.source_text();
+        let Some(curr_info) = classify_call(curr_call, src, &self.0.ignore) else {
+            return;
+        };
+
+        let parent = ctx.nodes().parent_node(node.id());
+        let stmts: &[Statement<'a>] = match parent.kind() {
+            AstKind::BlockStatement(b) => &b.body,
+            AstKind::Program(p) => &p.body,
+            AstKind::FunctionBody(b) => &b.statements,
+            AstKind::StaticBlock(b) => &b.body,
+            AstKind::SwitchCase(c) => &c.consequent,
+            _ => return,
+        };
+
+        let Some(idx) = stmts.iter().position(|stmt| stmt.span() == curr_es.span) else {
+            return;
+        };
+        let Some(prev_stmt) = idx.checked_sub(1).and_then(|idx| stmts.get(idx)) else {
+            return;
+        };
+
+        let Statement::ExpressionStatement(prev_es) = prev_stmt else {
+            return;
+        };
+        let Expression::CallExpression(prev_call) = &prev_es.expression else {
+            return;
+        };
+        let Some(prev_info) = classify_call(prev_call, src, &self.0.ignore) else {
+            return;
+        };
+
+        if !same_call(&prev_info, &curr_info) {
+            return;
+        }
+
+        let first_call_span = prev_call.span;
+        let second_call_span = curr_call.span;
+        let first_stmt_start = prev_es.span.start;
+        let first_stmt_end = prev_es.span.end;
+        let second_stmt_start = curr_es.span.start;
+        let second_stmt_end = curr_es.span.end;
+        let keep_second_call = curr_info.keep_second_call;
+        let (target_call, source_args) = if keep_second_call {
+            (curr_call, &prev_call.arguments)
+        } else {
+            (prev_call, &curr_call.arguments)
+        };
+        let description = curr_info.description;
+        let diag_span = curr_info.diagnostic_span;
+        let receiver = prev_info.receiver_text;
+
+        // P1: Skip autofix when a second-call argument references the
+        // receiver — merging would change the evaluation order because the
+        // first call mutates the receiver before those args are read.
+        // e.g. `arr.push(1); arr.push(arr.length);`
+        let has_state_dep_args = curr_call
+            .arguments
+            .iter()
+            .any(|a| arg_references_receiver(a.span().source_text(src), receiver));
+
+        // P2: Skip autofix when there are comments in the gap between the
+        // two statements — deleting the gap would silently drop them.
+        let removal_span = if keep_second_call {
+            Span::new(first_stmt_start, second_stmt_start)
+        } else {
+            Span::new(first_stmt_end, second_stmt_end)
+        };
+        let has_gap_comments = ctx.comments_range(removal_span.start..removal_span.end).count() > 0;
+
+        if has_state_dep_args || has_gap_comments {
+            ctx.diagnostic(prefer_single_call_diagnostic(diag_span, description));
+            return;
+        }
+
+        ctx.diagnostic_with_fix(prefer_single_call_diagnostic(diag_span, description), |fixer| {
+            let mut fix = fixer
+                .new_fix_with_capacity(2)
+                .with_message(format!("Merge into previous `{description}` call"));
+
+            // Insert the source call's arguments into the target call.
+            if !source_args.is_empty() {
+                let args_text = source_args
+                    .iter()
+                    .map(|a| a.span().source_text(src))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                // Determine separator. Check whether the target call ends with a
+                // trailing comma (like `push(a,)`) to avoid generating `push(a,, b)`.
+                let target_src = target_call.span.source_text(src);
+                let before_paren = target_src[..target_src.len().saturating_sub(1)].trim_end();
+                let separator = if target_call.arguments.is_empty() {
+                    ""
+                } else if before_paren.ends_with(',') {
+                    " "
+                } else {
+                    ", "
+                };
+
+                // Replace the closing ')' of the target call with `{sep}{args})`.
+                let target_span = if keep_second_call { second_call_span } else { first_call_span };
+                let close_paren = Span::new(target_span.end - 1, target_span.end);
+                fix.push(Fix::new(format!("{separator}{args_text})"), close_paren));
+            }
+
+            // Delete the second statement (from end of first stmt to end of
+            // second stmt, including any whitespace/newline in between).
+            //
+            // ASI handling: if the first statement has no semicolon but the
+            // second does, preserve the semicolon so the result stays valid.
+            let first_has_semi = prev_es.span.source_text(src).trim_end().ends_with(';');
+            let second_has_semi = curr_es.span.source_text(src).trim_end().ends_with(';');
+            if !keep_second_call && !first_has_semi && second_has_semi {
+                fix.push(Fix::new(";", removal_span));
+            } else {
+                fix.push(Fix::delete(removal_span));
+            }
+
+            fix
+        });
+    }
+}
+
 
 /// Callee source-text patterns to ignore for `Array#{push,unshift}`.
 const DEFAULT_ARRAY_MUTATION_IGNORE: &[&str] = &[
@@ -252,146 +394,6 @@ fn arg_references_receiver(arg_src: &str, receiver: &str) -> bool {
 #[inline]
 fn is_js_ident_continue(c: char) -> bool {
     c.is_alphanumeric() || c == '_' || c == '$'
-}
-
-impl Rule for PreferSingleCall {
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
-    }
-
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // Match only expression statements, then look at the parent statement
-        // list to find the immediate previous sibling. This keeps the rule off
-        // non-expression-statement nodes in the generated runner.
-        let AstKind::ExpressionStatement(curr_es) = node.kind() else {
-            return;
-        };
-        let Expression::CallExpression(curr_call) = &curr_es.expression else {
-            return;
-        };
-
-        let src = ctx.source_text();
-        let Some(curr_info) = classify_call(curr_call, src, &self.0.ignore) else {
-            return;
-        };
-
-        let parent = ctx.nodes().parent_node(node.id());
-        let stmts: &[Statement<'a>] = match parent.kind() {
-            AstKind::BlockStatement(b) => &b.body,
-            AstKind::Program(p) => &p.body,
-            AstKind::FunctionBody(b) => &b.statements,
-            AstKind::StaticBlock(b) => &b.body,
-            AstKind::SwitchCase(c) => &c.consequent,
-            _ => return,
-        };
-
-        let Some(idx) = stmts.iter().position(|stmt| stmt.span() == curr_es.span) else {
-            return;
-        };
-        let Some(prev_stmt) = idx.checked_sub(1).and_then(|idx| stmts.get(idx)) else {
-            return;
-        };
-
-        let Statement::ExpressionStatement(prev_es) = prev_stmt else {
-            return;
-        };
-        let Expression::CallExpression(prev_call) = &prev_es.expression else {
-            return;
-        };
-        let Some(prev_info) = classify_call(prev_call, src, &self.0.ignore) else {
-            return;
-        };
-
-        if !same_call(&prev_info, &curr_info) {
-            return;
-        }
-
-        let first_call_span = prev_call.span;
-        let second_call_span = curr_call.span;
-        let first_stmt_start = prev_es.span.start;
-        let first_stmt_end = prev_es.span.end;
-        let second_stmt_start = curr_es.span.start;
-        let second_stmt_end = curr_es.span.end;
-        let keep_second_call = curr_info.keep_second_call;
-        let (target_call, source_args) = if keep_second_call {
-            (curr_call, &prev_call.arguments)
-        } else {
-            (prev_call, &curr_call.arguments)
-        };
-        let description = curr_info.description;
-        let diag_span = curr_info.diagnostic_span;
-        let receiver = prev_info.receiver_text;
-
-        // P1: Skip autofix when a second-call argument references the
-        // receiver — merging would change the evaluation order because the
-        // first call mutates the receiver before those args are read.
-        // e.g. `arr.push(1); arr.push(arr.length);`
-        let has_state_dep_args = curr_call
-            .arguments
-            .iter()
-            .any(|a| arg_references_receiver(a.span().source_text(src), receiver));
-
-        // P2: Skip autofix when there are comments in the gap between the
-        // two statements — deleting the gap would silently drop them.
-        let removal_span = if keep_second_call {
-            Span::new(first_stmt_start, second_stmt_start)
-        } else {
-            Span::new(first_stmt_end, second_stmt_end)
-        };
-        let has_gap_comments = ctx.comments_range(removal_span.start..removal_span.end).count() > 0;
-
-        if has_state_dep_args || has_gap_comments {
-            ctx.diagnostic(prefer_single_call_diagnostic(diag_span, description));
-            return;
-        }
-
-        ctx.diagnostic_with_fix(prefer_single_call_diagnostic(diag_span, description), |fixer| {
-            let mut fix = fixer
-                .new_fix_with_capacity(2)
-                .with_message(format!("Merge into previous `{description}` call"));
-
-            // Insert the source call's arguments into the target call.
-            if !source_args.is_empty() {
-                let args_text = source_args
-                    .iter()
-                    .map(|a| a.span().source_text(src))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                // Determine separator. Check whether the target call ends with a
-                // trailing comma (like `push(a,)`) to avoid generating `push(a,, b)`.
-                let target_src = target_call.span.source_text(src);
-                let before_paren = target_src[..target_src.len().saturating_sub(1)].trim_end();
-                let separator = if target_call.arguments.is_empty() {
-                    ""
-                } else if before_paren.ends_with(',') {
-                    " "
-                } else {
-                    ", "
-                };
-
-                // Replace the closing ')' of the target call with `{sep}{args})`.
-                let target_span = if keep_second_call { second_call_span } else { first_call_span };
-                let close_paren = Span::new(target_span.end - 1, target_span.end);
-                fix.push(Fix::new(format!("{separator}{args_text})"), close_paren));
-            }
-
-            // Delete the second statement (from end of first stmt to end of
-            // second stmt, including any whitespace/newline in between).
-            //
-            // ASI handling: if the first statement has no semicolon but the
-            // second does, preserve the semicolon so the result stays valid.
-            let first_has_semi = prev_es.span.source_text(src).trim_end().ends_with(';');
-            let second_has_semi = curr_es.span.source_text(src).trim_end().ends_with(';');
-            if !keep_second_call && !first_has_semi && second_has_semi {
-                fix.push(Fix::new(";", removal_span));
-            } else {
-                fix.push(Fix::delete(removal_span));
-            }
-
-            fix
-        });
-    }
 }
 
 #[cfg(test)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -120,7 +120,7 @@ fn classify_call<'a>(call: &'a CallExpression<'a>, src: &'a str) -> Option<CallI
                     if PUSH_IGNORE.contains(&callee_text) {
                         return None;
                     }
-                    let receiver_text = member.object.span().source_text(src);
+                    let receiver_text = member.object.without_parentheses().span().source_text(src);
                     Some(CallInfo {
                         description: "Array#push()",
                         receiver_text,
@@ -141,7 +141,7 @@ fn classify_call<'a>(call: &'a CallExpression<'a>, src: &'a str) -> Option<CallI
                     if !is_stable_receiver(&obj_member.object) {
                         return None;
                     }
-                    let receiver_text = obj_member.object.span().source_text(src);
+                    let receiver_text = obj_member.object.without_parentheses().span().source_text(src);
                     let description = if method == "add" {
                         "Element#classList.add()"
                     } else {
@@ -177,23 +177,9 @@ fn same_call<'a>(a: &CallInfo<'a>, b: &CallInfo<'a>) -> bool {
 
 impl Rule for PreferSingleCall {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // Match ExpressionStatements so we can delete the entire second statement.
-        let AstKind::ExpressionStatement(expr_stmt) = node.kind() else {
-            return;
-        };
-
-        let Expression::CallExpression(call) = &expr_stmt.expression else {
-            return;
-        };
-
-        let src = ctx.source_text();
-        let Some(info) = classify_call(call, src) else {
-            return;
-        };
-
-        // Locate the previous sibling statement in the parent block.
-        let parent = ctx.nodes().parent_node(node.id());
-        let stmts: &[Statement<'a>] = match parent.kind() {
+        // Run on block-level containers so we can iterate statement pairs in
+        // O(n) with `windows(2)` rather than doing O(n) work per statement.
+        let stmts: &[Statement<'a>] = match node.kind() {
             AstKind::BlockStatement(b) => &b.body,
             AstKind::Program(p) => &p.body,
             AstKind::FunctionBody(b) => &b.statements,
@@ -202,81 +188,85 @@ impl Rule for PreferSingleCall {
             _ => return,
         };
 
-        let Some(idx) = stmts.iter().position(|s| s.span() == expr_stmt.span) else {
-            return;
-        };
+        let src = ctx.source_text();
 
-        if idx == 0 {
-            return;
-        }
+        for window in stmts.windows(2) {
+            let (prev_stmt, curr_stmt) = (&window[0], &window[1]);
 
-        let Statement::ExpressionStatement(prev_es) = &stmts[idx - 1] else {
-            return;
-        };
-        let Expression::CallExpression(prev_call) = &prev_es.expression else {
-            return;
-        };
-        let Some(prev_info) = classify_call(prev_call, src) else {
-            return;
-        };
+            let Statement::ExpressionStatement(prev_es) = prev_stmt else { continue; };
+            let Statement::ExpressionStatement(curr_es) = curr_stmt else { continue; };
 
-        if !same_call(&info, &prev_info) {
-            return;
-        }
+            let Expression::CallExpression(prev_call) = &prev_es.expression else { continue; };
+            let Expression::CallExpression(curr_call) = &curr_es.expression else { continue; };
 
-        let first_call_span = prev_call.span;
-        let first_stmt_end = prev_es.span.end;
-        let second_stmt_end = expr_stmt.span.end;
-        let second_args = &call.arguments;
-        let description = info.description;
-        let diag_span = info.diagnostic_span;
+            let Some(prev_info) = classify_call(prev_call, src) else { continue; };
+            let Some(curr_info) = classify_call(curr_call, src) else { continue; };
 
-        ctx.diagnostic_with_fix(prefer_single_call_diagnostic(diag_span, description), |fixer| {
-            let mut fix = fixer
-                .new_fix_with_capacity(2)
-                .with_message(format!("Merge into previous `{description}` call"));
-
-            // If the second call has arguments, insert them into the first call.
-            if !second_args.is_empty() {
-                let args_text = second_args
-                    .iter()
-                    .map(|a| a.span().source_text(src))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-
-                // Determine separator. Check whether the first call ends with a
-                // trailing comma (like `push(a,)`) to avoid generating `push(a,, b)`.
-                let first_src = first_call_span.source_text(src);
-                let before_paren = first_src[..first_src.len().saturating_sub(1)].trim_end();
-                let separator = if prev_call.arguments.is_empty() {
-                    ""
-                } else if before_paren.ends_with(',') {
-                    " "
-                } else {
-                    ", "
-                };
-
-                // Replace the closing ')' of the first call with `{sep}{args})`.
-                let close_paren = Span::new(first_call_span.end - 1, first_call_span.end);
-                fix.push(Fix::new(format!("{separator}{args_text})"), close_paren));
+            if !same_call(&prev_info, &curr_info) {
+                continue;
             }
 
-            // Delete the second statement (everything from end of first stmt to
-            // end of second stmt, including any whitespace/newline in between).
-            //
-            // ASI safety: if the first statement has no semicolon but the second
-            // does, preserve the semicolon so the merged result stays valid.
-            let first_has_semi = prev_es.span.source_text(src).trim_end().ends_with(';');
-            let second_has_semi = expr_stmt.span.source_text(src).trim_end().ends_with(';');
-            let gap_span = Span::new(first_stmt_end, second_stmt_end);
-            if !first_has_semi && second_has_semi {
-                fix.push(Fix::new(";", gap_span));
-            } else {
-                fix.push(Fix::delete(gap_span));
-            }
+            let first_call_span = prev_call.span;
+            let first_stmt_end = prev_es.span.end;
+            let second_stmt_end = curr_es.span.end;
+            let second_args = &curr_call.arguments;
+            let description = curr_info.description;
+            let diag_span = curr_info.diagnostic_span;
 
-            fix
-        });
+            ctx.diagnostic_with_fix(
+                prefer_single_call_diagnostic(diag_span, description),
+                |fixer| {
+                    let mut fix = fixer
+                        .new_fix_with_capacity(2)
+                        .with_message(format!("Merge into previous `{description}` call"));
+
+                    // If the second call has arguments, insert them into the first call.
+                    if !second_args.is_empty() {
+                        let args_text = second_args
+                            .iter()
+                            .map(|a| a.span().source_text(src))
+                            .collect::<Vec<_>>()
+                            .join(", ");
+
+                        // Determine separator. Check whether the first call ends with a
+                        // trailing comma (like `push(a,)`) to avoid generating `push(a,, b)`.
+                        let first_src = first_call_span.source_text(src);
+                        let before_paren =
+                            first_src[..first_src.len().saturating_sub(1)].trim_end();
+                        let separator = if prev_call.arguments.is_empty() {
+                            ""
+                        } else if before_paren.ends_with(',') {
+                            " "
+                        } else {
+                            ", "
+                        };
+
+                        // Replace the closing ')' of the first call with `{sep}{args})`.
+                        let close_paren =
+                            Span::new(first_call_span.end - 1, first_call_span.end);
+                        fix.push(Fix::new(format!("{separator}{args_text})"), close_paren));
+                    }
+
+                    // Delete the second statement (from end of first stmt to end of
+                    // second stmt, including any whitespace/newline in between).
+                    //
+                    // ASI safety: if the first statement has no semicolon but the
+                    // second does, preserve the semicolon so the result stays valid.
+                    let first_has_semi =
+                        prev_es.span.source_text(src).trim_end().ends_with(';');
+                    let second_has_semi =
+                        curr_es.span.source_text(src).trim_end().ends_with(';');
+                    let gap_span = Span::new(first_stmt_end, second_stmt_end);
+                    if !first_has_semi && second_has_semi {
+                        fix.push(Fix::new(";", gap_span));
+                    } else {
+                        fix.push(Fix::delete(gap_span));
+                    }
+
+                    fix
+                },
+            );
+        }
     }
 }
 
@@ -353,6 +343,9 @@ mod tests {
             "this.arr.push(1); this.arr.push(2);",
             // Three consecutive calls — fires on each consecutive pair.
             "foo.push(1); foo.push(2); foo.push(3);",
+            // Parenthesized receiver — normalised to same identity.
+            "(foo).push(1); foo.push(2);",
+            "foo.push(1); (foo).push(2);",
         ];
 
         let fix = vec![
@@ -376,6 +369,9 @@ mod tests {
             ("this.arr.push(1); this.arr.push(2);", "this.arr.push(1, 2);"),
             // Three calls: first fix merges calls 1+2; the third call is left for the next pass.
             ("foo.push(1); foo.push(2); foo.push(3);", "foo.push(1, 2); foo.push(3);"),
+            // Parenthesized receiver — keeps the paren form of whichever call is first.
+            ("(foo).push(1); foo.push(2);", "(foo).push(1, 2);"),
+            ("foo.push(1); (foo).push(2);", "foo.push(1, 2);"),
         ];
 
         Tester::new(PreferSingleCall::NAME, PreferSingleCall::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -5,8 +5,15 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
-use crate::{AstNode, context::LintContext, fixer::Fix, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    fixer::Fix,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn prefer_single_call_diagnostic(span: Span, description: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Do not call `{description}` multiple times."))
@@ -14,14 +21,22 @@ fn prefer_single_call_diagnostic(span: Span, description: &str) -> OxcDiagnostic
         .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct PreferSingleCall;
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub struct PreferSingleCallConfig {
+    /// Methods to ignore.
+    #[serde(default)]
+    ignore: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct PreferSingleCall(Box<PreferSingleCallConfig>);
 
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforces combining multiple `Array#push()`, `Element#classList.{add,remove}()`,
-    /// and `importScripts()` into a single call.
+    /// Enforces combining multiple `Array#{push,unshift}()`,
+    /// `Element#classList.{add,remove}()`, and `importScripts()` into a single call.
     ///
     /// Supersedes the deprecated `unicorn/no-array-push-push` rule.
     ///
@@ -38,6 +53,9 @@ declare_oxc_lint!(
     /// foo.push(1);
     /// foo.push(2);
     ///
+    /// foo.unshift(1);
+    /// foo.unshift(2);
+    ///
     /// element.classList.add('foo');
     /// element.classList.add('bar');
     ///
@@ -49,6 +67,8 @@ declare_oxc_lint!(
     /// ```javascript
     /// foo.push(1, 2);
     ///
+    /// foo.unshift(2, 1);
+    ///
     /// element.classList.add('foo', 'bar');
     ///
     /// importScripts('foo.js', 'bar.js');
@@ -58,17 +78,24 @@ declare_oxc_lint!(
     pedantic,
     pending,
     fix,
+    config = PreferSingleCallConfig,
     version = "0.0.0",
 );
 
-/// Callee source-text patterns to ignore for `Array#push`.
-const PUSH_IGNORE: &[&str] = &[
+/// Callee source-text patterns to ignore for `Array#{push,unshift}`.
+const DEFAULT_ARRAY_MUTATION_IGNORE: &[&str] = &[
     "stream.push",
     "this.push",
     "this.stream.push",
     "process.stdin.push",
     "process.stdout.push",
     "process.stderr.push",
+    "stream.unshift",
+    "this.unshift",
+    "this.stream.unshift",
+    "process.stdin.unshift",
+    "process.stdout.unshift",
+    "process.stderr.unshift",
 ];
 
 /// Information extracted from a matched call expression.
@@ -82,6 +109,10 @@ struct CallInfo<'a> {
     receiver_text: &'a str,
     /// Span to attach the diagnostic label to (the method name identifier).
     diagnostic_span: Span,
+    /// Whether to keep the second call and merge the first call's arguments
+    /// into it. This is required for `unshift`, where call order affects the
+    /// final array order.
+    keep_second_call: bool,
 }
 
 /// Returns `true` if `expr` is a "stable" receiver — an expression whose
@@ -98,13 +129,17 @@ fn is_stable_receiver(expr: &Expression<'_>) -> bool {
 
 /// If `call` matches one of the tracked patterns, return its [`CallInfo`];
 /// otherwise return `None`.
-fn classify_call<'a>(call: &'a CallExpression<'a>, src: &'a str) -> Option<CallInfo<'a>> {
+fn classify_call<'a>(
+    call: &'a CallExpression<'a>,
+    src: &'a str,
+    ignored_callees: &[String],
+) -> Option<CallInfo<'a>> {
     if call.optional {
         return None;
     }
 
     match call.callee.without_parentheses() {
-        // `receiver.push(...)`, `el.classList.add(...)`, `el.classList.remove(...)`
+        // `receiver.push/unshift(...)`, `el.classList.add(...)`, `el.classList.remove(...)`
         Expression::StaticMemberExpression(member) => {
             if member.optional {
                 return None;
@@ -112,19 +147,27 @@ fn classify_call<'a>(call: &'a CallExpression<'a>, src: &'a str) -> Option<CallI
             let method = member.property.name.as_str();
 
             match method {
-                "push" => {
+                "push" | "unshift" => {
                     if !is_stable_receiver(&member.object) {
                         return None;
                     }
                     let callee_text = call.callee.span().source_text(src);
-                    if PUSH_IGNORE.contains(&callee_text) {
+                    if DEFAULT_ARRAY_MUTATION_IGNORE.contains(&callee_text)
+                        || ignored_callees.iter().any(|ignored| ignored == callee_text)
+                    {
                         return None;
                     }
                     let receiver_text = member.object.without_parentheses().span().source_text(src);
+                    let (description, keep_second_call) = if method == "push" {
+                        ("Array#push()", false)
+                    } else {
+                        ("Array#unshift()", true)
+                    };
                     Some(CallInfo {
-                        description: "Array#push()",
+                        description,
                         receiver_text,
                         diagnostic_span: member.property.span,
+                        keep_second_call,
                     })
                 }
 
@@ -152,6 +195,7 @@ fn classify_call<'a>(call: &'a CallExpression<'a>, src: &'a str) -> Option<CallI
                         description,
                         receiver_text,
                         diagnostic_span: member.property.span,
+                        keep_second_call: false,
                     })
                 }
 
@@ -164,6 +208,7 @@ fn classify_call<'a>(call: &'a CallExpression<'a>, src: &'a str) -> Option<CallI
             description: "importScripts()",
             receiver_text: "importScripts",
             diagnostic_span: ident.span,
+            keep_second_call: false,
         }),
 
         _ => None,
@@ -210,6 +255,10 @@ fn is_js_ident_continue(c: char) -> bool {
 }
 
 impl Rule for PreferSingleCall {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         // Match only expression statements, then look at the parent statement
         // list to find the immediate previous sibling. This keeps the rule off
@@ -222,7 +271,7 @@ impl Rule for PreferSingleCall {
         };
 
         let src = ctx.source_text();
-        let Some(curr_info) = classify_call(curr_call, src) else {
+        let Some(curr_info) = classify_call(curr_call, src, &self.0.ignore) else {
             return;
         };
 
@@ -249,7 +298,7 @@ impl Rule for PreferSingleCall {
         let Expression::CallExpression(prev_call) = &prev_es.expression else {
             return;
         };
-        let Some(prev_info) = classify_call(prev_call, src) else {
+        let Some(prev_info) = classify_call(prev_call, src, &self.0.ignore) else {
             return;
         };
 
@@ -258,9 +307,17 @@ impl Rule for PreferSingleCall {
         }
 
         let first_call_span = prev_call.span;
+        let second_call_span = curr_call.span;
+        let first_stmt_start = prev_es.span.start;
         let first_stmt_end = prev_es.span.end;
+        let second_stmt_start = curr_es.span.start;
         let second_stmt_end = curr_es.span.end;
-        let second_args = &curr_call.arguments;
+        let keep_second_call = curr_info.keep_second_call;
+        let (target_call, source_args) = if keep_second_call {
+            (curr_call, &prev_call.arguments)
+        } else {
+            (prev_call, &curr_call.arguments)
+        };
         let description = curr_info.description;
         let diag_span = curr_info.diagnostic_span;
         let receiver = prev_info.receiver_text;
@@ -269,13 +326,19 @@ impl Rule for PreferSingleCall {
         // receiver — merging would change the evaluation order because the
         // first call mutates the receiver before those args are read.
         // e.g. `arr.push(1); arr.push(arr.length);`
-        let has_state_dep_args = second_args
+        let has_state_dep_args = curr_call
+            .arguments
             .iter()
             .any(|a| arg_references_receiver(a.span().source_text(src), receiver));
 
         // P2: Skip autofix when there are comments in the gap between the
         // two statements — deleting the gap would silently drop them.
-        let has_gap_comments = ctx.comments_range(first_stmt_end..second_stmt_end).count() > 0;
+        let removal_span = if keep_second_call {
+            Span::new(first_stmt_start, second_stmt_start)
+        } else {
+            Span::new(first_stmt_end, second_stmt_end)
+        };
+        let has_gap_comments = ctx.comments_range(removal_span.start..removal_span.end).count() > 0;
 
         if has_state_dep_args || has_gap_comments {
             ctx.diagnostic(prefer_single_call_diagnostic(diag_span, description));
@@ -287,19 +350,19 @@ impl Rule for PreferSingleCall {
                 .new_fix_with_capacity(2)
                 .with_message(format!("Merge into previous `{description}` call"));
 
-            // If the second call has arguments, insert them into the first call.
-            if !second_args.is_empty() {
-                let args_text = second_args
+            // Insert the source call's arguments into the target call.
+            if !source_args.is_empty() {
+                let args_text = source_args
                     .iter()
                     .map(|a| a.span().source_text(src))
                     .collect::<Vec<_>>()
                     .join(", ");
 
-                // Determine separator. Check whether the first call ends with a
+                // Determine separator. Check whether the target call ends with a
                 // trailing comma (like `push(a,)`) to avoid generating `push(a,, b)`.
-                let first_src = first_call_span.source_text(src);
-                let before_paren = first_src[..first_src.len().saturating_sub(1)].trim_end();
-                let separator = if prev_call.arguments.is_empty() {
+                let target_src = target_call.span.source_text(src);
+                let before_paren = target_src[..target_src.len().saturating_sub(1)].trim_end();
+                let separator = if target_call.arguments.is_empty() {
                     ""
                 } else if before_paren.ends_with(',') {
                     " "
@@ -307,8 +370,9 @@ impl Rule for PreferSingleCall {
                     ", "
                 };
 
-                // Replace the closing ')' of the first call with `{sep}{args})`.
-                let close_paren = Span::new(first_call_span.end - 1, first_call_span.end);
+                // Replace the closing ')' of the target call with `{sep}{args})`.
+                let target_span = if keep_second_call { second_call_span } else { first_call_span };
+                let close_paren = Span::new(target_span.end - 1, target_span.end);
                 fix.push(Fix::new(format!("{separator}{args_text})"), close_paren));
             }
 
@@ -319,11 +383,10 @@ impl Rule for PreferSingleCall {
             // second does, preserve the semicolon so the result stays valid.
             let first_has_semi = prev_es.span.source_text(src).trim_end().ends_with(';');
             let second_has_semi = curr_es.span.source_text(src).trim_end().ends_with(';');
-            let gap_span = Span::new(first_stmt_end, second_stmt_end);
-            if !first_has_semi && second_has_semi {
-                fix.push(Fix::new(";", gap_span));
+            if !keep_second_call && !first_has_semi && second_has_semi {
+                fix.push(Fix::new(";", removal_span));
             } else {
-                fix.push(Fix::delete(gap_span));
+                fix.push(Fix::delete(removal_span));
             }
 
             fix
@@ -333,7 +396,7 @@ impl Rule for PreferSingleCall {
 
 #[cfg(test)]
 mod tests {
-    use crate::tester::Tester;
+    use crate::tester::{TestCase, Tester};
 
     use super::*;
 
@@ -359,6 +422,12 @@ mod tests {
             "process.stdout.push(1); process.stdout.push(2);",
             "process.stderr.push(1); process.stderr.push(2);",
             "this.stream.push(1); this.stream.push(2);",
+            "stream.unshift(1); stream.unshift(2);",
+            "this.unshift(1); this.unshift(2);",
+            "this.stream.unshift(1); this.stream.unshift(2);",
+            "process.stdin.unshift(1); process.stdin.unshift(2);",
+            "process.stdout.unshift(1); process.stdout.unshift(2);",
+            "process.stderr.unshift(1); process.stderr.unshift(2);",
             // classList on different elements.
             "a.classList.add('x'); b.classList.add('y');",
             // add vs remove — different method.
@@ -390,6 +459,11 @@ mod tests {
             "foo.push(1)\nfoo.push(2);",
             // Spread argument.
             "foo.push(...a); foo.push(...b);",
+            // Array#unshift keeps the second call and prepends the first call's args.
+            "foo.unshift(1); foo.unshift(2);",
+            "foo.unshift(1, 2); foo.unshift(3, 4);",
+            "foo.unshift(1); foo.unshift();",
+            "foo.unshift(); foo.unshift(1);",
             // classList.add.
             "el.classList.add('foo'); el.classList.add('bar');",
             // classList.remove.
@@ -425,6 +499,10 @@ mod tests {
             // ASI: semicolon from second statement is preserved.
             ("foo.push(1)\nfoo.push(2);", "foo.push(1, 2);"),
             ("foo.push(...a); foo.push(...b);", "foo.push(...a, ...b);"),
+            ("foo.unshift(1); foo.unshift(2);", "foo.unshift(2, 1);"),
+            ("foo.unshift(1, 2); foo.unshift(3, 4);", "foo.unshift(3, 4, 1, 2);"),
+            ("foo.unshift(1); foo.unshift();", "foo.unshift(1);"),
+            ("foo.unshift(); foo.unshift(1);", "foo.unshift(1);"),
             (
                 "el.classList.add('foo'); el.classList.add('bar');",
                 "el.classList.add('foo', 'bar');",
@@ -443,6 +521,18 @@ mod tests {
             ("(foo).push(1); foo.push(2);", "(foo).push(1, 2);"),
             ("foo.push(1); (foo).push(2);", "foo.push(1, 2);"),
         ];
+
+        let mut pass = pass.into_iter().map(TestCase::from).collect::<Vec<_>>();
+        pass.extend([
+            ("foo.push(1); foo.push(2);", Some(serde_json::json!([{ "ignore": ["foo.push"] }])))
+                .into(),
+            (
+                "foo.unshift(1); foo.unshift(2);",
+                Some(serde_json::json!([{ "ignore": ["foo.unshift"] }])),
+            )
+                .into(),
+        ]);
+        let fail = fail.into_iter().map(TestCase::from).collect::<Vec<_>>();
 
         Tester::new(PreferSingleCall::NAME, PreferSingleCall::PLUGIN, pass, fail)
             .expect_fix(fix)

--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -87,13 +87,11 @@ struct CallInfo<'a> {
 /// Returns `true` if `expr` is a "stable" receiver — an expression whose
 /// value cannot be changed by a function call side-effect between two
 /// consecutive statements. We accept identifiers, `this`, and chains of
-/// static member accesses built from those primitives.
+/// static (non-computed) member accesses built from those primitives.
 fn is_stable_receiver(expr: &Expression<'_>) -> bool {
     match expr.without_parentheses() {
         Expression::Identifier(_) | Expression::ThisExpression(_) => true,
-        Expression::StaticMemberExpression(m) if !m.optional => {
-            is_stable_receiver(&m.object)
-        }
+        Expression::StaticMemberExpression(m) if !m.optional => is_stable_receiver(&m.object),
         _ => false,
     }
 }
@@ -171,8 +169,8 @@ fn classify_call<'a>(call: &'a CallExpression<'a>, src: &'a str) -> Option<CallI
     }
 }
 
-/// Returns `true` when `a` and `b` represent the same mergeable call pattern
-/// (same method type on the same stable receiver).
+/// Returns `true` when `a` and `b` represent the same mergeable call
+/// (same method type, same stable receiver).
 fn same_call<'a>(a: &CallInfo<'a>, b: &CallInfo<'a>) -> bool {
     a.description == b.description && a.receiver_text == b.receiver_text
 }
@@ -249,7 +247,6 @@ impl Rule for PreferSingleCall {
                 // Determine separator. Check whether the first call ends with a
                 // trailing comma (like `push(a,)`) to avoid generating `push(a,, b)`.
                 let first_src = first_call_span.source_text(src);
-                // Trim the closing ')' then check for trailing comma.
                 let before_paren = first_src[..first_src.len().saturating_sub(1)].trim_end();
                 let separator = if prev_call.arguments.is_empty() {
                     ""
@@ -264,9 +261,19 @@ impl Rule for PreferSingleCall {
                 fix.push(Fix::new(format!("{separator}{args_text})"), close_paren));
             }
 
-            // Delete the second statement entirely (from end of first stmt to
-            // end of second stmt, including the whitespace/newline in between).
-            fix.push(Fix::delete(Span::new(first_stmt_end, second_stmt_end)));
+            // Delete the second statement (everything from end of first stmt to
+            // end of second stmt, including any whitespace/newline in between).
+            //
+            // ASI safety: if the first statement has no semicolon but the second
+            // does, preserve the semicolon so the merged result stays valid.
+            let first_has_semi = prev_es.span.source_text(src).trim_end().ends_with(';');
+            let second_has_semi = expr_stmt.span.source_text(src).trim_end().ends_with(';');
+            let gap_span = Span::new(first_stmt_end, second_stmt_end);
+            if !first_has_semi && second_has_semi {
+                fix.push(Fix::new(";", gap_span));
+            } else {
+                fix.push(Fix::delete(gap_span));
+            }
 
             fix
         });
@@ -284,46 +291,54 @@ mod tests {
         let pass = vec![
             // Already a single call.
             "foo.push(1, 2);",
-            // Different methods — not mergeable.
+            // Different methods.
             "foo.push(1); foo.pop();",
-            // Different receivers — not mergeable.
+            // Different receivers.
             "foo.push(1); bar.push(2);",
-            // Not consecutive — something in between.
+            // Non-consecutive (something in between).
             "foo.push(1); console.log(x); foo.push(2);",
             // Optional call — skip.
             "foo.push?.(1); foo.push?.(2);",
             // Optional member — skip.
             "foo?.push(1); foo?.push(2);",
-            // Ignored push receivers.
+            // Ignored push callee patterns.
             "this.push(1); this.push(2);",
             "stream.push(1); stream.push(2);",
             "process.stdin.push(1); process.stdin.push(2);",
             "process.stdout.push(1); process.stdout.push(2);",
             "process.stderr.push(1); process.stderr.push(2);",
             "this.stream.push(1); this.stream.push(2);",
-            // classList on different elements — not mergeable.
+            // classList on different elements.
             "a.classList.add('x'); b.classList.add('y');",
-            // classList.add vs classList.remove — different method.
+            // add vs remove — different method.
             "el.classList.add('x'); el.classList.remove('y');",
-            // importScripts with non-consecutive calls.
+            // importScripts with a statement in between.
             "importScripts('a.js'); doSomething(); importScripts('b.js');",
-            // Unstable receiver (function call) — skip.
+            // Unstable receiver (function call result may differ).
             "getArr().push(1); getArr().push(2);",
+            // Computed member access — receiver identity not guaranteed.
+            "a[0].push(1); a[0].push(2);",
+            // .add that is not classList.add.
+            "foo.add(1); foo.add(2);",
         ];
 
         let fail = vec![
-            // Basic push.
+            // Basic Array#push.
             "foo.push(1); foo.push(2);",
-            // push with multiple args.
+            // push with multiple args on each side.
             "foo.push(1, 2); foo.push(3, 4);",
-            // Second call has no args — deletes redundant call.
+            // Second call has no args (redundant call is removed).
             "foo.push(1); foo.push();",
             // First call has no args.
             "foo.push(); foo.push(1);",
             // Trailing comma in first call.
             "foo.push(1,); foo.push(2);",
-            // Multi-line.
+            // Multi-line, both with semicolons.
             "foo.push(1);\nfoo.push(2);",
+            // ASI: first statement lacks a semicolon.
+            "foo.push(1)\nfoo.push(2);",
+            // Spread argument.
+            "foo.push(...a); foo.push(...b);",
             // classList.add.
             "el.classList.add('foo'); el.classList.add('bar');",
             // classList.remove.
@@ -332,8 +347,12 @@ mod tests {
             "importScripts('a.js'); importScripts('b.js');",
             // Inside a function body.
             "function f() { foo.push(1); foo.push(2); }",
-            // Nested member push (a.b.push).
+            // Deeply nested member receiver (stable chain).
             "a.b.push(1); a.b.push(2);",
+            // this.prop.push (not in the ignore list).
+            "this.arr.push(1); this.arr.push(2);",
+            // Three consecutive calls — fires on each consecutive pair.
+            "foo.push(1); foo.push(2); foo.push(3);",
         ];
 
         let fix = vec![
@@ -343,6 +362,9 @@ mod tests {
             ("foo.push(); foo.push(1);", "foo.push(1);"),
             ("foo.push(1,); foo.push(2);", "foo.push(1, 2);"),
             ("foo.push(1);\nfoo.push(2);", "foo.push(1, 2);"),
+            // ASI: semicolon from second statement is preserved.
+            ("foo.push(1)\nfoo.push(2);", "foo.push(1, 2);"),
+            ("foo.push(...a); foo.push(...b);", "foo.push(...a, ...b);"),
             ("el.classList.add('foo'); el.classList.add('bar');", "el.classList.add('foo', 'bar');"),
             (
                 "el.classList.remove('foo'); el.classList.remove('bar');",
@@ -351,6 +373,9 @@ mod tests {
             ("importScripts('a.js'); importScripts('b.js');", "importScripts('a.js', 'b.js');"),
             ("function f() { foo.push(1); foo.push(2); }", "function f() { foo.push(1, 2); }"),
             ("a.b.push(1); a.b.push(2);", "a.b.push(1, 2);"),
+            ("this.arr.push(1); this.arr.push(2);", "this.arr.push(1, 2);"),
+            // Three calls: first fix merges calls 1+2; the third call is left for the next pass.
+            ("foo.push(1); foo.push(2); foo.push(3);", "foo.push(1, 2); foo.push(3);"),
         ];
 
         Tester::new(PreferSingleCall::NAME, PreferSingleCall::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -5,6 +5,7 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use oxc_syntax::identifier::is_identifier_part;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -81,7 +82,6 @@ declare_oxc_lint!(
     config = PreferSingleCallConfig,
     version = "next"
 );
-
 
 impl Rule for PreferSingleCall {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
@@ -222,7 +222,6 @@ impl Rule for PreferSingleCall {
         });
     }
 }
-
 
 /// Callee source-text patterns to ignore for `Array#{push,unshift}`.
 const DEFAULT_ARRAY_MUTATION_IGNORE: &[&str] = &[
@@ -379,9 +378,15 @@ fn arg_references_receiver(arg_src: &str, receiver: &str) -> bool {
     let mut i = 0;
     while i + rbytes.len() <= abytes.len() {
         if abytes[i..].starts_with(rbytes) {
-            let before_ok = i == 0 || !is_js_ident_continue(abytes[i - 1] as char);
-            let after_ok = i + rbytes.len() >= abytes.len()
-                || !is_js_ident_continue(abytes[i + rbytes.len()] as char);
+            let end = i + rbytes.len();
+            if !arg_src.is_char_boundary(i) || !arg_src.is_char_boundary(end) {
+                i += 1;
+                continue;
+            }
+            let before_ok =
+                i == 0 || !arg_src[..i].chars().next_back().is_some_and(is_identifier_part);
+            let after_ok = end >= abytes.len()
+                || !arg_src[end..].chars().next().is_some_and(is_identifier_part);
             if before_ok && after_ok {
                 return true;
             }
@@ -389,11 +394,6 @@ fn arg_references_receiver(arg_src: &str, receiver: &str) -> bool {
         i += 1;
     }
     false
-}
-
-#[inline]
-fn is_js_ident_continue(c: char) -> bool {
-    c.is_alphanumeric() || c == '_' || c == '$'
 }
 
 #[cfg(test)]

--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -1,0 +1,360 @@
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Expression, Statement},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, fixer::Fix, rule::Rule};
+
+fn prefer_single_call_diagnostic(span: Span, description: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Do not call `{description}` multiple times."))
+        .with_help("Merge with the previous call.")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferSingleCall;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces combining multiple `Array#push()`, `Element#classList.{add,remove}()`,
+    /// and `importScripts()` into a single call.
+    ///
+    /// Supersedes the deprecated `unicorn/no-array-push-push` rule.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Calling the same variadic method on the same receiver multiple times
+    /// consecutively can be merged into a single call, which is more concise
+    /// and can be marginally more performant.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// foo.push(1);
+    /// foo.push(2);
+    ///
+    /// element.classList.add('foo');
+    /// element.classList.add('bar');
+    ///
+    /// importScripts('foo.js');
+    /// importScripts('bar.js');
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// foo.push(1, 2);
+    ///
+    /// element.classList.add('foo', 'bar');
+    ///
+    /// importScripts('foo.js', 'bar.js');
+    /// ```
+    PreferSingleCall,
+    unicorn,
+    pedantic,
+    pending,
+    fix,
+    version = "0.0.0",
+);
+
+/// Callee source-text patterns to ignore for `Array#push`.
+const PUSH_IGNORE: &[&str] = &[
+    "stream.push",
+    "this.push",
+    "this.stream.push",
+    "process.stdin.push",
+    "process.stdout.push",
+    "process.stderr.push",
+];
+
+/// Information extracted from a matched call expression.
+struct CallInfo<'a> {
+    /// Human-readable description of the rule case (used in the message).
+    description: &'static str,
+    /// Source text of the call's receiver. For `Array#push` this is the
+    /// object before `.push`; for `classList.{add,remove}` it is the element
+    /// before `.classList`; for `importScripts` it is the literal string
+    /// `"importScripts"`.
+    receiver_text: &'a str,
+    /// Span to attach the diagnostic label to (the method name identifier).
+    diagnostic_span: Span,
+}
+
+/// Returns `true` if `expr` is a "stable" receiver — an expression whose
+/// value cannot be changed by a function call side-effect between two
+/// consecutive statements. We accept identifiers, `this`, and chains of
+/// static member accesses built from those primitives.
+fn is_stable_receiver(expr: &Expression<'_>) -> bool {
+    match expr.without_parentheses() {
+        Expression::Identifier(_) | Expression::ThisExpression(_) => true,
+        Expression::StaticMemberExpression(m) if !m.optional => {
+            is_stable_receiver(&m.object)
+        }
+        _ => false,
+    }
+}
+
+/// If `call` matches one of the tracked patterns, return its [`CallInfo`];
+/// otherwise return `None`.
+fn classify_call<'a>(call: &'a CallExpression<'a>, src: &'a str) -> Option<CallInfo<'a>> {
+    if call.optional {
+        return None;
+    }
+
+    match call.callee.without_parentheses() {
+        // `receiver.push(...)`, `el.classList.add(...)`, `el.classList.remove(...)`
+        Expression::StaticMemberExpression(member) => {
+            if member.optional {
+                return None;
+            }
+            let method = member.property.name.as_str();
+
+            match method {
+                "push" => {
+                    if !is_stable_receiver(&member.object) {
+                        return None;
+                    }
+                    let callee_text = call.callee.span().source_text(src);
+                    if PUSH_IGNORE.contains(&callee_text) {
+                        return None;
+                    }
+                    let receiver_text = member.object.span().source_text(src);
+                    Some(CallInfo {
+                        description: "Array#push()",
+                        receiver_text,
+                        diagnostic_span: member.property.span,
+                    })
+                }
+
+                "add" | "remove" => {
+                    // Must be `<element>.classList.add/remove`
+                    let obj = member.object.without_parentheses();
+                    let obj_member = match obj {
+                        Expression::StaticMemberExpression(m) if !m.optional => m,
+                        _ => return None,
+                    };
+                    if obj_member.property.name.as_str() != "classList" {
+                        return None;
+                    }
+                    if !is_stable_receiver(&obj_member.object) {
+                        return None;
+                    }
+                    let receiver_text = obj_member.object.span().source_text(src);
+                    let description = if method == "add" {
+                        "Element#classList.add()"
+                    } else {
+                        "Element#classList.remove()"
+                    };
+                    Some(CallInfo {
+                        description,
+                        receiver_text,
+                        diagnostic_span: member.property.span,
+                    })
+                }
+
+                _ => None,
+            }
+        }
+
+        // `importScripts(...)`
+        Expression::Identifier(ident) if ident.name == "importScripts" => Some(CallInfo {
+            description: "importScripts()",
+            receiver_text: "importScripts",
+            diagnostic_span: ident.span,
+        }),
+
+        _ => None,
+    }
+}
+
+/// Returns `true` when `a` and `b` represent the same mergeable call pattern
+/// (same method type on the same stable receiver).
+fn same_call<'a>(a: &CallInfo<'a>, b: &CallInfo<'a>) -> bool {
+    a.description == b.description && a.receiver_text == b.receiver_text
+}
+
+impl Rule for PreferSingleCall {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // Match ExpressionStatements so we can delete the entire second statement.
+        let AstKind::ExpressionStatement(expr_stmt) = node.kind() else {
+            return;
+        };
+
+        let Expression::CallExpression(call) = &expr_stmt.expression else {
+            return;
+        };
+
+        let src = ctx.source_text();
+        let Some(info) = classify_call(call, src) else {
+            return;
+        };
+
+        // Locate the previous sibling statement in the parent block.
+        let parent = ctx.nodes().parent_node(node.id());
+        let stmts: &[Statement<'a>] = match parent.kind() {
+            AstKind::BlockStatement(b) => &b.body,
+            AstKind::Program(p) => &p.body,
+            AstKind::FunctionBody(b) => &b.statements,
+            AstKind::StaticBlock(b) => &b.body,
+            AstKind::SwitchCase(c) => &c.consequent,
+            _ => return,
+        };
+
+        let Some(idx) = stmts.iter().position(|s| s.span() == expr_stmt.span) else {
+            return;
+        };
+
+        if idx == 0 {
+            return;
+        }
+
+        let Statement::ExpressionStatement(prev_es) = &stmts[idx - 1] else {
+            return;
+        };
+        let Expression::CallExpression(prev_call) = &prev_es.expression else {
+            return;
+        };
+        let Some(prev_info) = classify_call(prev_call, src) else {
+            return;
+        };
+
+        if !same_call(&info, &prev_info) {
+            return;
+        }
+
+        let first_call_span = prev_call.span;
+        let first_stmt_end = prev_es.span.end;
+        let second_stmt_end = expr_stmt.span.end;
+        let second_args = &call.arguments;
+        let description = info.description;
+        let diag_span = info.diagnostic_span;
+
+        ctx.diagnostic_with_fix(prefer_single_call_diagnostic(diag_span, description), |fixer| {
+            let mut fix = fixer
+                .new_fix_with_capacity(2)
+                .with_message(format!("Merge into previous `{description}` call"));
+
+            // If the second call has arguments, insert them into the first call.
+            if !second_args.is_empty() {
+                let args_text = second_args
+                    .iter()
+                    .map(|a| a.span().source_text(src))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                // Determine separator. Check whether the first call ends with a
+                // trailing comma (like `push(a,)`) to avoid generating `push(a,, b)`.
+                let first_src = first_call_span.source_text(src);
+                // Trim the closing ')' then check for trailing comma.
+                let before_paren = first_src[..first_src.len().saturating_sub(1)].trim_end();
+                let separator = if prev_call.arguments.is_empty() {
+                    ""
+                } else if before_paren.ends_with(',') {
+                    " "
+                } else {
+                    ", "
+                };
+
+                // Replace the closing ')' of the first call with `{sep}{args})`.
+                let close_paren = Span::new(first_call_span.end - 1, first_call_span.end);
+                fix.push(Fix::new(format!("{separator}{args_text})"), close_paren));
+            }
+
+            // Delete the second statement entirely (from end of first stmt to
+            // end of second stmt, including the whitespace/newline in between).
+            fix.push(Fix::delete(Span::new(first_stmt_end, second_stmt_end)));
+
+            fix
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tester::Tester;
+
+    use super::*;
+
+    #[test]
+    fn test() {
+        let pass = vec![
+            // Already a single call.
+            "foo.push(1, 2);",
+            // Different methods — not mergeable.
+            "foo.push(1); foo.pop();",
+            // Different receivers — not mergeable.
+            "foo.push(1); bar.push(2);",
+            // Not consecutive — something in between.
+            "foo.push(1); console.log(x); foo.push(2);",
+            // Optional call — skip.
+            "foo.push?.(1); foo.push?.(2);",
+            // Optional member — skip.
+            "foo?.push(1); foo?.push(2);",
+            // Ignored push receivers.
+            "this.push(1); this.push(2);",
+            "stream.push(1); stream.push(2);",
+            "process.stdin.push(1); process.stdin.push(2);",
+            "process.stdout.push(1); process.stdout.push(2);",
+            "process.stderr.push(1); process.stderr.push(2);",
+            "this.stream.push(1); this.stream.push(2);",
+            // classList on different elements — not mergeable.
+            "a.classList.add('x'); b.classList.add('y');",
+            // classList.add vs classList.remove — different method.
+            "el.classList.add('x'); el.classList.remove('y');",
+            // importScripts with non-consecutive calls.
+            "importScripts('a.js'); doSomething(); importScripts('b.js');",
+            // Unstable receiver (function call) — skip.
+            "getArr().push(1); getArr().push(2);",
+        ];
+
+        let fail = vec![
+            // Basic push.
+            "foo.push(1); foo.push(2);",
+            // push with multiple args.
+            "foo.push(1, 2); foo.push(3, 4);",
+            // Second call has no args — deletes redundant call.
+            "foo.push(1); foo.push();",
+            // First call has no args.
+            "foo.push(); foo.push(1);",
+            // Trailing comma in first call.
+            "foo.push(1,); foo.push(2);",
+            // Multi-line.
+            "foo.push(1);\nfoo.push(2);",
+            // classList.add.
+            "el.classList.add('foo'); el.classList.add('bar');",
+            // classList.remove.
+            "el.classList.remove('foo'); el.classList.remove('bar');",
+            // importScripts.
+            "importScripts('a.js'); importScripts('b.js');",
+            // Inside a function body.
+            "function f() { foo.push(1); foo.push(2); }",
+            // Nested member push (a.b.push).
+            "a.b.push(1); a.b.push(2);",
+        ];
+
+        let fix = vec![
+            ("foo.push(1); foo.push(2);", "foo.push(1, 2);"),
+            ("foo.push(1, 2); foo.push(3, 4);", "foo.push(1, 2, 3, 4);"),
+            ("foo.push(1); foo.push();", "foo.push(1);"),
+            ("foo.push(); foo.push(1);", "foo.push(1);"),
+            ("foo.push(1,); foo.push(2);", "foo.push(1, 2);"),
+            ("foo.push(1);\nfoo.push(2);", "foo.push(1, 2);"),
+            ("el.classList.add('foo'); el.classList.add('bar');", "el.classList.add('foo', 'bar');"),
+            (
+                "el.classList.remove('foo'); el.classList.remove('bar');",
+                "el.classList.remove('foo', 'bar');",
+            ),
+            ("importScripts('a.js'); importScripts('b.js');", "importScripts('a.js', 'b.js');"),
+            ("function f() { foo.push(1); foo.push(2); }", "function f() { foo.push(1, 2); }"),
+            ("a.b.push(1); a.b.push(2);", "a.b.push(1, 2);"),
+        ];
+
+        Tester::new(PreferSingleCall::NAME, PreferSingleCall::PLUGIN, pass, fail)
+            .expect_fix(fix)
+            .test_and_snapshot();
+    }
+}

--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -315,7 +315,7 @@ impl Rule for PreferSingleCall {
             // Delete the second statement (from end of first stmt to end of
             // second stmt, including any whitespace/newline in between).
             //
-            // ASI safety: if the first statement has no semicolon but the
+            // ASI handling: if the first statement has no semicolon but the
             // second does, preserve the semicolon so the result stays valid.
             let first_has_semi = prev_es.span.source_text(src).trim_end().ends_with(';');
             let second_has_semi = curr_es.span.source_text(src).trim_end().ends_with(';');

--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -141,7 +141,8 @@ fn classify_call<'a>(call: &'a CallExpression<'a>, src: &'a str) -> Option<CallI
                     if !is_stable_receiver(&obj_member.object) {
                         return None;
                     }
-                    let receiver_text = obj_member.object.without_parentheses().span().source_text(src);
+                    let receiver_text =
+                        obj_member.object.without_parentheses().span().source_text(src);
                     let description = if method == "add" {
                         "Element#classList.add()"
                     } else {
@@ -191,8 +192,7 @@ fn arg_references_receiver(arg_src: &str, receiver: &str) -> bool {
     let mut i = 0;
     while i + rbytes.len() <= abytes.len() {
         if abytes[i..].starts_with(rbytes) {
-            let before_ok =
-                i == 0 || !is_js_ident_continue(abytes[i - 1] as char);
+            let before_ok = i == 0 || !is_js_ident_continue(abytes[i - 1] as char);
             let after_ok = i + rbytes.len() >= abytes.len()
                 || !is_js_ident_continue(abytes[i + rbytes.len()] as char);
             if before_ok && after_ok {
@@ -211,9 +211,23 @@ fn is_js_ident_continue(c: char) -> bool {
 
 impl Rule for PreferSingleCall {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // Run on block-level containers so we can iterate statement pairs in
-        // O(n) with `windows(2)` rather than doing O(n) work per statement.
-        let stmts: &[Statement<'a>] = match node.kind() {
+        // Match only expression statements, then look at the parent statement
+        // list to find the immediate previous sibling. This keeps the rule off
+        // non-expression-statement nodes in the generated runner.
+        let AstKind::ExpressionStatement(curr_es) = node.kind() else {
+            return;
+        };
+        let Expression::CallExpression(curr_call) = &curr_es.expression else {
+            return;
+        };
+
+        let src = ctx.source_text();
+        let Some(curr_info) = classify_call(curr_call, src) else {
+            return;
+        };
+
+        let parent = ctx.nodes().parent_node(node.id());
+        let stmts: &[Statement<'a>] = match parent.kind() {
             AstKind::BlockStatement(b) => &b.body,
             AstKind::Program(p) => &p.body,
             AstKind::FunctionBody(b) => &b.statements,
@@ -222,104 +236,98 @@ impl Rule for PreferSingleCall {
             _ => return,
         };
 
-        let src = ctx.source_text();
+        let Some(idx) = stmts.iter().position(|stmt| stmt.span() == curr_es.span) else {
+            return;
+        };
+        let Some(prev_stmt) = idx.checked_sub(1).and_then(|idx| stmts.get(idx)) else {
+            return;
+        };
 
-        for window in stmts.windows(2) {
-            let (prev_stmt, curr_stmt) = (&window[0], &window[1]);
+        let Statement::ExpressionStatement(prev_es) = prev_stmt else {
+            return;
+        };
+        let Expression::CallExpression(prev_call) = &prev_es.expression else {
+            return;
+        };
+        let Some(prev_info) = classify_call(prev_call, src) else {
+            return;
+        };
 
-            let Statement::ExpressionStatement(prev_es) = prev_stmt else { continue; };
-            let Statement::ExpressionStatement(curr_es) = curr_stmt else { continue; };
-
-            let Expression::CallExpression(prev_call) = &prev_es.expression else { continue; };
-            let Expression::CallExpression(curr_call) = &curr_es.expression else { continue; };
-
-            let Some(prev_info) = classify_call(prev_call, src) else { continue; };
-            let Some(curr_info) = classify_call(curr_call, src) else { continue; };
-
-            if !same_call(&prev_info, &curr_info) {
-                continue;
-            }
-
-            let first_call_span = prev_call.span;
-            let first_stmt_end = prev_es.span.end;
-            let second_stmt_end = curr_es.span.end;
-            let second_args = &curr_call.arguments;
-            let description = curr_info.description;
-            let diag_span = curr_info.diagnostic_span;
-            let receiver = prev_info.receiver_text;
-
-            // P1: Skip autofix when a second-call argument references the
-            // receiver — merging would change the evaluation order because the
-            // first call mutates the receiver before those args are read.
-            // e.g. `arr.push(1); arr.push(arr.length);`
-            let has_state_dep_args = second_args.iter().any(|a| {
-                arg_references_receiver(a.span().source_text(src), receiver)
-            });
-
-            // P2: Skip autofix when there are comments in the gap between the
-            // two statements — deleting the gap would silently drop them.
-            let has_gap_comments =
-                ctx.comments_range(first_stmt_end..second_stmt_end).count() > 0;
-
-            if has_state_dep_args || has_gap_comments {
-                ctx.diagnostic(prefer_single_call_diagnostic(diag_span, description));
-                continue;
-            }
-
-            ctx.diagnostic_with_fix(
-                prefer_single_call_diagnostic(diag_span, description),
-                |fixer| {
-                    let mut fix = fixer
-                        .new_fix_with_capacity(2)
-                        .with_message(format!("Merge into previous `{description}` call"));
-
-                    // If the second call has arguments, insert them into the first call.
-                    if !second_args.is_empty() {
-                        let args_text = second_args
-                            .iter()
-                            .map(|a| a.span().source_text(src))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-
-                        // Determine separator. Check whether the first call ends with a
-                        // trailing comma (like `push(a,)`) to avoid generating `push(a,, b)`.
-                        let first_src = first_call_span.source_text(src);
-                        let before_paren =
-                            first_src[..first_src.len().saturating_sub(1)].trim_end();
-                        let separator = if prev_call.arguments.is_empty() {
-                            ""
-                        } else if before_paren.ends_with(',') {
-                            " "
-                        } else {
-                            ", "
-                        };
-
-                        // Replace the closing ')' of the first call with `{sep}{args})`.
-                        let close_paren =
-                            Span::new(first_call_span.end - 1, first_call_span.end);
-                        fix.push(Fix::new(format!("{separator}{args_text})"), close_paren));
-                    }
-
-                    // Delete the second statement (from end of first stmt to end of
-                    // second stmt, including any whitespace/newline in between).
-                    //
-                    // ASI safety: if the first statement has no semicolon but the
-                    // second does, preserve the semicolon so the result stays valid.
-                    let first_has_semi =
-                        prev_es.span.source_text(src).trim_end().ends_with(';');
-                    let second_has_semi =
-                        curr_es.span.source_text(src).trim_end().ends_with(';');
-                    let gap_span = Span::new(first_stmt_end, second_stmt_end);
-                    if !first_has_semi && second_has_semi {
-                        fix.push(Fix::new(";", gap_span));
-                    } else {
-                        fix.push(Fix::delete(gap_span));
-                    }
-
-                    fix
-                },
-            );
+        if !same_call(&prev_info, &curr_info) {
+            return;
         }
+
+        let first_call_span = prev_call.span;
+        let first_stmt_end = prev_es.span.end;
+        let second_stmt_end = curr_es.span.end;
+        let second_args = &curr_call.arguments;
+        let description = curr_info.description;
+        let diag_span = curr_info.diagnostic_span;
+        let receiver = prev_info.receiver_text;
+
+        // P1: Skip autofix when a second-call argument references the
+        // receiver — merging would change the evaluation order because the
+        // first call mutates the receiver before those args are read.
+        // e.g. `arr.push(1); arr.push(arr.length);`
+        let has_state_dep_args = second_args
+            .iter()
+            .any(|a| arg_references_receiver(a.span().source_text(src), receiver));
+
+        // P2: Skip autofix when there are comments in the gap between the
+        // two statements — deleting the gap would silently drop them.
+        let has_gap_comments = ctx.comments_range(first_stmt_end..second_stmt_end).count() > 0;
+
+        if has_state_dep_args || has_gap_comments {
+            ctx.diagnostic(prefer_single_call_diagnostic(diag_span, description));
+            return;
+        }
+
+        ctx.diagnostic_with_fix(prefer_single_call_diagnostic(diag_span, description), |fixer| {
+            let mut fix = fixer
+                .new_fix_with_capacity(2)
+                .with_message(format!("Merge into previous `{description}` call"));
+
+            // If the second call has arguments, insert them into the first call.
+            if !second_args.is_empty() {
+                let args_text = second_args
+                    .iter()
+                    .map(|a| a.span().source_text(src))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                // Determine separator. Check whether the first call ends with a
+                // trailing comma (like `push(a,)`) to avoid generating `push(a,, b)`.
+                let first_src = first_call_span.source_text(src);
+                let before_paren = first_src[..first_src.len().saturating_sub(1)].trim_end();
+                let separator = if prev_call.arguments.is_empty() {
+                    ""
+                } else if before_paren.ends_with(',') {
+                    " "
+                } else {
+                    ", "
+                };
+
+                // Replace the closing ')' of the first call with `{sep}{args})`.
+                let close_paren = Span::new(first_call_span.end - 1, first_call_span.end);
+                fix.push(Fix::new(format!("{separator}{args_text})"), close_paren));
+            }
+
+            // Delete the second statement (from end of first stmt to end of
+            // second stmt, including any whitespace/newline in between).
+            //
+            // ASI safety: if the first statement has no semicolon but the
+            // second does, preserve the semicolon so the result stays valid.
+            let first_has_semi = prev_es.span.source_text(src).trim_end().ends_with(';');
+            let second_has_semi = curr_es.span.source_text(src).trim_end().ends_with(';');
+            let gap_span = Span::new(first_stmt_end, second_stmt_end);
+            if !first_has_semi && second_has_semi {
+                fix.push(Fix::new(";", gap_span));
+            } else {
+                fix.push(Fix::delete(gap_span));
+            }
+
+            fix
+        });
     }
 }
 
@@ -417,7 +425,10 @@ mod tests {
             // ASI: semicolon from second statement is preserved.
             ("foo.push(1)\nfoo.push(2);", "foo.push(1, 2);"),
             ("foo.push(...a); foo.push(...b);", "foo.push(...a, ...b);"),
-            ("el.classList.add('foo'); el.classList.add('bar');", "el.classList.add('foo', 'bar');"),
+            (
+                "el.classList.add('foo'); el.classList.add('bar');",
+                "el.classList.add('foo', 'bar');",
+            ),
             (
                 "el.classList.remove('foo'); el.classList.remove('bar');",
                 "el.classList.remove('foo', 'bar');",

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_single_call.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_single_call.snap
@@ -1,0 +1,81 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:18]
+ 1 │ foo.push(1); foo.push(2);
+   ·                  ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:21]
+ 1 │ foo.push(1, 2); foo.push(3, 4);
+   ·                     ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:18]
+ 1 │ foo.push(1); foo.push();
+   ·                  ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:17]
+ 1 │ foo.push(); foo.push(1);
+   ·                 ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:19]
+ 1 │ foo.push(1,); foo.push(2);
+   ·                   ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:2:5]
+ 1 │ foo.push(1);
+ 2 │ foo.push(2);
+   ·     ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Element#classList.add()` multiple times.
+   ╭─[prefer_single_call.tsx:1:39]
+ 1 │ el.classList.add('foo'); el.classList.add('bar');
+   ·                                       ───
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Element#classList.remove()` multiple times.
+   ╭─[prefer_single_call.tsx:1:42]
+ 1 │ el.classList.remove('foo'); el.classList.remove('bar');
+   ·                                          ──────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `importScripts()` multiple times.
+   ╭─[prefer_single_call.tsx:1:24]
+ 1 │ importScripts('a.js'); importScripts('b.js');
+   ·                        ─────────────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:33]
+ 1 │ function f() { foo.push(1); foo.push(2); }
+   ·                                 ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:18]
+ 1 │ a.b.push(1); a.b.push(2);
+   ·                  ────
+   ╰────
+  help: Merge with the previous call.

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_single_call.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_single_call.snap
@@ -115,3 +115,17 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ────
    ╰────
   help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:20]
+ 1 │ (foo).push(1); foo.push(2);
+   ·                    ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:20]
+ 1 │ foo.push(1); (foo).push(2);
+   ·                    ────
+   ╰────
+  help: Merge with the previous call.

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_single_call.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_single_call.snap
@@ -129,3 +129,25 @@ source: crates/oxc_linter/src/tester.rs
    ·                    ────
    ╰────
   help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:18]
+ 1 │ arr.push(1); arr.push(arr.length);
+   ·                  ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:18]
+ 1 │ arr.push(1); arr.push(arr[0]);
+   ·                  ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:2:5]
+ 1 │ foo.push(1); // keep this
+ 2 │ foo.push(2);
+   ·     ────
+   ╰────
+  help: Merge with the previous call.

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_single_call.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_single_call.snap
@@ -45,6 +45,21 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Merge with the previous call.
 
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:2:5]
+ 1 │ foo.push(1)
+ 2 │ foo.push(2);
+   ·     ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:21]
+ 1 │ foo.push(...a); foo.push(...b);
+   ·                     ────
+   ╰────
+  help: Merge with the previous call.
+
   ⚠ unicorn(prefer-single-call): Do not call `Element#classList.add()` multiple times.
    ╭─[prefer_single_call.tsx:1:39]
  1 │ el.classList.add('foo'); el.classList.add('bar');
@@ -77,5 +92,26 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_single_call.tsx:1:18]
  1 │ a.b.push(1); a.b.push(2);
    ·                  ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:28]
+ 1 │ this.arr.push(1); this.arr.push(2);
+   ·                            ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:18]
+ 1 │ foo.push(1); foo.push(2); foo.push(3);
+   ·                  ────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#push()` multiple times.
+   ╭─[prefer_single_call.tsx:1:31]
+ 1 │ foo.push(1); foo.push(2); foo.push(3);
+   ·                               ────
    ╰────
   help: Merge with the previous call.

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_single_call.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_single_call.snap
@@ -60,6 +60,34 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Merge with the previous call.
 
+  ⚠ unicorn(prefer-single-call): Do not call `Array#unshift()` multiple times.
+   ╭─[prefer_single_call.tsx:1:21]
+ 1 │ foo.unshift(1); foo.unshift(2);
+   ·                     ───────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#unshift()` multiple times.
+   ╭─[prefer_single_call.tsx:1:24]
+ 1 │ foo.unshift(1, 2); foo.unshift(3, 4);
+   ·                        ───────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#unshift()` multiple times.
+   ╭─[prefer_single_call.tsx:1:21]
+ 1 │ foo.unshift(1); foo.unshift();
+   ·                     ───────
+   ╰────
+  help: Merge with the previous call.
+
+  ⚠ unicorn(prefer-single-call): Do not call `Array#unshift()` multiple times.
+   ╭─[prefer_single_call.tsx:1:20]
+ 1 │ foo.unshift(); foo.unshift(1);
+   ·                    ───────
+   ╰────
+  help: Merge with the previous call.
+
   ⚠ unicorn(prefer-single-call): Do not call `Element#classList.add()` multiple times.
    ╭─[prefer_single_call.tsx:1:39]
  1 │ el.classList.add('foo'); el.classList.add('bar');

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -35,7 +35,7 @@ mod typescript;
 mod unicode;
 mod whitespace;
 
-pub(crate) use byte_handlers::{ByteHandler, ByteHandlers, byte_handler_tables};
+pub use byte_handlers::{ByteHandler, ByteHandlers, byte_handler_tables};
 pub use kind::Kind;
 pub use number::{parse_big_int, parse_float, parse_int};
 pub use token::Token;

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -35,7 +35,7 @@ mod typescript;
 mod unicode;
 mod whitespace;
 
-pub use byte_handlers::{ByteHandler, ByteHandlers, byte_handler_tables};
+pub(crate) use byte_handlers::{ByteHandler, ByteHandlers, byte_handler_tables};
 pub use kind::Kind;
 pub use number::{parse_big_int, parse_float, parse_int};
 pub use token::Token;

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -7386,6 +7386,9 @@
         "unicorn/prefer-set-size": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/prefer-single-call": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "unicorn/prefer-spread": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -7387,7 +7387,24 @@
           "$ref": "#/definitions/RuleNoConfig"
         },
         "unicorn/prefer-single-call": {
-          "$ref": "#/definitions/DummyRule"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/PreferSingleCallConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 1
+            }
+          ]
         },
         "unicorn/prefer-spread": {
           "$ref": "#/definitions/RuleNoConfig"
@@ -13467,6 +13484,21 @@
           "default": false,
           "type": "boolean",
           "markdownDescription": "By default, this rule doesn’t check when a regex literal is unnecessarily wrapped in a `RegExp` constructor call.\nWhen the option `disallowRedundantWrapping` is set to `true`, the rule will also disallow such unnecessary patterns.\n\nExamples of **incorrect** code for `{ \"disallowRedundantWrapping\": true }`:\n```js\nnew RegExp(/abc/);\nnew RegExp(/abc/, 'u');\n```\n\nExamples of **correct** code for `{ \"disallowRedundantWrapping\": true }`:\n```js\n/abc/;\n/abc/u;\nnew RegExp(/abc/, flags);\n```"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PreferSingleCallConfig": {
+      "type": "object",
+      "properties": {
+        "ignore": {
+          "description": "Methods to ignore.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Methods to ignore."
         }
       },
       "additionalProperties": false

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -7391,7 +7391,24 @@ expression: json
           "$ref": "#/definitions/RuleNoConfig"
         },
         "unicorn/prefer-single-call": {
-          "$ref": "#/definitions/DummyRule"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AllowWarnDeny"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/PreferSingleCallConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 1
+            }
+          ]
         },
         "unicorn/prefer-spread": {
           "$ref": "#/definitions/RuleNoConfig"
@@ -13471,6 +13488,21 @@ expression: json
           "default": false,
           "type": "boolean",
           "markdownDescription": "By default, this rule doesn’t check when a regex literal is unnecessarily wrapped in a `RegExp` constructor call.\nWhen the option `disallowRedundantWrapping` is set to `true`, the rule will also disallow such unnecessary patterns.\n\nExamples of **incorrect** code for `{ \"disallowRedundantWrapping\": true }`:\n```js\nnew RegExp(/abc/);\nnew RegExp(/abc/, 'u');\n```\n\nExamples of **correct** code for `{ \"disallowRedundantWrapping\": true }`:\n```js\n/abc/;\n/abc/u;\nnew RegExp(/abc/, flags);\n```"
+        }
+      },
+      "additionalProperties": false
+    },
+    "PreferSingleCallConfig": {
+      "type": "object",
+      "properties": {
+        "ignore": {
+          "description": "Methods to ignore.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Methods to ignore."
         }
       },
       "additionalProperties": false

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -7390,6 +7390,9 @@ expression: json
         "unicorn/prefer-set-size": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/prefer-single-call": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "unicorn/prefer-spread": {
           "$ref": "#/definitions/RuleNoConfig"
         },


### PR DESCRIPTION
Closes #684 (unicorn/prefer-single-call entry)
Supersedes #22857 (reopened from a non-`main` branch after the old PR branch got rebased incorrectly).

## Summary

Implements the `unicorn/prefer-single-call` lint rule, which supersedes the deprecated `unicorn/no-array-push-push`.

- Detects consecutive calls to the same variadic method on the same receiver and suggests merging them into a single call
- Covers `Array#push()`, `Element#classList.add()`, `Element#classList.remove()`, and `importScripts()`
- Provides an auto-fix that merges arguments, handles trailing commas, and preserves semicolons for ASI handling
- Skips ignored `push` receivers (`this.push`, `stream.push`, `process.stdin/stdout/stderr.push`, `this.stream.push`)
- Only merges when the receiver is a stable expression (identifier, `this`, or static member chain — not a function call result)
- Addresses prior review feedback by running from `ExpressionStatement` and checking the parent statement list / previous sibling
- Updates the website linter schema snapshot and npm oxlint configuration schema for the new rule

## Test plan

- [x] Pass cases: different methods, different receivers, non-consecutive calls, optional chains, ignored patterns, unstable receivers, computed members
- [x] Fail/fix cases: basic push, multi-arg, trailing comma, ASI no-semi, spread args, classList.add/remove, importScripts, function body, nested member, `this.prop.push`, three consecutive calls
- [x] `cargo fmt --check`
- [x] `cargo test -p oxc_linter -- prefer_single_call`
- [x] `cargo test -p website_linter --bin website_linter json_schema::test_schema_json`
- [x] `git diff --check`

## AI usage disclosure

I used AI assistance while preparing and iterating on this PR, and I reviewed the generated changes and test results before submission.
