### PR TITLE
feat(linter/jest/vitest): implement padding-around-expect-groups

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -595,6 +595,7 @@ export interface DummyRuleMap {
   "jest/no-unneeded-async-expect-function"?: DummyRule;
   "jest/no-untyped-mock-factory"?: DummyRule;
   "jest/padding-around-after-all-blocks"?: DummyRule;
+  "jest/padding-around-expect-groups"?: DummyRule;
   "jest/padding-around-test-blocks"?: DummyRule;
   "jest/prefer-called-with"?: DummyRule;
   "jest/prefer-comparison-matcher"?: DummyRule;
@@ -1249,6 +1250,7 @@ export interface DummyRuleMap {
   "vitest/no-test-return-statement"?: DummyRule;
   "vitest/no-unneeded-async-expect-function"?: DummyRule;
   "vitest/padding-around-after-all-blocks"?: DummyRule;
+  "vitest/padding-around-expect-groups"?: DummyRule;
   "vitest/prefer-called-exactly-once-with"?: DummyRule;
   "vitest/prefer-called-once"?: DummyRule;
   "vitest/prefer-called-times"?: DummyRule;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2331,6 +2331,11 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::jest::padding_around_expect_groups::PaddingAroundExpectGroups {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
 impl RuleRunner for crate::rules::jest::padding_around_test_blocks::PaddingAroundTestBlocks {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
@@ -4677,6 +4682,11 @@ impl RuleRunner
 impl RuleRunner
     for crate::rules::vitest::padding_around_after_all_blocks::PaddingAroundAfterAllBlocks
 {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
+}
+
+impl RuleRunner for crate::rules::vitest::padding_around_expect_groups::PaddingAroundExpectGroups {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -254,6 +254,7 @@ pub use crate::rules::jest::no_test_return_statement::NoTestReturnStatement as J
 pub use crate::rules::jest::no_unneeded_async_expect_function::NoUnneededAsyncExpectFunction as JestNoUnneededAsyncExpectFunction;
 pub use crate::rules::jest::no_untyped_mock_factory::NoUntypedMockFactory as JestNoUntypedMockFactory;
 pub use crate::rules::jest::padding_around_after_all_blocks::PaddingAroundAfterAllBlocks as JestPaddingAroundAfterAllBlocks;
+pub use crate::rules::jest::padding_around_expect_groups::PaddingAroundExpectGroups as JestPaddingAroundExpectGroups;
 pub use crate::rules::jest::padding_around_test_blocks::PaddingAroundTestBlocks as JestPaddingAroundTestBlocks;
 pub use crate::rules::jest::prefer_called_with::PreferCalledWith as JestPreferCalledWith;
 pub use crate::rules::jest::prefer_comparison_matcher::PreferComparisonMatcher as JestPreferComparisonMatcher;
@@ -748,6 +749,7 @@ pub use crate::rules::vitest::no_test_prefixes::NoTestPrefixes as VitestNoTestPr
 pub use crate::rules::vitest::no_test_return_statement::NoTestReturnStatement as VitestNoTestReturnStatement;
 pub use crate::rules::vitest::no_unneeded_async_expect_function::NoUnneededAsyncExpectFunction as VitestNoUnneededAsyncExpectFunction;
 pub use crate::rules::vitest::padding_around_after_all_blocks::PaddingAroundAfterAllBlocks as VitestPaddingAroundAfterAllBlocks;
+pub use crate::rules::vitest::padding_around_expect_groups::PaddingAroundExpectGroups as VitestPaddingAroundExpectGroups;
 pub use crate::rules::vitest::prefer_called_exactly_once_with::PreferCalledExactlyOnceWith as VitestPreferCalledExactlyOnceWith;
 pub use crate::rules::vitest::prefer_called_once::PreferCalledOnce as VitestPreferCalledOnce;
 pub use crate::rules::vitest::prefer_called_times::PreferCalledTimes as VitestPreferCalledTimes;
@@ -1190,6 +1192,7 @@ pub enum RuleEnum {
     JestNoUnneededAsyncExpectFunction(JestNoUnneededAsyncExpectFunction),
     JestNoUntypedMockFactory(JestNoUntypedMockFactory),
     JestPaddingAroundAfterAllBlocks(JestPaddingAroundAfterAllBlocks),
+    JestPaddingAroundExpectGroups(JestPaddingAroundExpectGroups),
     JestPaddingAroundTestBlocks(JestPaddingAroundTestBlocks),
     JestPreferCalledWith(JestPreferCalledWith),
     JestPreferComparisonMatcher(JestPreferComparisonMatcher),
@@ -1572,6 +1575,7 @@ pub enum RuleEnum {
     VitestNoTestReturnStatement(VitestNoTestReturnStatement),
     VitestNoUnneededAsyncExpectFunction(VitestNoUnneededAsyncExpectFunction),
     VitestPaddingAroundAfterAllBlocks(VitestPaddingAroundAfterAllBlocks),
+    VitestPaddingAroundExpectGroups(VitestPaddingAroundExpectGroups),
     VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith),
     VitestPreferCalledOnce(VitestPreferCalledOnce),
     VitestPreferCalledTimes(VitestPreferCalledTimes),
@@ -2059,7 +2063,9 @@ const JEST_NO_TEST_RETURN_STATEMENT_ID: usize = JEST_NO_TEST_PREFIXES_ID + 1usiz
 const JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID: usize = JEST_NO_TEST_RETURN_STATEMENT_ID + 1usize;
 const JEST_NO_UNTYPED_MOCK_FACTORY_ID: usize = JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID + 1usize;
 const JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID: usize = JEST_NO_UNTYPED_MOCK_FACTORY_ID + 1usize;
-const JEST_PADDING_AROUND_TEST_BLOCKS_ID: usize = JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID + 1usize;
+const JEST_PADDING_AROUND_EXPECT_GROUPS_ID: usize =
+    JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID + 1usize;
+const JEST_PADDING_AROUND_TEST_BLOCKS_ID: usize = JEST_PADDING_AROUND_EXPECT_GROUPS_ID + 1usize;
 const JEST_PREFER_CALLED_WITH_ID: usize = JEST_PADDING_AROUND_TEST_BLOCKS_ID + 1usize;
 const JEST_PREFER_COMPARISON_MATCHER_ID: usize = JEST_PREFER_CALLED_WITH_ID + 1usize;
 const JEST_PREFER_EACH_ID: usize = JEST_PREFER_COMPARISON_MATCHER_ID + 1usize;
@@ -2484,8 +2490,10 @@ const VITEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID: usize =
     VITEST_NO_TEST_RETURN_STATEMENT_ID + 1usize;
 const VITEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID: usize =
     VITEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID + 1usize;
-const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize =
+const VITEST_PADDING_AROUND_EXPECT_GROUPS_ID: usize =
     VITEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID + 1usize;
+const VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID: usize =
+    VITEST_PADDING_AROUND_EXPECT_GROUPS_ID + 1usize;
 const VITEST_PREFER_CALLED_ONCE_ID: usize = VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID + 1usize;
 const VITEST_PREFER_CALLED_TIMES_ID: usize = VITEST_PREFER_CALLED_ONCE_ID + 1usize;
 const VITEST_PREFER_CALLED_WITH_ID: usize = VITEST_PREFER_CALLED_TIMES_ID + 1usize;
@@ -3003,6 +3011,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => JEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID,
             Self::JestNoUntypedMockFactory(_) => JEST_NO_UNTYPED_MOCK_FACTORY_ID,
             Self::JestPaddingAroundAfterAllBlocks(_) => JEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID,
+            Self::JestPaddingAroundExpectGroups(_) => JEST_PADDING_AROUND_EXPECT_GROUPS_ID,
             Self::JestPaddingAroundTestBlocks(_) => JEST_PADDING_AROUND_TEST_BLOCKS_ID,
             Self::JestPreferCalledWith(_) => JEST_PREFER_CALLED_WITH_ID,
             Self::JestPreferComparisonMatcher(_) => JEST_PREFER_COMPARISON_MATCHER_ID,
@@ -3429,6 +3438,7 @@ impl RuleEnum {
                 VITEST_NO_UNNEEDED_ASYNC_EXPECT_FUNCTION_ID
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => VITEST_PADDING_AROUND_AFTER_ALL_BLOCKS_ID,
+            Self::VitestPaddingAroundExpectGroups(_) => VITEST_PADDING_AROUND_EXPECT_GROUPS_ID,
             Self::VitestPreferCalledExactlyOnceWith(_) => VITEST_PREFER_CALLED_EXACTLY_ONCE_WITH_ID,
             Self::VitestPreferCalledOnce(_) => VITEST_PREFER_CALLED_ONCE_ID,
             Self::VitestPreferCalledTimes(_) => VITEST_PREFER_CALLED_TIMES_ID,
@@ -3944,6 +3954,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => JestNoUnneededAsyncExpectFunction::NAME,
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::NAME,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::NAME,
+            Self::JestPaddingAroundExpectGroups(_) => JestPaddingAroundExpectGroups::NAME,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::NAME,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::NAME,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::NAME,
@@ -4362,6 +4373,7 @@ impl RuleEnum {
                 VitestNoUnneededAsyncExpectFunction::NAME
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => VitestPaddingAroundAfterAllBlocks::NAME,
+            Self::VitestPaddingAroundExpectGroups(_) => VitestPaddingAroundExpectGroups::NAME,
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::NAME,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::NAME,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::NAME,
@@ -4897,6 +4909,7 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::CATEGORY,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::CATEGORY,
+            Self::JestPaddingAroundExpectGroups(_) => JestPaddingAroundExpectGroups::CATEGORY,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::CATEGORY,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::CATEGORY,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::CATEGORY,
@@ -5337,6 +5350,7 @@ impl RuleEnum {
             Self::VitestPaddingAroundAfterAllBlocks(_) => {
                 VitestPaddingAroundAfterAllBlocks::CATEGORY
             }
+            Self::VitestPaddingAroundExpectGroups(_) => VitestPaddingAroundExpectGroups::CATEGORY,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::CATEGORY
             }
@@ -5861,6 +5875,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => JestNoUnneededAsyncExpectFunction::FIX,
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::FIX,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::FIX,
+            Self::JestPaddingAroundExpectGroups(_) => JestPaddingAroundExpectGroups::FIX,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::FIX,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::FIX,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::FIX,
@@ -6279,6 +6294,7 @@ impl RuleEnum {
                 VitestNoUnneededAsyncExpectFunction::FIX
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => VitestPaddingAroundAfterAllBlocks::FIX,
+            Self::VitestPaddingAroundExpectGroups(_) => VitestPaddingAroundExpectGroups::FIX,
             Self::VitestPreferCalledExactlyOnceWith(_) => VitestPreferCalledExactlyOnceWith::FIX,
             Self::VitestPreferCalledOnce(_) => VitestPreferCalledOnce::FIX,
             Self::VitestPreferCalledTimes(_) => VitestPreferCalledTimes::FIX,
@@ -6887,6 +6903,9 @@ impl RuleEnum {
             Self::JestPaddingAroundAfterAllBlocks(_) => {
                 JestPaddingAroundAfterAllBlocks::documentation()
             }
+            Self::JestPaddingAroundExpectGroups(_) => {
+                JestPaddingAroundExpectGroups::documentation()
+            }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::documentation(),
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::documentation(),
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::documentation(),
@@ -7432,6 +7451,9 @@ impl RuleEnum {
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => {
                 VitestPaddingAroundAfterAllBlocks::documentation()
+            }
+            Self::VitestPaddingAroundExpectGroups(_) => {
+                VitestPaddingAroundExpectGroups::documentation()
             }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::documentation()
@@ -8570,6 +8592,10 @@ impl RuleEnum {
                 JestPaddingAroundAfterAllBlocks::config_schema(generator)
                     .or_else(|| JestPaddingAroundAfterAllBlocks::schema(generator))
             }
+            Self::JestPaddingAroundExpectGroups(_) => {
+                JestPaddingAroundExpectGroups::config_schema(generator)
+                    .or_else(|| JestPaddingAroundExpectGroups::schema(generator))
+            }
             Self::JestPaddingAroundTestBlocks(_) => {
                 JestPaddingAroundTestBlocks::config_schema(generator)
                     .or_else(|| JestPaddingAroundTestBlocks::schema(generator))
@@ -9663,6 +9689,10 @@ impl RuleEnum {
                 VitestPaddingAroundAfterAllBlocks::config_schema(generator)
                     .or_else(|| VitestPaddingAroundAfterAllBlocks::schema(generator))
             }
+            Self::VitestPaddingAroundExpectGroups(_) => {
+                VitestPaddingAroundExpectGroups::config_schema(generator)
+                    .or_else(|| VitestPaddingAroundExpectGroups::schema(generator))
+            }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::config_schema(generator)
                     .or_else(|| VitestPreferCalledExactlyOnceWith::schema(generator))
@@ -10259,6 +10289,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(_) => "jest",
             Self::JestNoUntypedMockFactory(_) => "jest",
             Self::JestPaddingAroundAfterAllBlocks(_) => "jest",
+            Self::JestPaddingAroundExpectGroups(_) => "jest",
             Self::JestPaddingAroundTestBlocks(_) => "jest",
             Self::JestPreferCalledWith(_) => "jest",
             Self::JestPreferComparisonMatcher(_) => "jest",
@@ -10637,6 +10668,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(_) => "vitest",
             Self::VitestNoUnneededAsyncExpectFunction(_) => "vitest",
             Self::VitestPaddingAroundAfterAllBlocks(_) => "vitest",
+            Self::VitestPaddingAroundExpectGroups(_) => "vitest",
             Self::VitestPreferCalledExactlyOnceWith(_) => "vitest",
             Self::VitestPreferCalledOnce(_) => "vitest",
             Self::VitestPreferCalledTimes(_) => "vitest",
@@ -11879,6 +11911,9 @@ impl RuleEnum {
             Self::JestPaddingAroundAfterAllBlocks(_) => Ok(Self::JestPaddingAroundAfterAllBlocks(
                 JestPaddingAroundAfterAllBlocks::from_configuration(value)?,
             )),
+            Self::JestPaddingAroundExpectGroups(_) => Ok(Self::JestPaddingAroundExpectGroups(
+                JestPaddingAroundExpectGroups::from_configuration(value)?,
+            )),
             Self::JestPaddingAroundTestBlocks(_) => Ok(Self::JestPaddingAroundTestBlocks(
                 JestPaddingAroundTestBlocks::from_configuration(value)?,
             )),
@@ -13087,6 +13122,9 @@ impl RuleEnum {
                     VitestPaddingAroundAfterAllBlocks::from_configuration(value)?,
                 ))
             }
+            Self::VitestPaddingAroundExpectGroups(_) => Ok(Self::VitestPaddingAroundExpectGroups(
+                VitestPaddingAroundExpectGroups::from_configuration(value)?,
+            )),
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 Ok(Self::VitestPreferCalledExactlyOnceWith(
                     VitestPreferCalledExactlyOnceWith::from_configuration(value)?,
@@ -13712,6 +13750,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.to_configuration(),
             Self::JestNoUntypedMockFactory(rule) => rule.to_configuration(),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.to_configuration(),
+            Self::JestPaddingAroundExpectGroups(rule) => rule.to_configuration(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.to_configuration(),
             Self::JestPreferCalledWith(rule) => rule.to_configuration(),
             Self::JestPreferComparisonMatcher(rule) => rule.to_configuration(),
@@ -14090,6 +14129,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(rule) => rule.to_configuration(),
             Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.to_configuration(),
             Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.to_configuration(),
+            Self::VitestPaddingAroundExpectGroups(rule) => rule.to_configuration(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.to_configuration(),
             Self::VitestPreferCalledOnce(rule) => rule.to_configuration(),
             Self::VitestPreferCalledTimes(rule) => rule.to_configuration(),
@@ -14541,6 +14581,7 @@ impl RuleEnum {
                 Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run(node, ctx),
                 Self::JestNoUntypedMockFactory(rule) => rule.run(node, ctx),
                 Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run(node, ctx),
+                Self::JestPaddingAroundExpectGroups(rule) => rule.run(node, ctx),
                 Self::JestPaddingAroundTestBlocks(rule) => rule.run(node, ctx),
                 Self::JestPreferCalledWith(rule) => rule.run(node, ctx),
                 Self::JestPreferComparisonMatcher(rule) => rule.run(node, ctx),
@@ -14919,6 +14960,7 @@ impl RuleEnum {
                 Self::VitestNoTestReturnStatement(rule) => rule.run(node, ctx),
                 Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run(node, ctx),
                 Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.run(node, ctx),
+                Self::VitestPaddingAroundExpectGroups(rule) => rule.run(node, ctx),
                 Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run(node, ctx),
                 Self::VitestPreferCalledOnce(rule) => rule.run(node, ctx),
                 Self::VitestPreferCalledTimes(rule) => rule.run(node, ctx),
@@ -15363,6 +15405,7 @@ impl RuleEnum {
                 Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run(node, ctx),
                 Self::JestNoUntypedMockFactory(rule) => rule.run(node, ctx),
                 Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run(node, ctx),
+                Self::JestPaddingAroundExpectGroups(rule) => rule.run(node, ctx),
                 Self::JestPaddingAroundTestBlocks(rule) => rule.run(node, ctx),
                 Self::JestPreferCalledWith(rule) => rule.run(node, ctx),
                 Self::JestPreferComparisonMatcher(rule) => rule.run(node, ctx),
@@ -15741,6 +15784,7 @@ impl RuleEnum {
                 Self::VitestNoTestReturnStatement(rule) => rule.run(node, ctx),
                 Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run(node, ctx),
                 Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.run(node, ctx),
+                Self::VitestPaddingAroundExpectGroups(rule) => rule.run(node, ctx),
                 Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run(node, ctx),
                 Self::VitestPreferCalledOnce(rule) => rule.run(node, ctx),
                 Self::VitestPreferCalledTimes(rule) => rule.run(node, ctx),
@@ -16192,6 +16236,7 @@ impl RuleEnum {
                 Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_once(ctx),
                 Self::JestNoUntypedMockFactory(rule) => rule.run_once(ctx),
                 Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_once(ctx),
+                Self::JestPaddingAroundExpectGroups(rule) => rule.run_once(ctx),
                 Self::JestPaddingAroundTestBlocks(rule) => rule.run_once(ctx),
                 Self::JestPreferCalledWith(rule) => rule.run_once(ctx),
                 Self::JestPreferComparisonMatcher(rule) => rule.run_once(ctx),
@@ -16570,6 +16615,7 @@ impl RuleEnum {
                 Self::VitestNoTestReturnStatement(rule) => rule.run_once(ctx),
                 Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run_once(ctx),
                 Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.run_once(ctx),
+                Self::VitestPaddingAroundExpectGroups(rule) => rule.run_once(ctx),
                 Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_once(ctx),
                 Self::VitestPreferCalledOnce(rule) => rule.run_once(ctx),
                 Self::VitestPreferCalledTimes(rule) => rule.run_once(ctx),
@@ -17014,6 +17060,7 @@ impl RuleEnum {
                 Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_once(ctx),
                 Self::JestNoUntypedMockFactory(rule) => rule.run_once(ctx),
                 Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_once(ctx),
+                Self::JestPaddingAroundExpectGroups(rule) => rule.run_once(ctx),
                 Self::JestPaddingAroundTestBlocks(rule) => rule.run_once(ctx),
                 Self::JestPreferCalledWith(rule) => rule.run_once(ctx),
                 Self::JestPreferComparisonMatcher(rule) => rule.run_once(ctx),
@@ -17392,6 +17439,7 @@ impl RuleEnum {
                 Self::VitestNoTestReturnStatement(rule) => rule.run_once(ctx),
                 Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run_once(ctx),
                 Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.run_once(ctx),
+                Self::VitestPaddingAroundExpectGroups(rule) => rule.run_once(ctx),
                 Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_once(ctx),
                 Self::VitestPreferCalledOnce(rule) => rule.run_once(ctx),
                 Self::VitestPreferCalledTimes(rule) => rule.run_once(ctx),
@@ -17964,6 +18012,7 @@ impl RuleEnum {
                 Self::JestPaddingAroundAfterAllBlocks(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::JestPaddingAroundExpectGroups(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JestPaddingAroundTestBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JestPreferCalledWith(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JestPreferComparisonMatcher(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18450,6 +18499,9 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::VitestPaddingAroundAfterAllBlocks(rule) => {
+                    rule.run_on_jest_node(jest_node, ctx)
+                }
+                Self::VitestPaddingAroundExpectGroups(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::VitestPreferCalledExactlyOnceWith(rule) => {
@@ -19040,6 +19092,7 @@ impl RuleEnum {
                 Self::JestPaddingAroundAfterAllBlocks(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::JestPaddingAroundExpectGroups(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JestPaddingAroundTestBlocks(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JestPreferCalledWith(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::JestPreferComparisonMatcher(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19528,6 +19581,9 @@ impl RuleEnum {
                 Self::VitestPaddingAroundAfterAllBlocks(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::VitestPaddingAroundExpectGroups(rule) => {
+                    rule.run_on_jest_node(jest_node, ctx)
+                }
                 Self::VitestPreferCalledExactlyOnceWith(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
@@ -19996,6 +20052,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.should_run(ctx),
             Self::JestNoUntypedMockFactory(rule) => rule.should_run(ctx),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.should_run(ctx),
+            Self::JestPaddingAroundExpectGroups(rule) => rule.should_run(ctx),
             Self::JestPaddingAroundTestBlocks(rule) => rule.should_run(ctx),
             Self::JestPreferCalledWith(rule) => rule.should_run(ctx),
             Self::JestPreferComparisonMatcher(rule) => rule.should_run(ctx),
@@ -20374,6 +20431,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(rule) => rule.should_run(ctx),
             Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.should_run(ctx),
             Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.should_run(ctx),
+            Self::VitestPaddingAroundExpectGroups(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledOnce(rule) => rule.should_run(ctx),
             Self::VitestPreferCalledTimes(rule) => rule.should_run(ctx),
@@ -20977,6 +21035,9 @@ impl RuleEnum {
             Self::JestPaddingAroundAfterAllBlocks(_) => {
                 JestPaddingAroundAfterAllBlocks::IS_TSGOLINT_RULE
             }
+            Self::JestPaddingAroundExpectGroups(_) => {
+                JestPaddingAroundExpectGroups::IS_TSGOLINT_RULE
+            }
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::IS_TSGOLINT_RULE,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::IS_TSGOLINT_RULE,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::IS_TSGOLINT_RULE,
@@ -21522,6 +21583,9 @@ impl RuleEnum {
             }
             Self::VitestPaddingAroundAfterAllBlocks(_) => {
                 VitestPaddingAroundAfterAllBlocks::IS_TSGOLINT_RULE
+            }
+            Self::VitestPaddingAroundExpectGroups(_) => {
+                VitestPaddingAroundExpectGroups::IS_TSGOLINT_RULE
             }
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::IS_TSGOLINT_RULE
@@ -22092,6 +22156,7 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::VERSION,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::VERSION,
+            Self::JestPaddingAroundExpectGroups(_) => JestPaddingAroundExpectGroups::VERSION,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::VERSION,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::VERSION,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::VERSION,
@@ -22532,6 +22597,7 @@ impl RuleEnum {
             Self::VitestPaddingAroundAfterAllBlocks(_) => {
                 VitestPaddingAroundAfterAllBlocks::VERSION
             }
+            Self::VitestPaddingAroundExpectGroups(_) => VitestPaddingAroundExpectGroups::VERSION,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::VERSION
             }
@@ -23096,6 +23162,7 @@ impl RuleEnum {
             }
             Self::JestNoUntypedMockFactory(_) => JestNoUntypedMockFactory::HAS_CONFIG,
             Self::JestPaddingAroundAfterAllBlocks(_) => JestPaddingAroundAfterAllBlocks::HAS_CONFIG,
+            Self::JestPaddingAroundExpectGroups(_) => JestPaddingAroundExpectGroups::HAS_CONFIG,
             Self::JestPaddingAroundTestBlocks(_) => JestPaddingAroundTestBlocks::HAS_CONFIG,
             Self::JestPreferCalledWith(_) => JestPreferCalledWith::HAS_CONFIG,
             Self::JestPreferComparisonMatcher(_) => JestPreferComparisonMatcher::HAS_CONFIG,
@@ -23552,6 +23619,7 @@ impl RuleEnum {
             Self::VitestPaddingAroundAfterAllBlocks(_) => {
                 VitestPaddingAroundAfterAllBlocks::HAS_CONFIG
             }
+            Self::VitestPaddingAroundExpectGroups(_) => VitestPaddingAroundExpectGroups::HAS_CONFIG,
             Self::VitestPreferCalledExactlyOnceWith(_) => {
                 VitestPreferCalledExactlyOnceWith::HAS_CONFIG
             }
@@ -24013,6 +24081,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.types_info(),
             Self::JestNoUntypedMockFactory(rule) => rule.types_info(),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.types_info(),
+            Self::JestPaddingAroundExpectGroups(rule) => rule.types_info(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.types_info(),
             Self::JestPreferCalledWith(rule) => rule.types_info(),
             Self::JestPreferComparisonMatcher(rule) => rule.types_info(),
@@ -24391,6 +24460,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(rule) => rule.types_info(),
             Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.types_info(),
             Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.types_info(),
+            Self::VitestPaddingAroundExpectGroups(rule) => rule.types_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.types_info(),
             Self::VitestPreferCalledOnce(rule) => rule.types_info(),
             Self::VitestPreferCalledTimes(rule) => rule.types_info(),
@@ -24832,6 +24902,7 @@ impl RuleEnum {
             Self::JestNoUnneededAsyncExpectFunction(rule) => rule.run_info(),
             Self::JestNoUntypedMockFactory(rule) => rule.run_info(),
             Self::JestPaddingAroundAfterAllBlocks(rule) => rule.run_info(),
+            Self::JestPaddingAroundExpectGroups(rule) => rule.run_info(),
             Self::JestPaddingAroundTestBlocks(rule) => rule.run_info(),
             Self::JestPreferCalledWith(rule) => rule.run_info(),
             Self::JestPreferComparisonMatcher(rule) => rule.run_info(),
@@ -25210,6 +25281,7 @@ impl RuleEnum {
             Self::VitestNoTestReturnStatement(rule) => rule.run_info(),
             Self::VitestNoUnneededAsyncExpectFunction(rule) => rule.run_info(),
             Self::VitestPaddingAroundAfterAllBlocks(rule) => rule.run_info(),
+            Self::VitestPaddingAroundExpectGroups(rule) => rule.run_info(),
             Self::VitestPreferCalledExactlyOnceWith(rule) => rule.run_info(),
             Self::VitestPreferCalledOnce(rule) => rule.run_info(),
             Self::VitestPreferCalledTimes(rule) => rule.run_info(),
@@ -25739,6 +25811,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::JestNoUnneededAsyncExpectFunction(JestNoUnneededAsyncExpectFunction::default()),
         RuleEnum::JestNoUntypedMockFactory(JestNoUntypedMockFactory::default()),
         RuleEnum::JestPaddingAroundAfterAllBlocks(JestPaddingAroundAfterAllBlocks::default()),
+        RuleEnum::JestPaddingAroundExpectGroups(JestPaddingAroundExpectGroups::default()),
         RuleEnum::JestPaddingAroundTestBlocks(JestPaddingAroundTestBlocks::default()),
         RuleEnum::JestPreferCalledWith(JestPreferCalledWith::default()),
         RuleEnum::JestPreferComparisonMatcher(JestPreferComparisonMatcher::default()),
@@ -26157,6 +26230,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
             VitestNoUnneededAsyncExpectFunction::default(),
         ),
         RuleEnum::VitestPaddingAroundAfterAllBlocks(VitestPaddingAroundAfterAllBlocks::default()),
+        RuleEnum::VitestPaddingAroundExpectGroups(VitestPaddingAroundExpectGroups::default()),
         RuleEnum::VitestPreferCalledExactlyOnceWith(VitestPreferCalledExactlyOnceWith::default()),
         RuleEnum::VitestPreferCalledOnce(VitestPreferCalledOnce::default()),
         RuleEnum::VitestPreferCalledTimes(VitestPreferCalledTimes::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -372,6 +372,7 @@ pub(crate) mod jest {
     pub mod no_unneeded_async_expect_function;
     pub mod no_untyped_mock_factory;
     pub mod padding_around_after_all_blocks;
+    pub mod padding_around_expect_groups;
     pub mod padding_around_test_blocks;
     pub mod prefer_called_with;
     pub mod prefer_comparison_matcher;
@@ -785,6 +786,7 @@ pub(crate) mod vitest {
     pub mod no_test_return_statement;
     pub mod no_unneeded_async_expect_function;
     pub mod padding_around_after_all_blocks;
+    pub mod padding_around_expect_groups;
     pub mod prefer_called_exactly_once_with;
     pub mod prefer_called_once;
     pub mod prefer_called_times;

--- a/crates/oxc_linter/src/rules/jest/padding_around_expect_groups.rs
+++ b/crates/oxc_linter/src/rules/jest/padding_around_expect_groups.rs
@@ -1,0 +1,202 @@
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    rules::shared::padding_around_expect_groups::{DOCUMENTATION, run},
+    utils::PossibleJestNode,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct PaddingAroundExpectGroups;
+
+declare_oxc_lint!(
+    PaddingAroundExpectGroups,
+    jest,
+    style,
+    fix,
+    docs = DOCUMENTATION,
+    version = "1.68.0",
+);
+
+impl Rule for PaddingAroundExpectGroups {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        run(jest_node, ctx);
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    const VALID: &str = r"
+foo();
+bar();
+
+const someText = 'abc';
+const someObject = {
+  one: 1,
+  two: 2,
+};
+
+test('thing one', () => {
+  let abc = 123;
+
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc); // Line comment
+
+  abc = 456;
+
+  expect(abc).toEqual(456);
+});
+
+test('thing one', () => {
+  const abc = 123;
+
+  expect(abc).toEqual(123);
+
+  const xyz = 987;
+
+  expect(123).toEqual(abc); // Line comment
+});
+
+describe('someText', () => {
+  describe('some condition', () => {
+    test('foo', () => {
+      const xyz = 987;
+
+      // Comment
+      expect(xyz).toEqual(987);
+      expect(1)
+        .toEqual(1);
+      expect(true).toEqual(true);
+    });
+  });
+});
+
+test('awaited expect', async () => {
+  const abc = 123;
+  const hasAPromise = () => Promise.resolve('foo');
+
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  expect(abc).toEqual(123);
+
+  const efg = 456;
+
+  expect(123).toEqual(abc);
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const hij = 789;
+
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const somethingElseAsync = () => Promise.resolve('bar');
+  await somethingElseAsync();
+
+  await expect(hasAPromise()).resolves.toEqual('foo');
+});
+";
+
+    const INVALID: &str = r"
+foo();
+bar();
+
+const someText = 'abc';
+const someObject = {
+  one: 1,
+  two: 2,
+};
+
+test('thing one', () => {
+  let abc = 123;
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc); // Line comment
+  abc = 456;
+  expect(abc).toEqual(456);
+});
+
+test('thing one', () => {
+  const abc = 123;
+  expect(abc).toEqual(123);
+
+  const xyz = 987;
+  expect(123).toEqual(abc); // Line comment
+});
+
+describe('someText', () => {
+  describe('some condition', () => {
+    test('foo', () => {
+      const xyz = 987;
+      // Comment
+      expect(xyz).toEqual(987);
+      expect(1)
+        .toEqual(1);
+      expect(true).toEqual(true);
+    });
+  });
+});
+
+test('awaited expect', async () => {
+  const abc = 123;
+  const hasAPromise = () => Promise.resolve('foo');
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  expect(abc).toEqual(123);
+
+  const efg = 456;
+  expect(123).toEqual(abc);
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const hij = 789;
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const somethingElseAsync = () => Promise.resolve('bar');
+  await somethingElseAsync();
+  await expect(hasAPromise()).resolves.toEqual('foo');
+});
+";
+
+    let pass = vec![
+        "expect(1).toBe(1);",
+        "const thing = 123;\n\nexpect(thing).toBe(123);",
+        "expect(a).toBe(1);\nexpect(b).toBe(2);",
+        "const thing = 123;\n\nexpect.hasAssertions();\nexpect(thing).toBe(123);",
+        "const thing = 123;\nconst x = expect(thing);",
+        "test('foo', () => {\nexpect(1).toBe(1);\n});",
+        "test('foo', async () => {\nconst a = 1;\n\nawait expect(Promise.resolve(a)).resolves.toBe(1);\nexpect(a).toBe(1);\n});",
+        VALID,
+    ];
+
+    let fail = vec![
+        "const thing = 123;\nexpect(thing).toBe(123);",
+        "expect(thing).toBe(123);\nconst other = 456;",
+        "test('foo', async () => {\nconst a = 1;\nawait expect(Promise.resolve(a)).resolves.toBe(1);\n});",
+        INVALID,
+    ];
+
+    let fix = vec![
+        (
+            "const thing = 123;\nexpect(thing).toBe(123);",
+            "const thing = 123;\n\nexpect(thing).toBe(123);",
+        ),
+        (
+            "expect(thing).toBe(123);\nconst other = 456;",
+            "expect(thing).toBe(123);\n\nconst other = 456;",
+        ),
+        (
+            "test('foo', async () => {\nconst a = 1;\nawait expect(Promise.resolve(a)).resolves.toBe(1);\n});",
+            "test('foo', async () => {\nconst a = 1;\n\nawait expect(Promise.resolve(a)).resolves.toBe(1);\n});",
+        ),
+        (INVALID, VALID),
+    ];
+
+    Tester::new(PaddingAroundExpectGroups::NAME, PaddingAroundExpectGroups::PLUGIN, pass, fail)
+        .with_jest_plugin(true)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/mod.rs
@@ -21,6 +21,7 @@ pub mod no_test_prefixes;
 pub mod no_test_return_statement;
 pub mod no_unneeded_async_expect_function;
 pub mod padding_around_after_all_blocks;
+pub mod padding_around_expect_groups;
 pub mod prefer_called_with;
 pub mod prefer_comparison_matcher;
 pub mod prefer_each;

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_expect_groups.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/padding_around_expect_groups.rs
@@ -1,0 +1,129 @@
+use oxc_ast::AstKind;
+use oxc_semantic::AstNode;
+use oxc_span::GetSpan;
+
+use crate::{
+    context::LintContext,
+    utils::{
+        PaddingDirection, ParsedJestFnCallNew, PossibleJestNode, check_padding_between,
+        enclosing_statement_index, enclosing_statement_list, leading_token_of_statement,
+        parse_jest_fn_call,
+    },
+};
+
+pub const DOCUMENTATION: &str = r"### What it does
+
+This rule enforces a line of padding before and after 1 or more `expect`
+statements.
+
+Note that it doesn't add/enforce a padding line if it's the last statement
+in its scope and it doesn't add/enforce padding between two or more adjacent
+`expect` statements.
+
+### Why is this bad?
+
+Inconsistent formatting of code can make the code more difficult to read
+and follow. This rule helps ensure that groups of `expect` statements are
+visually separated from the rest of the code, making them easier to identify
+while looking through test files.
+
+### Examples
+
+Examples of **incorrect** code for this rule:
+```js
+test('thing one', () => {
+  let abc = 123;
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc);
+  abc = 456;
+  expect(abc).toEqual(456);
+});
+```
+
+Examples of **correct** code for this rule:
+```js
+test('thing one', () => {
+  let abc = 123;
+
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc);
+
+  abc = 456;
+
+  expect(abc).toEqual(456);
+});
+```
+";
+
+fn is_expect_token(name: &str) -> bool {
+    matches!(name, "expect" | "expectTypeOf")
+}
+
+pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
+    let node = possible_jest_node.node;
+    let AstKind::CallExpression(call_expr) = node.kind() else {
+        return;
+    };
+    let Some(jest_fn_call) = parse_jest_fn_call(call_expr, possible_jest_node, ctx) else {
+        return;
+    };
+    let (ParsedJestFnCallNew::Expect(expect_fn_call)
+    | ParsedJestFnCallNew::ExpectTypeOf(expect_fn_call)) = jest_fn_call
+    else {
+        return;
+    };
+    check_expect_statement_padding(node, ctx, &expect_fn_call.name, is_expect_token);
+}
+
+/// Consecutive statements with the same leading token form a group: padding
+/// is required before the first and after the last statement, not in between.
+/// The after-check is skipped when the next statement's token is covered by
+/// `next_token_skip`, as its own before-check reports the same gap.
+pub(super) fn check_expect_statement_padding<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+    name: &str,
+    next_token_skip: fn(&str) -> bool,
+) {
+    let Some(statements) = enclosing_statement_list(node, ctx) else {
+        return;
+    };
+    let Some(index) = enclosing_statement_index(node.span(), statements) else {
+        return;
+    };
+    let statement = &statements[index];
+    // The call must lead its statement; this also drops nested parses such as
+    // `expect.anything()` inside matcher arguments, which would double-report.
+    let Some(token) = leading_token_of_statement(statement) else {
+        return;
+    };
+    if token.expr_start != node.span().start {
+        return;
+    }
+
+    if let Some(prev) = index.checked_sub(1).map(|i| &statements[i]) {
+        let same_group = leading_token_of_statement(prev).is_some_and(|t| t.name == name);
+        if !same_group {
+            check_padding_between(
+                ctx,
+                prev.span().end,
+                statement.span().start,
+                PaddingDirection::Before,
+                name,
+            );
+        }
+    }
+
+    if let Some(next) = statements.get(index + 1) {
+        let skip = leading_token_of_statement(next).is_some_and(|t| next_token_skip(t.name));
+        if !skip {
+            check_padding_between(
+                ctx,
+                statement.span().end,
+                next.span().start,
+                PaddingDirection::After,
+                name,
+            );
+        }
+    }
+}

--- a/crates/oxc_linter/src/rules/vitest/padding_around_expect_groups.rs
+++ b/crates/oxc_linter/src/rules/vitest/padding_around_expect_groups.rs
@@ -1,0 +1,230 @@
+use oxc_macros::declare_oxc_lint;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    rules::shared::padding_around_expect_groups::{DOCUMENTATION, run},
+    utils::PossibleJestNode,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct PaddingAroundExpectGroups;
+
+declare_oxc_lint!(
+    PaddingAroundExpectGroups,
+    vitest,
+    style,
+    fix,
+    docs = DOCUMENTATION,
+    version = "1.68.0",
+);
+
+impl Rule for PaddingAroundExpectGroups {
+    fn run_on_jest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        run(jest_node, ctx);
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    const VALID: &str = r#"
+foo();
+bar();
+
+const someText = 'abc';
+const someObject = {
+  one: 1,
+  two: 2,
+};
+
+test('thing one', () => {
+  let abc = 123;
+
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc); // Line comment
+
+  abc = 456;
+
+  expect(abc).toEqual(456);
+});
+
+test('thing one', () => {
+  const abc = 123;
+
+  expect(abc).toEqual(123);
+
+  const xyz = 987;
+
+  expect(123).toEqual(abc); // Line comment
+});
+
+describe('someText', () => {
+  describe('some condition', () => {
+    test('foo', () => {
+      const xyz = 987;
+
+      // Comment
+      expect(xyz).toEqual(987);
+      expect(1)
+        .toEqual(1);
+      expect(true).toEqual(true);
+    });
+  });
+});
+
+test('awaited expect', async () => {
+  const abc = 123;
+  const hasAPromise = () => Promise.resolve('foo');
+
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  expect(abc).toEqual(123);
+
+  const efg = 456;
+
+  expect(123).toEqual(abc);
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const hij = 789;
+
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const somethingElseAsync = () => Promise.resolve('bar');
+  await somethingElseAsync();
+
+  await expect(hasAPromise()).resolves.toEqual('foo');
+});
+
+test('expectTypeOf test', () => {
+  const hoge = 123;
+
+  expectTypeOf(hoge).toBeNumber();
+  expectTypeOf(hoge).toBeNumber();
+
+  const foo = "abc";
+
+  // Comment
+  expectTypeOf(foo).toBeString();
+  expectTypeOf(foo).toBeString();
+});
+"#;
+
+    const INVALID: &str = r#"
+foo();
+bar();
+
+const someText = 'abc';
+const someObject = {
+  one: 1,
+  two: 2,
+};
+
+test('thing one', () => {
+  let abc = 123;
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc); // Line comment
+  abc = 456;
+  expect(abc).toEqual(456);
+});
+
+test('thing one', () => {
+  const abc = 123;
+  expect(abc).toEqual(123);
+
+  const xyz = 987;
+  expect(123).toEqual(abc); // Line comment
+});
+
+describe('someText', () => {
+  describe('some condition', () => {
+    test('foo', () => {
+      const xyz = 987;
+      // Comment
+      expect(xyz).toEqual(987);
+      expect(1)
+        .toEqual(1);
+      expect(true).toEqual(true);
+    });
+  });
+});
+
+test('awaited expect', async () => {
+  const abc = 123;
+  const hasAPromise = () => Promise.resolve('foo');
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  expect(abc).toEqual(123);
+
+  const efg = 456;
+  expect(123).toEqual(abc);
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const hij = 789;
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const somethingElseAsync = () => Promise.resolve('bar');
+  await somethingElseAsync();
+  await expect(hasAPromise()).resolves.toEqual('foo');
+});
+
+test('expectTypeOf test', () => {
+  const hoge = 123;
+  expectTypeOf(hoge).toBeNumber();
+  expectTypeOf(hoge).toBeNumber();
+  const foo = "abc";
+  // Comment
+  expectTypeOf(foo).toBeString();
+  expectTypeOf(foo).toBeString();
+});
+"#;
+
+    let pass = vec![
+        "expect(1).toBe(1);",
+        "const thing = 123;\n\nexpect(thing).toBe(123);",
+        "expect(a).toBe(1);\nexpect(b).toBe(2);",
+        "expectTypeOf(1).toBeNumber();\nexpectTypeOf(2).toBeNumber();",
+        "import { expect, test } from 'vitest';\n\ntest('foo', () => {\nexpect(1).toBe(1);\n});",
+        "test('foo', async () => {\nconst a = 1;\n\nawait expect(Promise.resolve(a)).resolves.toBe(1);\nexpect(a).toBe(1);\n});",
+        VALID,
+    ];
+
+    let fail = vec![
+        "const thing = 123;\nexpect(thing).toBe(123);",
+        "expect(thing).toBe(123);\nconst other = 456;",
+        "const thing = 123;\nexpectTypeOf(thing).toBeNumber();",
+        // expect and expectTypeOf are distinct groups
+        "test('foo', () => {\nconst a = 1;\n\nexpect(a).toBe(1);\nexpectTypeOf(a).toBeNumber();\n});",
+        INVALID,
+    ];
+
+    let fix = vec![
+        (
+            "const thing = 123;\nexpect(thing).toBe(123);",
+            "const thing = 123;\n\nexpect(thing).toBe(123);",
+        ),
+        (
+            "expect(thing).toBe(123);\nconst other = 456;",
+            "expect(thing).toBe(123);\n\nconst other = 456;",
+        ),
+        (
+            "const thing = 123;\nexpectTypeOf(thing).toBeNumber();",
+            "const thing = 123;\n\nexpectTypeOf(thing).toBeNumber();",
+        ),
+        (
+            "test('foo', () => {\nconst a = 1;\n\nexpect(a).toBe(1);\nexpectTypeOf(a).toBeNumber();\n});",
+            "test('foo', () => {\nconst a = 1;\n\nexpect(a).toBe(1);\n\nexpectTypeOf(a).toBeNumber();\n});",
+        ),
+        (INVALID, VALID),
+    ];
+
+    Tester::new(PaddingAroundExpectGroups::NAME, PaddingAroundExpectGroups::PLUGIN, pass, fail)
+        .with_vitest_plugin(true)
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/jest_padding_around_expect_groups.snap
+++ b/crates/oxc_linter/src/snapshots/jest_padding_around_expect_groups.snap
@@ -1,0 +1,118 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+   ╭─[padding_around_expect_groups.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ expect(thing).toBe(123);
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding after expect block
+   ╭─[padding_around_expect_groups.tsx:2:1]
+ 1 │ expect(thing).toBe(123);
+ 2 │ const other = 456;
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line after the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+   ╭─[padding_around_expect_groups.tsx:3:1]
+ 2 │ const a = 1;
+ 3 │ await expect(Promise.resolve(a)).resolves.toBe(1);
+   · ▲
+ 4 │ });
+   ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:13:3]
+ 12 │   let abc = 123;
+ 13 │   expect(abc).toEqual(123);
+    ·   ▲
+ 14 │   expect(123).toEqual(abc); // Line comment
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding after expect block
+    ╭─[padding_around_expect_groups.tsx:15:3]
+ 14 │   expect(123).toEqual(abc); // Line comment
+ 15 │   abc = 456;
+    ·   ▲
+ 16 │   expect(abc).toEqual(456);
+    ╰────
+  help: Make sure there is an empty new line after the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:16:3]
+ 15 │   abc = 456;
+ 16 │   expect(abc).toEqual(456);
+    ·   ▲
+ 17 │ });
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:21:3]
+ 20 │   const abc = 123;
+ 21 │   expect(abc).toEqual(123);
+    ·   ▲
+ 22 │ 
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:24:3]
+ 23 │   const xyz = 987;
+ 24 │   expect(123).toEqual(abc); // Line comment
+    ·   ▲
+ 25 │ });
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:32:7]
+ 31 │       // Comment
+ 32 │       expect(xyz).toEqual(987);
+    ·       ▲
+ 33 │       expect(1)
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:43:3]
+ 42 │   const hasAPromise = () => Promise.resolve('foo');
+ 43 │   await expect(hasAPromise()).resolves.toEqual('foo');
+    ·   ▲
+ 44 │   expect(abc).toEqual(123);
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:47:3]
+ 46 │   const efg = 456;
+ 47 │   expect(123).toEqual(abc);
+    ·   ▲
+ 48 │   await expect(hasAPromise()).resolves.toEqual('foo');
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:51:3]
+ 50 │   const hij = 789;
+ 51 │   await expect(hasAPromise()).resolves.toEqual('foo');
+    ·   ▲
+ 52 │   await expect(hasAPromise()).resolves.toEqual('foo');
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ jest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:56:3]
+ 55 │   await somethingElseAsync();
+ 56 │   await expect(hasAPromise()).resolves.toEqual('foo');
+    ·   ▲
+ 57 │ });
+    ╰────
+  help: Make sure there is an empty new line before the expect block

--- a/crates/oxc_linter/src/snapshots/vitest_padding_around_expect_groups.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_padding_around_expect_groups.snap
@@ -1,0 +1,153 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expect block
+   ╭─[padding_around_expect_groups.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ expect(thing).toBe(123);
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding after expect block
+   ╭─[padding_around_expect_groups.tsx:2:1]
+ 1 │ expect(thing).toBe(123);
+ 2 │ const other = 456;
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line after the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expectTypeOf block
+   ╭─[padding_around_expect_groups.tsx:2:1]
+ 1 │ const thing = 123;
+ 2 │ expectTypeOf(thing).toBeNumber();
+   · ▲
+   ╰────
+  help: Make sure there is an empty new line before the expectTypeOf block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expectTypeOf block
+   ╭─[padding_around_expect_groups.tsx:5:1]
+ 4 │ expect(a).toBe(1);
+ 5 │ expectTypeOf(a).toBeNumber();
+   · ▲
+ 6 │ });
+   ╰────
+  help: Make sure there is an empty new line before the expectTypeOf block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expectTypeOf block
+    ╭─[padding_around_expect_groups.tsx:61:3]
+ 60 │   const hoge = 123;
+ 61 │   expectTypeOf(hoge).toBeNumber();
+    ·   ▲
+ 62 │   expectTypeOf(hoge).toBeNumber();
+    ╰────
+  help: Make sure there is an empty new line before the expectTypeOf block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding after expectTypeOf block
+    ╭─[padding_around_expect_groups.tsx:63:3]
+ 62 │   expectTypeOf(hoge).toBeNumber();
+ 63 │   const foo = "abc";
+    ·   ▲
+ 64 │   // Comment
+    ╰────
+  help: Make sure there is an empty new line after the expectTypeOf block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expectTypeOf block
+    ╭─[padding_around_expect_groups.tsx:65:3]
+ 64 │   // Comment
+ 65 │   expectTypeOf(foo).toBeString();
+    ·   ▲
+ 66 │   expectTypeOf(foo).toBeString();
+    ╰────
+  help: Make sure there is an empty new line before the expectTypeOf block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:13:3]
+ 12 │   let abc = 123;
+ 13 │   expect(abc).toEqual(123);
+    ·   ▲
+ 14 │   expect(123).toEqual(abc); // Line comment
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding after expect block
+    ╭─[padding_around_expect_groups.tsx:15:3]
+ 14 │   expect(123).toEqual(abc); // Line comment
+ 15 │   abc = 456;
+    ·   ▲
+ 16 │   expect(abc).toEqual(456);
+    ╰────
+  help: Make sure there is an empty new line after the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:16:3]
+ 15 │   abc = 456;
+ 16 │   expect(abc).toEqual(456);
+    ·   ▲
+ 17 │ });
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:21:3]
+ 20 │   const abc = 123;
+ 21 │   expect(abc).toEqual(123);
+    ·   ▲
+ 22 │ 
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:24:3]
+ 23 │   const xyz = 987;
+ 24 │   expect(123).toEqual(abc); // Line comment
+    ·   ▲
+ 25 │ });
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:32:7]
+ 31 │       // Comment
+ 32 │       expect(xyz).toEqual(987);
+    ·       ▲
+ 33 │       expect(1)
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:43:3]
+ 42 │   const hasAPromise = () => Promise.resolve('foo');
+ 43 │   await expect(hasAPromise()).resolves.toEqual('foo');
+    ·   ▲
+ 44 │   expect(abc).toEqual(123);
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:47:3]
+ 46 │   const efg = 456;
+ 47 │   expect(123).toEqual(abc);
+    ·   ▲
+ 48 │   await expect(hasAPromise()).resolves.toEqual('foo');
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:51:3]
+ 50 │   const hij = 789;
+ 51 │   await expect(hasAPromise()).resolves.toEqual('foo');
+    ·   ▲
+ 52 │   await expect(hasAPromise()).resolves.toEqual('foo');
+    ╰────
+  help: Make sure there is an empty new line before the expect block
+
+  ⚠ vitest(padding-around-expect-groups): Missing padding before expect block
+    ╭─[padding_around_expect_groups.tsx:56:3]
+ 55 │   await somethingElseAsync();
+ 56 │   await expect(hasAPromise()).resolves.toEqual('foo');
+    ·   ▲
+ 57 │ });
+    ╰────
+  help: Make sure there is an empty new line before the expect block

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -19,7 +19,10 @@ pub use crate::utils::jest::parse_jest_fn::{
     MemberExpressionElement, ParsedExpectFnCall, ParsedGeneralJestFnCall,
     ParsedJestFnCall as ParsedJestFnCallNew, parse_jest_fn_call,
 };
-pub use padding_around_block::report_missing_padding_before_jest_block;
+pub use padding_around_block::{
+    PaddingDirection, check_padding_between, enclosing_statement_index, enclosing_statement_list,
+    leading_token_of_statement, report_missing_padding_before_jest_block,
+};
 
 mod padding_around_block;
 mod parse_jest_fn;

--- a/crates/oxc_linter/src/utils/jest/padding_around_block.rs
+++ b/crates/oxc_linter/src/utils/jest/padding_around_block.rs
@@ -1,50 +1,118 @@
-use oxc_ast::{AstKind, ast::Statement};
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, Statement, match_member_expression},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::AstNode;
 use oxc_span::{GetSpan, Span};
 
 use crate::context::LintContext;
 
-fn padding_around_jest_block_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!("Missing padding before {name} block"))
-        .with_help(format!("Make sure there is an empty new line before the {name} block"))
-        .with_label(span)
+#[derive(Debug, Clone, Copy)]
+pub enum PaddingDirection {
+    Before,
+    After,
 }
 
-pub fn report_missing_padding_before_jest_block<'a>(
+fn missing_padding_diagnostic(
+    span: Span,
+    direction: PaddingDirection,
+    name: &str,
+) -> OxcDiagnostic {
+    match direction {
+        PaddingDirection::Before => {
+            OxcDiagnostic::warn(format!("Missing padding before {name} block"))
+                .with_help(format!("Make sure there is an empty new line before the {name} block"))
+                .with_label(span)
+        }
+        PaddingDirection::After => {
+            OxcDiagnostic::warn(format!("Missing padding after {name} block"))
+                .with_help(format!("Make sure there is an empty new line after the {name} block"))
+                .with_label(span)
+        }
+    }
+}
+
+pub fn enclosing_statement_list<'a>(
     node: &AstNode<'a>,
     ctx: &LintContext<'a>,
-    name: &str,
-) {
+) -> Option<&'a [Statement<'a>]> {
     let scope_node = ctx.nodes().get_node(ctx.scoping().get_node_id(node.scope_id()));
-    let prev_statement_span = match scope_node.kind() {
-        AstKind::Program(program) => get_statement_span_before_node(node, program.body.as_slice()),
+    match scope_node.kind() {
+        AstKind::Program(program) => Some(program.body.as_slice()),
         AstKind::ArrowFunctionExpression(arrow_func_expr) => {
-            get_statement_span_before_node(node, arrow_func_expr.body.statements.as_slice())
+            Some(arrow_func_expr.body.statements.as_slice())
         }
         AstKind::Function(function) => {
-            let Some(body) = &function.body else {
-                return;
-            };
-            get_statement_span_before_node(node, body.statements.as_slice())
+            function.body.as_ref().map(|body| body.statements.as_slice())
         }
         _ => None,
-    };
-    let Some(prev_statement_span) = prev_statement_span else {
-        return;
-    };
+    }
+}
 
-    let comments_range = ctx.comments_range(prev_statement_span.end..node.span().start);
-    let mut span_between_start = prev_statement_span.end;
-    let mut span_between_end = node.span().start;
-    let mut next_attached_start = node.span().start;
+pub fn enclosing_statement_index(node_span: Span, statements: &[Statement]) -> Option<usize> {
+    statements.iter().position(|statement| statement.span().contains_inclusive(node_span))
+}
+
+pub struct LeadingStatementToken<'a> {
+    pub name: &'a str,
+    pub expr_start: u32,
+}
+
+/// Mirrors eslint-plugin-jest's token-based statement matching: labels and
+/// `await` are unwrapped, then the leftmost identifier of the expression
+/// chain is taken.
+pub fn leading_token_of_statement<'a>(
+    statement: &'a Statement<'a>,
+) -> Option<LeadingStatementToken<'a>> {
+    let mut statement = statement;
+    while let Statement::LabeledStatement(labeled) = statement {
+        statement = &labeled.body;
+    }
+    let Statement::ExpressionStatement(expr_stmt) = statement else {
+        return None;
+    };
+    let mut expression = &expr_stmt.expression;
+    while let Expression::AwaitExpression(await_expr) = expression {
+        expression = &await_expr.argument;
+    }
+    let expr_start = expression.span().start;
+    let mut current = expression;
+    loop {
+        match current {
+            Expression::Identifier(ident) => {
+                return Some(LeadingStatementToken { name: ident.name.as_str(), expr_start });
+            }
+            Expression::CallExpression(call_expr) => current = &call_expr.callee,
+            Expression::TaggedTemplateExpression(tagged) => current = &tagged.tag,
+            match_member_expression!(Expression) => {
+                current = current.to_member_expression().object();
+            }
+            _ => return None,
+        }
+    }
+}
+
+/// Report and fix a missing blank line between two adjacent statements.
+/// Comments attached to the next statement keep the padding before them.
+pub fn check_padding_between(
+    ctx: &LintContext<'_>,
+    prev_end: u32,
+    next_start: u32,
+    direction: PaddingDirection,
+    name: &str,
+) {
+    let comments_range = ctx.comments_range(prev_end..next_start);
+    let mut span_between_start = prev_end;
+    let mut span_between_end = next_start;
+    let mut next_attached_start = next_start;
     for comment in comments_range.rev() {
         let comment_span = comment.span;
         let space_after = ctx.source_range(Span::new(comment_span.end, next_attached_start));
         if space_after.matches('\n').count() > 1 {
             break;
         }
-        let space_before = ctx.source_range(Span::new(prev_statement_span.end, comment_span.start));
+        let space_before = ctx.source_range(Span::new(prev_end, comment_span.start));
         if space_before.matches('\n').count() == 0 {
             span_between_start = comment_span.end;
             break;
@@ -57,10 +125,7 @@ pub fn report_missing_padding_before_jest_block<'a>(
     let content = ctx.source_range(span_between);
     if content.matches('\n').count() < 2 {
         ctx.diagnostic_with_fix(
-            padding_around_jest_block_diagnostic(
-                Span::new(node.span().start, node.span().start),
-                name,
-            ),
+            missing_padding_diagnostic(Span::new(next_start, next_start), direction, name),
             |fixer| {
                 let whitespace_after_last_line =
                     content.rfind('\n').map_or("", |index| content.split_at(index + 1).1);
@@ -70,11 +135,33 @@ pub fn report_missing_padding_before_jest_block<'a>(
     }
 }
 
-fn get_statement_span_before_node(node: &AstNode, statements: &[Statement]) -> Option<Span> {
-    statements
-        .iter()
-        .filter_map(|statement| {
-            if statement.span().end <= node.span().start { Some(statement.span()) } else { None }
-        })
-        .next_back()
+pub fn report_missing_padding_before_jest_block<'a>(
+    node: &AstNode<'a>,
+    ctx: &LintContext<'a>,
+    name: &str,
+) {
+    let Some(statements) = enclosing_statement_list(node, ctx) else {
+        return;
+    };
+    let Some(index) = enclosing_statement_index(node.span(), statements) else {
+        return;
+    };
+    let statement = &statements[index];
+    // The call must lead its statement, e.g. `const x = it(...)` is not a block.
+    let Some(token) = leading_token_of_statement(statement) else {
+        return;
+    };
+    if token.expr_start != node.span().start {
+        return;
+    }
+    let Some(prev) = index.checked_sub(1).map(|i| &statements[i]) else {
+        return;
+    };
+    check_padding_between(
+        ctx,
+        prev.span().end,
+        statement.span().start,
+        PaddingDirection::Before,
+        name,
+    );
 }

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -496,6 +496,9 @@
         "jest/padding-around-after-all-blocks": {
           "$ref": "#/definitions/DummyRule"
         },
+        "jest/padding-around-expect-groups": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "jest/padding-around-test-blocks": {
           "$ref": "#/definitions/DummyRule"
         },
@@ -2458,6 +2461,9 @@
         "vitest/padding-around-after-all-blocks": {
           "$ref": "#/definitions/DummyRule"
         },
+        "vitest/padding-around-expect-groups": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "vitest/prefer-called-exactly-once-with": {
           "$ref": "#/definitions/DummyRule"
         },
@@ -3262,4 +3268,3 @@
   },
   "markdownDescription": "Oxlint Configuration File\n\nThis configuration is aligned with ESLint v8's configuration schema (`eslintrc.json`).\n\nUsage: `oxlint -c oxlintrc.json`\n\nExample\n\n`.oxlintrc.json`\n\n```json\n{\n\"$schema\": \"./node_modules/oxlint/configuration_schema.json\",\n\"plugins\": [\"import\", \"typescript\", \"unicorn\"],\n\"env\": {\n\"browser\": true\n},\n\"globals\": {\n\"foo\": \"readonly\"\n},\n\"settings\": {\n\"react\": {\n\"version\": \"18.2.0\"\n},\n\"custom\": { \"option\": true }\n},\n\"rules\": {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"react/self-closing-comp\": [\"error\", { \"html\": false }]\n},\n\"overrides\": [\n{\n\"files\": [\"*.test.ts\", \"*.spec.ts\"],\n\"rules\": {\n\"@typescript-eslint/no-explicit-any\": \"off\"\n}\n}\n]\n}\n```\n\n`oxlint.config.ts`\n\n```ts\nimport { defineConfig } from \"oxlint\";\n\nexport default defineConfig({\nplugins: [\"import\", \"typescript\", \"unicorn\"],\nenv: {\n\"browser\": true\n},\nglobals: {\n\"foo\": \"readonly\"\n},\nsettings: {\nreact: {\nversion: \"18.2.0\"\n},\ncustom: { option: true }\n},\nrules: {\n\"eqeqeq\": \"warn\",\n\"import/no-cycle\": \"error\",\n\"react/self-closing-comp\": [\"error\", { \"html\": false }]\n},\noverrides: [\n{\nfiles: [\"*.test.ts\", \"*.spec.ts\"],\nrules: {\n\"@typescript-eslint/no-explicit-any\": \"off\"\n}\n}\n]\n});\n```"
 }
-

--- a/tasks/website_linter/src/snapshots/schema_json.snap
+++ b/tasks/website_linter/src/snapshots/schema_json.snap
@@ -500,6 +500,9 @@ expression: json
         "jest/padding-around-after-all-blocks": {
           "$ref": "#/definitions/DummyRule"
         },
+        "jest/padding-around-expect-groups": {
+          "$ref": "#/definitions/DummyRule"
+        },
         "jest/padding-around-test-blocks": {
           "$ref": "#/definitions/DummyRule"
         },
@@ -2460,6 +2463,9 @@ expression: json
           "$ref": "#/definitions/DummyRule"
         },
         "vitest/padding-around-after-all-blocks": {
+          "$ref": "#/definitions/DummyRule"
+        },
+        "vitest/padding-around-expect-groups": {
           "$ref": "#/definitions/DummyRule"
         },
         "vitest/prefer-called-exactly-once-with": {


### PR DESCRIPTION
## What

Implements the `padding-around-expect-groups` rule for the `jest` and `vitest` plugins, enforcing a blank line before and after groups of consecutive `expect` statements (no padding required within a group).

Part of #492 (eslint-plugin-jest tracking issue).

## How

- Refactors the shared padding helper (`utils/jest/padding_around_block.rs`) to measure gaps between statement spans and support an after-direction check — needed for `await expect(...)` and for padding after a group. Existing padding rule snapshots are unchanged.
- Adds a shared `run`/`DOCUMENTATION` module in `rules/shared/jest_vitest/padding_around_expect_groups.rs` and thin `jest`/`vitest` wrappers, mirroring `padding-around-after-all-blocks`.
- Regenerated artifacts: rule enum/impls (`cargo lintgen`), config schema/types, website_linter snapshot.

## Test

- Ported the upstream test suites: error counts match exactly (10 for the eslint-plugin-jest composite case, 13 for @vitest/eslint-plugin including `expectTypeOf`).
- `cargo test -p oxc_linter` — all tests pass.

---