### PR TITLE
refactor(linter/consistent-function-scoping): use `Scoping::scope_is_descendant_of` API

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -1,5 +1,3 @@
-use rustc_hash::FxHashSet;
-
 use oxc_ast::{AstKind, ast::*};
 use oxc_ast_visit::{Visit, walk};
 use oxc_diagnostics::OxcDiagnostic;
@@ -267,16 +265,6 @@ impl Rule for ConsistentFunctionScoping {
             return;
         }
 
-        let parent_scope_ids = {
-            let mut current_scope_id = function_scope_id;
-            let mut parent_scope_ids = FxHashSet::default();
-            while let Some(parent_scope_id) = ctx.scoping().scope_parent_id(current_scope_id) {
-                parent_scope_ids.insert(parent_scope_id);
-                current_scope_id = parent_scope_id;
-            }
-            parent_scope_ids
-        };
-
         for reference_id in function_body_var_references {
             let reference = ctx.scoping().get_reference(reference_id);
             let Some(symbol_id) = reference.symbol_id() else { continue };
@@ -284,7 +272,9 @@ impl Rule for ConsistentFunctionScoping {
                 continue;
             }
             let scope_id = ctx.scoping().symbol_scope_id(symbol_id);
-            if parent_scope_ids.contains(&scope_id) && symbol_id != function_declaration_symbol_id {
+            if ctx.scoping().scope_is_descendant_of(function_scope_id, scope_id)
+                && symbol_id != function_declaration_symbol_id
+            {
                 return;
             }
         }


### PR DESCRIPTION
Make use of `Scoping::scope_is_descendant_of` introduced in #22313 for `consistent-function-scoping` parent-scope checks.

The rule previously built a set of parent scope IDs for each function scope. The shared scoping API now expresses the same proper-descendant relationship directly, so the temporary set allocation is no longer needed.