### PR TITLE
refactor(linter/exhaustive-deps): use `Scoping::scope_is_descendant_of` API

### DIFF
--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -369,9 +369,7 @@ impl Rule for ExhaustiveDeps {
                                 if ctx
                                     .semantic()
                                     .scoping()
-                                    .scope_ancestors(component_scope_id)
-                                    .skip(1)
-                                    .contains(&decl.scope_id())
+                                    .scope_is_descendant_of(component_scope_id, decl.scope_id())
                                 {
                                     return;
                                 }
@@ -587,9 +585,7 @@ impl Rule for ExhaustiveDeps {
                 if !(ctx
                     .semantic()
                     .scoping()
-                    .scope_ancestors(component_scope_id)
-                    .skip(1)
-                    .contains(&dependency_scope_id)
+                    .scope_is_descendant_of(component_scope_id, dependency_scope_id)
                     || is_ref_current_non_dependency)
                 {
                     continue;


### PR DESCRIPTION
Make use of `Scoping::scope_is_descendant_of` introduced in #22313 for ancestor scope checks in `react/exhaustive-deps`.

Both call sites already excluded the same-scope case with `.skip(1)`, so this delegates directly to the shared scoping API without changing behavior.
