### PR TITLE
refactor(transformer): order transform options by evaluation order

### DIFF
--- a/crates/oxc_transformer/src/es2020/options.rs
+++ b/crates/oxc_transformer/src/es2020/options.rs
@@ -12,13 +12,13 @@ pub struct ES2020Options {
     #[serde(skip)]
     pub nullish_coalescing_operator: bool,
 
-    /// Enable bigint syntax transform.
-    #[serde(skip)]
-    pub big_int: bool,
-
     /// Enable optional chaining transform.
     #[serde(skip)]
     pub optional_chaining: bool,
+
+    /// Enable bigint syntax transform.
+    #[serde(skip)]
+    pub big_int: bool,
 
     /// Enable arbitrary module namespace name transform.
     #[serde(skip)]

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -106,6 +106,9 @@ pub struct Transformer<'a> {
     state: TransformState<'a>,
     allocator: &'a Allocator,
 
+    // Options, in evaluation order.
+    #[cfg(feature = "react_compiler")]
+    react_compiler: Option<PluginOptions>,
     typescript: TypeScriptOptions,
     decorator: DecoratorOptions,
     plugins: PluginsOptions,
@@ -113,8 +116,6 @@ pub struct Transformer<'a> {
     env: EnvOptions,
     #[expect(dead_code)]
     proposals: ProposalOptions,
-    #[cfg(feature = "react_compiler")]
-    react_compiler: Option<PluginOptions>,
 }
 
 impl<'a> Transformer<'a> {
@@ -124,14 +125,14 @@ impl<'a> Transformer<'a> {
         Self {
             state,
             allocator,
+            #[cfg(feature = "react_compiler")]
+            react_compiler: options.react_compiler.clone(),
             typescript: options.typescript.clone(),
             decorator: options.decorator,
             plugins: options.plugins.clone(),
             jsx: options.jsx.clone(),
             env: options.env,
             proposals: options.proposals,
-            #[cfg(feature = "react_compiler")]
-            react_compiler: options.react_compiler.clone(),
         }
     }
 
@@ -240,6 +241,7 @@ impl<'a> Transformer<'a> {
 
 struct TransformerImpl<'a> {
     // NOTE: all callbacks must run in order.
+    // Keep `TransformOptions` field order and docs in sync with this order.
     x0_typescript: Option<TypeScript<'a>>,
     decorator: Decorator<'a>,
     plugins: Plugins<'a>,

--- a/crates/oxc_transformer/src/options/env.rs
+++ b/crates/oxc_transformer/src/options/env.rs
@@ -19,39 +19,46 @@ use oxc_compat::{ESFeature, EngineTargets};
 #[derive(Debug, Default, Clone, Copy, Deserialize)]
 #[serde(try_from = "BabelEnvOptions")]
 /// Feature toggles selected from target runtime support.
+///
+/// Options are listed in evaluation order: syntax is lowered from the newest
+/// supported edition (ES2026) down to ES2015, then RegExp features.
 pub struct EnvOptions {
     /// Specify what module code is generated.
+    ///
+    /// Evaluated by the TypeScript transform (`import =` / `export =` and namespaces).
     pub module: Module,
 
-    /// RegExp transform options.
-    pub regexp: RegExpOptions,
-
-    /// ES2015 transform options.
-    pub es2015: ES2015Options,
-
-    /// ES2016 transform options.
-    pub es2016: ES2016Options,
-
-    /// ES2017 transform options.
-    pub es2017: ES2017Options,
-
-    /// ES2018 transform options.
-    pub es2018: ES2018Options,
-
-    /// ES2019 transform options.
-    pub es2019: ES2019Options,
-
-    /// ES2020 transform options.
-    pub es2020: ES2020Options,
-
-    /// ES2021 transform options.
-    pub es2021: ES2021Options,
+    /// ES2026 transform options.
+    pub es2026: ES2026Options,
 
     /// ES2022 transform options.
     pub es2022: ES2022Options,
 
-    /// ES2026 transform options.
-    pub es2026: ES2026Options,
+    /// ES2021 transform options.
+    pub es2021: ES2021Options,
+
+    /// ES2020 transform options.
+    pub es2020: ES2020Options,
+
+    /// ES2019 transform options.
+    pub es2019: ES2019Options,
+
+    /// ES2018 transform options.
+    pub es2018: ES2018Options,
+
+    /// ES2017 transform options.
+    pub es2017: ES2017Options,
+
+    /// ES2016 transform options.
+    pub es2016: ES2016Options,
+
+    /// ES2015 transform options.
+    pub es2015: ES2015Options,
+
+    /// RegExp transform options.
+    ///
+    /// Runs after all syntax lowering.
+    pub regexp: RegExpOptions,
 }
 
 impl EnvOptions {
@@ -62,6 +69,37 @@ impl EnvOptions {
     pub fn enable_all(include_unfinished_plugins: bool) -> Self {
         Self {
             module: Module::default(),
+            es2026: ES2026Options { explicit_resource_management: true },
+            es2022: ES2022Options {
+                class_static_block: true,
+                class_properties: Some(ClassPropertiesOptions::default()),
+                // Turn this on would throw error for all top-level awaits.
+                top_level_await: false,
+            },
+            es2021: ES2021Options { logical_assignment_operators: true },
+            es2020: ES2020Options {
+                export_namespace_from: true,
+                nullish_coalescing_operator: true,
+                optional_chaining: true,
+                // Turn this on would throw error for all bigints.
+                big_int: false,
+                arbitrary_module_namespace_names: false,
+            },
+            es2019: ES2019Options { optional_catch_binding: true },
+            es2018: ES2018Options {
+                object_rest_spread: Some(ObjectRestSpreadOptions::default()),
+                async_generator_functions: true,
+            },
+            es2017: ES2017Options { async_to_generator: true },
+            es2016: ES2016Options { exponentiation_operator: true },
+            es2015: ES2015Options {
+                // Turned off because it is not ready.
+                arrow_function: if include_unfinished_plugins {
+                    Some(ArrowFunctionsOptions::default())
+                } else {
+                    None
+                },
+            },
             regexp: RegExpOptions {
                 sticky_flag: true,
                 unicode_flag: true,
@@ -72,37 +110,6 @@ impl EnvOptions {
                 match_indices: true,
                 set_notation: true,
             },
-            es2015: ES2015Options {
-                // Turned off because it is not ready.
-                arrow_function: if include_unfinished_plugins {
-                    Some(ArrowFunctionsOptions::default())
-                } else {
-                    None
-                },
-            },
-            es2016: ES2016Options { exponentiation_operator: true },
-            es2017: ES2017Options { async_to_generator: true },
-            es2018: ES2018Options {
-                object_rest_spread: Some(ObjectRestSpreadOptions::default()),
-                async_generator_functions: true,
-            },
-            es2019: ES2019Options { optional_catch_binding: true },
-            es2020: ES2020Options {
-                export_namespace_from: true,
-                nullish_coalescing_operator: true,
-                // Turn this on would throw error for all bigints.
-                big_int: false,
-                optional_chaining: true,
-                arbitrary_module_namespace_names: false,
-            },
-            es2021: ES2021Options { logical_assignment_operators: true },
-            es2022: ES2022Options {
-                class_static_block: true,
-                class_properties: Some(ClassPropertiesOptions::default()),
-                // Turn this on would throw error for all top-level awaits.
-                top_level_await: false,
-            },
-            es2026: ES2026Options { explicit_resource_management: true },
         }
     }
 
@@ -144,6 +151,39 @@ impl From<EngineTargets> for EnvOptions {
         use ESFeature::*;
         Self {
             module: Module::default(),
+            es2026: ES2026Options {
+                explicit_resource_management: o.has_feature(ES2026ExplicitResourceManagement),
+            },
+            es2022: ES2022Options {
+                class_static_block: o.has_feature(ES2022ClassStaticBlock),
+                class_properties: o.has_feature(ES2022ClassProperties).then(Default::default),
+                top_level_await: o.has_feature(ES2022TopLevelAwait),
+            },
+            es2021: ES2021Options {
+                logical_assignment_operators: o.has_feature(ES2021LogicalAssignmentOperators),
+            },
+            es2020: ES2020Options {
+                export_namespace_from: o.has_feature(ES2020ExportNamespaceFrom),
+                nullish_coalescing_operator: o.has_feature(ES2020NullishCoalescingOperator),
+                optional_chaining: o.has_feature(ES2020OptionalChaining),
+                big_int: o.has_feature(ES2020BigInt),
+                arbitrary_module_namespace_names: o
+                    .has_feature(ES2020ArbitraryModuleNamespaceNames),
+            },
+            es2019: ES2019Options {
+                optional_catch_binding: o.has_feature(ES2019OptionalCatchBinding),
+            },
+            es2018: ES2018Options {
+                object_rest_spread: o.has_feature(ES2018ObjectRestSpread).then(Default::default),
+                async_generator_functions: o.has_feature(ES2018AsyncGeneratorFunctions),
+            },
+            es2017: ES2017Options { async_to_generator: o.has_feature(ES2017AsyncToGenerator) },
+            es2016: ES2016Options {
+                exponentiation_operator: o.has_feature(ES2016ExponentiationOperator),
+            },
+            es2015: ES2015Options {
+                arrow_function: o.has_feature(ES2015ArrowFunctions).then(Default::default),
+            },
             regexp: RegExpOptions {
                 sticky_flag: o.has_feature(ES2015StickyRegex),
                 unicode_flag: o.has_feature(ES2015UnicodeRegex),
@@ -153,39 +193,6 @@ impl From<EngineTargets> for EnvOptions {
                 look_behind_assertions: o.has_feature(ES2018LookbehindRegex),
                 match_indices: o.has_feature(ES2022MatchIndicesRegex),
                 set_notation: o.has_feature(ES2024UnicodeSetsRegex),
-            },
-            es2015: ES2015Options {
-                arrow_function: o.has_feature(ES2015ArrowFunctions).then(Default::default),
-            },
-            es2016: ES2016Options {
-                exponentiation_operator: o.has_feature(ES2016ExponentiationOperator),
-            },
-            es2017: ES2017Options { async_to_generator: o.has_feature(ES2017AsyncToGenerator) },
-            es2018: ES2018Options {
-                object_rest_spread: o.has_feature(ES2018ObjectRestSpread).then(Default::default),
-                async_generator_functions: o.has_feature(ES2018AsyncGeneratorFunctions),
-            },
-            es2019: ES2019Options {
-                optional_catch_binding: o.has_feature(ES2019OptionalCatchBinding),
-            },
-            es2020: ES2020Options {
-                export_namespace_from: o.has_feature(ES2020ExportNamespaceFrom),
-                nullish_coalescing_operator: o.has_feature(ES2020NullishCoalescingOperator),
-                big_int: o.has_feature(ES2020BigInt),
-                optional_chaining: o.has_feature(ES2020OptionalChaining),
-                arbitrary_module_namespace_names: o
-                    .has_feature(ES2020ArbitraryModuleNamespaceNames),
-            },
-            es2021: ES2021Options {
-                logical_assignment_operators: o.has_feature(ES2021LogicalAssignmentOperators),
-            },
-            es2022: ES2022Options {
-                class_static_block: o.has_feature(ES2022ClassStaticBlock),
-                class_properties: o.has_feature(ES2022ClassProperties).then(Default::default),
-                top_level_await: o.has_feature(ES2022TopLevelAwait),
-            },
-            es2026: ES2026Options {
-                explicit_resource_management: o.has_feature(ES2026ExplicitResourceManagement),
             },
         }
     }

--- a/crates/oxc_transformer/src/options/mod.rs
+++ b/crates/oxc_transformer/src/options/mod.rs
@@ -35,6 +35,10 @@ pub use oxc_compat::{ESFeature, Engine, EngineTargets};
 pub use oxc_syntax::es_target::ESTarget;
 
 /// <https://babel.dev/docs/options>
+///
+/// Transform options are listed in evaluation order: `react_compiler` runs in its own
+/// pass before the main traversal, which then applies `typescript`, `decorator`, `plugins`,
+/// `jsx`, and `env` (newest edition to oldest, then RegExp) in order.
 #[derive(Debug, Default, Clone)]
 pub struct TransformOptions {
     //
@@ -46,14 +50,30 @@ pub struct TransformOptions {
     // Core
     /// Set assumptions in order to produce smaller output.
     /// For more information, check the [assumptions](https://babel.dev/docs/assumptions) documentation page.
+    ///
+    /// Shared by all transforms below; not a transform itself.
     pub assumptions: CompilerAssumptions,
 
-    // Plugins
+    //
+    // Transforms, in evaluation order.
+    //
+    /// Experimental [React Compiler](https://github.com/react/react/tree/main/compiler).
+    ///
+    /// Runs in a separate pass before all other transforms.
+    #[cfg(feature = "react_compiler")]
+    pub react_compiler: Option<PluginOptions>,
+
     /// [preset-typescript](https://babeljs.io/docs/babel-preset-typescript)
     pub typescript: TypeScriptOptions,
 
     /// Decorator
+    ///
+    /// Runs interleaved with the TypeScript transform: decorators are collected
+    /// before type information is stripped, and lowered afterwards.
     pub decorator: DecoratorOptions,
+
+    /// Third-party plugins (e.g. `styled-components`).
+    pub plugins: PluginsOptions,
 
     /// Jsx Transform
     ///
@@ -63,18 +83,15 @@ pub struct TransformOptions {
     /// ECMAScript Env Options
     pub env: EnvOptions,
 
-    /// Proposals
+    /// TC39 Proposals
+    ///
+    /// Currently none are implemented.
     pub proposals: ProposalOptions,
 
-    /// Plugins
-    pub plugins: PluginsOptions,
-
     /// Helper loading configuration for generated runtime helpers.
+    ///
+    /// Not a transform; serves all transforms above.
     pub helper_loader: HelperLoaderOptions,
-
-    /// Experimental [React Compiler](https://github.com/react/react/tree/main/compiler).
-    #[cfg(feature = "react_compiler")]
-    pub react_compiler: Option<PluginOptions>,
 }
 
 impl TransformOptions {
@@ -86,11 +103,17 @@ impl TransformOptions {
         Self {
             cwd: PathBuf::new(),
             assumptions: CompilerAssumptions::default(),
+            #[cfg(feature = "react_compiler")]
+            react_compiler: None,
             typescript: TypeScriptOptions::default(),
             decorator: DecoratorOptions {
                 legacy: true,
                 emit_decorator_metadata: true,
                 strict_null_checks: true,
+            },
+            plugins: PluginsOptions {
+                styled_components: Some(StyledComponentsOptions::default()),
+                tagged_template_transform: true,
             },
             jsx: JsxOptions {
                 development: true,
@@ -99,16 +122,10 @@ impl TransformOptions {
             },
             env: EnvOptions::enable_all(/* include_unfinished_plugins */ false),
             proposals: ProposalOptions::default(),
-            plugins: PluginsOptions {
-                styled_components: Some(StyledComponentsOptions::default()),
-                tagged_template_transform: true,
-            },
             helper_loader: HelperLoaderOptions {
                 mode: HelperLoaderMode::Runtime,
                 ..Default::default()
             },
-            #[cfg(feature = "react_compiler")]
-            react_compiler: None,
         }
     }
 
@@ -290,29 +307,29 @@ impl TryFrom<&BabelOptions> for TransformOptions {
         Ok(Self {
             cwd: options.cwd.clone().unwrap_or_default(),
             assumptions: options.assumptions,
+            #[cfg(feature = "react_compiler")]
+            react_compiler: None,
             typescript,
             decorator,
+            plugins,
             jsx,
             env: EnvOptions {
                 module,
-                regexp,
-                es2015,
-                es2016,
-                es2017,
-                es2018,
-                es2019,
-                es2020,
-                es2021,
-                es2022,
                 es2026: ES2026Options {
                     explicit_resource_management: options.plugins.explicit_resource_management,
                 },
+                es2022,
+                es2021,
+                es2020,
+                es2019,
+                es2018,
+                es2017,
+                es2016,
+                es2015,
+                regexp,
             },
             proposals: ProposalOptions::default(),
             helper_loader,
-            plugins,
-            #[cfg(feature = "react_compiler")]
-            react_compiler: None,
         })
     }
 }

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -537,6 +537,13 @@ export declare function transform(filename: string, sourceText: string, options?
 /**
  * Options for transforming a JavaScript or TypeScript file.
  *
+ * Options are listed in evaluation order: the source is parsed (`lang`,
+ * `sourceType`), declarations are emitted (`typescript.declaration`), then
+ * transforms run (`reactCompiler`, `typescript`, `decorator`, `plugins`,
+ * `jsx`, `target`), followed by the `inject` and `define` plugins, and
+ * finally codegen (`sourcemap`). `helpers` configures the runtime helpers
+ * the transforms emit.
+ *
  * @see {@link transform}
  */
 export interface TransformOptions {
@@ -549,23 +556,31 @@ export interface TransformOptions {
    * options.
    */
   cwd?: string
-  /**
-   * Enable source map generation.
-   *
-   * When `true`, the `sourceMap` field of transform result objects will be populated.
-   *
-   * @default false
-   *
-   * @see {@link SourceMap}
-   */
-  sourcemap?: boolean
   /** Set assumptions in order to produce smaller output. */
   assumptions?: CompilerAssumptions
   /**
+   * Enable the experimental [React Compiler](https://github.com/react/react/tree/main/compiler).
+   *
+   * `true` enables it with default options; an object enables it with the
+   * given options; `false` or omitted disables it. When enabled, the compiler
+   * runs as the first transform and memoizes React components and hooks.
+   */
+  reactCompiler?: boolean | ReactCompilerOptions
+  /**
    * Configure how TypeScript is transformed.
+   *
+   * `typescript.declaration` is evaluated before all transforms.
+   *
    * @see {@link https://oxc.rs/docs/guide/usage/transformer/typescript}
    */
   typescript?: TypeScriptOptions
+  /** Decorator plugin */
+  decorator?: DecoratorOptions
+  /**
+   * Third-party plugins to use.
+   * @see {@link https://oxc.rs/docs/guide/usage/transformer/plugins}
+   */
+  plugins?: PluginsOptions
   /**
    * Configure how TSX and JSX are transformed.
    * @see {@link https://oxc.rs/docs/guide/usage/transformer/jsx}
@@ -589,30 +604,31 @@ export interface TransformOptions {
   /** Behaviour for runtime helpers. */
   helpers?: Helpers
   /**
+   * Inject Plugin
+   *
+   * Runs after all transforms.
+   *
+   * @see {@link https://oxc.rs/docs/guide/usage/transformer/global-variable-replacement#inject}
+   */
+  inject?: Record<string, string | [string, string]>
+  /**
    * Define Plugin
+   *
+   * Runs after the inject plugin.
+   *
    * @see {@link https://oxc.rs/docs/guide/usage/transformer/global-variable-replacement#define}
    */
   define?: Record<string, string>
   /**
-   * Inject Plugin
-   * @see {@link https://oxc.rs/docs/guide/usage/transformer/global-variable-replacement#inject}
-   */
-  inject?: Record<string, string | [string, string]>
-  /** Decorator plugin */
-  decorator?: DecoratorOptions
-  /**
-   * Enable the experimental [React Compiler](https://github.com/react/react/tree/main/compiler).
+   * Enable source map generation.
    *
-   * `true` enables it with default options; an object enables it with the
-   * given options; `false` or omitted disables it. When enabled, the compiler
-   * runs as the first transform and memoizes React components and hooks.
+   * When `true`, the `sourceMap` field of transform result objects will be populated.
+   *
+   * @default false
+   *
+   * @see {@link SourceMap}
    */
-  reactCompiler?: boolean | ReactCompilerOptions
-  /**
-   * Third-party plugins to use.
-   * @see {@link https://oxc.rs/docs/guide/usage/transformer/plugins}
-   */
-  plugins?: PluginsOptions
+  sourcemap?: boolean
 }
 
 export interface TransformResult {

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -82,6 +82,13 @@ pub struct TransformResult {
 
 /// Options for transforming a JavaScript or TypeScript file.
 ///
+/// Options are listed in evaluation order: the source is parsed (`lang`,
+/// `sourceType`), declarations are emitted (`typescript.declaration`), then
+/// transforms run (`reactCompiler`, `typescript`, `decorator`, `plugins`,
+/// `jsx`, `target`), followed by the `inject` and `define` plugins, and
+/// finally codegen (`sourcemap`). `helpers` configures the runtime helpers
+/// the transforms emit.
+///
 /// @see {@link transform}
 #[napi(object)]
 #[derive(Default)]
@@ -98,21 +105,30 @@ pub struct TransformOptions {
     /// options.
     pub cwd: Option<String>,
 
-    /// Enable source map generation.
-    ///
-    /// When `true`, the `sourceMap` field of transform result objects will be populated.
-    ///
-    /// @default false
-    ///
-    /// @see {@link SourceMap}
-    pub sourcemap: Option<bool>,
-
     /// Set assumptions in order to produce smaller output.
     pub assumptions: Option<CompilerAssumptions>,
 
+    /// Enable the experimental [React Compiler](https://github.com/react/react/tree/main/compiler).
+    ///
+    /// `true` enables it with default options; an object enables it with the
+    /// given options; `false` or omitted disables it. When enabled, the compiler
+    /// runs as the first transform and memoizes React components and hooks.
+    #[napi(ts_type = "boolean | ReactCompilerOptions")]
+    pub react_compiler: Option<Either<bool, ReactCompilerOptions>>,
+
     /// Configure how TypeScript is transformed.
+    ///
+    /// `typescript.declaration` is evaluated before all transforms.
+    ///
     /// @see {@link https://oxc.rs/docs/guide/usage/transformer/typescript}
     pub typescript: Option<TypeScriptOptions>,
+
+    /// Decorator plugin
+    pub decorator: Option<DecoratorOptions>,
+
+    /// Third-party plugins to use.
+    /// @see {@link https://oxc.rs/docs/guide/usage/transformer/plugins}
+    pub plugins: Option<PluginsOptions>,
 
     /// Configure how TSX and JSX are transformed.
     /// @see {@link https://oxc.rs/docs/guide/usage/transformer/jsx}
@@ -136,30 +152,30 @@ pub struct TransformOptions {
     /// Behaviour for runtime helpers.
     pub helpers: Option<Helpers>,
 
-    /// Define Plugin
-    /// @see {@link https://oxc.rs/docs/guide/usage/transformer/global-variable-replacement#define}
-    #[napi(ts_type = "Record<string, string>")]
-    pub define: Option<FxHashMap<String, String>>,
-
     /// Inject Plugin
+    ///
+    /// Runs after all transforms.
+    ///
     /// @see {@link https://oxc.rs/docs/guide/usage/transformer/global-variable-replacement#inject}
     #[napi(ts_type = "Record<string, string | [string, string]>")]
     pub inject: Option<FxHashMap<String, Either<String, Vec<String>>>>,
 
-    /// Decorator plugin
-    pub decorator: Option<DecoratorOptions>,
-
-    /// Enable the experimental [React Compiler](https://github.com/react/react/tree/main/compiler).
+    /// Define Plugin
     ///
-    /// `true` enables it with default options; an object enables it with the
-    /// given options; `false` or omitted disables it. When enabled, the compiler
-    /// runs as the first transform and memoizes React components and hooks.
-    #[napi(ts_type = "boolean | ReactCompilerOptions")]
-    pub react_compiler: Option<Either<bool, ReactCompilerOptions>>,
+    /// Runs after the inject plugin.
+    ///
+    /// @see {@link https://oxc.rs/docs/guide/usage/transformer/global-variable-replacement#define}
+    #[napi(ts_type = "Record<string, string>")]
+    pub define: Option<FxHashMap<String, String>>,
 
-    /// Third-party plugins to use.
-    /// @see {@link https://oxc.rs/docs/guide/usage/transformer/plugins}
-    pub plugins: Option<PluginsOptions>,
+    /// Enable source map generation.
+    ///
+    /// When `true`, the `sourceMap` field of transform result objects will be populated.
+    ///
+    /// @default false
+    ///
+    /// @see {@link SourceMap}
+    pub sourcemap: Option<bool>,
 }
 
 impl TryFrom<TransformOptions> for oxc::transformer::TransformOptions {
@@ -174,6 +190,7 @@ impl TryFrom<TransformOptions> for oxc::transformer::TransformOptions {
         Ok(Self {
             cwd: options.cwd.map(PathBuf::from).unwrap_or_default(),
             assumptions: options.assumptions.map(Into::into).unwrap_or_default(),
+            react_compiler: crate::react_compiler::resolve(options.react_compiler),
             typescript: options
                 .typescript
                 .map(oxc::transformer::TypeScriptOptions::from)
@@ -181,6 +198,10 @@ impl TryFrom<TransformOptions> for oxc::transformer::TransformOptions {
             decorator: options
                 .decorator
                 .map(oxc::transformer::DecoratorOptions::from)
+                .unwrap_or_default(),
+            plugins: options
+                .plugins
+                .map(oxc::transformer::PluginsOptions::from)
                 .unwrap_or_default(),
             jsx: match options.jsx {
                 Some(Either::A(s)) => {
@@ -198,11 +219,6 @@ impl TryFrom<TransformOptions> for oxc::transformer::TransformOptions {
             helper_loader: options
                 .helpers
                 .map_or_else(HelperLoaderOptions::default, HelperLoaderOptions::from),
-            plugins: options
-                .plugins
-                .map(oxc::transformer::PluginsOptions::from)
-                .unwrap_or_default(),
-            react_compiler: crate::react_compiler::resolve(options.react_compiler),
         })
     }
 }


### PR DESCRIPTION
Reorders the option struct fields in `oxc_transformer` and the napi transform binding to match the order their transforms are evaluated, and documents that order on each struct. Behavior-neutral; the only externally visible change is field order and docs in the generated `index.d.ts`.

- **`TransformOptions`** (`oxc_transformer`): `react_compiler` (separate pass before the traversal) → `typescript` → `decorator` → `plugins` → `jsx` → `env`, with `helper_loader` last (not a transform). Previously `plugins` sat after `env` and `react_compiler` was last despite running first.
- **`EnvOptions`**: was ascending `es2015`→`es2026`; now `module` (consumed by the TypeScript transform), then `es2026` down to `es2015`, then `regexp` last.
- **`ES2020Options`**: `optional_chaining` moved next to `nullish_coalescing_operator`, matching their `enter_expression` order.
- **napi `TransformOptions`**: follows the full compiler pipeline — `lang`/`sourceType` (parse) → `assumptions` → `reactCompiler` → `typescript` → `decorator` → `plugins` → `jsx` → `target` → `helpers` → `inject` → `define` → `sourcemap` (codegen). Two things this surfaced: `inject` runs **before** `define` (the struct listed them reversed), and `sourcemap` is a codegen option so it belongs at the end. `index.d.ts` regenerated.

The canonical order is `TransformerImpl`'s field order in `lib.rs` (and `CompilerInterface::compile` for the napi pipeline stages); a note on `TransformerImpl` now reminds maintainers to keep `TransformOptions` in sync.

Verified: `cargo check`/`clippy --all-features --all-targets` (CI profile), `cargo test -p oxc_transformer`, napi vitest 62/62, transform conformance with zero snapshot diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)