### PR TITLE
fix(linter/react/display-name): handle default export function correctly

### DIFF
--- a/crates/oxc_linter/src/rules/react/display_name.rs
+++ b/crates/oxc_linter/src/rules/react/display_name.rs
@@ -650,15 +650,13 @@ fn is_anonymous_export_component(
                 });
             }
         ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
-            if let Some(name) = &func.id
-                && ignore_transpiler_name
-                && is_react_component_name(&name.name)
-                && function_contains_jsx(func)
-            {
+            // Named default-export functions are handled in phase 1 via symbols/references.
+            // Keep this path for anonymous default-export functions only.
+            if func.id.is_none() && function_contains_jsx(func) {
                 return Some(ReactComponentInfo {
                     span: export.span,
                     is_context: false,
-                    name: Some(CompactStr::from(name.name.as_str())),
+                    name: None,
                 });
             }
         }
@@ -1755,6 +1753,16 @@ fn test() {
             Some(serde_json::json!([{ "checkContextObjects": true }])),
             None,
         ),
+        (
+            "
+                    export default function Hello() {
+                      return <div>Hello {this.props.name}</div>;
+                    }
+                    Hello.displayName = 'Hello';
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -2195,6 +2203,13 @@ fn test() {
                     Hello = React.createContext();
                   ",
             Some(serde_json::json!([{ "checkContextObjects": true }])),
+            None,
+        ),
+        (
+            "export default function Hello() {
+  return <div>Hello {this.props.name}</div>;
+}",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/react_display_name.snap
+++ b/crates/oxc_linter/src/snapshots/react_display_name.snap
@@ -369,3 +369,11 @@ source: crates/oxc_linter/src/tester.rs
  6 │                   
    ╰────
   help: Add a `displayName` property to the context.
+
+  ⚠ react(display-name): Component definition is missing display name.
+   ╭─[display_name.tsx:1:16]
+ 1 │ ╭─▶ export default function Hello() {
+ 2 │ │     return <div>Hello {this.props.name}</div>;
+ 3 │ ╰─▶ }
+   ╰────
+  help: Add a `displayName` property to the component.


### PR DESCRIPTION
## Summary

Fixes a `react/display-name` false positive for named default-export function components when `ignoreTranspilerName` is enabled and the component has an explicit `displayName`.

```tsx
export default function Testing() {
  return <div>Text</div>;
}
Testing.displayName = 'Testing';
```

The false positive existed because named default-export function declarations were also handled by the export-default component path when `ignoreTranspilerName` was true. That path reported the export span directly and did not use the function symbol, so the later `Testing.displayName = 'Testing'` reference was not considered.

## Details

Named default-export functions now follow the same symbol/reference path already used by named declarations, allowing `has_display_name_via_semantic` to find explicit `displayName` assignments. Anonymous default exports are still handled by the export-default path.

This still reports when the explicit assignment is missing:

```tsx
export default function Testing() {
  return <div>Text</div>;
}
```

Fixes #23267