### PR TITLE
refactor(linter): move `vitest/consistent-each-for` to `style` category

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/consistent_each_for.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_each_for.rs
@@ -166,7 +166,7 @@ declare_oxc_lint!(
     /// ```
     ConsistentEachFor,
     vitest,
-    correctness,
+    style,
     config = ConsistentEachForJson,
     version = "1.39.0",
 );


### PR DESCRIPTION
> ```
> /// This rule enforces consistency in which method is used to create parameterized tests.
> /// This configuration affects different test function types (`test`, `it`, `describe`, `suite`).
> ///
> /// ### Why is this bad?
> ///
> /// Without a consistent way to create parameterized tests, we rely on the developer to remember that
> /// `.for` spreads the values as different arguments while `.each` passes the array as a single argument.
> ```

For me this sounds more like `style`, because both ways are valid.