### PR TITLE
feat(linter/vue): implement no-side-effects-in-computed-properties rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1636,6 +1636,7 @@ export interface DummyRuleMap {
   "vue/no-reserved-keys"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoReservedKeysConfig];
   "vue/no-reserved-props"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoReservedPropsConfig];
   "vue/no-shared-component-data"?: RuleNoConfig;
+  "vue/no-side-effects-in-computed-properties"?: RuleNoConfig;
   "vue/no-this-in-before-route-enter"?: RuleNoConfig;
   "vue/no-watch-after-await"?: RuleNoConfig;
   "vue/prefer-import-from-vue"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5147,7 +5147,10 @@ impl RuleRunner for crate::rules::vue::no_shared_component_data::NoSharedCompone
 impl RuleRunner
     for crate::rules::vue::no_side_effects_in_computed_properties::NoSideEffectsInComputedProperties
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ComputedMemberExpression,
+        AstType::StaticMemberExpression,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5147,8 +5147,7 @@ impl RuleRunner for crate::rules::vue::no_shared_component_data::NoSharedCompone
 impl RuleRunner
     for crate::rules::vue::no_side_effects_in_computed_properties::NoSideEffectsInComputedProperties
 {
-    const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::StaticMemberExpression]));
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5144,6 +5144,14 @@ impl RuleRunner for crate::rules::vue::no_shared_component_data::NoSharedCompone
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner
+    for crate::rules::vue::no_side_effects_in_computed_properties::NoSideEffectsInComputedProperties
+{
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::StaticMemberExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::no_this_in_before_route_enter::NoThisInBeforeRouteEnter {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::ExportDefaultDeclaration]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -821,6 +821,7 @@ pub use crate::rules::vue::no_reserved_component_names::NoReservedComponentNames
 pub use crate::rules::vue::no_reserved_keys::NoReservedKeys as VueNoReservedKeys;
 pub use crate::rules::vue::no_reserved_props::NoReservedProps as VueNoReservedProps;
 pub use crate::rules::vue::no_shared_component_data::NoSharedComponentData as VueNoSharedComponentData;
+pub use crate::rules::vue::no_side_effects_in_computed_properties::NoSideEffectsInComputedProperties as VueNoSideEffectsInComputedProperties;
 pub use crate::rules::vue::no_this_in_before_route_enter::NoThisInBeforeRouteEnter as VueNoThisInBeforeRouteEnter;
 pub use crate::rules::vue::no_watch_after_await::NoWatchAfterAwait as VueNoWatchAfterAwait;
 pub use crate::rules::vue::prefer_import_from_vue::PreferImportFromVue as VuePreferImportFromVue;
@@ -1668,6 +1669,7 @@ pub enum RuleEnum {
     VueNoReservedKeys(VueNoReservedKeys),
     VueNoReservedProps(VueNoReservedProps),
     VueNoSharedComponentData(VueNoSharedComponentData),
+    VueNoSideEffectsInComputedProperties(VueNoSideEffectsInComputedProperties),
     VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter),
     VueNoWatchAfterAwait(VueNoWatchAfterAwait),
     VuePreferImportFromVue(VuePreferImportFromVue),
@@ -2602,7 +2604,10 @@ const VUE_NO_RESERVED_COMPONENT_NAMES_ID: usize = VUE_NO_REQUIRED_PROP_WITH_DEFA
 const VUE_NO_RESERVED_KEYS_ID: usize = VUE_NO_RESERVED_COMPONENT_NAMES_ID + 1usize;
 const VUE_NO_RESERVED_PROPS_ID: usize = VUE_NO_RESERVED_KEYS_ID + 1usize;
 const VUE_NO_SHARED_COMPONENT_DATA_ID: usize = VUE_NO_RESERVED_PROPS_ID + 1usize;
-const VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID: usize = VUE_NO_SHARED_COMPONENT_DATA_ID + 1usize;
+const VUE_NO_SIDE_EFFECTS_IN_COMPUTED_PROPERTIES_ID: usize =
+    VUE_NO_SHARED_COMPONENT_DATA_ID + 1usize;
+const VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID: usize =
+    VUE_NO_SIDE_EFFECTS_IN_COMPUTED_PROPERTIES_ID + 1usize;
 const VUE_NO_WATCH_AFTER_AWAIT_ID: usize = VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID + 1usize;
 const VUE_PREFER_IMPORT_FROM_VUE_ID: usize = VUE_NO_WATCH_AFTER_AWAIT_ID + 1usize;
 const VUE_PROP_NAME_CASING_ID: usize = VUE_PREFER_IMPORT_FROM_VUE_ID + 1usize;
@@ -3560,6 +3565,9 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => VUE_NO_RESERVED_KEYS_ID,
             Self::VueNoReservedProps(_) => VUE_NO_RESERVED_PROPS_ID,
             Self::VueNoSharedComponentData(_) => VUE_NO_SHARED_COMPONENT_DATA_ID,
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                VUE_NO_SIDE_EFFECTS_IN_COMPUTED_PROPERTIES_ID
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID,
             Self::VueNoWatchAfterAwait(_) => VUE_NO_WATCH_AFTER_AWAIT_ID,
             Self::VuePreferImportFromVue(_) => VUE_PREFER_IMPORT_FROM_VUE_ID,
@@ -4503,6 +4511,9 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::NAME,
             Self::VueNoReservedProps(_) => VueNoReservedProps::NAME,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::NAME,
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                VueNoSideEffectsInComputedProperties::NAME
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::NAME,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::NAME,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::NAME,
@@ -5504,6 +5515,9 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::CATEGORY,
             Self::VueNoReservedProps(_) => VueNoReservedProps::CATEGORY,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::CATEGORY,
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                VueNoSideEffectsInComputedProperties::CATEGORY
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::CATEGORY,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::CATEGORY,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::CATEGORY,
@@ -6448,6 +6462,9 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::FIX,
             Self::VueNoReservedProps(_) => VueNoReservedProps::FIX,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::FIX,
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                VueNoSideEffectsInComputedProperties::FIX
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::FIX,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::FIX,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::FIX,
@@ -7652,6 +7669,9 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::documentation(),
             Self::VueNoReservedProps(_) => VueNoReservedProps::documentation(),
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::documentation(),
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                VueNoSideEffectsInComputedProperties::documentation()
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::documentation(),
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::documentation(),
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::documentation(),
@@ -10011,6 +10031,10 @@ impl RuleEnum {
                 .or_else(|| VueNoReservedProps::schema(generator)),
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::config_schema(generator)
                 .or_else(|| VueNoSharedComponentData::schema(generator)),
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                VueNoSideEffectsInComputedProperties::config_schema(generator)
+                    .or_else(|| VueNoSideEffectsInComputedProperties::schema(generator))
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => {
                 VueNoThisInBeforeRouteEnter::config_schema(generator)
                     .or_else(|| VueNoThisInBeforeRouteEnter::schema(generator))
@@ -10872,6 +10896,7 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => "vue",
             Self::VueNoReservedProps(_) => "vue",
             Self::VueNoSharedComponentData(_) => "vue",
+            Self::VueNoSideEffectsInComputedProperties(_) => "vue",
             Self::VueNoThisInBeforeRouteEnter(_) => "vue",
             Self::VueNoWatchAfterAwait(_) => "vue",
             Self::VuePreferImportFromVue(_) => "vue",
@@ -13512,6 +13537,11 @@ impl RuleEnum {
             Self::VueNoSharedComponentData(_) => Ok(Self::VueNoSharedComponentData(
                 VueNoSharedComponentData::from_configuration(value)?,
             )),
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                Ok(Self::VueNoSideEffectsInComputedProperties(
+                    VueNoSideEffectsInComputedProperties::from_configuration(value)?,
+                ))
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => Ok(Self::VueNoThisInBeforeRouteEnter(
                 VueNoThisInBeforeRouteEnter::from_configuration(value)?,
             )),
@@ -14385,6 +14415,7 @@ impl RuleEnum {
             Self::VueNoReservedKeys(rule) => rule.to_configuration(),
             Self::VueNoReservedProps(rule) => rule.to_configuration(),
             Self::VueNoSharedComponentData(rule) => rule.to_configuration(),
+            Self::VueNoSideEffectsInComputedProperties(rule) => rule.to_configuration(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.to_configuration(),
             Self::VueNoWatchAfterAwait(rule) => rule.to_configuration(),
             Self::VuePreferImportFromVue(rule) => rule.to_configuration(),
@@ -15228,6 +15259,7 @@ impl RuleEnum {
                 Self::VueNoReservedKeys(rule) => rule.run(node, ctx),
                 Self::VueNoReservedProps(rule) => rule.run(node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run(node, ctx),
+                Self::VueNoSideEffectsInComputedProperties(rule) => rule.run(node, ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run(node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
@@ -16064,6 +16096,7 @@ impl RuleEnum {
                 Self::VueNoReservedKeys(rule) => rule.run(node, ctx),
                 Self::VueNoReservedProps(rule) => rule.run(node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run(node, ctx),
+                Self::VueNoSideEffectsInComputedProperties(rule) => rule.run(node, ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run(node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
@@ -16907,6 +16940,7 @@ impl RuleEnum {
                 Self::VueNoReservedKeys(rule) => rule.run_once(ctx),
                 Self::VueNoReservedProps(rule) => rule.run_once(ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_once(ctx),
+                Self::VueNoSideEffectsInComputedProperties(rule) => rule.run_once(ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_once(ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
@@ -17743,6 +17777,7 @@ impl RuleEnum {
                 Self::VueNoReservedKeys(rule) => rule.run_once(ctx),
                 Self::VueNoReservedProps(rule) => rule.run_once(ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_once(ctx),
+                Self::VueNoSideEffectsInComputedProperties(rule) => rule.run_once(ctx),
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_once(ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
@@ -18843,6 +18878,9 @@ impl RuleEnum {
                 Self::VueNoReservedKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoReservedProps(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoSideEffectsInComputedProperties(rule) => {
+                    rule.run_on_jest_node(jest_node, ctx)
+                }
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19935,6 +19973,9 @@ impl RuleEnum {
                 Self::VueNoReservedKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoReservedProps(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoSharedComponentData(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoSideEffectsInComputedProperties(rule) => {
+                    rule.run_on_jest_node(jest_node, ctx)
+                }
                 Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20769,6 +20810,7 @@ impl RuleEnum {
             Self::VueNoReservedKeys(rule) => rule.should_run(ctx),
             Self::VueNoReservedProps(rule) => rule.should_run(ctx),
             Self::VueNoSharedComponentData(rule) => rule.should_run(ctx),
+            Self::VueNoSideEffectsInComputedProperties(rule) => rule.should_run(ctx),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.should_run(ctx),
             Self::VueNoWatchAfterAwait(rule) => rule.should_run(ctx),
             Self::VuePreferImportFromVue(rule) => rule.should_run(ctx),
@@ -21972,6 +22014,9 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::IS_TSGOLINT_RULE,
             Self::VueNoReservedProps(_) => VueNoReservedProps::IS_TSGOLINT_RULE,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::IS_TSGOLINT_RULE,
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                VueNoSideEffectsInComputedProperties::IS_TSGOLINT_RULE
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::IS_TSGOLINT_RULE,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::IS_TSGOLINT_RULE,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::IS_TSGOLINT_RULE,
@@ -22977,6 +23022,9 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::VERSION,
             Self::VueNoReservedProps(_) => VueNoReservedProps::VERSION,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::VERSION,
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                VueNoSideEffectsInComputedProperties::VERSION
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::VERSION,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::VERSION,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::VERSION,
@@ -24017,6 +24065,9 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::HAS_CONFIG,
             Self::VueNoReservedProps(_) => VueNoReservedProps::HAS_CONFIG,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::HAS_CONFIG,
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                VueNoSideEffectsInComputedProperties::HAS_CONFIG
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::HAS_CONFIG,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::HAS_CONFIG,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::HAS_CONFIG,
@@ -25800,6 +25851,7 @@ impl RuleEnum {
             Self::VueNoReservedKeys(rule) => rule.types_info(),
             Self::VueNoReservedProps(rule) => rule.types_info(),
             Self::VueNoSharedComponentData(rule) => rule.types_info(),
+            Self::VueNoSideEffectsInComputedProperties(rule) => rule.types_info(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.types_info(),
             Self::VueNoWatchAfterAwait(rule) => rule.types_info(),
             Self::VuePreferImportFromVue(rule) => rule.types_info(),
@@ -26633,6 +26685,7 @@ impl RuleEnum {
             Self::VueNoReservedKeys(rule) => rule.run_info(),
             Self::VueNoReservedProps(rule) => rule.run_info(),
             Self::VueNoSharedComponentData(rule) => rule.run_info(),
+            Self::VueNoSideEffectsInComputedProperties(rule) => rule.run_info(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_info(),
             Self::VueNoWatchAfterAwait(rule) => rule.run_info(),
             Self::VuePreferImportFromVue(rule) => rule.run_info(),
@@ -27598,6 +27651,9 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoReservedKeys(VueNoReservedKeys::default()),
         RuleEnum::VueNoReservedProps(VueNoReservedProps::default()),
         RuleEnum::VueNoSharedComponentData(VueNoSharedComponentData::default()),
+        RuleEnum::VueNoSideEffectsInComputedProperties(
+            VueNoSideEffectsInComputedProperties::default(),
+        ),
         RuleEnum::VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter::default()),
         RuleEnum::VueNoWatchAfterAwait(VueNoWatchAfterAwait::default()),
         RuleEnum::VuePreferImportFromVue(VuePreferImportFromVue::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -25013,6 +25013,9 @@ impl RuleEnum {
             Self::VueNoReservedKeys(_) => VueNoReservedKeys::INFO,
             Self::VueNoReservedProps(_) => VueNoReservedProps::INFO,
             Self::VueNoSharedComponentData(_) => VueNoSharedComponentData::INFO,
+            Self::VueNoSideEffectsInComputedProperties(_) => {
+                VueNoSideEffectsInComputedProperties::INFO
+            }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::INFO,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::INFO,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::INFO,

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -871,6 +871,7 @@ pub(crate) mod vue {
     pub mod no_reserved_keys;
     pub mod no_reserved_props;
     pub mod no_shared_component_data;
+    pub mod no_side_effects_in_computed_properties;
     pub mod no_this_in_before_route_enter;
     pub mod no_watch_after_await;
     pub mod prefer_import_from_vue;

--- a/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
@@ -1,0 +1,1038 @@
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    frameworks::FrameworkOptions,
+    module_record::ImportImportName,
+    rule::Rule,
+    utils::{is_this_object, is_vue_component_options_object},
+};
+
+fn unexpected_side_effect_in_property(span: Span, key: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected side effect in \"{key}\" computed property."))
+        .with_label(span)
+}
+
+fn unexpected_side_effect_in_function(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected side effect in computed function.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoSideEffectsInComputedProperties;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow side effects in computed properties.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// It is considered a very bad practice to introduce side effects inside computed properties.
+    /// It makes the code unpredictable and hard to understand.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   computed: {
+    ///     fullName() {
+    ///       this.firstName = 'lorem' // side effect
+    ///       return `${this.firstName} ${this.lastName}`
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   computed: {
+    ///     fullName() {
+    ///       return `${this.firstName} ${this.lastName}`
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    NoSideEffectsInComputedProperties,
+    vue,
+    correctness,
+    none,
+    version = "next",
+);
+
+impl Rule for NoSideEffectsInComputedProperties {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::StaticMemberExpression(mem) = node.kind() else { return };
+
+        match &mem.object {
+            // Options API: `this.xxx` mutations
+            expr if is_this_object(expr, ctx) => {
+                // Special case: `this.$set(...)` — report on the property name span
+                if mem.property.name == "$set" {
+                    let parent = ctx.nodes().parent_node(node.id());
+                    if matches!(parent.kind(), AstKind::CallExpression(_))
+                        && let Some(ComputedContext::OptionsApi(key)) =
+                            find_computed_context(node, ctx)
+                    {
+                        let key = key.as_deref().unwrap_or("Unknown");
+                        ctx.diagnostic(unexpected_side_effect_in_property(mem.property.span, key));
+                    }
+                    return;
+                }
+
+                // General mutation detection
+                let Some(mutation_span) = find_mutation_span(node, ctx) else { return };
+                if let Some(ComputedContext::OptionsApi(key)) = find_computed_context(node, ctx) {
+                    let key = key.as_deref().unwrap_or("Unknown");
+                    ctx.diagnostic(unexpected_side_effect_in_property(mutation_span, key));
+                }
+            }
+
+            // Options API special case: `Vue.set(...)`
+            Expression::Identifier(ident) if ident.name == "Vue" && mem.property.name == "set" => {
+                let parent = ctx.nodes().parent_node(node.id());
+                if matches!(parent.kind(), AstKind::CallExpression(_))
+                    && let Some(ComputedContext::OptionsApi(key)) = find_computed_context(node, ctx)
+                {
+                    let key = key.as_deref().unwrap_or("Unknown");
+                    ctx.diagnostic(unexpected_side_effect_in_property(mem.property.span, key));
+                }
+            }
+
+            // Composition API: `foo.xxx` mutations where foo might be a setup variable
+            Expression::Identifier(ident) => {
+                let Some(mutation_span) = find_mutation_span(node, ctx) else { return };
+                let Some(ComputedContext::CompositionApi(getter_fn_span)) =
+                    find_computed_context(node, ctx)
+                else {
+                    return;
+                };
+
+                if !is_setup_variable(ident, getter_fn_span, ctx) {
+                    return;
+                }
+
+                ctx.diagnostic(unexpected_side_effect_in_function(mutation_span));
+            }
+
+            _ => {}
+        }
+    }
+}
+
+// Describe where a computed getter lives
+enum ComputedContext {
+    OptionsApi(Option<String>), // key name (None if unnamed/unknown)
+    CompositionApi(Span),       // span of the getter function (to detect locally-declared vars)
+}
+
+/// Find the computed getter context for `node` by walking up to the nearest enclosing function
+/// and checking if that function is a computed getter.
+/// Returns None if the nearest function is NOT a computed getter (nested function case).
+fn find_computed_context(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<ComputedContext> {
+    let nodes = ctx.nodes();
+    let mut current = nodes.parent_node(node.id());
+
+    loop {
+        match current.kind() {
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {
+                // Found the nearest enclosing function — check if it's a computed getter
+                return get_computed_getter_context(current, ctx);
+            }
+            AstKind::Program(_) => return None,
+            _ => {
+                current = nodes.parent_node(current.id());
+            }
+        }
+    }
+}
+
+/// Given a function node, return Some(ComputedContext) if it is a computed getter.
+fn get_computed_getter_context(
+    fn_node: &AstNode<'_>,
+    ctx: &LintContext<'_>,
+) -> Option<ComputedContext> {
+    let nodes = ctx.nodes();
+    let fn_span = fn_node.span();
+    let parent = nodes.parent_node(fn_node.id());
+
+    match parent.kind() {
+        // Composition API: `computed(fn)` or `computed(() => ...)`
+        AstKind::CallExpression(call) if is_vue_computed_call(call, ctx) => {
+            return Some(ComputedContext::CompositionApi(fn_span));
+        }
+
+        AstKind::ObjectProperty(prop) => {
+            // setter is not a getter
+            if prop.key.is_specific_static_name("set") {
+                return None;
+            }
+
+            let grandparent = nodes.parent_node(parent.id());
+            let AstKind::ObjectExpression(_) = grandparent.kind() else { return None };
+            let great = nodes.parent_node(grandparent.id());
+
+            match great.kind() {
+                // Case A: `computed: { key() {} }` or `computed: { key: function() {} }`
+                AstKind::ObjectProperty(outer) if outer.key.is_specific_static_name("computed") => {
+                    if is_under_vue_root(great, ctx) {
+                        let key = prop.key.static_name().map(|s| s.to_string());
+                        return Some(ComputedContext::OptionsApi(key));
+                    }
+                }
+
+                // Case B: `computed: { key: { get() {} } }`
+                // fn -> ObjectProperty(get) -> ObjectExpression -> ObjectProperty(key)
+                //     -> ObjectExpression(computed body) -> ObjectProperty(computed)
+                AstKind::ObjectProperty(key_prop) if prop.key.is_specific_static_name("get") => {
+                    let key_obj_expr = nodes.parent_node(great.id());
+                    let AstKind::ObjectExpression(_) = key_obj_expr.kind() else { return None };
+                    let computed_prop_node = nodes.parent_node(key_obj_expr.id());
+                    if let AstKind::ObjectProperty(cp) = computed_prop_node.kind()
+                        && cp.key.is_specific_static_name("computed")
+                        && is_under_vue_root(computed_prop_node, ctx)
+                    {
+                        let key = key_prop.key.static_name().map(|s| s.to_string());
+                        return Some(ComputedContext::OptionsApi(key));
+                    }
+                }
+
+                // Case C: Composition API with `computed({ get() {}, set() {} })`
+                AstKind::CallExpression(call)
+                    if prop.key.is_specific_static_name("get")
+                        && is_vue_computed_call(call, ctx) =>
+                {
+                    return Some(ComputedContext::CompositionApi(fn_span));
+                }
+
+                _ => {}
+            }
+        }
+
+        _ => {}
+    }
+
+    None
+}
+
+fn is_under_vue_root(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    ctx.nodes().ancestors(node.id()).any(|a| is_vue_component_options_object(a, ctx))
+}
+
+/// Check if a `computed(...)` call uses `computed` imported from `vue`.
+fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
+    let Expression::Identifier(ident) = call.callee.get_inner_expression() else {
+        return false;
+    };
+    if ident.name != "computed" {
+        return false;
+    }
+    let scoping = ctx.scoping();
+    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
+        return false;
+    };
+    ctx.module_record().import_entries.iter().any(|entry| {
+        if entry.module_request.name() != "vue" {
+            return false;
+        }
+        let ImportImportName::Name(name_span) = &entry.import_name else { return false };
+        if name_span.name() != "computed" {
+            return false;
+        }
+        scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id)
+    })
+}
+
+const MUTATING_METHODS: &[&str] =
+    &["push", "pop", "shift", "unshift", "reverse", "splice", "sort", "copyWithin", "fill"];
+
+/// Starting from `start_node` (a StaticMemberExpression where object = this/ident),
+/// walk up through parent nodes and detect if the member chain is being mutated.
+/// Returns the span of the outermost mutation expression, or None if no mutation found.
+fn find_mutation_span(start_node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<Span> {
+    let nodes = ctx.nodes();
+    let mut current = start_node;
+    // Seed with the starting node's property name so `arr.reverse()` is immediately detectable.
+    let mut last_static_name: Option<String> =
+        if let AstKind::StaticMemberExpression(m) = start_node.kind() {
+            Some(m.property.name.to_string())
+        } else {
+            None
+        };
+
+    loop {
+        let parent = nodes.parent_node(current.id());
+        match parent.kind() {
+            // Walking through static member chain: this.foo.bar...
+            AstKind::StaticMemberExpression(mem) if mem.object.span() == current.span() => {
+                last_static_name = Some(mem.property.name.to_string());
+                current = parent;
+            }
+
+            // Walking through computed member: this.foo[bar]...
+            AstKind::ComputedMemberExpression(mem) if mem.object.span() == current.span() => {
+                last_static_name = None;
+                current = parent;
+            }
+
+            // ChainExpression is transparent (optional chaining wrapper)
+            AstKind::ChainExpression(_) => {
+                current = parent;
+            }
+
+            // Assignment: `this.xxx = val` or `this.arr[i] = val`
+            AstKind::AssignmentExpression(assign) if assign.left.span() == current.span() => {
+                return Some(assign.span());
+            }
+
+            // Update: `this.xxx++` / `++this.xxx`
+            AstKind::UpdateExpression(upd) => {
+                return Some(upd.span());
+            }
+
+            // Delete: `delete this.xxx`
+            AstKind::UnaryExpression(unary)
+                if unary.operator == oxc_ast::ast::UnaryOperator::Delete
+                    && unary.argument.span() == current.span() =>
+            {
+                return Some(unary.span());
+            }
+
+            // Call expression — check if we are the callee
+            AstKind::CallExpression(call) if call.callee.span() == current.span() => {
+                if last_static_name
+                    .as_deref()
+                    .is_some_and(|name| MUTATING_METHODS.contains(&name))
+                {
+                    return Some(call.span());
+                }
+                return None;
+            }
+
+            // Call expression — check Object.assign(thisNode, ...)
+            AstKind::CallExpression(call) if is_object_assign_first_arg(call, current.span()) => {
+                return Some(call.span());
+            }
+
+            // Anything else: not a mutation
+            _ => return None,
+        }
+    }
+}
+
+/// Return true if `call` is `Object.assign(...)` and `first_arg_span` is the span of its
+/// first argument (i.e., the thing being mutated).
+fn is_object_assign_first_arg(call: &CallExpression<'_>, first_arg_span: Span) -> bool {
+    let Some(first_arg) = call.arguments.first() else { return false };
+    if first_arg.span() != first_arg_span {
+        return false;
+    }
+    let Expression::StaticMemberExpression(callee) = call.callee.get_inner_expression() else {
+        return false;
+    };
+    let Expression::Identifier(obj) = callee.object.get_inner_expression() else { return false };
+    obj.name == "Object" && callee.property.name == "assign"
+}
+
+/// Check if `ident` is a "setup variable": declared outside the computed getter
+/// (`getter_fn_span`) but within the setup scope (or `<script setup>`).
+///
+/// In practice we check:
+/// 1. The identifier is resolved to a symbol with a declaration.
+/// 2. The declaration is NOT inside the computed getter itself.
+/// 3. The declaration IS within the setup function body OR is a top-level binding
+///    in a `<script setup>` file (FrameworkOptions::VueSetup).
+fn is_setup_variable(
+    ident: &oxc_ast::ast::IdentifierReference<'_>,
+    getter_fn_span: Span,
+    ctx: &LintContext<'_>,
+) -> bool {
+    let scoping = ctx.scoping();
+    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
+        return false;
+    };
+    let decl_node = ctx.nodes().get_node(scoping.symbol_declaration(symbol_id));
+    let decl_span = decl_node.span();
+
+    // If the variable is declared INSIDE the computed getter itself, it's local → skip
+    if getter_fn_span.contains_inclusive(decl_span) {
+        return false;
+    }
+
+    // Function or class declarations are valid setup variables (they can still be mutated)
+    // but we skip if the declaration is neither inside setup ranges nor a top-level script-setup binding
+
+    // <script setup>: all top-level bindings are setup variables
+    if ctx.frameworks_options() == FrameworkOptions::VueSetup {
+        return true;
+    }
+
+    // Options API `setup()`: check if decl is inside a setup() function body
+    // Walk ancestors of the declaration node to find if it's inside `setup()`
+    is_inside_setup_function(decl_node, ctx)
+}
+
+/// Check if `node` is declared within a `setup()` function of a Vue component options object.
+fn is_inside_setup_function(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
+    // Walk up from node's declaration and check if any ancestor is a setup() function
+    // whose parent is a Vue component options property named "setup"
+    ctx.nodes().ancestors(node.id()).any(|ancestor| {
+        let (AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)) = ancestor.kind() else {
+            return false;
+        };
+        let parent = ctx.nodes().parent_node(ancestor.id());
+        let AstKind::ObjectProperty(prop) = parent.kind() else { return false };
+        if !prop.key.is_specific_static_name("setup") {
+            return false;
+        }
+        let grandparent = ctx.nodes().parent_node(parent.id());
+        let AstKind::ObjectExpression(_) = grandparent.kind() else { return false };
+        is_vue_component_options_object(grandparent, ctx)
+    })
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+                  Vue.component('test', {
+                    ...foo,
+                    computed: {
+                      ...test0({}),
+                      test1() {
+                        return this.firstName + ' ' + this.lastName
+                      },
+                      test2() {
+                        return this.something.slice(0).reverse()
+                      },
+                      test3() {
+                        const example = this.something * 2
+                        return example + 'test'
+                      },
+                      test4() {
+                        return {
+                          ...this.something,
+                          test: 'example'
+                        }
+                      },
+                      test5: {
+                        get() {
+                          return this.firstName + ' ' + this.lastName
+                        },
+                        set(newValue) {
+                          const names = newValue.split(' ')
+                          this.firstName = names[0]
+                          this.lastName = names[names.length - 1]
+                        }
+                      },
+                      test6: {
+                        get() {
+                          return this.something.slice(0).reverse()
+                        }
+                      },
+                      test7: {
+                        get() {
+                          const example = this.something * 2
+                          return example + 'test'
+                        }
+                      },
+                      test8: {
+                        get() {
+                          return {
+                            ...this.something,
+                            test: 'example'
+                          }
+                        }
+                      },
+                      test9() {
+                        return Object.keys(this.a).sort()
+                      },
+                      test10: {
+                        get() {
+                          return Object.keys(this.a).sort()
+                        }
+                      },
+                      test11() {
+                        const categories = {}
+
+                        this.types.forEach(c => {
+                          categories[c.category] = categories[c.category] || []
+                          categories[c.category].push(c)
+                        })
+
+                        return categories
+                      },
+                      test12() {
+                        return this.types.map(t => {
+                          // [].push('xxx')
+                          return t
+                        })
+                      },
+                      test13 () {
+                        this.someArray.forEach(arr => console.log(arr))
+                      }
+                    }
+                  })
+                ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  Vue.component('test', {
+                    computed: {
+                      ...mapGetters(['example']),
+                      test1() {
+                        const num = 0
+                        const something = {
+                          a: 'val',
+                          b: ['1', '2']
+                        }
+                        num++
+                        something.a = 'something'
+                        something.b.reverse()
+                        return something.b
+                      }
+                    }
+                  })
+                ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  Vue.component('test', {
+                    name: 'something',
+                    data() {
+                      return {}
+                    }
+                  })
+                ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  Vue.component('test', {
+                    computed: {
+                      test () {
+                        let a;
+                        a = this.something
+                        return a
+                      },
+                    }
+                  })
+                ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  Vue.component('test', {
+                    computed: {
+                      test () {
+                        return {
+                          action1() {
+                            this.something++
+                          },
+                          action2() {
+                            this.something = 1
+                          },
+                          action3() {
+                            this.something.reverse()
+                          }
+                        }
+                      },
+                    }
+                  })
+                ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  Vue.component('test', {
+                    computed: {
+                      test () {
+                        return this.something['a']().reverse()
+                      },
+                    }
+                  })
+                ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  const test = { el: '#app' }
+                    Vue.component('test', {
+                    el: test.el
+                  })
+                ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  Vue.component('test', {
+                    computed: {
+                      test () {
+                        return [...this.items].reverse()
+                      },
+                    }
+                  })
+                ",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  <script>
+                  import { computed } from 'vue'
+                  const utils = {}
+                  export default {
+                    setup() {
+                      const foo = useFoo()
+                      function bar () {}
+                      class Baz {}
+
+                      const test0 = computed(test0f)
+                      const test1 = computed(() => foo.firstName + ' ' + foo.lastName)
+                      const test2 = computed(() => foo.something.slice(0).reverse())
+                      const test3 = computed(() => {
+                        return {
+                          ...foo.something,
+                          test: 'example'
+                        }
+                      })
+                      const test5 = computed({
+                        get: () => foo.firstName + ' ' + foo.lastName,
+                        set: newValue => {
+                          const names = newValue.split(' ')
+                          foo.firstName = names[0]
+                          foo.lastName = names[names.length - 1]
+                        }
+                      })
+                      const test6 = computed({
+                        get: () => foo.something.slice(0).reverse()
+                      })
+                      const test7 = computed({
+                        get: () => {
+                          const example = foo.something * 2
+                          return example + 'test'
+                        }
+                      })
+                      const test8 = computed({
+                        get: () => {
+                          return {
+                            ...foo.something,
+                            test: 'example'
+                          }
+                        }
+                      })
+                      const test9 = computed(() => Object.keys(foo.a).sort())
+                      const test10 = computed({
+                        get: () => Object.keys(foo.a).sort()
+                      })
+                      const test11 = computed(() => {
+                        const categories = {}
+
+                        foo.types.forEach(c => {
+                          categories[c.category] = categories[c.category] || []
+                          categories[c.category].push(c)
+                        })
+
+                        return categories
+                      })
+                      const test12 = computed(() => {
+                        return foo.types.map(t => {
+                          // [].push('xxx')
+                          return t
+                        })
+                      })
+                      const test13 = computed(() => {
+                        foo.someArray.forEach(arr => console.log(arr))
+                      })
+                      const test14 = computed(() => bar.name)
+                      const test15 = computed(() => Baz.name)
+                      const test16 = computed(() => {
+                        function b () {}
+                        b.name = 'c'
+                      })
+                      const test17 = computed(() => {
+                        class C {}
+                        C.name = 'D'
+                      })
+                      const test18 = computed(() => (console.log('a'), true))
+                      const test19 = computed(() => utils.reverse(foo.array))
+                      const test20 = computed(() => Object.assign({}, foo.data, { extra: 'value' }))
+                    }
+                  }
+                  </script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    let fail = vec![
+        (
+            "Vue.component('test', {
+                    computed: {
+                      test1() {
+                        this.firstName = 'lorem'
+                        asd.qwe.zxc = 'lorem'
+                        return this.firstName + ' ' + this.lastName
+                      },
+                      test2() {
+                        this.count += 2;
+                        this.count++;
+                        return this.count;
+                      },
+                      test3() {
+                        return this.something.reverse()
+                      },
+                      test4() {
+                        const test = this.another.something.push('example')
+                        return 'something'
+                      },
+                      test5() {
+                        this.something[index] = thing[index]
+                        return this.something
+                      },
+                      test6() {
+                        return this.something.keys.sort()
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "Vue.component('test', {
+                    computed: {
+                      test1: {
+                        get() {
+                          this.firstName = 'lorem'
+                          return this.firstName + ' ' + this.lastName
+                        }
+                      },
+                      test2: {
+                        get() {
+                          this.count += 2;
+                          this.count++;
+                          return this.count;
+                        }
+                      },
+                      test3: {
+                        get() {
+                          return this.something.reverse()
+                        }
+                      },
+                      test4: {
+                        get() {
+                          const test = this.another.something.push('example')
+                          return 'something'
+                        },
+                        set(newValue) {
+                          this.something = newValue
+                        }
+                      },
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  <script lang=\"ts\">
+                  export default Vue.extend({
+                    computed: {
+                      test1() : string {
+                        return this.something.reverse()
+                      }
+                    }
+                  });
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "app.component('test', {
+                    computed: {
+                      test1() {
+                        this.firstName = 'lorem'
+                        asd.qwe.zxc = 'lorem'
+                        return this.firstName + ' ' + this.lastName
+                      },
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "Vue.component('test', {
+                    computed: {
+                      test1() {
+                        return this?.something?.reverse?.()
+                      },
+                      test2() {
+                        return (this?.something)?.reverse?.()
+                      },
+                      test3() {
+                        return (this?.something?.reverse)?.()
+                      },
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "app.component('test', {
+                    computed: {
+                      fooBar() {
+                        this.$set(this, 'foo', 'lorem');
+                        Vue.set(this, 'bar', 'ipsum');
+                        return this.foo + ' ' + this.bar
+                      },
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        (
+            "
+                  <script>
+                  import {ref, computed} from 'vue'
+                  export default {
+                    setup() {
+                      const foo = useFoo()
+                      const asd = { qwe: {} }
+                      function a () {}
+                      class A {}
+
+                      const test1 = computed(() => {
+                        foo.firstName = 'lorem'
+                        asd.qwe.zxc = 'lorem'
+                        return foo.firstName + ' ' + foo.lastName
+                      })
+                      const test2 = computed(() => {
+                        foo.count += 2;
+                        foo.count++;
+                        return foo.count;
+                      })
+                      const test3 = computed(() => foo.something.reverse())
+                      const test4 = computed(() => {
+                        const test = foo.another.something.push('example')
+                        return 'something'
+                      })
+                      const test5 = computed(() => {
+                        foo.something[index] = foo.thing[index]
+                        return foo.something
+                      })
+                      const test6 = computed(() => foo.something.keys.sort())
+                      const test7 = computed({
+                        get() {
+                          return foo.something.reverse()
+                        }
+                      })
+                      const test8 = computed(() => {
+                        a.name = ''
+                      })
+                      const test9 = computed(() => {
+                        A.name = ''
+                      })
+                      const test10 = computed(() => (foo.a = '', true))
+
+                      const test100 = computed(() => {
+                        const a = foo
+                        a.count++ // false negative
+                      })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  import {reactive, computed} from 'vue'
+                  export default {
+                    setup() {
+                      const arr = reactive([])
+
+                      const test1 = computed(() => arr.reverse())
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                  <script lang="ts">
+                  import {ref, computed} from 'vue'
+                  export default {
+                    setup() {
+                      const foo = useFoo()
+
+                      const test1 = computed(() => foo.something.reverse())
+                    }
+                  }
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script setup>
+                  import {ref, computed} from 'vue'
+                  const foo = useFoo()
+                  const asd = { qwe: {} }
+                  function a () {}
+                  class A {}
+
+                  const test1 = computed(() => {
+                    foo.firstName = 'lorem'
+                    asd.qwe.zxc = 'lorem'
+                    return foo.firstName + ' ' + foo.lastName
+                  })
+                  const test2 = computed(() => {
+                    foo.count += 2;
+                    foo.count++;
+                    return foo.count;
+                  })
+                  const test3 = computed(() => foo.something.reverse())
+                  const test4 = computed(() => {
+                    const test = foo.another.something.push('example')
+                    return 'something'
+                  })
+                  const test5 = computed(() => {
+                    foo.something[index] = foo.thing[index]
+                    return foo.something
+                  })
+                  const test6 = computed(() => foo.something.keys.sort())
+                  const test7 = computed({
+                    get() {
+                      return foo.something.reverse()
+                    }
+                  })
+                  const test8 = computed(() => {
+                    a.name = ''
+                  })
+                  const test9 = computed(() => {
+                    A.name = ''
+                  })
+                  const test10 = computed(() => (foo.a = '', true))
+
+                  const test100 = computed(() => {
+                    const a = foo
+                    a.count++ // false negative
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script setup>
+                  import {reactive, computed} from 'vue'
+                  const arr = reactive([])
+
+                  const test1 = computed(() => arr.reverse())
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+                  <script lang="ts" setup>
+                  import {ref, computed} from 'vue'
+                  const foo = useFoo()
+
+                  const test1 = computed(() => foo.something.reverse())
+                  </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            "
+                  <script>
+                  import {ref, computed} from 'vue'
+                  export default {
+                    setup() {
+                      const foo = useFoo()
+
+                      const test1 = computed(() => Object.assign(foo.data, { extra: 'value' }))
+                      const test2 = computed(() => {
+                        return Object.assign(foo.user, foo.updates)
+                      })
+                      const test3 = computed({
+                        get() {
+                          Object.assign(foo.settings, { theme: 'dark' })
+                          return foo.settings
+                        }
+                      })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+    ];
+
+    Tester::new(
+        NoSideEffectsInComputedProperties::NAME,
+        NoSideEffectsInComputedProperties::PLUGIN,
+        pass,
+        fail,
+    )
+    .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
@@ -74,48 +74,12 @@ declare_oxc_lint!(
 
 impl Rule for NoSideEffectsInComputedProperties {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // Handle bracket-notation mutations: this['foo'] = 1, foo['arr'].reverse(), etc.
-        if let AstKind::ComputedMemberExpression(mem) = node.kind() {
-            match &mem.object {
-                expr if is_this_object(expr, ctx) => {
-                    let Some(mutation_span) = find_mutation_span(node, ctx) else { return };
-                    match find_computed_context(node, ctx) {
-                        Some(ComputedContext::OptionsApi(key)) => {
-                            let key = key.as_deref().unwrap_or("Unknown");
-                            ctx.diagnostic(unexpected_side_effect_in_property(mutation_span, key));
-                        }
-                        Some(ComputedContext::CompositionApi(_)) => {
-                            ctx.diagnostic(unexpected_side_effect_in_function(mutation_span));
-                        }
-                        None => {}
-                    }
-                }
-                Expression::Identifier(ident) => {
-                    let Some(mutation_span) = find_mutation_span(node, ctx) else { return };
-                    let Some(ComputedContext::CompositionApi(getter_fn_span)) =
-                        find_computed_context(node, ctx)
-                    else {
-                        return;
-                    };
-                    if !is_setup_variable(ident, getter_fn_span, ctx) {
-                        return;
-                    }
-                    ctx.diagnostic(unexpected_side_effect_in_function(mutation_span));
-                }
-                _ => {}
-            }
-            return;
-        }
-
-        let AstKind::StaticMemberExpression(mem) = node.kind() else { return };
-
-        match &mem.object {
-            // Options API: `this.xxx` mutations
-            expr if is_this_object(expr, ctx) => {
-                // Special case: `this.$set(...)` — report on the property name span and return early.
-                // If `this.$set` is not called (e.g. assignment `this.$set = fn`), fall through to
-                // general mutation detection so it is caught there.
-                if mem.property.name == "$set" {
+        match node.kind() {
+            AstKind::StaticMemberExpression(mem) => {
+                // Special case: `this.$set(...)` — report on the property name span and return.
+                // If `this.$set` is not called (e.g. assignment `this.$set = fn`), fall through
+                // to general mutation detection so it is caught there.
+                if mem.property.name == "$set" && is_this_object(&mem.object, ctx) {
                     let mut parent = ctx.nodes().parent_node(node.id());
                     // `(this.$set)(...)` — skip parenthesized wrappers between the member and the call
                     while matches!(parent.kind(), AstKind::ParenthesizedExpression(_)) {
@@ -135,50 +99,66 @@ impl Rule for NoSideEffectsInComputedProperties {
                     }
                 }
 
-                // General mutation detection
-                let Some(mutation_span) = find_mutation_span(node, ctx) else { return };
-                match find_computed_context(node, ctx) {
-                    Some(ComputedContext::OptionsApi(key)) => {
-                        let key = key.as_deref().unwrap_or("Unknown");
-                        ctx.diagnostic(unexpected_side_effect_in_property(mutation_span, key));
-                    }
-                    // `this`-alias (e.g. `const self = this`) used inside a Composition API computed
-                    Some(ComputedContext::CompositionApi(_)) => {
-                        ctx.diagnostic(unexpected_side_effect_in_function(mutation_span));
-                    }
-                    None => {}
-                }
-            }
-
-            // Options API special case: `Vue.set(...)`
-            Expression::Identifier(ident) if ident.name == "Vue" && mem.property.name == "set" => {
-                let parent = ctx.nodes().parent_node(node.id());
-                if matches!(parent.kind(), AstKind::CallExpression(_))
-                    && let Some(ComputedContext::OptionsApi(key)) = find_computed_context(node, ctx)
+                // Special case: `Vue.set(...)`
+                if mem.property.name == "set"
+                    && matches!(&mem.object, Expression::Identifier(ident) if ident.name == "Vue")
                 {
-                    let key = key.as_deref().unwrap_or("Unknown");
-                    ctx.diagnostic(unexpected_side_effect_in_property(mem.property.span, key));
-                }
-            }
-
-            // Composition API: `foo.xxx` mutations where foo might be a setup variable
-            Expression::Identifier(ident) => {
-                let Some(mutation_span) = find_mutation_span(node, ctx) else { return };
-                let Some(ComputedContext::CompositionApi(getter_fn_span)) =
-                    find_computed_context(node, ctx)
-                else {
-                    return;
-                };
-
-                if !is_setup_variable(ident, getter_fn_span, ctx) {
+                    let parent = ctx.nodes().parent_node(node.id());
+                    if matches!(parent.kind(), AstKind::CallExpression(_))
+                        && let Some(ComputedContext::OptionsApi(key)) =
+                            find_computed_context(node, ctx)
+                    {
+                        let key = key.as_deref().unwrap_or("Unknown");
+                        ctx.diagnostic(unexpected_side_effect_in_property(mem.property.span, key));
+                    }
                     return;
                 }
 
-                ctx.diagnostic(unexpected_side_effect_in_function(mutation_span));
+                check_mutation(node, &mem.object, ctx);
             }
-
+            AstKind::ComputedMemberExpression(mem) => {
+                check_mutation(node, &mem.object, ctx);
+            }
             _ => {}
         }
+    }
+}
+
+/// General mutation detection shared by static and computed member expressions.
+///
+/// Mirrors ESLint's split between the two contexts:
+/// - In an Options API computed property only `this` (and its aliases) is checked,
+///   and the mutation walk starts AT the member expression — so a first-level
+///   method call like `this.reverse()` is a component method, not a mutation.
+/// - In a Composition API computed function `this` is ignored entirely, and
+///   identifiers (including `this` aliases) are checked as setup variables with
+///   the walk starting at the identifier — so `foo.reverse()` IS a mutation.
+fn check_mutation<'a>(node: &AstNode<'a>, object: &Expression<'a>, ctx: &LintContext<'a>) {
+    if !matches!(object, Expression::ThisExpression(_) | Expression::Identifier(_)) {
+        return;
+    }
+
+    // The seeded walk finds a superset of the unseeded one — use it as a cheap gate
+    // before resolving the computed context.
+    let Some(mutation_span) = find_mutation_span(node, ctx, true) else { return };
+
+    match find_computed_context(node, ctx) {
+        Some(ComputedContext::OptionsApi(key)) => {
+            if !is_this_object(object, ctx) {
+                return;
+            }
+            let Some(mutation_span) = find_mutation_span(node, ctx, false) else { return };
+            let key = key.as_deref().unwrap_or("Unknown");
+            ctx.diagnostic(unexpected_side_effect_in_property(mutation_span, key));
+        }
+        Some(ComputedContext::CompositionApi(getter_fn_span)) => {
+            let Expression::Identifier(ident) = object else { return };
+            if !is_setup_variable(ident, getter_fn_span, ctx) {
+                return;
+            }
+            ctx.diagnostic(unexpected_side_effect_in_function(mutation_span));
+        }
+        None => {}
     }
 }
 
@@ -286,7 +266,8 @@ fn get_computed_getter_context(
     None
 }
 
-/// Check if a `computed(...)` call uses the `computed` export from `'vue'`, including aliases
+/// Check if a `computed(...)` call uses the `computed` export from `'vue'`,
+/// `'@vue/composition-api'`, or `'#imports'` (Nuxt), including aliases
 /// (`import { computed as c } from 'vue'`). Matches by symbol ID so the local name is irrelevant.
 fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
     let Expression::Identifier(ident) = call.callee.get_inner_expression() else {
@@ -297,7 +278,7 @@ fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> boo
         return false;
     };
     ctx.module_record().import_entries.iter().any(|entry| {
-        if !matches!(entry.module_request.name(), "vue" | "@vue/composition-api") {
+        if !matches!(entry.module_request.name(), "vue" | "@vue/composition-api" | "#imports") {
             return false;
         }
         let ImportImportName::Name(name_span) = &entry.import_name else { return false };
@@ -311,38 +292,35 @@ fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> boo
 const MUTATING_METHODS: &[&str] =
     &["push", "pop", "shift", "unshift", "reverse", "splice", "sort", "copyWithin", "fill"];
 
-/// Starting from `start_node` (a StaticMemberExpression where object = this/ident),
+/// Starting from `start_node` (a member expression where object = this/ident),
 /// walk up through parent nodes and detect if the member chain is being mutated.
 /// Returns the span of the outermost mutation expression, or None if no mutation found.
-fn find_mutation_span(start_node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<Span> {
+///
+/// `seed_start` controls where the walk conceptually begins, matching ESLint's
+/// two findMutating call sites: `true` starts at the identifier (Composition API),
+/// so the start node's own property counts as a chain step and a first-level
+/// mutating call like `foo.reverse()` is detected; `false` starts at the member
+/// expression itself (Options API), so `this.reverse()` is not a mutation.
+fn find_mutation_span(
+    start_node: &AstNode<'_>,
+    ctx: &LintContext<'_>,
+    seed_start: bool,
+) -> Option<Span> {
     let nodes = ctx.nodes();
     let mut current = start_node;
-    // Seed for Composition API (object is Identifier): compensates for starting at MemberExpression
-    // level rather than the inner Identifier like ESLint does.
-    // Do NOT seed for Options API (object is `this`): ESLint's findMutating starts from the
-    // MemberExpression with lastStaticPropertyName=null, so `this.reverse()` is not a mutation.
-    let mut last_static_name: Option<String> = match start_node.kind() {
-        AstKind::StaticMemberExpression(m) => {
-            if is_this_object(&m.object, ctx) {
-                None
-            } else {
-                Some(m.property.name.to_string())
-            }
+    let mut last_static_name: Option<String> = if seed_start {
+        match start_node.kind() {
+            AstKind::StaticMemberExpression(m) => Some(m.property.name.to_string()),
+            AstKind::ComputedMemberExpression(m) => m.static_property_name().map(|s| s.to_string()),
+            _ => None,
         }
-        AstKind::ComputedMemberExpression(m) => {
-            if is_this_object(&m.object, ctx) {
-                None
-            } else {
-                m.static_property_name().map(|s| s.to_string())
-            }
-        }
-        _ => None,
+    } else {
+        None
     };
 
     loop {
         let parent = nodes.parent_node(current.id());
         match parent.kind() {
-            // Walking through static member chain: this.foo.bar...
             AstKind::StaticMemberExpression(mem) if mem.object.span() == current.span() => {
                 last_static_name = Some(mem.property.name.to_string());
                 current = parent;
@@ -437,9 +415,6 @@ fn is_setup_variable(
     if getter_fn_span.contains_inclusive(decl_span) {
         return false;
     }
-
-    // Function or class declarations are valid setup variables (they can still be mutated)
-    // but we skip if the declaration is neither inside setup ranges nor a top-level script-setup binding
 
     // <script setup>: all top-level bindings are setup variables, except import declarations
     // (ESLint excludes def.type === 'ImportBinding' from setup ranges)
@@ -691,7 +666,7 @@ fn test() {
             None,
             None,
         ),
-        // Issue 1: <script setup> import bindings are not setup variables
+        // <script setup>: import bindings are not setup variables
         (
             "
                   <script setup>
@@ -709,7 +684,7 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Issue 4: Case B ({get, set}) arrow getter is not analyzed by ESLint
+        // arrow function getter in the {get, set} object form is not analyzed
         (
             "Vue.component('test', {
                     computed: {
@@ -724,7 +699,7 @@ fn test() {
             None,
             None,
         ),
-        // FP3: `this.method()` where method name matches MUTATING_METHODS is not a side effect
+        // component methods named like mutating array methods are not mutations
         (
             "Vue.component('test', {
                     computed: {
@@ -743,7 +718,7 @@ fn test() {
             None,
             None,
         ),
-        // FP2: setup() function parameters are not "setup variables"
+        // setup() function parameters are not setup variables
         (
             "
                   <script>
@@ -762,7 +737,7 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // FP4: arrow function values in Options API computed are not analyzed by ESLint
+        // arrow function values in Options API computed are not analyzed
         (
             "Vue.component('test', {
                     computed: {
@@ -775,7 +750,7 @@ fn test() {
             None,
             None,
         ),
-        // FP5: `computed:` key nested inside data() is not a Vue computed option
+        // a `computed:` key nested inside data() is not a Vue computed option
         (
             "Vue.component('test', {
                     data() {
@@ -791,6 +766,63 @@ fn test() {
             None,
             None,
             None,
+        ),
+        // ESLint ignores `this` inside Composition API computed functions
+        (
+            "
+                  <script>
+                  import { computed } from 'vue'
+                  export default {
+                    setup() {
+                      const test1 = computed(() => {
+                        this.x = 1
+                      })
+                      const test2 = computed(() => this['y'].push(1))
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // a `this`-alias local to the computed function is a local variable, not a setup variable
+        (
+            "
+                  <script>
+                  import { computed } from 'vue'
+                  export default {
+                    setup() {
+                      const test1 = computed(() => {
+                        const self = this
+                        self.x = 1
+                      })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // a `this`-alias declared at module scope is not a setup variable
+        (
+            "
+                  <script>
+                  import { computed } from 'vue'
+                  const self = this
+                  export default {
+                    setup() {
+                      const test1 = computed(() => {
+                        self.x = 1
+                      })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
         ),
         (
             "
@@ -1208,7 +1240,7 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // FN8: computed property whose key happens to be named "set" is incorrectly skipped
+        // a computed property literally named "set" is still a getter
         (
             "Vue.component('test', {
                     computed: {
@@ -1221,7 +1253,7 @@ fn test() {
             None,
             None,
         ),
-        // FN10: assignment to `this.$set` is not a call, should fall through to mutation detection
+        // assignment to `this.$set` is a plain property mutation
         (
             "Vue.component('test', {
                     computed: {
@@ -1235,7 +1267,7 @@ fn test() {
             None,
             None,
         ),
-        // FN9: bracket notation with string literal key for a mutating method
+        // bracket notation with a string-literal key for a mutating method
         (
             "Vue.component('test', {
                     computed: {
@@ -1251,7 +1283,7 @@ fn test() {
             None,
             None,
         ),
-        // FN7: aliased import of `computed` from 'vue' is not detected
+        // aliased import of `computed` from 'vue'
         (
             "
                   <script>
@@ -1271,7 +1303,7 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Issue 2: ComputedMemberExpression as starting point (this['foo'] = 1, etc.)
+        // bracket-notation mutations on `this`
         (
             "Vue.component('test', {
                     computed: {
@@ -1293,7 +1325,7 @@ fn test() {
             None,
             None,
         ),
-        // Issue 2 (Composition API): bracket-notation mutations on setup variables
+        // bracket-notation mutations on setup variables
         (
             "
                   <script>
@@ -1313,7 +1345,7 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Issue 3: @vue/composition-api support
+        // `computed` imported from '@vue/composition-api'
         (
             "
                   <script>
@@ -1333,7 +1365,7 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Issue 5: this-alias (const self = this) in Composition API context
+        // a `this`-alias declared in setup() is checked as a setup variable
         (
             "
                   <script>
@@ -1353,7 +1385,7 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ),
-        // Issue 6: (this.$set)(...) — parenthesized callee
+        // `(this.$set)(...)` — parenthesized callee
         (
             "Vue.component('test', {
                     computed: {
@@ -1366,6 +1398,44 @@ fn test() {
             None,
             None,
             None,
+        ),
+        // `computed` imported from '#imports' (Nuxt auto-import)
+        (
+            "
+                  <script>
+                  import { computed } from '#imports'
+                  export default {
+                    setup() {
+                      const foo = useFoo()
+                      const test1 = computed(() => foo.something.reverse())
+                      const test2 = computed(() => {
+                        foo.firstName = 'lorem'
+                      })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // a `this`-alias declared in setup() is an ordinary setup variable:
+        // the walk starts at the identifier, so a first-level mutating call counts
+        (
+            "
+                  <script>
+                  import { computed } from 'vue'
+                  export default {
+                    setup() {
+                      const self = this
+                      const test1 = computed(() => self.reverse())
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
@@ -287,8 +287,8 @@ fn find_mutation_span(start_node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option
                 current = parent;
             }
 
-            // ChainExpression is transparent (optional chaining wrapper)
-            AstKind::ChainExpression(_) => {
+            // ChainExpression and ParenthesizedExpression are transparent wrappers
+            AstKind::ChainExpression(_) | AstKind::ParenthesizedExpression(_) => {
                 current = parent;
             }
 
@@ -312,9 +312,7 @@ fn find_mutation_span(start_node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option
 
             // Call expression — check if we are the callee
             AstKind::CallExpression(call) if call.callee.span() == current.span() => {
-                if last_static_name
-                    .as_deref()
-                    .is_some_and(|name| MUTATING_METHODS.contains(&name))
+                if last_static_name.as_deref().is_some_and(|name| MUTATING_METHODS.contains(&name))
                 {
                     return Some(call.span());
                 }

--- a/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
@@ -74,29 +74,79 @@ declare_oxc_lint!(
 
 impl Rule for NoSideEffectsInComputedProperties {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // Handle bracket-notation mutations: this['foo'] = 1, foo['arr'].reverse(), etc.
+        if let AstKind::ComputedMemberExpression(mem) = node.kind() {
+            match &mem.object {
+                expr if is_this_object(expr, ctx) => {
+                    let Some(mutation_span) = find_mutation_span(node, ctx) else { return };
+                    match find_computed_context(node, ctx) {
+                        Some(ComputedContext::OptionsApi(key)) => {
+                            let key = key.as_deref().unwrap_or("Unknown");
+                            ctx.diagnostic(unexpected_side_effect_in_property(mutation_span, key));
+                        }
+                        Some(ComputedContext::CompositionApi(_)) => {
+                            ctx.diagnostic(unexpected_side_effect_in_function(mutation_span));
+                        }
+                        None => {}
+                    }
+                }
+                Expression::Identifier(ident) => {
+                    let Some(mutation_span) = find_mutation_span(node, ctx) else { return };
+                    let Some(ComputedContext::CompositionApi(getter_fn_span)) =
+                        find_computed_context(node, ctx)
+                    else {
+                        return;
+                    };
+                    if !is_setup_variable(ident, getter_fn_span, ctx) {
+                        return;
+                    }
+                    ctx.diagnostic(unexpected_side_effect_in_function(mutation_span));
+                }
+                _ => {}
+            }
+            return;
+        }
+
         let AstKind::StaticMemberExpression(mem) = node.kind() else { return };
 
         match &mem.object {
             // Options API: `this.xxx` mutations
             expr if is_this_object(expr, ctx) => {
-                // Special case: `this.$set(...)` — report on the property name span
+                // Special case: `this.$set(...)` — report on the property name span and return early.
+                // If `this.$set` is not called (e.g. assignment `this.$set = fn`), fall through to
+                // general mutation detection so it is caught there.
                 if mem.property.name == "$set" {
-                    let parent = ctx.nodes().parent_node(node.id());
-                    if matches!(parent.kind(), AstKind::CallExpression(_))
-                        && let Some(ComputedContext::OptionsApi(key)) =
-                            find_computed_context(node, ctx)
-                    {
-                        let key = key.as_deref().unwrap_or("Unknown");
-                        ctx.diagnostic(unexpected_side_effect_in_property(mem.property.span, key));
+                    let mut parent = ctx.nodes().parent_node(node.id());
+                    // `(this.$set)(...)` — skip parenthesized wrappers between the member and the call
+                    while matches!(parent.kind(), AstKind::ParenthesizedExpression(_)) {
+                        parent = ctx.nodes().parent_node(parent.id());
                     }
-                    return;
+                    if matches!(parent.kind(), AstKind::CallExpression(_)) {
+                        if let Some(ComputedContext::OptionsApi(key)) =
+                            find_computed_context(node, ctx)
+                        {
+                            let key = key.as_deref().unwrap_or("Unknown");
+                            ctx.diagnostic(unexpected_side_effect_in_property(
+                                mem.property.span,
+                                key,
+                            ));
+                        }
+                        return;
+                    }
                 }
 
                 // General mutation detection
                 let Some(mutation_span) = find_mutation_span(node, ctx) else { return };
-                if let Some(ComputedContext::OptionsApi(key)) = find_computed_context(node, ctx) {
-                    let key = key.as_deref().unwrap_or("Unknown");
-                    ctx.diagnostic(unexpected_side_effect_in_property(mutation_span, key));
+                match find_computed_context(node, ctx) {
+                    Some(ComputedContext::OptionsApi(key)) => {
+                        let key = key.as_deref().unwrap_or("Unknown");
+                        ctx.diagnostic(unexpected_side_effect_in_property(mutation_span, key));
+                    }
+                    // `this`-alias (e.g. `const self = this`) used inside a Composition API computed
+                    Some(ComputedContext::CompositionApi(_)) => {
+                        ctx.diagnostic(unexpected_side_effect_in_function(mutation_span));
+                    }
+                    None => {}
                 }
             }
 
@@ -175,19 +225,22 @@ fn get_computed_getter_context(
         }
 
         AstKind::ObjectProperty(prop) => {
-            // setter is not a getter
-            if prop.key.is_specific_static_name("set") {
-                return None;
-            }
-
             let grandparent = nodes.parent_node(parent.id());
             let AstKind::ObjectExpression(_) = grandparent.kind() else { return None };
             let great = nodes.parent_node(grandparent.id());
 
             match great.kind() {
                 // Case A: `computed: { key() {} }` or `computed: { key: function() {} }`
-                AstKind::ObjectProperty(outer) if outer.key.is_specific_static_name("computed") => {
-                    if is_under_vue_root(great, ctx) {
+                // Arrow functions are excluded: ESLint's getComputedProperties only matches
+                // FunctionExpression, so `computed: { foo: () => { this.x=1 } }` is not analyzed.
+                // Direct-parent check: `great`'s parent must be the Vue options object itself so
+                // that `computed:` keys nested inside e.g. `data()` return values are not matched.
+                AstKind::ObjectProperty(outer)
+                    if outer.key.is_specific_static_name("computed")
+                        && matches!(fn_node.kind(), AstKind::Function(_)) =>
+                {
+                    let vue_options = nodes.parent_node(great.id());
+                    if is_vue_component_options_object(vue_options, ctx) {
                         let key = prop.key.static_name().map(|s| s.to_string());
                         return Some(ComputedContext::OptionsApi(key));
                     }
@@ -196,16 +249,22 @@ fn get_computed_getter_context(
                 // Case B: `computed: { key: { get() {} } }`
                 // fn -> ObjectProperty(get) -> ObjectExpression -> ObjectProperty(key)
                 //     -> ObjectExpression(computed body) -> ObjectProperty(computed)
-                AstKind::ObjectProperty(key_prop) if prop.key.is_specific_static_name("get") => {
+                // Arrow functions are excluded here as well (same reasoning as Case A).
+                AstKind::ObjectProperty(key_prop)
+                    if prop.key.is_specific_static_name("get")
+                        && matches!(fn_node.kind(), AstKind::Function(_)) =>
+                {
                     let key_obj_expr = nodes.parent_node(great.id());
                     let AstKind::ObjectExpression(_) = key_obj_expr.kind() else { return None };
                     let computed_prop_node = nodes.parent_node(key_obj_expr.id());
                     if let AstKind::ObjectProperty(cp) = computed_prop_node.kind()
                         && cp.key.is_specific_static_name("computed")
-                        && is_under_vue_root(computed_prop_node, ctx)
                     {
-                        let key = key_prop.key.static_name().map(|s| s.to_string());
-                        return Some(ComputedContext::OptionsApi(key));
+                        let vue_options = nodes.parent_node(computed_prop_node.id());
+                        if is_vue_component_options_object(vue_options, ctx) {
+                            let key = key_prop.key.static_name().map(|s| s.to_string());
+                            return Some(ComputedContext::OptionsApi(key));
+                        }
                     }
                 }
 
@@ -227,24 +286,18 @@ fn get_computed_getter_context(
     None
 }
 
-fn is_under_vue_root(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    ctx.nodes().ancestors(node.id()).any(|a| is_vue_component_options_object(a, ctx))
-}
-
-/// Check if a `computed(...)` call uses `computed` imported from `vue`.
+/// Check if a `computed(...)` call uses the `computed` export from `'vue'`, including aliases
+/// (`import { computed as c } from 'vue'`). Matches by symbol ID so the local name is irrelevant.
 fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
     let Expression::Identifier(ident) = call.callee.get_inner_expression() else {
         return false;
     };
-    if ident.name != "computed" {
-        return false;
-    }
     let scoping = ctx.scoping();
     let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
         return false;
     };
     ctx.module_record().import_entries.iter().any(|entry| {
-        if entry.module_request.name() != "vue" {
+        if !matches!(entry.module_request.name(), "vue" | "@vue/composition-api") {
             return false;
         }
         let ImportImportName::Name(name_span) = &entry.import_name else { return false };
@@ -264,13 +317,27 @@ const MUTATING_METHODS: &[&str] =
 fn find_mutation_span(start_node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<Span> {
     let nodes = ctx.nodes();
     let mut current = start_node;
-    // Seed with the starting node's property name so `arr.reverse()` is immediately detectable.
-    let mut last_static_name: Option<String> =
-        if let AstKind::StaticMemberExpression(m) = start_node.kind() {
-            Some(m.property.name.to_string())
-        } else {
-            None
-        };
+    // Seed for Composition API (object is Identifier): compensates for starting at MemberExpression
+    // level rather than the inner Identifier like ESLint does.
+    // Do NOT seed for Options API (object is `this`): ESLint's findMutating starts from the
+    // MemberExpression with lastStaticPropertyName=null, so `this.reverse()` is not a mutation.
+    let mut last_static_name: Option<String> = match start_node.kind() {
+        AstKind::StaticMemberExpression(m) => {
+            if is_this_object(&m.object, ctx) {
+                None
+            } else {
+                Some(m.property.name.to_string())
+            }
+        }
+        AstKind::ComputedMemberExpression(m) => {
+            if is_this_object(&m.object, ctx) {
+                None
+            } else {
+                m.static_property_name().map(|s| s.to_string())
+            }
+        }
+        _ => None,
+    };
 
     loop {
         let parent = nodes.parent_node(current.id());
@@ -281,9 +348,11 @@ fn find_mutation_span(start_node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option
                 current = parent;
             }
 
-            // Walking through computed member: this.foo[bar]...
+            // Walking through computed member: this.foo[bar] / this.foo['push']...
+            // Resolve string-literal keys (e.g. `this.arr['push']`) so mutating methods are
+            // detected; dynamic keys (variables) remain None and correctly produce no match.
             AstKind::ComputedMemberExpression(mem) if mem.object.span() == current.span() => {
-                last_static_name = None;
+                last_static_name = mem.static_property_name().map(|s| s.to_string());
                 current = parent;
             }
 
@@ -372,9 +441,14 @@ fn is_setup_variable(
     // Function or class declarations are valid setup variables (they can still be mutated)
     // but we skip if the declaration is neither inside setup ranges nor a top-level script-setup binding
 
-    // <script setup>: all top-level bindings are setup variables
+    // <script setup>: all top-level bindings are setup variables, except import declarations
+    // (ESLint excludes def.type === 'ImportBinding' from setup ranges)
     if ctx.frameworks_options() == FrameworkOptions::VueSetup {
-        return true;
+        let is_import = ctx
+            .nodes()
+            .ancestors(decl_node.id())
+            .any(|a| matches!(a.kind(), AstKind::ImportDeclaration(_)));
+        return !is_import;
     }
 
     // Options API `setup()`: check if decl is inside a setup() function body
@@ -382,14 +456,23 @@ fn is_setup_variable(
     is_inside_setup_function(decl_node, ctx)
 }
 
-/// Check if `node` is declared within a `setup()` function of a Vue component options object.
+/// Check if `node` is declared within a `setup()` function body of a Vue component options object.
+/// Parameters of setup() are excluded: ESLint's setupRanges holds only node.body.range (the block
+/// statement), so formal parameters — whose span is before the opening `{` — fail the range check.
 fn is_inside_setup_function(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    // Walk up from node's declaration and check if any ancestor is a setup() function
-    // whose parent is a Vue component options property named "setup"
     ctx.nodes().ancestors(node.id()).any(|ancestor| {
-        let (AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)) = ancestor.kind() else {
-            return false;
+        let body_span = match ancestor.kind() {
+            AstKind::Function(f) => {
+                let Some(body) = &f.body else { return false };
+                body.span
+            }
+            AstKind::ArrowFunctionExpression(f) => f.body.span,
+            _ => return false,
         };
+        // Declaration must be inside the function body (not in the parameter list)
+        if !body_span.contains_inclusive(node.span()) {
+            return false;
+        }
         let parent = ctx.nodes().parent_node(ancestor.id());
         let AstKind::ObjectProperty(prop) = parent.kind() else { return false };
         if !prop.key.is_specific_static_name("setup") {
@@ -604,6 +687,107 @@ fn test() {
                     }
                   })
                 ",
+            None,
+            None,
+            None,
+        ),
+        // Issue 1: <script setup> import bindings are not setup variables
+        (
+            "
+                  <script setup>
+                  import { state } from './store'
+                  import store from './store'
+                  import { computed } from 'vue'
+
+                  const c1 = computed(() => state.items.reverse())
+                  const c2 = computed(() => {
+                    store.count++
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // Issue 4: Case B ({get, set}) arrow getter is not analyzed by ESLint
+        (
+            "Vue.component('test', {
+                    computed: {
+                      foo: {
+                        get: () => {
+                          this.x = 1
+                        }
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        // FP3: `this.method()` where method name matches MUTATING_METHODS is not a side effect
+        (
+            "Vue.component('test', {
+                    computed: {
+                      test1() {
+                        return this.reverse()
+                      },
+                      test2() {
+                        return this.push('x')
+                      },
+                      test3() {
+                        return this.sort()
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        // FP2: setup() function parameters are not "setup variables"
+        (
+            "
+                  <script>
+                  import { computed } from 'vue'
+                  export default {
+                    setup(props, context) {
+                      const test1 = computed(() => props.something.reverse())
+                      const test2 = computed(() => {
+                        props.count++
+                      })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // FP4: arrow function values in Options API computed are not analyzed by ESLint
+        (
+            "Vue.component('test', {
+                    computed: {
+                      foo: () => {
+                        this.x = 1
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        // FP5: `computed:` key nested inside data() is not a Vue computed option
+        (
+            "Vue.component('test', {
+                    data() {
+                      return {
+                        computed: {
+                          foo() {
+                            this.x = 1
+                          }
+                        }
+                      }
+                    }
+                  })",
             None,
             None,
             None,
@@ -1023,6 +1207,165 @@ fn test() {
             None,
             None,
             Some(PathBuf::from("test.vue")),
+        ),
+        // FN8: computed property whose key happens to be named "set" is incorrectly skipped
+        (
+            "Vue.component('test', {
+                    computed: {
+                      set() {
+                        return this.something.reverse()
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        // FN10: assignment to `this.$set` is not a call, should fall through to mutation detection
+        (
+            "Vue.component('test', {
+                    computed: {
+                      test1() {
+                        this.$set = function() {}
+                        return this.foo
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        // FN9: bracket notation with string literal key for a mutating method
+        (
+            "Vue.component('test', {
+                    computed: {
+                      test1() {
+                        return this.arr['push']('x')
+                      },
+                      test2() {
+                        return this.arr['reverse']()
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        // FN7: aliased import of `computed` from 'vue' is not detected
+        (
+            "
+                  <script>
+                  import { computed as c } from 'vue'
+                  export default {
+                    setup() {
+                      const foo = useFoo()
+                      const test1 = c(() => foo.something.reverse())
+                      const test2 = c(() => {
+                        foo.firstName = 'lorem'
+                      })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // Issue 2: ComputedMemberExpression as starting point (this['foo'] = 1, etc.)
+        (
+            "Vue.component('test', {
+                    computed: {
+                      test1() {
+                        this['foo'] = 1
+                      },
+                      test2() {
+                        return this['arr'].push(x)
+                      },
+                      test3() {
+                        this['count']++
+                      },
+                      test4() {
+                        delete this['foo']
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
+        ),
+        // Issue 2 (Composition API): bracket-notation mutations on setup variables
+        (
+            "
+                  <script>
+                  import { computed } from 'vue'
+                  export default {
+                    setup() {
+                      const foo = useFoo()
+                      const test1 = computed(() => {
+                        foo['firstName'] = 'lorem'
+                      })
+                      const test2 = computed(() => foo['arr'].reverse())
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // Issue 3: @vue/composition-api support
+        (
+            "
+                  <script>
+                  import { computed } from '@vue/composition-api'
+                  export default {
+                    setup() {
+                      const foo = useFoo()
+                      const test1 = computed(() => foo.something.reverse())
+                      const test2 = computed(() => {
+                        foo.firstName = 'lorem'
+                      })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // Issue 5: this-alias (const self = this) in Composition API context
+        (
+            "
+                  <script>
+                  import { computed } from 'vue'
+                  export default {
+                    setup() {
+                      const self = this
+                      const test1 = computed(() => self.items.reverse())
+                      const test2 = computed(() => {
+                        self.firstName = 'lorem'
+                      })
+                    }
+                  }
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // Issue 6: (this.$set)(...) — parenthesized callee
+        (
+            "Vue.component('test', {
+                    computed: {
+                      test1() {
+                        (this.$set)(this, 'foo', 'lorem')
+                        return this.foo
+                      }
+                    }
+                  })",
+            None,
+            None,
+            None,
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{CallExpression, Expression},
+    ast::{CallExpression, Expression, IdentifierReference, UnaryOperator},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -351,7 +351,7 @@ fn find_mutation_span(
 
             // Delete: `delete this.xxx`
             AstKind::UnaryExpression(unary)
-                if unary.operator == oxc_ast::ast::UnaryOperator::Delete
+                if unary.operator == UnaryOperator::Delete
                     && unary.argument.span() == current.span() =>
             {
                 return Some(unary.span());
@@ -400,7 +400,7 @@ fn is_object_assign_first_arg(call: &CallExpression<'_>, first_arg_span: Span) -
 /// 3. The declaration IS within the setup function body OR is a top-level binding
 ///    in a `<script setup>` file (FrameworkOptions::VueSetup).
 fn is_setup_variable(
-    ident: &oxc_ast::ast::IdentifierReference<'_>,
+    ident: &IdentifierReference<'_>,
     getter_fn_span: Span,
     ctx: &LintContext<'_>,
 ) -> bool {
@@ -1089,7 +1089,6 @@ fn test() {
                         A.name = ''
                       })
                       const test10 = computed(() => (foo.a = '', true))
-
                       const test100 = computed(() => {
                         const a = foo
                         a.count++ // false negative
@@ -1109,7 +1108,6 @@ fn test() {
                   export default {
                     setup() {
                       const arr = reactive([])
-
                       const test1 = computed(() => arr.reverse())
                     }
                   }
@@ -1126,7 +1124,6 @@ fn test() {
                   export default {
                     setup() {
                       const foo = useFoo()
-
                       const test1 = computed(() => foo.something.reverse())
                     }
                   }
@@ -1177,7 +1174,6 @@ fn test() {
                     A.name = ''
                   })
                   const test10 = computed(() => (foo.a = '', true))
-
                   const test100 = computed(() => {
                     const a = foo
                     a.count++ // false negative
@@ -1193,7 +1189,6 @@ fn test() {
                   <script setup>
                   import {reactive, computed} from 'vue'
                   const arr = reactive([])
-
                   const test1 = computed(() => arr.reverse())
                   </script>
                   ",
@@ -1206,7 +1201,6 @@ fn test() {
                   <script lang="ts" setup>
                   import {ref, computed} from 'vue'
                   const foo = useFoo()
-
                   const test1 = computed(() => foo.something.reverse())
                   </script>
                   "#,
@@ -1221,7 +1215,6 @@ fn test() {
                   export default {
                     setup() {
                       const foo = useFoo()
-
                       const test1 = computed(() => Object.assign(foo.data, { extra: 'value' }))
                       const test2 = computed(() => {
                         return Object.assign(foo.user, foo.updates)

--- a/crates/oxc_linter/src/snapshots/vue_no_side_effects_in_computed_properties.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_side_effects_in_computed_properties.snap
@@ -247,23 +247,23 @@ source: crates/oxc_linter/src/tester.rs
  41 │                       })
  42 │                       const test10 = computed(() => (foo.a = '', true))
     ·                                                      ──────────
- 43 │ 
+ 43 │                       const test100 = computed(() => {
     ╰────
 
   ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
-   ╭─[no_side_effects_in_computed_properties.tsx:8:52]
- 7 │ 
- 8 │                       const test1 = computed(() => arr.reverse())
+   ╭─[no_side_effects_in_computed_properties.tsx:7:52]
+ 6 │                       const arr = reactive([])
+ 7 │                       const test1 = computed(() => arr.reverse())
    ·                                                    ─────────────
- 9 │                     }
+ 8 │                     }
    ╰────
 
   ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
-   ╭─[no_side_effects_in_computed_properties.tsx:8:52]
- 7 │ 
- 8 │                       const test1 = computed(() => foo.something.reverse())
+   ╭─[no_side_effects_in_computed_properties.tsx:7:52]
+ 6 │                       const foo = useFoo()
+ 7 │                       const test1 = computed(() => foo.something.reverse())
    ·                                                    ───────────────────────
- 9 │                     }
+ 8 │                     }
    ╰────
 
   ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
@@ -359,47 +359,47 @@ source: crates/oxc_linter/src/tester.rs
  39 │                   })
  40 │                   const test10 = computed(() => (foo.a = '', true))
     ·                                                  ──────────
- 41 │ 
+ 41 │                   const test100 = computed(() => {
     ╰────
 
   ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
-   ╭─[no_side_effects_in_computed_properties.tsx:6:48]
- 5 │ 
- 6 │                   const test1 = computed(() => arr.reverse())
+   ╭─[no_side_effects_in_computed_properties.tsx:5:48]
+ 4 │                   const arr = reactive([])
+ 5 │                   const test1 = computed(() => arr.reverse())
    ·                                                ─────────────
- 7 │                   </script>
+ 6 │                   </script>
    ╰────
 
   ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
-   ╭─[no_side_effects_in_computed_properties.tsx:6:48]
- 5 │ 
- 6 │                   const test1 = computed(() => foo.something.reverse())
+   ╭─[no_side_effects_in_computed_properties.tsx:5:48]
+ 4 │                   const foo = useFoo()
+ 5 │                   const test1 = computed(() => foo.something.reverse())
    ·                                                ───────────────────────
- 7 │                   </script>
+ 6 │                   </script>
    ╰────
 
   ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
-   ╭─[no_side_effects_in_computed_properties.tsx:8:52]
- 7 │ 
- 8 │                       const test1 = computed(() => Object.assign(foo.data, { extra: 'value' }))
+   ╭─[no_side_effects_in_computed_properties.tsx:7:52]
+ 6 │                       const foo = useFoo()
+ 7 │                       const test1 = computed(() => Object.assign(foo.data, { extra: 'value' }))
    ·                                                    ───────────────────────────────────────────
- 9 │                       const test2 = computed(() => {
+ 8 │                       const test2 = computed(() => {
    ╰────
 
   ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
-    ╭─[no_side_effects_in_computed_properties.tsx:10:32]
-  9 │                       const test2 = computed(() => {
- 10 │                         return Object.assign(foo.user, foo.updates)
+    ╭─[no_side_effects_in_computed_properties.tsx:9:32]
+  8 │                       const test2 = computed(() => {
+  9 │                         return Object.assign(foo.user, foo.updates)
     ·                                ────────────────────────────────────
- 11 │                       })
+ 10 │                       })
     ╰────
 
   ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
-    ╭─[no_side_effects_in_computed_properties.tsx:14:27]
- 13 │                         get() {
- 14 │                           Object.assign(foo.settings, { theme: 'dark' })
+    ╭─[no_side_effects_in_computed_properties.tsx:13:27]
+ 12 │                         get() {
+ 13 │                           Object.assign(foo.settings, { theme: 'dark' })
     ·                           ──────────────────────────────────────────────
- 15 │                           return foo.settings
+ 14 │                           return foo.settings
     ╰────
 
   ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "set" computed property.

--- a/crates/oxc_linter/src/snapshots/vue_no_side_effects_in_computed_properties.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_side_effects_in_computed_properties.snap
@@ -401,3 +401,139 @@ source: crates/oxc_linter/src/tester.rs
     ·                           ──────────────────────────────────────────────
  15 │                           return foo.settings
     ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "set" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:4:32]
+ 3 │                       set() {
+ 4 │                         return this.something.reverse()
+   ·                                ────────────────────────
+ 5 │                       }
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test1" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:4:25]
+ 3 │                       test1() {
+ 4 │                         this.$set = function() {}
+   ·                         ─────────────────────────
+ 5 │                         return this.foo
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test1" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:4:32]
+ 3 │                       test1() {
+ 4 │                         return this.arr['push']('x')
+   ·                                ─────────────────────
+ 5 │                       },
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test2" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:7:32]
+ 6 │                       test2() {
+ 7 │                         return this.arr['reverse']()
+   ·                                ─────────────────────
+ 8 │                       }
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:7:45]
+ 6 │                       const foo = useFoo()
+ 7 │                       const test1 = c(() => foo.something.reverse())
+   ·                                             ───────────────────────
+ 8 │                       const test2 = c(() => {
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:9:25]
+  8 │                       const test2 = c(() => {
+  9 │                         foo.firstName = 'lorem'
+    ·                         ───────────────────────
+ 10 │                       })
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test1" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:4:25]
+ 3 │                       test1() {
+ 4 │                         this['foo'] = 1
+   ·                         ───────────────
+ 5 │                       },
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test2" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:7:32]
+ 6 │                       test2() {
+ 7 │                         return this['arr'].push(x)
+   ·                                ───────────────────
+ 8 │                       },
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test3" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:10:25]
+  9 │                       test3() {
+ 10 │                         this['count']++
+    ·                         ───────────────
+ 11 │                       },
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test4" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:13:25]
+ 12 │                       test4() {
+ 13 │                         delete this['foo']
+    ·                         ──────────────────
+ 14 │                       }
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:8:25]
+ 7 │                       const test1 = computed(() => {
+ 8 │                         foo['firstName'] = 'lorem'
+   ·                         ──────────────────────────
+ 9 │                       })
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:10:52]
+  9 │                       })
+ 10 │                       const test2 = computed(() => foo['arr'].reverse())
+    ·                                                    ────────────────────
+ 11 │                     }
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:7:52]
+ 6 │                       const foo = useFoo()
+ 7 │                       const test1 = computed(() => foo.something.reverse())
+   ·                                                    ───────────────────────
+ 8 │                       const test2 = computed(() => {
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:9:25]
+  8 │                       const test2 = computed(() => {
+  9 │                         foo.firstName = 'lorem'
+    ·                         ───────────────────────
+ 10 │                       })
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:7:52]
+ 6 │                       const self = this
+ 7 │                       const test1 = computed(() => self.items.reverse())
+   ·                                                    ────────────────────
+ 8 │                       const test2 = computed(() => {
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:9:25]
+  8 │                       const test2 = computed(() => {
+  9 │                         self.firstName = 'lorem'
+    ·                         ────────────────────────
+ 10 │                       })
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test1" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:4:31]
+ 3 │                       test1() {
+ 4 │                         (this.$set)(this, 'foo', 'lorem')
+   ·                               ────
+ 5 │                         return this.foo
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_side_effects_in_computed_properties.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_side_effects_in_computed_properties.snap
@@ -537,3 +537,27 @@ source: crates/oxc_linter/src/tester.rs
    ·                               ────
  5 │                         return this.foo
    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:7:52]
+ 6 │                       const foo = useFoo()
+ 7 │                       const test1 = computed(() => foo.something.reverse())
+   ·                                                    ───────────────────────
+ 8 │                       const test2 = computed(() => {
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:9:25]
+  8 │                       const test2 = computed(() => {
+  9 │                         foo.firstName = 'lorem'
+    ·                         ───────────────────────
+ 10 │                       })
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:7:52]
+ 6 │                       const self = this
+ 7 │                       const test1 = computed(() => self.reverse())
+   ·                                                    ──────────────
+ 8 │                     }
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_side_effects_in_computed_properties.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_side_effects_in_computed_properties.snap
@@ -1,0 +1,387 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test1" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:4:25]
+ 3 │                       test1() {
+ 4 │                         this.firstName = 'lorem'
+   ·                         ────────────────────────
+ 5 │                         asd.qwe.zxc = 'lorem'
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test2" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:9:25]
+  8 │                       test2() {
+  9 │                         this.count += 2;
+    ·                         ───────────────
+ 10 │                         this.count++;
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test2" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:10:25]
+  9 │                         this.count += 2;
+ 10 │                         this.count++;
+    ·                         ────────────
+ 11 │                         return this.count;
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test3" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:14:32]
+ 13 │                       test3() {
+ 14 │                         return this.something.reverse()
+    ·                                ────────────────────────
+ 15 │                       },
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test4" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:17:38]
+ 16 │                       test4() {
+ 17 │                         const test = this.another.something.push('example')
+    ·                                      ──────────────────────────────────────
+ 18 │                         return 'something'
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test5" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:21:25]
+ 20 │                       test5() {
+ 21 │                         this.something[index] = thing[index]
+    ·                         ────────────────────────────────────
+ 22 │                         return this.something
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test6" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:25:32]
+ 24 │                       test6() {
+ 25 │                         return this.something.keys.sort()
+    ·                                ──────────────────────────
+ 26 │                       }
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test1" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:5:27]
+ 4 │                         get() {
+ 5 │                           this.firstName = 'lorem'
+   ·                           ────────────────────────
+ 6 │                           return this.firstName + ' ' + this.lastName
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test2" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:11:27]
+ 10 │                         get() {
+ 11 │                           this.count += 2;
+    ·                           ───────────────
+ 12 │                           this.count++;
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test2" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:12:27]
+ 11 │                           this.count += 2;
+ 12 │                           this.count++;
+    ·                           ────────────
+ 13 │                           return this.count;
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test3" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:18:34]
+ 17 │                         get() {
+ 18 │                           return this.something.reverse()
+    ·                                  ────────────────────────
+ 19 │                         }
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test4" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:23:40]
+ 22 │                         get() {
+ 23 │                           const test = this.another.something.push('example')
+    ·                                        ──────────────────────────────────────
+ 24 │                           return 'something'
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test1" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:6:32]
+ 5 │                       test1() : string {
+ 6 │                         return this.something.reverse()
+   ·                                ────────────────────────
+ 7 │                       }
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test1" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:4:25]
+ 3 │                       test1() {
+ 4 │                         this.firstName = 'lorem'
+   ·                         ────────────────────────
+ 5 │                         asd.qwe.zxc = 'lorem'
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test1" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:4:32]
+ 3 │                       test1() {
+ 4 │                         return this?.something?.reverse?.()
+   ·                                ────────────────────────────
+ 5 │                       },
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "fooBar" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:4:30]
+ 3 │                       fooBar() {
+ 4 │                         this.$set(this, 'foo', 'lorem');
+   ·                              ────
+ 5 │                         Vue.set(this, 'bar', 'ipsum');
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "fooBar" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:5:29]
+ 4 │                         this.$set(this, 'foo', 'lorem');
+ 5 │                         Vue.set(this, 'bar', 'ipsum');
+   ·                             ───
+ 6 │                         return this.foo + ' ' + this.bar
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:12:25]
+ 11 │                       const test1 = computed(() => {
+ 12 │                         foo.firstName = 'lorem'
+    ·                         ───────────────────────
+ 13 │                         asd.qwe.zxc = 'lorem'
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:13:25]
+ 12 │                         foo.firstName = 'lorem'
+ 13 │                         asd.qwe.zxc = 'lorem'
+    ·                         ─────────────────────
+ 14 │                         return foo.firstName + ' ' + foo.lastName
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:17:25]
+ 16 │                       const test2 = computed(() => {
+ 17 │                         foo.count += 2;
+    ·                         ──────────────
+ 18 │                         foo.count++;
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:18:25]
+ 17 │                         foo.count += 2;
+ 18 │                         foo.count++;
+    ·                         ───────────
+ 19 │                         return foo.count;
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:21:52]
+ 20 │                       })
+ 21 │                       const test3 = computed(() => foo.something.reverse())
+    ·                                                    ───────────────────────
+ 22 │                       const test4 = computed(() => {
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:23:38]
+ 22 │                       const test4 = computed(() => {
+ 23 │                         const test = foo.another.something.push('example')
+    ·                                      ─────────────────────────────────────
+ 24 │                         return 'something'
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:27:25]
+ 26 │                       const test5 = computed(() => {
+ 27 │                         foo.something[index] = foo.thing[index]
+    ·                         ───────────────────────────────────────
+ 28 │                         return foo.something
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:30:52]
+ 29 │                       })
+ 30 │                       const test6 = computed(() => foo.something.keys.sort())
+    ·                                                    ─────────────────────────
+ 31 │                       const test7 = computed({
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:33:34]
+ 32 │                         get() {
+ 33 │                           return foo.something.reverse()
+    ·                                  ───────────────────────
+ 34 │                         }
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:37:25]
+ 36 │                       const test8 = computed(() => {
+ 37 │                         a.name = ''
+    ·                         ───────────
+ 38 │                       })
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:40:25]
+ 39 │                       const test9 = computed(() => {
+ 40 │                         A.name = ''
+    ·                         ───────────
+ 41 │                       })
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:42:54]
+ 41 │                       })
+ 42 │                       const test10 = computed(() => (foo.a = '', true))
+    ·                                                      ──────────
+ 43 │ 
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:8:52]
+ 7 │ 
+ 8 │                       const test1 = computed(() => arr.reverse())
+   ·                                                    ─────────────
+ 9 │                     }
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:8:52]
+ 7 │ 
+ 8 │                       const test1 = computed(() => foo.something.reverse())
+   ·                                                    ───────────────────────
+ 9 │                     }
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:10:21]
+  9 │                   const test1 = computed(() => {
+ 10 │                     foo.firstName = 'lorem'
+    ·                     ───────────────────────
+ 11 │                     asd.qwe.zxc = 'lorem'
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:11:21]
+ 10 │                     foo.firstName = 'lorem'
+ 11 │                     asd.qwe.zxc = 'lorem'
+    ·                     ─────────────────────
+ 12 │                     return foo.firstName + ' ' + foo.lastName
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:15:21]
+ 14 │                   const test2 = computed(() => {
+ 15 │                     foo.count += 2;
+    ·                     ──────────────
+ 16 │                     foo.count++;
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:16:21]
+ 15 │                     foo.count += 2;
+ 16 │                     foo.count++;
+    ·                     ───────────
+ 17 │                     return foo.count;
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:19:48]
+ 18 │                   })
+ 19 │                   const test3 = computed(() => foo.something.reverse())
+    ·                                                ───────────────────────
+ 20 │                   const test4 = computed(() => {
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:21:34]
+ 20 │                   const test4 = computed(() => {
+ 21 │                     const test = foo.another.something.push('example')
+    ·                                  ─────────────────────────────────────
+ 22 │                     return 'something'
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:25:21]
+ 24 │                   const test5 = computed(() => {
+ 25 │                     foo.something[index] = foo.thing[index]
+    ·                     ───────────────────────────────────────
+ 26 │                     return foo.something
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:28:48]
+ 27 │                   })
+ 28 │                   const test6 = computed(() => foo.something.keys.sort())
+    ·                                                ─────────────────────────
+ 29 │                   const test7 = computed({
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:31:30]
+ 30 │                     get() {
+ 31 │                       return foo.something.reverse()
+    ·                              ───────────────────────
+ 32 │                     }
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:35:21]
+ 34 │                   const test8 = computed(() => {
+ 35 │                     a.name = ''
+    ·                     ───────────
+ 36 │                   })
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:38:21]
+ 37 │                   const test9 = computed(() => {
+ 38 │                     A.name = ''
+    ·                     ───────────
+ 39 │                   })
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:40:50]
+ 39 │                   })
+ 40 │                   const test10 = computed(() => (foo.a = '', true))
+    ·                                                  ──────────
+ 41 │ 
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:6:48]
+ 5 │ 
+ 6 │                   const test1 = computed(() => arr.reverse())
+   ·                                                ─────────────
+ 7 │                   </script>
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:6:48]
+ 5 │ 
+ 6 │                   const test1 = computed(() => foo.something.reverse())
+   ·                                                ───────────────────────
+ 7 │                   </script>
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+   ╭─[no_side_effects_in_computed_properties.tsx:8:52]
+ 7 │ 
+ 8 │                       const test1 = computed(() => Object.assign(foo.data, { extra: 'value' }))
+   ·                                                    ───────────────────────────────────────────
+ 9 │                       const test2 = computed(() => {
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:10:32]
+  9 │                       const test2 = computed(() => {
+ 10 │                         return Object.assign(foo.user, foo.updates)
+    ·                                ────────────────────────────────────
+ 11 │                       })
+    ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in computed function.
+    ╭─[no_side_effects_in_computed_properties.tsx:14:27]
+ 13 │                         get() {
+ 14 │                           Object.assign(foo.settings, { theme: 'dark' })
+    ·                           ──────────────────────────────────────────────
+ 15 │                           return foo.settings
+    ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_side_effects_in_computed_properties.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_side_effects_in_computed_properties.snap
@@ -122,6 +122,22 @@ source: crates/oxc_linter/src/tester.rs
  5 │                       },
    ╰────
 
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test2" computed property.
+   ╭─[no_side_effects_in_computed_properties.tsx:7:32]
+ 6 │                       test2() {
+ 7 │                         return (this?.something)?.reverse?.()
+   ·                                ──────────────────────────────
+ 8 │                       },
+   ╰────
+
+  ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "test3" computed property.
+    ╭─[no_side_effects_in_computed_properties.tsx:10:32]
+  9 │                       test3() {
+ 10 │                         return (this?.something?.reverse)?.()
+    ·                                ──────────────────────────────
+ 11 │                       },
+    ╰────
+
   ⚠ vue(no-side-effects-in-computed-properties): Unexpected side effect in "fooBar" computed property.
    ╭─[no_side_effects_in_computed_properties.tsx:4:30]
  3 │                       fooBar() {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -8367,6 +8367,9 @@
         "vue/no-shared-component-data": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "vue/no-side-effects-in-computed-properties": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "vue/no-this-in-before-route-enter": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -8371,6 +8371,9 @@ expression: json
         "vue/no-shared-component-data": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "vue/no-side-effects-in-computed-properties": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "vue/no-this-in-before-route-enter": {
           "$ref": "#/definitions/RuleNoConfig"
         },


### PR DESCRIPTION
Implements `vue/no-side-effects-in-computed-properties` from eslint-plugin-vue.

Part of #11440.

eslint-plugin-vue reference: https://eslint.vuejs.org/rules/no-side-effects-in-computed-properties.html