### PR TITLE
fix(linter/vitest): validate `consistent-each-for` config

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/consistent_each_for.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_each_for.rs
@@ -173,12 +173,8 @@ declare_oxc_lint!(
 
 impl Rule for ConsistentEachFor {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        Ok(Self(Box::new(
-            serde_json::from_value::<DefaultRuleConfig<ConsistentEachForJson>>(value)
-                .unwrap_or_default()
-                .into_inner()
-                .into_consistent_each_for_config(),
-        )))
+        serde_json::from_value::<DefaultRuleConfig<ConsistentEachForJson>>(value)
+            .map(|config| Self(Box::new(config.into_inner().into_consistent_each_for_config())))
     }
 
     fn run_on_jest_node<'a, 'c>(


### PR DESCRIPTION
## Summary
- Return configuration deserialization errors for invalid `vitest/consistent-each-for` options instead of silently falling back to defaults.
