### PR TITLE
fix(linter/promise): validate param-names config

### DIFF
--- a/crates/oxc_linter/src/rules/promise/param_names.rs
+++ b/crates/oxc_linter/src/rules/promise/param_names.rs
@@ -1,4 +1,7 @@
 use lazy_regex::Regex;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::{
     AstKind,
     ast::{BindingPattern, Expression, FormalParameter, FormalParameters},
@@ -6,9 +9,13 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use schemars::JsonSchema;
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+    utils::deserialize_regex_option,
+};
 
 fn param_names_diagnostic(span: Span, pattern: &str) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -20,14 +27,16 @@ fn param_names_diagnostic(span: Span, pattern: &str) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct ParamNames(Box<ParamNamesConfig>);
 
-#[derive(Debug, Default, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase", default)]
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "camelCase", default)]
 pub struct ParamNamesConfig {
     /// Regex pattern used to validate the `resolve` parameter name. If provided, this pattern
     /// is used instead of the default `^_?resolve$` check.
+    #[serde(default, deserialize_with = "deserialize_regex_option")]
     resolve_pattern: Option<Regex>,
     /// Regex pattern used to validate the `reject` parameter name. If provided, this pattern
     /// is used instead of the default `^_?reject$` check.
+    #[serde(default, deserialize_with = "deserialize_regex_option")]
     reject_pattern: Option<Regex>,
 }
 
@@ -77,18 +86,9 @@ declare_oxc_lint!(
 
 impl Rule for ParamNames {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let mut cfg = ParamNamesConfig::default();
-
-        if let Some(config) = value.get(0) {
-            if let Some(val) = config.get("resolvePattern").and_then(serde_json::Value::as_str) {
-                cfg.resolve_pattern = Regex::new(val).ok();
-            }
-            if let Some(val) = config.get("rejectPattern").and_then(serde_json::Value::as_str) {
-                cfg.reject_pattern = Regex::new(val).ok();
-            }
-        }
-
-        Ok(Self(Box::new(cfg)))
+        serde_json::from_value::<DefaultRuleConfig<ParamNamesConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {


### PR DESCRIPTION
## Summary
- Deserialize `promise/param-names` options through `DefaultRuleConfig` so invalid regex patterns surface as configuration errors instead of being ignored.
- Keep the existing default behavior when `resolvePattern` or `rejectPattern` are omitted.