### PR TITLE
feat(formatter_css): implement `oxc_formatter_css`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hmac-sha1-compact"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2169,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_formatter_css"
+version = "0.54.0"
+dependencies = [
+ "cow-utils",
+ "oxc_allocator",
+ "oxc_diagnostics",
+ "oxc_formatter_core",
+ "oxc_span",
+ "pico-args",
+ "raffia",
+]
+
+[[package]]
 name = "oxc_formatter_graphql"
 version = "0.54.0"
 dependencies = [
@@ -2496,6 +2515,7 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_formatter",
  "oxc_formatter_core",
+ "oxc_formatter_css",
  "oxc_formatter_graphql",
  "oxc_formatter_json",
  "oxc_parser",
@@ -3128,6 +3148,27 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "raffia"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a589c5611a5f7713bf0c13e949c4c791a359ff517a9f27552475b470e8873229"
+dependencies = [
+ "raffia_macro",
+ "smallvec",
+]
+
+[[package]]
+name = "raffia_macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ac21f5e4bc6b29ea5d5e691a9aa08b2b9fd8891f48a99157b9f02d8a48e1318"
+dependencies = [
+ "heck",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "rand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ oxc_traverse = { version = "0.137.0", path = "crates/oxc_traverse" } # AST trave
 # publish = false
 oxc_formatter = { path = "crates/oxc_formatter" } # Code formatting
 oxc_formatter_core = { path = "crates/oxc_formatter_core" } # Language-agnostic formatter core
+oxc_formatter_css = { path = "crates/oxc_formatter_css" } # CSS formatter
 oxc_formatter_graphql = { path = "crates/oxc_formatter_graphql" } # GraphQL formatter
 oxc_formatter_json = { path = "crates/oxc_formatter_json" } # JSON formatter
 oxc_language_server = { path = "crates/oxc_language_server", default-features = false } # Language server
@@ -226,6 +227,7 @@ pico-args = "0.5.0" # Minimal argument parser
 prettyplease = "0.2.37" # Rust code formatting
 project-root = "0.2.2" # Project root detection
 quickcheck = "1.1.0" # Property-based testing
+raffia = "0.12.3" # CSS/SCSS/Less parser
 rand = "0.10.0" # Random number generation
 rayon = "1.11.0" # Data parallelism
 ropey = "1.6.1" # Rope text structure

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -1,0 +1,136 @@
+# Coding agent guides for `crates/oxc_formatter_css`
+
+## Overview
+
+Prettier compatible CSS/SCSS/Less formatter, using the `oxc_formatter_core` APIs.
+
+- Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
+- Parses with [raffia](https://docs.rs/raffia) 0.12 (AST with full spans + `raw` text; NOT a CST)
+  - Comments are NOT in the AST: collected via `ParserBuilder::comments()` into
+    a positional cursor (`src/comments.rs`, mirrors `oxc_formatter_graphql`)
+  - The canonical reference is Prettier's `src/language-css/printer-postcss.js`
+    (in `tasks/prettier_conformance/prettier`, v3.8.x) — port its layout
+    decisions, do not invent new ones
+- Two entry points: `format()` (standalone) and `format_to_ir()` (embedded/dispatcher)
+
+### Error semantics
+
+`format()` / `format_to_ir()` return `Err` on ANY parse error, including
+raffia's recoverable ones (`parser.recoverable_errors()`); oxfmt then falls
+back to Prettier (napi build).
+
+### Architecture notes (Prettier mapping)
+
+Prettier's CSS printer operates on postcss + three sub-parsers
+(postcss-selector-parser → `selector-*`, postcss-values-parser → `value-*`,
+postcss-media-query-parser → `media-*`) and depends on `raws` (source gaps).
+raffia parses everything structurally in one pass; source gaps are recovered
+by comparing span boundaries (`hasEmptyRawBefore(x)` == "no gap between spans").
+
+- `src/print/mod.rs` — statement sequences (hardline-separated, one blank line
+  preserved via `classify_gap`), trailing same-line comments
+- `src/print/statement.rs` — qualified rules, declarations, blocks, dispatch.
+  `stmt_end()` extends spans over whitespace/comments + `;` (postcss `locEnd`
+  includes the semicolon; blank-line detection counts from after it)
+- `src/print/value.rs` — the port of `printCommaSeparatedValueGroup` /
+  `printParenthesizedValueGroup` over flat `ComponentValue` streams
+  (raffia keeps `Delimiter` commas/solidi inline, like postcss-values tokens).
+  Key rules ported: solidus tightness (font sizes, leading `/`), grid hardlines
+  (+ leading hardline when the source breaks), `printNumber`/`printCssNumber`,
+  `printString` re-quoting, CSS_UNITS canonical casing, wide-keywords/hex
+  lowercase, `composes` removeLines, `progid:` verbatim, url() inner verbatim
+- `src/print/selector.rs` — selectors; combinators carry the break point
+  BEFORE themselves; `maybeToLowerCase` for pseudos; attribute values are
+  quoted via `printString`
+- `src/print/at_rule.rs` — prelude dispatch; media query port; TokenSeq
+  fallback printing (gap-based separators, break AFTER math operators);
+  "fused" preludes (`@page:first` stays tight when the source has no gap);
+  SCSS control directives wrap `[space, prelude, line]` in a group so `{`
+  drops to its own line when the prelude breaks — EXCEPT fully parenthesized
+  conditions (Prettier's `hasParensAroundNode` → `{` stays on the `)` line)
+- `src/print/scss.rs` — `$var` declarations, maps (always break, one item per
+  line, trailing comma per option), lists, `@each`/`@for`/`@if` chains
+  (`} @else` joined), mixin/include/function params, `@use`/`@forward` with
+  always-broken `with (...)` configs
+- `src/print/less.rs` — `@var` declarations, mixin definitions/calls, guards,
+  lookups (`[@result]` tight), detached rulesets
+
+### Comments
+
+Positional cursor over `CssComment { span, inline }` (`inline` = `//`).
+
+- Statement-level comments: flushed before each statement
+  (`flush_leading_comments`); consecutive same-line comments stay glued
+  (`*/ /*!`), but a comment is always followed by a line break before a node
+- Value-level comments: flushed inside fill entries before the component they
+  precede (`flush_value_comments`); `//` comments expand the parent group and
+  force a hardline after
+- Trailing (`value /* c */;`): flushed by `write_declaration` with the source
+  gap before `;` preserved
+- After each statement, the sequence DISCARDS unclaimed comments inside the
+  statement span (cursor must never point before a printed position)
+
+## Status (2026-06-11)
+
+`cargo run -p oxc_prettier_conformance` —
+**css 114/114, scss 85/85, less 39/39 — ALL 100%.**
+Keep it that way: any change here must re-run the conformance suite.
+
+Layout machinery notes discovered en route:
+
+- Our core `fill` breaks the separator AFTER a hard-broken entry (biome
+  semantics) and measures fits only up to a hardline; Prettier's fill
+  fit-checks `[item, sep, next-item]` and treats a hardline-bearing chunk
+  as never fitting. Where that diverges, separator breaks are SIMULATED
+  with static source widths (`write_commented_value_params` /
+  `write_commented_media_params` in `at_rule.rs`, the SassImport path,
+  the lead-comment fill in `write_value_groups`)
+- Prettier's printer counts a multi-line string doc at its FULL width (no
+  newline reset), so after a multi-line `raws.between` the first trailing
+  comment always wraps → `ValueContext::tail_break`
+- `css-decl` prints the WHOLE trimmed `raws.between` (prop → value, colon
+  and comments included) verbatim; a trailing `//` line drops the value to
+  `indent([hardline, dedent(value)])`; same-line space runs before `//`
+  collapse to one (postcss-less keeps inline comments out of between)
+- At-rule params containing block comments are rebuilt from the source
+  (postcss keeps them inside the params string): `@keyframes`-style names →
+  whitespace-normalized verbatim; `@media` → media-token reconstruction
+  (`)` ends a single-line paren token; spaced `feature : value` re-spaces,
+  glued/multi-line stays verbatim); `@import`/`@supports` → value-token
+  fill simulation with always-broken comment-bearing parens. `//` comments
+  stay on the structural printers
+- Selectors containing `//` comments are `selector-unknown` in Prettier:
+  raw verbatim, `{` pushed to the next line after a trailing `//`
+- SCSS control-directive conditions are `group(indent(parts))`, NOT a fill:
+  space before every operator, breakable line after it, all-or-nothing
+  (`write_condition_chain`); source-glued `$a==b` stays glued
+- `isSCSSMapItemNode` is ported as two ctx flags: `map_break` (SassMap in
+  `$var:`/function-arg/map-item positions always breaks) and `paren_break`
+  (paren groups break ONLY as direct map-item/config values); outside those
+  positions maps stay inline, preserve source blank lines between items,
+  and print no trailing comma
+- A function call directly after a `//` comment gets Prettier's quirky
+  double indent (args +2 levels, `)` +1 — `ValueContext::after_inline_comment`)
+- An interpolated string whose outer quote re-appears inside (`'#{f('a')}'`)
+  splits in postcss → every piece requotes to the preferred quote
+- YAML front matter: best-effort normalization in `format.rs`
+  (`try_format_yaml_front_matter`) — plain mappings/sequences/comments only,
+  anything else verbatim. Removed at plan Step 7 (front matter handling
+  moves up to oxfmt's shared pre-pass; `oxc_formatter_yaml` formats it)
+- TokenSeq mini-printer is recursive: top-level commas → fill;
+  balanced paren regions → groups; `name(`/`$k: (` glue; math ops break
+  after, comparisons stand alone; numbers/strings normalized
+- Static-width simulations assume top-level at-rules (column 0); deeply
+  nested commented at-rule params would mismeasure (not in the suite).
+  `prettier@3.8.1` runs directly via `npx prettier@3.8.1 --parser css` —
+  invaluable for verifying layout hypotheses against small repros
+
+## Verification
+
+```sh
+cargo check -p oxc_formatter_css
+cargo run -p oxc_prettier_conformance                          # pass rates
+cargo run -p oxc_prettier_conformance -- --filter css/atrule   # diff a fixture
+cargo run -p oxc_formatter_css --example css_formatter file.css
+cargo run -p oxc_formatter_css --example parse_debug -- --syntax scss file.scss  # dump raffia AST
+```

--- a/crates/oxc_formatter_css/CLAUDE.md
+++ b/crates/oxc_formatter_css/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/crates/oxc_formatter_css/Cargo.toml
+++ b/crates/oxc_formatter_css/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "oxc_formatter_css"
+version = "0.54.0"
+authors.workspace = true
+categories.workspace = true
+edition.workspace = true
+homepage.workspace = true
+include = ["/src"]
+keywords.workspace = true
+license.workspace = true
+publish = false
+repository.workspace = true
+rust-version.workspace = true
+description.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+cow-utils = { workspace = true }
+oxc_allocator = { workspace = true }
+oxc_diagnostics = { workspace = true }
+oxc_formatter_core = { workspace = true }
+oxc_span = { workspace = true }
+raffia = { workspace = true }
+
+[dev-dependencies]
+oxc_formatter_core = { workspace = true, features = ["test_harness"] }
+pico-args = { workspace = true }
+
+[build-dependencies]
+oxc_formatter_core = { workspace = true, features = ["test_harness"] }
+
+[lib]
+doctest = false

--- a/crates/oxc_formatter_css/examples/css_formatter.rs
+++ b/crates/oxc_formatter_css/examples/css_formatter.rs
@@ -1,0 +1,44 @@
+//! Format a CSS/SCSS/Less file and print the result.
+//!
+//! ```sh
+//! cargo run -p oxc_formatter_css --example css_formatter -- [filename]
+//! ```
+#![expect(clippy::print_stdout, clippy::print_stderr)]
+
+use std::path::Path;
+
+use oxc_allocator::Allocator;
+use oxc_formatter_css::{CssFormatOptions, CssVariant, format};
+
+fn main() {
+    let mut args = pico_args::Arguments::from_env();
+    let name = args.free_from_str().unwrap_or_else(|_| "test.css".to_string());
+    let path = Path::new(&name);
+
+    let source_text = std::fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("Failed to read {}: {err}", path.display()));
+
+    let variant = match path.extension().and_then(|e| e.to_str()) {
+        Some("scss") => CssVariant::Scss,
+        Some("less") => CssVariant::Less,
+        _ => CssVariant::Css,
+    };
+
+    let options = CssFormatOptions { variant, ..CssFormatOptions::default() };
+
+    let allocator = Allocator::new();
+    match format(&allocator, &source_text, options) {
+        Ok(formatted) => {
+            if std::env::var("DUMP_IR").is_ok() {
+                for el in formatted.document().elements() {
+                    eprintln!("{el:?}");
+                }
+            }
+            match formatted.print() {
+                Ok(printed) => print!("{}", printed.into_code()),
+                Err(err) => eprintln!("Print error: {err:?}"),
+            }
+        }
+        Err(diagnostic) => eprintln!("Parse error: {diagnostic:?}"),
+    }
+}

--- a/crates/oxc_formatter_css/examples/parse_debug.rs
+++ b/crates/oxc_formatter_css/examples/parse_debug.rs
@@ -1,0 +1,47 @@
+//! Dump raffia's AST for a CSS/SCSS/Less snippet.
+//!
+//! ```sh
+//! cargo run -p oxc_formatter_css --example parse_debug -- file.css
+//! echo 'a { color: red }' | cargo run -p oxc_formatter_css --example parse_debug -- --syntax scss -
+//! ```
+#![expect(clippy::print_stdout, clippy::print_stderr)]
+
+use std::io::Read;
+
+use raffia::{ParserBuilder, Syntax, ast::Stylesheet};
+
+fn main() {
+    let mut args = pico_args::Arguments::from_env();
+    let syntax =
+        match args.opt_value_from_str::<_, String>("--syntax").unwrap().as_deref().unwrap_or("css")
+        {
+            "scss" => Syntax::Scss,
+            "less" => Syntax::Less,
+            _ => Syntax::Css,
+        };
+    let name: String = args.free_from_str().unwrap_or_else(|_| "-".to_string());
+
+    let source = if name == "-" {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf).unwrap();
+        buf
+    } else {
+        std::fs::read_to_string(&name).unwrap()
+    };
+
+    let mut comments = vec![];
+    let mut parser = ParserBuilder::new(&source).syntax(syntax).comments(&mut comments).build();
+    let result = parser.parse::<Stylesheet>();
+    let errors = parser.recoverable_errors().to_vec();
+    drop(parser);
+    match result {
+        Ok(stylesheet) => {
+            println!("{stylesheet:#?}");
+            println!("--- comments ---");
+            println!("{comments:#?}");
+            println!("--- recoverable errors ---");
+            println!("{errors:#?}");
+        }
+        Err(err) => eprintln!("Parse error: {err:?}"),
+    }
+}

--- a/crates/oxc_formatter_css/src/comments.rs
+++ b/crates/oxc_formatter_css/src/comments.rs
@@ -1,0 +1,256 @@
+use std::cell::Cell;
+
+use oxc_formatter_core::{
+    Buffer, SourceText,
+    builders::{empty_line, expand_parent, hard_line_break, line_suffix, space, text},
+    spec::is_suppression_marker,
+    write,
+};
+use oxc_span::Span;
+
+use crate::print::{CssFormatter, format_with};
+
+/// A source comment.
+///
+/// raffia keeps comments out of the AST; `format()` collects them through
+/// `ParserBuilder::comments()` and stores their spans here.
+#[derive(Clone, Copy, Debug)]
+pub struct CssComment {
+    pub span: Span,
+    /// `// ...` line comment (SCSS/Less only). Block comments are `/* ... */`.
+    pub inline: bool,
+}
+
+/// Cursor over a sorted comment list that hands out unprinted comments in span order.
+///
+/// `cursor` is a [`Cell`] so the API works through `&self`
+/// (mirrors `oxc_formatter_graphql`'s `Comments`).
+pub struct Comments<'a> {
+    inner: &'a [CssComment],
+    cursor: Cell<usize>,
+}
+
+impl<'a> Comments<'a> {
+    pub fn new(comments: &'a [CssComment]) -> Self {
+        Self { inner: comments, cursor: Cell::new(0) }
+    }
+
+    /// Returns the next unprinted comment without consuming it.
+    pub fn peek(&self) -> Option<CssComment> {
+        self.inner.get(self.cursor.get()).copied()
+    }
+
+    /// Returns unprinted comments whose `span.end <= upper_bound`,
+    /// and advances the cursor past them so they won't be returned again.
+    pub fn take_before(&self, upper_bound: u32) -> &'a [CssComment] {
+        let start = self.cursor.get();
+        let mut end = start;
+        while end < self.inner.len() && self.inner[end].span.end <= upper_bound {
+            end += 1;
+        }
+        self.cursor.set(end);
+        &self.inner[start..end]
+    }
+
+    /// Drains all remaining unprinted comments and returns them.
+    pub fn take_remaining(&self) -> &'a [CssComment] {
+        let start = self.cursor.get();
+        self.cursor.set(self.inner.len());
+        &self.inner[start..]
+    }
+
+    /// Iterator over unprinted comments whose `span.end <= upper_bound`.
+    /// Does NOT advance the cursor.
+    pub fn iter_before(&self, upper_bound: u32) -> impl Iterator<Item = CssComment> {
+        let start = self.cursor.get();
+        self.inner[start..].iter().copied().take_while(move |c| c.span.end <= upper_bound)
+    }
+}
+
+/// Vertical spacing implied by an inter-token source gap.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Gap {
+    /// Same line (no line terminator).
+    None,
+    /// One or more line breaks, but no blank line.
+    Line,
+    /// At least one blank line.
+    Blank,
+}
+
+/// Classifies the gap `slice` between two source positions.
+///
+/// A blank line is a line strictly inside the gap consisting solely of whitespace.
+/// Recognizes `\n`, lone `\r`, and `\r\n` line terminators.
+pub fn classify_gap(slice: &[u8]) -> Gap {
+    let mut newline_count = 0;
+    let mut line_has_content = false;
+    let mut blank = false;
+    let mut i = 0;
+    while i < slice.len() {
+        match slice[i] {
+            b'\r' | b'\n' => {
+                if newline_count > 0 && !line_has_content {
+                    blank = true;
+                }
+                newline_count += 1;
+                line_has_content = false;
+                if slice[i] == b'\r' && slice.get(i + 1) == Some(&b'\n') {
+                    i += 1;
+                }
+            }
+            b' ' | b'\t' => {}
+            _ => line_has_content = true,
+        }
+        i += 1;
+    }
+    if blank {
+        Gap::Blank
+    } else if newline_count > 0 {
+        Gap::Line
+    } else {
+        Gap::None
+    }
+}
+
+/// Emit a single comment verbatim.
+/// Mirrors Prettier's `css-comment` case: the original text slice,
+/// with trailing whitespace trimmed for inline (`//`) comments.
+pub fn write_single_comment(comment: CssComment, f: &mut CssFormatter<'_, '_>) {
+    let content = f.context().source_text().text_for(&comment.span);
+    if comment.inline {
+        write!(f, text(content.trim_end()));
+    } else {
+        write!(f, text(content));
+    }
+}
+
+/// Emits the formatter element that reproduces the vertical spacing implied by `gap`.
+fn write_gap(gap: &[u8], f: &mut CssFormatter<'_, '_>) {
+    match classify_gap(gap) {
+        Gap::None => write!(f, space()),
+        Gap::Line => write!(f, hard_line_break()),
+        Gap::Blank => write!(f, empty_line()),
+    }
+}
+
+/// Emit comments that precede a node. Comments are statement-level nodes in
+/// postcss, so each one ends with a line break (a blank line is preserved);
+/// same-line gaps still produce a hardline.
+pub fn write_leading_comments(
+    comments: &[CssComment],
+    value_start: u32,
+    f: &mut CssFormatter<'_, '_>,
+) {
+    let source = f.context().source_text();
+    for (i, &comment) in comments.iter().enumerate() {
+        write_single_comment(comment, f);
+        match comments.get(i + 1) {
+            // Comment followed by another comment: keep same-line pairs
+            // (`*/ /*!`) together.
+            Some(next) => {
+                match classify_gap(source.bytes_range(comment.span.end, next.span.start)) {
+                    Gap::None => write!(f, space()),
+                    Gap::Line => write!(f, hard_line_break()),
+                    Gap::Blank => write!(f, empty_line()),
+                }
+            }
+            // Comment followed by the node: always on its own line.
+            None => {
+                if classify_gap(source.bytes_range(comment.span.end, value_start)) == Gap::Blank {
+                    write!(f, empty_line());
+                } else {
+                    write!(f, hard_line_break());
+                }
+            }
+        }
+    }
+}
+
+/// Drains and emits all pending comments ending at or before `value_start` as leading comments.
+pub fn flush_leading_comments(value_start: u32, f: &mut CssFormatter<'_, '_>) {
+    let leading = f.context().comments().take_before(value_start);
+    write_leading_comments(leading, value_start, f);
+}
+
+/// If the next pending comment sits on the same line as `prev_end`,
+/// drain it and emit it as a trailing line-suffix comment.
+/// `expand_parent()` keeps the enclosing container multi-line.
+pub fn write_trailing_same_line_comment<'a>(
+    prev_end: u32,
+    upper: u32,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let Some(comment) = f.context().comments().peek() else { return };
+    if comment.span.end > upper {
+        return;
+    }
+    let source = f.context().source_text();
+    if classify_gap(source.bytes_range(prev_end, comment.span.start)) != Gap::None {
+        return;
+    }
+    f.context().comments().take_before(comment.span.end);
+    let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        write!(f, space());
+        write_single_comment(comment, f);
+    });
+    write!(f, [line_suffix(&content), expand_parent()]);
+}
+
+/// Emit comments that sit between the last child of a container and its closing delimiter.
+pub fn write_trailing_inside_comments<'a>(
+    comments: &[CssComment],
+    lower_bound: u32,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    let mut prev_end = lower_bound;
+    for &comment in comments {
+        let gap_start = prev_end;
+        let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            let gap = source.bytes_range(gap_start, comment.span.start);
+            write_gap(gap, f);
+            write_single_comment(comment, f);
+        });
+        write!(f, [line_suffix(&content), expand_parent()]);
+        prev_end = comment.span.end;
+    }
+}
+
+/// Drains comments before `upper_bound` (typically a closing-delimiter position) and
+/// writes them via [`write_trailing_inside_comments`].
+pub fn flush_trailing_inside_comments(
+    lower_bound: u32,
+    upper_bound: u32,
+    f: &mut CssFormatter<'_, '_>,
+) {
+    let trailing = f.context().comments().take_before(upper_bound);
+    write_trailing_inside_comments(trailing, lower_bound, f);
+}
+
+/// Returns `true` if `comment` is an ignore marker (`/* oxfmt-ignore */` / `/* prettier-ignore */`).
+pub fn is_suppression_comment(source: SourceText<'_>, comment: CssComment) -> bool {
+    let content = source.text_for(&comment.span);
+    let content = content
+        .strip_prefix("/*")
+        .and_then(|c| c.strip_suffix("*/"))
+        .or_else(|| content.strip_prefix("//"))
+        .unwrap_or(content);
+    is_suppression_marker(content)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Gap, classify_gap};
+
+    #[test]
+    fn classify_gap_counts_line_terminators() {
+        assert_eq!(classify_gap(b" \t "), Gap::None);
+        assert_eq!(classify_gap(b"\n"), Gap::Line);
+        assert_eq!(classify_gap(b"\n  \n"), Gap::Blank);
+        assert_eq!(classify_gap(b"\r\n"), Gap::Line);
+        assert_eq!(classify_gap(b"\r\n\r\n"), Gap::Blank);
+        assert_eq!(classify_gap(b"\r"), Gap::Line);
+        assert_eq!(classify_gap(b"\r\r"), Gap::Blank);
+    }
+}

--- a/crates/oxc_formatter_css/src/context.rs
+++ b/crates/oxc_formatter_css/src/context.rs
@@ -1,0 +1,64 @@
+use oxc_formatter_core::{FormatContext, SourceText};
+
+use crate::{
+    comments::{Comments, CssComment},
+    options::CssFormatOptions,
+};
+
+/// Formatting context for CSS/SCSS/Less.
+pub struct CssFormatContext<'a> {
+    options: CssFormatOptions,
+    source_text: SourceText<'a>,
+    comments: Comments<'a>,
+    /// Inside a Less detached ruleset (`@var: { ... }`): property names keep
+    /// their case (Prettier checks `parentNode.variable`).
+    in_less_detached: std::cell::Cell<bool>,
+    /// Current block nesting depth (rules/at-rules).
+    block_depth: std::cell::Cell<u32>,
+}
+
+impl<'a> CssFormatContext<'a> {
+    pub fn new(
+        options: CssFormatOptions,
+        source_code: &'a str,
+        comments: &'a [CssComment],
+    ) -> Self {
+        Self {
+            options,
+            source_text: SourceText::new(source_code),
+            comments: Comments::new(comments),
+            in_less_detached: std::cell::Cell::new(false),
+            block_depth: std::cell::Cell::new(0),
+        }
+    }
+
+    pub fn block_depth(&self) -> &std::cell::Cell<u32> {
+        &self.block_depth
+    }
+
+    pub fn in_less_detached(&self) -> &std::cell::Cell<bool> {
+        &self.in_less_detached
+    }
+
+    /// Returns the source text with the arena lifetime (vs the trait's borrow-elided `&str`).
+    pub fn source_text(&self) -> SourceText<'a> {
+        self.source_text
+    }
+
+    /// Returns the comment cursor.
+    pub fn comments(&self) -> &Comments<'a> {
+        &self.comments
+    }
+}
+
+impl FormatContext for CssFormatContext<'_> {
+    type Options = CssFormatOptions;
+
+    fn options(&self) -> &Self::Options {
+        &self.options
+    }
+
+    fn source_code(&self) -> &str {
+        &self.source_text
+    }
+}

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -1,0 +1,274 @@
+use oxc_allocator::{Allocator, ArenaVec};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_formatter_core::{
+    Buffer, Document, EmbeddedContext, Format, FormatElement, FormatState, Formatted, VecBuffer,
+    builders::{empty_line, hard_line_break, text},
+    write,
+};
+use oxc_span::Span;
+use raffia::{ParserBuilder, ast::Stylesheet};
+
+use crate::{
+    comments::CssComment,
+    context::CssFormatContext,
+    options::CssFormatOptions,
+    print::{self, CssFormatter},
+};
+
+/// Parse `source_text` as a stylesheet and build its formatter IR.
+///
+/// # Errors
+/// Returns an [`OxcDiagnostic`] when the parse produces any error, including
+/// recoverable ones. raffia can recover from some syntax errors, but a tree
+/// with errors cannot be formatted faithfully, so a single error is enough to
+/// bail out. The caller (oxfmt) decides what to do next
+/// (report, or fall back to Prettier).
+pub fn format<'a>(
+    allocator: &'a Allocator,
+    source_text: &str,
+    options: CssFormatOptions,
+) -> Result<Formatted<'a, CssFormatContext<'a>>, OxcDiagnostic> {
+    let has_bom = source_text.starts_with('\u{feff}');
+    let (stylesheet, source, comments) = parse_stylesheet(allocator, source_text, options)?;
+    let front_matter = front_matter_end(source).map(|end| &source[..end]);
+
+    let context = CssFormatContext::new(options, source, comments);
+    let mut state = FormatState::new(context, allocator);
+    let mut buffer = VecBuffer::new(&mut state);
+
+    write!(&mut buffer, FormatCssRoot { stylesheet: &stylesheet, has_bom, front_matter });
+
+    let elements = buffer.into_vec();
+    let context = state.into_context();
+
+    let ir = Document::new(elements, Vec::new());
+    ir.propagate_expand();
+
+    Ok(Formatted::new(ir, context))
+}
+
+/// Parse `source_text` and build the formatter IR for embedding into another
+/// formatter's document (dispatcher path, e.g. css-in-js).
+///
+/// Unlike [`format()`], this:
+/// - allocates from the shared arena in `ctx`
+/// - emits neither a BOM nor the trailing newline
+/// - skips `propagate_expand()`, which the parent runs on the merged document
+///
+/// # Errors
+/// Same as [`format()`].
+pub fn format_to_ir<'a>(
+    ctx: &EmbeddedContext<'a, '_>,
+    source_text: &str,
+    options: CssFormatOptions,
+) -> Result<ArenaVec<'a, FormatElement<'a>>, OxcDiagnostic> {
+    let allocator = ctx.allocator;
+    let (stylesheet, source, comments) = parse_stylesheet(allocator, source_text, options)?;
+
+    let context = CssFormatContext::new(options, source, comments);
+    let mut state = FormatState::new(context, allocator);
+    let mut buffer = VecBuffer::new(&mut state);
+
+    write!(&mut buffer, FormatCssEmbedded { stylesheet: &stylesheet });
+
+    Ok(buffer.into_vec())
+}
+
+/// Parse the source into an AST and collect comments, bailing out on any error.
+///
+/// Copies the source into the arena (minus any BOM, which raffia would skip
+/// anyway) so every slice taken from it carries `'a`.
+fn parse_stylesheet<'a>(
+    allocator: &'a Allocator,
+    source_text: &str,
+    options: CssFormatOptions,
+) -> Result<(Stylesheet<'a>, &'a str, &'a [CssComment]), OxcDiagnostic> {
+    let source_text = source_text.strip_prefix('\u{feff}').unwrap_or(source_text);
+    let source: &'a str = allocator.alloc_str(source_text);
+
+    // Front matter is not CSS: blank it out (preserving line structure so
+    // spans and gaps stay aligned) and print it verbatim from `source`.
+    let parse_source: &'a str = match front_matter_end(source) {
+        Some(end) => {
+            let mut blanked = String::with_capacity(source.len());
+            for c in source[..end].chars() {
+                blanked.push(if c == '\n' || c == '\r' { c } else { ' ' });
+            }
+            blanked.push_str(&source[end..]);
+            allocator.alloc_str(&blanked)
+        }
+        None => source,
+    };
+
+    let mut comments = vec![];
+    let mut parser = ParserBuilder::new(parse_source)
+        .syntax(options.variant.to_raffia())
+        .comments(&mut comments)
+        .build();
+
+    let stylesheet = parser.parse::<Stylesheet>().map_err(|error| to_diagnostic(&error))?;
+    if let Some(error) = parser.recoverable_errors().first() {
+        return Err(to_diagnostic(error));
+    }
+    drop(parser);
+
+    let comments: &'a [CssComment] = ArenaVec::from_iter_in(
+        comments.iter().map(|c| CssComment {
+            span: to_span(&c.span),
+            inline: matches!(c.kind, raffia::token::CommentKind::Line),
+        }),
+        &allocator,
+    )
+    .into_arena_slice();
+
+    Ok((stylesheet, source, comments))
+}
+
+fn to_diagnostic(error: &raffia::error::Error) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Syntax error: {}", error.kind)).with_label(to_span(&error.span))
+}
+
+pub fn to_span(span: &raffia::Span) -> Span {
+    Span::new(
+        u32::try_from(span.start).unwrap_or(u32::MAX),
+        u32::try_from(span.end).unwrap_or(u32::MAX),
+    )
+}
+
+/// Detects Prettier-style front matter (`---` / `+++` fence starting at
+/// offset 0, closed by the same fence on its own line) and returns the end
+/// offset of the closing fence.
+fn front_matter_end(source: &str) -> Option<usize> {
+    let delim = if source.starts_with("---") {
+        "---"
+    } else if source.starts_with("+++") {
+        "+++"
+    } else {
+        return None;
+    };
+    let first_line_end = source.find('\n')?;
+    if !source[delim.len()..first_line_end].trim().is_empty() {
+        return None;
+    }
+    let mut line_start = first_line_end + 1;
+    while line_start < source.len() {
+        let line_end = source[line_start..].find('\n').map_or(source.len(), |i| line_start + i);
+        let line = source[line_start..line_end].trim_end_matches('\r');
+        if line.trim_end() == delim {
+            return Some(line_start + line.trim_end().len());
+        }
+        line_start = line_end + 1;
+    }
+    None
+}
+
+/// Best-effort YAML front-matter normalization (Prettier reformats it with
+/// its YAML printer): `key: value` spacing and 2-space nesting indents.
+/// Returns `None` (→ verbatim) for any construct beyond plain mappings,
+/// sequence items and comments — e.g. block scalars, quoted keys.
+fn try_format_yaml_front_matter(front_matter: &str) -> Option<String> {
+    let inner = front_matter.strip_prefix("---")?.strip_suffix("---")?;
+    let mut out = String::with_capacity(front_matter.len());
+    out.push_str("---\n");
+    // Source indents of mapping keys awaiting nested content.
+    let mut stack: Vec<usize> = vec![];
+    for line in inner.lines().skip(1) {
+        let content = line.trim();
+        if content.is_empty() {
+            continue;
+        }
+        let indent = line.len() - line.trim_start().len();
+        while stack.last().is_some_and(|&top| indent <= top) {
+            stack.pop();
+        }
+        let level = stack.len();
+        for _ in 0..level {
+            out.push_str("  ");
+        }
+        if let Some(rest) = content.strip_prefix("- ") {
+            out.push_str("- ");
+            out.push_str(rest.trim());
+        } else if content.starts_with('#') {
+            out.push_str(content);
+        } else if let Some(colon) = content.find(':') {
+            let key = &content[..colon];
+            if key.is_empty() || key.contains([' ', '\t', '"', '\'', '{', '[', '#']) {
+                return None;
+            }
+            let value = content[colon + 1..].trim();
+            if value.is_empty() {
+                out.push_str(key);
+                out.push(':');
+                stack.push(indent);
+            } else {
+                if value.starts_with(['|', '>', '&', '*', '{', '[']) {
+                    return None;
+                }
+                out.push_str(key);
+                out.push_str(": ");
+                out.push_str(value);
+            }
+        } else {
+            return None;
+        }
+        out.push('\n');
+    }
+    out.push_str("---");
+    Some(out)
+}
+
+/// Emits the stylesheet followed by any trailing comments, and the final newline.
+struct FormatCssRoot<'b, 'a> {
+    stylesheet: &'b Stylesheet<'a>,
+    has_bom: bool,
+    front_matter: Option<&'a str>,
+}
+
+impl<'a> Format<'a, CssFormatContext<'a>> for FormatCssRoot<'_, 'a> {
+    fn fmt(&self, f: &mut CssFormatter<'_, 'a>) {
+        if self.has_bom {
+            write!(f, text("\u{feff}"));
+        }
+
+        let has_content =
+            !self.stylesheet.statements.is_empty() || f.context().comments().peek().is_some();
+        if let Some(front_matter) = self.front_matter {
+            // Whitespace-only front matter collapses to adjacent fences.
+            let collapsed = front_matter
+                .strip_prefix("---")
+                .and_then(|s| s.strip_suffix("---"))
+                .is_some_and(|inner| inner.trim().is_empty());
+            if collapsed {
+                write!(f, ["---", hard_line_break(), "---"]);
+            } else if let Some(formatted) = try_format_yaml_front_matter(front_matter) {
+                write!(f, text(f.allocator().alloc_str(&formatted)));
+            } else {
+                write!(f, text(front_matter));
+            }
+            if has_content {
+                // A hardline plus a blank line (consecutive hardlines collapse).
+                write!(f, empty_line());
+            } else {
+                write!(f, hard_line_break());
+            }
+        }
+
+        print::write_stylesheet(self.stylesheet, f);
+
+        // POSIX convention: every formatted file ends with a newline.
+        if has_content {
+            write!(f, hard_line_break());
+        }
+    }
+}
+
+/// Emits the stylesheet only; no BOM, no final newline.
+struct FormatCssEmbedded<'b, 'a> {
+    stylesheet: &'b Stylesheet<'a>,
+}
+
+impl<'a> Format<'a, CssFormatContext<'a>> for FormatCssEmbedded<'_, 'a> {
+    fn fmt(&self, f: &mut CssFormatter<'_, 'a>) {
+        print::write_stylesheet(self.stylesheet, f);
+    }
+}

--- a/crates/oxc_formatter_css/src/lib.rs
+++ b/crates/oxc_formatter_css/src/lib.rs
@@ -1,0 +1,25 @@
+//! CSS/SCSS/Less formatter built on top of `oxc_formatter_core`.
+//!
+//! Parses with [raffia](https://docs.rs/raffia) and prints Prettier-compatible output.
+//!
+//! ```ignore
+//! use oxc_allocator::Allocator;
+//! use oxc_formatter_css::{CssFormatOptions, format};
+//!
+//! let allocator = Allocator::new();
+//! let formatted = format(&allocator, "a { color: red }", CssFormatOptions::default()).unwrap();
+//! let out = formatted.print().unwrap().into_code();
+//! assert_eq!(out, "a {\n  color: red;\n}\n");
+//! ```
+
+mod comments;
+mod context;
+mod format;
+mod options;
+mod print;
+
+pub use crate::{
+    context::CssFormatContext,
+    format::{format, format_to_ir},
+    options::{CssFormatOptions, CssVariant, SingleQuote, TrailingCommas},
+};

--- a/crates/oxc_formatter_css/src/options.rs
+++ b/crates/oxc_formatter_css/src/options.rs
@@ -1,0 +1,120 @@
+use oxc_formatter_core::{
+    FormatOptions, IndentStyle, IndentWidth, LineEnding, LineWidth, PrinterOptions,
+};
+
+/// CSS dialect variant.
+///
+/// Mirrors Prettier's `css` / `scss` / `less` parsers.
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+pub enum CssVariant {
+    /// Prettier's `parser: css` equivalent.
+    #[default]
+    Css,
+    /// Prettier's `parser: scss` equivalent.
+    /// `//` comments, `$var`, maps, control directives, the module system.
+    Scss,
+    /// Prettier's `parser: less` equivalent.
+    /// `//` comments, `@var`, mixins, guards, detached rulesets.
+    Less,
+}
+
+impl CssVariant {
+    pub(crate) fn to_raffia(self) -> raffia::Syntax {
+        match self {
+            Self::Css => raffia::Syntax::Css,
+            Self::Scss => raffia::Syntax::Scss,
+            Self::Less => raffia::Syntax::Less,
+        }
+    }
+
+    pub fn is_scss(self) -> bool {
+        matches!(self, Self::Scss)
+    }
+
+    pub fn is_less(self) -> bool {
+        matches!(self, Self::Less)
+    }
+}
+
+/// Format options for CSS/SCSS/Less.
+///
+/// Prettier's CSS languages consume the shared layout options plus
+/// `singleQuote` and `trailingComma` (SCSS maps only).
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
+pub struct CssFormatOptions {
+    pub indent_style: IndentStyle,
+    pub indent_width: IndentWidth,
+    pub line_width: LineWidth,
+    pub line_ending: LineEnding,
+    pub variant: CssVariant,
+    /// Prefer single quotes for strings. Mirrors Prettier's `singleQuote`.
+    pub single_quote: SingleQuote,
+    // Used by: SCSS (maps only)
+    pub trailing_commas: TrailingCommas,
+}
+
+impl CssFormatOptions {
+    /// Whether a trailing comma may follow the last item of a multi-line
+    /// SCSS map, per [`Self::trailing_commas`].
+    pub fn allow_trailing_comma(self) -> bool {
+        matches!(self.trailing_commas, TrailingCommas::Always)
+    }
+}
+
+/// Whether string literals prefer single quotes (`'`) over double (`"`).
+/// Mirrors Prettier's `singleQuote` (default `false`).
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct SingleQuote(bool);
+
+impl SingleQuote {
+    pub fn value(self) -> bool {
+        self.0
+    }
+}
+
+impl From<bool> for SingleQuote {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+/// Whether to print a trailing comma after the last item of a multi-line
+/// SCSS map (the only CSS construct Prettier's `trailingComma` reaches).
+///
+/// Mirrors Prettier's `trailingComma`, but the `all`/`es5` distinction is
+/// dead for CSS (`shouldPrintTrailingComma` only checks "not none"),
+/// so both collapse into `Always`.
+#[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+pub enum TrailingCommas {
+    /// Trailing comma where valid. Maps from Prettier `all`/`es5`.
+    #[default]
+    Always,
+    /// No trailing comma. Maps from Prettier `none`.
+    Never,
+}
+
+impl FormatOptions for CssFormatOptions {
+    fn indent_style(&self) -> IndentStyle {
+        self.indent_style
+    }
+
+    fn indent_width(&self) -> IndentWidth {
+        self.indent_width
+    }
+
+    fn line_width(&self) -> LineWidth {
+        self.line_width
+    }
+
+    fn line_ending(&self) -> LineEnding {
+        self.line_ending
+    }
+
+    fn as_print_options(&self) -> PrinterOptions {
+        PrinterOptions::default()
+            .with_indent_style(self.indent_style)
+            .with_indent_width(self.indent_width)
+            .with_line_ending(self.line_ending)
+            .with_print_width(self.line_width.into())
+    }
+}

--- a/crates/oxc_formatter_css/src/print/at_rule.rs
+++ b/crates/oxc_formatter_css/src/print/at_rule.rs
@@ -1,0 +1,1477 @@
+//! At-rule printing. Ports Prettier's `css-atrule` case and the
+//! postcss-media-query-parser printing (`media-*` cases).
+
+use cow_utils::CowUtils;
+use oxc_formatter_core::{
+    Buffer,
+    builders::{group, hard_line_break, indent, soft_line_break_or_space, space, text},
+    write,
+};
+use raffia::{
+    Spanned,
+    ast::{
+        AtRule, AtRulePrelude, ComponentValue, ImportPrelude, InterpolableStr, KeyframesName,
+        MediaCondition, MediaConditionKind, MediaFeature, MediaFeatureComparisonKind,
+        MediaFeatureName, MediaInParens, MediaInParensKind, MediaQuery, MediaQueryList,
+        SupportsCondition, SupportsConditionKind, SupportsInParens, SupportsInParensKind,
+    },
+};
+
+use crate::{
+    format::to_span,
+    print::{
+        CssFormatter, format_with, scss, selector,
+        statement::{write_block, write_maybe_lowercase},
+        value::{self, ValueContext},
+    },
+};
+
+/// Mirrors Prettier's `css-atrule`.
+pub fn write_at_rule<'a>(at_rule: &AtRule<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    write!(f, "@");
+    let name_span = to_span(at_rule.name.span());
+    write_maybe_lowercase(source.text_for(&name_span), f);
+
+    // Comments inside the params: postcss keeps them embedded in the params
+    // string / media tokens; reconstruct from the source.
+    let region_end = at_rule.block.as_ref().map_or_else(
+        || {
+            // Up to (excluding) the `;`.
+            let end = to_span(at_rule.span()).end;
+            let with_semi = crate::print::statement::end_with_semicolon(end, f);
+            if with_semi > end { with_semi - 1 } else { end }
+        },
+        |block| to_span(&block.span).start,
+    );
+    let has_params_comments = f
+        .context()
+        .comments()
+        .peek()
+        .is_some_and(|c| c.span.start >= name_span.end && c.span.end <= region_end);
+    // `//` comments have their own layout rules (e.g. less `selector(...)`)
+    // handled by the structural printers below.
+    let has_inline_params_comment = f
+        .context()
+        .comments()
+        .iter_before(region_end)
+        .any(|c| c.inline && c.span.start >= name_span.end);
+    if has_params_comments && !has_inline_params_comment {
+        let lowercased = at_rule.name.raw.cow_to_ascii_lowercase();
+        let raw = source.slice_range(name_span.end, region_end).trim();
+        match &*lowercased {
+            "media" | "custom-media" if !raw.contains("#{") => {
+                let _ = f.context().comments().take_before(region_end);
+                write!(f, space());
+                write_commented_media_params(raw, f);
+                write_block_or_semicolon(at_rule, f);
+                return;
+            }
+            "import" if matches!(at_rule.prelude, Some(AtRulePrelude::Import(_))) => {
+                let _ = f.context().comments().take_before(region_end);
+                write!(f, space());
+                write_commented_value_params(raw, 8, true, f);
+                write!(f, ";");
+                return;
+            }
+            "supports" if matches!(at_rule.prelude, Some(AtRulePrelude::Supports(_))) => {
+                let _ = f.context().comments().take_before(region_end);
+                write!(f, space());
+                write_commented_value_params(raw, 10, false, f);
+                write_block_or_semicolon(at_rule, f);
+                return;
+            }
+            // String params: whitespace-normalized verbatim, one line.
+            "keyframes"
+            | "page"
+            | "font-feature-values"
+            | "counter-style"
+            | "viewport"
+            | "namespace"
+            | "styleset"
+            | "property"
+            | "layer" => {
+                let _ = f.context().comments().take_before(region_end);
+                if !raw.is_empty() {
+                    write!(f, space());
+                    let normalized = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+                    write!(f, text(f.allocator().alloc_str(&normalized)));
+                }
+                write_block_or_semicolon(at_rule, f);
+                return;
+            }
+            _ => {}
+        }
+    }
+
+    // SCSS control directives wrap the prelude and the gap before `{` in one
+    // group: when the prelude breaks, `{` moves to its own line.
+    let is_control_directive = at_rule.block.is_some()
+        && matches!(at_rule.prelude, Some(AtRulePrelude::SassEach(_) | AtRulePrelude::SassFor(_)))
+        || (matches!(at_rule.prelude, Some(AtRulePrelude::SassExpr(_)))
+            && matches!(at_rule.name.raw, "if" | "else" | "while"));
+
+    if let Some(prelude) = &at_rule.prelude {
+        // postcss folds a no-gap, non-paren prelude into the at-rule NAME
+        // (`@page:first` stays tight); reproduce by checking the source gap.
+        let name_end = to_span(at_rule.name.span()).end;
+        let prelude_span = to_span(prelude.span());
+        let fused =
+            name_end == prelude_span.start && !source.text_for(&prelude_span).starts_with('(');
+        if fused {
+            write!(f, text(source.text_for(&prelude_span)));
+        } else if is_control_directive {
+            // A fully parenthesized condition keeps `{` on the `)` line
+            // (Prettier's `hasParensAroundNode`).
+            let has_parens = matches!(
+                prelude,
+                AtRulePrelude::SassExpr(value)
+                    if matches!(&**value, raffia::ast::ComponentValue::SassParenthesizedExpression(_))
+            );
+            if has_parens {
+                write!(f, space());
+                write_at_rule_prelude(prelude, f);
+                write!(f, space());
+            } else {
+                let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    write!(f, space());
+                    write_at_rule_prelude(prelude, f);
+                    write!(f, soft_line_break_or_space());
+                });
+                write!(f, group(&body));
+            }
+        } else {
+            write!(f, space());
+            write_at_rule_prelude(prelude, f);
+        }
+    }
+
+    if let Some(block) = &at_rule.block {
+        // An inline comment between the prelude and `{` keeps its own line
+        // (Prettier's `lastLineHasInlineComment` → line instead of space).
+        let block_start = to_span(&block.span).start;
+        let mut wrote_comment = false;
+        if f.context().comments().peek().is_some_and(|c| c.inline && c.span.end <= block_start) {
+            for &comment in f.context().comments().take_before(block_start) {
+                write!(f, hard_line_break());
+                crate::comments::write_single_comment(comment, f);
+            }
+            write!(f, hard_line_break());
+            wrote_comment = true;
+        }
+        if !is_control_directive && !wrote_comment {
+            write!(f, space());
+        }
+        write_block(block, f);
+    } else {
+        write!(f, ";");
+    }
+}
+
+/// ` {...}` when the at-rule has a block, `;` otherwise.
+fn write_block_or_semicolon<'a>(at_rule: &AtRule<'a>, f: &mut CssFormatter<'_, 'a>) {
+    if let Some(block) = &at_rule.block {
+        write!(f, space());
+        write_block(block, f);
+    } else {
+        write!(f, ";");
+    }
+}
+
+/// `@media` params containing comments, rebuilt the way
+/// postcss-media-query-parser + Prettier's `media-*` cases lay them out:
+/// queries split on top-level commas (`,` + line in a group), tokens joined
+/// by single spaces, `( feature : value )` re-spaced when the parser would
+/// have recognized it (spaces around the `:`), kept verbatim otherwise.
+fn write_commented_media_params<'a>(raw: &'a str, f: &mut CssFormatter<'_, 'a>) {
+    let queries = split_top_level(raw, b',');
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        for (i, query) in queries.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",");
+                write!(f, soft_line_break_or_space());
+            }
+            let tokens = media_tokens(query.trim());
+            for (j, token) in tokens.iter().enumerate() {
+                if j > 0 {
+                    write!(f, space());
+                }
+                write_media_token(token, f);
+            }
+        }
+    });
+    write!(f, group(&indent(&body)));
+}
+
+/// `@import` / `@supports` params containing comments, laid out the way
+/// Prettier's value parser + fill does. Separator breaks are simulated with
+/// static widths (Prettier's fill fit-checks the next item; our core fill
+/// measures only up to a hardline). `allow_commas`: comma chunks get an
+/// extra indent level for their internal wraps.
+fn write_commented_value_params<'a>(
+    raw: &'a str,
+    start_col: u32,
+    allow_commas: bool,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    // One value-parser token (the comma glues to its chunk's tail).
+    struct Tok<'a> {
+        text: &'a str,
+        comma: bool,
+        chunk: usize,
+        hard: bool,
+    }
+    let width = u32::from(f.options().line_width.value());
+    let chunks: Vec<&str> = if allow_commas { split_top_level(raw, b',') } else { vec![raw] };
+    let multi = chunks.len() > 1;
+
+    let mut tokens: Vec<Tok<'a>> = vec![];
+    for (ci, chunk) in chunks.iter().enumerate() {
+        let toks = value_tokens(chunk.trim());
+        let last = toks.len().saturating_sub(1);
+        for (ti, t) in toks.into_iter().enumerate() {
+            tokens.push(Tok {
+                text: t,
+                comma: ci + 1 < chunks.len() && ti == last,
+                chunk: ci,
+                hard: t.contains('(') && t.contains("/*"),
+            });
+        }
+    }
+
+    let tok_width =
+        |t: &Tok<'_>| u32::try_from(t.text.len()).unwrap_or(u32::MAX) + u32::from(t.comma);
+    // Per-chunk flat width / hardness (chunk separators compare WHOLE chunks,
+    // Prettier's fill over the comma-joined chunk docs).
+    let mut chunk_w = vec![0u32; chunks.len()];
+    let mut chunk_hard = vec![false; chunks.len()];
+    for t in &tokens {
+        if chunk_w[t.chunk] > 0 {
+            chunk_w[t.chunk] += 1;
+        }
+        chunk_w[t.chunk] += u32::try_from(t.text.len()).unwrap_or(u32::MAX) + u32::from(t.comma);
+        chunk_hard[t.chunk] = chunk_hard[t.chunk] || t.hard;
+    }
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        let mut x = start_col;
+        let mut chunk_start_x = start_col;
+        for i in 0..tokens.len() {
+            let t = &tokens[i];
+            if i > 0 {
+                let prev = &tokens[i - 1];
+                if prev.chunk == t.chunk {
+                    let fits = !prev.hard && !t.hard && x + 1 + tok_width(t) <= width;
+                    if fits {
+                        write!(f, space());
+                        x += 1;
+                    } else {
+                        write!(f, hard_line_break());
+                        if multi {
+                            write!(f, text("  "));
+                            x = 4;
+                        } else {
+                            x = 2;
+                        }
+                    }
+                } else {
+                    let fits = !chunk_hard[prev.chunk]
+                        && !chunk_hard[t.chunk]
+                        && chunk_start_x + chunk_w[prev.chunk] + 1 + chunk_w[t.chunk] <= width;
+                    if fits {
+                        write!(f, space());
+                        x += 1;
+                    } else {
+                        write!(f, hard_line_break());
+                        x = 2;
+                    }
+                    chunk_start_x = x;
+                }
+            }
+            if t.hard {
+                write_structured_paren(t.text, x, f);
+                // `)` lands back at column x.
+                x += 1;
+            } else {
+                let printed = requote_token(t.text, f);
+                write!(f, text(printed));
+                x += u32::try_from(printed.len()).unwrap_or(0);
+            }
+            if t.comma {
+                write!(f, ",");
+                x += 1;
+            }
+        }
+    });
+    write!(f, indent(&body));
+}
+
+/// Value-parser tokens: comments are standalone nodes (split even when
+/// touching their neighbors), paren groups glue to their leading word
+/// (`url(...)`) and end at `)`.
+/// `start` points at the `/` of a `/*`; returns the index of the closing `/`
+/// (clamped to the last byte when unterminated).
+fn block_comment_end(bytes: &[u8], start: usize) -> usize {
+    let mut i = start + 2;
+    while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+        i += 1;
+    }
+    (i + 1).min(bytes.len() - 1)
+}
+
+fn value_tokens(raw: &str) -> Vec<&str> {
+    let bytes = raw.as_bytes();
+    let mut tokens = vec![];
+    let mut depth = 0i32;
+    let mut start: Option<usize> = None;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'/' if bytes.get(i + 1) == Some(&b'*') && depth == 0 => {
+                if let Some(s) = start.take() {
+                    tokens.push(&raw[s..i]);
+                }
+                let end = block_comment_end(bytes, i);
+                tokens.push(&raw[i..=end]);
+                i = end;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i = block_comment_end(bytes, i);
+            }
+            b'(' => {
+                if start.is_none() {
+                    start = Some(i);
+                }
+                depth += 1;
+            }
+            b')' => {
+                depth -= 1;
+                if depth == 0
+                    && let Some(s) = start.take()
+                {
+                    tokens.push(&raw[s..=i]);
+                }
+            }
+            b' ' | b'\t' | b'\n' | b'\r' if depth == 0 => {
+                if let Some(s) = start.take() {
+                    tokens.push(&raw[s..i]);
+                }
+            }
+            _ => {
+                if start.is_none() {
+                    start = Some(i);
+                }
+            }
+        }
+        i += 1;
+    }
+    if let Some(s) = start {
+        tokens.push(&raw[s..]);
+    }
+    tokens
+}
+
+/// Re-quotes `'...'` strings in a token to the preferred quote (Prettier's
+/// `adjustStrings`).
+fn requote_token<'a>(token: &'a str, f: &CssFormatter<'_, 'a>) -> &'a str {
+    let preferred = if f.options().single_quote.value() { '\'' } else { '"' };
+    let other = if preferred == '"' { '\'' } else { '"' };
+    if !token.contains(other) || token.contains(preferred) {
+        return token;
+    }
+    let replaced = token.cow_replace(other, preferred.encode_utf8(&mut [0; 4]));
+    f.allocator().alloc_str(&replaced)
+}
+
+/// A comment-bearing paren group always breaks:
+/// `(` + indented fill of its words (`:` glued left, spaced right) + `)`.
+fn write_structured_paren<'a>(token: &'a str, open_col: u32, f: &mut CssFormatter<'_, 'a>) {
+    let width = u32::from(f.options().line_width.value());
+    let Some(open) = find_outside_comments(token, b'(') else {
+        write!(f, text(token));
+        return;
+    };
+    let Some(close) = token.rfind(')') else {
+        write!(f, text(token));
+        return;
+    };
+    write!(f, text(&token[..=open]));
+    let inner = &token[open + 1..close];
+    // Words, requoted up front; a lone `:` glues to the previous word.
+    let preferred = if f.options().single_quote.value() { '\'' } else { '"' };
+    let other = if preferred == '"' { '\'' } else { '"' };
+    let requote = |w: &str| -> String {
+        if w.contains(other) && !w.contains(preferred) {
+            w.cow_replace(other, preferred.encode_utf8(&mut [0; 4])).into_owned()
+        } else {
+            w.to_string()
+        }
+    };
+    let mut words: Vec<String> = vec![];
+    for w in value_tokens(inner.trim()) {
+        if (w == ":" || w.starts_with(':'))
+            && let Some(last) = words.last_mut()
+        {
+            last.push(':');
+            if w.len() > 1 {
+                words.push(requote(&w[1..]));
+            }
+            continue;
+        }
+        words.push(requote(w));
+    }
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        write!(f, hard_line_break());
+        let mut x = open_col + 2;
+        for (i, w) in words.iter().enumerate() {
+            let w_len = u32::try_from(w.len()).unwrap_or(0);
+            if i > 0 {
+                if x + 1 + w_len <= width {
+                    write!(f, space());
+                    x += 1;
+                } else {
+                    write!(f, hard_line_break());
+                    write!(f, text("  "));
+                    x = open_col + 4;
+                }
+            }
+            write!(f, text(f.allocator().alloc_str(w)));
+            x += w_len;
+        }
+    });
+    write!(f, indent(&body));
+    write!(f, hard_line_break());
+    write!(f, ")");
+    let suffix = &token[close + 1..];
+    if !suffix.is_empty() {
+        write!(f, text(suffix));
+    }
+}
+
+/// Splits on `sep` at paren depth 0, outside comments.
+fn split_top_level(raw: &str, sep: u8) -> Vec<&str> {
+    let bytes = raw.as_bytes();
+    let mut parts = vec![];
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i = block_comment_end(bytes, i);
+            }
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b if b == sep && depth == 0 => {
+                parts.push(&raw[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    parts.push(&raw[start..]);
+    parts
+}
+
+/// Whitespace-separated tokens; comments and balanced paren regions glue to
+/// adjacent touching text. A `)` closing a single-line paren region ends the
+/// token (postcss-media-query-parser splits there); a multi-line region is a
+/// `media-unknown` and keeps its touching suffix.
+fn media_tokens(raw: &str) -> Vec<&str> {
+    let bytes = raw.as_bytes();
+    let mut tokens = vec![];
+    let mut depth = 0i32;
+    let mut start: Option<usize> = None;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                if start.is_none() {
+                    start = Some(i);
+                }
+                i = block_comment_end(bytes, i);
+            }
+            b'(' => {
+                if start.is_none() {
+                    start = Some(i);
+                }
+                depth += 1;
+            }
+            b')' => {
+                depth -= 1;
+                if depth == 0
+                    && let Some(s) = start.take()
+                {
+                    tokens.push(&raw[s..=i]);
+                }
+            }
+            b' ' | b'\t' | b'\n' | b'\r' if depth == 0 => {
+                if let Some(s) = start.take() {
+                    tokens.push(&raw[s..i]);
+                }
+            }
+            _ => {
+                if start.is_none() {
+                    start = Some(i);
+                }
+            }
+        }
+        i += 1;
+    }
+    if let Some(s) = start {
+        tokens.push(&raw[s..]);
+    }
+    tokens
+}
+
+/// One media token: a paren region (with glued prefix/suffix) gets the
+/// `( feature: value )` re-spacing when the `:` has space around it.
+fn write_media_token<'a>(token: &'a str, f: &mut CssFormatter<'_, 'a>) {
+    let Some(open) = find_outside_comments(token, b'(') else {
+        write!(f, text(token));
+        return;
+    };
+    let Some(close) = token.rfind(')') else {
+        write!(f, text(token));
+        return;
+    };
+    let inner = &token[open + 1..close];
+    let colon = find_outside_comments(inner, b':');
+    let respace = colon.is_some_and(|c| {
+        let before_ws = inner[..c].ends_with([' ', '\t', '\n', '\r']);
+        let after_ws = inner[c + 1..].starts_with([' ', '\t', '\n', '\r']);
+        before_ws || after_ws
+    });
+    if !respace {
+        // Unparsable for postcss-media-query-parser: verbatim.
+        write!(f, text(token));
+        return;
+    }
+    let colon = colon.unwrap();
+    write!(f, text(&token[..=open]));
+    let feature = inner[..colon].trim();
+    let value = inner[colon + 1..].trim();
+    let normalized = format!(
+        "{}: {}",
+        feature.split_whitespace().collect::<Vec<_>>().join(" "),
+        value.split_whitespace().collect::<Vec<_>>().join(" ")
+    );
+    write!(f, text(f.allocator().alloc_str(&normalized)));
+    write!(f, text(&token[close..]));
+}
+
+/// First position of `needle` outside `/* */` comments.
+fn find_outside_comments(raw: &str, needle: u8) -> Option<usize> {
+    let bytes = raw.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
+            i = block_comment_end(bytes, i) + 1;
+            continue;
+        }
+        if bytes[i] == needle {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+fn write_at_rule_prelude<'a>(prelude: &AtRulePrelude<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    match prelude {
+        AtRulePrelude::Media(media) => write_media_query_list(media, f),
+        AtRulePrelude::CustomMedia(custom) => {
+            let name_span = to_span(custom.name.span());
+            write!(f, text(source.text_for(&name_span)));
+            write!(f, space());
+            match &custom.value {
+                raffia::ast::CustomMediaValue::MediaQueryList(list) => {
+                    write_media_query_list(list, f);
+                }
+                raffia::ast::CustomMediaValue::True(ident)
+                | raffia::ast::CustomMediaValue::False(ident) => {
+                    let span = to_span(ident.span());
+                    write!(f, text(source.text_for(&span)));
+                }
+            }
+        }
+        AtRulePrelude::Keyframes(name) => write_keyframes_name(name, f),
+        AtRulePrelude::CustomSelector(custom) => {
+            let custom_span = to_span(custom.custom_selector.span());
+            let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                // raffia's CustomSelector span excludes the leading `:`.
+                write!(f, ":");
+                write!(f, text(source.text_for(&custom_span)));
+                write!(f, soft_line_break_or_space());
+                // Selectors share THIS group: when the prelude breaks,
+                // each selector gets its own line.
+                for (i, complex) in custom.selector.selectors.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ",");
+                        write!(f, soft_line_break_or_space());
+                    }
+                    selector::write_complex_selector(complex, f);
+                }
+            });
+            write!(f, group(&indent(&body)));
+        }
+        AtRulePrelude::Charset(str) => {
+            let span = to_span(str.span());
+            write!(f, text(source.text_for(&span)));
+        }
+        AtRulePrelude::Import(import) => write_import_prelude(import, f),
+        AtRulePrelude::Namespace(namespace) => {
+            if let Some(prefix) = &namespace.prefix {
+                let span = to_span(prefix.span());
+                write!(f, text(source.text_for(&span)));
+                write!(f, space());
+            }
+            match &namespace.uri {
+                raffia::ast::NamespacePreludeUri::Str(InterpolableStr::Literal(str)) => {
+                    value::write_str(str, f);
+                }
+                raffia::ast::NamespacePreludeUri::Url(url) => value::write_url(url, f),
+                uri @ raffia::ast::NamespacePreludeUri::Str(_) => {
+                    let span = to_span(uri.span());
+                    write!(f, text(source.text_for(&span)));
+                }
+            }
+        }
+        // Prettier keeps `@page` params verbatim (e.g. `@page:first` stays).
+        AtRulePrelude::Page(page) => {
+            let span = to_span(page.span());
+            write!(f, text(source.text_for(&span)));
+        }
+        AtRulePrelude::Supports(condition) => write_supports_condition(condition, f),
+        AtRulePrelude::Layer(layers) => {
+            for (i, layer) in layers.names.iter().enumerate() {
+                if i > 0 {
+                    write!(f, [",", space()]);
+                }
+                let span = to_span(layer.span());
+                write!(f, text(source.text_for(&span)));
+            }
+        }
+        AtRulePrelude::Property(ident)
+        | AtRulePrelude::CounterStyle(ident)
+        | AtRulePrelude::FontPaletteValues(ident)
+        | AtRulePrelude::PositionTry(ident)
+        | AtRulePrelude::ScrollTimeline(ident) => {
+            let span = to_span(ident.span());
+            write!(f, text(source.text_for(&span)));
+        }
+        AtRulePrelude::Nest(list) => {
+            selector::write_selector_list(list, selector::SelectorListStyle::Line, f);
+        }
+        AtRulePrelude::SassAtRoot(at_root) => match &at_root.kind {
+            raffia::ast::SassAtRootKind::Selector(list) => {
+                selector::write_selector_list(list, selector::SelectorListStyle::Line, f);
+            }
+            raffia::ast::SassAtRootKind::Query(query) => {
+                let span = to_span(query.span());
+                write!(f, text(source.text_for(&span)));
+            }
+        },
+        AtRulePrelude::SassExpr(value) => {
+            value::write_component_value(value, ValueContext::default(), f);
+        }
+        AtRulePrelude::SassEach(each) => scss::write_sass_each(each, f),
+        AtRulePrelude::SassFor(sass_for) => scss::write_sass_for(sass_for, f),
+        AtRulePrelude::SassMixin(mixin) => scss::write_sass_mixin(mixin, f),
+        AtRulePrelude::SassFunction(function) => scss::write_sass_function(function, f),
+        AtRulePrelude::SassInclude(include) => scss::write_sass_include(include, f),
+        AtRulePrelude::SassUse(sass_use) => scss::write_sass_use(sass_use, f),
+        AtRulePrelude::SassForward(forward) => scss::write_sass_forward(forward, f),
+        AtRulePrelude::SassImport(import) => {
+            // Comments force the path list to break, one path per line.
+            let last_end = to_span(import.span()).end;
+            let has_comments = f.context().comments().iter_before(last_end).next().is_some();
+            if has_comments && import.paths.len() > 1 {
+                // Comments fuse with the following path into ONE fill chunk
+                // (Prettier's comma_group). Prettier's fill treats a chunk
+                // with a hardline as never-fitting — our core fill measures
+                // up to the hardline and calls it fit — so the separator
+                // breaks are simulated here with static widths.
+                let all: Vec<crate::comments::CssComment> =
+                    f.context().comments().iter_before(last_end).collect();
+                let n = import.paths.len();
+                let mut leads: Vec<Vec<crate::comments::CssComment>> = Vec::with_capacity(n);
+                for (i, path) in import.paths.iter().enumerate() {
+                    let path_start = to_span(path.span()).start;
+                    leads.push(
+                        all.iter()
+                            .filter(|c| c.span.end <= path_start)
+                            .filter(|c| {
+                                i == 0 || c.span.start >= to_span(import.paths[i - 1].span()).end
+                            })
+                            .copied()
+                            .collect(),
+                    );
+                }
+                // Prettier fill: separator stays flat only when
+                // [chunk, ", ", next chunk] fits and neither chunk has a
+                // comment (hardline).
+                let width = u32::from(f.options().line_width.value());
+                let indent_w = u32::from(f.options().indent_width.value());
+                let chunk_w: Vec<u32> = import
+                    .paths
+                    .iter()
+                    .enumerate()
+                    .map(|(i, p)| {
+                        let span = to_span(p.span());
+                        span.end - span.start + u32::from(i + 1 < n)
+                    })
+                    .collect();
+                let mut breaks_before = vec![false; n];
+                let mut x = 8; // after `@import `
+                for i in 0..n {
+                    if i + 1 == n {
+                        break;
+                    }
+                    let hard = leads[i].iter().any(|c| c.inline);
+                    let next_hard = leads[i + 1].iter().any(|c| c.inline);
+                    let fits2 = !hard && !next_hard && x + chunk_w[i] + 1 + chunk_w[i + 1] <= width;
+                    if fits2 {
+                        x += chunk_w[i] + 1;
+                    } else {
+                        breaks_before[i + 1] = true;
+                        x = indent_w;
+                    }
+                }
+                let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    for (i, path) in import.paths.iter().enumerate() {
+                        if i > 0 {
+                            if breaks_before[i] {
+                                write!(f, hard_line_break());
+                            } else {
+                                write!(f, space());
+                            }
+                        }
+                        for &comment in &leads[i] {
+                            f.context().comments().take_before(comment.span.end);
+                            crate::comments::write_single_comment(comment, f);
+                            if comment.inline {
+                                write!(f, hard_line_break());
+                            } else {
+                                write!(f, space());
+                            }
+                        }
+                        value::write_str(path, f);
+                        if i + 1 < n {
+                            write!(f, ",");
+                        }
+                    }
+                });
+                write!(f, indent(&body));
+            } else if has_comments {
+                let path = &import.paths[0];
+                let path_start = to_span(path.span()).start;
+                let lead: Vec<crate::comments::CssComment> =
+                    f.context().comments().take_before(path_start).to_vec();
+                for &comment in &lead {
+                    crate::comments::write_single_comment(comment, f);
+                    if comment.inline {
+                        write!(f, hard_line_break());
+                    } else {
+                        write!(f, space());
+                    }
+                }
+                value::write_str(path, f);
+            } else {
+                for (i, path) in import.paths.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, [",", space()]);
+                    }
+                    value::write_str(path, f);
+                }
+            }
+        }
+        AtRulePrelude::Unknown(unknown) => match &**unknown {
+            raffia::ast::UnknownAtRulePrelude::ComponentValue(value) => {
+                value::write_component_value(value, ValueContext::default(), f);
+            }
+            raffia::ast::UnknownAtRulePrelude::TokenSeq(seq) => {
+                write_token_seq(seq, f);
+            }
+        },
+        // Sass/Less and not-yet-ported preludes: verbatim.
+        _ => {
+            let span = to_span(prelude.span());
+            write!(f, text(source.text_for(&span)));
+        }
+    }
+}
+
+/// Prints a raw token sequence, collapsing whitespace runs to a single
+/// breakable space and keeping tight tokens tight (mirrors how Prettier's
+/// `parseValue` + comma-group printing treats unknown at-rule params).
+pub fn write_token_seq<'a>(seq: &raffia::ast::TokenSeq<'a>, f: &mut CssFormatter<'_, 'a>) {
+    write_tokens(&seq.tokens, f);
+}
+
+/// Mini value printer over a raw token stream, normalizing whitespace the way
+/// postcss-values-parser + Prettier do: `, ` after commas (no space before),
+/// `(`/`)` hug their contents, `:` hugs left, math operators break after.
+fn write_tokens<'a>(tokens: &[raffia::token::TokenWithSpan<'a>], f: &mut CssFormatter<'_, 'a>) {
+    write_token_value(tokens, true, f);
+}
+
+fn token_depth_delta(token: &raffia::token::Token<'_>) -> i32 {
+    use raffia::token::Token;
+    match token {
+        Token::LParen(_) | Token::LBracket(_) | Token::LBrace(_) => 1,
+        Token::RParen(_) | Token::RBracket(_) | Token::RBrace(_) => -1,
+        _ => 0,
+    }
+}
+
+/// Comma-separated token value: groups joined by `, ` (breakable), blank
+/// lines preserved after multi-token groups.
+fn write_token_value<'a>(
+    tokens: &[raffia::token::TokenWithSpan<'a>],
+    top_level: bool,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    use raffia::token::Token;
+    let source = f.context().source_text();
+    // Split at top-level commas.
+    let mut groups: Vec<&[raffia::token::TokenWithSpan<'a>]> = vec![];
+    let mut depth = 0i32;
+    let mut start = 0;
+    for (i, tok) in tokens.iter().enumerate() {
+        depth += token_depth_delta(&tok.token);
+        if depth == 0 && matches!(&tok.token, Token::Comma(_)) {
+            groups.push(&tokens[start..i]);
+            start = i + 1;
+        }
+    }
+    groups.push(&tokens[start..]);
+    if groups.len() > 1 && groups.last().is_some_and(|g| g.is_empty()) {
+        groups.pop();
+    }
+
+    if groups.len() == 1 {
+        let only = groups[0];
+        // `name( ... )` covering the whole group: the parens govern
+        // breaking/indent; anything else gets the continuation indent.
+        let whole_call = only.len() > 2
+            && matches!(&only[only.len() - 1].token, Token::RParen(_))
+            && (matches!(&only[0].token, Token::LParen(_))
+                || (matches!(&only[0].token, Token::Ident(_))
+                    && matches!(&only[1].token, Token::LParen(_))));
+        if top_level && !whole_call {
+            let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                write_token_comma_group(only, f);
+            });
+            write!(f, group(&indent(&body)));
+        } else if whole_call {
+            write_token_comma_group(only, f);
+        } else {
+            write_token_comma_group_grouped(only, f);
+        }
+        return;
+    }
+    let groups_ref = &groups;
+    if top_level {
+        // Top level: fill (as many groups per line as fit).
+        let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            let mut filler = f.fill();
+            for (i, group_tokens) in groups_ref.iter().enumerate() {
+                let is_last = i + 1 == groups_ref.len();
+                let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    write_token_comma_group_grouped(group_tokens, f);
+                    if !is_last {
+                        write!(f, ",");
+                    }
+                });
+                filler.entry(&soft_line_break_or_space(), &content);
+            }
+            filler.finish();
+        });
+        write!(f, group(&indent(&body)));
+    } else {
+        // Inside parens: `join(line, ...)` — when the paren group breaks,
+        // every group goes on its own line; blank lines are preserved after
+        // key-value-ish groups.
+        for (i, group_tokens) in groups_ref.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",");
+                let sep_blank =
+                    groups_ref[i - 1].iter().any(|t| matches!(&t.token, Token::Colon(_))) && {
+                        let prev_end =
+                            groups_ref[i - 1].last().map_or(0, |t| to_span(t.span()).end);
+                        let next_start =
+                            group_tokens.first().map_or(prev_end, |t| to_span(t.span()).start);
+                        crate::comments::classify_gap(source.bytes_range(prev_end, next_start))
+                            == crate::comments::Gap::Blank
+                    };
+                if sep_blank {
+                    write!(f, oxc_formatter_core::builders::empty_line());
+                } else {
+                    write!(f, soft_line_break_or_space());
+                }
+            }
+            write_token_comma_group_grouped(group_tokens, f);
+        }
+    }
+}
+
+/// Space-separated tokens within one comma group; balanced paren regions are
+/// printed as breakable groups.
+fn write_token_comma_group<'a>(
+    tokens: &[raffia::token::TokenWithSpan<'a>],
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    use raffia::token::Token;
+    let source = f.context().source_text();
+
+    let hug_lparen = tokens.len() > 1
+        && matches!(&tokens[1].token, Token::LParen(_))
+        && matches!(&tokens[0].token, Token::Ident(_))
+        && !source.text_for(&to_span(tokens[0].span())).eq_ignore_ascii_case("if");
+
+    let mut filler = f.fill();
+    let mut i = 0;
+    while i < tokens.len() {
+        // A run: tokens glued by gap/punctuation rules; a paren region opener
+        // ends the run scan (the region is appended to the same run).
+        let mut run_end = i + 1;
+        // A run starting at an opener swallows its balanced region.
+        if matches!(&tokens[i].token, Token::LParen(_) | Token::LBracket(_) | Token::LBrace(_)) {
+            let mut depth = 0i32;
+            let mut j = i;
+            while j < tokens.len() {
+                depth += token_depth_delta(&tokens[j].token);
+                j += 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            run_end = j.max(i + 1);
+        }
+        while run_end < tokens.len() {
+            let prev = &tokens[run_end - 1];
+            let curr = &tokens[run_end];
+            if matches!(&curr.token, Token::LParen(_) | Token::LBracket(_) | Token::LBrace(_)) {
+                // Opener glues to the run when fused in source, after a
+                // colon (`$arg: (...)`), or as a call (`name(...)`).
+                let glued = to_span(prev.span()).end == to_span(curr.span()).start
+                    || matches!(&prev.token, Token::Colon(_))
+                    || (run_end == 1 && hug_lparen);
+                if !glued {
+                    break;
+                }
+                // Append the whole balanced region (and continue the run).
+                let mut depth = 0i32;
+                let mut j = run_end;
+                while j < tokens.len() {
+                    depth += token_depth_delta(&tokens[j].token);
+                    j += 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                run_end = j;
+                continue;
+            }
+            let tight = to_span(prev.span()).end == to_span(curr.span()).start
+                || matches!(
+                    &curr.token,
+                    Token::Comma(_)
+                        | Token::Colon(_)
+                        | Token::Semicolon(_)
+                        | Token::DotDotDot(_)
+                        | Token::Dot(_)
+                )
+                // Math operators glue to their LEFT operand (break after);
+                // comparisons glue to their RIGHT operand (break before).
+                || matches!(
+                    &curr.token,
+                    Token::Plus(_)
+                        | Token::Minus(_)
+                        | Token::Asterisk(_)
+                        | Token::Percent(_)
+                        | Token::Solidus(_)
+                )
+                || matches!(&curr.token, Token::Equal(_))
+                || matches!(&prev.token, Token::Equal(_));
+            if tight {
+                run_end += 1;
+            } else {
+                break;
+            }
+        }
+        let run = &tokens[i..run_end];
+        let run_start = i;
+        let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            write_token_run(run, run_start == 0 && hug_lparen, f);
+        });
+        filler.entry(&soft_line_break_or_space(), &content);
+        i = run_end;
+    }
+    filler.finish();
+}
+
+/// Wrapper: a comma group is its own breakable group with indent —
+/// except when it contains paren regions, which provide their own
+/// indentation (avoids double-indenting `name(...)` contents).
+fn write_token_comma_group_grouped<'a>(
+    tokens: &[raffia::token::TokenWithSpan<'a>],
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    use raffia::token::Token;
+    // A group that IS one call/paren region delegates breaking to the parens.
+    let whole_region = !tokens.is_empty()
+        && matches!(&tokens[tokens.len() - 1].token, Token::RParen(_))
+        && (matches!(&tokens[0].token, Token::LParen(_))
+            || (tokens.len() > 1
+                && matches!(&tokens[0].token, Token::Ident(_))
+                && matches!(&tokens[1].token, Token::LParen(_))));
+    // A `$key: (region)` pair also delegates to the parens.
+    let kv_region = !whole_region
+        && matches!(tokens.last().map(|t| &t.token), Some(Token::RParen(_)))
+        && tokens
+            .iter()
+            .take_while(|t| {
+                !matches!(&t.token, Token::LParen(_) | Token::LBracket(_) | Token::LBrace(_))
+            })
+            .any(|t| matches!(&t.token, Token::Colon(_)));
+    if whole_region || kv_region {
+        write_token_comma_group(tokens, f);
+        return;
+    }
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        write_token_comma_group(tokens, f);
+    });
+    write!(f, group(&indent(&body)));
+}
+
+/// One run: spacing normalized; paren regions recurse as breakable groups.
+fn write_token_run<'a>(
+    run: &[raffia::token::TokenWithSpan<'a>],
+    hug_lparen: bool,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    use raffia::token::Token;
+    let source = f.context().source_text();
+    let mut j = 0;
+    while j < run.len() {
+        let tok = &run[j];
+        // A paren region: recurse.
+        if matches!(&tok.token, Token::LParen(_) | Token::LBracket(_) | Token::LBrace(_)) {
+            let mut depth = 0i32;
+            let mut k = j;
+            while k < run.len() {
+                depth += token_depth_delta(&run[k].token);
+                k += 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            // Unbalanced region: print the opener verbatim and move on.
+            if depth != 0 || k < j + 2 {
+                if j > 0 {
+                    write_token_pair_space(run, j, hug_lparen, f);
+                }
+                let span = to_span(tok.span());
+                write!(f, text(source.text_for(&span)));
+                j += 1;
+                continue;
+            }
+            let inner = &run[j + 1..k - 1];
+            let (open, close): (&str, &str) = match &tok.token {
+                Token::LParen(_) => ("(", ")"),
+                Token::LBracket(_) => ("[", "]"),
+                _ => ("{", "}"),
+            };
+            if j > 0 {
+                write_token_pair_space(run, j, hug_lparen, f);
+            }
+            if inner.is_empty() {
+                write!(f, [text(open), text(close)]);
+            } else {
+                let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    write!(f, oxc_formatter_core::builders::soft_line_break());
+                    write_token_value(inner, false, f);
+                });
+                write!(
+                    f,
+                    group(&format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                        write!(f, text(open));
+                        write!(f, indent(&body));
+                        write!(f, oxc_formatter_core::builders::soft_line_break());
+                        write!(f, text(close));
+                    }))
+                );
+            }
+            j = k;
+            continue;
+        }
+        if j > 0 {
+            write_token_pair_space(run, j, hug_lparen, f);
+        }
+        let span = to_span(tok.span());
+        match &tok.token {
+            Token::Str(_) => write_raw_str(source.text_for(&span), f),
+            Token::Number(n) => match value::print_css_number(n.raw) {
+                std::borrow::Cow::Borrowed(s) => write!(f, text(s)),
+                std::borrow::Cow::Owned(s) => write!(f, text(f.allocator().alloc_str(&s))),
+            },
+            Token::Dimension(d) => {
+                match value::print_css_number(d.value.raw) {
+                    std::borrow::Cow::Borrowed(s) => write!(f, text(s)),
+                    std::borrow::Cow::Owned(s) => write!(f, text(f.allocator().alloc_str(&s))),
+                }
+                write!(f, text(d.unit.raw));
+            }
+            Token::Percentage(pct) => {
+                match value::print_css_number(pct.value.raw) {
+                    std::borrow::Cow::Borrowed(s) => write!(f, text(s)),
+                    std::borrow::Cow::Owned(s) => write!(f, text(f.allocator().alloc_str(&s))),
+                }
+                write!(f, "%");
+            }
+            _ => write!(f, text(source.text_for(&span))),
+        }
+        j += 1;
+    }
+}
+
+/// Normalized spacing between `run[j-1]` and `run[j]`.
+#[expect(clippy::match_same_arms)]
+fn write_token_pair_space<'a>(
+    run: &[raffia::token::TokenWithSpan<'a>],
+    j: usize,
+    hug_lparen: bool,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    use raffia::token::Token;
+    let prev = &run[j - 1];
+    let tok = &run[j];
+    let gap = to_span(prev.span()).end != to_span(tok.span()).start;
+    let wordish = |t: &Token<'_>| {
+        matches!(t, Token::Ident(_) | Token::DollarVar(_) | Token::AtKeyword(_) | Token::RParen(_))
+    };
+    let space = match (&prev.token, &tok.token) {
+        (Token::LParen(_) | Token::LBracket(_) | Token::LBrace(_), _)
+        | (
+            _,
+            Token::RParen(_)
+            | Token::RBracket(_)
+            | Token::RBrace(_)
+            | Token::Comma(_)
+            | Token::Colon(_)
+            | Token::Semicolon(_)
+            | Token::Equal(_)
+            | Token::DotDotDot(_)
+            | Token::Dot(_),
+        ) => false,
+        (Token::Equal(_) | Token::Dot(_), _) => false,
+        (_, Token::LParen(_)) if j == 1 && hug_lparen => false,
+        (Token::Colon(_) | Token::Comma(_), _) => true,
+        (Token::Ident(i), Token::Asterisk(_)) if !gap && i.raw.ends_with('-') => false,
+        (p, Token::Asterisk(_) | Token::Plus(_)) if wordish(p) => true,
+        (Token::Asterisk(_) | Token::Plus(_), n) if wordish(n) => true,
+        (Token::Asterisk(_) | Token::Plus(_), Token::LParen(_)) => true,
+        (
+            Token::RParen(_),
+            Token::GreaterThan(_)
+            | Token::LessThan(_)
+            | Token::GreaterThanEqual(_)
+            | Token::LessThanEqual(_)
+            | Token::EqualEqual(_)
+            | Token::ExclamationEqual(_),
+        ) => true,
+        _ => gap,
+    };
+    if space {
+        write!(f, " ");
+    }
+}
+
+fn write_raw_str<'a>(raw: &'a str, f: &mut CssFormatter<'_, 'a>) {
+    let single_quote = f.options().single_quote.value();
+    if raw.len() < 2 {
+        write!(f, text(raw));
+        return;
+    }
+    let content = &raw[1..raw.len() - 1];
+    let (preferred, alternate) = if single_quote { ('\'', '"') } else { ('"', '\'') };
+    let mut preferred_count = 0usize;
+    let mut alternate_count = 0usize;
+    for b in content.bytes() {
+        if b == preferred as u8 {
+            preferred_count += 1;
+        } else if b == alternate as u8 {
+            alternate_count += 1;
+        }
+    }
+    let enclosing = if preferred_count > alternate_count { alternate } else { preferred };
+    if raw.as_bytes()[0] == enclosing as u8 {
+        write!(f, text(raw));
+    } else {
+        let out = format!("{enclosing}{content}{enclosing}");
+        write!(f, text(f.allocator().alloc_str(&out)));
+    }
+}
+
+fn write_keyframes_name<'a>(name: &KeyframesName<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    if let KeyframesName::Str(InterpolableStr::Literal(str)) = name {
+        value::write_str(str, f);
+    } else {
+        let span = to_span(name.span());
+        write!(f, text(source.text_for(&span)));
+    }
+}
+
+fn write_import_prelude<'a>(import: &ImportPrelude<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    match &import.href {
+        raffia::ast::ImportPreludeHref::Str(InterpolableStr::Literal(str)) => {
+            value::write_str(str, f);
+        }
+        raffia::ast::ImportPreludeHref::Url(url) => value::write_url(url, f),
+        href @ raffia::ast::ImportPreludeHref::Str(_) => {
+            let span = to_span(href.span());
+            write!(f, text(source.text_for(&span)));
+        }
+    }
+    if let Some(layer) = &import.layer {
+        write!(f, space());
+        let span = to_span(layer.span());
+        write!(f, text(source.text_for(&span)));
+    }
+    if let Some(supports) = &import.supports {
+        write!(f, [space(), "supports(", ")"]);
+        let _ = supports;
+    }
+    if let Some(media) = &import.media {
+        write!(f, space());
+        write_media_query_list(media, f);
+    }
+}
+
+/// Mirrors Prettier's `media-query-list`: queries joined by `,` + line,
+/// wrapped in `group(indent(...))`.
+pub fn write_media_query_list<'a>(list: &MediaQueryList<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        for (i, query) in list.queries.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",");
+                write!(f, soft_line_break_or_space());
+            }
+            write_media_query(query, f);
+        }
+    });
+    write!(f, group(&indent(&body)));
+}
+
+fn write_media_query<'a>(query: &MediaQuery<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    match query {
+        MediaQuery::ConditionOnly(condition) => write_media_condition(condition, f),
+        MediaQuery::WithType(with_type) => {
+            if let Some(modifier) = &with_type.modifier {
+                let span = to_span(modifier.span());
+                write_maybe_lowercase(source.text_for(&span), f);
+                write!(f, space());
+            }
+            let span = to_span(with_type.media_type.span());
+            write_maybe_lowercase(source.text_for(&span), f);
+            if let Some(condition) = &with_type.condition {
+                write!(f, space());
+                let and_span = to_span(condition.and.span());
+                write_maybe_lowercase(source.text_for(&and_span), f);
+                write!(f, space());
+                write_media_condition(&condition.condition, f);
+            }
+        }
+        _ => {
+            let span = to_span(query.span());
+            write!(f, text(source.text_for(&span)));
+        }
+    }
+}
+
+fn write_media_condition<'a>(condition: &MediaCondition<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    for (i, kind) in condition.conditions.iter().enumerate() {
+        if i > 0 {
+            write!(f, space());
+        }
+        match kind {
+            MediaConditionKind::MediaInParens(in_parens) => {
+                write_media_in_parens(in_parens, f);
+            }
+            MediaConditionKind::And(and) => {
+                let span = to_span(and.keyword.span());
+                write_maybe_lowercase(source.text_for(&span), f);
+                write!(f, space());
+                write_media_in_parens(&and.media_in_parens, f);
+            }
+            MediaConditionKind::Or(or) => {
+                let span = to_span(or.keyword.span());
+                write_maybe_lowercase(source.text_for(&span), f);
+                write!(f, space());
+                write_media_in_parens(&or.media_in_parens, f);
+            }
+            MediaConditionKind::Not(not) => {
+                let span = to_span(not.keyword.span());
+                write_maybe_lowercase(source.text_for(&span), f);
+                write!(f, space());
+                write_media_in_parens(&not.media_in_parens, f);
+            }
+        }
+    }
+}
+
+fn write_media_in_parens<'a>(in_parens: &MediaInParens<'a>, f: &mut CssFormatter<'_, 'a>) {
+    match &in_parens.kind {
+        MediaInParensKind::MediaCondition(condition) => {
+            write!(f, "(");
+            write_media_condition(condition, f);
+            write!(f, ")");
+        }
+        MediaInParensKind::MediaFeature(feature) => {
+            write!(f, "(");
+            write_media_feature(feature, f);
+            write!(f, ")");
+        }
+    }
+}
+
+fn write_media_feature_name<'a>(name: &MediaFeatureName<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let span = to_span(name.span());
+    match name {
+        MediaFeatureName::Ident(_) => write_maybe_lowercase(source.text_for(&span), f),
+        MediaFeatureName::SassVariable(_) => write!(f, text(source.text_for(&span))),
+    }
+}
+
+fn write_comparison(kind: &MediaFeatureComparisonKind, f: &mut CssFormatter<'_, '_>) {
+    match kind {
+        MediaFeatureComparisonKind::LessThan => write!(f, "<"),
+        MediaFeatureComparisonKind::LessThanOrEqual => write!(f, "<="),
+        MediaFeatureComparisonKind::GreaterThan => write!(f, ">"),
+        MediaFeatureComparisonKind::GreaterThanOrEqual => write!(f, ">="),
+        MediaFeatureComparisonKind::Equal => write!(f, "="),
+    }
+}
+
+fn write_media_feature_value<'a>(value: &ComponentValue<'a>, f: &mut CssFormatter<'_, 'a>) {
+    value::write_component_value(value, ValueContext::default(), f);
+}
+
+fn write_media_feature<'a>(feature: &MediaFeature<'a>, f: &mut CssFormatter<'_, 'a>) {
+    match feature {
+        MediaFeature::Plain(plain) => {
+            write_media_feature_name(&plain.name, f);
+            write!(f, [":", space()]);
+            write_media_feature_value(&plain.value, f);
+        }
+        MediaFeature::Boolean(boolean) => {
+            write_media_feature_name(&boolean.name, f);
+        }
+        MediaFeature::Range(range) => {
+            write_media_feature_value(&range.left, f);
+            write!(f, space());
+            write_comparison(&range.comparison.kind, f);
+            write!(f, space());
+            write_media_feature_value(&range.right, f);
+        }
+        MediaFeature::RangeInterval(interval) => {
+            write_media_feature_value(&interval.left, f);
+            write!(f, space());
+            write_comparison(&interval.left_comparison.kind, f);
+            write!(f, space());
+            write_media_feature_name(&interval.name, f);
+            write!(f, space());
+            write_comparison(&interval.right_comparison.kind, f);
+            write!(f, space());
+            write_media_feature_value(&interval.right, f);
+        }
+    }
+}
+
+fn write_supports_condition<'a>(condition: &SupportsCondition<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    for (i, kind) in condition.conditions.iter().enumerate() {
+        if i > 0 {
+            write!(f, space());
+        }
+        match kind {
+            SupportsConditionKind::SupportsInParens(in_parens) => {
+                write_supports_in_parens(in_parens, f);
+            }
+            SupportsConditionKind::And(and) => {
+                let span = to_span(and.keyword.span());
+                write_maybe_lowercase(source.text_for(&span), f);
+                write!(f, space());
+                write_supports_in_parens(&and.condition, f);
+            }
+            SupportsConditionKind::Or(or) => {
+                let span = to_span(or.keyword.span());
+                write_maybe_lowercase(source.text_for(&span), f);
+                write!(f, space());
+                write_supports_in_parens(&or.condition, f);
+            }
+            SupportsConditionKind::Not(not) => {
+                let span = to_span(not.keyword.span());
+                write_maybe_lowercase(source.text_for(&span), f);
+                write!(f, space());
+                write_supports_in_parens(&not.condition, f);
+            }
+        }
+    }
+}
+
+fn write_supports_in_parens<'a>(in_parens: &SupportsInParens<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    match &in_parens.kind {
+        SupportsInParensKind::SupportsCondition(condition) => {
+            write!(f, "(");
+            write_supports_condition(condition, f);
+            write!(f, ")");
+        }
+        SupportsInParensKind::Feature(feature) => {
+            write!(f, "(");
+            crate::print::statement::write_declaration_inline(&feature.decl, f);
+            write!(f, ")");
+        }
+        SupportsInParensKind::Selector(list) => {
+            write!(f, "selector(");
+            // An inline comment inside `selector(...)` forces the parens
+            // open and trails the selector.
+            // raffia's span may stop at the selector; scan to the `)`.
+            let span_end = to_span(in_parens.span()).end;
+            let bytes = source.as_bytes();
+            let mut scan = span_end.saturating_sub(1) as usize;
+            while scan < bytes.len() && bytes[scan] != b')' {
+                scan += 1;
+            }
+            let r_paren = u32::try_from(scan).unwrap_or(span_end);
+            let has_inline_inside = f.context().comments().iter_before(r_paren).any(|c| c.inline);
+            if has_inline_inside {
+                let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    write!(f, hard_line_break());
+                    selector::write_selector_list(list, selector::SelectorListStyle::Line, f);
+                    for &comment in f.context().comments().take_before(r_paren) {
+                        write!(f, space());
+                        crate::comments::write_single_comment(comment, f);
+                    }
+                });
+                write!(f, [indent(&body), hard_line_break(), ")"]);
+            } else {
+                selector::write_selector_list(list, selector::SelectorListStyle::Line, f);
+                write!(f, ")");
+            }
+        }
+        SupportsInParensKind::Function(func) => {
+            let func_value = raffia::ast::ComponentValue::Function(func.clone());
+            value::write_component_value(&func_value, ValueContext::default(), f);
+        }
+    }
+}

--- a/crates/oxc_formatter_css/src/print/less.rs
+++ b/crates/oxc_formatter_css/src/print/less.rs
@@ -1,0 +1,265 @@
+//! Less-specific printing: variable declarations, mixins, lookups, guards.
+
+use oxc_formatter_core::{
+    Buffer,
+    builders::{space, text},
+    write,
+};
+use raffia::{
+    Spanned,
+    ast::{
+        ComponentValue, LessCondition, LessConditions, LessMixinArgument, LessMixinCall,
+        LessMixinDefinition, LessMixinName, LessMixinParameter, LessVariableDeclaration,
+    },
+};
+
+use crate::{
+    format::to_span,
+    print::{
+        CssFormatter,
+        statement::write_block,
+        value::{self, ValueContext},
+    },
+};
+
+/// `@name: value`. Returns `true` when the caller should append `;`.
+pub fn write_less_variable_declaration<'a>(
+    decl: &LessVariableDeclaration<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) -> bool {
+    let source = f.context().source_text();
+    write!(f, "@");
+    let name_span = to_span(decl.name.name.span());
+    write!(f, text(source.text_for(&name_span)));
+    let colon_end = to_span(&decl.colon_span).end;
+    // Inline comments around the colon make postcss-less treat this as a
+    // plain at-rule: the raw text is kept and the block loses its `;`.
+    let value_start_pos = to_span(decl.value.span()).start;
+    let inline_before_colon = f.context().comments().iter_before(colon_end).any(|c| c.inline);
+    let inline_after_colon = f
+        .context()
+        .comments()
+        .iter_before(value_start_pos)
+        .any(|c| c.inline && c.span.start >= colon_end);
+    // Inline comment AFTER the colon only: still a variable; the comment and
+    // line structure are kept (`@var: // c\n{`).
+    if !inline_before_colon && inline_after_colon {
+        write!(f, [":", space()]);
+        for &comment in f.context().comments().take_before(value_start_pos) {
+            crate::comments::write_single_comment(comment, f);
+            write!(f, oxc_formatter_core::builders::hard_line_break());
+        }
+        crate::print::scss::write_top_level_value(&decl.value, ValueContext::default(), f);
+        return true;
+    }
+    if inline_before_colon {
+        let value_start = to_span(decl.value.span()).start;
+        let _ = f.context().comments().take_before(value_start);
+        let raw = source.slice_range(name_span.end, value_start);
+        write!(f, text(raw.trim_end()));
+        if let ComponentValue::LessDetachedRuleset(ruleset) = &decl.value {
+            // Plain at-rule semantics: props are lowercased, no `;`.
+            if raw.trim_end().ends_with(':') {
+                write!(f, space());
+            } else {
+                write!(f, oxc_formatter_core::builders::hard_line_break());
+            }
+            write_block(&ruleset.block, f);
+            return false;
+        }
+        write!(f, space());
+        crate::print::scss::write_top_level_value(&decl.value, ValueContext::default(), f);
+        return true;
+    }
+    // postcss-less drops (block) comments between the name and the colon.
+    let _ = f.context().comments().take_before(colon_end);
+    write!(f, [":", space()]);
+    crate::print::scss::write_top_level_value(&decl.value, ValueContext::default(), f);
+    true
+}
+
+fn write_mixin_name<'a>(name: &LessMixinName<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let span = to_span(name.span());
+    write!(f, text(source.text_for(&span)));
+}
+
+/// `.mixin(@params...) when (guard) { ... }`
+pub fn write_less_mixin_definition<'a>(
+    def: &LessMixinDefinition<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    write_mixin_name(&def.name, f);
+    write_mixin_parameters(&def.params, f);
+    if let Some(guard) = &def.guard {
+        write_less_guard(guard, f);
+    }
+    write!(f, space());
+    write_block(&def.block, f);
+}
+
+fn write_mixin_parameters<'a>(
+    params: &raffia::ast::LessMixinParameters<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    write!(f, "(");
+    let separator: &str = if params.is_comma_separated { ", " } else { "; " };
+    for (i, param) in params.params.iter().enumerate() {
+        if i > 0 {
+            write!(f, text(separator));
+        }
+        match param {
+            LessMixinParameter::Named(named) => {
+                let span = to_span(named.name.span());
+                write!(f, text(source.text_for(&span)));
+                if let Some(default) = &named.value {
+                    write!(f, [":", space()]);
+                    value::write_component_value(&default.value, ValueContext::default(), f);
+                }
+            }
+            LessMixinParameter::Unnamed(unnamed) => {
+                value::write_component_value(&unnamed.value, ValueContext::default(), f);
+            }
+            LessMixinParameter::Variadic(variadic) => {
+                if let Some(name) = &variadic.name {
+                    let span = to_span(name.span());
+                    write!(f, text(source.text_for(&span)));
+                }
+                write!(f, "...");
+            }
+        }
+    }
+    write!(f, ")");
+}
+
+/// `.mixin(args) !important` — used both as a statement and as a value.
+pub fn write_less_mixin_call<'a>(call: &LessMixinCall<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    for child in &call.callee.children {
+        if let Some(combinator) = &child.combinator {
+            let span = to_span(combinator.span());
+            write!(f, [space(), text(source.text_for(&span)), space()]);
+        }
+        write_mixin_name(&child.name, f);
+    }
+    if let Some(args) = &call.args {
+        write!(f, "(");
+        let separator: &str = if args.is_comma_separated { ", " } else { "; " };
+        for (i, arg) in args.args.iter().enumerate() {
+            if i > 0 {
+                write!(f, text(separator));
+            }
+            match arg {
+                LessMixinArgument::Named(named) => {
+                    let span = to_span(named.name.span());
+                    write!(f, [text(source.text_for(&span)), ":", space()]);
+                    value::write_component_value(&named.value, ValueContext::default(), f);
+                }
+                LessMixinArgument::Value(value) => {
+                    value::write_component_value(value, ValueContext::default(), f);
+                }
+                LessMixinArgument::Variadic(variadic) => {
+                    let span = to_span(variadic.name.span());
+                    write!(f, [text(source.text_for(&span)), "..."]);
+                }
+            }
+        }
+        write!(f, ")");
+    }
+    if call.important.is_some() {
+        write!(f, [space(), "!important"]);
+    }
+}
+
+/// ` when (cond), (cond) and (cond)`
+pub fn write_less_guard<'a>(guard: &LessConditions<'a>, f: &mut CssFormatter<'_, 'a>) {
+    write!(f, [space(), "when", space()]);
+    for (i, condition) in guard.conditions.iter().enumerate() {
+        if i > 0 {
+            write!(f, [",", space()]);
+        }
+        write_less_condition(condition, f);
+    }
+}
+
+pub fn write_less_condition<'a>(condition: &LessCondition<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    match condition {
+        LessCondition::Binary(binary) => {
+            write_less_condition(&binary.left, f);
+            let op_span = to_span(binary.op.span());
+            write!(f, [space(), text(source.text_for(&op_span)), space()]);
+            write_less_condition(&binary.right, f);
+        }
+        LessCondition::Negated(negated) => {
+            write!(f, ["not", space()]);
+            write_less_condition(&negated.condition, f);
+        }
+        LessCondition::Parenthesized(paren) => {
+            write!(f, "(");
+            write_less_condition(&paren.condition, f);
+            write!(f, ")");
+        }
+        LessCondition::Value(value) => {
+            value::write_component_value(value, ValueContext::default(), f);
+        }
+    }
+}
+
+/// `.mixin(args)[@lookup][...]` / `@var[lookup]`
+pub fn write_less_namespace_value<'a>(
+    namespace: &raffia::ast::LessNamespaceValue<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    match &namespace.callee {
+        raffia::ast::LessNamespaceValueCallee::LessMixinCall(call) => {
+            write_less_mixin_call(call, f);
+        }
+        raffia::ast::LessNamespaceValueCallee::LessVariable(variable) => {
+            let span = to_span(variable.span());
+            write!(f, text(source.text_for(&span)));
+        }
+    }
+    for lookup in &namespace.lookups.lookups {
+        write!(f, "[");
+        if let Some(name) = &lookup.name {
+            let span = to_span(name.span());
+            write!(f, text(source.text_for(&span)));
+        }
+        write!(f, "]");
+    }
+}
+
+/// `{ ... }` detached ruleset as a value. Property names inside keep their
+/// case (Prettier checks the enclosing `variable` at-rule).
+pub fn write_less_detached_ruleset<'a>(
+    ruleset: &raffia::ast::LessDetachedRuleset<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    // Comments before `{` stay on the same line.
+    let block_start = to_span(&ruleset.block.span).start;
+    for &comment in f.context().comments().take_before(block_start) {
+        crate::comments::write_single_comment(comment, f);
+        write!(f, space());
+    }
+    let was = f.context().in_less_detached().replace(true);
+    write_block(&ruleset.block, f);
+    f.context().in_less_detached().set(was);
+}
+
+/// `value` of a ComponentValue that is Less-specific; returns false if not handled.
+pub fn write_less_component_value<'a>(
+    value: &ComponentValue<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) -> bool {
+    match value {
+        ComponentValue::LessMixinCall(call) => write_less_mixin_call(call, f),
+        ComponentValue::LessNamespaceValue(namespace) => write_less_namespace_value(namespace, f),
+        ComponentValue::LessDetachedRuleset(ruleset) => write_less_detached_ruleset(ruleset, f),
+        ComponentValue::LessCondition(condition) => write_less_condition(condition, f),
+        _ => return false,
+    }
+    true
+}

--- a/crates/oxc_formatter_css/src/print/mod.rs
+++ b/crates/oxc_formatter_css/src/print/mod.rs
@@ -1,0 +1,128 @@
+use oxc_formatter_core::{
+    Buffer, Format, Formatter,
+    builders::{FormatWith, empty_line, hard_line_break},
+    write,
+};
+use raffia::ast::Stylesheet;
+
+use crate::{
+    comments::{
+        Gap, classify_gap, flush_leading_comments, write_leading_comments,
+        write_trailing_same_line_comment,
+    },
+    context::CssFormatContext,
+};
+
+pub mod at_rule;
+pub mod less;
+pub mod scss;
+pub mod selector;
+pub mod statement;
+pub mod value;
+
+pub type CssFormatter<'buf, 'a> = Formatter<'buf, 'a, CssFormatContext<'a>>;
+
+/// `Format` impl for `&'static str` specialized to `CssFormatContext`.
+///
+/// Hardcoded to `CssFormatContext` rather than generic over `C` so the blanket
+/// `&T where T: Format` doesn't overlap.
+impl<'a> Format<'a, CssFormatContext<'a>> for &'static str {
+    #[inline]
+    fn fmt(&self, f: &mut CssFormatter<'_, 'a>) {
+        write!(f, oxc_formatter_core::builders::token(self));
+    }
+}
+
+/// Wraps a re-entrant CSS closure in a [`FormatWith`]. The closure's context is
+/// pinned to [`CssFormatContext`] so call sites don't have to annotate it.
+#[inline]
+pub const fn format_with<'a, T>(formatter: T) -> FormatWith<T>
+where
+    T: Fn(&mut CssFormatter<'_, 'a>),
+{
+    FormatWith::new(formatter)
+}
+
+/// Emits the whole stylesheet: top-level statements separated by hard lines
+/// (blank lines preserved, max one), then any trailing comments.
+///
+/// Mirrors Prettier's `css-root` + `printSequence`.
+pub fn write_stylesheet<'a>(stylesheet: &Stylesheet<'a>, f: &mut CssFormatter<'_, 'a>) {
+    write_statement_sequence(&stylesheet.statements, f);
+
+    // Comments after the last statement (or in an otherwise empty file).
+    let remaining = f.context().comments().take_remaining();
+    if !remaining.is_empty() {
+        if !stylesheet.statements.is_empty() {
+            let source = f.context().source_text();
+            let prev_end = stylesheet.statements.last().map_or(0, |s| statement::stmt_end(s, f));
+            match classify_gap(source.bytes_range(prev_end, remaining[0].span.start)) {
+                Gap::None => write!(f, oxc_formatter_core::builders::space()),
+                Gap::Line => write!(f, hard_line_break()),
+                Gap::Blank => write!(f, empty_line()),
+            }
+        }
+        let last_end = remaining.last().unwrap().span.end;
+        write_leading_comments(remaining, last_end, f);
+    }
+}
+
+/// Emits `statements` separated by hard lines, preserving at most one blank line
+/// between consecutive statements, flushing comments at their source positions.
+///
+/// Mirrors Prettier's `printSequence`.
+pub fn write_statement_sequence<'a>(
+    statements: &[raffia::ast::Statement<'a>],
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    write_statement_sequence_bounded(statements, u32::MAX, f);
+}
+
+/// Like [`write_statement_sequence`], but trailing same-line comments are
+/// only claimed when they end before `upper` (a block's closing `}`),
+/// so inline rules don't steal comments that belong to the parent.
+pub fn write_statement_sequence_bounded<'a>(
+    statements: &[raffia::ast::Statement<'a>],
+    upper: u32,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    for (i, stmt) in statements.iter().enumerate() {
+        let start = statement::stmt_start(stmt);
+        if i > 0 {
+            let prev_end = statement::stmt_end(&statements[i - 1], f);
+            // Trailing comment on the same line as the previous statement
+            // (but not one that sits after the NEXT statement on that line).
+            write_trailing_same_line_comment(prev_end, upper.min(start), f);
+            write!(f, hard_line_break());
+            // Preserve a single blank line. The gap considered is from the end of
+            // the previous statement to the next printed position (comment or stmt).
+            let next_start =
+                f.context().comments().peek().map_or(start, |c| c.span.start.min(start));
+            if classify_gap(source.bytes_range(prev_end, next_start)) == Gap::Blank {
+                write!(f, empty_line());
+            }
+        }
+        // `prettier-ignore` / `oxfmt-ignore`: print the statement verbatim.
+        let suppressed = f
+            .context()
+            .comments()
+            .iter_before(start)
+            .last()
+            .is_some_and(|c| crate::comments::is_suppression_comment(source, c));
+        flush_leading_comments(start, f);
+        if suppressed {
+            let end = statement::stmt_end(stmt, f);
+            write!(f, oxc_formatter_core::builders::text(source.slice_range(start, end)));
+        } else {
+            statement::write_statement(stmt, f);
+        }
+        // Discard comments inside spans the statement printer didn't claim
+        // (e.g. inside selectors/values that are still printed verbatim),
+        // so the cursor never points before an already-printed position.
+        let _ = f.context().comments().take_before(statement::stmt_end(stmt, f));
+    }
+    if let Some(last) = statements.last() {
+        write_trailing_same_line_comment(statement::stmt_end(last, f), upper, f);
+    }
+}

--- a/crates/oxc_formatter_css/src/print/scss.rs
+++ b/crates/oxc_formatter_css/src/print/scss.rs
@@ -1,0 +1,816 @@
+//! SCSS-specific printing: variable declarations, maps, lists,
+//! control directives, mixins/includes/functions, module system.
+
+use oxc_formatter_core::{
+    Buffer,
+    builders::{
+        group, hard_line_break, indent, soft_line_break, soft_line_break_or_space, space, text,
+    },
+    write,
+};
+use raffia::{
+    Spanned,
+    ast::{
+        ComponentValue, SassEach, SassFor, SassForBoundaryKind, SassIfAtRule, SassInclude,
+        SassList, SassMap, SassMixin, SassParameters, SassVariableDeclaration,
+    },
+};
+
+use crate::{
+    format::to_span,
+    print::{
+        CssFormatter, format_with,
+        statement::write_block,
+        value::{self, ValueContext},
+    },
+};
+
+/// `$var: value !flags;`
+pub fn write_sass_variable_declaration<'a>(
+    decl: &SassVariableDeclaration<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    if let Some(namespace) = &decl.namespace {
+        let span = to_span(namespace.span());
+        write!(f, [text(source.text_for(&span)), "."]);
+    }
+    write!(f, "$");
+    let name_span = to_span(decl.name.name.span());
+    write!(f, text(source.text_for(&name_span)));
+    // Comments between the name and the colon are kept verbatim.
+    let colon_end = to_span(&decl.colon_span).end;
+    let between = source.slice_range(name_span.end, colon_end);
+    if between.trim() == ":" {
+        write!(f, ":");
+    } else {
+        write!(f, text(between.trim_ascii()));
+        let _ = f.context().comments().take_before(colon_end);
+    }
+    write!(f, space());
+
+    let ctx = ValueContext { decl_prop: Some("$"), map_break: true, ..ValueContext::default() };
+    // Comments between the colon and the value: inline ones get their own
+    // line under the colon (`$x:\n  // c\n  value`).
+    let value_start = to_span(decl.value.span()).start;
+    if f.context().comments().peek().is_some_and(|c| c.inline && c.span.end <= value_start) {
+        let lead = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            for &comment in f.context().comments().take_before(value_start) {
+                write!(f, hard_line_break());
+                crate::comments::write_single_comment(comment, f);
+            }
+        });
+        write!(f, indent(&lead));
+    } else {
+        value::flush_value_comments(value_start, f);
+    }
+    write_top_level_value(&decl.value, ctx, f);
+
+    for flag in &decl.flags {
+        let span = to_span(flag.span());
+        value::flush_trailing_value_comments(span.start, f);
+        write!(f, space());
+        write!(f, text(source.text_for(&span)));
+    }
+    // Comments between the value/flags and the `;`.
+    let decl_end = to_span(decl.span()).end;
+    let end = crate::print::statement::end_with_semicolon(decl_end, f);
+    let bound = if end > decl_end { end - 1 } else { decl_end };
+    if let Some(comment_end) = value::flush_trailing_value_comments(bound, f)
+        && end > decl_end
+        && comment_end < end - 1
+    {
+        write!(f, space());
+    }
+}
+
+/// A single `ComponentValue` in declaration-value position: comma-separated
+/// `SassList`s get Prettier's top-level list layout (one entry per line when
+/// any entry has multiple parts).
+pub fn write_top_level_value<'a>(
+    value: &ComponentValue<'a>,
+    ctx: ValueContext<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let (elements, is_comma) = match value {
+        ComponentValue::SassList(list) => (&list.elements, list.comma_spans.is_some()),
+        ComponentValue::LessList(list) => (&list.elements, list.comma_spans.is_some()),
+        _ => {
+            value::write_component_value(value, ctx, f);
+            return;
+        }
+    };
+    // `paren_break` only applies to a paren group that IS the whole value,
+    // not to parens nested inside lists.
+    let ctx = ValueContext { paren_break: false, ..ctx };
+    if is_comma {
+        let groups: Vec<&[ComponentValue<'a>]> = elements
+            .iter()
+            .map(|el| match el {
+                ComponentValue::SassList(inner) if inner.comma_spans.is_none() => {
+                    &inner.elements[..]
+                }
+                ComponentValue::LessList(inner) if inner.comma_spans.is_none() => {
+                    &inner.elements[..]
+                }
+                other => std::slice::from_ref(other),
+            })
+            .collect();
+        let value_span = to_span(value.span());
+        let has_comments = f
+            .context()
+            .comments()
+            .iter_before(value_span.end)
+            .any(|c| c.span.start >= value_span.start);
+        let force_hard_line = !ctx.decl_prop.is_some_and(|p| p.starts_with("--"))
+            && (groups.iter().any(|g| g.len() > 1) || has_comments);
+        value::write_value_groups(&groups, ctx, force_hard_line, true, f);
+    } else {
+        value::write_comma_group(elements, ctx, f);
+    }
+}
+
+/// `(key: value, ...)`: SCSS maps in map-item positions always break,
+/// one item per line, with a trailing comma per the `trailingComma` option.
+pub fn write_sass_map<'a>(map: &SassMap<'a>, ctx: ValueContext<'a>, f: &mut CssFormatter<'_, 'a>) {
+    if map.items.is_empty() {
+        write!(f, ["(", ")"]);
+        return;
+    }
+    // Maps break only in "map item" positions (`$var:` values, map item
+    // values, function arguments — Prettier's `isSCSSMapItemNode`). In key
+    // position or elsewhere (e.g. `@each ... in (k: v)`) they stay inline.
+    if ctx.map_key || !ctx.map_break {
+        let source = f.context().source_text();
+        let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            write!(f, soft_line_break());
+            for (i, item) in map.items.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ",");
+                    // A blank line between items in the source is preserved
+                    // (Prettier's isNextLineEmpty → hardline).
+                    let prev_end = to_span(map.items[i - 1].span()).end;
+                    let start = to_span(item.span()).start;
+                    if crate::comments::classify_gap(source.bytes_range(prev_end, start))
+                        == crate::comments::Gap::Blank
+                    {
+                        write!(f, oxc_formatter_core::builders::empty_line());
+                    } else {
+                        write!(f, soft_line_break_or_space());
+                    }
+                }
+                // `key: value` may break after the colon when too long.
+                let pair = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    let mut filler = f.fill();
+                    let key = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                        value::write_component_value(&item.key, ctx, f);
+                        write!(f, ":");
+                    });
+                    let val = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                        value::write_component_value(&item.value, ctx, f);
+                    });
+                    filler.entry(&soft_line_break_or_space(), &key);
+                    filler.entry(&soft_line_break_or_space(), &val);
+                    filler.finish();
+                });
+                write!(f, group(&indent(&pair)));
+            }
+            // Outside map-item positions (e.g. `@each ... in (k: v)`),
+            // isSCSSMapItemNode is false → no trailing comma.
+            if ctx.map_key && f.options().allow_trailing_comma() {
+                write!(f, oxc_formatter_core::builders::if_group_breaks(&text(",")));
+            }
+        });
+        write!(
+            f,
+            group(&format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                write!(f, "(");
+                write!(f, indent(&body));
+                write!(f, soft_line_break());
+                write!(f, ")");
+            }))
+        );
+        return;
+    }
+    let trailing = f.options().allow_trailing_comma();
+    let r_paren = to_span(map.span()).end.saturating_sub(1);
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        write!(f, hard_line_break());
+        let source = f.context().source_text();
+        let mut last_item_block_with_comment = false;
+        for (i, item) in map.items.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",");
+                write!(f, hard_line_break());
+                // Preserve one blank line between items.
+                let prev_end = to_span(map.items[i - 1].span()).end;
+                let item_start = to_span(item.span()).start;
+                let next_start = f
+                    .context()
+                    .comments()
+                    .peek()
+                    .map_or(item_start, |c| c.span.start.min(item_start));
+                if crate::comments::classify_gap(source.bytes_range(prev_end, next_start))
+                    == crate::comments::Gap::Blank
+                {
+                    write!(f, oxc_formatter_core::builders::empty_line());
+                }
+            }
+            let key_ctx =
+                ValueContext { map_key: true, paren_break: false, map_break: false, ..ctx };
+            let val_ctx =
+                ValueContext { map_key: false, paren_break: true, map_break: true, ..ctx };
+            // Nested maps / paren lists hug the colon (`key: (`); the pair
+            // never breaks after the colon (Prettier dedents these).
+            let value_is_block = matches!(
+                item.value,
+                ComponentValue::SassMap(_) | ComponentValue::SassParenthesizedExpression(_)
+            );
+
+            // Comments between items: block comments join the item when the
+            // pair fits on one line (Prettier's fill); `//` comments and
+            // pairs that don't fit keep their own line.
+            let item_start = to_span(item.span()).start;
+            let item_width = to_span(item.span()).end - item_start;
+            let mut had_leading_comment = false;
+            let mut leading_comment_inline = false;
+            for &comment in f.context().comments().take_before(item_start) {
+                had_leading_comment = true;
+                leading_comment_inline = comment.inline;
+                let comment_width = comment.span.end - comment.span.start;
+                let fits = !value_is_block
+                    && u32::from(f.options().indent_width.value()) + comment_width + 2 + item_width
+                        <= u32::from(f.options().line_width.value());
+                crate::comments::write_single_comment(comment, f);
+                if comment.inline || !fits {
+                    write!(f, hard_line_break());
+                } else {
+                    write!(f, " ");
+                }
+            }
+            let key_is_block = matches!(
+                item.key,
+                ComponentValue::SassMap(_) | ComponentValue::SassParenthesizedExpression(_)
+            );
+            if i + 1 == map.items.len() {
+                // Suppressed only when the source ALSO had a trailing comma
+                // (the comment lands inside the last comma_group in postcss).
+                let _ = leading_comment_inline;
+                last_item_block_with_comment = value_is_block
+                    && had_leading_comment
+                    && map.comma_spans.len() >= map.items.len();
+            }
+            if key_is_block && !value_is_block {
+                // Block keys never break before their value (`): "v",`).
+                value::write_component_value(&item.key, key_ctx, f);
+                write!(f, [":", space()]);
+                write_top_level_value(&item.value, val_ctx, f);
+            } else if value_is_block {
+                value::write_component_value(&item.key, key_ctx, f);
+                write!(f, [":", space()]);
+                // A paren/map KEY — or a leading comment — keeps the pair's
+                // indent on the value (Prettier's dedent applies only when
+                // the doc is a plain `group(indent(fill))`).
+                let key_is_block = matches!(
+                    item.key,
+                    ComponentValue::SassMap(_) | ComponentValue::SassParenthesizedExpression(_)
+                ) || had_leading_comment
+                    || f.context().block_depth().get() > 0;
+                if key_is_block {
+                    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                        write_top_level_value(&item.value, val_ctx, f);
+                    });
+                    write!(f, indent(&body));
+                } else {
+                    write_top_level_value(&item.value, val_ctx, f);
+                }
+            } else {
+                // `key: value` breaks after the colon when too long.
+                let pair = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    let mut filler = f.fill();
+                    let key = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                        // Paren/map keys cancel the pair indent (Prettier's
+                        // `isKey` → dedent).
+                        if matches!(
+                            item.key,
+                            ComponentValue::SassMap(_)
+                                | ComponentValue::SassParenthesizedExpression(_)
+                        ) {
+                            let inner = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                                value::write_component_value(&item.key, key_ctx, f);
+                            });
+                            write!(f, oxc_formatter_core::builders::dedent(&inner));
+                        } else {
+                            value::write_component_value(&item.key, key_ctx, f);
+                        }
+                        write!(f, ":");
+                    });
+                    let val = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                        write_top_level_value(&item.value, val_ctx, f);
+                    });
+                    filler.entry(&soft_line_break_or_space(), &key);
+                    filler.entry(&soft_line_break_or_space(), &val);
+                    filler.finish();
+                });
+                write!(f, group(&indent(&pair)));
+            }
+        }
+        // Own-line comments after the last item make it "non-last" in
+        // Prettier's sequence, so it always gets a comma.
+        let last_item_end = map.items.last().map_or(0, |it| to_span(it.span()).end);
+        let has_ownline_tail = f
+            .context()
+            .comments()
+            .iter_before(r_paren)
+            .any(|c| c.span.start >= last_item_end && value::comment_is_own_line(c, source));
+        // Prettier drops the trailing comma after a comment-preceded block
+        // value (the pair doc isn't the plain dedent shape).
+        let printed_comma = (trailing && !last_item_block_with_comment) || has_ownline_tail;
+        if printed_comma {
+            write!(f, ",");
+        }
+        // The comment goes to its own line only when BOTH a comma is printed
+        // and the source comma preceded the comment (true next-slot comment).
+        if let Some(last) = map.items.last() {
+            let source_comma_start =
+                map.comma_spans.get(map.items.len() - 1).map_or(u32::MAX, |sp| to_span(sp).start);
+            // Only inside function/include arguments does the comment move
+            // to the next slot; `$map:` declarations keep it attached.
+            let next_slot = printed_comma
+                && ctx.in_args
+                && f.context().comments().peek().is_some_and(|c| c.span.start > source_comma_start);
+            if !next_slot {
+                value::flush_same_line_comments(to_span(last.span()).end, f);
+            }
+        }
+        // Own-line comments before `)`: same-line runs stay glued.
+        let tail: Vec<crate::comments::CssComment> =
+            f.context().comments().take_before(r_paren).to_vec();
+        for (i, &comment) in tail.iter().enumerate() {
+            if i == 0 || comment.inline || tail[i - 1].inline {
+                write!(f, hard_line_break());
+            } else {
+                // Block comments are fill items: they join when they fit.
+                write!(f, " ");
+            }
+            crate::comments::write_single_comment(comment, f);
+        }
+    });
+    write!(f, ["(", indent(&body), hard_line_break(), ")"]);
+}
+
+/// Space- or comma-separated SCSS list in a nested position.
+pub fn write_sass_list<'a>(
+    list: &SassList<'a>,
+    ctx: ValueContext<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    if list.comma_spans.is_some() {
+        let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            let mut filler = f.fill();
+            for (i, el) in list.elements.iter().enumerate() {
+                let is_last = i + 1 == list.elements.len();
+                let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    value::write_component_value(el, ctx, f);
+                    if !is_last {
+                        write!(f, ",");
+                    }
+                });
+                filler.entry(&soft_line_break_or_space(), &content);
+            }
+            filler.finish();
+        });
+        write!(f, group(&indent(&body)));
+    } else {
+        value::write_comma_group(&list.elements, ctx, f);
+    }
+}
+
+/// `@each $key, $value in $expr`: printed as one flat comma list
+/// (`$k, $v in (a), (b), (c)`), filling and indenting like a value.
+pub fn write_sass_each<'a>(each: &SassEach<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let in_span = to_span(&each.in_span);
+    let in_tight = in_span.end == to_span(each.expr.span()).start;
+
+    // Comma-list expr: the first element joins the `... in` entry, the rest
+    // are separate fill entries (mirrors postcss's flat comma groups).
+    let expr_elements: &[ComponentValue<'a>] = match &each.expr {
+        ComponentValue::SassList(list) if list.comma_spans.is_some() => &list.elements,
+        expr => std::slice::from_ref(expr),
+    };
+
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        let mut filler = f.fill();
+        let last_binding = each.bindings.len() - 1;
+        for (i, binding) in each.bindings.iter().enumerate() {
+            let span = to_span(binding.span());
+            let is_last = i == last_binding;
+            let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                if is_last {
+                    // `$binding in expr` — breakable before `in`, with the
+                    // continuation indented one level deeper.
+                    let tail = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                        let mut inner = f.fill();
+                        let binding = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                            write!(f, text(source.text_for(&span)));
+                        });
+                        let in_expr = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                            write!(f, "in");
+                            if !in_tight {
+                                write!(f, " ");
+                            }
+                            value::write_component_value(
+                                &expr_elements[0],
+                                ValueContext::default(),
+                                f,
+                            );
+                            if expr_elements.len() > 1 {
+                                write!(f, ",");
+                            }
+                        });
+                        inner.entry(&soft_line_break_or_space(), &binding);
+                        if span.end == in_span.start {
+                            // `in` fused to the binding in the source.
+                            inner.entry(&format_with(|_| {}), &in_expr);
+                        } else {
+                            inner.entry(&soft_line_break_or_space(), &in_expr);
+                        }
+                        inner.finish();
+                    });
+                    write!(f, group(&indent(&tail)));
+                } else {
+                    write!(f, text(source.text_for(&span)));
+                    write!(f, ",");
+                }
+            });
+            filler.entry(&soft_line_break_or_space(), &content);
+        }
+        for (i, el) in expr_elements.iter().enumerate().skip(1) {
+            let is_last = i + 1 == expr_elements.len();
+            let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                value::write_component_value(el, ValueContext::default(), f);
+                if !is_last {
+                    write!(f, ",");
+                }
+            });
+            filler.entry(&soft_line_break_or_space(), &content);
+        }
+        filler.finish();
+    });
+    write!(f, group(&indent(&body)));
+}
+
+/// `@for $i from <start> to|through <end>`
+pub fn write_sass_for<'a>(sass_for: &SassFor<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let binding_span = to_span(sass_for.binding.span());
+    write!(f, text(source.text_for(&binding_span)));
+    write!(f, [space(), "from", space()]);
+    value::write_component_value(&sass_for.start, ValueContext::default(), f);
+    match sass_for.boundary.kind {
+        SassForBoundaryKind::Inclusive => write!(f, [space(), "through", space()]),
+        SassForBoundaryKind::Exclusive => write!(f, [space(), "to", space()]),
+    }
+    value::write_component_value(&sass_for.end, ValueContext::default(), f);
+}
+
+/// `@mixin name($params...)`
+pub fn write_sass_mixin<'a>(mixin: &SassMixin<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let name_span = to_span(mixin.name.span());
+    write!(f, text(source.text_for(&name_span)));
+    if let Some(parameters) = &mixin.parameters {
+        write_sass_parameters(parameters, f);
+    }
+}
+
+/// `@function name($params...)`
+pub fn write_sass_function<'a>(
+    function: &raffia::ast::SassFunction<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    let name_span = to_span(function.name.span());
+    write!(f, text(source.text_for(&name_span)));
+    write_sass_parameters(&function.parameters, f);
+}
+
+fn write_sass_parameters<'a>(parameters: &SassParameters<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        write!(f, soft_line_break());
+        let mut first = true;
+        for param in &parameters.params {
+            if !first {
+                write!(f, ",");
+                write!(f, soft_line_break_or_space());
+            }
+            first = false;
+            let name_span = to_span(param.name.span());
+            write!(f, text(source.text_for(&name_span)));
+            if let Some(default) = &param.default_value {
+                write!(f, [":", space()]);
+                value::write_component_value(&default.value, ValueContext::default(), f);
+            }
+        }
+        if let Some(arbitrary) = &parameters.arbitrary_param {
+            if !first {
+                write!(f, ",");
+                write!(f, soft_line_break_or_space());
+            }
+            let span = to_span(arbitrary.name.span());
+            write!(f, [text(source.text_for(&span)), "..."]);
+        }
+    });
+    write!(
+        f,
+        group(&format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            write!(f, "(");
+            write!(f, indent(&body));
+            write!(f, soft_line_break());
+            write!(f, ")");
+        }))
+    );
+}
+
+/// `@include name(args...) [using (params)]`
+pub fn write_sass_include<'a>(include: &SassInclude<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let name_span = to_span(include.name.span());
+    write!(f, text(source.text_for(&name_span)));
+    if let Some(arguments) = &include.arguments {
+        let args = &arguments.args;
+        let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            let source = f.context().source_text();
+            write!(f, soft_line_break());
+            for (i, arg) in args.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ",");
+                    // Preserve a blank line, but only after a multi-part
+                    // argument (Prettier checks `value-comma_group`s only).
+                    let prev = &args[i - 1];
+                    let prev_is_group = matches!(
+                        prev,
+                        ComponentValue::SassKeywordArgument(_) | ComponentValue::SassList(_)
+                    );
+                    let prev_end = to_span(prev.span()).end;
+                    let start = to_span(arg.span()).start;
+                    if prev_is_group
+                        && crate::comments::classify_gap(source.bytes_range(prev_end, start))
+                            == crate::comments::Gap::Blank
+                    {
+                        write!(f, oxc_formatter_core::builders::empty_line());
+                    } else {
+                        write!(f, soft_line_break_or_space());
+                    }
+                }
+                let arg_ctx =
+                    ValueContext { map_break: true, in_args: true, ..ValueContext::default() };
+                write_top_level_value(arg, arg_ctx, f);
+            }
+        });
+        write!(
+            f,
+            group(&format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                write!(f, "(");
+                write!(f, indent(&body));
+                write!(f, soft_line_break());
+                write!(f, ")");
+            }))
+        );
+    }
+    if let Some(content_params) = &include.content_block_params {
+        write!(f, [space(), "using", space()]);
+        write_sass_parameters(&content_params.params, f);
+    }
+}
+
+/// `@if cond { } @else if cond { } @else { }`
+pub fn write_sass_if_at_rule<'a>(if_rule: &SassIfAtRule<'a>, f: &mut CssFormatter<'_, 'a>) {
+    write!(f, ["@if", space()]);
+    write_control_condition(&if_rule.if_clause.condition, f);
+    write_block(&if_rule.if_clause.block, f);
+    for clause in &if_rule.else_if_clauses {
+        // Comments between `}` and `@else` break the join.
+        let cond_start = to_span(clause.condition.span()).start;
+        let mut broke_join = false;
+        while let Some(comment) = f.context().comments().peek() {
+            if comment.span.end > cond_start {
+                break;
+            }
+            f.context().comments().take_before(comment.span.end);
+            write!(f, hard_line_break());
+            crate::comments::write_single_comment(comment, f);
+            broke_join = true;
+        }
+        if broke_join {
+            write!(f, hard_line_break());
+            write!(f, ["@else", space()]);
+        } else {
+            write!(f, [space(), "@else", space()]);
+        }
+        // `if` is a value word in postcss, so the condition may break after it.
+        if matches!(clause.condition, ComponentValue::SassParenthesizedExpression(_)) {
+            write!(f, ["if", space()]);
+            write_control_condition(&clause.condition, f);
+        } else {
+            write_condition_chain(Some("if"), &clause.condition, f);
+        }
+        write_block(&clause.block, f);
+    }
+    if let Some(else_block) = &if_rule.else_clause {
+        write!(f, [space(), "@else", space()]);
+        write_block(else_block, f);
+    }
+}
+
+/// Control-directive condition followed by a breakable gap before `{`
+/// (Prettier wraps the value + line in a group, without extra indent).
+/// A fully parenthesized condition keeps `{` on the `)` line.
+fn write_control_condition<'a>(condition: &ComponentValue<'a>, f: &mut CssFormatter<'_, 'a>) {
+    if matches!(condition, ComponentValue::SassParenthesizedExpression(_)) {
+        value::write_component_value(condition, ValueContext::default(), f);
+        write!(f, space());
+        return;
+    }
+    if matches!(condition, ComponentValue::SassBinaryExpression(_)) {
+        write_condition_chain(None, condition, f);
+        return;
+    }
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        value::write_component_value(condition, ValueContext::default(), f);
+        write!(f, soft_line_break_or_space());
+    });
+    write!(f, group(&body));
+}
+
+/// Operand-or-operator part of a flattened control-directive condition.
+enum CondPart<'b, 'a> {
+    Value(&'b ComponentValue<'a>),
+    /// Operator/keyword raw text (`and`, `or`, `not`, `==`, `*`, ...).
+    Op(oxc_span::Span),
+}
+
+fn flatten_condition<'b, 'a>(cond: &'b ComponentValue<'a>, out: &mut Vec<CondPart<'b, 'a>>) {
+    match cond {
+        ComponentValue::SassBinaryExpression(binary) => {
+            flatten_condition(&binary.left, out);
+            out.push(CondPart::Op(to_span(binary.op.span())));
+            flatten_condition(&binary.right, out);
+        }
+        ComponentValue::SassUnaryExpression(unary)
+            if matches!(unary.op.kind, raffia::ast::SassUnaryOperatorKind::Not) =>
+        {
+            out.push(CondPart::Op(to_span(unary.op.span())));
+            flatten_condition(&unary.expr, out);
+        }
+        other => out.push(CondPart::Value(other)),
+    }
+}
+
+/// Prettier's control-directive condition layout (`group(indent(parts))`,
+/// NOT a fill): a space before every operator/keyword, a breakable line
+/// after it — breaking is all-or-nothing.
+fn write_condition_chain<'a>(
+    prefix: Option<&'static str>,
+    condition: &ComponentValue<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let mut parts = Vec::new();
+    flatten_condition(condition, &mut parts);
+    let source = f.context().source_text();
+    let parts_ref = &parts;
+    let inner = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        if let Some(word) = prefix {
+            write!(f, text(word));
+            // Separator to the first part: space when it's an operator.
+            if let Some(CondPart::Op(_)) = parts_ref.first() {
+                write!(f, space());
+            } else {
+                write!(f, soft_line_break_or_space());
+            }
+        }
+        let part_span = |p: &CondPart<'_, 'a>| match p {
+            CondPart::Op(span) => *span,
+            CondPart::Value(v) => to_span(v.span()),
+        };
+        for (i, part) in parts_ref.iter().enumerate() {
+            if i > 0 {
+                // Tokens glued in the source stay glued (postcss parses
+                // `$type==ocean` as ONE word and prints it verbatim).
+                let glued = part_span(&parts_ref[i - 1]).end == part_span(part).start;
+                if !glued {
+                    match part {
+                        CondPart::Op(_) => write!(f, space()),
+                        CondPart::Value(_) => write!(f, soft_line_break_or_space()),
+                    }
+                }
+            }
+            match part {
+                CondPart::Op(span) => write!(f, text(source.text_for(span))),
+                CondPart::Value(v) => {
+                    value::write_component_value(v, ValueContext::default(), f);
+                }
+            }
+        }
+    });
+    write!(
+        f,
+        group(&format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            write!(f, indent(&inner));
+            write!(f, soft_line_break_or_space());
+        }))
+    );
+}
+
+/// `@use "path" as ns with (...)` / `@forward "path" as p-* show a, b with (...)`
+pub fn write_sass_use<'a>(sass_use: &raffia::ast::SassUse<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    if let raffia::ast::InterpolableStr::Literal(str) = &sass_use.path {
+        value::write_str(str, f);
+    } else {
+        let span = to_span(sass_use.path.span());
+        write!(f, text(source.text_for(&span)));
+    }
+    if let Some(namespace) = &sass_use.namespace {
+        write!(f, [space(), "as", space()]);
+        match &namespace.kind {
+            raffia::ast::SassUseNamespaceKind::Named(ident) => {
+                let span = to_span(ident.span());
+                write!(f, text(source.text_for(&span)));
+            }
+            raffia::ast::SassUseNamespaceKind::Unnamed(_) => write!(f, "*"),
+        }
+    }
+    if let Some(config) = &sass_use.config {
+        write_sass_module_config(config, f);
+    }
+}
+
+pub fn write_sass_forward<'a>(
+    forward: &raffia::ast::SassForward<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    if let raffia::ast::InterpolableStr::Literal(str) = &forward.path {
+        value::write_str(str, f);
+    } else {
+        let span = to_span(forward.path.span());
+        write!(f, text(source.text_for(&span)));
+    }
+    if let Some(prefix) = &forward.prefix {
+        let span = to_span(prefix.name.span());
+        write!(f, [space(), "as", space(), text(source.text_for(&span)), "*"]);
+    }
+    if let Some(visibility) = &forward.visibility {
+        match visibility.modifier.kind {
+            raffia::ast::SassForwardVisibilityModifierKind::Show => {
+                write!(f, [space(), "show", space()]);
+            }
+            raffia::ast::SassForwardVisibilityModifierKind::Hide => {
+                write!(f, [space(), "hide", space()]);
+            }
+        }
+        for (i, member) in visibility.members.iter().enumerate() {
+            if i > 0 {
+                write!(f, [",", space()]);
+            }
+            let span = to_span(member.span());
+            write!(f, text(source.text_for(&span)));
+        }
+    }
+    if let Some(config) = &forward.config {
+        write_sass_module_config(config, f);
+    }
+}
+
+/// `with ($var: value, ...)`: configurations always break, one item per line,
+/// without a trailing comma.
+fn write_sass_module_config<'a>(
+    config: &raffia::ast::SassModuleConfig<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    write!(f, [space(), "with", space(), "("]);
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        write!(f, hard_line_break());
+        for (i, item) in config.items.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",");
+                write!(f, hard_line_break());
+            }
+            let span = to_span(item.variable.span());
+            write!(f, [text(source.text_for(&span)), ":", space()]);
+            let item_ctx =
+                ValueContext { paren_break: true, map_break: true, ..ValueContext::default() };
+            write_top_level_value(&item.value, item_ctx, f);
+            for flag in &item.flags {
+                let span = to_span(flag.span());
+                write!(f, space());
+                write!(f, text(source.text_for(&span)));
+            }
+        }
+    });
+    write!(f, [indent(&body), hard_line_break(), ")"]);
+}

--- a/crates/oxc_formatter_css/src/print/selector.rs
+++ b/crates/oxc_formatter_css/src/print/selector.rs
@@ -1,0 +1,369 @@
+//! Selector printing. Ports Prettier's `selector-*` cases (postcss-selector-parser)
+//! onto raffia's structured selector AST.
+
+use std::borrow::Cow;
+
+use cow_utils::CowUtils;
+use oxc_formatter_core::{
+    Buffer,
+    builders::{group, hard_line_break, indent, soft_line_break, soft_line_break_or_space, text},
+    write,
+};
+use raffia::{
+    Spanned,
+    ast::{
+        AttributeSelector, AttributeSelectorMatcherKind, AttributeSelectorValue, Combinator,
+        CombinatorKind, ComplexSelector, ComplexSelectorChild, CompoundSelector, InterpolableIdent,
+        NsPrefixKind, PseudoClassSelector, PseudoClassSelectorArgKind, PseudoElementSelector,
+        PseudoElementSelectorArgKind, SelectorList, SimpleSelector, TypeSelector, WqName,
+    },
+};
+
+use crate::{
+    format::to_span,
+    print::{CssFormatter, format_with, statement::write_maybe_lowercase},
+};
+
+/// How a selector list separates its selectors.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SelectorListStyle {
+    /// `,` + hardline (rule selectors at any nesting level).
+    Hard,
+    /// `,` + line (inside `@extend`, `@custom-selector`, `@nest`, pseudo args).
+    Line,
+}
+
+/// Mirrors Prettier's `selector-root`.
+pub fn write_selector_list<'a>(
+    list: &SelectorList<'a>,
+    style: SelectorListStyle,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        for (i, complex) in list.selectors.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",");
+                // A comment trailing the comma stays on the same line.
+                let next_start = to_span(complex.span()).start;
+                if let Some(comment) = f.context().comments().peek()
+                    && comment.span.end <= next_start
+                {
+                    let source = f.context().source_text();
+                    let prev_end = to_span(list.selectors[i - 1].span()).end;
+                    if crate::comments::classify_gap(
+                        source.bytes_range(prev_end, comment.span.start),
+                    ) == crate::comments::Gap::None
+                    {
+                        f.context().comments().take_before(comment.span.end);
+                        write!(f, " ");
+                        crate::comments::write_single_comment(comment, f);
+                    }
+                }
+                match style {
+                    SelectorListStyle::Hard => write!(f, hard_line_break()),
+                    SelectorListStyle::Line => write!(f, soft_line_break_or_space()),
+                }
+            }
+            // Comments on their own line between selectors.
+            let start = to_span(complex.span()).start;
+            for &comment in f.context().comments().take_before(start) {
+                crate::comments::write_single_comment(comment, f);
+                write!(f, hard_line_break());
+            }
+            write_complex_selector(complex, f);
+        }
+    });
+    write!(f, group(&body));
+}
+
+/// Mirrors Prettier's `selector-selector`: group, indented when long
+/// (more than 2 children).
+pub fn write_complex_selector<'a>(complex: &ComplexSelector<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let should_indent = complex.children.len() > 2;
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        for (i, child) in complex.children.iter().enumerate() {
+            match child {
+                ComplexSelectorChild::CompoundSelector(compound) => {
+                    write_compound_selector(compound, f);
+                }
+                ComplexSelectorChild::Combinator(combinator) => {
+                    write_combinator(combinator, i == 0, i + 1 == complex.children.len(), f);
+                }
+            }
+        }
+    });
+    if should_indent {
+        write!(f, group(&indent(&body)));
+    } else {
+        write!(f, group(&body));
+    }
+}
+
+/// Mirrors Prettier's `selector-combinator`:
+/// breakable line BEFORE the combinator, space after.
+fn write_combinator(
+    combinator: &Combinator,
+    is_first: bool,
+    is_last: bool,
+    f: &mut CssFormatter<'_, '_>,
+) {
+    match &combinator.kind {
+        CombinatorKind::Descendant => {
+            write!(f, soft_line_break_or_space());
+        }
+        kind => {
+            if !is_first {
+                write!(f, soft_line_break_or_space());
+            }
+            match kind {
+                CombinatorKind::Child => write!(f, ">"),
+                CombinatorKind::NextSibling => write!(f, "+"),
+                CombinatorKind::LaterSibling => write!(f, "~"),
+                CombinatorKind::Column => write!(f, "||"),
+                CombinatorKind::Descendant => unreachable!(),
+            }
+            if !is_last {
+                write!(f, " ");
+            }
+        }
+    }
+}
+
+pub fn write_compound_selector<'a>(compound: &CompoundSelector<'a>, f: &mut CssFormatter<'_, 'a>) {
+    for child in &compound.children {
+        write_simple_selector(child, f);
+    }
+}
+
+fn write_simple_selector<'a>(selector: &SimpleSelector<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    match selector {
+        SimpleSelector::Class(class) => {
+            write!(f, ".");
+            write_interpolable_ident(&class.name, f);
+        }
+        SimpleSelector::Id(id) => {
+            write!(f, "#");
+            write_interpolable_ident(&id.name, f);
+        }
+        SimpleSelector::Type(type_selector) => write_type_selector(type_selector, f),
+        SimpleSelector::Attribute(attribute) => write_attribute_selector(attribute, f),
+        SimpleSelector::PseudoClass(pseudo) => write_pseudo_class(pseudo, f),
+        SimpleSelector::PseudoElement(pseudo) => write_pseudo_element(pseudo, f),
+        SimpleSelector::Nesting(nesting) => {
+            write!(f, "&");
+            if let Some(suffix) = &nesting.suffix {
+                write_interpolable_ident(suffix, f);
+            }
+        }
+        SimpleSelector::SassPlaceholder(placeholder) => {
+            let span = to_span(placeholder.span());
+            write!(f, text(source.text_for(&span)));
+        }
+    }
+}
+
+fn write_interpolable_ident<'a>(ident: &InterpolableIdent<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let span = to_span(ident.span());
+    let raw = source.text_for(&span);
+    // Multi-line interpolations collapse to single spaces.
+    if raw.contains('\n') || raw.contains('\r') {
+        let joined = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+        write!(f, text(f.allocator().alloc_str(&joined)));
+    } else {
+        write!(f, text(raw));
+    }
+}
+
+fn write_wq_name<'a>(name: &WqName<'a>, f: &mut CssFormatter<'_, 'a>) {
+    if let Some(prefix) = &name.prefix {
+        if let Some(kind) = &prefix.kind {
+            match kind {
+                NsPrefixKind::Ident(ident) => write_interpolable_ident(ident, f),
+                NsPrefixKind::Universal(_) => write!(f, "*"),
+            }
+        }
+        write!(f, "|");
+    }
+    write_interpolable_ident(&name.name, f);
+}
+
+/// Mirrors Prettier's `selector-tag`: lowercase `from`/`to` inside
+/// `@keyframes`; HTML tag names are printed as-is (adjustNumbers is a no-op
+/// for plain identifiers).
+fn write_type_selector<'a>(type_selector: &TypeSelector<'a>, f: &mut CssFormatter<'_, 'a>) {
+    match type_selector {
+        TypeSelector::TagName(tag) => write_wq_name(&tag.name, f),
+        TypeSelector::Universal(universal) => {
+            if let Some(prefix) = &universal.prefix {
+                if let Some(kind) = &prefix.kind {
+                    match kind {
+                        NsPrefixKind::Ident(ident) => write_interpolable_ident(ident, f),
+                        NsPrefixKind::Universal(_) => write!(f, "*"),
+                    }
+                }
+                write!(f, "|");
+            }
+            write!(f, "*");
+        }
+    }
+}
+
+/// Mirrors Prettier's `selector-attribute`.
+fn write_attribute_selector<'a>(attribute: &AttributeSelector<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    write!(f, "[");
+    write_wq_name(&attribute.name, f);
+    if let Some(matcher) = &attribute.matcher {
+        match matcher.kind {
+            AttributeSelectorMatcherKind::Exact => write!(f, "="),
+            AttributeSelectorMatcherKind::MatchWord => write!(f, "~="),
+            AttributeSelectorMatcherKind::ExactOrPrefixThenHyphen => write!(f, "|="),
+            AttributeSelectorMatcherKind::Prefix => write!(f, "^="),
+            AttributeSelectorMatcherKind::Suffix => write!(f, "$="),
+            AttributeSelectorMatcherKind::Substring => write!(f, "*="),
+        }
+    }
+    if let Some(value) = &attribute.value {
+        match value {
+            // Unquoted values get quoted (Prettier's `quoteAttributeValue`).
+            AttributeSelectorValue::Ident(ident) => {
+                let quote = if f.options().single_quote.value() { "'" } else { "\"" };
+                let span = to_span(ident.span());
+                write!(f, [text(quote), text(source.text_for(&span)), text(quote)]);
+            }
+            AttributeSelectorValue::Str(raffia::ast::InterpolableStr::Literal(str)) => {
+                crate::print::value::write_str(str, f);
+            }
+            _ => {
+                let span = to_span(value.span());
+                write!(f, text(source.text_for(&span)));
+            }
+        }
+    }
+    if let Some(modifier) = &attribute.modifier {
+        write!(f, " ");
+        let span = to_span(modifier.ident.span());
+        write!(f, text(source.text_for(&span)));
+    }
+    write!(f, "]");
+}
+
+/// Mirrors Prettier's `selector-pseudo`.
+fn write_pseudo_class<'a>(pseudo: &PseudoClassSelector<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    write!(f, ":");
+    let name_span = to_span(pseudo.name.span());
+    write_maybe_lowercase(source.text_for(&name_span), f);
+    if let Some(arg) = &pseudo.arg {
+        let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            write!(f, soft_line_break());
+            write_pseudo_class_arg(&arg.kind, f);
+        });
+        write!(
+            f,
+            group(&format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                write!(f, "(");
+                write!(f, indent(&body));
+                write!(f, soft_line_break());
+                write!(f, ")");
+            }))
+        );
+    }
+}
+
+fn write_pseudo_class_arg<'a>(kind: &PseudoClassSelectorArgKind<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    match kind {
+        PseudoClassSelectorArgKind::SelectorList(list) => {
+            write_selector_list_inline(list, f);
+        }
+        PseudoClassSelectorArgKind::RelativeSelectorList(list) => {
+            for (i, selector) in list.selectors.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ",");
+                    write!(f, soft_line_break_or_space());
+                }
+                if let Some(combinator) = &selector.combinator {
+                    write_combinator(combinator, true, false, f);
+                    write!(f, " ");
+                }
+                write_complex_selector(&selector.complex_selector, f);
+            }
+        }
+        PseudoClassSelectorArgKind::CompoundSelector(compound) => {
+            write_compound_selector(compound, f);
+        }
+        PseudoClassSelectorArgKind::CompoundSelectorList(list) => {
+            for (i, compound) in list.selectors.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ",");
+                    write!(f, soft_line_break_or_space());
+                }
+                write_compound_selector(compound, f);
+            }
+        }
+        PseudoClassSelectorArgKind::Ident(ident) => write_interpolable_ident(ident, f),
+        // Nth, Number, LanguageRangeList, TokenSeq, LessExtendList:
+        // print the source verbatim (normalized below where needed).
+        _ => {
+            let span = to_span(kind.span());
+            write!(f, text(source.text_for(&span)));
+        }
+    }
+}
+
+/// Selector list inside pseudo args: `,` + line.
+fn write_selector_list_inline<'a>(list: &SelectorList<'a>, f: &mut CssFormatter<'_, 'a>) {
+    for (i, complex) in list.selectors.iter().enumerate() {
+        if i > 0 {
+            write!(f, ",");
+            write!(f, soft_line_break_or_space());
+        }
+        write_complex_selector(complex, f);
+    }
+}
+
+fn write_pseudo_element<'a>(pseudo: &PseudoElementSelector<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    write!(f, "::");
+    let name_span = to_span(pseudo.name.span());
+    write_maybe_lowercase(source.text_for(&name_span), f);
+    if let Some(arg) = &pseudo.arg {
+        write!(f, "(");
+        match &arg.kind {
+            PseudoElementSelectorArgKind::CompoundSelector(compound) => {
+                write_compound_selector(compound, f);
+            }
+            PseudoElementSelectorArgKind::Ident(ident) => write_interpolable_ident(ident, f),
+            PseudoElementSelectorArgKind::TokenSeq(seq) => {
+                let span = to_span(seq.span());
+                write!(f, text(source.text_for(&span)));
+            }
+        }
+        write!(f, ")");
+    }
+}
+
+/// Lowercase `from` / `to` keyframe selectors; keep percentages as numbers.
+pub fn write_keyframe_selector<'a>(
+    selector: &raffia::ast::KeyframeSelector<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    match selector {
+        raffia::ast::KeyframeSelector::Ident(ident) => {
+            let span = to_span(ident.span());
+            let raw = source.text_for(&span);
+            match raw.cow_to_ascii_lowercase() {
+                Cow::Borrowed(s) => write!(f, text(s)),
+                Cow::Owned(s) => write!(f, text(f.allocator().alloc_str(&s))),
+            }
+        }
+        raffia::ast::KeyframeSelector::Percentage(percentage) => {
+            crate::print::value::write_number(&percentage.value, f);
+            write!(f, "%");
+        }
+    }
+}

--- a/crates/oxc_formatter_css/src/print/statement.rs
+++ b/crates/oxc_formatter_css/src/print/statement.rs
@@ -1,0 +1,540 @@
+use std::borrow::Cow;
+
+use cow_utils::CowUtils;
+use oxc_formatter_core::{
+    Buffer,
+    builders::{block_indent, hard_line_break, indent, space, text},
+    write,
+};
+use raffia::{
+    Spanned,
+    ast::{Declaration, QualifiedRule, SimpleBlock, Statement},
+};
+
+use crate::{
+    comments::{flush_trailing_inside_comments, write_leading_comments},
+    format::to_span,
+    print::{
+        CssFormatter, at_rule, format_with, less, scss, selector,
+        value::{self, ValueContext},
+    },
+};
+
+/// Start offset of a statement.
+pub fn stmt_start(stmt: &Statement<'_>) -> u32 {
+    to_span(stmt.span()).start
+}
+
+/// End offset of a statement, extended over a trailing semicolon
+/// (raffia's spans exclude it; postcss's `locEnd` includes it, and blank-line
+/// detection counts from after the `;`).
+pub fn stmt_end(stmt: &Statement<'_>, f: &CssFormatter<'_, '_>) -> u32 {
+    end_with_semicolon(to_span(stmt.span()).end, f)
+}
+
+/// Extends `end` over any whitespace, comments and a final `;` in the source.
+pub fn end_with_semicolon(end: u32, f: &CssFormatter<'_, '_>) -> u32 {
+    let source = f.context().source_text();
+    let bytes = source.as_bytes();
+    let mut i = end as usize;
+    loop {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        // Skip a block comment between the statement and its `;`.
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            match source[i + 2..].find("*/") {
+                Some(close) => {
+                    i = i + 2 + close + 2;
+                    continue;
+                }
+                None => break,
+            }
+        }
+        break;
+    }
+    if i < bytes.len() && bytes[i] == b';' { u32::try_from(i + 1).unwrap_or(end) } else { end }
+}
+
+/// Dispatch a single statement.
+pub fn write_statement<'a>(stmt: &Statement<'a>, f: &mut CssFormatter<'_, 'a>) {
+    match stmt {
+        Statement::QualifiedRule(rule) => write_qualified_rule(rule, f),
+        Statement::Declaration(decl) => {
+            write_declaration(decl, f);
+            // Nested declaration blocks (`background: { ... }`) get no `;`.
+            if !matches!(
+                decl.value.last(),
+                Some(raffia::ast::ComponentValue::SassNestingDeclaration(_))
+            ) {
+                write!(f, ";");
+            }
+        }
+        Statement::AtRule(at_rule) => at_rule::write_at_rule(at_rule, f),
+        Statement::LessVariableDeclaration(decl) => {
+            if less::write_less_variable_declaration(decl, f) {
+                write!(f, ";");
+            }
+        }
+        Statement::LessMixinDefinition(def) => less::write_less_mixin_definition(def, f),
+        Statement::LessMixinCall(call) => {
+            less::write_less_mixin_call(call, f);
+            write!(f, ";");
+        }
+        Statement::SassVariableDeclaration(decl) => {
+            scss::write_sass_variable_declaration(decl, f);
+            write!(f, ";");
+        }
+        Statement::SassIfAtRule(if_rule) => scss::write_sass_if_at_rule(if_rule, f),
+        Statement::UnknownSassAtRule(unknown) => {
+            let source = f.context().source_text();
+            write!(f, "@");
+            let name_span = to_span(unknown.name.span());
+            write_maybe_lowercase(source.text_for(&name_span), f);
+            if let Some(prelude) = &unknown.prelude {
+                write!(f, space());
+                match prelude {
+                    raffia::ast::UnknownAtRulePrelude::ComponentValue(value) => {
+                        value::write_component_value(value, ValueContext::default(), f);
+                    }
+                    raffia::ast::UnknownAtRulePrelude::TokenSeq(seq) => {
+                        at_rule::write_token_seq(seq, f);
+                    }
+                }
+            }
+            if let Some(block) = &unknown.block {
+                write!(f, space());
+                write_block(block, f);
+            } else {
+                write!(f, ";");
+            }
+        }
+        Statement::KeyframeBlock(keyframe_block) => {
+            for (i, sel) in keyframe_block.selectors.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ",");
+                    write!(f, hard_line_break());
+                }
+                selector::write_keyframe_selector(sel, f);
+            }
+            write!(f, space());
+            write_block(&keyframe_block.block, f);
+        }
+        // Not yet ported: emit the original source verbatim.
+        _ => {
+            let span = to_span(stmt.span());
+            let source = f.context().source_text();
+            write!(f, text(source.text_for(&span)));
+            write!(f, ";");
+        }
+    }
+}
+
+/// Mirrors Prettier's `css-rule`.
+fn write_qualified_rule<'a>(rule: &QualifiedRule<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let sel_span = to_span(rule.selector.span());
+    let block_start = to_span(rule.block.span()).start;
+    // `//` comments inside the selector break postcss-selector-parser:
+    // Prettier prints the raw selector verbatim (`selector-unknown`), and a
+    // trailing `//` comment pushes `{` to the next line.
+    let has_inline_comment = f
+        .context()
+        .comments()
+        .iter_before(block_start)
+        .any(|c| c.inline && c.span.start >= sel_span.start);
+    if has_inline_comment {
+        let raw = source.slice_range(sel_span.start, block_start).trim_end();
+        let _ = f.context().comments().take_before(block_start);
+        write!(f, text(raw));
+        let last_line = raw.rsplit('\n').next().unwrap_or(raw);
+        if last_line.contains("//") {
+            write!(f, hard_line_break());
+        } else {
+            write!(f, space());
+        }
+        write_block(&rule.block, f);
+        return;
+    }
+    selector::write_selector_list(&rule.selector, selector::SelectorListStyle::Hard, f);
+    write!(f, space());
+    write_block(&rule.block, f);
+}
+
+/// Mirrors Prettier's `maybeToLowerCase`: lowercase unless the identifier
+/// contains variable/interpolation markers.
+pub fn write_maybe_lowercase<'a>(value: &'a str, f: &mut CssFormatter<'_, 'a>) {
+    if value.contains('$')
+        || value.contains('@')
+        || value.contains('#')
+        || value.starts_with('%')
+        || value.starts_with("--")
+        || value.starts_with(":--")
+        || (value.contains('(') && value.contains(')'))
+    {
+        write!(f, text(value));
+    } else {
+        match value.cow_to_ascii_lowercase() {
+            Cow::Borrowed(s) => write!(f, text(s)),
+            Cow::Owned(s) => write!(f, text(f.allocator().alloc_str(&s))),
+        }
+    }
+}
+
+/// A declaration without trailing semicolon (also used for `@supports (...)` features).
+pub fn write_declaration_inline<'a>(decl: &Declaration<'a>, f: &mut CssFormatter<'_, 'a>) {
+    write_declaration(decl, f);
+}
+
+/// Mirrors Prettier's `css-decl`.
+fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let name_span = to_span(decl.name.span());
+    let prop = source.text_for(&name_span);
+    if f.context().in_less_detached().get() {
+        write!(f, text(prop));
+    } else {
+        write_maybe_lowercase(prop, f);
+    }
+    // Prettier prints the WHOLE `raws.between` (prop → value, `:` and any
+    // comments included) trimmed but otherwise verbatim, with a space before
+    // a leading `//` comment and a space before the value.
+    let colon_end = to_span(&decl.colon_span).end;
+    let between_upper =
+        if decl.value.is_empty() { colon_end } else { to_span(decl.value[0].span()).start };
+    let between = source.slice_range(name_span.end, between_upper);
+    let trimmed_between = between.trim_ascii();
+    // `lastLineHasInlineComment`: the value drops to the next line, one
+    // indent under the prop (`indent([hardline, dedent(value)])`).
+    let between_breaks = trimmed_between != ":"
+        && trimmed_between.rsplit(['\n', '\r']).next().unwrap_or(trimmed_between).contains("//");
+    if trimmed_between == ":" {
+        write!(f, ":");
+    } else {
+        let _ = f.context().comments().take_before(between_upper);
+        if trimmed_between.starts_with("//") {
+            write!(f, space());
+        }
+        // Runs of spaces before a same-line `//` comment collapse to one
+        // (postcss-less keeps inline comments out of `raws.between`).
+        if trimmed_between.contains("  //") {
+            let mut out = String::with_capacity(trimmed_between.len());
+            for (i, line) in trimmed_between.split('\n').enumerate() {
+                if i > 0 {
+                    out.push('\n');
+                }
+                if let Some(pos) = line.find("//") {
+                    let (head, tail) = line.split_at(pos);
+                    let trimmed_head = head.trim_end();
+                    if head.len() > trimmed_head.len() + 1 && !trimmed_head.is_empty() {
+                        out.push_str(trimmed_head);
+                        out.push(' ');
+                        out.push_str(tail);
+                        continue;
+                    }
+                }
+                out.push_str(line);
+            }
+            write!(f, text(f.allocator().alloc_str(&out)));
+        } else {
+            write!(f, text(trimmed_between));
+        }
+    }
+    if decl.value.is_empty() {
+        // Custom properties with a whitespace-only value keep it verbatim
+        // (`--one-space: ;` stays as-is). Scan up to the `;` in the source.
+        let colon_end = to_span(&decl.colon_span).end;
+        let bytes = source.as_bytes();
+        let mut i = colon_end as usize;
+        while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+            i += 1;
+        }
+        if i < bytes.len() && bytes[i] == b';' && i > colon_end as usize {
+            write!(f, text(source.slice_range(colon_end, u32::try_from(i).unwrap())));
+        }
+    } else {
+        write!(f, space());
+        let prop_lower = prop.cow_to_ascii_lowercase();
+        let prop_lower: &'a str = match prop_lower {
+            Cow::Borrowed(s) => s,
+            Cow::Owned(s) => f.allocator().alloc_str(&s),
+        };
+
+        // `filter: progid:...` values are printed verbatim.
+        let value_start = to_span(decl.value[0].span()).start;
+        let value_end = to_span(decl.value[decl.value.len() - 1].span()).end;
+        let value_text = source.slice_range(value_start, value_end);
+        if value_text.starts_with("progid:") {
+            write!(f, text(value_text));
+        } else if (value_text.contains("\\(") || value_text.contains("\\)"))
+            && value_text.contains('\n')
+        {
+            // Escaped parens break postcss's value parser: the whole value
+            // is a `value-unknown`, printed verbatim.
+            write!(f, text(value_text));
+            let _ = f.context().comments().take_before(value_end);
+        } else if (value_text.starts_with('"') || value_text.starts_with('\''))
+            && value_text.ends_with(value_text.as_bytes()[0] as char)
+            && value_text[1..value_text.len() - 1].contains("#{")
+            && decl.value.len() > 1
+            // Only when raffia split ONE string apart (no gaps between parts).
+            && decl.value.windows(2).all(|w| {
+                to_span(w[0].span()).end == to_span(w[1].span()).start
+            })
+        {
+            // A string containing SCSS interpolation that raffia tokenized
+            // apart (`"#{".5"}"`): print the pieces glued — numbers get
+            // normalized, strings keep their quotes.
+            // Interpolation among the pieces → `value-unknown`: verbatim,
+            // except bare quoted numbers, which postcss saw unquoted.
+            value::write_requoted_verbatim(value_text, f);
+            let _ = f.context().comments().take_before(value_end);
+        } else if prop.starts_with("--") && value_text.starts_with('{') {
+            if value_text.trim_end().ends_with('}')
+                && value_text.bytes().filter(|&b| b == b'{').count() == 1
+            {
+                // `--prop: { decls };` custom-property rule blocks (postcss
+                // re-parses these as a rule): print the token stream as a block.
+                value::flush_value_comments(value_start, f);
+                write_custom_property_block(value_text, f);
+            } else {
+                // Unparsable rule-ish value (e.g. missing `;` swallowed the
+                // following declarations): keep the source verbatim.
+                write!(f, text(value_text));
+            }
+            // The raw text includes any comments; drop them from the cursor.
+            let _ = f.context().comments().take_before(value_end);
+        } else {
+            let ctx = ValueContext {
+                decl_prop: Some(prop_lower),
+                // Prettier applies `removeLines` to `composes` values.
+                no_break: prop_lower == "composes",
+                // Prettier's printer counts a multi-line between's FULL
+                // width, so the first trailing comment always wraps.
+                tail_break: trimmed_between.contains('\n'),
+                ..ValueContext::default()
+            };
+
+            // The `;` position bounds wrapped trailing comments — only when
+            // such comments exist (keeps simple declarations on the
+            // single-component fast path).
+            let decl_end_pre = to_span(decl.span()).end;
+            let semi = end_with_semicolon(decl_end_pre, f);
+            let bound = if semi > decl_end_pre { semi - 1 } else { decl_end_pre };
+            let has_tail = decl.important.is_none()
+                && f.context().comments().iter_before(bound).any(|c| c.span.start >= value_end);
+            let ctx = ValueContext { tail_bound: has_tail.then_some(bound), ..ctx };
+            // `prop: <values> { decls }` — a trailing nested block hugs the
+            // declaration; leading values are space-joined flat.
+            if let Some(raffia::ast::ComponentValue::SassNestingDeclaration(nesting)) =
+                decl.value.last()
+            {
+                for v in &decl.value[..decl.value.len() - 1] {
+                    value::write_component_value(v, ctx, f);
+                    write!(f, space());
+                }
+                write_block(&nesting.block, f);
+                return;
+            }
+            if between_breaks {
+                // `indent([hardline, dedent(value)])` — the value's own indent
+                // is cancelled so it sits exactly one level under the prop.
+                let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    write!(f, hard_line_break());
+                    let inner = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                        value::write_declaration_value(&decl.value, ctx, f);
+                    });
+                    write!(f, oxc_formatter_core::builders::dedent(&inner));
+                });
+                write!(f, indent(&body));
+            } else {
+                value::write_declaration_value(&decl.value, ctx, f);
+            }
+        }
+    }
+    if let Some(important) = &decl.important {
+        value::flush_trailing_value_comments(to_span(important.span()).start, f);
+        write!(f, [space(), "!important"]);
+    }
+    // Comments between the value and the `;`. Note: the `;` position is the
+    // flush bound, so a comment after `;` stays for the trailing-comment pass.
+    let decl_end = to_span(decl.span()).end;
+    let end = end_with_semicolon(decl_end, f);
+    let bound = if end > decl_end { end - 1 } else { decl_end };
+    if let Some(comment_end) = value::flush_trailing_value_comments(bound, f) {
+        // Preserve a source gap between the last comment and the `;`.
+        if end > decl_end && comment_end < end - 1 {
+            write!(f, space());
+        }
+    }
+}
+
+/// Prints a `--prop: { a: b; c: d }` rule-block value by re-flowing the raw
+/// text: one declaration per line, normalized `prop: value;` spacing.
+fn write_custom_property_block<'a>(value_text: &'a str, f: &mut CssFormatter<'_, 'a>) {
+    let inner = value_text.trim_end();
+    let inner = &inner[1..inner.len() - 1];
+    // Split on `;`, keeping a comment that follows a `;` on the SAME line
+    // attached to the previous declaration (`...; /* c */`).
+    let mut decls: Vec<(&str, Option<&str>)> = vec![];
+    for seg in inner.split(';') {
+        let (first_line, rest) = match seg.find('\n') {
+            Some(idx) => (&seg[..idx], &seg[idx..]),
+            None => (seg, ""),
+        };
+        let prefix = first_line.trim();
+        if !decls.is_empty()
+            && !prefix.is_empty()
+            && prefix.starts_with("/*")
+            && prefix.ends_with("*/")
+            && !rest.trim().is_empty()
+        {
+            decls.last_mut().unwrap().1 = Some(prefix);
+            let remainder = rest.trim();
+            if !remainder.is_empty() {
+                decls.push((remainder, None));
+            }
+        } else {
+            let t = seg.trim();
+            if !t.is_empty() {
+                decls.push((t, None));
+            }
+        }
+    }
+    if decls.is_empty() {
+        write!(f, ["{", hard_line_break(), "}"]);
+        return;
+    }
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        write!(f, hard_line_break());
+        for (i, (decl, trailing)) in decls.iter().enumerate() {
+            if i > 0 {
+                write!(f, hard_line_break());
+            }
+            // Re-flow line by line (keeps interior comments in place).
+            for (j, line) in decl.lines().map(str::trim).filter(|l| !l.is_empty()).enumerate() {
+                if j > 0 {
+                    write!(f, hard_line_break());
+                }
+                // Normalize `prop : value` spacing on declaration lines:
+                // split at the first colon OUTSIDE comments, keep the prop
+                // side verbatim, re-space the value side tokens.
+                if let Some(colon) = find_colon_outside_comments(line) {
+                    let (p, v) = line.split_at(colon);
+                    let v = &v[1..];
+                    write!(f, [text(p.trim_end()), ":", space()]);
+                    let normalized = respace_value_tokens(v.trim());
+                    if normalized == v.trim() {
+                        write!(f, text(v.trim()));
+                    } else {
+                        write!(f, text(f.allocator().alloc_str(&normalized)));
+                    }
+                } else {
+                    write!(f, text(line));
+                }
+            }
+            // A trailing comment-only segment gets no semicolon.
+            if !(i + 1 == decls.len() && decl.starts_with("/*") && decl.ends_with("*/")) {
+                write!(f, ";");
+            }
+            if let Some(comment) = trailing {
+                write!(f, [space(), text(comment)]);
+            }
+        }
+    });
+    write!(f, ["{", indent(&body), hard_line_break(), "}"]);
+}
+
+/// First `:` outside `/* ... */` comments, or None.
+fn find_colon_outside_comments(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
+            match line[i + 2..].find("*/") {
+                Some(close) => i = i + 2 + close + 2,
+                None => return None,
+            }
+            continue;
+        }
+        if bytes[i] == b':' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Single spaces between value tokens and comments (`/* c */ #fff /* c */`).
+fn respace_value_tokens(v: &str) -> String {
+    let mut out = String::with_capacity(v.len() + 8);
+    let bytes = v.as_bytes();
+    let mut i = 0;
+    let mut last_was_token = false;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        if bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*') {
+            match v[i + 2..].find("*/") {
+                Some(close) => i = i + 2 + close + 2,
+                None => i = bytes.len(),
+            }
+        } else {
+            while i < bytes.len()
+                && !bytes[i].is_ascii_whitespace()
+                && !(bytes[i] == b'/' && bytes.get(i + 1) == Some(&b'*'))
+            {
+                i += 1;
+            }
+        }
+        if last_was_token {
+            out.push(' ');
+        }
+        out.push_str(&v[start..i]);
+        last_was_token = true;
+    }
+    out
+}
+
+/// Mirrors Prettier's block printing: `{` + indented statements + `}`.
+/// An empty block prints as `{\n}`.
+pub fn write_block<'a>(block: &SimpleBlock<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let depth = f.context().block_depth();
+    depth.set(depth.get() + 1);
+    write_block_inner(block, f);
+    let depth = f.context().block_depth();
+    depth.set(depth.get() - 1);
+}
+
+fn write_block_inner<'a>(block: &SimpleBlock<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let block_span = to_span(&block.span);
+    let r_curly = block_span.end.saturating_sub(1);
+
+    write!(f, "{");
+
+    if block.statements.is_empty() {
+        // Dangling comments inside an otherwise empty block.
+        let comments = f.context().comments().take_before(r_curly);
+        if comments.is_empty() {
+            write!(f, hard_line_break());
+        } else {
+            let body = format_with(|f: &mut CssFormatter<'_, 'a>| {
+                let last_end = comments.last().unwrap().span.end;
+                write_leading_comments(comments, last_end, f);
+            });
+            write!(f, block_indent(&body));
+        }
+    } else {
+        let body = format_with(|f: &mut CssFormatter<'_, 'a>| {
+            crate::print::write_statement_sequence_bounded(&block.statements, r_curly, f);
+            let last_end = block.statements.last().map_or(block_span.start, |s| stmt_end(s, f));
+            flush_trailing_inside_comments(last_end, r_curly, f);
+        });
+        write!(f, block_indent(&body));
+    }
+
+    write!(f, "}");
+}

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -1,0 +1,1586 @@
+//! Component value printing.
+//!
+//! Ports Prettier's `print/comma-separated-value-group.js`,
+//! `print/parenthesized-value-group.js` and `print/misc.js` onto raffia's
+//! flat `ComponentValue` streams (which mirror postcss-values-parser tokens:
+//! commas and solidi appear as `Delimiter` components).
+
+use std::borrow::Cow;
+
+use cow_utils::CowUtils;
+use oxc_formatter_core::{
+    Buffer, Format,
+    builders::{
+        group, hard_line_break, indent, soft_line_break, soft_line_break_or_space, space, text,
+        token,
+    },
+    write,
+};
+use raffia::{
+    Spanned,
+    ast::{ComponentValue, Delimiter, DelimiterKind, Dimension, Function, Number, Str, Url},
+};
+
+use crate::{
+    format::to_span,
+    print::{CssFormatter, format_with},
+};
+
+/// Prettier's `css-units-list`: lowercase -> canonical casing.
+fn canonical_unit(lowercased: &str) -> Option<&'static str> {
+    Some(match lowercased {
+        "em" => "em",
+        "rem" => "rem",
+        "ex" => "ex",
+        "rex" => "rex",
+        "cap" => "cap",
+        "rcap" => "rcap",
+        "ch" => "ch",
+        "rch" => "rch",
+        "ic" => "ic",
+        "ric" => "ric",
+        "lh" => "lh",
+        "rlh" => "rlh",
+        "vw" => "vw",
+        "svw" => "svw",
+        "lvw" => "lvw",
+        "dvw" => "dvw",
+        "vh" => "vh",
+        "svh" => "svh",
+        "lvh" => "lvh",
+        "dvh" => "dvh",
+        "vi" => "vi",
+        "svi" => "svi",
+        "lvi" => "lvi",
+        "dvi" => "dvi",
+        "vb" => "vb",
+        "svb" => "svb",
+        "lvb" => "lvb",
+        "dvb" => "dvb",
+        "vmin" => "vmin",
+        "svmin" => "svmin",
+        "lvmin" => "lvmin",
+        "dvmin" => "dvmin",
+        "vmax" => "vmax",
+        "svmax" => "svmax",
+        "lvmax" => "lvmax",
+        "dvmax" => "dvmax",
+        "cm" => "cm",
+        "mm" => "mm",
+        "q" => "Q",
+        "in" => "in",
+        "pt" => "pt",
+        "pc" => "pc",
+        "px" => "px",
+        "deg" => "deg",
+        "grad" => "grad",
+        "rad" => "rad",
+        "turn" => "turn",
+        "s" => "s",
+        "ms" => "ms",
+        "hz" => "Hz",
+        "khz" => "kHz",
+        "dpi" => "dpi",
+        "dpcm" => "dpcm",
+        "dppx" => "dppx",
+        "x" => "x",
+        "cqw" => "cqw",
+        "cqh" => "cqh",
+        "cqi" => "cqi",
+        "cqb" => "cqb",
+        "cqmin" => "cqmin",
+        "cqmax" => "cqmax",
+        "fr" => "fr",
+        _ => return None,
+    })
+}
+
+/// Prettier's `printNumber` + `printCssNumber` (trailing `.0` removal included).
+pub fn print_css_number(raw: &str) -> Cow<'_, str> {
+    if raw.len() == 1 {
+        return Cow::Borrowed(raw);
+    }
+    let lowered = raw.cow_to_ascii_lowercase();
+
+    // Split off scientific notation exponent.
+    let (mantissa, exponent) = match lowered.find('e') {
+        Some(idx) => (&lowered[..idx], Some(&lowered[idx + 1..])),
+        None => (&lowered[..], None),
+    };
+
+    // Normalize exponent: remove `+` and leading zeroes; drop `e0`.
+    let exponent = exponent.map(|exp| {
+        let (sign, digits) = match exp.as_bytes().first() {
+            Some(b'+') => ("", &exp[1..]),
+            Some(b'-') => ("-", &exp[1..]),
+            _ => ("", exp),
+        };
+        let digits = digits.trim_start_matches('0');
+        if digits.is_empty() { String::new() } else { format!("e{sign}{digits}") }
+    });
+
+    // Normalize mantissa (the sign, including `+`, is kept).
+    let (sign, digits) = match mantissa.as_bytes().first() {
+        Some(b'+') => ("+", &mantissa[1..]),
+        Some(b'-') => ("-", &mantissa[1..]),
+        _ => ("", mantissa),
+    };
+    let mut digits = digits.to_string();
+    if digits.contains('.') {
+        // Remove extraneous trailing decimal zeroes and the trailing dot.
+        let trimmed = digits.trim_end_matches('0');
+        let trimmed = trimmed.strip_suffix('.').unwrap_or(trimmed);
+        digits = trimmed.to_string();
+    }
+    // Make sure numbers always start with a digit.
+    if digits.starts_with('.') {
+        digits.insert(0, '0');
+    } else if digits.is_empty() {
+        digits.push('0');
+    }
+
+    let exponent = exponent.unwrap_or_default();
+    let result = format!("{sign}{digits}{exponent}");
+    if result == raw { Cow::Borrowed(raw) } else { Cow::Owned(result) }
+}
+
+/// Prettier's `printUnit`.
+fn print_unit<'a>(raw_unit: &'a str, f: &mut CssFormatter<'_, 'a>) {
+    let lowered = raw_unit.cow_to_ascii_lowercase();
+    if let Some(canonical) = canonical_unit(&lowered) {
+        write!(f, token(canonical));
+    } else {
+        write!(f, text(raw_unit));
+    }
+}
+
+pub fn write_number<'a>(number: &Number<'a>, f: &mut CssFormatter<'_, 'a>) {
+    match print_css_number(number.raw) {
+        Cow::Borrowed(s) => write!(f, text(s)),
+        Cow::Owned(s) => write!(f, text(f.allocator().alloc_str(&s))),
+    }
+}
+
+pub fn write_dimension<'a>(dimension: &Dimension<'a>, f: &mut CssFormatter<'_, 'a>) {
+    write_number(&dimension.value, f);
+    print_unit(dimension.unit.raw, f);
+}
+
+/// Prettier's `printString`: re-quote according to `singleQuote` unless the
+/// content contains quotes that would need extra escaping.
+pub fn write_str<'a>(str: &Str<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let raw = str.raw;
+    let single_quote = f.options().single_quote.value();
+    let content = &raw[1..raw.len() - 1];
+
+    let (preferred, alternate) = if single_quote { ('\'', '"') } else { ('"', '\'') };
+    let mut preferred_count = 0usize;
+    let mut alternate_count = 0usize;
+    for b in content.bytes() {
+        if b == preferred as u8 {
+            preferred_count += 1;
+        } else if b == alternate as u8 {
+            alternate_count += 1;
+        }
+    }
+    let enclosing = if preferred_count > alternate_count { alternate } else { preferred };
+
+    if raw.as_bytes()[0] == enclosing as u8 {
+        write!(f, text(raw));
+        return;
+    }
+
+    // makeString: flip escapes as needed.
+    let other = if enclosing == '"' { '\'' } else { '"' };
+    let mut out = String::with_capacity(raw.len());
+    out.push(enclosing);
+    let mut chars = content.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => match chars.next() {
+                Some(next @ ('"' | '\'' | '\\')) => {
+                    if next == other {
+                        out.push(other);
+                    } else {
+                        out.push('\\');
+                        out.push(next);
+                    }
+                }
+                Some(next) => {
+                    out.push('\\');
+                    out.push(next);
+                }
+                None => out.push('\\'),
+            },
+            c if c == enclosing => {
+                out.push('\\');
+                out.push(c);
+            }
+            c => out.push(c),
+        }
+    }
+    out.push(enclosing);
+    write!(f, text(f.allocator().alloc_str(&out)));
+}
+
+/// Re-quotes the OUTER quotes of a raw quoted string per `singleQuote`,
+/// keeping the content (e.g. `#{...}` interpolation) verbatim.
+pub fn write_requoted_verbatim<'a>(raw: &'a str, f: &mut CssFormatter<'_, 'a>) {
+    if raw.len() < 2 || !(raw.starts_with('\'') || raw.starts_with('"')) {
+        write!(f, text(raw));
+        return;
+    }
+    let content = &raw[1..raw.len() - 1];
+    // Interpolated strings whose content has quote characters keep their
+    // original quotes (the inner quotes confuse the preference count) —
+    // but bare quoted numbers inside `#{}` are normalized (postcss sees
+    // them as unquoted numbers).
+    if content.contains("#{") && (content.contains('"') || content.contains('\'')) {
+        // The outer quote re-appearing inside the content splits the string
+        // in postcss; every piece gets requoted to the preferred quote.
+        let outer = raw.as_bytes()[0] as char;
+        let preferred = if f.options().single_quote.value() { '\'' } else { '"' };
+        if outer != preferred && content.contains(outer) && !content.contains(preferred) {
+            let replaced = raw.cow_replace(outer, preferred.encode_utf8(&mut [0; 4]));
+            let normalized = normalize_quoted_numbers(&replaced);
+            write!(f, text(f.allocator().alloc_str(&normalized)));
+            return;
+        }
+        let normalized = normalize_quoted_numbers(raw);
+        if normalized == raw {
+            write!(f, text(raw));
+        } else {
+            write!(f, text(f.allocator().alloc_str(&normalized)));
+        }
+        return;
+    }
+    let single_quote = f.options().single_quote.value();
+    let (preferred, alternate) = if single_quote { ('\'', '"') } else { ('"', '\'') };
+    let mut pc = 0usize;
+    let mut ac = 0usize;
+    for b in content.bytes() {
+        if b == preferred as u8 {
+            pc += 1;
+        } else if b == alternate as u8 {
+            ac += 1;
+        }
+    }
+    let enclosing = if pc > ac { alternate } else { preferred };
+    if raw.as_bytes()[0] == enclosing as u8 {
+        write!(f, text(raw));
+    } else {
+        let out = format!("{enclosing}{content}{enclosing}");
+        write!(f, text(f.allocator().alloc_str(&out)));
+    }
+}
+
+/// Normalizes `".5"`-style quoted bare numbers inside an interpolated string.
+fn normalize_quoted_numbers(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out = String::with_capacity(raw.len());
+    let mut i = 0;
+    // Skip the outer opening quote.
+    out.push(bytes[0] as char);
+    i += 1;
+    let end = raw.len() - 1;
+    while i < end {
+        let b = bytes[i];
+        if (b == b'"' || b == b'\'') && i + 1 < end {
+            // Find the matching close within the content.
+            if let Some(close_rel) = raw[i + 1..end].find(b as char) {
+                let inner = &raw[i + 1..i + 1 + close_rel];
+                if !inner.is_empty() && inner.bytes().all(|c| c.is_ascii_digit() || c == b'.') {
+                    out.push(b as char);
+                    out.push_str(&print_css_number(inner));
+                    out.push(b as char);
+                    i = i + 1 + close_rel + 1;
+                    continue;
+                }
+            }
+        }
+        out.push(b as char);
+        i += 1;
+    }
+    out.push(bytes[end] as char);
+    out
+}
+
+fn is_wide_keyword(value: &str) -> bool {
+    value.eq_ignore_ascii_case("initial")
+        || value.eq_ignore_ascii_case("inherit")
+        || value.eq_ignore_ascii_case("unset")
+        || value.eq_ignore_ascii_case("revert")
+}
+
+fn is_comma(value: &ComponentValue<'_>) -> bool {
+    matches!(value, ComponentValue::Delimiter(Delimiter { kind: DelimiterKind::Comma, .. }))
+}
+
+fn is_solidus(value: &ComponentValue<'_>) -> bool {
+    matches!(value, ComponentValue::Delimiter(Delimiter { kind: DelimiterKind::Solidus, .. }))
+}
+
+fn is_word_like(value: &ComponentValue<'_>) -> bool {
+    matches!(
+        value,
+        ComponentValue::InterpolableIdent(_)
+            | ComponentValue::LessVariable(_)
+            | ComponentValue::SassVariable(_)
+    )
+}
+
+fn is_func_like(value: &ComponentValue<'_>) -> bool {
+    matches!(value, ComponentValue::Function(_) | ComponentValue::Url(_))
+}
+
+/// Is this number-ish or a font-size-capable function? (Prettier's `isPossibleFontSize`)
+fn is_possible_font_size(value: &ComponentValue<'_>) -> bool {
+    match value {
+        ComponentValue::Number(_)
+        | ComponentValue::Dimension(_)
+        | ComponentValue::Percentage(_) => true,
+        ComponentValue::Function(func) => {
+            let name = function_name_text(func);
+            name.eq_ignore_ascii_case("var")
+                || name.eq_ignore_ascii_case("calc")
+                || name.eq_ignore_ascii_case("min")
+                || name.eq_ignore_ascii_case("max")
+                || name.eq_ignore_ascii_case("clamp")
+                || name.starts_with("--")
+        }
+        _ => false,
+    }
+}
+
+fn function_name_text<'a>(func: &Function<'a>) -> &'a str {
+    use raffia::ast::FunctionName;
+    match &func.name {
+        FunctionName::Ident(raffia::ast::InterpolableIdent::Literal(ident)) => ident.raw,
+        _ => "",
+    }
+}
+
+/// Layout context for a value being printed.
+#[derive(Clone, Copy, Default)]
+pub struct ValueContext<'a> {
+    /// Lowercased property name of the enclosing declaration, if any.
+    pub decl_prop: Option<&'a str>,
+    /// `composes` values never break (Prettier's `removeLines`).
+    pub no_break: bool,
+    /// SCSS map printed in key position: stays inline (Prettier's `isKey`).
+    pub map_key: bool,
+    /// A parenthesized comma list here breaks one item per line
+    /// (only as a direct map-item value — `isSCSSMapItemNode` needs key-value
+    /// pairs in the group or its grandparent).
+    pub paren_break: bool,
+    /// SCSS maps here always break (`$var:` values, function args, map items).
+    pub map_break: bool,
+    /// Comments before this bound are flushed as wrapped fill items at the
+    /// end of the outermost comma group (declaration tail).
+    pub tail_bound: Option<u32>,
+    /// Inside `url(...)`: colons stay tight (`url(fbglyph:cross-outline)`).
+    pub in_url: bool,
+    /// Inside function/include arguments (comment-slot rules differ).
+    pub in_args: bool,
+    /// This component directly follows a `//` comment: a function call here
+    /// gets Prettier's quirky double indent (args +2 levels, `)` +1).
+    pub after_inline_comment: bool,
+    /// A multi-line `raws.between` was printed before the value: Prettier's
+    /// printer counts its full width, so the first trailing comment always
+    /// wraps.
+    pub tail_break: bool,
+}
+
+impl ValueContext<'_> {
+    fn is_grid(&self) -> bool {
+        self.decl_prop.is_some_and(|p| p == "grid" || p.starts_with("grid-template"))
+    }
+
+    fn is_font_or_custom(&self) -> bool {
+        self.decl_prop.is_some_and(|p| p == "font" || p.starts_with("--"))
+    }
+}
+
+/// Splits a flat component stream at top-level commas.
+fn split_comma_groups<'b, 'a>(values: &'b [ComponentValue<'a>]) -> Vec<&'b [ComponentValue<'a>]> {
+    let mut groups = vec![];
+    let mut start = 0;
+    for (i, v) in values.iter().enumerate() {
+        if is_comma(v) {
+            groups.push(&values[start..i]);
+            start = i + 1;
+        }
+    }
+    groups.push(&values[start..]);
+    // A trailing comma produces an empty last group; Prettier drops it.
+    if groups.len() > 1 && groups.last().is_some_and(|g| g.is_empty()) {
+        groups.pop();
+    }
+    groups
+}
+
+/// Mirrors Prettier's top-level declaration value printing
+/// (`value-root` -> `value-paren_group` without parens).
+pub fn write_declaration_value<'a>(
+    values: &[ComponentValue<'a>],
+    ctx: ValueContext<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    // A lone SCSS list/map IS the value (`$var: 1px 2px, 3px;`).
+    if values.len() == 1
+        && matches!(values[0], ComponentValue::SassList(_) | ComponentValue::SassMap(_))
+    {
+        crate::print::scss::write_top_level_value(&values[0], ctx, f);
+        return;
+    }
+
+    let groups = split_comma_groups(values);
+
+    if groups.len() == 1 {
+        // Flattened to a single comma group.
+        write_comma_group(groups[0], ctx, f);
+        return;
+    }
+
+    // Multiple comma groups: `shouldBreakList` forces one per line when any
+    // group has multiple elements (a real `value-comma_group` survives
+    // flattening — comments count as members) and the property is not a
+    // custom property.
+    let value_start = to_span(values[0].span()).start;
+    let value_end = to_span(values[values.len() - 1].span()).end;
+    let has_comments =
+        f.context().comments().iter_before(value_end).any(|c| c.span.start >= value_start);
+    let force_hard_line = !ctx.decl_prop.is_some_and(|p| p.starts_with("--"))
+        && (groups.iter().any(|g| g.len() > 1) || has_comments);
+
+    write_value_groups(&groups, ctx, force_hard_line, true, f);
+}
+
+/// Top-level comma-group list layout, shared between flat component streams
+/// and SCSS comma lists.
+pub fn write_value_groups<'a>(
+    groups: &[&[ComponentValue<'a>]],
+    ctx: ValueContext<'a>,
+    force_hard_line: bool,
+    _top_level: bool,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    // A single comma group never forces (it isn't a list).
+    let force_hard_line = force_hard_line && groups.len() > 1;
+    if force_hard_line {
+        let body = format_with(|f: &mut CssFormatter<'_, 'a>| {
+            write!(f, hard_line_break());
+            for (i, group_values) in groups.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ",");
+                    write!(f, hard_line_break());
+                }
+                // The declaration tail belongs to the LAST group only.
+                let gctx = if i + 1 < groups.len() {
+                    ValueContext { tail_bound: None, ..ctx }
+                } else {
+                    ctx
+                };
+                // Comments between groups (e.g. after the previous comma)
+                // fill together with the group they precede; `//` comments
+                // (and leading own-line comments) keep their own line.
+                let lead: Vec<crate::comments::CssComment> = group_values
+                    .first()
+                    .map(|first| {
+                        f.context().comments().take_before(to_span(first.span()).start).to_vec()
+                    })
+                    .unwrap_or_default();
+                if lead.is_empty() {
+                    write_comma_group(group_values, gctx, f);
+                } else if i == 0 {
+                    let source = f.context().source_text();
+                    for &comment in &lead {
+                        let own_line = comment_is_own_line(comment, source);
+                        crate::comments::write_single_comment(comment, f);
+                        if comment.inline || own_line {
+                            write!(f, hard_line_break());
+                        } else {
+                            write!(f, " ");
+                        }
+                    }
+                    write_comma_group(group_values, gctx, f);
+                } else {
+                    // Prettier-fill the comments with the group they lead.
+                    // Simulated with static widths: the group's fit must NOT
+                    // include its declaration tail, which our entry would.
+                    let width = u32::from(f.options().line_width.value());
+                    let group_w =
+                        group_values.first().zip(group_values.last()).map_or(0, |(first, last)| {
+                            to_span(last.span()).end - to_span(first.span()).start
+                        }) + u32::from(i + 1 < groups.len());
+                    let mut x = 4u32; // hardline indent under the value
+                    for (k, &comment) in lead.iter().enumerate() {
+                        crate::comments::write_single_comment(comment, f);
+                        x += comment.span.end - comment.span.start;
+                        let next_w = lead.get(k + 1).map_or(group_w, |c| c.span.end - c.span.start);
+                        if comment.inline {
+                            write!(f, hard_line_break());
+                            x = 4;
+                        } else if x + 1 + next_w <= width {
+                            write!(f, space());
+                            x += 1;
+                        } else {
+                            write!(f, hard_line_break());
+                            x = 4;
+                        }
+                    }
+                    write_comma_group(group_values, gctx, f);
+                }
+            }
+        });
+        write!(f, indent(&body));
+    } else {
+        let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            write!(f, soft_line_break());
+            let mut filler = f.fill();
+            for (i, group_values) in groups.iter().enumerate() {
+                let is_last = i + 1 == groups.len();
+                let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    if let Some(first) = group_values.first() {
+                        flush_value_comments(to_span(first.span()).start, f);
+                    }
+                    write_comma_group(group_values, ctx, f);
+                    if !is_last {
+                        write!(f, ",");
+                    }
+                });
+                filler.entry(&soft_line_break_or_space(), &content);
+            }
+            filler.finish();
+        });
+        write!(f, indent(&group(&body)));
+    }
+}
+
+/// `true` when only whitespace including a newline precedes the comment.
+pub fn comment_is_own_line(
+    comment: crate::comments::CssComment,
+    source: oxc_formatter_core::SourceText<'_>,
+) -> bool {
+    let bytes = source.as_bytes();
+    let mut i = comment.span.start as usize;
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b'\n' | b'\r' => return true,
+            b' ' | b'\t' => {}
+            _ => return false,
+        }
+    }
+    true
+}
+
+/// Emits pending comments that precede `upper_bound` inline
+/// (`//` comments force a break after themselves and expand the parent).
+/// Returns true when the last emitted comment was a `//` comment.
+pub fn flush_value_comments(upper_bound: u32, f: &mut CssFormatter<'_, '_>) -> bool {
+    let mut last_inline = false;
+    for &comment in f.context().comments().take_before(upper_bound) {
+        crate::comments::write_single_comment(comment, f);
+        if comment.inline {
+            write!(f, [oxc_formatter_core::builders::expand_parent(), hard_line_break()]);
+        } else {
+            write!(f, " ");
+        }
+        last_inline = comment.inline;
+    }
+    last_inline
+}
+
+/// Emits pending comments that sit on the same line as the just-printed
+/// content ending at `prev_end` (` // c` / ` /* c */`), up to `upper_bound`.
+pub fn flush_same_line_comments_before(
+    prev_end: u32,
+    upper_bound: u32,
+    f: &mut CssFormatter<'_, '_>,
+) {
+    loop {
+        let Some(comment) = f.context().comments().peek() else { return };
+        let source = f.context().source_text();
+        if comment.span.start < prev_end
+            || comment.span.end > upper_bound
+            || comment_is_own_line(comment, source)
+        {
+            return;
+        }
+        f.context().comments().take_before(comment.span.end);
+        write!(f, " ");
+        crate::comments::write_single_comment(comment, f);
+        if comment.inline {
+            write!(f, [oxc_formatter_core::builders::expand_parent()]);
+            return;
+        }
+    }
+}
+
+/// Unbounded variant (used at container tails where everything pending
+/// belongs to the container).
+pub fn flush_same_line_comments(prev_end: u32, f: &mut CssFormatter<'_, '_>) {
+    flush_same_line_comments_before(prev_end, u32::MAX, f);
+}
+
+/// Emits pending comments before `upper_bound` as ` /* c */` suffixes
+/// (used after the last value component, before `;` / `!important`).
+/// Returns the end offset of the last emitted comment.
+pub fn flush_trailing_value_comments(
+    upper_bound: u32,
+    f: &mut CssFormatter<'_, '_>,
+) -> Option<u32> {
+    let mut last_end = None;
+    for &comment in f.context().comments().take_before(upper_bound) {
+        write!(f, " ");
+        crate::comments::write_single_comment(comment, f);
+        if comment.inline {
+            write!(f, [oxc_formatter_core::builders::expand_parent(), hard_line_break()]);
+        }
+        last_end = Some(comment.span.end);
+    }
+    last_end
+}
+
+/// Mirrors Prettier's `printCommaSeparatedValueGroup`:
+/// joins components with `line`, except for pairs that must stay tight.
+pub fn write_comma_group<'a>(
+    values: &[ComponentValue<'a>],
+    ctx: ValueContext<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    if values.is_empty() {
+        return;
+    }
+    // Prettier's `flattenGroups`: a single-element comma group collapses to
+    // the element itself (no extra group/indent level).
+    if values.len() == 1 && ctx.tail_bound.is_none() {
+        let after_inline = flush_value_comments(to_span(values[0].span()).start, f);
+        let ctx =
+            if after_inline { ValueContext { after_inline_comment: true, ..ctx } } else { ctx };
+        write_component_value(&values[0], ctx, f);
+        return;
+    }
+    // A single value WITH a tail bound routes through the fill below so its
+    // trailing comments wrap.
+    let source = f.context().source_text();
+    let upper_bound = to_span(values[values.len() - 1].span()).end;
+    // Grid values that break across source lines start on their own line
+    // (Prettier's `didBreak` + `parts.unshift(hardline)`) — but breaks caused
+    // by inline comments in the gap don't count (the comment-hardline branch
+    // runs before the grid check in Prettier).
+    let grid_did_break = ctx.is_grid()
+        && (1..values.len()).any(|i| {
+            separator_between(values, i, ctx, source) == Separator::Hard && {
+                let prev_end = to_span(values[i - 1].span()).end;
+                let start = to_span(values[i].span()).start;
+                !f.context()
+                    .comments()
+                    .iter_before(upper_bound)
+                    .any(|c| c.span.start >= prev_end && c.span.end <= start)
+            }
+        });
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        if grid_did_break {
+            write!(f, hard_line_break());
+        }
+        // Snapshot of pending comments inside the value (for separator
+        // decisions; consumption happens inside the entries).
+        let pending: Vec<crate::comments::CssComment> =
+            f.context().comments().iter_before(upper_bound).collect();
+        let tail_bound = ctx.tail_bound;
+        let ctx = ValueContext { tail_bound: None, ..ctx };
+        let tail_comments: Vec<crate::comments::CssComment> = tail_bound
+            .map(|bound| {
+                f.context()
+                    .comments()
+                    .iter_before(bound)
+                    .filter(|c| c.span.start >= upper_bound)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let mut filler = f.fill();
+        let mut i = 0;
+        while i < values.len() {
+            // Separator between the previous component and this one
+            // (ignored by the fill builder for the first entry).
+            let mut sep =
+                if i == 0 { Separator::Line } else { separator_between(values, i, ctx, source) };
+            // An inline comment trailing the PREVIOUS run forces a break.
+            if i > 0 {
+                let prev_end = to_span(values[i - 1].span()).end;
+                let start = to_span(values[i].span()).start;
+                if pending.iter().any(|c| {
+                    c.inline
+                        && c.span.start >= prev_end
+                        && c.span.end <= start
+                        && !comment_is_own_line(*c, source)
+                }) {
+                    sep = Separator::Hard;
+                }
+            }
+            // Merge runs of tight / non-breaking-space components into one fill entry.
+            let mut run_end = i + 1;
+            while run_end < values.len()
+                && matches!(
+                    separator_between(values, run_end, ctx, source),
+                    Separator::Tight | Separator::Space
+                )
+            {
+                run_end += 1;
+            }
+            let run_start = i;
+            let run = &values[i..run_end];
+            let start = to_span(values[i].span()).start;
+            let run_end_pos = to_span(values[run_end - 1].span()).end;
+            let is_last_run = run_end == values.len();
+            let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                let after_inline = flush_value_comments(start, f);
+                for (j, v) in run.iter().enumerate() {
+                    if j > 0
+                        && separator_between(values, run_start + j, ctx, source) == Separator::Space
+                    {
+                        write!(f, " ");
+                    }
+                    let vctx = if j == 0 && after_inline {
+                        ValueContext { after_inline_comment: true, ..ctx }
+                    } else {
+                        ctx
+                    };
+                    write_component_value(v, vctx, f);
+                }
+                // Same-line `//` comments stay attached to this entry
+                // (a separate entry would break with the expanded group).
+                if !is_last_run {
+                    let next_start = to_span(values[run_end].span()).start;
+                    while let Some(comment) = f.context().comments().peek() {
+                        if !comment.inline
+                            || comment.span.start < run_end_pos
+                            || comment.span.end > next_start
+                            || comment_is_own_line(comment, f.context().source_text())
+                        {
+                            break;
+                        }
+                        f.context().comments().take_before(comment.span.end);
+                        write!(f, " ");
+                        crate::comments::write_single_comment(comment, f);
+                        write!(f, oxc_formatter_core::builders::expand_parent());
+                    }
+                }
+            });
+            match sep {
+                Separator::Hard => {
+                    filler.entry(&hard_line_break(), &content);
+                }
+                _ if ctx.no_break => {
+                    filler.entry(&text(" "), &content);
+                }
+                _ => {
+                    filler.entry(&soft_line_break_or_space(), &content);
+                }
+            }
+            // Trailing same-line comments become their own fill items
+            // (they wrap independently when the line is too long).
+            if !is_last_run {
+                let next_start = to_span(values[run_end].span()).start;
+                for &comment in pending.iter().filter(|c| {
+                    !c.inline
+                        && c.span.start >= run_end_pos
+                        && c.span.end <= next_start
+                        && !comment_is_own_line(**c, source)
+                }) {
+                    let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                        if f.context().comments().peek().is_some_and(|c| c.span == comment.span) {
+                            f.context().comments().take_before(comment.span.end);
+                            crate::comments::write_single_comment(comment, f);
+                            if comment.inline {
+                                write!(f, oxc_formatter_core::builders::expand_parent());
+                            }
+                        }
+                    });
+                    filler.entry(&soft_line_break_or_space(), &entry);
+                }
+            }
+            i = run_end;
+        }
+        // Declaration-tail comments wrap as fill items.
+        for (k, &comment) in tail_comments.iter().enumerate() {
+            let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                f.context().comments().take_before(comment.span.end);
+                crate::comments::write_single_comment(comment, f);
+                if comment.inline {
+                    write!(f, oxc_formatter_core::builders::expand_parent());
+                }
+            });
+            if k == 0 && ctx.tail_break {
+                filler.entry(&hard_line_break(), &entry);
+            } else {
+                filler.entry(&soft_line_break_or_space(), &entry);
+            }
+        }
+        filler.finish();
+    });
+    write!(f, group(&indent(&body)));
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Separator {
+    /// No separator (components merged into one run).
+    Tight,
+    /// Plain space, no break opportunity (word before a math operator).
+    Space,
+    /// Breakable space.
+    Line,
+    /// Forced line break (grid rows).
+    Hard,
+}
+
+/// Math-operator-ish raw token (`+`, `-`, `*`, `%`, `/`) parsed as a fallback token.
+fn math_op_token(value: &ComponentValue<'_>) -> bool {
+    if let ComponentValue::TokenWithSpan(token) = value {
+        matches!(
+            &token.token,
+            raffia::token::Token::Plus(_)
+                | raffia::token::Token::Minus(_)
+                | raffia::token::Token::Asterisk(_)
+                | raffia::token::Token::Percent(_)
+                | raffia::token::Token::Solidus(_)
+        )
+    } else {
+        false
+    }
+}
+
+fn raw_token<'b, 'a>(value: &'b ComponentValue<'a>) -> Option<&'b raffia::token::Token<'a>> {
+    if let ComponentValue::TokenWithSpan(token) = value { Some(&token.token) } else { None }
+}
+
+/// Decides the separator BEFORE `values[i]` (i >= 1).
+///
+/// In Prettier's loop terms: `iNode` = `values[i - 1]`, `iNextNode` =
+/// `values[i]`, `iPrevNode` = `values[i - 2]`, `iNextNextNode` = `values[i + 1]`.
+fn separator_between(
+    values: &[ComponentValue<'_>],
+    i: usize,
+    ctx: ValueContext<'_>,
+    source: oxc_formatter_core::SourceText<'_>,
+) -> Separator {
+    let prev = &values[i - 1];
+    let curr = &values[i];
+    let prev_span = to_span(prev.span());
+    let curr_span = to_span(curr.span());
+    // `hasEmptyRawBefore(iNextNode)`
+    let gap_empty = prev_span.end == curr_span.start;
+    // `hasEmptyRawBefore(iNode)`
+    let prev_gap_empty = i >= 2 && to_span(values[i - 2].span()).end == prev_span.start;
+
+    // Grid: preserve source line structure.
+    if ctx.is_grid() {
+        let gap = source.bytes_range(prev_span.end, curr_span.start);
+        if gap.contains(&b'\n') || gap.contains(&b'\r') {
+            return Separator::Hard;
+        }
+        return Separator::Line;
+    }
+
+    // Solidus (`/`) spacing rules.
+    if is_solidus(curr) || is_solidus(prev) {
+        // Path-like streams (`-fb-url(/a/b.png)`): glued tokens stay glued.
+        if is_solidus(&values[0]) && gap_empty {
+            return Separator::Tight;
+        }
+        // Fully glued `/` (`center/80%`, `12px/1.5`): one postcss word.
+        if is_solidus(curr)
+            && gap_empty
+            && values.get(i + 1).is_none_or(|n| to_span(curr.span()).end == to_span(n.span()).start)
+        {
+            return Separator::Tight;
+        }
+        if is_solidus(prev) && gap_empty && prev_gap_empty {
+            return Separator::Tight;
+        }
+        // `font: 12px/1.5` and custom properties: keep tight when the source
+        // is tight around a font-size-capable node.
+        if ctx.is_font_or_custom() {
+            if is_solidus(curr) && gap_empty && is_possible_font_size(prev) {
+                return Separator::Tight;
+            }
+            if is_solidus(prev) && prev_gap_empty && i >= 2 && is_possible_font_size(&values[i - 2])
+            {
+                return Separator::Tight;
+            }
+        }
+
+        // Leading `/` (e.g. `-fb-url(/abs/path)`).
+        if i == 1 && is_solidus(prev) {
+            return Separator::Tight;
+        }
+
+        let require_space_before = values.get(i + 1).is_some_and(is_word_like)
+            || values.get(i + 1).is_some_and(is_func_like)
+            || is_func_like(prev)
+            || is_word_like(prev);
+        let require_space_after = is_word_like(curr)
+            || is_func_like(curr)
+            || (i >= 2 && (is_word_like(&values[i - 2]) || is_func_like(&values[i - 2])));
+
+        let tight_rule = (is_solidus(curr) && !require_space_before)
+            || (is_solidus(prev) && !require_space_after);
+        // `hasEmptyRawBefore(iNextNode) || (isMathOperator && iPrevNode is math op)`
+        let position_rule =
+            gap_empty || (is_solidus(prev) && (i < 2 || is_solidus(&values[i - 2])));
+
+        if tight_rule && position_rule {
+            return Separator::Tight;
+        }
+        return Separator::Line;
+    }
+
+    // Less lookups: `@var [@result]` loses the gap (`var [@lookup]` rule).
+    if matches!(curr, ComponentValue::BracketBlock(_))
+        && matches!(
+            prev,
+            ComponentValue::LessVariable(_)
+                | ComponentValue::LessNamespaceValue(_)
+                | ComponentValue::BracketBlock(_)
+                | ComponentValue::LessMixinCall(_)
+        )
+    {
+        return Separator::Tight;
+    }
+
+    // Raw token punctuation: `:` hugs left and spaces right, braces hug
+    // their contents (custom-property JSON-ish values).
+    {
+        use raffia::token::Token;
+        if matches!(
+            raw_token(curr),
+            Some(
+                Token::Colon(_)
+                    | Token::RBrace(_)
+                    | Token::Comma(_)
+                    | Token::RParen(_)
+                    | Token::RBracket(_)
+                    | Token::Semicolon(_)
+            )
+        ) || matches!(
+            raw_token(prev),
+            Some(Token::LBrace(_) | Token::LParen(_) | Token::LBracket(_))
+        ) {
+            return Separator::Tight;
+        }
+        if matches!(raw_token(prev), Some(Token::Colon(_) | Token::Comma(_))) {
+            // No space after `:` inside `url(...)`.
+            if ctx.in_url && matches!(raw_token(prev), Some(Token::Colon(_))) {
+                return Separator::Tight;
+            }
+            return Separator::Space;
+        }
+        // `*` is never glued (Prettier excludes multiplication from the
+        // tight rules) — except Tailwind's `ident-*` pattern.
+        if matches!(raw_token(curr), Some(Token::Asterisk(_)))
+            || matches!(raw_token(prev), Some(Token::Asterisk(_)))
+        {
+            if gap_empty
+                && matches!(prev, ComponentValue::InterpolableIdent(raffia::ast::InterpolableIdent::Literal(id)) if id.raw.ends_with('-'))
+            {
+                return Separator::Tight;
+            }
+            return Separator::Line;
+        }
+        // Token-level division, mirroring the structural rules: tight only
+        // when glued in the source and no word/function neighbors.
+        let is_solidus_tok =
+            |v: &ComponentValue<'_>| matches!(raw_token(v), Some(Token::Solidus(_)));
+        // A leading `/` makes the stream path-like (`-fb-url(/a/b.png)`):
+        // glued tokens stay glued.
+        if is_solidus_tok(&values[0]) && gap_empty {
+            return Separator::Tight;
+        }
+        // Token-level font shorthand rule (`--font: var(--size)/2` in
+        // custom properties, where the value is a raw token stream).
+        if ctx.is_font_or_custom() {
+            let font_size_ish = |v: Option<&ComponentValue<'_>>| {
+                v.is_some_and(|v| {
+                    matches!(
+                        raw_token(v),
+                        Some(
+                            Token::Number(_)
+                                | Token::Dimension(_)
+                                | Token::Percentage(_)
+                                | Token::RParen(_)
+                        )
+                    )
+                })
+            };
+            if is_solidus_tok(curr) && gap_empty && font_size_ish(Some(prev)) {
+                return Separator::Tight;
+            }
+            if is_solidus_tok(prev)
+                && prev_gap_empty
+                && font_size_ish(values.get(i.wrapping_sub(2)))
+            {
+                return Separator::Tight;
+            }
+        }
+        let wordish = |v: Option<&ComponentValue<'_>>| {
+            v.is_some_and(|v| {
+                matches!(raw_token(v), Some(Token::Ident(_) | Token::RParen(_)))
+                    || is_word_like(v)
+                    || is_func_like(v)
+            })
+        };
+        if is_solidus_tok(curr) {
+            let require_space = wordish(values.get(i + 1)) || wordish(Some(prev));
+            return if gap_empty && !require_space { Separator::Tight } else { Separator::Line };
+        }
+        if is_solidus_tok(prev) {
+            let require_space = wordish(Some(curr)) || wordish(values.get(i.wrapping_sub(2)));
+            return if gap_empty && !require_space { Separator::Tight } else { Separator::Line };
+        }
+    }
+
+    // Raw token fallbacks (postcss-values would have produced operator/word
+    // tokens): keep gap-free neighbors tight (`10em+12em`, `-fb-url(/a/b)`).
+    if gap_empty
+        && (matches!(prev, ComponentValue::TokenWithSpan(_))
+            || matches!(curr, ComponentValue::TokenWithSpan(_))
+            || matches!(prev, ComponentValue::Delimiter(_))
+            || matches!(curr, ComponentValue::Delimiter(_)))
+    {
+        return Separator::Tight;
+    }
+
+    // Math operators with surrounding spaces: `a + b` keeps the space before
+    // the operator non-breaking and breaks after it (Prettier's
+    // `isNextMathOperator` merge).
+    if math_op_token(curr) {
+        return Separator::Space;
+    }
+
+    Separator::Line
+}
+
+/// Dispatch a single component value.
+pub fn write_component_value<'a>(
+    value: &ComponentValue<'a>,
+    ctx: ValueContext<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    match value {
+        ComponentValue::Delimiter(delimiter) => match delimiter.kind {
+            DelimiterKind::Comma => write!(f, ","),
+            DelimiterKind::Solidus => write!(f, "/"),
+            DelimiterKind::Semicolon => write!(f, ";"),
+        },
+        ComponentValue::Number(number) => write_number(number, f),
+        ComponentValue::Dimension(dimension) => write_dimension(dimension, f),
+        ComponentValue::Percentage(percentage) => {
+            write_number(&percentage.value, f);
+            write!(f, "%");
+        }
+        ComponentValue::Ratio(ratio) => {
+            write_number(&ratio.numerator, f);
+            write!(f, "/");
+            write_number(&ratio.denominator, f);
+        }
+        ComponentValue::HexColor(hex) => {
+            write!(f, "#");
+            match hex.raw.cow_to_ascii_lowercase() {
+                Cow::Borrowed(s) => write!(f, text(s)),
+                Cow::Owned(s) => write!(f, text(f.allocator().alloc_str(&s))),
+            }
+        }
+        ComponentValue::InterpolableIdent(raffia::ast::InterpolableIdent::Literal(ident)) => {
+            if is_wide_keyword(ident.raw) {
+                match ident.raw.cow_to_ascii_lowercase() {
+                    Cow::Borrowed(s) => write!(f, text(s)),
+                    Cow::Owned(s) => write!(f, text(f.allocator().alloc_str(&s))),
+                }
+            } else {
+                write!(f, text(ident.raw));
+            }
+        }
+        ComponentValue::InterpolableStr(raffia::ast::InterpolableStr::Literal(str)) => {
+            write_str(str, f);
+        }
+        ComponentValue::InterpolableStr(istr) => {
+            let span = to_span(istr.span());
+            write_requoted_verbatim(source.text_for(&span), f);
+        }
+        ComponentValue::Function(func) => write_function(func, ctx, f),
+        ComponentValue::Calc(calc) => write_calc(calc, ctx, f),
+        ComponentValue::SassMap(map) => crate::print::scss::write_sass_map(map, ctx, f),
+        ComponentValue::SassList(list) => crate::print::scss::write_sass_list(list, ctx, f),
+        ComponentValue::SassParenthesizedExpression(paren) => {
+            // `$var: ((a, b), (c, d))` / map item values: one item per line.
+            if ctx.paren_break {
+                // Map-item values always break (`isSCSSMapItemNode`),
+                // with a trailing comma per option.
+                let inner_ctx = ValueContext { paren_break: false, ..ctx };
+                let trailing = f.options().allow_trailing_comma();
+                let elements: &[ComponentValue<'a>] = match &*paren.expr {
+                    ComponentValue::SassList(list) if list.comma_spans.is_some() => &list.elements,
+                    expr => std::slice::from_ref(expr),
+                };
+                let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    write!(f, hard_line_break());
+                    for (i, el) in elements.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ",");
+                            write!(f, hard_line_break());
+                        }
+                        write_component_value(el, inner_ctx, f);
+                    }
+                    if trailing {
+                        write!(f, ",");
+                    }
+                });
+                write!(f, ["(", indent(&body), hard_line_break(), ")"]);
+                return;
+            }
+            let inner_ctx = ValueContext { paren_break: false, ..ctx };
+            let trailing = f.options().allow_trailing_comma();
+            let r_paren = to_span(paren.span()).end.saturating_sub(1);
+            let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                write!(f, soft_line_break());
+                // A comma list directly inside parens shares the paren's
+                // indent (no nested group level).
+                if let ComponentValue::SassList(list) = &*paren.expr
+                    && list.comma_spans.is_some()
+                {
+                    for (i, el) in list.elements.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ",");
+                            write!(f, soft_line_break_or_space());
+                        }
+                        write_component_value(el, inner_ctx, f);
+                    }
+                    if trailing && (ctx.map_key || ctx.paren_break) {
+                        write!(f, oxc_formatter_core::builders::if_group_breaks(&text(",")));
+                    }
+                } else {
+                    write_component_value(&paren.expr, inner_ctx, f);
+                }
+                // Inline comments before `)` stay inside, forcing the break.
+                for &comment in f.context().comments().take_before(r_paren) {
+                    write!(f, " ");
+                    crate::comments::write_single_comment(comment, f);
+                    if comment.inline {
+                        write!(f, oxc_formatter_core::builders::expand_parent());
+                    }
+                }
+            });
+            write!(
+                f,
+                group(&format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    write!(f, "(");
+                    write!(f, indent(&body));
+                    write!(f, soft_line_break());
+                    write!(f, ")");
+                }))
+            );
+        }
+        ComponentValue::SassUnaryExpression(unary) => {
+            let keyword_not = matches!(unary.op.kind, raffia::ast::SassUnaryOperatorKind::Not);
+            match unary.op.kind {
+                raffia::ast::SassUnaryOperatorKind::Plus => write!(f, "+"),
+                raffia::ast::SassUnaryOperatorKind::Minus => write!(f, "-"),
+                raffia::ast::SassUnaryOperatorKind::Not => write!(f, ["not", " "]),
+            }
+            // Keep the source gap (`- pow(2, 2)` stays spaced); `not` already
+            // wrote its single separator space.
+            if !keyword_not && to_span(unary.op.span()).end != to_span(unary.expr.span()).start {
+                write!(f, " ");
+            }
+            write_component_value(&unary.expr, ctx, f);
+        }
+        ComponentValue::SassBinaryExpression(binary) => write_sass_binary(binary, ctx, f),
+        ComponentValue::SassKeywordArgument(kw) => {
+            // Block values (maps/parens) hug the colon without pair indent.
+            if matches!(
+                &*kw.value,
+                ComponentValue::SassMap(_) | ComponentValue::SassParenthesizedExpression(_)
+            ) {
+                let name_span = to_span(kw.name.span());
+                write!(f, [text(source.text_for(&name_span)), ":", " "]);
+                write_component_value(&kw.value, ctx, f);
+                return;
+            }
+            // `$name: value` may break after the colon when too long.
+            let pair = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                let mut filler = f.fill();
+                let name_span = to_span(kw.name.span());
+                let key = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    write!(f, [text(f.context().source_text().text_for(&name_span)), ":"]);
+                });
+                let val = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                    write_component_value(&kw.value, ctx, f);
+                });
+                filler.entry(&soft_line_break_or_space(), &key);
+                filler.entry(&soft_line_break_or_space(), &val);
+                filler.finish();
+            });
+            write!(f, group(&indent(&pair)));
+        }
+        ComponentValue::SassNestingDeclaration(nesting) => {
+            crate::print::statement::write_block(&nesting.block, f);
+        }
+        ComponentValue::SassArbitraryArgument(arg) => {
+            write_component_value(&arg.value, ctx, f);
+            write!(f, "...");
+        }
+        ComponentValue::Url(url) => write_url(url, f),
+        // Less lookups / nth bracket blocks: `[...]` hugs its contents.
+        ComponentValue::BracketBlock(bracket) => {
+            write!(f, "[");
+            for (i, v) in bracket.value.iter().enumerate() {
+                if i > 0 {
+                    write!(f, " ");
+                }
+                write_component_value(v, ctx, f);
+            }
+            write!(f, "]");
+        }
+        ComponentValue::UnicodeRange(range) => {
+            let span = to_span(range.span());
+            write!(f, text(source.text_for(&span)));
+        }
+        // Everything else (Sass/Less constructs, interpolations, token
+        // fallbacks): print the source verbatim until ported structurally.
+        _ => {
+            if crate::print::less::write_less_component_value(value, f) {
+                return;
+            }
+            let span = to_span(value.span());
+            write!(f, text(source.text_for(&span)));
+        }
+    }
+}
+
+/// Flattens a left-leaning SCSS binary chain (`a == 0 and b == 0`) into
+/// `(operand, following-op)` pairs, mirroring postcss's flat token stream.
+fn flatten_sass_binary<'b, 'a>(
+    expr: &'b ComponentValue<'a>,
+    out: &mut Vec<(&'b ComponentValue<'a>, Option<&'b raffia::ast::SassBinaryOperator>)>,
+) {
+    if let ComponentValue::SassBinaryExpression(binary) = expr {
+        flatten_sass_binary(&binary.left, out);
+        // Attach this operator to the last operand collected.
+        if let Some(last) = out.last_mut() {
+            last.1 = Some(&binary.op);
+        }
+        flatten_sass_binary(&binary.right, out);
+    } else {
+        out.push((expr, None));
+    }
+}
+
+/// SCSS binary expression: a flat fill of `operand op` entries; spaces follow
+/// the source around each operator, breaking after operators.
+fn write_sass_binary<'a>(
+    binary: &raffia::ast::SassBinaryExpression<'a>,
+    ctx: ValueContext<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    let mut parts = Vec::new();
+    flatten_sass_binary(&binary.left, &mut parts);
+    if let Some(last) = parts.last_mut() {
+        last.1 = Some(&binary.op);
+    }
+    flatten_sass_binary(&binary.right, &mut parts);
+
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        let mut filler = f.fill();
+        let mut i = 0;
+        while i < parts.len() {
+            // Merge a run while operators are tight to the next operand.
+            let mut run_end = i;
+            while let Some(op) = parts[run_end].1 {
+                let op_span = to_span(op.span());
+                let next_start = to_span(parts[run_end + 1].0.span()).start;
+                if op_span.end == next_start {
+                    run_end += 1;
+                } else {
+                    break;
+                }
+            }
+            let run = &parts[i..=run_end];
+            let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                for (j, (operand, op)) in run.iter().enumerate() {
+                    write_component_value(operand, ctx, f);
+                    if let Some(op) = op {
+                        let op_span = to_span(op.span());
+                        let operand_end = to_span(operand.span()).end;
+                        let next_start = run.get(j + 1).map(|(next, _)| to_span(next.span()).start);
+                        // `op(paren)` fuses like a postcss function token,
+                        // which always gets a space before it; word-like
+                        // operands force spaces (`$a + $b` even when glued).
+                        let fuses_paren = next_start == Some(op_span.end);
+                        let op_text = source.text_for(&op_span);
+                        let wordish = matches!(op_text, "+" | "-")
+                            && (is_word_like(operand)
+                                || is_func_like(operand)
+                                || run.get(j + 1).is_some_and(|(next, _)| {
+                                    is_word_like(next) || is_func_like(next)
+                                }));
+                        if operand_end != op_span.start
+                            || wordish
+                            || (fuses_paren
+                                && run.get(j + 1).is_some_and(|(next, _)| {
+                                    matches!(next, ComponentValue::SassParenthesizedExpression(_))
+                                }))
+                        {
+                            write!(f, " ");
+                        }
+                        write!(f, text(source.text_for(&op_span)));
+                    }
+                }
+            });
+            filler.entry(&soft_line_break_or_space(), &content);
+            i = run_end + 1;
+        }
+        filler.finish();
+    });
+    write!(f, group(&indent(&body)));
+}
+
+/// Calc expression (`a + b` inside `calc(...)`): spaces around `+`/`-` follow
+/// the source (invalid syntax otherwise), with a break opportunity after the
+/// operator only.
+fn write_calc<'a>(
+    calc: &raffia::ast::Calc<'a>,
+    ctx: ValueContext<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    use raffia::ast::CalcOperatorKind;
+    let left_end = to_span(calc.left.span()).end;
+    let op_span = to_span(calc.op.span());
+    let right_start = to_span(calc.right.span()).start;
+    let gap_before_op = left_end != op_span.start;
+    let gap_after_op = op_span.end != right_start;
+
+    let op_str: &'static str = match calc.op.kind {
+        CalcOperatorKind::Plus => "+",
+        CalcOperatorKind::Minus => "-",
+        CalcOperatorKind::Multiply => "*",
+        CalcOperatorKind::Division => "/",
+    };
+
+    let head = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        write_component_value(&calc.left, ctx, f);
+        if gap_before_op {
+            write!(f, " ");
+        }
+        write!(f, token(op_str));
+        if !gap_after_op {
+            write_component_value(&calc.right, ctx, f);
+        }
+    });
+
+    if gap_after_op {
+        let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            let mut filler = f.fill();
+            let right = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                write_component_value(&calc.right, ctx, f);
+            });
+            filler.entry(&soft_line_break_or_space(), &head);
+            filler.entry(&soft_line_break_or_space(), &right);
+            filler.finish();
+        });
+        write!(f, group(&indent(&body)));
+    } else {
+        head.fmt(f);
+    }
+}
+
+/// Function call: `name(` + args + `)`.
+/// Mirrors `value-func` + `value-paren_group` with parens.
+fn write_function<'a>(func: &Function<'a>, ctx: ValueContext<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let name_span = to_span(func.name.span());
+    write!(f, text(source.text_for(&name_span)));
+
+    let groups = split_comma_groups(&func.args);
+
+    if func.args.is_empty() {
+        write!(f, ["(", ")"]);
+        return;
+    }
+
+    // `url(...)` as a function (e.g. `url(if(...))`): parens hug the content,
+    // no break opportunities of their own (Prettier's `isURLFunctionNode`).
+    if function_name_text(func).eq_ignore_ascii_case("url") {
+        write!(f, "(");
+        // Single plain argument: verbatim (matches the `Url` node path).
+        if groups.len() == 1
+            && groups[0].len() == 1
+            && matches!(
+                groups[0][0],
+                ComponentValue::InterpolableIdent(_) | ComponentValue::TokenWithSpan(_)
+            )
+        {
+            let span = to_span(groups[0][0].span());
+            write!(f, text(source.text_for(&span)));
+        } else {
+            let url_ctx = ValueContext { in_url: true, ..ctx };
+            for (i, group_values) in groups.iter().enumerate() {
+                if i > 0 {
+                    write!(f, [",", " "]);
+                }
+                write_comma_group(group_values, url_ctx, f);
+            }
+        }
+        write!(f, ")");
+        return;
+    }
+
+    let groups_ref = &groups;
+    let r_paren = to_span(func.span()).end.saturating_sub(1);
+    let extra_indent = ctx.after_inline_comment;
+    // Function arguments are "map item" positions (maps break).
+    let ctx = ValueContext {
+        map_break: true,
+        paren_break: false,
+        in_args: true,
+        after_inline_comment: false,
+        ..ctx
+    };
+    let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+        let source = f.context().source_text();
+        write!(f, soft_line_break());
+        for (i, group_values) in groups_ref.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",");
+                // Preserve a blank line between argument groups, but only
+                // after a multi-part group (Prettier checks comma_groups).
+                let prev_end = groups_ref[i - 1].last().map_or(0, |v| to_span(v.span()).end);
+                let next_start = group_values.first().map_or(prev_end, |v| to_span(v.span()).start);
+                let next_start = f
+                    .context()
+                    .comments()
+                    .peek()
+                    .map_or(next_start, |c| c.span.start.min(next_start));
+                if prev_end != 0
+                    && groups_ref[i - 1].len() > 1
+                    && crate::comments::classify_gap(source.bytes_range(prev_end, next_start))
+                        == crate::comments::Gap::Blank
+                {
+                    write!(f, oxc_formatter_core::builders::empty_line());
+                } else {
+                    write!(f, soft_line_break_or_space());
+                }
+            }
+            write_comma_group(group_values, ctx, f);
+        }
+        // Comments between the last argument and `)` wrap as fill items;
+        // `//` comments stay glued to the argument (their hardline follows).
+        let tail: Vec<crate::comments::CssComment> =
+            f.context().comments().take_before(r_paren).to_vec();
+        if tail.iter().any(|c| c.inline) {
+            for &comment in &tail {
+                write!(f, " ");
+                crate::comments::write_single_comment(comment, f);
+                if comment.inline {
+                    write!(f, [oxc_formatter_core::builders::expand_parent(), hard_line_break()]);
+                }
+            }
+        } else if !tail.is_empty() {
+            let inner = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                let mut filler = f.fill();
+                // Anchor entry: lets the first comment's separator attach it
+                // to the last argument (a fill ignores the first separator).
+                filler.entry(&soft_line_break_or_space(), &format_with(|_| {}));
+                for &comment in &tail {
+                    let entry = format_with(move |f: &mut CssFormatter<'_, 'a>| {
+                        crate::comments::write_single_comment(comment, f);
+                        if comment.inline {
+                            write!(
+                                f,
+                                [oxc_formatter_core::builders::expand_parent(), hard_line_break()]
+                            );
+                        }
+                    });
+                    filler.entry(&soft_line_break_or_space(), &entry);
+                }
+                filler.finish();
+            });
+            write!(f, [space(), indent(&inner)]);
+        }
+    });
+    write!(
+        f,
+        group(&format_with(move |f: &mut CssFormatter<'_, 'a>| {
+            write!(f, "(");
+            if extra_indent {
+                // Prettier's comment-in-paren-group quirk: arguments sit two
+                // levels deep and the `)` one level deep.
+                write!(f, indent(&indent(&body)));
+                write!(f, indent(&soft_line_break()));
+            } else {
+                write!(f, indent(&body));
+                write!(f, soft_line_break());
+            }
+            write!(f, ")");
+        }))
+    );
+}
+
+/// `url(...)`: contents are never reformatted.
+pub fn write_url<'a>(url: &Url<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let name_span = to_span(url.name.span());
+    let name = source.text_for(&name_span);
+    match name.cow_to_ascii_lowercase() {
+        Cow::Borrowed(s) => write!(f, text(s)),
+        Cow::Owned(s) => write!(f, text(f.allocator().alloc_str(&s))),
+    }
+    write!(f, "(");
+    match &url.value {
+        Some(raffia::ast::UrlValue::Str(raffia::ast::InterpolableStr::Literal(str))) => {
+            write_str(str, f);
+            for modifier in &url.modifiers {
+                write!(f, " ");
+                let span = to_span(modifier.span());
+                write!(f, text(source.text_for(&span)));
+            }
+        }
+        // Quoted url with interpolation: requote the outer quotes only.
+        Some(raffia::ast::UrlValue::Str(istr)) => {
+            let span = to_span(istr.span());
+            write_requoted_verbatim(source.text_for(&span), f);
+        }
+        // Unquoted url contents are printed verbatim, including inner spaces.
+        _ => {
+            let url_span = to_span(url.span());
+            let inner_start = to_span(url.name.span()).end + 1;
+            // raffia's url span may stop before trailing padding; scan to `)`.
+            let bytes = source.as_bytes();
+            let mut close = url_span.end.saturating_sub(1) as usize;
+            while close < bytes.len() && bytes[close] != b')' {
+                close += 1;
+            }
+            let inner_end = u32::try_from(close).unwrap_or(url_span.end.saturating_sub(1));
+            if inner_start < inner_end {
+                let inner = source.slice_range(inner_start, inner_end);
+                // Escaped parens keep their padding verbatim; otherwise trim.
+                if inner.contains("\\(") || inner.contains("\\)") {
+                    write!(f, text(inner));
+                } else {
+                    let trimmed = inner.trim();
+                    // `url($a+$b)`: SCSS concatenation gets spaced.
+                    if trimmed.contains('$') && trimmed.contains('+') && !trimmed.contains(' ') {
+                        let spaced = trimmed.cow_replace('+', " + ");
+                        write!(f, text(f.allocator().alloc_str(&spaced)));
+                    } else {
+                        write!(f, text(trimmed));
+                    }
+                }
+            }
+        }
+    }
+    write!(f, ")");
+}

--- a/oxc_release.toml
+++ b/oxc_release.toml
@@ -35,5 +35,6 @@ versioned_files = [
   "crates/oxc_formatter/Cargo.toml",
   "crates/oxc_formatter_json/Cargo.toml",
   "crates/oxc_formatter_graphql/Cargo.toml",
+  "crates/oxc_formatter_css/Cargo.toml",
   "npm/oxfmt/package.json",
 ]

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -28,6 +28,7 @@ oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 oxc_ast_visit = { workspace = true }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }
+oxc_formatter_css = { workspace = true }
 oxc_formatter_graphql = { workspace = true }
 oxc_formatter_json = { workspace = true }
 oxc_parser = { workspace = true }

--- a/tasks/prettier_conformance/snapshots/prettier.css.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.css.snap.md
@@ -1,0 +1,36 @@
+css compatibility: 114/114 (100.00%), 27 files skipped
+
+# Failed
+
+| Spec path | Failed or Passed | Match ratio |
+| :-------- | :--------------: | :---------: |
+
+# Skipped (parse error, TODO: should be ignored or supported)
+
+- css/atrule/charset.css
+- css/atrule/extend.css
+- css/atrule/if-else.css
+- css/atrule/import.css
+- css/atrule/supports.css
+- css/attribute/quotes.css
+- css/atword/atword.css
+- css/character-escaping/character_escaping.css
+- css/combinator/combinator.css
+- css/comments/selectors.css
+- css/fill-value/fill.css
+- css/front-matter/custom-parser.css
+- css/front-matter/embedded-language-formatting/yaml.css
+- css/inline-url/inline_url.css
+- css/loose/loose.css
+- css/modules/modules.css
+- css/no-semicolon/url.css
+- css/parens/empty-lines.css
+- css/parens/parens.css
+- css/postcss-plugins/postcss-mixins.css
+- css/postcss-plugins/postcss-nested-props.css
+- css/postcss-plugins/postcss-nesting.css
+- css/postcss-plugins/postcss-simple-vars.css
+- css/prefix/prefix.css
+- css/quotes/quotes.css
+- css/selector-list/selectors.css
+- css/selector-string/string.css

--- a/tasks/prettier_conformance/snapshots/prettier.less.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.less.snap.md
@@ -1,0 +1,18 @@
+less compatibility: 39/39 (100.00%), 9 files skipped
+
+# Failed
+
+| Spec path | Failed or Passed | Match ratio |
+| :-------- | :--------------: | :---------: |
+
+# Skipped (parse error, TODO: should be ignored or supported)
+
+- less/case/15460.less
+- less/case/case.less
+- less/comments/in-value.less
+- less/interpolation/interpolation.less
+- less/less/less.less
+- less/lookup/lookup-1.less
+- less/no-semicolon/url.less
+- less/parens/parens.less
+- less/postcss-8-improment/test.less

--- a/tasks/prettier_conformance/snapshots/prettier.scss.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.scss.snap.md
@@ -1,0 +1,18 @@
+scss compatibility: 85/85 (100.00%), 9 files skipped
+
+# Failed
+
+| Spec path | Failed or Passed | Match ratio |
+| :-------- | :--------------: | :---------: |
+
+# Skipped (parse error, TODO: should be ignored or supported)
+
+- scss/atrule/for.scss
+- scss/case/case.scss
+- scss/comments/CRLF.scss
+- scss/function/arbitrary-arguments.scss
+- scss/interpolation/3719.scss
+- scss/interpolation/3943.scss
+- scss/math/3945.scss
+- scss/no-semicolon/url.scss
+- scss/parens/parens.scss

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -17,6 +17,7 @@ use walkdir::WalkDir;
 
 use oxc_allocator::Allocator;
 use oxc_formatter::JsFormatOptions;
+use oxc_formatter_css::CssFormatOptions;
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::JsonFormatOptions;
 use oxc_span::SourceType;
@@ -247,7 +248,7 @@ impl TestRunner {
                     !options.experimental_operator_position.is_start()
                         && !options.experimental_ternaries
                 }
-                SpecOptions::Json(_) | SpecOptions::Graphql(_) => true,
+                SpecOptions::Json(_) | SpecOptions::Graphql(_) | SpecOptions::Css(_) => true,
             })
             .collect::<Vec<_>>();
 
@@ -448,6 +449,7 @@ impl TestRunner {
             SpecOptions::Js(opts) => Self::run_js_formatter(path, source_text, *opts),
             SpecOptions::Json(opts) => Self::run_json_formatter(source_text, opts),
             SpecOptions::Graphql(opts) => Self::run_graphql_formatter(source_text, opts),
+            SpecOptions::Css(opts) => Self::run_css_formatter(source_text, opts),
         }
     }
 
@@ -479,6 +481,13 @@ impl TestRunner {
         let allocator = Allocator::default();
         let formatted =
             oxc_formatter_graphql::format(&allocator, source_text, format_options).ok()?;
+        let printed = formatted.print().ok()?;
+        Some(printed.into_code())
+    }
+
+    fn run_css_formatter(source_text: &str, format_options: CssFormatOptions) -> Option<String> {
+        let allocator = Allocator::default();
+        let formatted = oxc_formatter_css::format(&allocator, source_text, format_options).ok()?;
         let printed = formatted.print().ok()?;
         Some(printed.into_code())
     }

--- a/tasks/prettier_conformance/src/main.rs
+++ b/tasks/prettier_conformance/src/main.rs
@@ -22,6 +22,9 @@ fn main() {
         TestLanguage::Json5,
         TestLanguage::JsonStringify,
         TestLanguage::Graphql,
+        TestLanguage::Css,
+        TestLanguage::Scss,
+        TestLanguage::Less,
     ] {
         TestRunner::new(TestRunnerOptions { language, debug, filter: filter.clone() }).run();
     }

--- a/tasks/prettier_conformance/src/options.rs
+++ b/tasks/prettier_conformance/src/options.rs
@@ -17,6 +17,9 @@ pub enum TestLanguage {
     Json5,
     JsonStringify,
     Graphql,
+    Css,
+    Scss,
+    Less,
 }
 
 impl TestLanguage {
@@ -29,6 +32,9 @@ impl TestLanguage {
             Self::Json5 => "json5",
             Self::JsonStringify => "json-stringify",
             Self::Graphql => "graphql",
+            Self::Css => "css",
+            Self::Scss => "scss",
+            Self::Less => "less",
         }
     }
 
@@ -60,6 +66,9 @@ impl TestLanguage {
             // `json-stringify` runs only on the shared `json/` dir
             Self::JsonStringify => vec![base.join("json").join("json")],
             Self::Graphql => vec![base.join("graphql")],
+            Self::Css => vec![base.join("css")],
+            Self::Scss => vec![base.join("scss")],
+            Self::Less => vec![base.join("less")],
         }
     }
 }

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -11,6 +11,7 @@ use oxc_formatter::{
     OperatorPosition, QuoteProperties, QuoteStyle, Semicolons, TrailingCommas,
 };
 use oxc_formatter_core::{IndentStyle, IndentWidth, LineEnding, LineWidth};
+use oxc_formatter_css::{CssFormatOptions, CssVariant};
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant, QuoteProps};
 use oxc_parser::Parser;
@@ -31,6 +32,7 @@ pub enum SpecOptions {
     Js(Box<JsFormatOptions>),
     Json(JsonFormatOptions),
     Graphql(GraphqlFormatOptions),
+    Css(CssFormatOptions),
 }
 
 impl SpecOptions {
@@ -39,6 +41,7 @@ impl SpecOptions {
             Self::Js(o) => o.line_width,
             Self::Json(o) => o.line_width,
             Self::Graphql(o) => o.line_width,
+            Self::Css(o) => o.line_width,
         }
     }
 }
@@ -148,6 +151,9 @@ impl VisitMut<'_> for SpecParser {
                 | TestLanguage::Json5
                 | TestLanguage::JsonStringify
                 | TestLanguage::Graphql
+                | TestLanguage::Css
+                | TestLanguage::Scss
+                | TestLanguage::Less
         );
         if is_exact_parser_language && !parsers.iter().any(|p| p == self.language.as_str()) {
             return;
@@ -170,6 +176,15 @@ impl VisitMut<'_> for SpecParser {
         };
         let mut graphql_options = GraphqlFormatOptions {
             line_width: LineWidth::try_from(80).unwrap(),
+            ..Default::default()
+        };
+        let mut css_options = CssFormatOptions {
+            line_width: LineWidth::try_from(80).unwrap(),
+            variant: match self.language {
+                TestLanguage::Scss => CssVariant::Scss,
+                TestLanguage::Less => CssVariant::Less,
+                _ => CssVariant::Css,
+            },
             ..Default::default()
         };
 
@@ -203,6 +218,7 @@ impl VisitMut<'_> for SpecParser {
                                     QuoteStyle::Double
                                 };
                                 json_options.single_quote = literal.value.into();
+                                css_options.single_quote = literal.value.into();
                             } else if name == "jsxSingleQuote" {
                                 js_options.jsx_quote_style = if literal.value {
                                     QuoteStyle::Single
@@ -218,6 +234,7 @@ impl VisitMut<'_> for SpecParser {
                                 js_options.indent_style = style;
                                 json_options.indent_style = style;
                                 graphql_options.indent_style = style;
+                                css_options.indent_style = style;
                             } else if name == "experimentalTernaries" {
                                 js_options.experimental_ternaries = literal.value;
                             } else if name == "singleAttributePerLine" {
@@ -235,12 +252,14 @@ impl VisitMut<'_> for SpecParser {
                                 js_options.line_width = width;
                                 json_options.line_width = width;
                                 graphql_options.line_width = width;
+                                css_options.line_width = width;
                             }
                             "tabWidth" => {
                                 let w = IndentWidth::try_from(literal.value as u8).unwrap();
                                 js_options.indent_width = w;
                                 json_options.indent_width = w;
                                 graphql_options.indent_width = w;
+                                css_options.indent_width = w;
                             }
                             _ => {}
                         },
@@ -255,6 +274,11 @@ impl VisitMut<'_> for SpecParser {
                                         "none" => oxc_formatter_json::TrailingCommas::Never,
                                         _ => unreachable!("Prettier's trailingComma should be 'all' | 'es5' | 'none'"),
                                     };
+                                    css_options.trailing_commas = match s {
+                                        "all" | "es5" => oxc_formatter_css::TrailingCommas::Always,
+                                        "none" => oxc_formatter_css::TrailingCommas::Never,
+                                        _ => unreachable!("Prettier's trailingComma should be 'all' | 'es5' | 'none'"),
+                                    };
                                 }
                                 "endOfLine" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`
@@ -262,6 +286,7 @@ impl VisitMut<'_> for SpecParser {
                                     js_options.line_ending = ending;
                                     json_options.line_ending = ending;
                                     graphql_options.line_ending = ending;
+                                    css_options.line_ending = ending;
                                 }
                                 "quoteProps" => {
                                     // TODO: change `unwrap_or_default` to `unwrap`
@@ -334,6 +359,9 @@ impl VisitMut<'_> for SpecParser {
             | TestLanguage::Json5
             | TestLanguage::JsonStringify => SpecOptions::Json(json_options),
             TestLanguage::Graphql => SpecOptions::Graphql(graphql_options),
+            TestLanguage::Css | TestLanguage::Scss | TestLanguage::Less => {
+                SpecOptions::Css(css_options)
+            }
             TestLanguage::Js | TestLanguage::Ts => SpecOptions::Js(Box::new(js_options)),
         };
         self.calls.push((options, snapshot_options));


### PR DESCRIPTION
- Implement `oxc_formatter_css` crate
- Use `raffia` crate
  - https://github.com/g-plane/raffia
  - Supports CSS, LESS and SCSS
- Prettier uses `postcss` for parser
  - https://github.com/prettier/prettier/blob/1c6ba5539141552e0e8e22d401ea620d8fdff468/package.json#L100-L105

Since design of `postcss`, this parser is very lenient with syntax.
Because of this, the AST is also less detailed, so formatting processes often rely on text-based.

On the other hand, `raffia` is relatively strict, so it cannot parse some postcss plugin syntax.

While this part clearly creates a difference from Prettier, we have judged that it is not an issue since it still supports major plugins syntax and aligns with current trends.