### PR TITLE
ci(miri): run doctests under Miri

### DIFF
--- a/.github/workflows/miri-windows.yml
+++ b/.github/workflows/miri-windows.yml
@@ -65,13 +65,11 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
           shared-key: miri-windows
 
-      # `--lib --bins --tests` omits doctests, which Miri can't run
-      # https://github.com/oxc-project/oxc/pull/11092
-      # `-Zmiri-strict-provenance` enables strict provenance checks
       - name: Test oxc_allocator with Miri
         working-directory: ${{ env.DEV_DRIVE_WORKSPACE }}
         shell: bash
+        # Enable strict provenance checks
         env:
           MIRIFLAGS: -Zmiri-strict-provenance
         run: |
-          cargo +"${MIRI_TOOLCHAIN}" miri test --lib --bins --tests --all-features -p oxc_allocator
+          cargo +"${MIRI_TOOLCHAIN}" miri test --all-features -p oxc_allocator

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -60,13 +60,11 @@ jobs:
           rustup toolchain install "${MIRI_TOOLCHAIN}" --component miri
           cargo +"${MIRI_TOOLCHAIN}" miri setup
 
-      # `--lib --bins --tests` omits doctests, which Miri can't run
-      # https://github.com/oxc-project/oxc/pull/11092
-      # `-Zmiri-strict-provenance` enables strict provenance checks
       - name: Test with Miri
         if: steps.filter.outputs.changed == 'true'
+        # Enable strict provenance checks
         env:
           MIRIFLAGS: -Zmiri-strict-provenance
         run: |
-          cargo +"${MIRI_TOOLCHAIN}" miri test --lib --bins --tests --all-features -p oxc_allocator -p oxc_ast -p oxc_data_structures
-          cargo +"${MIRI_TOOLCHAIN}" miri test --lib --bins --tests -p oxc_parser -p oxc_transformer
+          cargo +"${MIRI_TOOLCHAIN}" miri test --all-features -p oxc_allocator -p oxc_ast -p oxc_data_structures
+          cargo +"${MIRI_TOOLCHAIN}" miri test -p oxc_parser -p oxc_transformer

--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -113,7 +113,8 @@ use oxc_data_structures::assert_unchecked;
 ///
 /// If workload is completely uniform, it reaches stable state on the 3rd round.
 ///
-/// ```
+/// ```no_run
+/// # // This isn't run as a doctest. It's much too slow.
 /// # use oxc_allocator::Allocator;
 /// let mut allocator = Allocator::new();
 ///


### PR DESCRIPTION
Running Miri on doctests was disabled in #11092. Unclear what oddity in the version of Rust nightly we were running at the time caused it not to work, but it now seems to be fixed, so we can re-enable the doctests now.

This is what caught the memory leaks in doc comment examples which were fixed in #23257.