### PR TITLE
feat(oxfmt): format `parser:graphql` files by `oxc_formatter_graphql`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,6 +2842,7 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_formatter",
  "oxc_formatter_core",
+ "oxc_formatter_graphql",
  "oxc_formatter_json",
  "oxc_language_server",
  "oxc_napi",

--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -6,7 +6,7 @@ The `oxfmt` implemented under this directory serves several purposes.
 
 - Pure Rust CLI
   - Minimum feature set, CLI usage only, no LSP, no Stdin support
-  - Formats JS/TS, JSON and TOML files, no xxx-in-js support
+  - Formats JS/TS, JSON, GraphQL and TOML files, no xxx-in-js support
   - Entry point: `main()` in `src/main.rs`
   - Build with `cargo build --no-default-features`
 - JS/Rust hybrid CLI using `napi-rs`
@@ -35,10 +35,14 @@ When working with file paths in CLI code, be aware of Windows path differences:
 
 Oxfmt utilizes different implementations depending on the file extension and filename:
 
-- Tier 1: Rust implementations using `oxc_formatter` or `oxc_formatter_json` found in this repository
+- Tier 1: Rust implementations using `oxc_formatter`, `oxc_formatter_json` or `oxc_formatter_graphql` found in this repository
 - Tier 2: Rust implementations using external libraries like `oxc_toml`
 - Tier 3: Delegations to Prettier via NAPI-JS calls (e.g., for Vue or Markdown)
 - Tier 4: Delegations to Prettier that require additional plugins (e.g., for Svelte)
+
+NOTE: Some Tier 1 formatters can fallback to Prettier with NAPI CLI.
+e.g. `oxc_formatter_graphql` (uses `apollo-parser`) only covers the stable GraphQL spec.
+When it returns an error (e.g. draft-spec syntax that Prettier's `graphql-js` accepts), the format step retries via Prettier.
 
 Consequently, managing these various formatter implementations and handling their respective options are also part of Oxfmt's responsibilities.
 

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -33,6 +33,7 @@ oxc_config = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }
+oxc_formatter_graphql = { workspace = true }
 oxc_formatter_json = { workspace = true }
 oxc_language_server = { workspace = true }
 oxc_napi = { workspace = true }

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -5,6 +5,7 @@ use tracing::instrument;
 use oxc_allocator::AllocatorPool;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter::JsFormatOptions;
+use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant};
 use oxc_span::SourceType;
 use oxc_toml::Options as TomlFormatterOptions;
@@ -15,7 +16,10 @@ use super::options::{
     inject_tailwind_plugin_payload, to_prettier,
 };
 use super::{
-    options::{to_oxc_formatter, to_oxc_formatter_json, to_oxc_toml, to_sort_package_json},
+    options::{
+        to_oxc_formatter, to_oxc_formatter_graphql, to_oxc_formatter_json, to_oxc_toml,
+        to_sort_package_json,
+    },
     oxfmtrc::FormatConfig,
     support::FileKind,
 };
@@ -54,6 +58,16 @@ pub enum FormatStrategy {
         sort_package_json: Option<sort_package_json::SortOptions>,
         insert_final_newline: bool,
     },
+    /// For GraphQL files formatted by `oxc_formatter_graphql`.
+    /// `config` is retained (napi only) so the format step can fall back to Prettier
+    /// when the Rust parser rejects the input (e.g. draft-spec syntax).
+    OxcFormatterGraphql {
+        path: Arc<Path>,
+        format_options: Box<GraphqlFormatOptions>,
+        #[cfg(feature = "napi")]
+        config: Box<FormatConfig>,
+        insert_final_newline: bool,
+    },
     /// For TOML files.
     OxfmtToml { path: Arc<Path>, toml_options: TomlFormatterOptions, insert_final_newline: bool },
     /// For non-JS files formatted by external formatter (Prettier).
@@ -82,6 +96,7 @@ impl FormatStrategy {
             Self::OxcFormatter { path, .. }
             | Self::OxcFormatterJson { path, .. }
             | Self::OxcFormatterJsonPackageJson { path, .. }
+            | Self::OxcFormatterGraphql { path, .. }
             | Self::OxfmtToml { path, .. } => path,
             #[cfg(feature = "napi")]
             Self::ExternalFormatter { path, .. } => path,
@@ -127,6 +142,13 @@ impl FormatStrategy {
                     JsonVariant::JsonStringify,
                 )?),
                 sort_package_json: to_sort_package_json(&config),
+                insert_final_newline,
+            },
+            FileKind::OxcFormatterGraphql { path } => Self::OxcFormatterGraphql {
+                path,
+                format_options: Box::new(to_oxc_formatter_graphql(&config)?),
+                #[cfg(feature = "napi")]
+                config: Box::new(config),
                 insert_final_newline,
             },
             FileKind::OxfmtToml { path } => {
@@ -222,6 +244,22 @@ impl SourceFormatter {
                     &path,
                     *format_options,
                     sort_package_json.as_ref(),
+                ),
+                insert_final_newline,
+            ),
+            FormatStrategy::OxcFormatterGraphql {
+                path,
+                format_options,
+                #[cfg(feature = "napi")]
+                config,
+                insert_final_newline,
+            } => (
+                self.format_by_oxc_formatter_graphql(
+                    source_text,
+                    &path,
+                    *format_options,
+                    #[cfg(feature = "napi")]
+                    &config,
                 ),
                 insert_final_newline,
             ),
@@ -365,6 +403,49 @@ impl SourceFormatter {
         };
 
         self.format_by_oxc_formatter_json(&source_text, path, format_options)
+    }
+
+    /// Format GraphQL source using `oxc_formatter_graphql`.
+    ///
+    /// apollo-parser covers the stable GraphQL spec only, while Prettier (graphql-js)
+    /// also accepts draft-level syntax. So when the Rust formatter returns `Err`
+    /// (parse error or internal failure), the napi build falls back to Prettier;
+    /// if Prettier also fails, its error is reported.
+    /// The pure Rust build has no fallback and reports the diagnostic as-is.
+    #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter_graphql", skip_all)]
+    fn format_by_oxc_formatter_graphql(
+        &self,
+        source_text: &str,
+        path: &Path,
+        format_options: GraphqlFormatOptions,
+        #[cfg(feature = "napi")] config: &FormatConfig,
+    ) -> Result<String, OxcDiagnostic> {
+        let result = (|| -> Result<String, OxcDiagnostic> {
+            let allocator = self.allocator_pool.get();
+            let formatted = oxc_formatter_graphql::format(&allocator, source_text, format_options)?;
+            let printed = formatted.print().map_err(|err| {
+                OxcDiagnostic::error(format!(
+                    "Failed to print formatted GraphQL: {}\n{err}",
+                    path.display()
+                ))
+            })?;
+            Ok(printed.into_code())
+        })();
+
+        #[cfg(feature = "napi")]
+        let result = result.or_else(|_| {
+            self.format_by_external_formatter(
+                source_text,
+                path,
+                "graphql",
+                config,
+                /* supports_tailwind */ false,
+                /* supports_oxfmt */ false,
+                /* supports_svelte */ false,
+            )
+        });
+
+        result
     }
 
     /// Format TOML file using `oxc_toml`.

--- a/apps/oxfmt/src/core/options/mod.rs
+++ b/apps/oxfmt/src/core/options/mod.rs
@@ -4,6 +4,7 @@
 //! - [`to_oxc_formatter_json()`]: `oxc_formatter_json::JsonFormatOptions` for JSON formatting
 //!   - [`to_sort_package_json()`]: its companion `sort_package_json::SortOptions`
 //!     for `package.json`'s sorting pre-process
+//! - [`to_oxc_formatter_graphql()`]: `oxc_formatter_graphql::GraphqlFormatOptions` for GraphQL formatting
 //! - [`to_oxc_toml()`]: `oxc_toml::Options` for TOML formatting
 //! - `to_prettier`(NAPI-only): Prettier-compatible JSON, plus `inject_*` helpers for
 //!   layering in `parser` / `filepath` / plugin payloads at the format step
@@ -11,6 +12,7 @@
 
 mod to_core_options;
 mod to_oxc_formatter;
+mod to_oxc_formatter_graphql;
 mod to_oxc_formatter_json;
 mod to_oxc_toml;
 #[cfg(feature = "napi")]
@@ -18,6 +20,7 @@ mod to_prettier;
 mod validate;
 
 pub use to_oxc_formatter::to_oxc_formatter;
+pub use to_oxc_formatter_graphql::to_oxc_formatter_graphql;
 pub use to_oxc_formatter_json::{to_oxc_formatter_json, to_sort_package_json};
 pub use to_oxc_toml::to_oxc_toml;
 #[cfg(feature = "napi")]

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_graphql.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_graphql.rs
@@ -1,0 +1,28 @@
+use oxc_formatter_graphql::{BracketSpacing, GraphqlFormatOptions};
+
+use super::{super::oxfmtrc::FormatConfig, to_core_options::to_core_options};
+
+/// Convert `FormatConfig` into validated `GraphqlFormatOptions` for `oxc_formatter_graphql`.
+///
+/// Prettier's `graphql` language consumes only the shared layout options plus `bracketSpacing`.
+///
+/// # Errors
+/// Returns error if any option value is invalid.
+pub fn to_oxc_formatter_graphql(config: &FormatConfig) -> Result<GraphqlFormatOptions, String> {
+    let core = to_core_options(config)?;
+
+    let mut options = GraphqlFormatOptions {
+        indent_style: core.indent_style,
+        indent_width: core.indent_width,
+        line_width: core.line_width,
+        line_ending: core.line_ending,
+        ..GraphqlFormatOptions::default()
+    };
+
+    // [Prettier] bracketSpacing: boolean
+    if let Some(spacing) = config.bracket_spacing {
+        options.bracket_spacing = BracketSpacing::from(spacing);
+    }
+
+    Ok(options)
+}

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -56,6 +56,9 @@ pub fn classify_file_kind(path: Arc<Path>) -> Option<FileKind> {
     if is_json5_file(extension) {
         return Some(FileKind::OxcFormatterJson { path, variant: JsonVariant::Json5 });
     }
+    if is_graphql_file(extension) {
+        return Some(FileKind::OxcFormatterGraphql { path });
+    }
 
     // External formatter files are only supported with the `napi` feature
     #[cfg(feature = "napi")]
@@ -90,6 +93,11 @@ pub enum FileKind {
     /// `package.json` is special: sorted by `sort-package-json` then formatted
     /// by `oxc_formatter_json` with the `json-stringify` variant.
     OxcFormatterJsonPackageJson { path: Arc<Path> },
+    /// GraphQL files formatted by `oxc_formatter_graphql`.
+    /// On parse error, the format step falls back to Prettier (`napi` feature only):
+    /// apollo-parser covers the stable spec, while Prettier (graphql-js) also
+    /// accepts draft-level syntax.
+    OxcFormatterGraphql { path: Arc<Path> },
     /// TOML files formatted by taplo (Pure Rust).
     OxfmtToml { path: Arc<Path> },
     /// Files formatted by external formatter (Prettier).
@@ -114,6 +122,7 @@ impl FileKind {
             Self::OxcFormatter { path, .. }
             | Self::OxcFormatterJson { path, .. }
             | Self::OxcFormatterJsonPackageJson { path }
+            | Self::OxcFormatterGraphql { path }
             | Self::OxfmtToml { path } => path,
             #[cfg(feature = "napi")]
             Self::ExternalFormatter { path, .. } => path,
@@ -315,6 +324,19 @@ fn is_json5_file(extension: Option<&str>) -> bool {
 
 // ---
 
+/// Returns `true` if this is a GraphQL file (handled by `oxc_formatter_graphql`).
+fn is_graphql_file(extension: Option<&str>) -> bool {
+    extension.is_some_and(|ext| GRAPHQL_EXTENSIONS.contains(ext))
+}
+
+static GRAPHQL_EXTENSIONS: phf::Set<&'static str> = phf_set! {
+    "graphql",
+    "gql",
+    "graphqls",
+};
+
+// ---
+
 /// Returns parser name for external formatter, if supported.
 /// See also `prettier --support-info | jq '.languages[]'`
 #[cfg(feature = "napi")]
@@ -378,13 +400,6 @@ fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<
         return Some("scss");
     }
 
-    // GraphQL
-    if let Some(ext) = extension
-        && GRAPHQL_EXTENSIONS.contains(ext)
-    {
-        return Some("graphql");
-    }
-
     // Handlebars
     if let Some(ext) = extension
         && HANDLEBARS_EXTENSIONS.contains(ext)
@@ -411,13 +426,6 @@ static CSS_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "wxss",
     "pcss",
     "postcss",
-};
-
-#[cfg(feature = "napi")]
-static GRAPHQL_EXTENSIONS: phf::Set<&'static str> = phf_set! {
-    "graphql",
-    "gql",
-    "graphqls",
 };
 
 #[cfg(feature = "napi")]
@@ -627,10 +635,11 @@ mod tests {
             ("styles.postcss", Some("css")),
             ("theme.less", Some("less")),
             ("main.scss", Some("scss")),
-            // GraphQL
-            ("schema.graphql", Some("graphql")),
-            ("query.gql", Some("graphql")),
-            ("types.graphqls", Some("graphql")),
+            // GraphQL files are routed to `oxc_formatter_graphql` in `classify_file_kind`
+            // and excluded from this map.
+            ("schema.graphql", None),
+            ("query.gql", None),
+            ("types.graphqls", None),
             // Handlebars
             ("template.handlebars", Some("glimmer")),
             ("partial.hbs", Some("glimmer")),
@@ -696,6 +705,17 @@ mod tests {
         // but is the lone dedicated kind for the sorting pre-process
         let kind = classify_file_kind(Arc::from(Path::new("package.json"))).unwrap();
         assert!(matches!(kind, FileKind::OxcFormatterJsonPackageJson { .. }));
+    }
+
+    #[test]
+    fn test_graphql_files_route_to_oxc_formatter_graphql() {
+        for file_name in ["schema.graphql", "query.gql", "types.graphqls"] {
+            let result = classify_file_kind(Arc::from(Path::new(file_name)));
+            assert!(
+                matches!(result, Some(FileKind::OxcFormatterGraphql { .. })),
+                "`{file_name}` should be routed to oxc_formatter_graphql"
+            );
+        }
     }
 
     #[test]

--- a/apps/oxfmt/test/api/graphql.test.ts
+++ b/apps/oxfmt/test/api/graphql.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../dist/index.js";
+
+describe("GraphQL files (oxc_formatter_graphql)", () => {
+  it("should format standalone GraphQL files in Rust", async () => {
+    const source = `query { user(id:1){ name  email } }`;
+    const result = await format("query.graphql", source);
+    expect(result.code).toMatchInlineSnapshot(`
+      "query {
+        user(id: 1) {
+          name
+          email
+        }
+      }
+      "
+    `);
+  });
+
+  it("should format .gql and .graphqls extensions", async () => {
+    const source = `type Query { hello:String }`;
+    for (const filename of ["schema.gql", "schema.graphqls"]) {
+      // oxlint-disable-next-line no-await-in-loop
+      const result = await format(filename, source);
+      expect(result.code).toBe("type Query {\n  hello: String\n}\n");
+    }
+  });
+
+  it("should respect bracketSpacing and useTabs", async () => {
+    const source = `{ user(filters: { active: true }) { name } }`;
+    const result = await format("query.graphql", source, {
+      bracketSpacing: false,
+      useTabs: true,
+    });
+    expect(result.code).toMatchInlineSnapshot(`
+      "{
+      	user(filters: {active: true}) {
+      		name
+      	}
+      }
+      "
+    `);
+  });
+
+  it("should fall back to Prettier for draft-spec syntax apollo-parser rejects", async () => {
+    // Fragment arguments are graphql-js experimental syntax, not in the stable spec
+    const source = `fragment F($x: Int) on T { f(arg: $x) }`;
+    const result = await format("draft.graphql", source);
+    expect(result.code).toMatchInlineSnapshot(`
+      "fragment F($x: Int) on T {
+        f(arg: $x)
+      }
+      "
+    `);
+  });
+
+  it("should report Prettier's error when both parsers fail", async () => {
+    const source = `query {{{`;
+    const result = await format("broken.graphql", source);
+    expect(result.code).toBe(source);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/Syntax Error/);
+  });
+});


### PR DESCRIPTION
- Use `oxc_formatter_graphql` from Oxfmt to handle `.gql` and `.graphql` files
- At point of this PR, gql-in-js is still handled by Prettier

As described in #23317, Prettier supports more syntax than ours, so for now fallback to Prettier when `oxc_formatter_graphql` failed to format.

NOTE: This fallback will be removed in later PR.