### PR TITLE
refactor(linter): use `u32` instead of `usize` for rule options

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/complexity.rs
+++ b/crates/oxc_linter/src/rules/eslint/complexity.rs
@@ -17,21 +17,21 @@ use crate::{
     rule::{DefaultRuleConfig, Rule},
 };
 
-fn complexity_diagnostic(span: Span, name: &str, complexity: usize, max: usize) -> OxcDiagnostic {
+fn complexity_diagnostic(span: Span, name: &str, complexity: u32, max: u32) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "{name} has a complexity of {complexity}. Maximum allowed is {max}."
     ))
     .with_label(span)
 }
 
-const THRESHOLD_DEFAULT: usize = 20;
+const THRESHOLD_DEFAULT: u32 = 20;
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct ComplexityConfig {
     /// Maximum amount of cyclomatic complexity
     #[serde(alias = "maximum")]
-    max: usize,
+    max: u32,
     /// The cyclomatic complexity variant to use
     variant: Variant,
 }
@@ -156,7 +156,7 @@ impl Rule for Complexity {
             .get(0)
             .and_then(Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
         {
             Ok(Self(Box::new(ComplexityConfig { max, variant: Variant::Classic })))
         } else {
@@ -236,7 +236,7 @@ impl Rule for Complexity {
 
 struct ComplexityVisitor {
     variant: Variant,
-    complexity: usize,
+    complexity: u32,
     has_entered_complexity_evaluation: bool,
 }
 

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -11,7 +11,7 @@ use crate::{
     rule::{DefaultRuleConfig, Rule},
 };
 
-fn max_classes_per_file_diagnostic(total: usize, max: usize, span: Span) -> OxcDiagnostic {
+fn max_classes_per_file_diagnostic(total: u32, max: u32, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("File has too many classes ({total}). Maximum allowed is {max}"))
         .with_help("Reduce the number of classes in this file")
         .with_label(span)
@@ -24,7 +24,7 @@ pub struct MaxClassesPerFile(Box<MaxClassesPerFileConfig>);
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxClassesPerFileConfig {
     /// The maximum number of classes allowed per file.
-    pub max: usize,
+    pub max: u32,
     /// Whether to ignore class expressions when counting classes.
     pub ignore_expressions: bool,
 }
@@ -95,7 +95,7 @@ impl Rule for MaxClassesPerFile {
             .get(0)
             .and_then(serde_json::Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
         {
             Ok(Self(Box::new(MaxClassesPerFileConfig { max, ignore_expressions: false })))
         } else {
@@ -105,15 +105,16 @@ impl Rule for MaxClassesPerFile {
         }
     }
 
+    #[expect(clippy::cast_possible_truncation)] // the count of classes can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run_once(&self, ctx: &LintContext<'_>) {
-        let mut class_count = ctx.classes().declarations.len();
+        let mut class_count = ctx.classes().declarations.len() as u32;
 
         if self.ignore_expressions {
             let class_expressions = ctx
                 .classes()
                 .iter_enumerated()
                 .filter(|(_class_id, node_id)| !ctx.nodes().kind(**node_id).is_declaration())
-                .count();
+                .count() as u32;
             class_count -= class_expressions;
         }
 
@@ -121,7 +122,7 @@ impl Rule for MaxClassesPerFile {
             return;
         }
 
-        let node_id = ctx.classes().get_node_id(ClassId::from(self.max));
+        let node_id = ctx.classes().get_node_id(ClassId::new(self.max as usize));
         let span = if let AstKind::Class(class) = ctx.nodes().kind(node_id) {
             class.span
         } else {

--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -11,19 +11,19 @@ use serde_json::Value;
 use crate::rule::DefaultRuleConfig;
 use crate::{AstNode, ast_util::is_function_node, context::LintContext, rule::Rule};
 
-fn max_depth_diagnostic(num: usize, max: usize, span: Span) -> OxcDiagnostic {
+fn max_depth_diagnostic(num: u32, max: u32, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Blocks are nested too deeply ({num}). Maximum allowed is {max}."))
         .with_help("Consider refactoring your code.")
         .with_label(span)
 }
 
-const DEFAULT_MAX_DEPTH: usize = 4;
+const DEFAULT_MAX_DEPTH: u32 = 4;
 
 #[derive(Debug, Clone, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxDepth {
     /// The `max` enforces a maximum depth that blocks can be nested
-    max: usize,
+    max: u32,
 }
 
 impl Default for MaxDepth {
@@ -114,7 +114,7 @@ impl Rule for MaxDepth {
             .get(0)
             .and_then(Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
         {
             Ok(MaxDepth { max })
         } else {
@@ -124,6 +124,7 @@ impl Rule for MaxDepth {
         }
     }
 
+    #[expect(clippy::cast_possible_truncation)] // the length of ancestors can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if should_count(node, ctx.nodes()) {
             let depth = 1 + ctx
@@ -131,7 +132,7 @@ impl Rule for MaxDepth {
                 .ancestors(node.id())
                 .take_while(|node| !should_stop(node))
                 .filter(|node| should_count(node, ctx.nodes()))
-                .count();
+                .count() as u32;
             if depth > self.max {
                 ctx.diagnostic(max_depth_diagnostic(depth, self.max, node.span()));
             }

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -11,7 +11,7 @@ use crate::{
     utils::count_comment_lines,
 };
 
-fn max_lines_diagnostic(count: usize, max: usize, span: Span) -> OxcDiagnostic {
+fn max_lines_diagnostic(count: u32, max: u32, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("File has too many lines ({count})."))
         .with_help(format!("Maximum allowed is {max}."))
         .with_label(span)
@@ -24,7 +24,7 @@ pub struct MaxLines(Box<MaxLinesConfig>);
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxLinesConfig {
     /// Maximum number of lines allowed per file.
-    max: usize,
+    max: u32,
     /// Whether to ignore blank lines when counting.
     skip_blank_lines: bool,
     /// Whether to ignore comments when counting.
@@ -82,7 +82,7 @@ impl Rule for MaxLines {
             .get(0)
             .and_then(Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
         {
             Ok(Self(Box::new(MaxLinesConfig {
                 max,
@@ -115,7 +115,7 @@ impl Rule for MaxLines {
             if ctx.source_text().ends_with('\n') { newlines } else { newlines + 1 }
         };
 
-        let final_lines = lines_in_file.max(1).saturating_sub(comment_lines);
+        let final_lines = lines_in_file.max(1).saturating_sub(comment_lines) as u32;
         if final_lines > self.max {
             // Point to end of the file for `eslint-disable max-lines` to work.
             let end = ctx.source_text().len().saturating_sub(1) as u32;

--- a/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
@@ -19,8 +19,8 @@ use crate::{
 
 fn max_lines_per_function_diagnostic(
     name: &str,
-    count: usize,
-    max: usize,
+    count: u32,
+    max: u32,
     span: Span,
 ) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -34,7 +34,7 @@ fn max_lines_per_function_diagnostic(
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxLinesPerFunctionConfig {
     /// Maximum number of lines allowed in a function.
-    max: usize,
+    max: u32,
     /// Skip lines containing just comments.
     skip_comments: bool,
     /// Skip lines made up purely of whitespace.
@@ -46,7 +46,7 @@ pub struct MaxLinesPerFunctionConfig {
     iifes: bool,
 }
 
-const DEFAULT_MAX_LINES_PER_FUNCTION: usize = 50;
+const DEFAULT_MAX_LINES_PER_FUNCTION: u32 = 50;
 
 impl Default for MaxLinesPerFunctionConfig {
     fn default() -> Self {
@@ -140,7 +140,7 @@ impl Rule for MaxLinesPerFunction {
         if let Some(max) = config
             .and_then(Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
         {
             Ok(Self(Box::new(MaxLinesPerFunctionConfig {
                 max,
@@ -154,6 +154,7 @@ impl Rule for MaxLinesPerFunction {
         }
     }
 
+    #[expect(clippy::cast_possible_truncation)] // the length of lines can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Function(f) if f.is_function_declaration() => {}
@@ -184,7 +185,7 @@ impl Rule for MaxLinesPerFunction {
             if code.ends_with('\n') { newlines } else { newlines + 1 }
         };
 
-        let final_lines = lines_in_function.saturating_sub(comment_lines);
+        let final_lines = lines_in_function.saturating_sub(comment_lines) as u32;
         if final_lines > self.max {
             let name = get_function_name_with_kind(node, ctx.nodes().parent_node(node.id()));
             ctx.diagnostic(max_lines_per_function_diagnostic(&name, final_lines, self.max, span));

--- a/crates/oxc_linter/src/rules/eslint/max_nested_callbacks.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_nested_callbacks.rs
@@ -14,7 +14,7 @@ use crate::{
     rule::{DefaultRuleConfig, Rule},
 };
 
-fn max_nested_callbacks_diagnostic(num: usize, max: usize, span: Span) -> OxcDiagnostic {
+fn max_nested_callbacks_diagnostic(num: u32, max: u32, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("Too many nested callbacks ({num}). Maximum allowed is {max}."))
         .with_help("Reduce nesting with promises or refactoring your code.")
         .with_label(span)
@@ -24,10 +24,10 @@ fn max_nested_callbacks_diagnostic(num: usize, max: usize, span: Span) -> OxcDia
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxNestedCallbacks {
     /// The `max` enforces a maximum depth that callbacks can be nested.
-    max: usize,
+    max: u32,
 }
 
-const DEFAULT_MAX_NESTED_CALLBACKS: usize = 10;
+const DEFAULT_MAX_NESTED_CALLBACKS: u32 = 10;
 
 impl Default for MaxNestedCallbacks {
     fn default() -> Self {
@@ -104,6 +104,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for MaxNestedCallbacks {
+    #[expect(clippy::cast_possible_truncation)] // the length of nested ancestors can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Function(f) if f.is_function_declaration() => {}
@@ -118,7 +119,7 @@ impl Rule for MaxNestedCallbacks {
                 .nodes()
                 .ancestors(node.id())
                 .filter(|node| is_callback(node, ctx))
-                .count();
+                .count() as u32;
             if depth > self.max {
                 ctx.diagnostic(max_nested_callbacks_diagnostic(depth, self.max, node.span()));
             }
@@ -130,7 +131,7 @@ impl Rule for MaxNestedCallbacks {
             .get(0)
             .and_then(Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
         {
             Ok(Self { max })
         } else {

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -31,7 +31,7 @@ pub struct MaxParams(Box<MaxParamsConfig>);
 pub struct MaxParamsConfig {
     /// Maximum number of parameters allowed in function definitions.
     #[serde(alias = "maximum")]
-    max: usize,
+    max: u32,
     /// This option controls when to count a `this` parameter.
     ///
     /// - "always": always count `this`
@@ -102,8 +102,9 @@ impl MaxParams {
         }
     }
 
-    fn ts_function_type_param_count(&self, function: &TSFunctionType) -> usize {
-        let mut real_len = function.params.items.len();
+    #[expect(clippy::cast_possible_truncation)] // the length of parameters can't be over u32::MAX, because the source code is already limited by u32::MAX.
+    fn ts_function_type_param_count(&self, function: &TSFunctionType) -> u32 {
+        let mut real_len = function.params.items.len() as u32;
         if let Some(this_params) = &function.this_param {
             let is_void_this = this_params
                 .type_annotation
@@ -171,7 +172,7 @@ impl Rule for MaxParams {
             .get(0)
             .and_then(Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
         {
             Ok(Self(Box::new(MaxParamsConfig { max, ..MaxParamsConfig::default() })))
         } else {
@@ -180,6 +181,7 @@ impl Rule for MaxParams {
         }
     }
 
+    #[expect(clippy::cast_possible_truncation)] // the length of parameters can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Function(function) => {
@@ -187,7 +189,7 @@ impl Rule for MaxParams {
                     return;
                 }
                 let params = &function.params;
-                let mut real_len = params.items.len();
+                let mut real_len = params.items.len() as u32;
                 if let Some(this_params) = &function.this_param {
                     let is_void_this = this_params
                         .type_annotation
@@ -218,7 +220,7 @@ impl Rule for MaxParams {
                 }
             }
             AstKind::ArrowFunctionExpression(function)
-                if function.params.items.len() > self.max =>
+                if function.params.items.len() as u32 > self.max =>
             {
                 let error_msg = format!(
                     "Arrow function has too many parameters ({}). Maximum allowed is {}.",

--- a/crates/oxc_linter/src/rules/eslint/max_statements.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_statements.rs
@@ -18,8 +18,8 @@ use crate::{context::LintContext, rule::Rule};
 
 fn max_statements_diagnostic(
     name: Option<&str>,
-    count: usize,
-    max: usize,
+    count: u32,
+    max: u32,
     span: Span,
 ) -> OxcDiagnostic {
     let message = if let Some(name) = name {
@@ -33,13 +33,13 @@ fn max_statements_diagnostic(
         .with_label(span)
 }
 
-const DEFAULT_MAX_STATEMENTS: usize = 10;
+const DEFAULT_MAX_STATEMENTS: u32 = 10;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxStatementsConfig {
     /// Maximum number of statements allowed per function.
-    max: usize,
+    max: u32,
     /// Whether to ignore top-level functions.
     ignore_top_level_functions: bool,
 }
@@ -218,7 +218,7 @@ impl Rule for MaxStatements {
         let max = if let Some(max) = config
             .and_then(Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
         {
             max
         } else {
@@ -227,7 +227,7 @@ impl Rule for MaxStatements {
                 .and_then(Value::as_number)
                 .and_then(serde_json::Number::as_u64)
                 .map_or(DEFAULT_MAX_STATEMENTS, |v| {
-                    usize::try_from(v).unwrap_or(DEFAULT_MAX_STATEMENTS)
+                    u32::try_from(v).unwrap_or(DEFAULT_MAX_STATEMENTS)
                 })
         };
 
@@ -263,14 +263,14 @@ impl Rule for MaxStatements {
 }
 
 struct StatementCounter<'a> {
-    max: usize,
+    max: u32,
     ignore_top_level_functions: bool,
     /// Stack of statement counts for each function we're currently inside
-    function_stack: Vec<usize>,
+    function_stack: Vec<u32>,
     /// Top-level functions that exceed the limit (reported only if > 1)
-    top_level_functions: Vec<(Option<&'a str>, usize, Span)>,
+    top_level_functions: Vec<(Option<&'a str>, u32, Span)>,
     /// Diagnostics for non-top-level functions
-    diagnostics: Vec<(Option<&'a str>, usize, Span)>,
+    diagnostics: Vec<(Option<&'a str>, u32, Span)>,
 }
 
 impl<'a> StatementCounter<'a> {
@@ -294,7 +294,7 @@ impl<'a> StatementCounter<'a> {
         }
     }
 
-    fn count_statements(&mut self, count: usize) {
+    fn count_statements(&mut self, count: u32) {
         if let Some(current) = self.function_stack.last_mut() {
             *current += count;
         }
@@ -326,13 +326,15 @@ impl<'a> Visit<'a> for StatementCounter<'a> {
         self.function_stack.pop();
     }
 
+    #[expect(clippy::cast_possible_truncation)] // the length of body statements can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn visit_function_body(&mut self, body: &FunctionBody<'a>) {
-        self.count_statements(body.statements.len());
+        self.count_statements(body.statements.len() as u32);
         walk_function_body(self, body);
     }
 
+    #[expect(clippy::cast_possible_truncation)] // the length of the body can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn visit_block_statement(&mut self, block: &BlockStatement<'a>) {
-        self.count_statements(block.body.len());
+        self.count_statements(block.body.len() as u32);
         for stmt in &block.body {
             self.visit_statement(stmt);
         }

--- a/crates/oxc_linter/src/rules/eslint/sort_keys.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_keys.rs
@@ -37,7 +37,7 @@ pub struct SortKeysOptions {
     /// Use natural sort order so that, for example, "a2" comes before "a10".
     natural: bool,
     /// Minimum number of properties required in an object before sorting is enforced.
-    min_keys: usize,
+    min_keys: u32,
     /// When true, groups of properties separated by a blank line are sorted independently.
     allow_line_separated_groups: bool,
 }
@@ -102,11 +102,12 @@ impl Rule for SortKeys {
         serde_json::from_value::<TupleRuleConfig<Self>>(value).map(TupleRuleConfig::into_inner)
     }
 
+    #[expect(clippy::cast_possible_truncation)] // the length of properties can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::ObjectExpression(dec) = node.kind() {
             let SortKeysConfig(sort_order, options) = &*self.0;
 
-            if dec.properties.len() < options.min_keys {
+            if (dec.properties.len() as u32) < options.min_keys {
                 return;
             }
 

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -30,7 +30,7 @@ pub struct MaxDependencies(Box<MaxDependenciesConfig>);
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxDependenciesConfig {
     /// Maximum number of dependencies allowed in a file.
-    max: usize,
+    max: u32,
     /// Whether to ignore type imports when counting dependencies.
     ///
     /// ```ts
@@ -59,7 +59,7 @@ impl Default for MaxDependenciesConfig {
 #[serde(untagged)]
 #[expect(unused)] // only for schema generation
 enum MaxDependenciesConfigJson {
-    Number(usize),
+    Number(u32),
     Object(MaxDependenciesConfig),
 }
 
@@ -110,7 +110,7 @@ impl Rule for MaxDependencies {
             .get(0)
             .and_then(Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
         {
             Ok(Self(Box::new(MaxDependenciesConfig { max, ignore_type_imports: false })))
         } else {

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -10,7 +10,7 @@ use oxc_span::Span;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-fn no_barrel_file(total: usize, threshold: usize, labels: Vec<LabeledSpan>) -> OxcDiagnostic {
+fn no_barrel_file(total: u32, threshold: u32, labels: Vec<LabeledSpan>) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "Barrel file detected, {total} modules are loaded which exceeds the threshold of {threshold}.",
     ))
@@ -24,7 +24,7 @@ fn no_barrel_file(total: usize, threshold: usize, labels: Vec<LabeledSpan>) -> O
 pub struct NoBarrelFile {
     /// The maximum number of modules that can be re-exported via `export *`
     /// before the rule is triggered.
-    threshold: usize,
+    threshold: u32,
 }
 
 impl Default for NoBarrelFile {
@@ -103,7 +103,7 @@ impl Rule for NoBarrelFile {
             .collect::<Vec<_>>();
 
         let mut labels = vec![];
-        let mut total: usize = 0;
+        let mut total: u32 = 0;
 
         for module_request in module_requests {
             // the own module is counted as well
@@ -132,7 +132,7 @@ impl Rule for NoBarrelFile {
     }
 }
 
-fn count_loaded_modules(module_record: &ModuleRecord) -> Option<usize> {
+fn count_loaded_modules(module_record: &ModuleRecord) -> Option<u32> {
     if module_record.loaded_modules().is_empty() {
         return None;
     }

--- a/crates/oxc_linter/src/rules/react/jsx_max_depth.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_max_depth.rs
@@ -17,7 +17,7 @@ use crate::{
     rule::{DefaultRuleConfig, Rule},
 };
 
-fn jsx_max_depth_diagnostic(depth: usize, max: usize, span: Span) -> OxcDiagnostic {
+fn jsx_max_depth_diagnostic(depth: u32, max: u32, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
         "JSX nesting depth of {depth} exceeds the configured maximum of {max}"
     ))
@@ -39,7 +39,7 @@ impl std::ops::Deref for JsxMaxDepth {
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct JsxMaxDepthConfig {
     /// The maximum allowed depth of nested JSX elements and fragments.
-    pub max: usize,
+    pub max: u32,
 }
 
 impl Default for JsxMaxDepthConfig {
@@ -125,7 +125,7 @@ fn calculate_variable_jsx_depth(
     symbol_id: SymbolId,
     ctx: &LintContext<'_>,
     visited: &mut FxHashSet<SymbolId>,
-) -> usize {
+) -> u32 {
     if !visited.insert(symbol_id) {
         return 0;
     }
@@ -146,7 +146,7 @@ fn calculate_expression_jsx_depth(
     expr: &Expression<'_>,
     ctx: &LintContext<'_>,
     visited: &mut FxHashSet<SymbolId>,
-) -> usize {
+) -> u32 {
     match expr {
         Expression::JSXElement(elem) => calculate_jsx_children_depth(&elem.children, ctx, visited),
         Expression::JSXFragment(frag) => calculate_jsx_children_depth(&frag.children, ctx, visited),
@@ -166,7 +166,7 @@ fn calculate_node_jsx_depth(
     node: &AstNode<'_>,
     ctx: &LintContext<'_>,
     visited_symbols: &mut FxHashSet<SymbolId>,
-) -> usize {
+) -> u32 {
     let children = match node.kind() {
         AstKind::JSXElement(elem) => &elem.children,
         AstKind::JSXFragment(frag) => &frag.children,
@@ -179,7 +179,7 @@ fn calculate_jsx_children_depth(
     children: &[JSXChild<'_>],
     ctx: &LintContext<'_>,
     visited_symbols: &mut FxHashSet<SymbolId>,
-) -> usize {
+) -> u32 {
     if children.is_empty() {
         return 0;
     }
@@ -228,13 +228,14 @@ fn is_leaf_jsx_node(node: &AstNode<'_>) -> bool {
     !children.iter().any(|child| matches!(child, JSXChild::Element(_) | JSXChild::Fragment(_)))
 }
 
-fn jsx_ancestor_depth(node: &AstNode<'_>, ctx: &LintContext<'_>) -> usize {
+#[expect(clippy::cast_possible_truncation)] // the length of ancestors can't be over u32::MAX, because the source code is already limited by u32::MAX.
+fn jsx_ancestor_depth(node: &AstNode<'_>, ctx: &LintContext<'_>) -> u32 {
     ctx.nodes()
         .ancestors(node.id())
         .filter(|ancestor| {
             matches!(ancestor.kind(), AstKind::JSXElement(_) | AstKind::JSXFragment(_))
         })
-        .count()
+        .count() as u32
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/max_expects.rs
@@ -11,7 +11,7 @@ use crate::{
     utils::{PossibleJestNode, collect_possible_jest_call_node},
 };
 
-fn exceeded_max_assertion(count: usize, max: usize, span: Span) -> OxcDiagnostic {
+fn exceeded_max_assertion(count: u32, max: u32, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforces a maximum number assertion calls in a test body.")
         .with_help(format!("Too many assertion calls ({count}) - maximum allowed is {max}"))
         .with_label(span)
@@ -55,7 +55,7 @@ it('should not pass', () => {
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxExpectsConfig {
     /// Maximum number of `expect()` assertion calls allowed within a single test.
-    pub max: usize,
+    pub max: u32,
 }
 
 impl Default for MaxExpectsConfig {
@@ -66,7 +66,7 @@ impl Default for MaxExpectsConfig {
 
 impl MaxExpectsConfig {
     pub fn run_once(&self, ctx: &LintContext) {
-        let mut count_map: FxHashMap<usize, usize> = FxHashMap::default();
+        let mut count_map: FxHashMap<usize, u32> = FxHashMap::default();
 
         for possible_jest_node in &collect_possible_jest_call_node(ctx) {
             self.run(possible_jest_node, &mut count_map, ctx);
@@ -76,7 +76,7 @@ impl MaxExpectsConfig {
     fn run<'a>(
         &self,
         jest_node: &PossibleJestNode<'a, '_>,
-        count_map: &mut FxHashMap<usize, usize>,
+        count_map: &mut FxHashMap<usize, u32>,
         ctx: &LintContext<'a>,
     ) {
         let node = jest_node.node;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/max_nested_describe.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 
-fn exceeded_max_depth(current: usize, max: usize, span: Span) -> OxcDiagnostic {
+fn exceeded_max_depth(current: u32, max: u32, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Enforces a maximum depth to nested describe calls.")
         .with_help(format!("Too many nested describe calls ({current}) - maximum allowed is {max}"))
         .with_label(span)
@@ -108,7 +108,7 @@ describe('foo', function () {
 #[schemars(default)]
 pub struct MaxNestedDescribeConfig {
     /// Maximum allowed depth of nested describe calls.
-    pub max: usize,
+    pub max: u32,
 }
 
 impl Default for MaxNestedDescribeConfig {
@@ -118,6 +118,7 @@ impl Default for MaxNestedDescribeConfig {
 }
 
 impl MaxNestedDescribeConfig {
+    #[expect(clippy::cast_possible_truncation)] // the depth of `describe` can't be over u32::MAX, because the source code is already limited by u32::MAX.
     pub fn run_once(&self, ctx: &LintContext) {
         let mut describe_call_spans = collect_possible_jest_call_node(ctx)
             .into_iter()
@@ -146,7 +147,7 @@ impl MaxNestedDescribeConfig {
             }
             active_describes.push(span);
 
-            let current_depth = active_describes.len();
+            let current_depth = active_describes.len() as u32;
             if current_depth > self.max {
                 ctx.diagnostic(exceeded_max_depth(current_depth, self.max, span));
             }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_large_snapshots.rs
@@ -15,7 +15,7 @@ use crate::{
     utils::{PossibleJestNode, iter_possible_jest_call_node, parse_expect_jest_fn_call},
 };
 
-fn no_snapshot(line_count: usize, span: Span) -> OxcDiagnostic {
+fn no_snapshot(line_count: u32, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Snapshot is too long.")
         .with_help(format!(
             "Expected to not encounter a Jest or Vitest snapshot but one was found that is {line_count} lines long"
@@ -23,7 +23,7 @@ fn no_snapshot(line_count: usize, span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-fn too_long_snapshot(line_limit: usize, line_count: usize, span: Span) -> OxcDiagnostic {
+fn too_long_snapshot(line_limit: u32, line_count: u32, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Snapshot is too long.")
         .with_help(format!(
             "Expected Jest or Vitest snapshot to be no longer than {line_limit} lines but it was {line_count} lines long"
@@ -117,9 +117,9 @@ line 4
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoLargeSnapshotsConfig {
     /// Maximum number of lines allowed for external snapshot files.
-    pub max_size: usize,
+    pub max_size: u32,
     /// Maximum number of lines allowed for inline snapshots.
-    pub inline_max_size: usize,
+    pub inline_max_size: u32,
     /// A map of snapshot file paths to arrays of snapshot names that are allowed to exceed the size limit.
     /// Snapshot names can be specified as regular expressions.
     pub allowed_snapshots: FxHashMap<CompactStr, Vec<CompactStr>>,
@@ -140,14 +140,14 @@ impl NoLargeSnapshotsConfig {
             .and_then(|c| c.get("maxSize"))
             .and_then(serde_json::Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
             .unwrap_or(50);
 
         let inline_max_size = config
             .and_then(|c| c.get("inlineMaxSize"))
             .and_then(serde_json::Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .and_then(|v| usize::try_from(v).ok())
+            .and_then(|v| u32::try_from(v).ok())
             .unwrap_or(max_size);
 
         let allowed_snapshots = config
@@ -276,10 +276,11 @@ impl NoLargeSnapshotsConfig {
         })
     }
 
-    fn get_line_count(span: Span, ctx: &LintContext) -> usize {
+    #[expect(clippy::cast_possible_truncation)] // the line count can't be over u32::MAX, because the source code is already limited by u32::MAX.
+    fn get_line_count(span: Span, ctx: &LintContext) -> u32 {
         let start = span.start as usize;
         let end = span.end as usize;
-        ctx.source_text()[start..=end].lines().count() - 1
+        ctx.source_text()[start..=end].lines().count() as u32 - 1
     }
 
     pub fn compile_allowed_snapshots(

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect.rs
@@ -57,9 +57,9 @@ pub struct ValidExpectConfig {
     /// List of matchers that are considered async and therefore require awaiting (e.g. `toResolve`, `toReject`).
     async_matchers: Vec<String>,
     /// Minimum number of arguments `expect` should be called with.
-    min_args: usize,
+    min_args: u32,
     /// Maximum number of arguments `expect` should be called with.
-    max_args: usize,
+    max_args: u32,
     /// When `true`, allow a string or template literal second argument as a custom message.
     #[serde(skip)]
     allow_string_message_arg: bool,
@@ -94,13 +94,13 @@ impl ValidExpectConfig {
             .and_then(|config| config.get("minArgs"))
             .and_then(serde_json::Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .map_or(1, |v| usize::try_from(v).unwrap_or(1));
+            .map_or(1, |v| u32::try_from(v).unwrap_or(1));
 
         let max_args = config
             .and_then(|config| config.get("maxArgs"))
             .and_then(serde_json::Value::as_number)
             .and_then(serde_json::Number::as_u64)
-            .map_or(1, |v| usize::try_from(v).unwrap_or(1));
+            .map_or(1, |v| u32::try_from(v).unwrap_or(1));
 
         let always_await = config
             .and_then(|config| config.get("alwaysAwait"))
@@ -125,6 +125,7 @@ impl ValidExpectConfig {
         }
     }
 
+    #[expect(clippy::cast_possible_truncation)] // the length of arguments can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run<'a>(
         &self,
         possible_jest_node: &PossibleJestNode<'a, '_>,
@@ -173,7 +174,7 @@ impl ValidExpectConfig {
                 matches!(expr, Expression::StringLiteral(_) | Expression::TemplateLiteral(_))
             });
 
-        if call_expr.arguments.len() > self.max_args && !allow_message_arg {
+        if (call_expr.arguments.len() as u32) > self.max_args && !allow_message_arg {
             let error = format!(
                 "Expect takes at most {} argument{} ",
                 self.max_args,
@@ -183,7 +184,7 @@ impl ValidExpectConfig {
             ctx.diagnostic(valid_expect_diagnostic(error, help, call_expr.span));
             return;
         }
-        if call_expr.arguments.len() < self.min_args {
+        if (call_expr.arguments.len() as u32) < self.min_args {
             let error = format!(
                 "Expect requires at least {} argument{} ",
                 self.min_args,

--- a/crates/oxc_linter/src/rules/vue/max_props.rs
+++ b/crates/oxc_linter/src/rules/vue/max_props.rs
@@ -24,7 +24,7 @@ use crate::{
     utils::find_property,
 };
 
-fn max_props_diagnostic(span: Span, cur: usize, limit: usize) -> OxcDiagnostic {
+fn max_props_diagnostic(span: Span, cur: u32, limit: u32) -> OxcDiagnostic {
     let msg = format!("This component has too many props ({cur}). Maximum allowed is {limit}.");
     OxcDiagnostic::warn(msg)
         .with_help(
@@ -37,7 +37,7 @@ fn max_props_diagnostic(span: Span, cur: usize, limit: usize) -> OxcDiagnostic {
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct MaxProps {
     /// The maximum number of props allowed in a Vue SFC.
-    max_props: usize,
+    max_props: u32,
 }
 
 impl Default for MaxProps {
@@ -106,6 +106,7 @@ impl Rule for MaxProps {
 }
 
 impl MaxProps {
+    #[expect(clippy::cast_possible_truncation)] // the length of properties/arrays can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run_on_setup<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -119,20 +120,20 @@ impl MaxProps {
         if let Some(first_arg) = call_expr.arguments.first() {
             match first_arg.as_expression() {
                 Some(Expression::ObjectExpression(obj_expr))
-                    if obj_expr.properties.len() > self.max_props =>
+                    if obj_expr.properties.len() as u32 > self.max_props =>
                 {
                     ctx.diagnostic(max_props_diagnostic(
                         call_expr.span,
-                        obj_expr.properties.len(),
+                        obj_expr.properties.len() as u32,
                         self.max_props,
                     ));
                 }
                 Some(Expression::ArrayExpression(arr_expr))
-                    if arr_expr.elements.len() > self.max_props =>
+                    if arr_expr.elements.len() as u32 > self.max_props =>
                 {
                     ctx.diagnostic(max_props_diagnostic(
                         call_expr.span,
-                        arr_expr.elements.len(),
+                        arr_expr.elements.len() as u32,
                         self.max_props,
                     ));
                 }
@@ -147,13 +148,14 @@ impl MaxProps {
                 return;
             };
 
-            let all_key_len = get_type_argument_keys(ctx, first_type_argument).len();
+            let all_key_len = get_type_argument_keys(ctx, first_type_argument).len() as u32;
             if all_key_len > self.max_props {
                 ctx.diagnostic(max_props_diagnostic(call_expr.span, all_key_len, self.max_props));
             }
         }
     }
 
+    #[expect(clippy::cast_possible_truncation)] // the length of properties can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run_on_options<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::ExportDefaultDeclaration(export_default_decl) = node.kind() else {
             return;
@@ -172,10 +174,10 @@ impl MaxProps {
             return;
         };
 
-        if props_obj_expr.properties.len() > self.max_props {
+        if props_obj_expr.properties.len() as u32 > self.max_props {
             ctx.diagnostic(max_props_diagnostic(
                 props_obj_expr.span,
-                props_obj_expr.properties.len(),
+                props_obj_expr.properties.len() as u32,
                 self.max_props,
             ));
         }

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -920,7 +920,7 @@
           "description": "Maximum amount of cyclomatic complexity",
           "default": 20,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum amount of cyclomatic complexity"
         },
@@ -9568,7 +9568,7 @@
           "description": "The maximum allowed depth of nested JSX elements and fragments.",
           "default": 2,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The maximum allowed depth of nested JSX elements and fragments."
         }
@@ -9731,7 +9731,7 @@
           "description": "The maximum number of classes allowed per file.",
           "default": 1,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The maximum number of classes allowed per file."
         }
@@ -9751,7 +9751,7 @@
           "description": "Maximum number of dependencies allowed in a file.",
           "default": 10,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of dependencies allowed in a file."
         }
@@ -9762,7 +9762,7 @@
       "anyOf": [
         {
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0
         },
         {
@@ -9777,7 +9777,7 @@
           "description": "The `max` enforces a maximum depth that blocks can be nested",
           "default": 4,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The `max` enforces a maximum depth that blocks can be nested"
         }
@@ -9791,7 +9791,7 @@
           "description": "Maximum number of `expect()` assertion calls allowed within a single test.",
           "default": 5,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of `expect()` assertion calls allowed within a single test."
         }
@@ -9805,7 +9805,7 @@
           "description": "Maximum number of lines allowed per file.",
           "default": 300,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of lines allowed per file."
         },
@@ -9837,7 +9837,7 @@
           "description": "Maximum number of lines allowed in a function.",
           "default": 50,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of lines allowed in a function."
         },
@@ -9863,7 +9863,7 @@
           "description": "The `max` enforces a maximum depth that callbacks can be nested.",
           "default": 10,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The `max` enforces a maximum depth that callbacks can be nested."
         }
@@ -9877,7 +9877,7 @@
           "description": "Maximum allowed depth of nested describe calls.",
           "default": 5,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum allowed depth of nested describe calls."
         }
@@ -9906,7 +9906,7 @@
           "description": "Maximum number of parameters allowed in function definitions.",
           "default": 3,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of parameters allowed in function definitions."
         }
@@ -9920,7 +9920,7 @@
           "description": "The maximum number of props allowed in a Vue SFC.",
           "default": 1,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The maximum number of props allowed in a Vue SFC."
         }
@@ -9940,7 +9940,7 @@
           "description": "Maximum number of statements allowed per function.",
           "default": 10,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of statements allowed per function."
         }
@@ -10344,7 +10344,7 @@
           "description": "The maximum number of modules that can be re-exported via `export *`\nbefore the rule is triggered.",
           "default": 100,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The maximum number of modules that can be re-exported via `export *`\nbefore the rule is triggered."
         }
@@ -11200,7 +11200,7 @@
           "description": "Maximum number of lines allowed for inline snapshots.",
           "default": 50,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of lines allowed for inline snapshots."
         },
@@ -11208,7 +11208,7 @@
           "description": "Maximum number of lines allowed for external snapshot files.",
           "default": 50,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of lines allowed for external snapshot files."
         }
@@ -14187,7 +14187,7 @@
           "description": "Minimum number of properties required in an object before sorting is enforced.",
           "default": 2,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Minimum number of properties required in an object before sorting is enforced."
         },
@@ -14560,7 +14560,7 @@
           "description": "Maximum number of arguments `expect` should be called with.",
           "default": 1,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of arguments `expect` should be called with."
         },
@@ -14568,7 +14568,7 @@
           "description": "Minimum number of arguments `expect` should be called with.",
           "default": 1,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Minimum number of arguments `expect` should be called with."
         }

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -924,7 +924,7 @@ expression: json
           "description": "Maximum amount of cyclomatic complexity",
           "default": 20,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum amount of cyclomatic complexity"
         },
@@ -9572,7 +9572,7 @@ expression: json
           "description": "The maximum allowed depth of nested JSX elements and fragments.",
           "default": 2,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The maximum allowed depth of nested JSX elements and fragments."
         }
@@ -9735,7 +9735,7 @@ expression: json
           "description": "The maximum number of classes allowed per file.",
           "default": 1,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The maximum number of classes allowed per file."
         }
@@ -9755,7 +9755,7 @@ expression: json
           "description": "Maximum number of dependencies allowed in a file.",
           "default": 10,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of dependencies allowed in a file."
         }
@@ -9766,7 +9766,7 @@ expression: json
       "anyOf": [
         {
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0
         },
         {
@@ -9781,7 +9781,7 @@ expression: json
           "description": "The `max` enforces a maximum depth that blocks can be nested",
           "default": 4,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The `max` enforces a maximum depth that blocks can be nested"
         }
@@ -9795,7 +9795,7 @@ expression: json
           "description": "Maximum number of `expect()` assertion calls allowed within a single test.",
           "default": 5,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of `expect()` assertion calls allowed within a single test."
         }
@@ -9809,7 +9809,7 @@ expression: json
           "description": "Maximum number of lines allowed per file.",
           "default": 300,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of lines allowed per file."
         },
@@ -9841,7 +9841,7 @@ expression: json
           "description": "Maximum number of lines allowed in a function.",
           "default": 50,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of lines allowed in a function."
         },
@@ -9867,7 +9867,7 @@ expression: json
           "description": "The `max` enforces a maximum depth that callbacks can be nested.",
           "default": 10,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The `max` enforces a maximum depth that callbacks can be nested."
         }
@@ -9881,7 +9881,7 @@ expression: json
           "description": "Maximum allowed depth of nested describe calls.",
           "default": 5,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum allowed depth of nested describe calls."
         }
@@ -9910,7 +9910,7 @@ expression: json
           "description": "Maximum number of parameters allowed in function definitions.",
           "default": 3,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of parameters allowed in function definitions."
         }
@@ -9924,7 +9924,7 @@ expression: json
           "description": "The maximum number of props allowed in a Vue SFC.",
           "default": 1,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The maximum number of props allowed in a Vue SFC."
         }
@@ -9944,7 +9944,7 @@ expression: json
           "description": "Maximum number of statements allowed per function.",
           "default": 10,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of statements allowed per function."
         }
@@ -10348,7 +10348,7 @@ expression: json
           "description": "The maximum number of modules that can be re-exported via `export *`\nbefore the rule is triggered.",
           "default": 100,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The maximum number of modules that can be re-exported via `export *`\nbefore the rule is triggered."
         }
@@ -11204,7 +11204,7 @@ expression: json
           "description": "Maximum number of lines allowed for inline snapshots.",
           "default": 50,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of lines allowed for inline snapshots."
         },
@@ -11212,7 +11212,7 @@ expression: json
           "description": "Maximum number of lines allowed for external snapshot files.",
           "default": 50,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of lines allowed for external snapshot files."
         }
@@ -14191,7 +14191,7 @@ expression: json
           "description": "Minimum number of properties required in an object before sorting is enforced.",
           "default": 2,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Minimum number of properties required in an object before sorting is enforced."
         },
@@ -14564,7 +14564,7 @@ expression: json
           "description": "Maximum number of arguments `expect` should be called with.",
           "default": 1,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Maximum number of arguments `expect` should be called with."
         },
@@ -14572,7 +14572,7 @@ expression: json
           "description": "Minimum number of arguments `expect` should be called with.",
           "default": 1,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "Minimum number of arguments `expect` should be called with."
         }


### PR DESCRIPTION
Because `oxc_parser` skips every file with over `u32::MAX` bytes, every option in `oxc_linter` can be safely `u32` too.
Refactored all rules which accepts in some for `usize` into `u32`.
- Added clippy-expects with a simple description why the cast is safe.
- Updated the schema to reflect the changes

Generated By 🧠 and ✋ 