### PR TITLE
refactor(parser): parse parenthesized arrows with cover grammar

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -1,9 +1,10 @@
 use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{ast::*, builder::NONE};
-use oxc_span::FileExtension;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_span::{FileExtension, GetSpan, Span};
 use oxc_syntax::precedence::Precedence;
 
-use super::{FunctionKind, Tristate};
+use super::{FunctionKind, Tristate, grammar, grammar::CoverGrammar};
 use crate::{Context, ParserConfig as Config, ParserImpl, diagnostics, lexer::Kind};
 
 struct ArrowFunctionHead<'a> {
@@ -14,19 +15,79 @@ struct ArrowFunctionHead<'a> {
     span: u32,
 }
 
+pub(super) enum ArrowOrExpression<'a> {
+    Arrow(Expression<'a>),
+    /// `Tristate::Maybe` refined to a non-arrow: the parenthesized expression.
+    /// Member/call/binary continuations have not been parsed yet.
+    Expression(Expression<'a>),
+    NotArrow,
+}
+
+/// [`CoverParenthesizedExpressionAndArrowParameterList`](https://tc39.es/ecma262/#prod-CoverParenthesizedExpressionAndArrowParameterList),
+/// parsed once and refined by what follows:
+///     `CoverParenthesizedExpressionAndArrowParameterList`[Yield, Await] :
+///         ( `Expression`[+In, ?Yield, ?Await] )
+///         ( `Expression`[+In, ?Yield, ?Await] , )
+///         ( )
+///         ( ... `BindingIdentifier`[?Yield, ?Await] )
+///         ( ... `BindingPattern`[?Yield, ?Await] )
+///         ( `Expression`[+In, ?Yield, ?Await] , ... `BindingIdentifier`[?Yield, ?Await] )
+///         ( `Expression`[+In, ?Yield, ?Await] , ... `BindingPattern`[?Yield, ?Await] )
+struct CoverParen<'a> {
+    /// Span of `( ... )` including parens, for `FormalParameters`.
+    params_span: Span,
+    /// Span of the items excluding parens, for `SequenceExpression`.
+    inner_span: Span,
+    items: ArenaVec<'a, Expression<'a>>,
+    extras: std::vec::Vec<CoverItemExtras<'a>>,
+    trailing_comma: Option<Span>,
+    /// First parameter-only TS syntax (`?` / `: Type`) — invalid in a parenthesized expression.
+    ts_error: Option<(u32, OxcDiagnostic)>,
+    /// First `...` spread — invalid in a parenthesized expression.
+    spread_error: Option<(u32, OxcDiagnostic)>,
+    has_no_side_effects_comment: bool,
+}
+
+/// Parameter-only syntax attached to a cover item, keyed by item index.
+struct CoverItemExtras<'a> {
+    index: u32,
+    spread_span: Option<Span>,
+    optional_span: Option<Span>,
+    type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+    /// Initializer following a type annotation or optional marker (`(a: T = 1)`).
+    init: Option<Expression<'a>>,
+}
+
 impl<'a, C: Config> ParserImpl<'a, C> {
     pub(super) fn try_parse_parenthesized_arrow_function_expression(
         &mut self,
         allow_return_type_in_arrow_function: bool,
-    ) -> Option<Expression<'a>> {
+    ) -> ArrowOrExpression<'a> {
         match self.is_parenthesized_arrow_function_expression() {
-            Tristate::False => None,
-            Tristate::True => Some(self.parse_parenthesized_arrow_function_expression(
-                allow_return_type_in_arrow_function,
-            )),
-            Tristate::Maybe => self.parse_possible_parenthesized_arrow_function_expression(
-                allow_return_type_in_arrow_function,
-            ),
+            Tristate::False => ArrowOrExpression::NotArrow,
+            Tristate::True => {
+                ArrowOrExpression::Arrow(self.parse_parenthesized_arrow_function_expression(
+                    allow_return_type_in_arrow_function,
+                ))
+            }
+            Tristate::Maybe => {
+                // Only plain `( ... )` is parsed once via the cover grammar. `async (...)`
+                // heads re-parse under `[+Await]` and generic `<T>(...)` heads under
+                // type-parameter rules — both can parse differently from the expression
+                // interpretation, so they keep the speculative parse + rewind.
+                if self.cur_kind() == Kind::LParen {
+                    self.parse_cover_parenthesized_expression_or_arrow(
+                        allow_return_type_in_arrow_function,
+                    )
+                } else {
+                    match self.parse_possible_parenthesized_arrow_function_expression(
+                        allow_return_type_in_arrow_function,
+                    ) {
+                        Some(expr) => ArrowOrExpression::Arrow(expr),
+                        None => ArrowOrExpression::NotArrow,
+                    }
+                }
+            }
         }
     }
 
@@ -165,8 +226,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                                 }
                                 Tristate::False
                             }
-                            // If we have "(a," or "(a=" or "(a)" this *could* be an arrow function
-                            Kind::Comma | Kind::Eq | Kind::RParen => Tristate::Maybe,
+                            // If we have "(a," or "(a=" this *could* be an arrow function
+                            Kind::Comma | Kind::Eq => Tristate::Maybe,
+                            // "(a)": peek past `)` — a `=>` makes it unambiguously an arrow.
+                            // Not for `(this)`, whose head parse fails where the speculative
+                            // parser recovered to a parenthesized expression.
+                            Kind::RParen => {
+                                self.bump_any();
+                                if second != Kind::This && self.cur_kind() == Kind::Arrow {
+                                    Tristate::True
+                                } else {
+                                    Tristate::Maybe
+                                }
+                            }
                             // It is definitely not an arrow function
                             _ => Tristate::False,
                         }
@@ -308,9 +380,30 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> Expression<'a> {
         let ArrowFunctionHead { type_parameters, params, return_type, r#async, span } =
             arrow_function_head;
+        let (expression, body) =
+            self.parse_arrow_function_body_only(r#async, allow_return_type_in_arrow_function);
+        Expression::new_arrow_function_expression(
+            self.end_span(span),
+            expression,
+            r#async,
+            type_parameters,
+            params,
+            return_type,
+            body,
+            self,
+        )
+    }
+
+    fn parse_arrow_function_body_only(
+        &mut self,
+        r#async: bool,
+        allow_return_type_in_arrow_function: bool,
+    ) -> (bool, ArenaBox<'a, FunctionBody<'a>>) {
         let has_await = self.ctx.has_await();
         let has_yield = self.ctx.has_yield();
         self.ctx = self.ctx.and_await(r#async).and_yield(false);
+        // An arrow body is not part of any enclosing cover paren frame.
+        let cover_paren_depth = std::mem::replace(&mut self.state.cover_paren_depth, 0);
 
         let expression = !self.at(Kind::LCurly);
         let body = if expression {
@@ -331,18 +424,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.parse_function_body()
         };
 
+        self.state.cover_paren_depth = cover_paren_depth;
         self.ctx = self.ctx.and_await(has_await).and_yield(has_yield);
-
-        Expression::new_arrow_function_expression(
-            self.end_span(span),
-            expression,
-            r#async,
-            type_parameters,
-            params,
-            return_type,
-            body,
-            self,
-        )
+        (expression, body)
     }
 
     /// Section [Arrow Function](https://tc39.es/ecma262/#sec-arrow-function-definitions)
@@ -409,5 +493,505 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         Some(body)
+    }
+
+    /// Parse `( ... )` once as [`CoverParen`], then apply the
+    /// [supplemental syntax](https://tc39.es/ecma262/#sec-primary-expression) refinement:
+    /// * `=>` (or `: Type =>`) — `ArrowParameters : CoverParenthesizedExpressionAndArrowParameterList`
+    ///   is reinterpreted as its
+    ///   [`CoveredFormalsList`](https://tc39.es/ecma262/#sec-static-semantics-coveredformalslist),
+    ///   i.e. [`ArrowFormalParameters`](https://tc39.es/ecma262/#prod-ArrowFormalParameters).
+    /// * otherwise — `PrimaryExpression : CoverParenthesizedExpressionAndArrowParameterList`
+    ///   is reinterpreted as its
+    ///   [`ParenthesizedExpression`](https://tc39.es/ecma262/#prod-ParenthesizedExpression).
+    fn parse_cover_parenthesized_expression_or_arrow(
+        &mut self,
+        allow_return_type_in_arrow_function: bool,
+    ) -> ArrowOrExpression<'a> {
+        let result = self.parse_cover_parenthesized_expression_or_arrow_impl(
+            allow_return_type_in_arrow_function,
+        );
+        if self.state.cover_paren_depth == 0 {
+            self.state.cover_invalid_patterns.clear();
+        }
+        result
+    }
+
+    fn parse_cover_parenthesized_expression_or_arrow_impl(
+        &mut self,
+        allow_return_type_in_arrow_function: bool,
+    ) -> ArrowOrExpression<'a> {
+        let span = self.start_span();
+        let checkpoint = self.checkpoint_with_error_recovery();
+        let frame = self.parse_cover_paren_contents();
+        if self.fatal_error.is_some() {
+            // An arrow head parses some of these softly where the expression grammar is fatal
+            // (binding-only forms like `([...x = []]) => {}`, `await`/`yield` bindings under
+            // `[+Await]`/`[+Yield]`). Fall back to the speculative arrow parse, which also
+            // reproduces the expression re-parse and its diagnostics when it rejects.
+            self.rewind(checkpoint);
+            return match self.parse_possible_parenthesized_arrow_function_expression(
+                allow_return_type_in_arrow_function,
+            ) {
+                Some(expr) => ArrowOrExpression::Arrow(expr),
+                None => ArrowOrExpression::NotArrow,
+            };
+        }
+
+        if self.at(Kind::Arrow) {
+            if self.cover_refines_to_arrow_params(&frame) {
+                return ArrowOrExpression::Arrow(self.cover_to_arrow(
+                    span,
+                    frame,
+                    None,
+                    allow_return_type_in_arrow_function,
+                ));
+            }
+        } else if self.is_ts && self.at(Kind::Colon) {
+            let checkpoint = self.checkpoint_with_error_recovery();
+            let return_type = self.parse_ts_return_type_annotation();
+            if self.fatal_error.is_none()
+                && self.at(Kind::Arrow)
+                && self.cover_refines_to_arrow_params(&frame)
+            {
+                if allow_return_type_in_arrow_function {
+                    return ArrowOrExpression::Arrow(self.cover_to_arrow(
+                        span,
+                        frame,
+                        return_type,
+                        allow_return_type_in_arrow_function,
+                    ));
+                }
+                // In the true branch of a conditional, `(a): T => x` is an arrow function only
+                // if another `:` follows the body (`cond ? (a): T => x : y`); otherwise the
+                // first `:` terminates the conditional. Parse the body before converting the
+                // items to parameters so they survive the rewind if the arrow is rejected.
+                if self.cur_token().is_on_new_line() {
+                    self.error(diagnostics::lineterminator_before_arrow(self.cur_token().span()));
+                }
+                self.expect(Kind::Arrow);
+                let (expression, body) = self.parse_arrow_function_body_only(
+                    /* async */ false, /* allow_return_type */ false,
+                );
+                if self.fatal_error.is_none() && self.at(Kind::Colon) {
+                    let params = self.cover_to_formal_parameters(frame);
+                    return ArrowOrExpression::Arrow(Expression::new_arrow_function_expression(
+                        self.end_span(span),
+                        expression,
+                        false,
+                        NONE,
+                        params,
+                        return_type,
+                        body,
+                        self,
+                    ));
+                }
+            }
+            // Not an arrow; rewind to the `:` and refine as expression — the caller handles it.
+            self.rewind(checkpoint);
+        }
+
+        ArrowOrExpression::Expression(self.cover_to_expression(span, frame))
+    }
+
+    /// Whether the cover is "covering" an
+    /// [`ArrowFormalParameters`](https://tc39.es/ecma262/#prod-ArrowFormalParameters) —
+    /// the reparse demanded by
+    /// [`CoveredFormalsList`](https://tc39.es/ecma262/#sec-static-semantics-coveredformalslist),
+    /// as a read-only check mirroring the speculative head parse's accept/reject decision.
+    /// When the items cannot refine to parameters, the cover refines to a parenthesized
+    /// expression and the stray `=>` errors downstream, exactly like the speculative
+    /// parser's rewind did.
+    fn cover_refines_to_arrow_params(&self, frame: &CoverParen<'a>) -> bool {
+        let len = frame.items.len();
+        let mut extras = frame.extras.iter().peekable();
+        frame.items.iter().enumerate().all(|(i, expr)| {
+            let extra = if extras.peek().is_some_and(|e| e.index as usize == i) {
+                extras.next()
+            } else {
+                None
+            };
+            if extra.is_some_and(|e| e.spread_span.is_some()) && i != len - 1 {
+                return false;
+            }
+            if matches!(expr, Expression::ThisExpression(_)) {
+                // `(this: T) => {}` parses with an error; anywhere else `this` is fatal.
+                return i == 0 && self.is_ts && extra.is_none_or(|e| e.spread_span.is_none());
+            }
+            grammar::is_binding_pattern_expression(expr, self)
+        })
+    }
+
+    /// Parse the `( ... )` of [`CoverParen`]: a comma-separated list of cover items,
+    /// allowing the trailing-comma and rest productions that only refine to arrows.
+    fn parse_cover_paren_contents(&mut self) -> CoverParen<'a> {
+        let span = self.start_span();
+        let opening_span = self.cur_token().span();
+        let has_no_side_effects_comment =
+            self.lexer.trivia_builder.previous_token_has_no_side_effects_comment();
+        self.bump_any(); // `(`
+        let inner_span_start = self.start_span();
+        let mut frame = CoverParen {
+            params_span: opening_span,
+            inner_span: opening_span,
+            items: ArenaVec::new_in(self),
+            extras: std::vec::Vec::new(),
+            trailing_comma: None,
+            ts_error: None,
+            spread_error: None,
+            has_no_side_effects_comment,
+        };
+        self.state.cover_paren_depth += 1;
+        self.context(Context::In, Context::Decorator, |p| {
+            loop {
+                let kind = p.cur_kind();
+                if kind == Kind::RParen
+                    || matches!(kind, Kind::Eof | Kind::Undetermined)
+                    || p.fatal_error.is_some()
+                {
+                    break;
+                }
+                p.parse_cover_item(&mut frame, opening_span);
+                let kind = p.cur_kind();
+                if kind == Kind::RParen
+                    || matches!(kind, Kind::Eof | Kind::Undetermined)
+                    || p.fatal_error.is_some()
+                {
+                    break;
+                }
+                if kind != Kind::Comma {
+                    p.set_fatal_error(diagnostics::expect_closing_or_separator(
+                        Kind::RParen.to_str(),
+                        Kind::Comma.to_str(),
+                        kind.to_str(),
+                        p.cur_token().span(),
+                        opening_span,
+                    ));
+                    break;
+                }
+                p.advance(Kind::Comma);
+                if p.cur_kind() == Kind::RParen {
+                    let comma_pos = p.prev_token_end - 1;
+                    frame.trailing_comma = Some(Span::new(comma_pos, p.prev_token_end));
+                    break;
+                }
+            }
+        });
+        self.state.cover_paren_depth -= 1;
+        frame.inner_span = Span::new(inner_span_start, self.prev_token_end);
+        self.expect_closing(Kind::RParen, opening_span);
+        frame.params_span = Span::new(span, self.prev_token_end);
+        frame
+    }
+
+    /// One element of the cover list:
+    ///     `AssignmentExpression`[+In, ?Yield, ?Await]
+    ///     ... `BindingIdentifier`[?Yield, ?Await]
+    ///     ... `BindingPattern`[?Yield, ?Await]
+    /// plus TypeScript parameter-only syntax after a pattern-shaped item — `?`, `: Type`,
+    /// and `= Initializer` following either. The `...` and TS pieces are recorded in
+    /// [`CoverItemExtras`]; they are only valid if the arrow refinement is taken.
+    fn parse_cover_item(&mut self, frame: &mut CoverParen<'a>, opening_span: Span) {
+        let index = u32::try_from(frame.items.len()).unwrap_or(u32::MAX);
+        let mut spread_span = None;
+        if self.at(Kind::Dot3) {
+            let span = self.cur_token().span();
+            if frame.spread_error.is_none() {
+                frame.spread_error = Some((span.start, diagnostics::unexpected_token(span)));
+            }
+            spread_span = Some(span);
+            self.bump_any();
+        }
+
+        let expr = self.parse_assignment_expression_or_higher();
+
+        let mut optional_span = None;
+        let mut type_annotation = None;
+        let mut init = None;
+        // Parameter-only TS syntax after a pattern-shaped item: `?`, `: Type`, and an
+        // initializer following either.
+        if self.is_ts
+            && self.fatal_error.is_none()
+            && matches!(
+                expr,
+                Expression::Identifier(_)
+                    | Expression::ObjectExpression(_)
+                    | Expression::ArrayExpression(_)
+                    | Expression::ThisExpression(_)
+            )
+        {
+            if self.at(Kind::Question) {
+                // Only reachable when `?` is followed by `:`/`,`/`)`/`=`, which
+                // `parse_conditional_expression_rest` declines inside a cover frame.
+                let question_span = self.cur_token().span();
+                if frame.ts_error.is_none() {
+                    let next_span = self.lexer.peek_token().span();
+                    frame.ts_error =
+                        Some((question_span.start, diagnostics::unexpected_token(next_span)));
+                }
+                optional_span = Some(question_span);
+                self.bump_any();
+            }
+            if self.at(Kind::Colon) {
+                let colon_span = self.cur_token().span();
+                if frame.ts_error.is_none() {
+                    frame.ts_error = Some((
+                        colon_span.start,
+                        diagnostics::expect_closing_or_separator(
+                            Kind::RParen.to_str(),
+                            Kind::Comma.to_str(),
+                            Kind::Colon.to_str(),
+                            colon_span,
+                            opening_span,
+                        ),
+                    ));
+                }
+                type_annotation = self.parse_ts_type_annotation();
+            }
+            if (optional_span.is_some() || type_annotation.is_some()) && self.eat(Kind::Eq) {
+                init = Some(self.parse_assignment_expression_or_higher());
+            }
+        }
+
+        if spread_span.is_some()
+            || optional_span.is_some()
+            || type_annotation.is_some()
+            || init.is_some()
+        {
+            frame.extras.push(CoverItemExtras {
+                index,
+                spread_span,
+                optional_span,
+                type_annotation,
+                init,
+            });
+        }
+        frame.items.push(expr);
+    }
+
+    /// [`ArrowFunction`](https://tc39.es/ecma262/#prod-ArrowFunction) :
+    ///     `ArrowParameters`[?Yield, ?Await] [no `LineTerminator` here] => `ConciseBody`[?In]
+    fn cover_to_arrow(
+        &mut self,
+        span: u32,
+        frame: CoverParen<'a>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
+        allow_return_type_in_arrow_function: bool,
+    ) -> Expression<'a> {
+        let params = self.cover_to_formal_parameters(frame);
+        if self.cur_token().is_on_new_line() {
+            self.error(diagnostics::lineterminator_before_arrow(self.cur_token().span()));
+        }
+        self.expect(Kind::Arrow);
+        self.parse_arrow_function_expression_body(
+            ArrowFunctionHead { type_parameters: None, params, return_type, r#async: false, span },
+            allow_return_type_in_arrow_function,
+        )
+    }
+
+    /// Refine the cover to
+    /// [`ArrowFormalParameters`](https://tc39.es/ecma262/#prod-ArrowFormalParameters) :
+    ///     ( `UniqueFormalParameters`[?Yield, ?Await] )
+    ///
+    /// Items become `BindingElement`s, a trailing `...` item the `BindingRestElement`, and
+    /// the recorded TS `?` / `: Type` / initializer extras attach to their parameters.
+    fn cover_to_formal_parameters(
+        &mut self,
+        frame: CoverParen<'a>,
+    ) -> ArenaBox<'a, FormalParameters<'a>> {
+        let CoverParen { params_span, items, extras, trailing_comma, .. } = frame;
+        let mut extras_iter = extras.into_iter().peekable();
+        let mut list = ArenaVec::with_capacity_in(items.len(), self);
+        let mut rest: Option<ArenaBox<'a, FormalParameterRest<'a>>> = None;
+
+        for (i, expr) in items.into_iter().enumerate() {
+            if self.fatal_error.is_some() {
+                break;
+            }
+            let extra = if extras_iter.peek().is_some_and(|e| e.index as usize == i) {
+                extras_iter.next()
+            } else {
+                None
+            };
+            let (spread_span, optional_span, type_annotation, extra_init) = match extra {
+                Some(e) => (e.spread_span, e.optional_span, e.type_annotation, e.init),
+                None => (None, None, None, None),
+            };
+
+            if let Some(r) = &rest {
+                self.set_fatal_error(diagnostics::rest_parameter_last(
+                    r.type_annotation.as_ref().map_or(r.rest.span, |type_annotation| {
+                        r.rest.span.merge(type_annotation.span())
+                    }),
+                ));
+                break;
+            }
+
+            let expr_span = expr.span();
+
+            if let Some(spread_span) = spread_span {
+                let argument = BindingPattern::cover(expr, self);
+                if let Some(optional_span) = optional_span {
+                    self.error(diagnostics::a_rest_parameter_cannot_be_optional(optional_span));
+                }
+                if let BindingPattern::AssignmentPattern(pat) = &argument {
+                    self.error(diagnostics::a_rest_parameter_cannot_have_an_initializer(pat.span));
+                }
+                let rest_span = Span::new(spread_span.start, expr_span.end);
+                let rest_element = BindingRestElement::new(rest_span, argument, self);
+                let full_span = type_annotation
+                    .as_ref()
+                    .map_or(rest_span, |type_annotation| rest_span.merge(type_annotation.span()));
+                rest = Some(FormalParameterRest::boxed(
+                    full_span,
+                    ArenaVec::new_in(self),
+                    rest_element,
+                    type_annotation,
+                    self,
+                ));
+                continue;
+            }
+
+            if matches!(&expr, Expression::ThisExpression(_)) {
+                let this_span = type_annotation
+                    .as_ref()
+                    .map_or(expr_span, |type_annotation| expr_span.merge(type_annotation.span()));
+                // `(this: T) => {}` — the speculative head reported and dropped the
+                // `this` parameter; do the same for the first item.
+                if i == 0 && self.is_ts {
+                    self.error(diagnostics::ts_arrow_function_this_parameter(this_span));
+                    continue;
+                }
+                return self.fatal_error(diagnostics::invalid_binding_pattern(this_span));
+            }
+
+            let (pattern, init) = match expr {
+                Expression::AssignmentExpression(assign) => {
+                    let assign = assign.unbox();
+                    if assign.operator != AssignmentOperator::Assign {
+                        return self.fatal_error(
+                            diagnostics::invalid_assignment_target_default_value_operator(
+                                assign.span,
+                            ),
+                        );
+                    }
+                    (BindingPattern::cover(assign.left, self), Some(assign.right))
+                }
+                expr => (BindingPattern::cover(expr, self), extra_init),
+            };
+            if optional_span.is_some() && init.is_some() {
+                self.error(diagnostics::a_parameter_cannot_have_question_mark_and_initializer(
+                    pattern.span(),
+                ));
+            }
+
+            let mut param_span = expr_span;
+            if let Some(optional_span) = optional_span {
+                param_span = param_span.merge(optional_span);
+            }
+            if let Some(type_annotation) = &type_annotation {
+                param_span = param_span.merge(type_annotation.span());
+            }
+            if let Some(init) = &init {
+                param_span = param_span.merge(init.span());
+            }
+            list.push(FormalParameter::new(
+                param_span,
+                ArenaVec::new_in(self),
+                pattern,
+                type_annotation,
+                init,
+                optional_span.is_some(),
+                None,
+                false,
+                false,
+                self,
+            ));
+        }
+
+        if let Some(comma_span) = trailing_comma
+            && rest.is_some()
+            && !self.ctx.has_ambient()
+        {
+            self.error(diagnostics::rest_element_trailing_comma(comma_span));
+        }
+
+        FormalParameters::boxed(
+            params_span,
+            FormalParameterKind::ArrowFormalParameters,
+            list,
+            rest,
+            self,
+        )
+    }
+
+    /// Refine the cover to
+    /// [`ParenthesizedExpression`](https://tc39.es/ecma262/#prod-ParenthesizedExpression) :
+    ///     ( `Expression`[+In, ?Yield, ?Await] )
+    ///
+    /// Per the [grouping operator early errors](https://tc39.es/ecma262/#sec-grouping-operator-static-semantics-early-errors)
+    /// the cover must actually cover a `ParenthesizedExpression`: `( )`, a trailing comma,
+    /// `...`, and TS parameter syntax exist only in the arrow productions and are syntax
+    /// errors here.
+    fn cover_to_expression(&mut self, span: u32, frame: CoverParen<'a>) -> Expression<'a> {
+        let CoverParen {
+            inner_span,
+            mut items,
+            ts_error,
+            spread_error,
+            trailing_comma,
+            has_no_side_effects_comment,
+            ..
+        } = frame;
+
+        let error = match (ts_error, spread_error) {
+            (Some(a), Some(b)) => Some(if a.0 <= b.0 { a.1 } else { b.1 }),
+            (Some(a), None) => Some(a.1),
+            (None, Some(b)) => Some(b.1),
+            (None, None) => None,
+        };
+        if let Some(error) = error {
+            return self.fatal_error(error);
+        }
+        if let Some(comma_span) = trailing_comma {
+            let error =
+                diagnostics::unexpected_trailing_comma("Parenthesized expressions", comma_span);
+            return self.fatal_error(error);
+        }
+        if items.is_empty() {
+            let error = diagnostics::empty_parenthesized_expression(self.end_span(span));
+            return self.fatal_error(error);
+        }
+
+        let mut expression = if items.len() == 1 {
+            items.remove(0)
+        } else {
+            Expression::new_sequence_expression(inner_span, items, self)
+        };
+
+        match &mut expression {
+            Expression::ArrowFunctionExpression(arrow_expr) => {
+                arrow_expr.pife = true;
+                if has_no_side_effects_comment {
+                    arrow_expr.pure = true;
+                }
+            }
+            Expression::FunctionExpression(func_expr) => {
+                func_expr.pife = true;
+                if has_no_side_effects_comment {
+                    func_expr.pure = true;
+                }
+            }
+            _ => {}
+        }
+
+        if self.options.preserve_parens {
+            Expression::new_parenthesized_expression(self.end_span(span), expression, self)
+        } else {
+            if self.state.cover_paren_depth != 0 {
+                self.state.cover_invalid_patterns.push(self.end_span(span));
+            }
+            expression
+        }
     }
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -11,6 +11,7 @@ use oxc_syntax::{
 };
 
 use super::{
+    arrow::ArrowOrExpression,
     grammar::CoverGrammar,
     operator::{
         kind_to_precedence, map_assignment_operator, map_binary_operator, map_logical_operator,
@@ -303,6 +304,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.options.preserve_parens {
             Expression::new_parenthesized_expression(self.end_span(span), expression, self)
         } else {
+            if self.state.cover_paren_depth != 0 {
+                self.state.cover_invalid_patterns.push(self.end_span(span));
+            }
             expression
         }
     }
@@ -718,9 +722,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// Section 13.3 Left-Hand-Side Expression
     pub(crate) fn parse_lhs_expression_or_higher(&mut self) -> Expression<'a> {
         let span = self.start_span();
-        let mut in_optional_chain = false;
         // `MemberExpression`
         let primary = self.parse_primary_expression();
+        self.parse_lhs_expression_rest(span, primary)
+    }
+
+    /// Continue a `LeftHandSideExpression` from an already-parsed `PrimaryExpression`.
+    fn parse_lhs_expression_rest(&mut self, span: u32, primary: Expression<'a>) -> Expression<'a> {
+        let mut in_optional_chain = false;
         let member_expression = self.parse_member_expression_rest(
             span,
             primary,
@@ -1179,7 +1188,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let span = self.start_span();
         let lhs = self.parse_lhs_expression_or_higher();
-        // ++ -- postfix update expressions
+        self.parse_update_expression_rest(span, lhs)
+    }
+
+    /// ++ -- postfix update expressions
+    fn parse_update_expression_rest(&mut self, span: u32, lhs: Expression<'a>) -> Expression<'a> {
         let post_kind = self.cur_kind();
         if post_kind.is_update_operator() && !self.cur_token().is_on_new_line() {
             let operator = map_update_operator(post_kind);
@@ -1415,9 +1428,22 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         allow_return_type_in_arrow_function: bool,
     ) -> Expression<'a> {
         let question_span = self.token.span();
-        if !self.eat(Kind::Question) {
+        if !self.at(Kind::Question) {
             return lhs;
         }
+        // Inside a cover-parenthesized frame, `?` followed by `:`/`,`/`)`/`=` can only be a TS
+        // optional parameter marker (`(a, b?: T) => {}`), never a valid conditional — leave it
+        // for the cover item loop.
+        if self.is_ts
+            && self.state.cover_paren_depth != 0
+            && matches!(
+                self.lexer.peek_token().kind(),
+                Kind::Colon | Kind::Comma | Kind::RParen | Kind::Eq
+            )
+        {
+            return lhs;
+        }
+        self.bump_any();
         let consequent = self.context_add(Context::In, |p| {
             p.parse_assignment_expression_or_higher_impl(
                 /* allow_return_type_in_arrow_function */ false,
@@ -1453,32 +1479,46 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.is_yield_expression() {
             return self.parse_yield_expression();
         }
-        // `() => {}`, `(x) => {}`
-        if let Some(mut arrow_expr) = self
-            .try_parse_parenthesized_arrow_function_expression(allow_return_type_in_arrow_function)
-        {
-            if has_no_side_effects_comment
-                && let Expression::ArrowFunctionExpression(func) = &mut arrow_expr
-            {
-                func.pure = true;
-            }
-            return arrow_expr;
-        }
-        // `async x => {}`
-        if let Some(mut arrow_expr) = self
-            .try_parse_async_simple_arrow_function_expression(allow_return_type_in_arrow_function)
-        {
-            if has_no_side_effects_comment
-                && let Expression::ArrowFunctionExpression(func) = &mut arrow_expr
-            {
-                func.pure = true;
-            }
-            return arrow_expr;
-        }
-
         let span = self.start_span();
         let lhs_parenthesized = self.at(Kind::LParen);
-        let lhs = self.parse_binary_expression_or_higher(Precedence::Comma);
+        // `() => {}`, `(x) => {}`
+        let covered_lhs = match self
+            .try_parse_parenthesized_arrow_function_expression(allow_return_type_in_arrow_function)
+        {
+            ArrowOrExpression::Arrow(mut arrow_expr) => {
+                if has_no_side_effects_comment
+                    && let Expression::ArrowFunctionExpression(func) = &mut arrow_expr
+                {
+                    func.pure = true;
+                }
+                return arrow_expr;
+            }
+            // A cover grammar `( ... )` refined to a parenthesized expression or `async(...)`
+            // call; continue parsing its member/call/binary continuations below.
+            ArrowOrExpression::Expression(expr) => Some(expr),
+            ArrowOrExpression::NotArrow => {
+                // `async x => {}`
+                if let Some(mut arrow_expr) = self.try_parse_async_simple_arrow_function_expression(
+                    allow_return_type_in_arrow_function,
+                ) {
+                    if has_no_side_effects_comment
+                        && let Expression::ArrowFunctionExpression(func) = &mut arrow_expr
+                    {
+                        func.pure = true;
+                    }
+                    return arrow_expr;
+                }
+                None
+            }
+        };
+
+        let lhs = if let Some(expr) = covered_lhs {
+            let expr = self.parse_lhs_expression_rest(span, expr);
+            let expr = self.parse_update_expression_rest(span, expr);
+            self.parse_binary_expression_rest(span, expr, lhs_parenthesized, Precedence::Comma)
+        } else {
+            self.parse_binary_expression_or_higher(Precedence::Comma)
+        };
         let lhs_parenthesized_span = lhs_parenthesized.then(|| self.end_span(span));
         let kind = self.cur_kind();
 

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -39,6 +39,11 @@ impl<'a, C: Config> CoverGrammar<'a, Expression<'a>, C> for SimpleAssignmentTarg
             }
             Expression::ParenthesizedExpression(expr) => {
                 let span = expr.span;
+                // The parens are unwrapped here; remember them in case this target is later
+                // refined to an arrow parameter, where they are invalid.
+                if p.state.cover_paren_depth != 0 {
+                    p.state.cover_invalid_patterns.push(span);
+                }
                 match expr.unbox().expression {
                     Expression::ObjectExpression(_) | Expression::ArrayExpression(_) => {
                         p.fatal_error(diagnostics::invalid_assignment(span))
@@ -150,6 +155,11 @@ impl<'a, C: Config> CoverGrammar<'a, Expression<'a>, C> for AssignmentTargetMayb
                     p.error(diagnostics::invalid_assignment_target_default_value_operator(
                         assignment_expr.span,
                     ));
+                    // The operator is erased by this conversion; a binding pattern requires a
+                    // plain `=` default, so a containing arrow head must not refine.
+                    if p.state.cover_paren_depth != 0 {
+                        p.state.cover_invalid_patterns.push(assignment_expr.span);
+                    }
                 }
                 let target = AssignmentTargetWithDefault::cover(assignment_expr.unbox(), p);
                 AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(p.alloc(target))
@@ -211,6 +221,108 @@ impl<'a, C: Config> CoverGrammar<'a, ObjectExpression<'a>, C> for ObjectAssignme
         }
 
         ObjectAssignmentTarget::new(expr.span, properties, rest, p)
+    }
+}
+
+/// Whether this pattern position overlaps syntax that the cover grammar parse erased from
+/// the AST (unwrapped parens, compound-operator defaults), making it invalid as a binding.
+fn span_has_invalid_pattern<C: Config>(span: Span, p: &ParserImpl<'_, C>) -> bool {
+    !p.state.cover_invalid_patterns.is_empty()
+        && p.state
+            .cover_invalid_patterns
+            .iter()
+            .any(|invalid| invalid.start <= span.start && span.end <= invalid.end)
+}
+
+/// Read-only check that an expression parsed by the cover grammar can refine to a
+/// [`BindingPattern`](https://tc39.es/ecma262/#sec-destructuring-binding-patterns),
+/// mirroring the fatal arms of the `cover` conversions below. When this fails, the
+/// enclosing `( ... )` refines to a parenthesized expression instead — matching the
+/// speculative parser, which rewound and re-parsed as an expression, leaving the stray
+/// `=>` to error downstream.
+pub(super) fn is_binding_pattern_expression<'a, C: Config>(
+    expr: &Expression<'a>,
+    p: &ParserImpl<'a, C>,
+) -> bool {
+    if span_has_invalid_pattern(expr.span(), p) {
+        return false;
+    }
+    match expr {
+        Expression::Identifier(_) => true,
+        // `(yield, a) => {}` in a generator: the item parses as a bare yield expression, but
+        // the speculative parser accepted it as a binding named `yield` (with an error).
+        Expression::YieldExpression(e) => e.argument.is_none() && !e.delegate,
+        Expression::ObjectExpression(obj) => {
+            let len = obj.properties.len();
+            obj.properties.iter().enumerate().all(|(i, prop)| match prop {
+                ObjectPropertyKind::ObjectProperty(property) => {
+                    property.kind == PropertyKind::Init
+                        && !property.method
+                        && (property.shorthand || is_binding_pattern_expression(&property.value, p))
+                }
+                ObjectPropertyKind::SpreadProperty(spread) => {
+                    i == len - 1 && matches!(spread.argument, Expression::Identifier(_))
+                }
+            })
+        }
+        Expression::ArrayExpression(arr) => {
+            let len = arr.elements.len();
+            arr.elements.iter().enumerate().all(|(i, elem)| match elem {
+                ArrayExpressionElement::Elision(_) => true,
+                ArrayExpressionElement::SpreadElement(spread) => {
+                    i == len - 1 && is_binding_pattern_expression(&spread.argument, p)
+                }
+                match_expression!(ArrayExpressionElement) => {
+                    is_binding_pattern_expression(elem.to_expression(), p)
+                }
+            })
+        }
+        Expression::AssignmentExpression(assign) => {
+            assign.operator == AssignmentOperator::Assign
+                && is_binding_pattern_target(&assign.left, p)
+        }
+        _ => false,
+    }
+}
+
+fn is_binding_pattern_target<'a, C: Config>(
+    target: &AssignmentTarget<'a>,
+    p: &ParserImpl<'a, C>,
+) -> bool {
+    if span_has_invalid_pattern(target.span(), p) {
+        return false;
+    }
+    match target {
+        AssignmentTarget::AssignmentTargetIdentifier(_) => true,
+        AssignmentTarget::ArrayAssignmentTarget(t) => {
+            t.elements.iter().flatten().all(|elem| is_binding_pattern_maybe_default(elem, p))
+                && t.rest.as_ref().is_none_or(|rest| is_binding_pattern_target(&rest.target, p))
+        }
+        AssignmentTarget::ObjectAssignmentTarget(t) => {
+            t.properties.iter().all(|prop| match prop {
+                AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(_) => true,
+                AssignmentTargetProperty::AssignmentTargetPropertyProperty(prop) => {
+                    is_binding_pattern_maybe_default(&prop.binding, p)
+                }
+            }) && t.rest.as_ref().is_none_or(|rest| {
+                matches!(rest.target, AssignmentTarget::AssignmentTargetIdentifier(_))
+            })
+        }
+        _ => false,
+    }
+}
+
+fn is_binding_pattern_maybe_default<'a, C: Config>(
+    target: &AssignmentTargetMaybeDefault<'a>,
+    p: &ParserImpl<'a, C>,
+) -> bool {
+    match target {
+        AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(t) => {
+            is_binding_pattern_target(&t.binding, p)
+        }
+        match_assignment_target!(AssignmentTargetMaybeDefault) => {
+            is_binding_pattern_target(target.to_assignment_target(), p)
+        }
     }
 }
 

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -14,6 +14,12 @@ pub struct ParserState<'a> {
     /// which re-establish their own `await`/`yield` contexts.
     pub cover_paren_depth: u32,
 
+    /// Spans inside cover paren frames whose pattern-invalidating syntax left no trace in the
+    /// AST: parenthesized expressions unwrapped by the assignment cover grammar (or dropped
+    /// when `preserve_parens` is off), and destructuring defaults with a compound operator.
+    /// A pattern position contained in one of these spans cannot refine to arrow parameters.
+    pub cover_invalid_patterns: Vec<Span>,
+
     /// Temporary storage for `CoverInitializedName` `({ foo = bar })`.
     /// Keyed by `ObjectProperty`'s span.start.
     pub cover_initialized_name: FxHashMap<u32, AssignmentExpression<'a>>,
@@ -44,6 +50,7 @@ impl ParserState<'_> {
         Self {
             not_parenthesized_arrow: FxHashSet::default(),
             cover_paren_depth: 0,
+            cover_invalid_patterns: Vec::new(),
             cover_initialized_name: FxHashMap::default(),
             trailing_commas: FxHashMap::default(),
             potential_await_reparse: Vec::new(),


### PR DESCRIPTION
Parse plain parenthesized arrow candidates once with cover grammar, preserving speculative parsing for async and generic heads.

AI-assisted.