### PR TITLE
perf(codegen): preallocate sourcemap line offsets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ dependencies = [
  "dragonbox_ecma",
  "insta",
  "itoa",
+ "memchr",
  "oxc_allocator",
  "oxc_ast",
  "oxc_data_structures",

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -34,6 +34,7 @@ bitflags = { workspace = true }
 cow-utils = { workspace = true }
 dragonbox_ecma = { workspace = true }
 itoa = { workspace = true }
+memchr = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -321,7 +321,21 @@ impl<'a> SourcemapBuilder<'a> {
     }
 
     fn generate_line_offset_tables(content: &str) -> LineOffsetTables {
-        let mut lines = vec![];
+        let content_bytes = content.as_bytes();
+        let lines_capacity = memchr::memchr3_iter(b'\n', b'\r', LS_OR_PS_FIRST_BYTE, content_bytes)
+            .filter(|&index| match content_bytes[index] {
+                b'\n' => index == 0 || content_bytes[index - 1] != b'\r',
+                b'\r' => true,
+                LS_OR_PS_FIRST_BYTE => {
+                    let next_two_bytes = content_bytes.get(index + 1..index + 3);
+                    next_two_bytes == Some(&LS_LAST_2_BYTES[..])
+                        || next_two_bytes == Some(&PS_LAST_2_BYTES[..])
+                }
+                _ => unreachable!(),
+            })
+            .count()
+            + 1;
+        let mut lines = Vec::with_capacity(lines_capacity);
         let mut column_offsets = IndexVec::new();
 
         // Used as a buffer to reduce memory reallocations.


### PR DESCRIPTION
## Summary
- Preallocates sourcemap line offset storage by counting line terminators with `memchr` before building the table.
- Adds `memchr` as a direct `oxc_codegen` dependency.
