### PR TITLE
refactor(oxfmt): handle gql-in-js by `oxc_formatter_graphql`

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -44,6 +44,11 @@ NOTE: Some Tier 1 formatters can fallback to Prettier with NAPI CLI.
 e.g. `oxc_formatter_graphql` (uses `apollo-parser`) only covers the stable GraphQL spec.
 When it returns an error (e.g. draft-spec syntax that Prettier's `graphql-js` accepts), the format step retries via Prettier.
 
+The same applies to embedded languages (xxx-in-js): `src/core/external_formatter.rs`
+assembles a `FormatDispatcher` (defined in `oxc_formatter_core`) that maps each
+language to a Rust formatter where implemented (currently GraphQL, with the same
+parse-error fallback) and to the Prettier Doc→IR path otherwise.
+
 Consequently, managing these various formatter implementations and handling their respective options are also part of Oxfmt's responsibilities.
 
 ### CLI implementations

--- a/apps/oxfmt/conformance/fixtures/edge-cases/gql-in-js/draft-syntax.js
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/gql-in-js/draft-syntax.js
@@ -1,0 +1,16 @@
+// Draft-spec syntax not supported by apollo-parser.
+// Fragment variable definitions: Prettier's graphql-js accepts them
+// (experimental), so this must be formatted via the Prettier fallback.
+const fragmentVariableDefs = gql`
+  fragment    Foo (  $x : Int   =  3 ) on Bar {
+    baz( arg : $x )
+  }
+`;
+
+// Fragment spread arguments: rejected by BOTH apollo-parser and graphql-js.
+// Both sides must leave the template content as-is.
+const fragmentSpreadArgs = gql`
+  query {
+    ...Foo( x : 1 )
+  }
+`;

--- a/apps/oxfmt/conformance/fixtures/edge-cases/gql-in-js/syntax-error.js
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/gql-in-js/syntax-error.js
@@ -1,0 +1,12 @@
+// Invalid GraphQL: neither Rust nor Prettier can parse it.
+// Both sides must leave the template content as-is.
+const broken = gql`
+  query {
+    user(   id:
+  }
+`;
+
+// Valid template after a broken one, to ensure the failure does not leak.
+const ok = gql`
+  query {   user( id : 5 ) { name }  }
+`;

--- a/apps/oxfmt/conformance/fixtures/edge-cases/gql-in-js/type-system.js
+++ b/apps/oxfmt/conformance/fixtures/edge-cases/gql-in-js/type-system.js
@@ -1,0 +1,64 @@
+// Stable-spec type-system definitions in embedded position,
+// exercising the breadth of the GraphQL formatter.
+export const typeDefs = gql`
+  "Schema description"
+  schema    {
+    query: Query
+    mutation:    Mutation
+  }
+
+  """
+  Block string
+  description
+  """
+  type Query implements Node   &   Timestamped {
+    node( id : ID! ) : Node
+    items( first : Int = 10 , filter : ItemFilter ) : [Item!]!   @deprecated( reason : "use nodes" )
+  }
+
+  interface Node {
+    id: ID!
+  }
+
+  union SearchResult =   User   |   Item
+
+  enum Color {
+    RED
+    GREEN
+
+    "with description"
+    BLUE   @deprecated
+  }
+
+  input ItemFilter {
+    name : String =   "default"
+    tags : [ String! ]   =   [ "a" , "b" ]
+    nested : ItemFilter
+  }
+
+  directive   @cacheControl ( maxAge : Int ) on FIELD_DEFINITION   |   OBJECT
+
+  extend type Query {
+    extra : String
+  }
+
+  scalar DateTime   @specifiedBy( url : "https://example.com" )
+`;
+
+export const ops = gql`
+  query Search( $term : String! , $color : Color = RED )   @cached {
+    search( term : $term , filter : { tags : [ "x" ] , nested : { name : "y" } } ) {
+      ... on User {  name  }
+      ...itemFields    @include( if : true )
+    }
+  }
+
+  subscription   OnChange {
+    changed {   id   }
+  }
+
+  fragment itemFields on Item {
+    id
+    name
+  }
+`;

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -24,13 +24,13 @@
 
 ## gql-in-js
 
-### Option 1: 9/9 (100.00%)
+### Option 1: 12/12 (100.00%)
 
 ```json
 {"printWidth":80}
 ```
 
-### Option 2: 9/9 (100.00%)
+### Option 2: 12/12 (100.00%)
 
 ```json
 {"printWidth":100}

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -12,7 +12,9 @@ use crate::{
     core::{
         ExternalFormatter, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
         JsSortTailwindClassesCb,
-        options::{inject_filepath, inject_tailwind_plugin_payload, to_prettier},
+        options::{
+            inject_filepath, inject_tailwind_plugin_payload, to_oxc_formatter_graphql, to_prettier,
+        },
         oxfmtrc::FormatConfig,
         resolve_for_embedded_js,
     },
@@ -125,8 +127,17 @@ fn run_full(
     inject_filepath(&mut external_options, &resolved.parent_filepath);
     inject_tailwind_plugin_payload(&mut external_options, &resolved.config);
 
-    let external_callbacks =
-        external_formatter.to_external_callbacks(&resolved.format_options, external_options);
+    // Dual mapping of the same resolved config for the dispatcher's Rust GraphQL branch.
+    // Cannot fail here: `resolve_for_embedded_js()` already built `JsFormatOptions`
+    // from this config, and both share the same `to_core_options()` validation.
+    let graphql_options = to_oxc_formatter_graphql(&resolved.config)
+        .expect("config was already validated by `resolve_for_embedded_js()`");
+
+    let external_callbacks = external_formatter.to_external_callbacks(
+        &resolved.format_options,
+        external_options,
+        graphql_options,
+    );
     let format_options = resolved.format_options;
 
     let allocator = Allocator::default();

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -10,9 +10,10 @@ use serde_json::Value;
 use tracing::{debug, debug_span};
 
 use oxc_formatter::{
-    EmbeddedDocFormatterCallback, EmbeddedFormatterCallback, ExternalCallbacks, JsFormatOptions,
-    TailwindCallback,
+    EmbeddedFormatterCallback, ExternalCallbacks, JsFormatOptions, TailwindCallback,
 };
+use oxc_formatter_core::{DispatchResult, EmbeddedContext, FormatDispatcher};
+use oxc_formatter_graphql::GraphqlFormatOptions;
 
 use crate::{core::options::inject_parser, prettier_compat::from_prettier_doc};
 
@@ -239,10 +240,14 @@ impl ExternalFormatter {
 
     /// Convert this external formatter to the oxc_formatter::ExternalCallbacks type.
     /// The options (including `filepath`) are captured in the closures and passed to JS on each call.
+    ///
+    /// `graphql_options` is the dual mapping of the same resolved config for the
+    /// dispatcher's Rust GraphQL branch (graphql-in-js).
     pub fn to_external_callbacks(
         &self,
         format_options: &JsFormatOptions,
         options: Value,
+        graphql_options: GraphqlFormatOptions,
     ) -> ExternalCallbacks {
         let needs_embedded = !format_options.embedded_language_formatting.is_off();
         let embedded_callback: Option<EmbeddedFormatterCallback> = if needs_embedded {
@@ -278,50 +283,33 @@ impl ExternalFormatter {
             None
         };
 
-        let embedded_doc_callback: Option<EmbeddedDocFormatterCallback> = if needs_embedded {
-            let format_embedded_doc = Arc::clone(&self.format_embedded_doc);
-            let options_for_doc = options.clone();
-            Some(Arc::new(move |allocator, group_id_builder, language: &str, texts: &[&str]| {
-                let Some(parser_name) = language_to_prettier_parser(language) else {
-                    return Err(format!("Unsupported language: {language}"));
-                };
-                debug_span!("oxfmt::external::format_embedded_doc", parser = parser_name)
-                    .in_scope(|| {
-                        let mut options = options_for_doc.clone();
-                        inject_parser(&mut options, parser_name);
-                        let doc_json_strs =
-                            (format_embedded_doc)(options, texts).map_err(|err| {
-                                format!(
-                                    "Failed to get Doc for embedded code (parser '{parser_name}'): {err}"
-                                )
-                            })?;
-                        let doc_jsons = doc_json_strs
-                            .into_iter()
-                            .map(|s| {
-                                // Prettier's Doc can produce deeply nested arrays.
-                                // (e.g., md-in-js with `proseWrap: preserve`,
-                                // which nests each word in `[[[prev, " "], word], " "]`)
-                                // The default recursion limit of 128 is not enough for long paragraphs.
-                                // This only affects this deserialization call;
-                                // other `serde_json` usage in the codebase keeps the default limit.
-                                let mut de = serde_json::Deserializer::from_str(&s);
-                                de.disable_recursion_limit();
-                                serde_json::Value::deserialize(&mut de)
-                            })
-                            .collect::<Result<Vec<_>, _>>()
-                            .map_err(|e| format!("Failed to parse Doc JSON: {e}"))?;
-
-                        from_prettier_doc::to_format_elements_for_template(
-                            language,
-                            doc_jsons,
-                            allocator,
-                            group_id_builder,
-                        )
-                    })
-                    .inspect_err(|err| {
-                        debug!("Failed to format embedded doc for parser '{parser_name}': {err}");
-                    })
-            }))
+        // The dispatcher maps a language name to a formatter implementation.
+        // Rust implementations replace branches one by one;
+        // the rest go through the Prettier Doc→IR fallback.
+        let dispatcher: Option<FormatDispatcher> = if needs_embedded {
+            let prettier_fallback =
+                build_prettier_fallback(Arc::clone(&self.format_embedded_doc), options.clone());
+            Some(Arc::new(
+                move |ctx: &EmbeddedContext<'_, '_>,
+                      language: &str,
+                      texts: &[&str],
+                      _parent_context| {
+                    match language {
+                        // Rust implementation; Prettier fallback on parse errors
+                        // (apollo-parser covers the stable spec only, while
+                        // Prettier's graphql-js also accepts draft-level syntax)
+                        "graphql" | "gql" => format_graphql_to_irs(ctx, texts, graphql_options)
+                            .or_else(|err| {
+                                debug!(
+                                    "`oxc_formatter_graphql` failed, falling back to Prettier: {err}"
+                                );
+                                prettier_fallback(ctx, language, texts)
+                            }),
+                        // Everything else: Prettier fallback (Doc→IR path)
+                        _ => prettier_fallback(ctx, language, texts),
+                    }
+                },
+            ))
         } else {
             None
         };
@@ -339,7 +327,7 @@ impl ExternalFormatter {
 
         ExternalCallbacks::new()
             .with_embedded_formatter(embedded_callback)
-            .with_embedded_doc_formatter(embedded_doc_callback)
+            .with_dispatcher(dispatcher)
             .with_tailwind(tailwind_callback)
     }
 
@@ -367,6 +355,95 @@ impl ExternalFormatter {
 }
 
 // ---
+
+/// Format each text as a standalone GraphQL document via `oxc_formatter_graphql`,
+/// returning one IR per text (the dispatcher contract for GraphQL).
+///
+/// Template-literal characters in the output are re-escaped because the parent
+/// re-inserts the IR into a JS template literal built from `.cooked` values.
+///
+/// Any parse error fails the whole batch so the caller can fall back to
+/// Prettier for all texts at once (an embedded template is all-or-nothing).
+fn format_graphql_to_irs<'a>(
+    ctx: &EmbeddedContext<'a, '_>,
+    texts: &[&str],
+    options: GraphqlFormatOptions,
+) -> Result<DispatchResult<'a>, String> {
+    let docs = texts
+        .iter()
+        .map(|text| {
+            debug_span!("oxfmt::external::format_graphql_to_ir").in_scope(|| {
+                let mut ir = oxc_formatter_graphql::format_to_ir(ctx, text, options)
+                    .map_err(|err| err.to_string())?;
+                from_prettier_doc::escape_template_characters_in_ir(
+                    &mut ir,
+                    ctx.allocator,
+                    options.indent_width,
+                );
+                Ok(ir)
+            })
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    Ok(DispatchResult { docs, meta: None })
+}
+
+/// Type of the Prettier Doc→IR fallback used by the dispatcher.
+/// Same shape as `FormatDispatcher` minus the `parent_context` passthrough.
+type PrettierDocFallback = Arc<
+    dyn for<'a, 'g> Fn(
+            &EmbeddedContext<'a, 'g>,
+            &str,
+            &[&str],
+        ) -> Result<DispatchResult<'a>, String>
+        + Send
+        + Sync,
+>;
+
+/// Build the Prettier Doc→IR fallback for embedded languages:
+/// sends texts to JS `printToDoc()`, then converts the returned Doc JSON into formatter IR.
+fn build_prettier_fallback(
+    format_embedded_doc: FormatEmbeddedDocWithConfigCallback,
+    options: Value,
+) -> PrettierDocFallback {
+    Arc::new(move |ctx: &EmbeddedContext<'_, '_>, language: &str, texts: &[&str]| {
+        let Some(parser_name) = language_to_prettier_parser(language) else {
+            return Err(format!("Unsupported language: {language}"));
+        };
+        debug_span!("oxfmt::external::format_embedded_doc", parser = parser_name)
+            .in_scope(|| {
+                let mut options = options.clone();
+                inject_parser(&mut options, parser_name);
+                let doc_json_strs = (format_embedded_doc)(options, texts).map_err(|err| {
+                    format!("Failed to get Doc for embedded code (parser '{parser_name}'): {err}")
+                })?;
+                let doc_jsons = doc_json_strs
+                    .into_iter()
+                    .map(|s| {
+                        // Prettier's Doc can produce deeply nested arrays.
+                        // (e.g., md-in-js with `proseWrap: preserve`,
+                        // which nests each word in `[[[prev, " "], word], " "]`)
+                        // The default recursion limit of 128 is not enough for long paragraphs.
+                        // This only affects this deserialization call;
+                        // other `serde_json` usage in the codebase keeps the default limit.
+                        let mut de = serde_json::Deserializer::from_str(&s);
+                        de.disable_recursion_limit();
+                        serde_json::Value::deserialize(&mut de)
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| format!("Failed to parse Doc JSON: {e}"))?;
+
+                from_prettier_doc::to_format_elements_for_template(
+                    language,
+                    doc_jsons,
+                    ctx.allocator,
+                    ctx.group_id_builder,
+                )
+            })
+            .inspect_err(|err| {
+                debug!("Failed to format embedded doc for parser '{parser_name}': {err}");
+            })
+    })
+}
 
 /// Mapping from language identifiers to Prettier `parser` names.
 /// This is the single source of truth for supported embedded languages.

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -492,7 +492,13 @@ impl SourceFormatter {
         inject_filepath(&mut external_options, path);
         inject_tailwind_plugin_payload(&mut external_options, config);
 
-        external_formatter.to_external_callbacks(format_options, external_options)
+        // Dual mapping of the same resolved config for the dispatcher's Rust GraphQL branch.
+        // Cannot fail here: building `JsFormatOptions` from this config already succeeded,
+        // and both share the same `to_core_options()` validation.
+        let graphql_options = to_oxc_formatter_graphql(config)
+            .expect("config was already validated when building `JsFormatOptions`");
+
+        external_formatter.to_external_callbacks(format_options, external_options, graphql_options)
     }
 
     /// Format non-JS/TS file using external formatter (Prettier).

--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -3,11 +3,11 @@ use std::num::NonZeroU8;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
 
-use oxc_allocator::{Allocator, ArenaStringBuilder};
-use oxc_formatter::EmbeddedDocResult;
+use oxc_allocator::{Allocator, ArenaStringBuilder, ArenaVec};
+use oxc_formatter::{CssEmbedMeta, HtmlEmbedMeta};
 use oxc_formatter_core::{
-    Align, Condition, DedentMode, FormatElement, Group, GroupId, GroupMode, IndentWidth, LineMode,
-    PrintMode, Tag, TextWidth, UniqueGroupIdBuilder,
+    Align, Condition, DedentMode, DispatchResult, FormatElement, Group, GroupId, GroupMode,
+    IndentWidth, LineMode, PrintMode, Tag, TextWidth, UniqueGroupIdBuilder,
 };
 
 /// Marker string used to represent `-Infinity` in JSON.
@@ -15,11 +15,12 @@ use oxc_formatter_core::{
 /// See `src-js/lib/apis.ts` for details.
 const NEGATIVE_INFINITY_MARKER: &str = "__NEGATIVE_INFINITY__";
 
-/// Converts parsed Prettier Doc JSON values into an [`EmbeddedDocResult`].
+/// Converts parsed Prettier Doc JSON values into a [`DispatchResult`].
 ///
 /// Handles language-specific processing:
-/// - GraphQL: converts each doc independently → [`EmbeddedDocResult::MultipleDocs`]
-/// - CSS, HTML: merges consecutive Text nodes, counts placeholders → [`EmbeddedDocResult::DocWithPlaceholders`]
+/// - GraphQL: converts each doc independently → one IR per doc
+/// - CSS, HTML: merges consecutive Text nodes, counts placeholders →
+///   single IR + [`CssEmbedMeta`] / [`HtmlEmbedMeta`]
 ///
 /// All Doc JSONs use a uniform `[doc, metadata]` envelope from the JS side.
 pub fn to_format_elements_for_template<'a>(
@@ -27,14 +28,14 @@ pub fn to_format_elements_for_template<'a>(
     doc_jsons: Vec<Value>,
     allocator: &'a Allocator,
     group_id_builder: &UniqueGroupIdBuilder,
-) -> Result<EmbeddedDocResult<'a>, String> {
+) -> Result<DispatchResult<'a>, String> {
     /// Unwrap `[doc, metadata]` envelope and convert doc JSON to IR.
     /// Panics on invalid envelope format (internal protocol we control on both sides).
     fn convert<'a>(
         envelope: Value,
         allocator: &'a Allocator,
         group_id_builder: &UniqueGroupIdBuilder,
-    ) -> Result<(Vec<FormatElement<'a>>, serde_json::Map<String, Value>), String> {
+    ) -> Result<(ArenaVec<'a, FormatElement<'a>>, serde_json::Map<String, Value>), String> {
         let Value::Array(mut arr) = envelope else {
             unreachable!("Doc JSON envelope must be [doc, metadata]");
         };
@@ -45,7 +46,7 @@ pub fn to_format_elements_for_template<'a>(
         let doc_json = arr.into_iter().next().expect("Doc JSON envelope must contain doc");
 
         let mut ctx = FmtCtx::new(allocator, group_id_builder);
-        let mut ir = vec![];
+        let mut ir = ArenaVec::new_in(&allocator);
         convert_doc(&doc_json, &mut ir, &mut ctx)?;
         Ok((ir, metadata))
     }
@@ -66,7 +67,7 @@ pub fn to_format_elements_for_template<'a>(
                     Ok(ir)
                 })
                 .collect::<Result<Vec<_>, String>>()?;
-            Ok(EmbeddedDocResult::MultipleDocs(irs))
+            Ok(DispatchResult { docs: irs, meta: None })
         }
         "css" => {
             let (mut ir, _) = convert(
@@ -81,10 +82,9 @@ pub fn to_format_elements_for_template<'a>(
                 TemplateEscape::None,
                 Some(("@prettier-placeholder-", "-id")),
             );
-            Ok(EmbeddedDocResult::DocWithPlaceholders {
-                ir,
-                placeholder_count,
-                html_has_multiple_root_elements: None,
+            Ok(DispatchResult {
+                docs: vec![ir],
+                meta: Some(Box::new(CssEmbedMeta { placeholder_count })),
             })
         }
         "html" | "angular" => {
@@ -102,10 +102,12 @@ pub fn to_format_elements_for_template<'a>(
                 TemplateEscape::Full,
                 Some(("PRETTIER_HTML_PLACEHOLDER_", "_IN_JS")),
             );
-            Ok(EmbeddedDocResult::DocWithPlaceholders {
-                ir,
-                placeholder_count,
-                html_has_multiple_root_elements,
+            Ok(DispatchResult {
+                docs: vec![ir],
+                meta: Some(Box::new(HtmlEmbedMeta {
+                    placeholder_count,
+                    has_multiple_root_elements: html_has_multiple_root_elements,
+                })),
             })
         }
         "markdown" => {
@@ -121,9 +123,36 @@ pub fn to_format_elements_for_template<'a>(
                 TemplateEscape::RawBacktick,
                 None,
             );
-            Ok(EmbeddedDocResult::SingleDoc(ir))
+            Ok(DispatchResult { docs: vec![ir], meta: None })
         }
         _ => unreachable!("Unsupported embedded_doc language: {language}"),
+    }
+}
+
+/// Escape template-literal characters (`` ` ``, `${`, `\`) in every `Text`
+/// element of a Rust-built embedded IR.
+///
+/// Mirrors the `TemplateEscape::Full` step of [`postprocess`] for IRs that
+/// come from a Rust formatter instead of a Prettier Doc: when the embedded
+/// output is re-inserted into a JS template literal built from `.cooked`
+/// values (e.g. graphql-in-js), these characters must be re-escaped.
+///
+/// Only top-level `Text` elements are visited; the IR produced by formatter
+/// crates is a flat tag stream (no nested element containers).
+pub fn escape_template_characters_in_ir<'a>(
+    ir: &mut [FormatElement<'a>],
+    allocator: &'a Allocator,
+    indent_width: IndentWidth,
+) {
+    for element in ir.iter_mut() {
+        if let FormatElement::Text { text, .. } = element {
+            let escaped = escape_template_characters(text, allocator);
+            // `escape_template_characters` returns the input slice when nothing needed escaping
+            if !std::ptr::eq(escaped, *text) {
+                let width = TextWidth::from_text(escaped, indent_width);
+                *element = FormatElement::Text { text: escaped, width };
+            }
+        }
     }
 }
 
@@ -149,7 +178,7 @@ impl<'a, 'b> FmtCtx<'a, 'b> {
 
 fn convert_doc<'a>(
     doc: &Value,
-    out: &mut Vec<FormatElement<'a>>,
+    out: &mut ArenaVec<'a, FormatElement<'a>>,
     ctx: &mut FmtCtx<'a, '_>,
 ) -> Result<(), String> {
     match doc {
@@ -213,7 +242,7 @@ fn convert_doc<'a>(
 
 fn convert_line<'a>(
     obj: &serde_json::Map<String, Value>,
-    out: &mut Vec<FormatElement<'a>>,
+    out: &mut ArenaVec<'a, FormatElement<'a>>,
     ctx: &FmtCtx<'a, '_>,
 ) {
     let hard = obj.get("hard").and_then(Value::as_bool).unwrap_or(false);
@@ -236,7 +265,7 @@ fn convert_line<'a>(
 
 fn convert_group<'a>(
     obj: &serde_json::Map<String, Value>,
-    out: &mut Vec<FormatElement<'a>>,
+    out: &mut ArenaVec<'a, FormatElement<'a>>,
     ctx: &mut FmtCtx<'a, '_>,
 ) -> Result<(), String> {
     if obj.contains_key("expandedStates") {
@@ -258,7 +287,7 @@ fn convert_group<'a>(
 
 fn convert_indent<'a>(
     obj: &serde_json::Map<String, Value>,
-    out: &mut Vec<FormatElement<'a>>,
+    out: &mut ArenaVec<'a, FormatElement<'a>>,
     ctx: &mut FmtCtx<'a, '_>,
 ) -> Result<(), String> {
     out.push(FormatElement::Tag(Tag::StartIndent));
@@ -271,7 +300,7 @@ fn convert_indent<'a>(
 
 fn convert_align<'a>(
     obj: &serde_json::Map<String, Value>,
-    out: &mut Vec<FormatElement<'a>>,
+    out: &mut ArenaVec<'a, FormatElement<'a>>,
     ctx: &mut FmtCtx<'a, '_>,
 ) -> Result<(), String> {
     let n = &obj["n"];
@@ -367,7 +396,7 @@ fn convert_align<'a>(
 
 fn convert_if_break<'a>(
     obj: &serde_json::Map<String, Value>,
-    out: &mut Vec<FormatElement<'a>>,
+    out: &mut ArenaVec<'a, FormatElement<'a>>,
     ctx: &mut FmtCtx<'a, '_>,
 ) -> Result<(), String> {
     let group_id_num = extract_group_id(obj, "groupId")?;
@@ -396,7 +425,7 @@ fn convert_if_break<'a>(
 
 fn convert_indent_if_break<'a>(
     obj: &serde_json::Map<String, Value>,
-    out: &mut Vec<FormatElement<'a>>,
+    out: &mut ArenaVec<'a, FormatElement<'a>>,
     ctx: &mut FmtCtx<'a, '_>,
 ) -> Result<(), String> {
     if obj.get("negate").and_then(Value::as_bool).unwrap_or(false) {
@@ -417,7 +446,7 @@ fn convert_indent_if_break<'a>(
 
 fn convert_fill<'a>(
     obj: &serde_json::Map<String, Value>,
-    out: &mut Vec<FormatElement<'a>>,
+    out: &mut ArenaVec<'a, FormatElement<'a>>,
     ctx: &mut FmtCtx<'a, '_>,
 ) -> Result<(), String> {
     out.push(FormatElement::Tag(Tag::StartFill));
@@ -434,7 +463,7 @@ fn convert_fill<'a>(
 
 fn convert_line_suffix<'a>(
     obj: &serde_json::Map<String, Value>,
-    out: &mut Vec<FormatElement<'a>>,
+    out: &mut ArenaVec<'a, FormatElement<'a>>,
     ctx: &mut FmtCtx<'a, '_>,
 ) -> Result<(), String> {
     out.push(FormatElement::Tag(Tag::StartLineSuffix));
@@ -483,7 +512,7 @@ enum TemplateEscape {
 ///
 /// Returns the placeholder count (0 when `placeholder` is `None`).
 fn postprocess<'a>(
-    ir: &mut Vec<FormatElement<'a>>,
+    ir: &mut ArenaVec<'a, FormatElement<'a>>,
     allocator: &'a Allocator,
     escape: TemplateEscape,
     placeholder: Option<(&str, &str)>,
@@ -493,7 +522,8 @@ fn postprocess<'a>(
         && matches!(ir[ir.len() - 1], FormatElement::ExpandParent)
         && matches!(ir[ir.len() - 2], FormatElement::Line(LineMode::Hard))
     {
-        ir.truncate(ir.len() - 2);
+        let new_len = ir.len() - 2;
+        ir.truncate(new_len);
     }
 
     let mut placeholder_count = 0;

--- a/crates/oxc_formatter/AGENTS.md
+++ b/crates/oxc_formatter/AGENTS.md
@@ -21,7 +21,9 @@ The AST-wrapping IR primitives (`AstNode`, `Format`, `Buffer`, …) are `pub(cra
   - Drives context-dependent decisions like forced parentheses / quote style
   - The formatter knows nothing about Prettier/Vue vocabulary, callers pass wrapped source
 - `format_program`: Special-purpose AST-in entry point
-- `ExternalCallbacks` (in `external_formatter.rs`): Callbacks for embedded-doc / Tailwind formatting delegated back to the host
+- `ExternalCallbacks` (in `external_formatter.rs`): The host-supplied `FormatDispatcher`
+  (embedded-language formatting, see `oxc_formatter_core`'s `embedded` module)
+  plus string-based / Tailwind callbacks delegated back to the host
 
 ### Generated code
 
@@ -49,8 +51,10 @@ After changing AST shapes or the generators, regenerate with `just ast`, never h
 ### Embedded language formatting
 
 - Two directions: xxx-in-js (e.g. css/graphql/html in template literals) and js-in-xxx (e.g. vue/svelte)
-- Both work by Oxfmt injecting Prettier calls through `ExternalCallbacks`
-  - This crate stays unaware of Prettier and only invokes the supplied callbacks
+- xxx-in-js goes through the `FormatDispatcher` Oxfmt assembles (Rust formatter
+  per language where implemented — currently GraphQL — Prettier Doc→IR fallback otherwise);
+  js-in-xxx works by Oxfmt injecting Prettier calls through `ExternalCallbacks`
+  - This crate stays unaware of Prettier and only invokes the supplied dispatcher/callbacks
 
 ## Fixing IR construction
 

--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -1,50 +1,36 @@
 use std::sync::Arc;
 
 use oxc_allocator::Allocator;
+use oxc_formatter_core::{DispatchResult, EmbeddedContext, FormatDispatcher};
 
-use super::formatter::{FormatElement, UniqueGroupIdBuilder};
+use super::formatter::UniqueGroupIdBuilder;
 
 /// Callback function type for formatting embedded code.
 /// Takes (tag_name, code) and returns formatted code or an error.
 pub type EmbeddedFormatterCallback =
     Arc<dyn Fn(&str, &str) -> Result<String, String> + Send + Sync>;
 
-/// Result of formatting embedded code via the Doc→IR path.
+/// Child→parent metadata for CSS formatted as an embedded child.
 ///
-/// The variant depends on the language being formatted:
-/// - GraphQL: multiple IRs (one per quasi text)
-/// - CSS/HTML: single IR with placeholder survival count
-/// - Markdown: single IR only (no placeholders or metadata)
-pub enum EmbeddedDocResult<'a> {
-    MultipleDocs(Vec<Vec<FormatElement<'a>>>),
-    DocWithPlaceholders {
-        ir: Vec<FormatElement<'a>>,
-        /// This indicates how many placeholder patterns survived formatting.
-        placeholder_count: usize,
-        /// HTML-specific: whether the parsed HTML has more than one root element.
-        /// Used to decide whether to `indent` the template content, `None` for non-HTML languages.
-        html_has_multiple_root_elements: Option<bool>,
-    },
-    SingleDoc(Vec<FormatElement<'a>>),
+/// NOTE: Belongs to the CSS formatter crate once it exists
+/// (see `refactor-oxfmt-architecture.md`); lives here until then because
+/// both the producer (oxfmt's dispatcher) and the consumer (`embed/css.rs`)
+/// can reach this crate.
+pub struct CssEmbedMeta {
+    /// How many `@prettier-placeholder-N-id` patterns survived formatting.
+    pub placeholder_count: usize,
 }
 
-/// Callback function type for formatting embedded code via `Doc`.
+/// Child→parent metadata for HTML/Angular formatted as an embedded child.
 ///
-/// Takes (allocator, group_id_builder, language, texts) and returns [`EmbeddedDocResult`].
-/// Used for the Doc→IR path (e.g., `JS:printToDoc()` → Doc JSON → `Rust:FormatElement`).
-///
-/// The `&Allocator` allows the callback to allocate arena strings for `FormatElement::Text`.
-/// The `&UniqueGroupIdBuilder` allows the callback to create `GroupId`s for group/conditional constructs.
-pub type EmbeddedDocFormatterCallback = Arc<
-    dyn for<'a> Fn(
-            &'a Allocator,
-            &UniqueGroupIdBuilder,
-            &str,
-            &[&str],
-        ) -> Result<EmbeddedDocResult<'a>, String>
-        + Send
-        + Sync,
->;
+/// NOTE: Belongs to the HTML formatter crate once it exists (same as [`CssEmbedMeta`]).
+pub struct HtmlEmbedMeta {
+    /// How many `PRETTIER_HTML_PLACEHOLDER_N_0_IN_JS` patterns survived formatting.
+    pub placeholder_count: usize,
+    /// Whether the parsed HTML has more than one root element.
+    /// Used to decide whether to `indent` the template content.
+    pub has_multiple_root_elements: Option<bool>,
+}
 
 /// Callback function type for sorting Tailwind CSS classes.
 /// Takes classes and returns the sorted versions.
@@ -52,20 +38,21 @@ pub type TailwindCallback = Arc<dyn Fn(Vec<String>) -> Vec<String> + Send + Sync
 
 /// External callbacks for JS-side functionality.
 ///
-/// This struct holds all callbacks that delegate to external (typically JS) implementations:
+/// This struct holds all callbacks that delegate to external implementations:
 /// - Embedded language formatting (CSS, GraphQL, HTML in template literals)
+///   via the orchestrator-assembled [`FormatDispatcher`]
 /// - Tailwind CSS class sorting
 #[derive(Default)]
 pub struct ExternalCallbacks {
     embedded_formatter: Option<EmbeddedFormatterCallback>,
-    embedded_doc_formatter: Option<EmbeddedDocFormatterCallback>,
+    dispatcher: Option<FormatDispatcher>,
     tailwind: Option<TailwindCallback>,
 }
 
 impl ExternalCallbacks {
     /// Create a new `ExternalCallbacks` with no callbacks set.
     pub fn new() -> Self {
-        Self { embedded_formatter: None, embedded_doc_formatter: None, tailwind: None }
+        Self { embedded_formatter: None, dispatcher: None, tailwind: None }
     }
 
     /// Set the embedded formatter callback.
@@ -75,13 +62,10 @@ impl ExternalCallbacks {
         self
     }
 
-    /// Set the embedded Doc formatter callback (Doc→IR path).
+    /// Set the embedded-language dispatcher (IR path).
     #[must_use]
-    pub fn with_embedded_doc_formatter(
-        mut self,
-        callback: Option<EmbeddedDocFormatterCallback>,
-    ) -> Self {
-        self.embedded_doc_formatter = callback;
+    pub fn with_dispatcher(mut self, dispatcher: Option<FormatDispatcher>) -> Self {
+        self.dispatcher = dispatcher;
         self
     }
 
@@ -108,31 +92,38 @@ impl ExternalCallbacks {
         self.embedded_formatter.as_ref().map(|cb| cb(language, code))
     }
 
-    /// Format embedded code as Doc.
+    /// Format embedded code through the dispatcher (IR path).
+    ///
+    /// Builds an [`EmbeddedContext`] from the current formatting state and
+    /// invokes the dispatcher with it, so the child formatter shares this
+    /// formatter's arena and `GroupId` space (and can recurse further).
     ///
     /// # Arguments
     /// * `allocator` - The arena allocator for allocating strings in `FormatElement::Text`
     /// * `group_id_builder` - Builder for creating unique `GroupId`s
     /// * `language` - A generic language identifier (e.g., "css", "graphql", "html", "angular").
     ///   These are NOT specific to any external formatter.
-    ///   The callback implementation is responsible for mapping them to its own parser/language names.
+    ///   The dispatcher implementation is responsible for mapping them to its own parser/language names.
     /// * `texts` - The code texts to format (multiple quasis for GraphQL, single joined text for CSS/HTML)
     ///
     /// # Returns
-    /// * `Some(Ok(EmbeddedDocResult))` - The formatted Doc result, which may contain multiple IRs or placeholder counts depending on the language (see [`EmbeddedDocResult`])
+    /// * `Some(Ok(DispatchResult))` - The formatted IR(s) plus optional child→parent metadata
     /// * `Some(Err(String))` - An error message if formatting failed
-    /// * `None` - No embedded Doc formatter callback is set
-    ///
-    pub fn format_embedded_doc<'a>(
+    /// * `None` - No dispatcher is set
+    pub fn dispatch_embedded<'a>(
         &self,
         allocator: &'a Allocator,
         group_id_builder: &UniqueGroupIdBuilder,
         language: &str,
         texts: &[&str],
-    ) -> Option<Result<EmbeddedDocResult<'a>, String>> {
-        self.embedded_doc_formatter
-            .as_ref()
-            .map(|cb| cb(allocator, group_id_builder, language, texts))
+    ) -> Option<Result<DispatchResult<'a>, String>> {
+        let dispatcher = self.dispatcher.as_ref()?;
+        let ctx = EmbeddedContext {
+            allocator,
+            group_id_builder,
+            dispatcher: Some(Arc::clone(dispatcher)),
+        };
+        Some(dispatcher(&ctx, language, texts, None))
     }
 
     /// Sort Tailwind CSS classes.

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -25,8 +25,7 @@ use oxc_span::SourceType;
 // or the special-purpose AST-in `format_program`.
 pub(crate) use crate::ast_nodes::{AstNode, AstNodes};
 pub use crate::external_formatter::{
-    EmbeddedDocFormatterCallback, EmbeddedDocResult, EmbeddedFormatterCallback, ExternalCallbacks,
-    TailwindCallback,
+    CssEmbedMeta, EmbeddedFormatterCallback, ExternalCallbacks, HtmlEmbedMeta, TailwindCallback,
 };
 // `JsFormatContext` is public solely as the type parameter of the `Formatted`
 // returned by `format` / `format_fragment`.

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -4,7 +4,7 @@ use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::AstNode,
-    external_formatter::EmbeddedDocResult,
+    external_formatter::CssEmbedMeta,
     format_args,
     formatter::{FormatElement, prelude::*},
     write,
@@ -39,11 +39,15 @@ pub(super) fn format_css_doc<'a>(
 
         let allocator = f.allocator();
         let group_id_builder = f.group_id_builder();
-        let Some(Ok(EmbeddedDocResult::DocWithPlaceholders { ir, .. })) = f
-            .context()
-            .external_callbacks()
-            .format_embedded_doc(allocator, group_id_builder, "css", &[raw])
-        else {
+        let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
+            allocator,
+            group_id_builder,
+            "css",
+            &[raw],
+        ) else {
+            return false;
+        };
+        let Some(ir) = result.into_single_doc() else {
             return false;
         };
 
@@ -68,14 +72,26 @@ pub(super) fn format_css_doc<'a>(
         sb.into_str()
     };
 
-    // Phase 2: Format via the Doc→IR path
+    // Phase 2: Format via the dispatcher (IR path)
     let allocator = f.allocator();
     let group_id_builder = f.group_id_builder();
-    let Some(Ok(EmbeddedDocResult::DocWithPlaceholders { ir, placeholder_count, .. })) = f
-        .context()
-        .external_callbacks()
-        .format_embedded_doc(allocator, group_id_builder, "css", &[joined])
+    let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
+        allocator,
+        group_id_builder,
+        "css",
+        &[joined],
+    ) else {
+        return false;
+    };
+    let Some(placeholder_count) = result
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.downcast_ref::<CssEmbedMeta>())
+        .map(|meta| meta.placeholder_count)
     else {
+        return false;
+    };
+    let Some(ir) = result.into_single_doc() else {
         return false;
     };
 

--- a/crates/oxc_formatter/src/print/template/embed/graphql.rs
+++ b/crates/oxc_formatter/src/print/template/embed/graphql.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Allocator;
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_formatter_core::IndentWidth;
 
@@ -90,20 +90,25 @@ pub(super) fn format_graphql_doc<'a>(
     } else {
         let allocator = f.allocator();
         let group_id_builder = f.group_id_builder();
-        let Some(Ok(crate::external_formatter::EmbeddedDocResult::MultipleDocs(irs))) = f
-            .context()
-            .external_callbacks()
-            .format_embedded_doc(allocator, group_id_builder, "graphql", &texts_to_format)
-        else {
+        let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
+            allocator,
+            group_id_builder,
+            "graphql",
+            &texts_to_format,
+        ) else {
             return false;
         };
-        irs
+        // One IR per sent text is the dispatcher contract for GraphQL.
+        if result.docs.len() != texts_to_format.len() {
+            return false;
+        }
+        result.docs
     };
 
     // Phase 3: Build `ir_parts` by mapping formatted results back to original indices.
     // Use `into_iter` to take ownership and avoid cloning.
     let mut irs_iter = all_irs.into_iter();
-    let mut ir_parts: Vec<Option<Vec<FormatElement<'a>>>> = Vec::with_capacity(num_quasis);
+    let mut ir_parts: Vec<Option<ArenaVec<'a, FormatElement<'a>>>> = Vec::with_capacity(num_quasis);
     for (idx, info) in infos.iter().enumerate() {
         if format_index_map[idx].is_some() {
             ir_parts.push(irs_iter.next());
@@ -195,10 +200,10 @@ fn build_graphql_comment_ir<'a>(
     text: &str,
     allocator: &'a Allocator,
     indent_width: IndentWidth,
-) -> Option<Vec<FormatElement<'a>>> {
+) -> Option<ArenaVec<'a, FormatElement<'a>>> {
     // This comes from `.cooked`, which has normalized line terminators
     let lines: Vec<&str> = text.split('\n').map(str::trim).collect();
-    let mut parts: Vec<FormatElement<'a>> = vec![];
+    let mut parts: ArenaVec<'a, FormatElement<'a>> = ArenaVec::new_in(&allocator);
     let mut seen_comment = false;
 
     for (i, line) in lines.iter().enumerate() {

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -7,7 +7,7 @@ use oxc_syntax::line_terminator::LineTerminatorSplitter;
 
 use crate::{
     ast_nodes::AstNode,
-    external_formatter::EmbeddedDocResult,
+    external_formatter::HtmlEmbedMeta,
     format_args,
     formatter::{
         FormatElement, buffer::RemoveSoftLinesBuffer, prelude::*, trivia::FormatTrailingComments,
@@ -55,17 +55,23 @@ pub(super) fn format_html_doc<'a>(
 
         let allocator = f.allocator();
         let group_id_builder = f.group_id_builder();
-        let Some(Ok(EmbeddedDocResult::DocWithPlaceholders {
-            ir,
-            html_has_multiple_root_elements,
-            ..
-        })) = f.context().external_callbacks().format_embedded_doc(
+        let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
             allocator,
             group_id_builder,
             embedded_language,
             &[cooked],
-        )
+        ) else {
+            return false;
+        };
+        let Some(html_has_multiple_root_elements) = result
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.downcast_ref::<HtmlEmbedMeta>())
+            .map(|meta| meta.has_multiple_root_elements)
         else {
+            return false;
+        };
+        let Some(ir) = result.into_single_doc() else {
             return false;
         };
 
@@ -106,24 +112,19 @@ pub(super) fn format_html_doc<'a>(
     let has_leading_ws = joined.starts_with(|c: char| c.is_ascii_whitespace());
     let has_trailing_ws = joined.ends_with(|c: char| c.is_ascii_whitespace());
 
-    // Phase 2: Format via the Doc->IR path
+    // Phase 2: Format via the dispatcher (IR path)
     let allocator = f.allocator();
     let group_id_builder = f.group_id_builder();
-    let Some(Ok(EmbeddedDocResult::DocWithPlaceholders {
-        ir,
-        placeholder_count,
-        html_has_multiple_root_elements,
-    })) = f.context().external_callbacks().format_embedded_doc(
+    let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
         allocator,
         group_id_builder,
         embedded_language,
         &[joined],
-    )
-    else {
+    ) else {
         // NOTE: If this html-in-js part contains `<script>` (= js-in-html-in-js),
         // returned Prettier's `Doc` output may contain `conditionalGroup`.
         // But currently, `oxfmt/prettier_compat/from_prettier_doc.rs` does not support this.
-        // So `format_embedded_doc()` will return `Err`.
+        // So `dispatch_embedded()` will return `Err`.
         //
         // In Prettier, `conditionalGroup` is only used by JS and YAML formatting.
         // And we want to format JS by `oxc_formatter` via oxfmt-plugin,
@@ -132,6 +133,17 @@ pub(super) fn format_html_doc<'a>(
         // Support `conditionalGroup` and convert to our `BestFitting` may be possible,
         // but it also requires placeholder replacement, which is non-trivial.
         return format_js_in_html_as_fallback(joined, &expressions, f);
+    };
+    let Some((placeholder_count, html_has_multiple_root_elements)) = result
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.downcast_ref::<HtmlEmbedMeta>())
+        .map(|meta| (meta.placeholder_count, meta.has_multiple_root_elements))
+    else {
+        return false;
+    };
+    let Some(ir) = result.into_single_doc() else {
+        return false;
     };
 
     // Verify all placeholders survived HTML formatting.

--- a/crates/oxc_formatter/src/print/template/embed/markdown.rs
+++ b/crates/oxc_formatter/src/print/template/embed/markdown.rs
@@ -29,14 +29,18 @@ pub(super) fn try_embed_markdown<'a>(
     let has_indent = !indentation.is_empty();
     let text = if has_indent { strip_indentation(text, indentation, allocator) } else { text };
 
-    // Phase 3: Get Doc→IR from external formatter
+    // Phase 3: Get the IR from the dispatcher
     let allocator = f.allocator();
     let group_id_builder = f.group_id_builder();
-    let Some(Ok(crate::external_formatter::EmbeddedDocResult::SingleDoc(ir))) = f
-        .context()
-        .external_callbacks()
-        .format_embedded_doc(allocator, group_id_builder, "markdown", &[text])
-    else {
+    let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
+        allocator,
+        group_id_builder,
+        "markdown",
+        &[text],
+    ) else {
+        return false;
+    };
+    let Some(ir) = result.into_single_doc() else {
         return false;
     };
 

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -29,6 +29,17 @@ The core is parameterized over a consumer-supplied context so it stays language-
   - All generic over the context `C`, consumers add a `C` bound only on `impl` blocks
   - Not on struct definitions, and typically define a `type FooFormatter<…> = Formatter<…, FooContext<…>>` alias to keep lifetimes aligned
 
+### Embedded-language infrastructure (`embedded.rs`)
+
+`EmbeddedContext` / `FormatDispatcher` / `DispatchResult` / `TailwindCollector` let one
+formatter's IR be built inside another's document (e.g. graphql-in-js):
+
+- The orchestrator (oxfmt) assembles the dispatcher, mapping language names to
+  formatter implementations (or a Prettier fallback); formatter crates only invoke it
+- Parent and child share one arena and one `GroupId` space through `EmbeddedContext`
+- Language-pair specific data crosses the boundary as `dyn Any` only —
+  core never learns concrete languages
+
 ### What belongs in core (the boundary)
 
 Two layers, two admission rules. A type/fn that fits neither belongs in a consumer crate.

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -1,0 +1,91 @@
+//! Embedded-language formatting infrastructure.
+//!
+//! All formatters are peers: any formatter may act as a parent (containing
+//! embedded code) or as a child (being embedded). Only the entry formatter is
+//! called directly by the orchestrator (oxfmt); every further embedded call
+//! goes through a [`FormatDispatcher`] that the orchestrator assembles,
+//! mapping a language name to a formatter implementation (or a fallback).
+//!
+//! Core only carries the shared plumbing (arena, group-id space, recursion
+//! handle) plus `dyn Any` passthroughs for language-pair specific data;
+//! it knows nothing about any concrete language.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use oxc_allocator::{Allocator, ArenaVec};
+
+use crate::{FormatElement, group_id::UniqueGroupIdBuilder};
+
+/// Shared IR-infrastructure context for formatting embedded code.
+///
+/// The same context is threaded through recursive dispatcher calls so that
+/// nested embeddings (e.g. css-in-html-in-js) share one arena and one
+/// `GroupId` space.
+pub struct EmbeddedContext<'a, 'g> {
+    /// Arena shared between parent and child formatters;
+    /// strings allocated by the child live as long as the parent's IR.
+    pub allocator: &'a Allocator,
+    /// `GroupId` builder shared to avoid id collisions across formatters.
+    pub group_id_builder: &'g UniqueGroupIdBuilder,
+    /// Dispatcher for the child formatter to format its own embedded languages.
+    /// `None` when recursion is not available (e.g. plain standalone formatting).
+    pub dispatcher: Option<FormatDispatcher>,
+}
+
+/// Dispatcher resolving a language name to a formatter implementation.
+///
+/// Assembled by the orchestrator (oxfmt), which knows all languages;
+/// formatter crates only invoke it. Arguments are
+/// `(context, language, texts, parent_context)`:
+///
+/// - `language`: generic language identifier (e.g. `"css"`, `"graphql"`)
+/// - `texts`: code to format. Usually a single text; GraphQL sends N quasis
+///   and receives N IRs back
+/// - `parent_context`: parent→child language-pair specific data, downcast by
+///   the implementation (`None` for most pairs)
+pub type FormatDispatcher = Arc<
+    dyn for<'a, 'g> Fn(
+            &EmbeddedContext<'a, 'g>,
+            &str,
+            &[&str],
+            Option<&dyn Any>,
+        ) -> Result<DispatchResult<'a>, String>
+        + Send
+        + Sync,
+>;
+
+/// Result of a [`FormatDispatcher`] call.
+pub struct DispatchResult<'a> {
+    /// One IR per input text (usually one; GraphQL returns one per quasi).
+    /// Each IR is arena-allocated alongside its elements.
+    pub docs: Vec<ArenaVec<'a, FormatElement<'a>>>,
+    /// Child→parent language-specific metadata; the parent downcasts it
+    /// (e.g. placeholder survival counts for CSS/HTML).
+    pub meta: Option<Box<dyn Any>>,
+}
+
+impl<'a> DispatchResult<'a> {
+    /// Extract the IR for single-text dispatches (every language except GraphQL).
+    /// Returns `None` when the dispatcher produced no docs.
+    pub fn into_single_doc(self) -> Option<ArenaVec<'a, FormatElement<'a>>> {
+        self.docs.into_iter().next()
+    }
+}
+
+/// Collector sharing one Tailwind class index space across embedded boundaries.
+///
+/// `FormatElement::TailwindClass(usize)` holds pre-sort class strings by index;
+/// sorting happens in one batch after the entry formatter completes. Parent and
+/// child must allocate indices from the same collector to avoid collisions.
+pub trait TailwindCollector {
+    /// Register a class string, returning its index in the shared space.
+    fn add_class(&mut self, class: String) -> usize;
+}
+
+/// No-op collector for languages without Tailwind support (JSON, GraphQL, …).
+impl TailwindCollector for () {
+    fn add_class(&mut self, _class: String) -> usize {
+        0
+    }
+}

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -17,6 +17,7 @@ mod arguments;
 pub mod buffer;
 pub mod builders;
 mod diagnostics;
+mod embedded;
 pub mod format;
 pub mod format_element;
 mod format_extensions;
@@ -42,6 +43,7 @@ pub use buffer::{
     VecBuffer,
 };
 pub use diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError};
+pub use embedded::{DispatchResult, EmbeddedContext, FormatDispatcher, TailwindCollector};
 pub use format::{Format, write};
 pub use format_element::debug::DisplayDocument;
 pub use format_element::document::Document;

--- a/crates/oxc_formatter_graphql/AGENTS.md
+++ b/crates/oxc_formatter_graphql/AGENTS.md
@@ -7,6 +7,11 @@ Prettier compatible GraphQL formatter (`oxfmt`'s Tier 1 backend), using the `oxc
 - Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
   - See `crates/oxc_formatter_core/AGENTS.md` for the IR/pipeline details
 - This crate holds only the GraphQL-specific layer
+- Two entry points:
+  - `format()`: standalone files (returns a printable `Formatted`)
+  - `format_to_ir()`: embedded use via the dispatcher (graphql-in-js); allocates
+    from the shared `EmbeddedContext` arena, emits no BOM / trailing newline,
+    and leaves `propagate_expand()` to the parent document
 - Parses with [apollo-parser](https://docs.rs/apollo-parser) (rowan-based lossless CST)
   - Spec coverage: **October 2021 GraphQL spec only**
   - Prettier parses with `graphql-js`, which also accepts draft-level syntax
@@ -17,7 +22,7 @@ Prettier compatible GraphQL formatter (`oxfmt`'s Tier 1 backend), using the `oxc
 
 ### Error semantics
 
-`format()` returns `Err` whenever it cannot produce output it can stand behind:
+`format()` / `format_to_ir()` return `Err` whenever they cannot produce output they can stand behind:
 
 - apollo-parser is error-tolerant (returns a CST even for invalid input),
   but any parse error bails out; never format a broken CST

--- a/crates/oxc_formatter_graphql/src/format.rs
+++ b/crates/oxc_formatter_graphql/src/format.rs
@@ -2,7 +2,7 @@ use apollo_parser::{Parser, SyntaxKind, cst, cst::CstNode};
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
-    Buffer, Document, Format, FormatState, Formatted, VecBuffer,
+    Buffer, Document, EmbeddedContext, Format, FormatElement, FormatState, Formatted, VecBuffer,
     builders::{hard_line_break, text},
     write,
 };
@@ -27,7 +27,63 @@ pub fn format<'a>(
     source_text: &str,
     options: GraphqlFormatOptions,
 ) -> Result<Formatted<'a, GraphqlFormatContext<'a>>, OxcDiagnostic> {
-    // Copy the source into the arena so every slice taken from it carries `'a`.
+    let (document, source, comments) = parse_document(allocator, source_text)?;
+
+    let context = GraphqlFormatContext::new(options, source, comments);
+    let mut state = FormatState::new(context, allocator);
+    let mut buffer = VecBuffer::new(&mut state);
+
+    let has_bom = source.starts_with('\u{feff}');
+    write!(&mut buffer, FormatGraphqlRoot { document: &document, has_bom });
+
+    let elements = buffer.into_vec();
+    let context = state.into_context();
+
+    let ir = Document::new(elements, Vec::new());
+    ir.propagate_expand();
+
+    Ok(Formatted::new(ir, context))
+}
+
+/// Parse `source_text` and build the formatter IR for embedding into another
+/// formatter's document (dispatcher path, e.g. graphql-in-js).
+///
+/// Unlike [`format()`], this:
+/// - allocates from the shared arena in `ctx`, so the IR lives as long as the
+///   parent's document
+/// - emits neither a BOM nor the trailing newline (the parent owns the layout
+///   around the embedded part, matching Prettier's `textToDoc` +
+///   `stripTrailingHardline` behavior)
+/// - skips `propagate_expand()`, which the parent runs on the merged document
+///
+/// # Errors
+/// Same as [`format()`]: any parse error bails out, and the caller decides
+/// what to do next (e.g. fall back to Prettier).
+pub fn format_to_ir<'a>(
+    ctx: &EmbeddedContext<'a, '_>,
+    source_text: &str,
+    options: GraphqlFormatOptions,
+) -> Result<ArenaVec<'a, FormatElement<'a>>, OxcDiagnostic> {
+    let allocator = ctx.allocator;
+    let (document, source, comments) = parse_document(allocator, source_text)?;
+
+    let context = GraphqlFormatContext::new(options, source, comments);
+    let mut state = FormatState::new(context, allocator);
+    let mut buffer = VecBuffer::new(&mut state);
+
+    write!(&mut buffer, FormatGraphqlEmbedded { document: &document });
+
+    Ok(buffer.into_vec())
+}
+
+/// Parse the source into a CST and collect comment trivia,
+/// bailing out on any parse error.
+///
+/// Copies the source into the arena so every slice taken from it carries `'a`.
+fn parse_document<'a>(
+    allocator: &'a Allocator,
+    source_text: &str,
+) -> Result<(cst::Document, &'a str, &'a [Span]), OxcDiagnostic> {
     let source: &'a str = allocator.alloc_str(source_text);
 
     let tree = Parser::new(source).parse();
@@ -55,20 +111,7 @@ pub fn format<'a>(
     )
     .into_arena_slice();
 
-    let context = GraphqlFormatContext::new(options, source, comments);
-    let mut state = FormatState::new(context, allocator);
-    let mut buffer = VecBuffer::new(&mut state);
-
-    let has_bom = source.starts_with('\u{feff}');
-    write!(&mut buffer, FormatGraphqlRoot { document: &document, has_bom });
-
-    let elements = buffer.into_vec();
-    let context = state.into_context();
-
-    let ir = Document::new(elements, Vec::new());
-    ir.propagate_expand();
-
-    Ok(Formatted::new(ir, context))
+    Ok((document, source, comments))
 }
 
 /// Emits the document's definitions followed by any trailing comments,
@@ -88,5 +131,17 @@ impl<'a> Format<'a, GraphqlFormatContext<'a>> for FormatGraphqlRoot<'_> {
 
         // POSIX convention: every formatted file ends with a newline.
         write!(f, hard_line_break());
+    }
+}
+
+/// Emits the document's definitions and trailing comments only;
+/// no BOM, no final newline (the parent document owns the surrounding layout).
+struct FormatGraphqlEmbedded<'b> {
+    document: &'b cst::Document,
+}
+
+impl<'a> Format<'a, GraphqlFormatContext<'a>> for FormatGraphqlEmbedded<'_> {
+    fn fmt(&self, f: &mut GraphqlFormatter<'_, 'a>) {
+        print::write_document(self.document, f);
     }
 }

--- a/crates/oxc_formatter_graphql/src/lib.rs
+++ b/crates/oxc_formatter_graphql/src/lib.rs
@@ -21,6 +21,6 @@ mod print;
 
 pub use crate::{
     context::GraphqlFormatContext,
-    format::format,
+    format::{format, format_to_ir},
     options::{BracketSpacing, GraphqlFormatOptions},
 };


### PR DESCRIPTION
- To use `oxc_formatter_graphql` in gql-in-js context, ground level refactoring was needed
- Extracted common logic for handling embeddings into `oxc_formatter_core`
- Updated other `xxx-in-js` callers to reflect these changes
- Added a `format_to_ir()` method to each formatter in addition to the existing `format()` method