### PR TITLE
ci(miri): run Miri with strict provenance enabled

### DIFF
--- a/.github/workflows/miri-windows.yml
+++ b/.github/workflows/miri-windows.yml
@@ -67,8 +67,11 @@ jobs:
 
       # `--lib --bins --tests` omits doctests, which Miri can't run
       # https://github.com/oxc-project/oxc/pull/11092
+      # `-Zmiri-strict-provenance` enables strict provenance checks
       - name: Test oxc_allocator with Miri
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         shell: bash
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance
         run: |
           cargo +"${MIRI_TOOLCHAIN}" miri test --lib --bins --tests --all-features -p oxc_allocator

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -62,8 +62,11 @@ jobs:
 
       # `--lib --bins --tests` omits doctests, which Miri can't run
       # https://github.com/oxc-project/oxc/pull/11092
+      # `-Zmiri-strict-provenance` enables strict provenance checks
       - name: Test with Miri
         if: steps.filter.outputs.changed == 'true'
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance
         run: |
           cargo +"${MIRI_TOOLCHAIN}" miri test --lib --bins --tests --all-features -p oxc_allocator -p oxc_ast -p oxc_data_structures
           cargo +"${MIRI_TOOLCHAIN}" miri test --lib --bins --tests -p oxc_parser -p oxc_transformer


### PR DESCRIPTION
I had always understood that Miri ran its checks under strict provenance rules by default, but apparently not. Enable strict provenance in Miri in CI.