### PR TITLE
refactor(linter/vue): share defineProps type-signature resolution across rules

### DIFF
--- a/crates/oxc_linter/src/rules/vue/max_props.rs
+++ b/crates/oxc_linter/src/rules/vue/max_props.rs
@@ -1,9 +1,6 @@
-use oxc_allocator::Vec;
 use oxc_ast::{
     AstKind,
-    ast::{
-        ExportDefaultDeclarationKind, Expression, TSSignature, TSType, TSTypeName, TSTypeReference,
-    },
+    ast::{ExportDefaultDeclarationKind, Expression, TSSignature, TSType},
 };
 
 use oxc_diagnostics::OxcDiagnostic;
@@ -17,11 +14,10 @@ use serde_json::Value;
 
 use crate::{
     AstNode,
-    ast_util::get_declaration_from_reference_id,
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::{DefaultRuleConfig, Rule},
-    utils::find_property,
+    utils::{find_property, for_each_define_props_type_signature},
 };
 
 fn max_props_diagnostic(span: Span, cur: u32, limit: u32) -> OxcDiagnostic {
@@ -184,69 +180,22 @@ impl MaxProps {
     }
 }
 
-fn get_type_argument_keys(ctx: &LintContext, type_argument: &TSType) -> FxHashSet<CompactStr> {
-    match type_argument {
-        // e.g defineProps<A | B>();
-        TSType::TSUnionType(union_type) => {
-            union_type.types.iter().fold(FxHashSet::default(), |mut all_keys, args| {
-                let type_arg_keys = get_type_argument_keys(ctx, args);
-                all_keys.extend(type_arg_keys);
-                all_keys
-            })
-        }
-        // e.g defineProps<A & B>();
-        TSType::TSIntersectionType(intersection_type) => {
-            intersection_type.types.iter().fold(FxHashSet::default(), |mut all_keys, args| {
-                let type_arg_keys = get_type_argument_keys(ctx, args);
-                all_keys.extend(type_arg_keys);
-                all_keys
-            })
-        }
-        // e.g defineProps<A>();
-        TSType::TSTypeReference(type_ref) => collect_key_from_type_reference(ctx, type_ref),
-        // e.g defineProps<{ a: string }>();
-        TSType::TSTypeLiteral(type_literal) => collect_keys_from_signatures(&type_literal.members),
-        _ => FxHashSet::default(),
-    }
-}
-
-fn collect_key_from_type_reference(
-    ctx: &LintContext,
-    type_ref: &TSTypeReference,
+fn get_type_argument_keys<'a>(
+    ctx: &LintContext<'a>,
+    type_argument: &TSType<'a>,
 ) -> FxHashSet<CompactStr> {
-    let TSTypeName::IdentifierReference(ident_ref) = &type_ref.type_name else {
-        return FxHashSet::default();
-    };
-    // we need to find the reference of type_ref
-    let reference = ctx.scoping().get_reference(ident_ref.reference_id());
-    if !reference.is_type() {
-        return FxHashSet::default();
-    }
-    let Some(reference_node) =
-        get_declaration_from_reference_id(ident_ref.reference_id(), ctx.semantic())
-    else {
-        return FxHashSet::default();
-    };
-    let AstKind::TSInterfaceDeclaration(interface_decl) = reference_node.kind() else {
-        return FxHashSet::default();
-    };
-    let interface_body = &interface_decl.body;
-    collect_keys_from_signatures(&interface_body.body)
-}
-
-fn collect_keys_from_signatures(signatures: &Vec<TSSignature<'_>>) -> FxHashSet<CompactStr> {
-    signatures
-        .iter()
-        .filter_map(|member| match member {
-            TSSignature::TSPropertySignature(prop_signature) => {
-                prop_signature.key.static_name().map(CompactStr::from)
-            }
-            TSSignature::TSMethodSignature(method_signature) => {
-                method_signature.key.static_name().map(CompactStr::from)
-            }
-            _ => None,
-        })
-        .collect()
+    let mut keys = FxHashSet::default();
+    for_each_define_props_type_signature(type_argument, ctx, &mut |signature| {
+        let name = match signature {
+            TSSignature::TSPropertySignature(prop) => prop.key.static_name(),
+            TSSignature::TSMethodSignature(method) => method.key.static_name(),
+            _ => return,
+        };
+        if let Some(name) = name {
+            keys.insert(CompactStr::from(name));
+        }
+    });
+    keys
 }
 
 #[test]
@@ -419,6 +368,17 @@ fn test() {
 			        prop2?: false;
 			        prop3?: boolean;
 			      }>()
+			      </script>
+			      "#,
+            Some(serde_json::json!([{ "maxProps": 2 }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } }
+        (
+            r#"
+			      <script setup lang="ts">
+			      type Props = { prop1: string, prop2: string, prop3: string };
+			      defineProps<Props>();
 			      </script>
 			      "#,
             Some(serde_json::json!([{ "maxProps": 2 }])),

--- a/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
+++ b/crates/oxc_linter/src/rules/vue/no_required_prop_with_default.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
     ast::{
         BindingPattern, CallExpression, ExportDefaultDeclaration, ExportDefaultDeclarationKind,
         Expression, ObjectExpression, ObjectPropertyKind, PropertyKey, TSMethodSignatureKind,
-        TSSignature, TSType, TSTypeName, VariableDeclarator,
+        TSSignature, TSType, VariableDeclarator,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -19,7 +19,7 @@ use crate::{
     fixer::{RuleFix, RuleFixer},
     frameworks::FrameworkOptions,
     rule::Rule,
-    utils::find_property,
+    utils::{find_property, for_each_define_props_type_signature},
 };
 
 fn no_required_prop_with_default_diagnostic(span: Span, prop_name: &str) -> OxcDiagnostic {
@@ -251,9 +251,9 @@ fn get_first_variable_decl_ancestor<'a>(
     })
 }
 
-fn process_define_props_call(
-    ctx: &LintContext,
-    first_arg_expr: &Expression,
+fn process_define_props_call<'a>(
+    ctx: &LintContext<'a>,
+    first_arg_expr: &Expression<'a>,
     key_hash: &FxHashSet<String>,
 ) {
     let Expression::CallExpression(first_call_expr) = first_arg_expr.get_inner_expression() else {
@@ -281,90 +281,38 @@ fn create_optional_fix(fixer: RuleFixer<'_, '_>, key: &PropertyKey) -> RuleFix {
     fixer.insert_text_after_range(Span::new(insert_pos, insert_pos), "?")
 }
 
-fn handle_type_argument(ctx: &LintContext, ts_type: &TSType, key_hash: &FxHashSet<String>) {
-    match ts_type {
-        // e.g. `const props = defineProps<IProps>()`
-        TSType::TSTypeReference(type_ref) => {
-            let TSTypeName::IdentifierReference(ident_ref) = &type_ref.type_name else {
-                return;
-            };
-            // we need to find the reference of type_ref
-            let reference = ctx.scoping().get_reference(ident_ref.reference_id());
-            if !reference.is_type() {
-                return;
+fn handle_type_argument<'a>(
+    ctx: &LintContext<'a>,
+    ts_type: &TSType<'a>,
+    key_hash: &FxHashSet<String>,
+) {
+    for_each_define_props_type_signature(ts_type, ctx, &mut |item| {
+        let (key_name, optional, key) = match item {
+            TSSignature::TSPropertySignature(prop_sign) => {
+                (prop_sign.key.static_name(), prop_sign.optional, &prop_sign.key)
             }
-            let Some(symbol_id) = reference.symbol_id() else {
-                return;
-            };
-            let reference_node = ctx.symbol_declaration(symbol_id);
-            let AstKind::TSInterfaceDeclaration(interface_decl) = reference_node.kind() else {
-                return;
-            };
-            let body = &interface_decl.body;
-            body.body.iter().for_each(|item| {
-                let (key_name, optional, key) = match item {
-                    TSSignature::TSPropertySignature(prop_sign) => {
-                        (prop_sign.key.static_name(), prop_sign.optional, &prop_sign.key)
-                    }
-                    TSSignature::TSMethodSignature(method_sign)
-                        if method_sign.kind == TSMethodSignatureKind::Method =>
-                    {
-                        (method_sign.key.static_name(), method_sign.optional, &method_sign.key)
-                    }
-                    _ => return,
-                };
-                if let Some(key_name) = key_name
-                    && !optional
-                    && key_hash.contains(key_name.as_ref())
-                {
-                    let diagnostic =
-                        no_required_prop_with_default_diagnostic(item.span(), key_name.as_ref());
-                    // Check for comments around the key before applying fix
-                    let fix_span = Span::new(key.span().start, key.span().end + 1);
-                    if ctx.has_comments_between(fix_span) {
-                        ctx.diagnostic(diagnostic);
-                    } else {
-                        ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
-                            create_optional_fix(fixer, key)
-                        });
-                    }
-                }
-            });
+            TSSignature::TSMethodSignature(method_sign)
+                if method_sign.kind == TSMethodSignatureKind::Method =>
+            {
+                (method_sign.key.static_name(), method_sign.optional, &method_sign.key)
+            }
+            _ => return,
+        };
+        if let Some(key_name) = key_name
+            && !optional
+            && key_hash.contains(key_name.as_ref())
+        {
+            let diagnostic =
+                no_required_prop_with_default_diagnostic(item.span(), key_name.as_ref());
+            // Check for comments around the key before applying fix
+            let fix_span = Span::new(key.span().start, key.span().end + 1);
+            if ctx.has_comments_between(fix_span) {
+                ctx.diagnostic(diagnostic);
+            } else {
+                ctx.diagnostic_with_suggestion(diagnostic, |fixer| create_optional_fix(fixer, key));
+            }
         }
-        // e.g. `const props = defineProps<{ name: string }>()`
-        TSType::TSTypeLiteral(type_literal) => {
-            type_literal.members.iter().for_each(|item| {
-                let (key_name, optional, key) = match item {
-                    TSSignature::TSPropertySignature(prop_sign) => {
-                        (prop_sign.key.static_name(), prop_sign.optional, &prop_sign.key)
-                    }
-                    TSSignature::TSMethodSignature(method_sign)
-                        if method_sign.kind == TSMethodSignatureKind::Method =>
-                    {
-                        (method_sign.key.static_name(), method_sign.optional, &method_sign.key)
-                    }
-                    _ => return,
-                };
-                if let Some(key_name) = key_name
-                    && !optional
-                    && key_hash.contains(key_name.as_ref())
-                {
-                    let diagnostic =
-                        no_required_prop_with_default_diagnostic(item.span(), key_name.as_ref());
-                    // Check for comments around the key before applying fix
-                    let fix_span = Span::new(key.span().start, key.span().end + 1);
-                    if ctx.has_comments_between(fix_span) {
-                        ctx.diagnostic(diagnostic);
-                    } else {
-                        ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
-                            create_optional_fix(fixer, key)
-                        });
-                    }
-                }
-            });
-        }
-        _ => {}
-    }
+    });
 }
 
 fn handle_object_expression(ctx: &LintContext, obj: &ObjectExpression) {
@@ -1054,6 +1002,25 @@ fn test() {
                     </script>
                   "#,
             None, // Some(serde_json::json!([{ "autofix": true }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                    <script setup lang="ts">
+                      type TestPropType = {
+                        name: string
+                        age?: number
+                      }
+                      const props = withDefaults(
+                        defineProps<TestPropType>(),
+                        {
+                          name: "World",
+                        }
+                      );
+                    </script>
+                  "#,
+            None,
             None,
             Some(PathBuf::from("test.vue")),
         ),

--- a/crates/oxc_linter/src/rules/vue/no_reserved_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_reserved_keys.rs
@@ -5,7 +5,6 @@ use oxc_ast::{
     AstKind,
     ast::{
         CallExpression, Expression, ObjectExpression, ObjectPropertyKind, Statement, TSSignature,
-        TSType, TSTypeName,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -15,11 +14,10 @@ use oxc_str::CompactStr;
 
 use crate::{
     AstNode,
-    ast_util::get_declaration_from_reference_id,
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::{DefaultRuleConfig, Rule},
-    utils::is_vue_component_options_object,
+    utils::{for_each_define_props_type_signature, is_vue_component_options_object},
 };
 
 /// Reserved instance properties of the Vue instance (Vue 2/3 common).
@@ -269,47 +267,9 @@ impl NoReservedKeys {
         if let Some(type_args) = call.type_arguments.as_ref()
             && let Some(first) = type_args.params.first()
         {
-            self.check_type_keys(first, ctx);
-        }
-    }
-
-    fn check_type_keys<'a>(&self, ty: &TSType<'a>, ctx: &LintContext<'a>) {
-        match ty {
-            TSType::TSTypeLiteral(literal) => {
-                for sig in &literal.members {
-                    self.check_signature(sig, ctx);
-                }
-            }
-            TSType::TSUnionType(union) => {
-                for member in &union.types {
-                    self.check_type_keys(member, ctx);
-                }
-            }
-            TSType::TSIntersectionType(intersection) => {
-                for member in &intersection.types {
-                    self.check_type_keys(member, ctx);
-                }
-            }
-            TSType::TSTypeReference(type_ref) => {
-                let TSTypeName::IdentifierReference(ident) = &type_ref.type_name else { return };
-                let Some(decl) =
-                    get_declaration_from_reference_id(ident.reference_id(), ctx.semantic())
-                else {
-                    return;
-                };
-                match decl.kind() {
-                    AstKind::TSInterfaceDeclaration(interface) => {
-                        for sig in &interface.body.body {
-                            self.check_signature(sig, ctx);
-                        }
-                    }
-                    AstKind::TSTypeAliasDeclaration(alias) => {
-                        self.check_type_keys(&alias.type_annotation, ctx);
-                    }
-                    _ => {}
-                }
-            }
-            _ => {}
+            for_each_define_props_type_signature(first, ctx, &mut |sig| {
+                self.check_signature(sig, ctx);
+            });
         }
     }
 

--- a/crates/oxc_linter/src/rules/vue/no_reserved_props.rs
+++ b/crates/oxc_linter/src/rules/vue/no_reserved_props.rs
@@ -5,7 +5,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         ArrayExpression, CallExpression, Expression, ObjectExpression, ObjectPropertyKind,
-        TSSignature, TSType, TSTypeName,
+        TSSignature,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -14,11 +14,13 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     AstNode,
-    ast_util::get_declaration_from_reference_id,
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::{DefaultRuleConfig, Rule},
-    utils::{is_vue_component_options_object, vue_casing::kebab_case},
+    utils::{
+        for_each_define_props_type_signature, is_vue_component_options_object,
+        vue_casing::kebab_case,
+    },
 };
 
 /// Reserved attribute names that cannot be used as prop names, by Vue version.
@@ -186,47 +188,9 @@ impl NoReservedProps {
         if let Some(type_args) = call.type_arguments.as_ref()
             && let Some(first) = type_args.params.first()
         {
-            self.check_type_props(first, ctx);
-        }
-    }
-
-    fn check_type_props<'a>(&self, ty: &TSType<'a>, ctx: &LintContext<'a>) {
-        match ty {
-            TSType::TSTypeLiteral(literal) => {
-                for sig in &literal.members {
-                    self.check_signature(sig, ctx);
-                }
-            }
-            TSType::TSUnionType(union) => {
-                for member in &union.types {
-                    self.check_type_props(member, ctx);
-                }
-            }
-            TSType::TSIntersectionType(intersection) => {
-                for member in &intersection.types {
-                    self.check_type_props(member, ctx);
-                }
-            }
-            TSType::TSTypeReference(type_ref) => {
-                let TSTypeName::IdentifierReference(ident) = &type_ref.type_name else { return };
-                let Some(decl) =
-                    get_declaration_from_reference_id(ident.reference_id(), ctx.semantic())
-                else {
-                    return;
-                };
-                match decl.kind() {
-                    AstKind::TSInterfaceDeclaration(interface) => {
-                        for sig in &interface.body.body {
-                            self.check_signature(sig, ctx);
-                        }
-                    }
-                    AstKind::TSTypeAliasDeclaration(alias) => {
-                        self.check_type_props(&alias.type_annotation, ctx);
-                    }
-                    _ => {}
-                }
-            }
-            _ => {}
+            for_each_define_props_type_signature(first, ctx, &mut |sig| {
+                self.check_signature(sig, ctx);
+            });
         }
     }
 

--- a/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
+++ b/crates/oxc_linter/src/rules/vue/prop_name_casing.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         ArrayExpression, ArrayExpressionElement, CallExpression, Expression, ObjectExpression,
-        ObjectPropertyKind, PropertyKey, TSSignature, TSType, TSTypeName, TSTypeReference,
+        ObjectPropertyKind, PropertyKey, TSSignature,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -15,11 +15,13 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     AstNode,
-    ast_util::get_declaration_from_reference_id,
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::{Rule, TupleRuleConfig},
-    utils::{find_property, is_vue_component_options_object_excluding_instance, vue_casing},
+    utils::{
+        find_property, for_each_define_props_type_signature,
+        is_vue_component_options_object_excluding_instance, vue_casing,
+    },
 };
 
 fn prop_name_casing_diagnostic(span: Span, name: &str, case_type: &str) -> OxcDiagnostic {
@@ -134,12 +136,15 @@ impl PropNameCasing {
             self.check_props_value(arg, ctx);
             return;
         }
-        // `defineProps<T>()` — only the same-file `interface Props { ... }` shape is checked.
-        // The `import { Props } from './x'` shape requires cross-file TS type resolution and
-        // is handled by tsgolint (see the test() comment for details).
+        // `defineProps<T>()` — only same-file type shapes are checked. The
+        // `import { Props } from './x'` shape requires cross-file TS type
+        // resolution and is handled by tsgolint (see the test() comment for
+        // details).
         let Some(type_arguments) = call.type_arguments.as_deref() else { return };
         let Some(first_type) = type_arguments.params.first() else { return };
-        self.check_type_argument(first_type, ctx);
+        for_each_define_props_type_signature(first_type, ctx, &mut |signature| {
+            self.check_signature(signature, ctx);
+        });
     }
 
     fn check_props_value<'a>(&self, expr: &Expression<'a>, ctx: &LintContext<'a>) {
@@ -165,41 +170,14 @@ impl PropNameCasing {
         }
     }
 
-    fn check_type_argument<'a>(&self, ts_type: &TSType<'a>, ctx: &LintContext<'a>) {
-        match ts_type {
-            TSType::TSTypeReference(type_ref) => self.check_type_reference(type_ref, ctx),
-            TSType::TSTypeLiteral(type_literal) => {
-                self.check_signatures(&type_literal.members, ctx);
-            }
-            _ => {}
-        }
-    }
-
-    fn check_type_reference<'a>(&self, type_ref: &TSTypeReference<'a>, ctx: &LintContext<'a>) {
-        let TSTypeName::IdentifierReference(ident_ref) = &type_ref.type_name else { return };
-        let reference = ctx.scoping().get_reference(ident_ref.reference_id());
-        if !reference.is_type() {
-            return;
-        }
-        let Some(declaration) =
-            get_declaration_from_reference_id(ident_ref.reference_id(), ctx.semantic())
-        else {
-            return;
+    fn check_signature<'a>(&self, signature: &TSSignature<'a>, ctx: &LintContext<'a>) {
+        let (key_opt, span) = match signature {
+            TSSignature::TSPropertySignature(sig) => (sig.key.static_name(), sig.key.span()),
+            TSSignature::TSMethodSignature(sig) => (sig.key.static_name(), sig.key.span()),
+            _ => return,
         };
-        let AstKind::TSInterfaceDeclaration(interface_decl) = declaration.kind() else { return };
-        self.check_signatures(&interface_decl.body.body, ctx);
-    }
-
-    fn check_signatures<'a>(&self, signatures: &[TSSignature<'a>], ctx: &LintContext<'a>) {
-        for signature in signatures {
-            let (key_opt, span) = match signature {
-                TSSignature::TSPropertySignature(sig) => (sig.key.static_name(), sig.key.span()),
-                TSSignature::TSMethodSignature(sig) => (sig.key.static_name(), sig.key.span()),
-                _ => continue,
-            };
-            let Some(name) = key_opt else { continue };
-            self.report_if_invalid(name.as_ref(), span, ctx);
-        }
+        let Some(name) = key_opt else { return };
+        self.report_if_invalid(name.as_ref(), span, ctx);
     }
 
     fn report_if_invalid(&self, name: &str, span: Span, ctx: &LintContext<'_>) {
@@ -970,6 +948,29 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ), // languageOptions,
+        (
+            r#"
+                  <script setup lang="ts">
+                  type Props = {
+                    greeting_text: number
+                  }
+                  defineProps<Props>()
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
+        (
+            r#"
+                  <script setup lang="ts">
+                  defineProps<{ greeting_text: number } | { another_text: string }>()
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } },
            // NOTE: upstream `prop-name-casing` invalid test using `getTypeScriptFixtureTestOptions`
            // (`import {Props3 as Props} from './test01' ; defineProps<Props>()`) is skipped here —
            // cross-file TypeScript type resolution is the `tsgolint` domain in oxc (59 typescript/* rules

--- a/crates/oxc_linter/src/rules/vue/require_default_prop.rs
+++ b/crates/oxc_linter/src/rules/vue/require_default_prop.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         ArrayExpressionElement, BindingPattern, CallExpression, Expression, ObjectExpression,
-        ObjectPattern, ObjectPropertyKind, PropertyKey, TSSignature, TSType, TSTypeName,
+        ObjectPattern, ObjectPropertyKind, PropertyKey, TSSignature, TSType,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -11,11 +11,13 @@ use oxc_span::{GetSpan, Span};
 
 use crate::{
     AstNode,
-    ast_util::get_declaration_from_reference_id,
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::Rule,
-    utils::{find_property, is_vue_component_options_object_excluding_instance},
+    utils::{
+        find_property, for_each_define_props_type_signature,
+        is_vue_component_options_object_excluding_instance,
+    },
 };
 
 const NATIVE_TYPES: [&str; 7] =
@@ -154,7 +156,9 @@ fn handle_define_props<'a>(
     if let Some(type_args) = call.type_arguments.as_ref()
         && let Some(first) = type_args.params.first()
     {
-        check_type_props(first, ctx, pc);
+        for_each_define_props_type_signature(first, ctx, &mut |sig| {
+            check_type_signature(sig, ctx, pc);
+        });
     }
 }
 
@@ -230,53 +234,6 @@ fn object_has_key(obj: &ObjectExpression, name: &str) -> bool {
         matches!(prop, ObjectPropertyKind::ObjectProperty(prop)
             if prop.key.static_name().as_deref() == Some(name))
     })
-}
-
-/// Mirrors upstream `flattenTypeNodes`: a `defineProps<T>()` type is walked
-/// recursively so unions, intersections and `interface`/`type` references are
-/// all resolved down to their property signatures.
-fn check_type_props<'a>(ts_type: &TSType<'a>, ctx: &LintContext<'a>, pc: &PropsContext<'a>) {
-    match ts_type {
-        TSType::TSTypeLiteral(literal) => {
-            for signature in &literal.members {
-                check_type_signature(signature, ctx, pc);
-            }
-        }
-        TSType::TSUnionType(union) => {
-            for member in &union.types {
-                check_type_props(member, ctx, pc);
-            }
-        }
-        TSType::TSIntersectionType(intersection) => {
-            for member in &intersection.types {
-                check_type_props(member, ctx, pc);
-            }
-        }
-        TSType::TSTypeReference(type_ref) => {
-            let TSTypeName::IdentifierReference(ident) = &type_ref.type_name else { return };
-            let reference = ctx.scoping().get_reference(ident.reference_id());
-            if !reference.is_type() {
-                return;
-            }
-            let Some(declaration) =
-                get_declaration_from_reference_id(ident.reference_id(), ctx.semantic())
-            else {
-                return;
-            };
-            match declaration.kind() {
-                AstKind::TSInterfaceDeclaration(interface) => {
-                    for signature in &interface.body.body {
-                        check_type_signature(signature, ctx, pc);
-                    }
-                }
-                AstKind::TSTypeAliasDeclaration(alias) => {
-                    check_type_props(&alias.type_annotation, ctx, pc);
-                }
-                _ => {}
-            }
-        }
-        _ => {}
-    }
 }
 
 fn check_type_signature<'a>(

--- a/crates/oxc_linter/src/snapshots/vue_max_props.snap
+++ b/crates/oxc_linter/src/snapshots/vue_max_props.snap
@@ -55,3 +55,12 @@ source: crates/oxc_linter/src/tester.rs
  12 │                       </script>
     ╰────
   help: Consider refactoring the component to reduce the number of props that are needed.
+
+  ⚠ vue(max-props): This component has too many props (3). Maximum allowed is 2.
+   ╭─[max_props.tsx:4:10]
+ 3 │                   type Props = { prop1: string, prop2: string, prop3: string };
+ 4 │                   defineProps<Props>();
+   ·                   ────────────────────
+ 5 │                   </script>
+   ╰────
+  help: Consider refactoring the component to reduce the number of props that are needed.

--- a/crates/oxc_linter/src/snapshots/vue_no_required_prop_with_default.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_required_prop_with_default.snap
@@ -214,3 +214,12 @@ source: crates/oxc_linter/src/tester.rs
  7 │                           });
    ╰────
   help: Remove the `required: true` option, or drop the `required` key entirely to make this prop optional.
+
+  ⚠ vue(no-required-prop-with-default): Prop "name" should be optional.
+   ╭─[no_required_prop_with_default.tsx:4:25]
+ 3 │                       type TestPropType = {
+ 4 │                         name: string
+   ·                         ────────────
+ 5 │                         age?: number
+   ╰────
+  help: Remove the `required: true` option, or drop the `required` key entirely to make this prop optional.

--- a/crates/oxc_linter/src/snapshots/vue_prop_name_casing.snap
+++ b/crates/oxc_linter/src/snapshots/vue_prop_name_casing.snap
@@ -177,3 +177,27 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                  ─────────────────
  5 │                     }
    ╰────
+
+  ⚠ vue(prop-name-casing): Prop 'greeting_text' is not in camelCase.
+   ╭─[prop_name_casing.tsx:4:21]
+ 3 │                   type Props = {
+ 4 │                     greeting_text: number
+   ·                     ─────────────
+ 5 │                   }
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop 'greeting_text' is not in camelCase.
+   ╭─[prop_name_casing.tsx:3:33]
+ 2 │                   <script setup lang="ts">
+ 3 │                   defineProps<{ greeting_text: number } | { another_text: string }>()
+   ·                                 ─────────────
+ 4 │                   </script>
+   ╰────
+
+  ⚠ vue(prop-name-casing): Prop 'another_text' is not in camelCase.
+   ╭─[prop_name_casing.tsx:3:61]
+ 2 │                   <script setup lang="ts">
+ 3 │                   defineProps<{ greeting_text: number } | { another_text: string }>()
+   ·                                                             ────────────
+ 4 │                   </script>
+   ╰────

--- a/crates/oxc_linter/src/utils/vue.rs
+++ b/crates/oxc_linter/src/utils/vue.rs
@@ -4,14 +4,14 @@ use oxc_ast::{
     AstKind,
     ast::{
         CallExpression, ExportDefaultDeclarationKind, Expression, IdentifierReference,
-        ObjectExpression, ObjectProperty, ObjectPropertyKind,
+        ObjectExpression, ObjectProperty, ObjectPropertyKind, TSSignature, TSType, TSTypeName,
     },
 };
 use oxc_span::GetSpan;
 
 use crate::{
-    AstNode, ContextSubHost, LintContext, frameworks::FrameworkOptions,
-    module_record::ImportImportName,
+    AstNode, ContextSubHost, LintContext, ast_util::get_declaration_from_reference_id,
+    frameworks::FrameworkOptions, module_record::ImportImportName,
 };
 
 // These sets mirror eslint-plugin-vue's `vue/no-reserved-component-names`.
@@ -364,4 +364,57 @@ pub fn find_property<'a, 'b>(
         let ObjectPropertyKind::ObjectProperty(obj_prop) = prop else { return None };
         obj_prop.key.is_specific_static_name(name).then_some(obj_prop.as_ref())
     })
+}
+
+/// Walks a `defineProps<T>()` type argument and invokes `f` for every member
+/// signature it contains, mirroring eslint-plugin-vue's `flattenTypeNodes`:
+/// unions, intersections and `interface`/`type` references are resolved
+/// recursively down to their signatures. `f` receives every `TSSignature`
+/// member (including non-property kinds), leaving the caller to pick out what
+/// it needs.
+pub fn for_each_define_props_type_signature<'a>(
+    ts_type: &TSType<'a>,
+    ctx: &LintContext<'a>,
+    f: &mut dyn FnMut(&TSSignature<'a>),
+) {
+    match ts_type {
+        TSType::TSTypeLiteral(literal) => {
+            for signature in &literal.members {
+                f(signature);
+            }
+        }
+        TSType::TSUnionType(union) => {
+            for member in &union.types {
+                for_each_define_props_type_signature(member, ctx, f);
+            }
+        }
+        TSType::TSIntersectionType(intersection) => {
+            for member in &intersection.types {
+                for_each_define_props_type_signature(member, ctx, f);
+            }
+        }
+        TSType::TSTypeReference(type_ref) => {
+            let TSTypeName::IdentifierReference(ident) = &type_ref.type_name else { return };
+            if !ctx.scoping().get_reference(ident.reference_id()).is_type() {
+                return;
+            }
+            let Some(declaration) =
+                get_declaration_from_reference_id(ident.reference_id(), ctx.semantic())
+            else {
+                return;
+            };
+            match declaration.kind() {
+                AstKind::TSInterfaceDeclaration(interface) => {
+                    for signature in &interface.body.body {
+                        f(signature);
+                    }
+                }
+                AstKind::TSTypeAliasDeclaration(alias) => {
+                    for_each_define_props_type_signature(&alias.type_annotation, ctx, f);
+                }
+                _ => {}
+            }
+        }
+        _ => {}
+    }
 }


### PR DESCRIPTION
Follow-up to #22951.

De-duplicates the `defineProps<T>()` type resolution shared across several vue rules. As a result `max-props`, `prop-name-casing` and `no-required-prop-with-default` now also handle `type` aliases / unions / intersections, matching upstream.

Part of #11440.