### PR TITLE
refactor(linter/block-scoped-var): use `Scoping::scope_is_descendant_of` API

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
@@ -223,16 +223,8 @@ fn check_if_has_reference_outside_scope(
     reference_scope_id: ScopeId,
     scoping: &Scoping,
 ) -> bool {
-    // Walk up the scope chain from the reference scope to see if we reach the declaration scope,
-    // if we do, then the reference is inside the scope, otherwise it's outside
-    for ancestor_scope_id in scoping.scope_ancestors(reference_scope_id) {
-        // Already reached the declaration scope, so the reference is inside the scope
-        if ancestor_scope_id == declare_scope_id {
-            return false;
-        }
-    }
-
-    true
+    reference_scope_id != declare_scope_id
+        && !scoping.scope_is_descendant_of(reference_scope_id, declare_scope_id)
 }
 
 #[test]


### PR DESCRIPTION
Make use of `Scoping::scope_is_descendant_of` introduced in #22313 for the `block-scoped-var` outside-scope check.

The helper now preserves the previous same-scope behavior with an explicit equality check before delegating descendant checks to the shared scoping API.