### PR TITLE
fix(linter/typescript): deserialize rule config with serde for `consistent-generic-constructors`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -12,7 +12,12 @@ use oxc_span::{GetSpan, Span};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::{AstNode, context::LintContext, fixer::RuleFixer, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    fixer::RuleFixer,
+    rule::{DefaultRuleConfig, Rule},
+};
 
 fn consistent_generic_constructors_diagnostic_prefer_annotation(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -30,19 +35,8 @@ fn consistent_generic_constructors_diagnostic_prefer_constructor(span: Span) -> 
     .with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
-pub struct ConsistentGenericConstructors(Box<ConsistentGenericConstructorsConfig>);
-
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
-pub struct ConsistentGenericConstructorsConfig {
-    /// Specifies where the generic type should be specified.
-    ///
-    /// Possible values:
-    /// - `"constructor"` (default): Type arguments that only appear on the type annotation are disallowed.
-    /// - `"type-annotation"`: Type arguments that only appear on the constructor are disallowed.
-    option: PreferGenericType,
-}
+pub struct ConsistentGenericConstructors(PreferGenericType);
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
@@ -52,18 +46,6 @@ enum PreferGenericType {
     Constructor,
     /// Type arguments that only appear on the constructor are disallowed.
     TypeAnnotation,
-}
-
-impl TryFrom<&str> for PreferGenericType {
-    type Error = &'static str;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        match value {
-            "constructor" => Ok(Self::Constructor),
-            "type-annotation" => Ok(Self::TypeAnnotation),
-            _ => Err("Invalid value"),
-        }
-    }
 }
 
 declare_oxc_lint!(
@@ -94,7 +76,7 @@ declare_oxc_lint!(
     typescript,
     style,
     fix,
-    config = ConsistentGenericConstructorsConfig,
+    config = PreferGenericType,
     version = "0.14.0",
 );
 
@@ -126,13 +108,7 @@ impl Rule for ConsistentGenericConstructors {
     }
 
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(Self(Box::new(ConsistentGenericConstructorsConfig {
-            option: value
-                .get(0)
-                .and_then(|v| v.as_str())
-                .and_then(|s| PreferGenericType::try_from(s).ok())
-                .unwrap_or_default(),
-        })))
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
@@ -174,7 +150,7 @@ impl ConsistentGenericConstructors {
             }
         }
 
-        if matches!(self.0.option, PreferGenericType::TypeAnnotation) {
+        if matches!(self.0, PreferGenericType::TypeAnnotation) {
             if type_annotation.is_none()
                 && let Some(type_arguments) = &new_expression.type_arguments
             {


### PR DESCRIPTION
## Summary

- Use `PreferGenericType` as the rule config for `typescript/consistent-generic-constructors` instead of wrapping it in `ConsistentGenericConstructorsConfig`.
- Deserialize the positional rule option through `DefaultRuleConfig<Self>`, so serde parses the enum directly with its kebab-case names.

## Fixes

- The generated rule config shape no longer implies an object with an `option` property, which this rule did not accept.
- Invalid option strings now surface serde configuration errors instead of being swallowed by the manual `TryFrom<&str>` parser and defaulting to `constructor`.
- Removes the redundant config wrapper and manual string parser now that `PreferGenericType` derives `Deserialize`.

