### PR TITLE
refactor(parser): remove speculative JSX parsing for jsx-in-non-jsx error

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1217,20 +1217,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// A leading `<` in a file where JSX is disabled and which is not TypeScript (so it is not a
-    /// type assertion either) is always an error. Speculatively parse the JSX so the diagnostic can
-    /// span the whole element (e.g. `<Foo />`), and so well-formed JSX gets the "enable JSX" help
-    /// while anything that is not valid JSX rewinds and falls back to a generic "unexpected token".
-    /// The parsed expression is intentionally discarded.
+    /// type assertion either) is always an error. Report it against the `<` token with a help to
+    /// enable JSX in the parser options.
     fn parse_jsx_in_non_jsx_error(&mut self) -> Expression<'a> {
-        let checkpoint = self.checkpoint_with_error_recovery();
-        let start = self.start_span();
-        self.parse_jsx_expression();
-        if self.fatal_error.is_none() {
-            self.fatal_error(diagnostics::jsx_in_non_jsx(self.end_span(start)))
-        } else {
-            self.rewind(checkpoint);
-            self.unexpected()
-        }
+        self.fatal_error(diagnostics::jsx_in_non_jsx(self.cur_token().span()))
     }
 
     fn parse_unary_expression(&mut self) -> Expression<'a> {

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -12209,7 +12209,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-fragment/input.js:3:5]
  2 │   return (
  3 │     <>Hello</>
-   ·     ──────────
+   ·     ─
  4 │   );
    ╰────
   help: JSX syntax is disabled and should be enabled via the parser options
@@ -12217,30 +12217,29 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
   × Unexpected JSX expression
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-jsx-expression/input.js:1:1]
  1 │ <div>{name}</div>
-   · ─────────────────
+   · ─
    ╰────
   help: JSX syntax is disabled and should be enabled via the parser options
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-type-param/input.js:1:1]
  1 │ <div>() => {}
    · ─
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
   × Unexpected JSX expression
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin/input.js:1:1]
  1 │ <div></div>
-   · ───────────
+   · ─
    ╰────
   help: JSX syntax is disabled and should be enabled via the parser options
 
   × Unexpected JSX expression
    ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no_plugin-non-BMP-identifier/input.js:1:1]
- 1 │ ╭─▶ <
- 2 │ │     𠮷
- 3 │ │   ></
- 4 │ │     𠮷
- 5 │ ╰─▶ >
+ 1 │ <
+   · ─
+ 2 │   𠮷
    ╰────
   help: JSX syntax is disabled and should be enabled via the parser options
 

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -364,15 +364,16 @@ Negative Passed: 146/146 (100.00%)
   × Unexpected JSX expression
    ╭─[misc/fail/jsx-in-js.js:1:20]
  1 │ export const foo = <Foo />;
-   ·                    ───────
+   ·                    ─
    ╰────
   help: JSX syntax is disabled and should be enabled via the parser options
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[misc/fail/jsx-like-in-js.js:1:20]
  1 │ export const foo = <Foo;
    ·                    ─
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
   × The keyword 'let' is reserved
    ╭─[misc/fail/let-member-expression.js:4:1]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -8380,12 +8380,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  2 │ var v = <string>undefined;
    ╰────
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[typescript/tests/cases/compiler/jsFileCompilationTypeAssertions.ts:2:9]
  1 │ 0 as number;
  2 │ var v = <string>undefined;
    ·         ─
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
   × Expected `,` or `)` but found `:`
    ╭─[typescript/tests/cases/compiler/jsFileCompilationTypeOfParameter.ts:1:13]
@@ -10642,45 +10643,50 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
     ╰────
   help: Did you mean to write 'undefined | null | undefined'?
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash1.ts:1:2]
  1 │ ~< <
    ·  ─
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
   × Unexpected JSX expression
    ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash2.ts:1:2]
  1 │ ~<></> <
-   ·  ─────
+   ·  ─
    ╰────
   help: JSX syntax is disabled and should be enabled via the parser options
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[typescript/tests/cases/compiler/parseJsxElementInUnaryExpressionNoCrash3.ts:1:2]
  1 │ !< {:>
    ·  ─
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx1.ts:2:13]
  1 │ const x = "oops";
  2 │ const y = + <number> x;
    ·             ─
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx2.ts:2:13]
  1 │ const x = "oops";
  2 │ const y = + <> x;
    ·             ─
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
-  × Unexpected token
+  × Unexpected JSX expression
    ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx3.ts:2:13]
  1 │ const x = "oops";
  2 │ const y = + <1234> x;
    ·             ─
    ╰────
+  help: JSX syntax is disabled and should be enabled via the parser options
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx4.ts:5:14]


### PR DESCRIPTION
Part of the effort to remove all checkpoint usage from the parser.

Replace the speculative JSX parse (checkpoint + rewind) in `parse_jsx_in_non_jsx_error` with a direct fatal error on the `<` token, with help to enable JSX in the parser options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)