### PR TITLE
feat(oxfmt)!: format `parser:css,less,scss` files + css-in-js by `oxc_formatter_css`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,7 @@ name = "oxc_formatter_css"
 version = "0.54.0"
 dependencies = [
  "cow-utils",
+ "insta",
  "oxc_allocator",
  "oxc_diagnostics",
  "oxc_formatter_core",
@@ -2862,6 +2863,7 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_formatter",
  "oxc_formatter_core",
+ "oxc_formatter_css",
  "oxc_formatter_graphql",
  "oxc_formatter_json",
  "oxc_language_server",
@@ -3152,8 +3154,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 [[package]]
 name = "raffia"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a589c5611a5f7713bf0c13e949c4c791a359ff517a9f27552475b470e8873229"
+source = "git+https://github.com/leaysgur/raffia?rev=96b45733b3b10bf5907c3ee4caed960959429001#96b45733b3b10bf5907c3ee4caed960959429001"
 dependencies = [
  "raffia_macro",
  "smallvec",
@@ -3162,8 +3163,7 @@ dependencies = [
 [[package]]
 name = "raffia_macro"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac21f5e4bc6b29ea5d5e691a9aa08b2b9fd8891f48a99157b9f02d8a48e1318"
+source = "git+https://github.com/leaysgur/raffia?rev=96b45733b3b10bf5907c3ee4caed960959429001#96b45733b3b10bf5907c3ee4caed960959429001"
 dependencies = [
  "heck",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,7 @@ pico-args = "0.5.0" # Minimal argument parser
 prettyplease = "0.2.37" # Rust code formatting
 project-root = "0.2.2" # Project root detection
 quickcheck = "1.1.0" # Property-based testing
-raffia = "0.12.3" # CSS/SCSS/Less parser
+raffia = { git = "https://github.com/leaysgur/raffia", rev = "96b45733b3b10bf5907c3ee4caed960959429001" } # CSS/SCSS/Less parser (fork of 0.12.3: adds `tolerate_at_keyword_placeholders` for css-in-js placeholders)
 rand = "0.10.0" # Random number generation
 rayon = "1.11.0" # Data parallelism
 ropey = "1.6.1" # Rope text structure
@@ -315,3 +315,4 @@ overflow-checks = true # Catch arithmetic overflow errors
 [profile.dev-no-debug-assertions]
 inherits = "dev"
 debug-assertions = false
+

--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -35,19 +35,20 @@ When working with file paths in CLI code, be aware of Windows path differences:
 
 Oxfmt utilizes different implementations depending on the file extension and filename:
 
-- Tier 1: Rust implementations using `oxc_formatter`, `oxc_formatter_json` or `oxc_formatter_graphql` found in this repository
+- Tier 1: Rust implementations using `oxc_formatter`, `oxc_formatter_json`, `oxc_formatter_graphql` or `oxc_formatter_css` found in this repository
 - Tier 2: Rust implementations using external libraries like `oxc_toml`
 - Tier 3: Delegations to Prettier via NAPI-JS calls (e.g., for Vue or Markdown)
 - Tier 4: Delegations to Prettier that require additional plugins (e.g., for Svelte)
 
 NOTE: Some Tier 1 formatters can fallback to Prettier with NAPI CLI.
+
 e.g. `oxc_formatter_graphql` (uses `apollo-parser`) only covers the stable GraphQL spec.
 When it returns an error (e.g. draft-spec syntax that Prettier's `graphql-js` accepts), the format step retries via Prettier.
 
-The same applies to embedded languages (xxx-in-js): `src/core/external_formatter.rs`
-assembles a `FormatDispatcher` (defined in `oxc_formatter_core`) that maps each
-language to a Rust formatter where implemented (currently GraphQL, with the same
-parse-error fallback) and to the Prettier Doc→IR path otherwise.
+`oxc_formatter_css` (uses `raffia`) is different: standalone css/scss/less files have NO parse-error fallback.
+`raffia` covers the stable grammar, and what it rejects is genuinely broken CSS or the tail of postcss's error tolerance (e.g. IE star hacks), reported as diagnostics.
+
+Embedded languages (e.g. css-in-js) go through `src/core/external_formatter.rs`, which assembles a `FormatDispatcher` (defined in `oxc_formatter_core`) that maps each language to a Rust formatter where implemented (currently GraphQL and CSS/SCSS/Less) and to the Prettier Doc→IR path otherwise.
 
 Consequently, managing these various formatter implementations and handling their respective options are also part of Oxfmt's responsibilities.
 

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -33,6 +33,7 @@ oxc_config = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }
+oxc_formatter_css = { workspace = true }
 oxc_formatter_graphql = { workspace = true }
 oxc_formatter_json = { workspace = true }
 oxc_language_server = { workspace = true }

--- a/apps/oxfmt/conformance/run.ts
+++ b/apps/oxfmt/conformance/run.ts
@@ -99,6 +99,10 @@ const categories: Category[] = [
     notes: {
       "externals/prettier/js/multiparser-html/issue-10691.js":
         "js-in-html(`<script>`)-in-js needs lot more work; Please see oxc_formatter/src/print/template/embed/html.rs",
+      "externals/webawesome/number-input/number-input.styles.ts":
+        "Layout-only: Prettier's fill fit-check breaks inside `var()` args in a long `calc()`; ours breaks after the operator. See crates/oxc_formatter_css/AGENTS.md",
+      "externals/webawesome/page/page.styles.ts":
+        "Layout-only: Prettier's fill fit-check breaks inside `::slotted()` after a long `:not(...)`; ours breaks inside `:not(...)`. See crates/oxc_formatter_css/AGENTS.md",
     },
   },
   {

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -60,7 +60,7 @@
 
 ## html-in-js
 
-### Option 1: 190/191 (99.48%)
+### Option 1: 188/191 (98.43%)
 
 ```json
 {"printWidth":80}
@@ -69,8 +69,10 @@
 | File | Note |
 | :--- | :--- |
 | [externals/prettier/js/multiparser-html/issue-10691.js](diffs/html-in-js/externals__prettier__js__multiparser-html__issue-10691.js.md) | js-in-html(`<script>`)-in-js needs lot more work; Please see oxc_formatter/src/print/template/embed/html.rs |
+| [externals/webawesome/number-input/number-input.styles.ts](diffs/html-in-js/externals__webawesome__number-input__number-input.styles.ts.md) | Layout-only: Prettier's fill fit-check breaks inside `var()` args in a long `calc()`; ours breaks after the operator. See crates/oxc_formatter_css/AGENTS.md |
+| [externals/webawesome/page/page.styles.ts](diffs/html-in-js/externals__webawesome__page__page.styles.ts.md) | Layout-only: Prettier's fill fit-check breaks inside `::slotted()` after a long `:not(...)`; ours breaks inside `:not(...)`. See crates/oxc_formatter_css/AGENTS.md |
 
-### Option 2: 190/191 (99.48%)
+### Option 2: 189/191 (98.95%)
 
 ```json
 {"printWidth":100,"htmlWhitespaceSensitivity":"ignore"}
@@ -79,6 +81,7 @@
 | File | Note |
 | :--- | :--- |
 | [externals/prettier/js/multiparser-html/issue-10691.js](diffs/html-in-js/externals__prettier__js__multiparser-html__issue-10691.js.md) | js-in-html(`<script>`)-in-js needs lot more work; Please see oxc_formatter/src/print/template/embed/html.rs |
+| [externals/webawesome/page/page.styles.ts](diffs/html-in-js/externals__webawesome__page__page.styles.ts.md) | Layout-only: Prettier's fill fit-check breaks inside `::slotted()` after a long `:not(...)`; ours breaks inside `:not(...)`. See crates/oxc_formatter_css/AGENTS.md |
 
 ## angular-in-js
 

--- a/apps/oxfmt/conformance/snapshots/diffs/html-in-js/externals__webawesome__number-input__number-input.styles.ts.md
+++ b/apps/oxfmt/conformance/snapshots/diffs/html-in-js/externals__webawesome__number-input__number-input.styles.ts.md
@@ -1,0 +1,603 @@
+# externals/webawesome/number-input/number-input.styles.ts
+
+> Layout-only: Prettier's fill fit-check breaks inside `var()` args in a long `calc()`; ours breaks after the operator. See crates/oxc_formatter_css/AGENTS.md
+
+## Option 1
+
+`````json
+{"printWidth":80}
+`````
+
+### Diff
+
+`````diff
+===================================================================
+--- prettier
++++ oxfmt
+@@ -249,12 +249,10 @@
+     height: calc(100% - var(--wa-form-control-border-width) * 2);
+     flex: 0 0 auto;
+     border: none;
+     border-radius: calc(
+-      var(--wa-form-control-border-radius) - var(
+-          --wa-form-control-border-width
+-        ) *
+-        2
++      var(--wa-form-control-border-radius) -
++        var(--wa-form-control-border-width) * 2
+     );
+     background: transparent;
+     cursor: pointer;
+     margin: var(--wa-form-control-border-width);
+
+`````
+
+### Actual (oxfmt)
+
+`````ts
+import { css } from "lit";
+
+export default css`
+  :host(:focus) {
+    outline: none;
+  }
+
+  .number-field {
+    display: flex;
+    align-items: stretch;
+    justify-content: start;
+    position: relative;
+    height: var(--wa-form-control-height);
+    border-color: var(--wa-form-control-border-color);
+    border-radius: var(--wa-form-control-border-radius);
+    border-style: var(--wa-form-control-border-style);
+    border-width: var(--wa-form-control-border-width);
+    cursor: text;
+    color: var(--wa-form-control-value-color);
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: var(--wa-form-control-value-font-weight);
+    line-height: var(--wa-form-control-value-line-height);
+    vertical-align: middle;
+    width: 100%;
+    transition:
+      background-color var(--wa-transition-normal),
+      border-color var(--wa-transition-normal),
+      outline-color var(--wa-transition-fast);
+    transition-timing-function: var(--wa-transition-easing);
+    background-color: var(--wa-form-control-background-color);
+    padding: 0;
+    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) transparent;
+    outline-offset: var(--wa-focus-ring-offset);
+
+    &:focus-within {
+      outline-color: var(--wa-color-focus);
+    }
+
+    /* Style disabled inputs */
+    &:has(input:disabled) {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  }
+
+  /* Appearance modifiers */
+  :host([appearance="outlined"]) {
+    .number-field {
+      background-color: var(--wa-form-control-background-color);
+      border-color: var(--wa-form-control-border-color);
+    }
+
+    .stepper {
+      color: var(--wa-color-neutral-on-quiet);
+
+      @media (hover: hover) {
+        &:hover:not(:disabled) {
+          color: var(--wa-color-neutral-on-quiet);
+          background-color: var(--wa-color-neutral-fill-quiet);
+        }
+      }
+
+      &:active:not(:disabled) {
+        color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-on-quiet),
+          var(--wa-color-mix-active)
+        );
+        background-color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-fill-quiet),
+          var(--wa-color-mix-active)
+        );
+      }
+    }
+  }
+
+  :host([appearance="filled"]) {
+    .number-field {
+      background-color: var(--wa-color-neutral-fill-quiet);
+      border-color: var(--wa-color-neutral-fill-quiet);
+    }
+
+    .stepper {
+      color: var(--wa-color-neutral-on-quiet);
+
+      @media (hover: hover) {
+        &:hover:not(:disabled) {
+          color: var(--wa-color-neutral-on-normal);
+          background-color: var(--wa-color-neutral-fill-normal);
+        }
+      }
+
+      &:active:not(:disabled) {
+        color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-on-normal),
+          var(--wa-color-mix-active)
+        );
+        background-color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-fill-normal),
+          var(--wa-color-mix-active)
+        );
+      }
+    }
+  }
+
+  :host([appearance="filled-outlined"]) {
+    .number-field {
+      background-color: var(--wa-color-neutral-fill-quiet);
+      border-color: var(--wa-form-control-border-color);
+    }
+
+    .stepper {
+      color: var(--wa-color-neutral-on-quiet);
+
+      @media (hover: hover) {
+        &:hover:not(:disabled) {
+          color: var(--wa-color-neutral-on-normal);
+          background-color: var(--wa-color-neutral-fill-normal);
+        }
+      }
+
+      &:active:not(:disabled) {
+        color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-on-normal),
+          var(--wa-color-mix-active)
+        );
+        background-color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-fill-normal),
+          var(--wa-color-mix-active)
+        );
+      }
+    }
+  }
+
+  :host([pill]) {
+    .number-field,
+    .stepper {
+      border-radius: var(--wa-border-radius-pill);
+    }
+  }
+
+  .number-field {
+    /* Show autofill styles over the entire number field, not just the native <input> */
+    &:has(:autofill),
+    &:has(:-webkit-autofill) {
+      background-color: var(--wa-color-brand-fill-quiet) !important;
+    }
+
+    input {
+      flex: auto;
+      height: 100%;
+      width: auto;
+      min-width: 0;
+      margin: 0;
+      padding: 0 var(--wa-form-control-padding-inline);
+      outline: none;
+      box-shadow: none;
+      border: none;
+      background-color: transparent;
+      font: inherit;
+      transition: inherit;
+      cursor: inherit;
+      -webkit-appearance: none;
+
+      /* Center-align and use tabular numbers for better alignment */
+      text-align: center;
+      font-variant-numeric: tabular-nums;
+
+      /* Hide the number spinners in Firefox */
+      -moz-appearance: textfield;
+
+      /* Hide the number spinners in Chrome/Safari */
+      &::-webkit-outer-spin-button,
+      &::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+        display: none;
+      }
+
+      /* Turn off Safari's autofill styles */
+      &:-webkit-autofill,
+      &:-webkit-autofill:hover,
+      &:-webkit-autofill:focus,
+      &:-webkit-autofill:active {
+        -webkit-background-clip: text;
+        background-color: transparent;
+        -webkit-text-fill-color: inherit;
+      }
+    }
+
+    &:autofill {
+      &,
+      &:hover,
+      &:focus,
+      &:active {
+        box-shadow: none;
+        caret-color: var(--wa-form-control-value-color);
+      }
+    }
+
+    &::placeholder {
+      color: var(--wa-form-control-placeholder-color);
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  .start,
+  .end {
+    display: inline-flex;
+    flex: 1;
+    align-items: center;
+    cursor: default;
+
+    &::slotted(wa-icon) {
+      color: var(--wa-color-neutral-on-quiet);
+    }
+  }
+
+  .start {
+    justify-content: start;
+    margin-inline-start: var(--wa-form-control-padding-inline);
+  }
+
+  .end {
+    justify-content: end;
+    margin-inline-end: var(--wa-form-control-padding-inline);
+  }
+
+  /*
+   * Steppers - horizontal layout with minus on start, plus on end
+   */
+
+  .stepper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    aspect-ratio: 1 / 1;
+    height: calc(100% - var(--wa-form-control-border-width) * 2);
+    flex: 0 0 auto;
+    border: none;
+    border-radius: calc(
+      var(--wa-form-control-border-radius) -
+        var(--wa-form-control-border-width) * 2
+    );
+    background: transparent;
+    cursor: pointer;
+    margin: var(--wa-form-control-border-width);
+    padding: 0;
+    font-size: inherit;
+    transition-property: background-color, color;
+    transition-duration: var(--wa-transition-fast);
+    transition-timing-function: var(--wa-transition-easing);
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  :host([without-steppers]) .stepper {
+    display: none;
+  }
+`;
+
+`````
+
+### Expected (prettier)
+
+`````ts
+import { css } from "lit";
+
+export default css`
+  :host(:focus) {
+    outline: none;
+  }
+
+  .number-field {
+    display: flex;
+    align-items: stretch;
+    justify-content: start;
+    position: relative;
+    height: var(--wa-form-control-height);
+    border-color: var(--wa-form-control-border-color);
+    border-radius: var(--wa-form-control-border-radius);
+    border-style: var(--wa-form-control-border-style);
+    border-width: var(--wa-form-control-border-width);
+    cursor: text;
+    color: var(--wa-form-control-value-color);
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: var(--wa-form-control-value-font-weight);
+    line-height: var(--wa-form-control-value-line-height);
+    vertical-align: middle;
+    width: 100%;
+    transition:
+      background-color var(--wa-transition-normal),
+      border-color var(--wa-transition-normal),
+      outline-color var(--wa-transition-fast);
+    transition-timing-function: var(--wa-transition-easing);
+    background-color: var(--wa-form-control-background-color);
+    padding: 0;
+    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) transparent;
+    outline-offset: var(--wa-focus-ring-offset);
+
+    &:focus-within {
+      outline-color: var(--wa-color-focus);
+    }
+
+    /* Style disabled inputs */
+    &:has(input:disabled) {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+  }
+
+  /* Appearance modifiers */
+  :host([appearance="outlined"]) {
+    .number-field {
+      background-color: var(--wa-form-control-background-color);
+      border-color: var(--wa-form-control-border-color);
+    }
+
+    .stepper {
+      color: var(--wa-color-neutral-on-quiet);
+
+      @media (hover: hover) {
+        &:hover:not(:disabled) {
+          color: var(--wa-color-neutral-on-quiet);
+          background-color: var(--wa-color-neutral-fill-quiet);
+        }
+      }
+
+      &:active:not(:disabled) {
+        color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-on-quiet),
+          var(--wa-color-mix-active)
+        );
+        background-color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-fill-quiet),
+          var(--wa-color-mix-active)
+        );
+      }
+    }
+  }
+
+  :host([appearance="filled"]) {
+    .number-field {
+      background-color: var(--wa-color-neutral-fill-quiet);
+      border-color: var(--wa-color-neutral-fill-quiet);
+    }
+
+    .stepper {
+      color: var(--wa-color-neutral-on-quiet);
+
+      @media (hover: hover) {
+        &:hover:not(:disabled) {
+          color: var(--wa-color-neutral-on-normal);
+          background-color: var(--wa-color-neutral-fill-normal);
+        }
+      }
+
+      &:active:not(:disabled) {
+        color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-on-normal),
+          var(--wa-color-mix-active)
+        );
+        background-color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-fill-normal),
+          var(--wa-color-mix-active)
+        );
+      }
+    }
+  }
+
+  :host([appearance="filled-outlined"]) {
+    .number-field {
+      background-color: var(--wa-color-neutral-fill-quiet);
+      border-color: var(--wa-form-control-border-color);
+    }
+
+    .stepper {
+      color: var(--wa-color-neutral-on-quiet);
+
+      @media (hover: hover) {
+        &:hover:not(:disabled) {
+          color: var(--wa-color-neutral-on-normal);
+          background-color: var(--wa-color-neutral-fill-normal);
+        }
+      }
+
+      &:active:not(:disabled) {
+        color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-on-normal),
+          var(--wa-color-mix-active)
+        );
+        background-color: color-mix(
+          in oklab,
+          var(--wa-color-neutral-fill-normal),
+          var(--wa-color-mix-active)
+        );
+      }
+    }
+  }
+
+  :host([pill]) {
+    .number-field,
+    .stepper {
+      border-radius: var(--wa-border-radius-pill);
+    }
+  }
+
+  .number-field {
+    /* Show autofill styles over the entire number field, not just the native <input> */
+    &:has(:autofill),
+    &:has(:-webkit-autofill) {
+      background-color: var(--wa-color-brand-fill-quiet) !important;
+    }
+
+    input {
+      flex: auto;
+      height: 100%;
+      width: auto;
+      min-width: 0;
+      margin: 0;
+      padding: 0 var(--wa-form-control-padding-inline);
+      outline: none;
+      box-shadow: none;
+      border: none;
+      background-color: transparent;
+      font: inherit;
+      transition: inherit;
+      cursor: inherit;
+      -webkit-appearance: none;
+
+      /* Center-align and use tabular numbers for better alignment */
+      text-align: center;
+      font-variant-numeric: tabular-nums;
+
+      /* Hide the number spinners in Firefox */
+      -moz-appearance: textfield;
+
+      /* Hide the number spinners in Chrome/Safari */
+      &::-webkit-outer-spin-button,
+      &::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+        display: none;
+      }
+
+      /* Turn off Safari's autofill styles */
+      &:-webkit-autofill,
+      &:-webkit-autofill:hover,
+      &:-webkit-autofill:focus,
+      &:-webkit-autofill:active {
+        -webkit-background-clip: text;
+        background-color: transparent;
+        -webkit-text-fill-color: inherit;
+      }
+    }
+
+    &:autofill {
+      &,
+      &:hover,
+      &:focus,
+      &:active {
+        box-shadow: none;
+        caret-color: var(--wa-form-control-value-color);
+      }
+    }
+
+    &::placeholder {
+      color: var(--wa-form-control-placeholder-color);
+      user-select: none;
+      -webkit-user-select: none;
+    }
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  .start,
+  .end {
+    display: inline-flex;
+    flex: 1;
+    align-items: center;
+    cursor: default;
+
+    &::slotted(wa-icon) {
+      color: var(--wa-color-neutral-on-quiet);
+    }
+  }
+
+  .start {
+    justify-content: start;
+    margin-inline-start: var(--wa-form-control-padding-inline);
+  }
+
+  .end {
+    justify-content: end;
+    margin-inline-end: var(--wa-form-control-padding-inline);
+  }
+
+  /*
+   * Steppers - horizontal layout with minus on start, plus on end
+   */
+
+  .stepper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    aspect-ratio: 1 / 1;
+    height: calc(100% - var(--wa-form-control-border-width) * 2);
+    flex: 0 0 auto;
+    border: none;
+    border-radius: calc(
+      var(--wa-form-control-border-radius) - var(
+          --wa-form-control-border-width
+        ) *
+        2
+    );
+    background: transparent;
+    cursor: pointer;
+    margin: var(--wa-form-control-border-width);
+    padding: 0;
+    font-size: inherit;
+    transition-property: background-color, color;
+    transition-duration: var(--wa-transition-fast);
+    transition-timing-function: var(--wa-transition-easing);
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  :host([without-steppers]) .stepper {
+    display: none;
+  }
+`;
+
+`````

--- a/apps/oxfmt/conformance/snapshots/diffs/html-in-js/externals__webawesome__page__page.styles.ts.md
+++ b/apps/oxfmt/conformance/snapshots/diffs/html-in-js/externals__webawesome__page__page.styles.ts.md
@@ -1,0 +1,1217 @@
+# externals/webawesome/page/page.styles.ts
+
+> Layout-only: Prettier's fill fit-check breaks inside `::slotted()` after a long `:not(...)`; ours breaks inside `:not(...)`. See crates/oxc_formatter_css/AGENTS.md
+
+## Option 1
+
+`````json
+{"printWidth":80}
+`````
+
+### Diff
+
+`````diff
+===================================================================
+--- prettier
++++ oxfmt
+@@ -20,11 +20,12 @@
+     --header-top: var(--header-height);
+     --subheader-top: var(--subheader-height);
+   }
+ 
+-  slot[name]:not([name="skip-to-content"], [name="navigation-toggle"])::slotted(
+-      *
+-    ) {
++  slot[name]:not(
++    [name="skip-to-content"],
++    [name="navigation-toggle"]
++  )::slotted(*) {
+     display: flex;
+     background-color: var(--wa-color-surface-default);
+   }
+ 
+@@ -122,12 +123,10 @@
+ 
+   [part~="base"] {
+     min-height: 100dvh;
+     display: grid;
+-    grid-template-rows: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(
+-        0,
+-        auto
+-      );
++    grid-template-rows: repeat(3, minmax(0, auto)) minmax(0, 1fr)
++      minmax(0, auto);
+     grid-template-columns: 100%;
+     width: 100%;
+     grid-template-areas:
+       "banner"
+@@ -188,12 +187,10 @@
+   [part~="body"] {
+     display: grid;
+     min-height: 100%;
+     align-items: flex-start;
+-    grid-template-columns: minmax(0, var(--menu-width)) minmax(
+-        0,
+-        var(--main-width)
+-      ) minmax(0, var(--aside-width));
++    grid-template-columns: minmax(0, var(--menu-width))
++      minmax(0, var(--main-width)) minmax(0, var(--aside-width));
+     grid-template-rows: minmax(0, 1fr);
+     grid-template-areas: "menu main aside";
+   }
+   [part~="main"] {
+
+`````
+
+### Actual (oxfmt)
+
+`````ts
+import { css } from "lit";
+
+export default css`
+  :host {
+    display: block;
+    background-color: var(--wa-color-surface-default);
+    box-sizing: border-box;
+    min-height: 100%;
+    --menu-width: auto;
+    --main-width: 1fr;
+    --aside-width: auto;
+    --banner-height: 0px;
+    --header-height: 0px;
+    --subheader-height: 0px;
+    --scroll-margin-top: calc(
+      var(--header-height, 0px) + var(--subheader-height, 0px) + 0.5em
+    );
+
+    --banner-top: var(--banner-height);
+    --header-top: var(--header-height);
+    --subheader-top: var(--subheader-height);
+  }
+
+  slot[name]:not(
+    [name="skip-to-content"],
+    [name="navigation-toggle"]
+  )::slotted(*) {
+    display: flex;
+    background-color: var(--wa-color-surface-default);
+  }
+
+  ::slotted([slot="banner"]) {
+    align-items: center;
+    justify-content: center;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-xs) var(--wa-space-m);
+  }
+
+  ::slotted([slot="header"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m);
+    flex: auto;
+  }
+
+  ::slotted([slot="subheader"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-xs) var(--wa-space-m);
+  }
+
+  ::slotted([slot*="navigation"]),
+  ::slotted([slot="menu"]),
+  ::slotted([slot="aside"]) {
+    flex-direction: column;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m);
+  }
+
+  ::slotted([slot="main-header"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m) var(--wa-space-3xl);
+  }
+
+  slot:not([name]) {
+    /* See #331 */
+    &::slotted(main),
+    &::slotted(section) {
+      padding: var(--wa-space-3xl);
+    }
+  }
+
+  ::slotted([slot="main-footer"]),
+  ::slotted([slot="footer"]) {
+    align-items: start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-3xl);
+  }
+
+  :host([disable-sticky~="banner"]) {
+    --banner-top: 0px;
+  }
+  :host([disable-sticky~="header"]) {
+    --header-top: 0px;
+  }
+  :host([disable-sticky~="subheader"]) {
+    --subheader-top: 0px;
+  }
+
+  /* Nothing else depends on subheader-height. */
+  :host([disable-sticky~="subheader"]) {
+  }
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    height: unset;
+    max-height: unset;
+  }
+
+  :host([disable-sticky~="banner"]) [part~="banner"],
+  :host([disable-sticky~="header"]) [part~="header"],
+  :host([disable-sticky~="subheader"]) [part~="subheader"],
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    position: static;
+    overflow: unset;
+    z-index: unset;
+  }
+
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    height: auto;
+    max-height: auto;
+  }
+
+  [part~="base"] {
+    min-height: 100dvh;
+    display: grid;
+    grid-template-rows: repeat(3, minmax(0, auto)) minmax(0, 1fr)
+      minmax(0, auto);
+    grid-template-columns: 100%;
+    width: 100%;
+    grid-template-areas:
+      "banner"
+      "header"
+      "subheader"
+      "body"
+      "footer";
+  }
+
+  /* Grid areas */
+  [part~="banner"] {
+    grid-area: banner;
+  }
+  [part~="header"] {
+    grid-area: header;
+  }
+  [part~="subheader"] {
+    grid-area: subheader;
+  }
+  [part~="menu"] {
+    grid-area: menu;
+  }
+  [part~="body"] {
+    grid-area: body;
+  }
+  [part~="main"] {
+    grid-area: main;
+  }
+  [part~="aside"] {
+    grid-area: aside;
+  }
+  [part~="footer"] {
+    grid-area: footer;
+  }
+
+  /* Z-indexes */
+  [part~="banner"],
+  [part~="header"],
+  [part~="subheader"] {
+    position: sticky;
+    z-index: 5;
+  }
+  [part~="banner"] {
+    top: 0px;
+  }
+  [part~="header"] {
+    top: var(--banner-top);
+
+    /** Make the header flex so that you don't unexpectedly have the default toggle button appearing above a slotted div because block elements are fun. */
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+  }
+  [part~="subheader"] {
+    top: calc(var(--header-top) + var(--banner-top));
+  }
+  [part~="body"] {
+    display: grid;
+    min-height: 100%;
+    align-items: flex-start;
+    grid-template-columns: minmax(0, var(--menu-width))
+      minmax(0, var(--main-width)) minmax(0, var(--aside-width));
+    grid-template-rows: minmax(0, 1fr);
+    grid-template-areas: "menu main aside";
+  }
+  [part~="main"] {
+    display: grid;
+    min-height: 100%;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+    grid-template-areas:
+      "main-header"
+      "main-content"
+      "main-footer";
+  }
+  [part~="main-header"] {
+    grid-area: main-header;
+  }
+  [part~="main-content"] {
+    grid-area: main-content;
+  }
+  [part~="main-footer"] {
+    grid-area: main-footer;
+  }
+
+  .skip-to-content {
+    position: absolute;
+    top: var(--wa-space-m);
+    left: var(--wa-space-m);
+    z-index: 6;
+    border-radius: var(--wa-corners-1x);
+    background-color: var(--wa-color-surface-default);
+    color: var(--wa-color-text-link);
+    text-decoration: none;
+    padding: var(--wa-space-s) var(--wa-space-m);
+    box-shadow: var(--wa-shadow-l);
+    outline: var(--wa-focus-ring);
+    outline-offset: var(--wa-focus-ring-offset);
+  }
+
+  [part~="menu"],
+  [part~="aside"] {
+    position: sticky;
+    top: calc(var(--banner-top) + var(--header-top) + var(--subheader-top));
+    z-index: 4;
+    height: min(
+      var(--main-height),
+      calc(
+        100dvh - var(--header-top) - var(--banner-top) - var(--subheader-top)
+      )
+    );
+    max-height: min(
+      var(--main-height),
+      calc(
+        100dvh - var(--header-top) - var(--banner-top) - var(--subheader-top)
+      )
+    );
+    overflow: auto;
+  }
+
+  [part~="navigation"] {
+    height: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+  }
+
+  [part~="drawer"]::part(dialog) {
+    background-color: var(--wa-color-surface-default);
+  }
+
+  /* Set these on the slot because we don't always control the navigation-toggle since that may be slotted. */
+  slot[name~="navigation-toggle"],
+  :host([disable-navigation-toggle]) slot[name~="navigation-toggle"] {
+    display: none;
+  }
+
+  /* Sometimes the media query in the viewport is stubborn in iframes. This is an extra check to make it behave properly. */
+  :host(:not([disable-navigation-toggle])[view="mobile"])
+    slot[name~="navigation-toggle"] {
+    display: contents;
+  }
+
+  [part~="navigation-toggle"] {
+    /* Use only a margin-inline-start because the slotted header is expected to have default padding
+        so it looks really awkward if this sets a margin-inline-end and the slotted header has a padding-inline-start. */
+    margin-inline-start: var(--wa-space-m);
+  }
+`;
+
+`````
+
+### Expected (prettier)
+
+`````ts
+import { css } from "lit";
+
+export default css`
+  :host {
+    display: block;
+    background-color: var(--wa-color-surface-default);
+    box-sizing: border-box;
+    min-height: 100%;
+    --menu-width: auto;
+    --main-width: 1fr;
+    --aside-width: auto;
+    --banner-height: 0px;
+    --header-height: 0px;
+    --subheader-height: 0px;
+    --scroll-margin-top: calc(
+      var(--header-height, 0px) + var(--subheader-height, 0px) + 0.5em
+    );
+
+    --banner-top: var(--banner-height);
+    --header-top: var(--header-height);
+    --subheader-top: var(--subheader-height);
+  }
+
+  slot[name]:not([name="skip-to-content"], [name="navigation-toggle"])::slotted(
+      *
+    ) {
+    display: flex;
+    background-color: var(--wa-color-surface-default);
+  }
+
+  ::slotted([slot="banner"]) {
+    align-items: center;
+    justify-content: center;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-xs) var(--wa-space-m);
+  }
+
+  ::slotted([slot="header"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m);
+    flex: auto;
+  }
+
+  ::slotted([slot="subheader"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-xs) var(--wa-space-m);
+  }
+
+  ::slotted([slot*="navigation"]),
+  ::slotted([slot="menu"]),
+  ::slotted([slot="aside"]) {
+    flex-direction: column;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m);
+  }
+
+  ::slotted([slot="main-header"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m) var(--wa-space-3xl);
+  }
+
+  slot:not([name]) {
+    /* See #331 */
+    &::slotted(main),
+    &::slotted(section) {
+      padding: var(--wa-space-3xl);
+    }
+  }
+
+  ::slotted([slot="main-footer"]),
+  ::slotted([slot="footer"]) {
+    align-items: start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-3xl);
+  }
+
+  :host([disable-sticky~="banner"]) {
+    --banner-top: 0px;
+  }
+  :host([disable-sticky~="header"]) {
+    --header-top: 0px;
+  }
+  :host([disable-sticky~="subheader"]) {
+    --subheader-top: 0px;
+  }
+
+  /* Nothing else depends on subheader-height. */
+  :host([disable-sticky~="subheader"]) {
+  }
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    height: unset;
+    max-height: unset;
+  }
+
+  :host([disable-sticky~="banner"]) [part~="banner"],
+  :host([disable-sticky~="header"]) [part~="header"],
+  :host([disable-sticky~="subheader"]) [part~="subheader"],
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    position: static;
+    overflow: unset;
+    z-index: unset;
+  }
+
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    height: auto;
+    max-height: auto;
+  }
+
+  [part~="base"] {
+    min-height: 100dvh;
+    display: grid;
+    grid-template-rows: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(
+        0,
+        auto
+      );
+    grid-template-columns: 100%;
+    width: 100%;
+    grid-template-areas:
+      "banner"
+      "header"
+      "subheader"
+      "body"
+      "footer";
+  }
+
+  /* Grid areas */
+  [part~="banner"] {
+    grid-area: banner;
+  }
+  [part~="header"] {
+    grid-area: header;
+  }
+  [part~="subheader"] {
+    grid-area: subheader;
+  }
+  [part~="menu"] {
+    grid-area: menu;
+  }
+  [part~="body"] {
+    grid-area: body;
+  }
+  [part~="main"] {
+    grid-area: main;
+  }
+  [part~="aside"] {
+    grid-area: aside;
+  }
+  [part~="footer"] {
+    grid-area: footer;
+  }
+
+  /* Z-indexes */
+  [part~="banner"],
+  [part~="header"],
+  [part~="subheader"] {
+    position: sticky;
+    z-index: 5;
+  }
+  [part~="banner"] {
+    top: 0px;
+  }
+  [part~="header"] {
+    top: var(--banner-top);
+
+    /** Make the header flex so that you don't unexpectedly have the default toggle button appearing above a slotted div because block elements are fun. */
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+  }
+  [part~="subheader"] {
+    top: calc(var(--header-top) + var(--banner-top));
+  }
+  [part~="body"] {
+    display: grid;
+    min-height: 100%;
+    align-items: flex-start;
+    grid-template-columns: minmax(0, var(--menu-width)) minmax(
+        0,
+        var(--main-width)
+      ) minmax(0, var(--aside-width));
+    grid-template-rows: minmax(0, 1fr);
+    grid-template-areas: "menu main aside";
+  }
+  [part~="main"] {
+    display: grid;
+    min-height: 100%;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+    grid-template-areas:
+      "main-header"
+      "main-content"
+      "main-footer";
+  }
+  [part~="main-header"] {
+    grid-area: main-header;
+  }
+  [part~="main-content"] {
+    grid-area: main-content;
+  }
+  [part~="main-footer"] {
+    grid-area: main-footer;
+  }
+
+  .skip-to-content {
+    position: absolute;
+    top: var(--wa-space-m);
+    left: var(--wa-space-m);
+    z-index: 6;
+    border-radius: var(--wa-corners-1x);
+    background-color: var(--wa-color-surface-default);
+    color: var(--wa-color-text-link);
+    text-decoration: none;
+    padding: var(--wa-space-s) var(--wa-space-m);
+    box-shadow: var(--wa-shadow-l);
+    outline: var(--wa-focus-ring);
+    outline-offset: var(--wa-focus-ring-offset);
+  }
+
+  [part~="menu"],
+  [part~="aside"] {
+    position: sticky;
+    top: calc(var(--banner-top) + var(--header-top) + var(--subheader-top));
+    z-index: 4;
+    height: min(
+      var(--main-height),
+      calc(
+        100dvh - var(--header-top) - var(--banner-top) - var(--subheader-top)
+      )
+    );
+    max-height: min(
+      var(--main-height),
+      calc(
+        100dvh - var(--header-top) - var(--banner-top) - var(--subheader-top)
+      )
+    );
+    overflow: auto;
+  }
+
+  [part~="navigation"] {
+    height: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+  }
+
+  [part~="drawer"]::part(dialog) {
+    background-color: var(--wa-color-surface-default);
+  }
+
+  /* Set these on the slot because we don't always control the navigation-toggle since that may be slotted. */
+  slot[name~="navigation-toggle"],
+  :host([disable-navigation-toggle]) slot[name~="navigation-toggle"] {
+    display: none;
+  }
+
+  /* Sometimes the media query in the viewport is stubborn in iframes. This is an extra check to make it behave properly. */
+  :host(:not([disable-navigation-toggle])[view="mobile"])
+    slot[name~="navigation-toggle"] {
+    display: contents;
+  }
+
+  [part~="navigation-toggle"] {
+    /* Use only a margin-inline-start because the slotted header is expected to have default padding
+        so it looks really awkward if this sets a margin-inline-end and the slotted header has a padding-inline-start. */
+    margin-inline-start: var(--wa-space-m);
+  }
+`;
+
+`````
+
+## Option 2
+
+`````json
+{"printWidth":100,"htmlWhitespaceSensitivity":"ignore"}
+`````
+
+### Diff
+
+`````diff
+===================================================================
+--- prettier
++++ oxfmt
+@@ -181,12 +181,10 @@
+   [part~="body"] {
+     display: grid;
+     min-height: 100%;
+     align-items: flex-start;
+-    grid-template-columns: minmax(0, var(--menu-width)) minmax(0, var(--main-width)) minmax(
+-        0,
+-        var(--aside-width)
+-      );
++    grid-template-columns: minmax(0, var(--menu-width)) minmax(0, var(--main-width))
++      minmax(0, var(--aside-width));
+     grid-template-rows: minmax(0, 1fr);
+     grid-template-areas: "menu main aside";
+   }
+   [part~="main"] {
+
+`````
+
+### Actual (oxfmt)
+
+`````ts
+import { css } from "lit";
+
+export default css`
+  :host {
+    display: block;
+    background-color: var(--wa-color-surface-default);
+    box-sizing: border-box;
+    min-height: 100%;
+    --menu-width: auto;
+    --main-width: 1fr;
+    --aside-width: auto;
+    --banner-height: 0px;
+    --header-height: 0px;
+    --subheader-height: 0px;
+    --scroll-margin-top: calc(var(--header-height, 0px) + var(--subheader-height, 0px) + 0.5em);
+
+    --banner-top: var(--banner-height);
+    --header-top: var(--header-height);
+    --subheader-top: var(--subheader-height);
+  }
+
+  slot[name]:not([name="skip-to-content"], [name="navigation-toggle"])::slotted(*) {
+    display: flex;
+    background-color: var(--wa-color-surface-default);
+  }
+
+  ::slotted([slot="banner"]) {
+    align-items: center;
+    justify-content: center;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-xs) var(--wa-space-m);
+  }
+
+  ::slotted([slot="header"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m);
+    flex: auto;
+  }
+
+  ::slotted([slot="subheader"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-xs) var(--wa-space-m);
+  }
+
+  ::slotted([slot*="navigation"]),
+  ::slotted([slot="menu"]),
+  ::slotted([slot="aside"]) {
+    flex-direction: column;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m);
+  }
+
+  ::slotted([slot="main-header"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m) var(--wa-space-3xl);
+  }
+
+  slot:not([name]) {
+    /* See #331 */
+    &::slotted(main),
+    &::slotted(section) {
+      padding: var(--wa-space-3xl);
+    }
+  }
+
+  ::slotted([slot="main-footer"]),
+  ::slotted([slot="footer"]) {
+    align-items: start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-3xl);
+  }
+
+  :host([disable-sticky~="banner"]) {
+    --banner-top: 0px;
+  }
+  :host([disable-sticky~="header"]) {
+    --header-top: 0px;
+  }
+  :host([disable-sticky~="subheader"]) {
+    --subheader-top: 0px;
+  }
+
+  /* Nothing else depends on subheader-height. */
+  :host([disable-sticky~="subheader"]) {
+  }
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    height: unset;
+    max-height: unset;
+  }
+
+  :host([disable-sticky~="banner"]) [part~="banner"],
+  :host([disable-sticky~="header"]) [part~="header"],
+  :host([disable-sticky~="subheader"]) [part~="subheader"],
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    position: static;
+    overflow: unset;
+    z-index: unset;
+  }
+
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    height: auto;
+    max-height: auto;
+  }
+
+  [part~="base"] {
+    min-height: 100dvh;
+    display: grid;
+    grid-template-rows: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(0, auto);
+    grid-template-columns: 100%;
+    width: 100%;
+    grid-template-areas:
+      "banner"
+      "header"
+      "subheader"
+      "body"
+      "footer";
+  }
+
+  /* Grid areas */
+  [part~="banner"] {
+    grid-area: banner;
+  }
+  [part~="header"] {
+    grid-area: header;
+  }
+  [part~="subheader"] {
+    grid-area: subheader;
+  }
+  [part~="menu"] {
+    grid-area: menu;
+  }
+  [part~="body"] {
+    grid-area: body;
+  }
+  [part~="main"] {
+    grid-area: main;
+  }
+  [part~="aside"] {
+    grid-area: aside;
+  }
+  [part~="footer"] {
+    grid-area: footer;
+  }
+
+  /* Z-indexes */
+  [part~="banner"],
+  [part~="header"],
+  [part~="subheader"] {
+    position: sticky;
+    z-index: 5;
+  }
+  [part~="banner"] {
+    top: 0px;
+  }
+  [part~="header"] {
+    top: var(--banner-top);
+
+    /** Make the header flex so that you don't unexpectedly have the default toggle button appearing above a slotted div because block elements are fun. */
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+  }
+  [part~="subheader"] {
+    top: calc(var(--header-top) + var(--banner-top));
+  }
+  [part~="body"] {
+    display: grid;
+    min-height: 100%;
+    align-items: flex-start;
+    grid-template-columns: minmax(0, var(--menu-width)) minmax(0, var(--main-width))
+      minmax(0, var(--aside-width));
+    grid-template-rows: minmax(0, 1fr);
+    grid-template-areas: "menu main aside";
+  }
+  [part~="main"] {
+    display: grid;
+    min-height: 100%;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+    grid-template-areas:
+      "main-header"
+      "main-content"
+      "main-footer";
+  }
+  [part~="main-header"] {
+    grid-area: main-header;
+  }
+  [part~="main-content"] {
+    grid-area: main-content;
+  }
+  [part~="main-footer"] {
+    grid-area: main-footer;
+  }
+
+  .skip-to-content {
+    position: absolute;
+    top: var(--wa-space-m);
+    left: var(--wa-space-m);
+    z-index: 6;
+    border-radius: var(--wa-corners-1x);
+    background-color: var(--wa-color-surface-default);
+    color: var(--wa-color-text-link);
+    text-decoration: none;
+    padding: var(--wa-space-s) var(--wa-space-m);
+    box-shadow: var(--wa-shadow-l);
+    outline: var(--wa-focus-ring);
+    outline-offset: var(--wa-focus-ring-offset);
+  }
+
+  [part~="menu"],
+  [part~="aside"] {
+    position: sticky;
+    top: calc(var(--banner-top) + var(--header-top) + var(--subheader-top));
+    z-index: 4;
+    height: min(
+      var(--main-height),
+      calc(100dvh - var(--header-top) - var(--banner-top) - var(--subheader-top))
+    );
+    max-height: min(
+      var(--main-height),
+      calc(100dvh - var(--header-top) - var(--banner-top) - var(--subheader-top))
+    );
+    overflow: auto;
+  }
+
+  [part~="navigation"] {
+    height: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+  }
+
+  [part~="drawer"]::part(dialog) {
+    background-color: var(--wa-color-surface-default);
+  }
+
+  /* Set these on the slot because we don't always control the navigation-toggle since that may be slotted. */
+  slot[name~="navigation-toggle"],
+  :host([disable-navigation-toggle]) slot[name~="navigation-toggle"] {
+    display: none;
+  }
+
+  /* Sometimes the media query in the viewport is stubborn in iframes. This is an extra check to make it behave properly. */
+  :host(:not([disable-navigation-toggle])[view="mobile"]) slot[name~="navigation-toggle"] {
+    display: contents;
+  }
+
+  [part~="navigation-toggle"] {
+    /* Use only a margin-inline-start because the slotted header is expected to have default padding
+        so it looks really awkward if this sets a margin-inline-end and the slotted header has a padding-inline-start. */
+    margin-inline-start: var(--wa-space-m);
+  }
+`;
+
+`````
+
+### Expected (prettier)
+
+`````ts
+import { css } from "lit";
+
+export default css`
+  :host {
+    display: block;
+    background-color: var(--wa-color-surface-default);
+    box-sizing: border-box;
+    min-height: 100%;
+    --menu-width: auto;
+    --main-width: 1fr;
+    --aside-width: auto;
+    --banner-height: 0px;
+    --header-height: 0px;
+    --subheader-height: 0px;
+    --scroll-margin-top: calc(var(--header-height, 0px) + var(--subheader-height, 0px) + 0.5em);
+
+    --banner-top: var(--banner-height);
+    --header-top: var(--header-height);
+    --subheader-top: var(--subheader-height);
+  }
+
+  slot[name]:not([name="skip-to-content"], [name="navigation-toggle"])::slotted(*) {
+    display: flex;
+    background-color: var(--wa-color-surface-default);
+  }
+
+  ::slotted([slot="banner"]) {
+    align-items: center;
+    justify-content: center;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-xs) var(--wa-space-m);
+  }
+
+  ::slotted([slot="header"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m);
+    flex: auto;
+  }
+
+  ::slotted([slot="subheader"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-xs) var(--wa-space-m);
+  }
+
+  ::slotted([slot*="navigation"]),
+  ::slotted([slot="menu"]),
+  ::slotted([slot="aside"]) {
+    flex-direction: column;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m);
+  }
+
+  ::slotted([slot="main-header"]) {
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-m) var(--wa-space-3xl);
+  }
+
+  slot:not([name]) {
+    /* See #331 */
+    &::slotted(main),
+    &::slotted(section) {
+      padding: var(--wa-space-3xl);
+    }
+  }
+
+  ::slotted([slot="main-footer"]),
+  ::slotted([slot="footer"]) {
+    align-items: start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--wa-space-m);
+    padding: var(--wa-space-3xl);
+  }
+
+  :host([disable-sticky~="banner"]) {
+    --banner-top: 0px;
+  }
+  :host([disable-sticky~="header"]) {
+    --header-top: 0px;
+  }
+  :host([disable-sticky~="subheader"]) {
+    --subheader-top: 0px;
+  }
+
+  /* Nothing else depends on subheader-height. */
+  :host([disable-sticky~="subheader"]) {
+  }
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    height: unset;
+    max-height: unset;
+  }
+
+  :host([disable-sticky~="banner"]) [part~="banner"],
+  :host([disable-sticky~="header"]) [part~="header"],
+  :host([disable-sticky~="subheader"]) [part~="subheader"],
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    position: static;
+    overflow: unset;
+    z-index: unset;
+  }
+
+  :host([disable-sticky~="aside"]) [part~="aside"],
+  :host([disable-sticky~="menu"]) [part~="menu"] {
+    height: auto;
+    max-height: auto;
+  }
+
+  [part~="base"] {
+    min-height: 100dvh;
+    display: grid;
+    grid-template-rows: repeat(3, minmax(0, auto)) minmax(0, 1fr) minmax(0, auto);
+    grid-template-columns: 100%;
+    width: 100%;
+    grid-template-areas:
+      "banner"
+      "header"
+      "subheader"
+      "body"
+      "footer";
+  }
+
+  /* Grid areas */
+  [part~="banner"] {
+    grid-area: banner;
+  }
+  [part~="header"] {
+    grid-area: header;
+  }
+  [part~="subheader"] {
+    grid-area: subheader;
+  }
+  [part~="menu"] {
+    grid-area: menu;
+  }
+  [part~="body"] {
+    grid-area: body;
+  }
+  [part~="main"] {
+    grid-area: main;
+  }
+  [part~="aside"] {
+    grid-area: aside;
+  }
+  [part~="footer"] {
+    grid-area: footer;
+  }
+
+  /* Z-indexes */
+  [part~="banner"],
+  [part~="header"],
+  [part~="subheader"] {
+    position: sticky;
+    z-index: 5;
+  }
+  [part~="banner"] {
+    top: 0px;
+  }
+  [part~="header"] {
+    top: var(--banner-top);
+
+    /** Make the header flex so that you don't unexpectedly have the default toggle button appearing above a slotted div because block elements are fun. */
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+  }
+  [part~="subheader"] {
+    top: calc(var(--header-top) + var(--banner-top));
+  }
+  [part~="body"] {
+    display: grid;
+    min-height: 100%;
+    align-items: flex-start;
+    grid-template-columns: minmax(0, var(--menu-width)) minmax(0, var(--main-width)) minmax(
+        0,
+        var(--aside-width)
+      );
+    grid-template-rows: minmax(0, 1fr);
+    grid-template-areas: "menu main aside";
+  }
+  [part~="main"] {
+    display: grid;
+    min-height: 100%;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+    grid-template-areas:
+      "main-header"
+      "main-content"
+      "main-footer";
+  }
+  [part~="main-header"] {
+    grid-area: main-header;
+  }
+  [part~="main-content"] {
+    grid-area: main-content;
+  }
+  [part~="main-footer"] {
+    grid-area: main-footer;
+  }
+
+  .skip-to-content {
+    position: absolute;
+    top: var(--wa-space-m);
+    left: var(--wa-space-m);
+    z-index: 6;
+    border-radius: var(--wa-corners-1x);
+    background-color: var(--wa-color-surface-default);
+    color: var(--wa-color-text-link);
+    text-decoration: none;
+    padding: var(--wa-space-s) var(--wa-space-m);
+    box-shadow: var(--wa-shadow-l);
+    outline: var(--wa-focus-ring);
+    outline-offset: var(--wa-focus-ring-offset);
+  }
+
+  [part~="menu"],
+  [part~="aside"] {
+    position: sticky;
+    top: calc(var(--banner-top) + var(--header-top) + var(--subheader-top));
+    z-index: 4;
+    height: min(
+      var(--main-height),
+      calc(100dvh - var(--header-top) - var(--banner-top) - var(--subheader-top))
+    );
+    max-height: min(
+      var(--main-height),
+      calc(100dvh - var(--header-top) - var(--banner-top) - var(--subheader-top))
+    );
+    overflow: auto;
+  }
+
+  [part~="navigation"] {
+    height: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, auto) minmax(0, 1fr) minmax(0, auto);
+  }
+
+  [part~="drawer"]::part(dialog) {
+    background-color: var(--wa-color-surface-default);
+  }
+
+  /* Set these on the slot because we don't always control the navigation-toggle since that may be slotted. */
+  slot[name~="navigation-toggle"],
+  :host([disable-navigation-toggle]) slot[name~="navigation-toggle"] {
+    display: none;
+  }
+
+  /* Sometimes the media query in the viewport is stubborn in iframes. This is an extra check to make it behave properly. */
+  :host(:not([disable-navigation-toggle])[view="mobile"]) slot[name~="navigation-toggle"] {
+    display: contents;
+  }
+
+  [part~="navigation-toggle"] {
+    /* Use only a margin-inline-start because the slotted header is expected to have default padding
+        so it looks really awkward if this sets a margin-inline-end and the slotted header has a padding-inline-start. */
+    margin-inline-start: var(--wa-space-m);
+  }
+`;
+
+`````

--- a/apps/oxfmt/src/api/text_to_doc_api.rs
+++ b/apps/oxfmt/src/api/text_to_doc_api.rs
@@ -6,6 +6,7 @@ use tracing::{debug, instrument};
 
 use oxc_allocator::Allocator;
 use oxc_formatter::FragmentContext;
+use oxc_formatter_css::CssVariant;
 use oxc_span::SourceType;
 
 use crate::{
@@ -13,7 +14,8 @@ use crate::{
         ExternalFormatter, JsFormatEmbeddedCb, JsFormatEmbeddedDocCb, JsFormatFileCb,
         JsSortTailwindClassesCb,
         options::{
-            inject_filepath, inject_tailwind_plugin_payload, to_oxc_formatter_graphql, to_prettier,
+            inject_filepath, inject_tailwind_plugin_payload, to_oxc_formatter_css,
+            to_oxc_formatter_graphql, to_prettier,
         },
         oxfmtrc::FormatConfig,
         resolve_for_embedded_js,
@@ -127,16 +129,20 @@ fn run_full(
     inject_filepath(&mut external_options, &resolved.parent_filepath);
     inject_tailwind_plugin_payload(&mut external_options, &resolved.config);
 
-    // Dual mapping of the same resolved config for the dispatcher's Rust GraphQL branch.
+    // Dual mapping of the same resolved config for the dispatcher's Rust branches.
     // Cannot fail here: `resolve_for_embedded_js()` already built `JsFormatOptions`
     // from this config, and both share the same `to_core_options()` validation.
     let graphql_options = to_oxc_formatter_graphql(&resolved.config)
+        .expect("config was already validated by `resolve_for_embedded_js()`");
+    // CSS-in-JS is always parsed as SCSS, mirroring Prettier's embed.
+    let css_options = to_oxc_formatter_css(&resolved.config, CssVariant::Scss)
         .expect("config was already validated by `resolve_for_embedded_js()`");
 
     let external_callbacks = external_formatter.to_external_callbacks(
         &resolved.format_options,
         external_options,
         graphql_options,
+        css_options,
     );
     let format_options = resolved.format_options;
 

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -10,9 +10,10 @@ use serde_json::Value;
 use tracing::{debug, debug_span};
 
 use oxc_formatter::{
-    EmbeddedFormatterCallback, ExternalCallbacks, JsFormatOptions, TailwindCallback,
+    CssEmbedMeta, EmbeddedFormatterCallback, ExternalCallbacks, JsFormatOptions, TailwindCallback,
 };
 use oxc_formatter_core::{DispatchResult, EmbeddedContext, FormatDispatcher};
+use oxc_formatter_css::CssFormatOptions;
 use oxc_formatter_graphql::GraphqlFormatOptions;
 
 use crate::{core::options::inject_parser, prettier_compat::from_prettier_doc};
@@ -241,13 +242,14 @@ impl ExternalFormatter {
     /// Convert this external formatter to the oxc_formatter::ExternalCallbacks type.
     /// The options (including `filepath`) are captured in the closures and passed to JS on each call.
     ///
-    /// `graphql_options` is the dual mapping of the same resolved config for the
-    /// dispatcher's Rust GraphQL branch (graphql-in-js).
+    /// `graphql_options` / `css_options` are dual mappings of the same resolved
+    /// config for the dispatcher's Rust branches (graphql-in-js / css-in-js).
     pub fn to_external_callbacks(
         &self,
         format_options: &JsFormatOptions,
         options: Value,
         graphql_options: GraphqlFormatOptions,
+        css_options: CssFormatOptions,
     ) -> ExternalCallbacks {
         let needs_embedded = !format_options.embedded_language_formatting.is_off();
         let embedded_callback: Option<EmbeddedFormatterCallback> = if needs_embedded {
@@ -283,10 +285,14 @@ impl ExternalFormatter {
             None
         };
 
+        let tailwind_enabled = format_options.sort_tailwindcss.is_some();
+
         // The dispatcher maps a language name to a formatter implementation.
         // Rust implementations replace branches one by one;
         // the rest go through the Prettier Doc→IR fallback.
         let dispatcher: Option<FormatDispatcher> = if needs_embedded {
+            // `@apply` class sorting only happens in `prettier-plugin-tailwindcss`,
+            // so css-in-js must stay on the Prettier path while it is enabled.
             let prettier_fallback =
                 build_prettier_fallback(Arc::clone(&self.format_embedded_doc), options.clone());
             Some(Arc::new(
@@ -305,6 +311,19 @@ impl ExternalFormatter {
                                 );
                                 prettier_fallback(ctx, language, texts)
                             }),
+                        // Rust implementation; Prettier fallback on parse errors.
+                        // Since the raffia fork accepts `${}` placeholders in
+                        // value/selector position (plan Step 6), this is a pure
+                        // safety net: what still errors is garbage that
+                        // Prettier's embed cannot format either.
+                        "css" | "scss" | "less" if !tailwind_enabled => {
+                            format_css_to_irs(ctx, texts, css_options).or_else(|err| {
+                                debug!(
+                                    "`oxc_formatter_css` failed, falling back to Prettier: {err}"
+                                );
+                                prettier_fallback(ctx, language, texts)
+                            })
+                        }
                         // Everything else: Prettier fallback (Doc→IR path)
                         _ => prettier_fallback(ctx, language, texts),
                     }
@@ -314,8 +333,7 @@ impl ExternalFormatter {
             None
         };
 
-        let needs_tailwind = format_options.sort_tailwindcss.is_some();
-        let tailwind_callback: Option<TailwindCallback> = if needs_tailwind {
+        let tailwind_callback: Option<TailwindCallback> = if tailwind_enabled {
             let sort_tailwindcss_classes = Arc::clone(&self.sort_tailwindcss_classes);
             Some(Arc::new(move |classes: Vec<String>| {
                 debug_span!("oxfmt::external::sort_tailwind", classes_count = classes.len())
@@ -385,6 +403,40 @@ fn format_graphql_to_irs<'a>(
         })
         .collect::<Result<Vec<_>, String>>()?;
     Ok(DispatchResult { docs, meta: None })
+}
+
+/// Format the single joined CSS text (placeholders included) via
+/// `oxc_formatter_css`, returning one IR plus [`CssEmbedMeta`]
+/// (the dispatcher contract for CSS, mirroring the Prettier Doc path).
+///
+/// CSS-in-js uses `.raw` template values, so unlike GraphQL no template-char
+/// re-escaping is needed. The parent replaces `@prettier-placeholder-N-id`
+/// per `Text` element, so consecutive `Text`s are merged first (the at-rule
+/// printer emits `@` and the name as separate elements) and the surviving
+/// placeholders counted into the meta.
+fn format_css_to_irs<'a>(
+    ctx: &EmbeddedContext<'a, '_>,
+    texts: &[&str],
+    options: CssFormatOptions,
+) -> Result<DispatchResult<'a>, String> {
+    // Unlike GraphQL's one-IR-per-quasi, the CSS embed joins quasis with
+    // placeholders into a single text before dispatching.
+    let [text] = texts else {
+        return Err(format!("CSS dispatch expects exactly one text, got {}", texts.len()));
+    };
+    debug_span!("oxfmt::external::format_css_to_ir").in_scope(|| {
+        let mut ir =
+            oxc_formatter_css::format_to_ir(ctx, text, options).map_err(|err| err.to_string())?;
+        let placeholder_count = from_prettier_doc::merge_texts_and_count_css_placeholders(
+            &mut ir,
+            ctx.allocator,
+            options.indent_width,
+        );
+        Ok(DispatchResult {
+            docs: vec![ir],
+            meta: Some(Box::new(CssEmbedMeta { placeholder_count })),
+        })
+    })
 }
 
 /// Type of the Prettier Doc→IR fallback used by the dispatcher.

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -5,6 +5,9 @@ use tracing::instrument;
 use oxc_allocator::AllocatorPool;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter::JsFormatOptions;
+use oxc_formatter_css::CssFormatOptions;
+#[cfg(feature = "napi")]
+use oxc_formatter_css::CssVariant;
 use oxc_formatter_graphql::GraphqlFormatOptions;
 use oxc_formatter_json::{JsonFormatOptions, JsonVariant};
 use oxc_span::SourceType;
@@ -17,8 +20,8 @@ use super::options::{
 };
 use super::{
     options::{
-        to_oxc_formatter, to_oxc_formatter_graphql, to_oxc_formatter_json, to_oxc_toml,
-        to_sort_package_json,
+        to_oxc_formatter, to_oxc_formatter_css, to_oxc_formatter_graphql, to_oxc_formatter_json,
+        to_oxc_toml, to_sort_package_json,
     },
     oxfmtrc::FormatConfig,
     support::FileKind,
@@ -68,6 +71,17 @@ pub enum FormatStrategy {
         config: Box<FormatConfig>,
         insert_final_newline: bool,
     },
+    /// For CSS/SCSS/Less files formatted by `oxc_formatter_css`.
+    /// Parse errors are surfaced as diagnostics — no Prettier fallback.
+    /// `config` is retained (napi only) solely to route to Prettier up front
+    /// when it enables Tailwind class sorting (not implemented in Rust yet).
+    OxcFormatterCss {
+        path: Arc<Path>,
+        format_options: Box<CssFormatOptions>,
+        #[cfg(feature = "napi")]
+        config: Box<FormatConfig>,
+        insert_final_newline: bool,
+    },
     /// For TOML files.
     OxfmtToml { path: Arc<Path>, toml_options: TomlFormatterOptions, insert_final_newline: bool },
     /// For non-JS files formatted by external formatter (Prettier).
@@ -97,6 +111,7 @@ impl FormatStrategy {
             | Self::OxcFormatterJson { path, .. }
             | Self::OxcFormatterJsonPackageJson { path, .. }
             | Self::OxcFormatterGraphql { path, .. }
+            | Self::OxcFormatterCss { path, .. }
             | Self::OxfmtToml { path, .. } => path,
             #[cfg(feature = "napi")]
             Self::ExternalFormatter { path, .. } => path,
@@ -147,6 +162,13 @@ impl FormatStrategy {
             FileKind::OxcFormatterGraphql { path } => Self::OxcFormatterGraphql {
                 path,
                 format_options: Box::new(to_oxc_formatter_graphql(&config)?),
+                #[cfg(feature = "napi")]
+                config: Box::new(config),
+                insert_final_newline,
+            },
+            FileKind::OxcFormatterCss { path, variant } => Self::OxcFormatterCss {
+                path,
+                format_options: Box::new(to_oxc_formatter_css(&config, variant)?),
                 #[cfg(feature = "napi")]
                 config: Box::new(config),
                 insert_final_newline,
@@ -255,6 +277,22 @@ impl SourceFormatter {
                 insert_final_newline,
             } => (
                 self.format_by_oxc_formatter_graphql(
+                    source_text,
+                    &path,
+                    *format_options,
+                    #[cfg(feature = "napi")]
+                    &config,
+                ),
+                insert_final_newline,
+            ),
+            FormatStrategy::OxcFormatterCss {
+                path,
+                format_options,
+                #[cfg(feature = "napi")]
+                config,
+                insert_final_newline,
+            } => (
+                self.format_by_oxc_formatter_css(
                     source_text,
                     &path,
                     *format_options,
@@ -448,6 +486,54 @@ impl SourceFormatter {
         result
     }
 
+    /// Format CSS/SCSS/Less source using `oxc_formatter_css`.
+    ///
+    /// Unlike GraphQL, there is NO Prettier fallback on parse errors: raffia
+    /// covers the stable grammar (conformance 100%), and what it rejects is
+    /// genuinely broken CSS or the tail of postcss's error tolerance
+    /// (e.g. IE star hacks). Both the napi and pure builds report the
+    /// diagnostic as-is.
+    ///
+    /// When the config enables Tailwind class sorting (`@apply` sorting lives in
+    /// `prettier-plugin-tailwindcss`, not implemented in Rust yet), the napi
+    /// build routes to Prettier up front to keep the sorting behavior.
+    #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter_css", skip_all)]
+    fn format_by_oxc_formatter_css(
+        &self,
+        source_text: &str,
+        path: &Path,
+        format_options: CssFormatOptions,
+        #[cfg(feature = "napi")] config: &FormatConfig,
+    ) -> Result<String, OxcDiagnostic> {
+        #[cfg(feature = "napi")]
+        if config.is_tailwind_enabled() {
+            let parser_name = match format_options.variant {
+                CssVariant::Css => "css",
+                CssVariant::Scss => "scss",
+                CssVariant::Less => "less",
+            };
+            return self.format_by_external_formatter(
+                source_text,
+                path,
+                parser_name,
+                config,
+                /* supports_tailwind */ true,
+                /* supports_oxfmt */ false,
+                /* supports_svelte */ false,
+            );
+        }
+
+        let allocator = self.allocator_pool.get();
+        let formatted = oxc_formatter_css::format(&allocator, source_text, format_options)?;
+        let printed = formatted.print().map_err(|err| {
+            OxcDiagnostic::error(format!(
+                "Failed to print formatted CSS: {}\n{err}",
+                path.display()
+            ))
+        })?;
+        Ok(printed.into_code())
+    }
+
     /// Format TOML file using `oxc_toml`.
     #[instrument(level = "debug", name = "oxfmt::format::oxc_toml", skip_all)]
     fn format_by_toml(source_text: &str, options: oxc_toml::Options) -> String {
@@ -492,13 +578,22 @@ impl SourceFormatter {
         inject_filepath(&mut external_options, path);
         inject_tailwind_plugin_payload(&mut external_options, config);
 
-        // Dual mapping of the same resolved config for the dispatcher's Rust GraphQL branch.
+        // Dual mapping of the same resolved config for the dispatcher's Rust branches.
         // Cannot fail here: building `JsFormatOptions` from this config already succeeded,
         // and both share the same `to_core_options()` validation.
         let graphql_options = to_oxc_formatter_graphql(config)
             .expect("config was already validated when building `JsFormatOptions`");
+        // CSS-in-JS is always parsed as SCSS, mirroring Prettier's embed
+        // (`language_to_prettier_parser` maps css/scss/less to the `scss` parser).
+        let css_options = to_oxc_formatter_css(config, CssVariant::Scss)
+            .expect("config was already validated when building `JsFormatOptions`");
 
-        external_formatter.to_external_callbacks(format_options, external_options, graphql_options)
+        external_formatter.to_external_callbacks(
+            format_options,
+            external_options,
+            graphql_options,
+            css_options,
+        )
     }
 
     /// Format non-JS/TS file using external formatter (Prettier).

--- a/apps/oxfmt/src/core/options/mod.rs
+++ b/apps/oxfmt/src/core/options/mod.rs
@@ -4,6 +4,7 @@
 //! - [`to_oxc_formatter_json()`]: `oxc_formatter_json::JsonFormatOptions` for JSON formatting
 //!   - [`to_sort_package_json()`]: its companion `sort_package_json::SortOptions`
 //!     for `package.json`'s sorting pre-process
+//! - [`to_oxc_formatter_css()`]: `oxc_formatter_css::CssFormatOptions` for CSS/SCSS/Less formatting
 //! - [`to_oxc_formatter_graphql()`]: `oxc_formatter_graphql::GraphqlFormatOptions` for GraphQL formatting
 //! - [`to_oxc_toml()`]: `oxc_toml::Options` for TOML formatting
 //! - `to_prettier`(NAPI-only): Prettier-compatible JSON, plus `inject_*` helpers for
@@ -12,6 +13,7 @@
 
 mod to_core_options;
 mod to_oxc_formatter;
+mod to_oxc_formatter_css;
 mod to_oxc_formatter_graphql;
 mod to_oxc_formatter_json;
 mod to_oxc_toml;
@@ -20,6 +22,7 @@ mod to_prettier;
 mod validate;
 
 pub use to_oxc_formatter::to_oxc_formatter;
+pub use to_oxc_formatter_css::to_oxc_formatter_css;
 pub use to_oxc_formatter_graphql::to_oxc_formatter_graphql;
 pub use to_oxc_formatter_json::{to_oxc_formatter_json, to_sort_package_json};
 pub use to_oxc_toml::to_oxc_toml;

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_css.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_css.rs
@@ -1,0 +1,44 @@
+use oxc_formatter_css::{CssFormatOptions, CssVariant, SingleQuote, TrailingCommas};
+
+use super::{
+    super::oxfmtrc::{FormatConfig, TrailingCommaConfig},
+    to_core_options::to_core_options,
+};
+
+/// Convert `FormatConfig` into validated `CssFormatOptions` for `oxc_formatter_css`.
+///
+/// Prettier's CSS languages consume the shared layout options plus
+/// `singleQuote` and `trailingComma` (SCSS maps only).
+///
+/// # Errors
+/// Returns error if any option value is invalid.
+pub fn to_oxc_formatter_css(
+    config: &FormatConfig,
+    variant: CssVariant,
+) -> Result<CssFormatOptions, String> {
+    let core = to_core_options(config)?;
+
+    let mut options = CssFormatOptions {
+        indent_style: core.indent_style,
+        indent_width: core.indent_width,
+        line_width: core.line_width,
+        line_ending: core.line_ending,
+        variant,
+        ..CssFormatOptions::default()
+    };
+
+    // [Prettier] singleQuote: boolean
+    if let Some(single_quote) = config.single_quote {
+        options.single_quote = SingleQuote::from(single_quote);
+    }
+    // [Prettier] trailingComma: "all" | "es5" | "none"
+    // `all`/`es5` are indistinguishable for CSS (SCSS maps only check "not none")
+    if let Some(trailing_comma) = config.trailing_comma {
+        options.trailing_commas = match trailing_comma {
+            TrailingCommaConfig::All | TrailingCommaConfig::Es5 => TrailingCommas::Always,
+            TrailingCommaConfig::None => TrailingCommas::Never,
+        };
+    }
+
+    Ok(options)
+}

--- a/apps/oxfmt/src/core/oxfmtrc.rs
+++ b/apps/oxfmt/src/core/oxfmtrc.rs
@@ -296,6 +296,17 @@ impl FormatConfig {
         matches!(self.svelte, Some(SvelteUserConfig::Bool(true) | SvelteUserConfig::Object(_)))
     }
 
+    /// Whether Tailwind class sorting is enabled by this config.
+    ///
+    /// Enabled when `sortTailwindcss` is set to `true` or an object;
+    /// disabled when unset or `false`.
+    pub fn is_tailwind_enabled(&self) -> bool {
+        matches!(
+            self.sort_tailwindcss,
+            Some(SortTailwindcssUserConfig::Bool(true) | SortTailwindcssUserConfig::Object(_))
+        )
+    }
+
     /// Resolve relative tailwind paths (`config`, `stylesheet`) to absolute paths.
     /// Otherwise, the plugin tries to resolve the Prettier's configuration file, not Oxfmt's.
     /// <https://github.com/tailwindlabs/prettier-plugin-tailwindcss/blob/125a8bc77639529a5a0c7e4e8a02174d7ed2d70b/src/config.ts#L50-L54>

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -2,6 +2,7 @@ use std::{path::Path, sync::Arc};
 
 use phf::phf_set;
 
+use oxc_formatter_css::CssVariant;
 use oxc_formatter_json::JsonVariant;
 use oxc_span::SourceType;
 
@@ -59,6 +60,9 @@ pub fn classify_file_kind(path: Arc<Path>) -> Option<FileKind> {
     if is_graphql_file(extension) {
         return Some(FileKind::OxcFormatterGraphql { path });
     }
+    if let Some(variant) = classify_css_variant(extension) {
+        return Some(FileKind::OxcFormatterCss { path, variant });
+    }
 
     // External formatter files are only supported with the `napi` feature
     #[cfg(feature = "napi")]
@@ -98,6 +102,13 @@ pub enum FileKind {
     /// apollo-parser covers the stable spec, while Prettier (graphql-js) also
     /// accepts draft-level syntax.
     OxcFormatterGraphql { path: Arc<Path> },
+    /// CSS/SCSS/Less files formatted by `oxc_formatter_css`.
+    /// Parse errors are surfaced as diagnostics — no Prettier fallback
+    /// (raffia covers the stable grammar; what it rejects is genuinely broken
+    /// CSS or the tail of postcss's error tolerance, e.g. IE star hacks).
+    /// Tailwind class sorting (`@apply`) is not implemented in Rust yet, so the
+    /// format step routes to Prettier up front when the config enables it.
+    OxcFormatterCss { path: Arc<Path>, variant: CssVariant },
     /// TOML files formatted by taplo (Pure Rust).
     OxfmtToml { path: Arc<Path> },
     /// Files formatted by external formatter (Prettier).
@@ -123,6 +134,7 @@ impl FileKind {
             | Self::OxcFormatterJson { path, .. }
             | Self::OxcFormatterJsonPackageJson { path }
             | Self::OxcFormatterGraphql { path }
+            | Self::OxcFormatterCss { path, .. }
             | Self::OxfmtToml { path } => path,
             #[cfg(feature = "napi")]
             Self::ExternalFormatter { path, .. } => path,
@@ -150,15 +162,14 @@ impl FileKind {
 // ---
 
 /// Parsers(files) that benefit from Tailwind plugin.
+/// CSS/SCSS/Less also benefit, but are classified as [`FileKind::OxcFormatterCss`];
+/// their Tailwind gating happens at the format step.
 #[cfg(feature = "napi")]
 static TAILWIND_PARSERS: phf::Set<&'static str> = phf_set! {
     "html",
     "vue",
     "angular",
     "glimmer",
-    "css",
-    "scss",
-    "less",
     "svelte",
 };
 
@@ -337,6 +348,28 @@ static GRAPHQL_EXTENSIONS: phf::Set<&'static str> = phf_set! {
 
 // ---
 
+/// Classify the CSS dialect (handled by `oxc_formatter_css`) from the extension.
+fn classify_css_variant(extension: Option<&str>) -> Option<CssVariant> {
+    let extension = extension?;
+    if CSS_EXTENSIONS.contains(extension) {
+        return Some(CssVariant::Css);
+    }
+    match extension {
+        "scss" => Some(CssVariant::Scss),
+        "less" => Some(CssVariant::Less),
+        _ => None,
+    }
+}
+
+static CSS_EXTENSIONS: phf::Set<&'static str> = phf_set! {
+    "css",
+    "wxss",
+    "pcss",
+    "postcss",
+};
+
+// ---
+
 /// Returns parser name for external formatter, if supported.
 /// See also `prettier --support-info | jq '.languages[]'`
 #[cfg(feature = "napi")]
@@ -387,19 +420,6 @@ fn get_external_parser_name(file_name: &str, extension: Option<&str>) -> Option<
         return Some("mjml");
     }
 
-    // CSS and variants
-    if let Some(ext) = extension
-        && CSS_EXTENSIONS.contains(ext)
-    {
-        return Some("css");
-    }
-    if extension == Some("less") {
-        return Some("less");
-    }
-    if extension == Some("scss") {
-        return Some("scss");
-    }
-
     // Handlebars
     if let Some(ext) = extension
         && HANDLEBARS_EXTENSIONS.contains(ext)
@@ -418,14 +438,6 @@ static HTML_EXTENSIONS: phf::Set<&'static str> = phf_set! {
     "inc",
     "xht",
     "xhtml",
-};
-
-#[cfg(feature = "napi")]
-static CSS_EXTENSIONS: phf::Set<&'static str> = phf_set! {
-    "css",
-    "wxss",
-    "pcss",
-    "postcss",
 };
 
 #[cfg(feature = "napi")]
@@ -628,13 +640,11 @@ mod tests {
             ("email.mjml", Some("mjml")),
             // Vue
             ("App.vue", Some("vue")),
-            // CSS
-            ("styles.css", Some("css")),
-            ("app.wxss", Some("css")),
-            ("styles.pcss", Some("css")),
-            ("styles.postcss", Some("css")),
-            ("theme.less", Some("less")),
-            ("main.scss", Some("scss")),
+            // CSS files are routed to `oxc_formatter_css` in `classify_file_kind`
+            // and excluded from this map.
+            ("styles.css", None),
+            ("theme.less", None),
+            ("main.scss", None),
             // GraphQL files are routed to `oxc_formatter_graphql` in `classify_file_kind`
             // and excluded from this map.
             ("schema.graphql", None),
@@ -714,6 +724,26 @@ mod tests {
             assert!(
                 matches!(result, Some(FileKind::OxcFormatterGraphql { .. })),
                 "`{file_name}` should be routed to oxc_formatter_graphql"
+            );
+        }
+    }
+
+    #[test]
+    fn test_css_files_route_to_oxc_formatter_css() {
+        let test_cases = vec![
+            ("styles.css", CssVariant::Css),
+            ("app.wxss", CssVariant::Css),
+            ("styles.pcss", CssVariant::Css),
+            ("styles.postcss", CssVariant::Css),
+            ("main.scss", CssVariant::Scss),
+            ("theme.less", CssVariant::Less),
+        ];
+
+        for (file_name, expected) in test_cases {
+            let result = classify_file_kind(Arc::from(Path::new(file_name)));
+            assert!(
+                matches!(result, Some(FileKind::OxcFormatterCss { variant, .. }) if variant == expected),
+                "`{file_name}` should be routed to oxc_formatter_css ({expected:?})"
             );
         }
     }

--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -9,6 +9,7 @@ use oxc_formatter_core::{
     Align, Condition, DedentMode, DispatchResult, FormatElement, Group, GroupId, GroupMode,
     IndentWidth, LineMode, PrintMode, Tag, TextWidth, UniqueGroupIdBuilder,
 };
+use oxc_formatter_css::{TEMPLATE_PLACEHOLDER_PREFIX, TEMPLATE_PLACEHOLDER_SUFFIX};
 
 /// Marker string used to represent `-Infinity` in JSON.
 /// JS side replaces `-Infinity` with this string before `JSON.stringify()`.
@@ -80,7 +81,7 @@ pub fn to_format_elements_for_template<'a>(
                 allocator,
                 // CSS uses `.raw` values, so no template char escaping needed
                 TemplateEscape::None,
-                Some(("@prettier-placeholder-", "-id")),
+                Some((TEMPLATE_PLACEHOLDER_PREFIX, TEMPLATE_PLACEHOLDER_SUFFIX)),
             );
             Ok(DispatchResult {
                 docs: vec![ir],
@@ -154,6 +155,74 @@ pub fn escape_template_characters_in_ir<'a>(
             }
         }
     }
+}
+
+/// Merge consecutive text-like elements (`Text` / `Token` / `Space`) of a
+/// Rust-built embedded IR and count `@prettier-placeholder-N-id` occurrences.
+///
+/// Mirrors the text-merging + placeholder-counting step of [`postprocess`]
+/// for IRs that come from `oxc_formatter_css` instead of a Prettier Doc:
+/// the parent (`embed/css.rs`) replaces placeholders per `Text` element, so a
+/// placeholder split across elements (e.g. `Token("@")` +
+/// `Text("prettier-placeholder-0-id")` from the at-rule printer) must be
+/// fused into one `Text` to be detectable. Unlike Doc-converted IRs, Rust
+/// printers also emit `Token`/`Space` elements, so those join the run too.
+pub fn merge_texts_and_count_css_placeholders<'a>(
+    ir: &mut ArenaVec<'a, FormatElement<'a>>,
+    allocator: &'a Allocator,
+    indent_width: IndentWidth,
+) -> usize {
+    fn text_like<'i>(element: &'i FormatElement<'_>) -> Option<&'i str> {
+        match element {
+            FormatElement::Text { text, .. } | FormatElement::Token { text } => Some(text),
+            FormatElement::Space => Some(" "),
+            _ => None,
+        }
+    }
+
+    let (prefix, suffix) = (TEMPLATE_PLACEHOLDER_PREFIX, TEMPLATE_PLACEHOLDER_SUFFIX);
+    let mut placeholder_count = 0;
+    let mut write = 0;
+    let mut read = 0;
+    while read < ir.len() {
+        if text_like(&ir[read]).is_some() {
+            let run_start = read;
+            read += 1;
+            while read < ir.len() && text_like(&ir[read]).is_some() {
+                read += 1;
+            }
+
+            if read - run_start == 1 {
+                // Single element: keep it (and its width) as-is.
+                // A lone `Token` (static strings only) or `Space` can never
+                // contain a placeholder, so only `Text` is worth counting.
+                if let FormatElement::Text { text, .. } = &ir[run_start] {
+                    placeholder_count += count_placeholders(text, prefix, suffix);
+                }
+                if write != run_start {
+                    ir[write] = ir[run_start].clone();
+                }
+            } else {
+                let mut sb = ArenaStringBuilder::new_in(allocator);
+                for element in &ir[run_start..read] {
+                    sb.push_str(text_like(element).unwrap());
+                }
+                let text = sb.into_str();
+                placeholder_count += count_placeholders(text, prefix, suffix);
+                let width = TextWidth::from_text(text, indent_width);
+                ir[write] = FormatElement::Text { text, width };
+            }
+            write += 1;
+        } else {
+            if write != read {
+                ir[write] = ir[read].clone();
+            }
+            write += 1;
+            read += 1;
+        }
+    }
+    ir.truncate(write);
+    placeholder_count
 }
 
 // ---

--- a/apps/oxfmt/test/api/css.test.ts
+++ b/apps/oxfmt/test/api/css.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { format } from "../../dist/index.js";
+
+describe("CSS/SCSS/Less files (oxc_formatter_css)", () => {
+  it("should format standalone CSS files in Rust", async () => {
+    const source = `a{color:red;background:blue}`;
+    const result = await format("styles.css", source);
+    expect(result.code).toMatchInlineSnapshot(`
+      "a {
+        color: red;
+        background: blue;
+      }
+      "
+    `);
+  });
+
+  it("should format .wxss, .pcss and .postcss extensions as CSS", async () => {
+    const source = `a{color:red}`;
+    for (const filename of ["app.wxss", "styles.pcss", "styles.postcss"]) {
+      // oxlint-disable-next-line no-await-in-loop
+      const result = await format(filename, source);
+      expect(result.code).toBe("a {\n  color: red;\n}\n");
+    }
+  });
+
+  it("should format SCSS files in Rust", async () => {
+    const source = `$gap:8px;.card{margin:$gap;&:hover{color:blue}}`;
+    const result = await format("main.scss", source);
+    expect(result.code).toMatchInlineSnapshot(`
+      "$gap: 8px;
+      .card {
+        margin: $gap;
+        &:hover {
+          color: blue;
+        }
+      }
+      "
+    `);
+  });
+
+  it("should format Less files in Rust", async () => {
+    const source = `@gap:8px;.card{margin:@gap}`;
+    const result = await format("theme.less", source);
+    expect(result.code).toMatchInlineSnapshot(`
+      "@gap: 8px;
+      .card {
+        margin: @gap;
+      }
+      "
+    `);
+  });
+
+  it("should respect singleQuote and useTabs", async () => {
+    const source = `a { content: "hi"; font-family: "Arial" }`;
+    const result = await format("styles.css", source, {
+      singleQuote: true,
+      useTabs: true,
+    });
+    expect(result.code).toMatchInlineSnapshot(`
+      "a {
+      	content: 'hi';
+      	font-family: 'Arial';
+      }
+      "
+    `);
+  });
+
+  it("should report a diagnostic for input raffia rejects (no Prettier fallback)", async () => {
+    // IE star hack: postcss would tolerate it as a raw declaration,
+    // but CSS has no Prettier fallback — the parse error is surfaced as-is.
+    const source = `a { *zoom: 1; color: red }`;
+    const result = await format("legacy.css", source);
+    expect(result.code).toBe(source);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/Syntax error/);
+  });
+
+  it("should report a diagnostic for genuinely broken input", async () => {
+    const source = `a {\n  color: red;\n`;
+    const result = await format("broken.css", source);
+    expect(result.code).toBe(source);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].message).toMatch(/Syntax error/);
+  });
+});

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -6,6 +6,11 @@ Prettier compatible CSS/SCSS/Less formatter, using the `oxc_formatter_core` APIs
 
 - Built on `oxc_formatter_core` for the language-agnostic IR + Printer + builders + macros
 - Parses with [raffia](https://docs.rs/raffia) 0.12 (AST with full spans + `raw` text; NOT a CST)
+  - A FORK (git dep on `leaysgur/raffia` in workspace deps): adds
+    `ParserOptions::tolerate_at_keyword_placeholders`, which accepts at-keywords
+    in declaration values (`ComponentValue::TokenWithSpan`) and selectors
+    (type/class selector idents whose `raw` INCLUDES the leading `@`).
+    Only `format_to_ir` enables it; `format()` stays strict
   - Comments are NOT in the AST: collected via `ParserBuilder::comments()` into
     a positional cursor (`src/comments.rs`, mirrors `oxc_formatter_graphql`)
   - The canonical reference is Prettier's `src/language-css/printer-postcss.js`
@@ -16,8 +21,15 @@ Prettier compatible CSS/SCSS/Less formatter, using the `oxc_formatter_core` APIs
 ### Error semantics
 
 `format()` / `format_to_ir()` return `Err` on ANY parse error, including
-raffia's recoverable ones (`parser.recoverable_errors()`); oxfmt then falls
-back to Prettier (napi build).
+raffia's recoverable ones (`parser.recoverable_errors()`) — except
+`TopLevelDeclaration`, which postcss accepts (the dominant css-in-js shape).
+What oxfmt does with the `Err` differs by entry point: standalone files
+report it as a diagnostic (NO Prettier fallback), while the css-in-js
+dispatcher falls back to Prettier. Since the raffia fork (plan Step 6),
+value/selector-position `${}` placeholders parse on the Rust path, so that
+fallback is a pure safety net: what still `Err`s is garbage Prettier can't
+format either (e.g. `foo\n${a}\n${b}` bare words — Prettier's embed throws
+too and the template prints as-is).
 
 ### Architecture notes (Prettier mapping)
 
@@ -74,7 +86,64 @@ Positional cursor over `CssComment { span, inline }` (`inline` = `//`).
 
 `cargo run -p oxc_prettier_conformance` —
 **css 114/114, scss 85/85, less 39/39 — ALL 100%.**
-Keep it that way: any change here must re-run the conformance suite.
+
+Wired into oxfmt: standalone css/scss/less files AND the
+css-in-js dispatcher route (`apps/oxfmt`). The embedded suite
+(`pnpm conformance` in `apps/oxfmt`) also exercises this crate via
+`format_to_ir`; re-run it for printer changes too.
+
+Keep them that way: any change here must re-run the conformance suite.
+
+### css-in-js specifics
+
+- `format_to_ir` input contains `@prettier-placeholder-N-id` markers for
+  `${}` interpolations. raffia parses statement-position markers as
+  at-rules (a `;`-less one SWALLOWS the following statements into its
+  prelude); value/selector-position markers parse via the fork option
+  (see Overview) — `format_to_ir` passes `tolerate_placeholders: true`
+- Value-position placeholders are `ComponentValue::TokenWithSpan` and mostly
+  ride the existing gap-based separator rules (glued → `Tight`, spaced →
+  `Line`). ONE added rule: placeholder glued to a paren group separates with
+  `Separator::SoftBreak` (Prettier's `isAtWordPlaceholderNode +
+isParenGroupNode → softline`: `${fn}(30px)` breaks BEFORE the parens)
+- Selector-position placeholders trigger "garbage mode"
+  (`write_selector_list`): postcss-selector-parser degrades on at-words, so
+  from the selector containing the FIRST placeholder onwards Prettier prints
+  near-verbatim — our port emits the raw source slice with whitespace runs
+  collapsed to single spaces, never breaking. Commas BEFORE the first
+  placeholder still split selectors normally. Detection is a source-text
+  scan for `@prettier-placeholder-`
+- Ignored (`prettier-ignore`) `;`-less placeholder at-rule at EOF VANISHES
+  (`write_statement_sequence`): postcss leaves no `source.end` on it, so
+  Prettier's `printIgnored` slices an empty string. Reproduced for
+  placeholder at-rules ONLY — the resulting placeholder-count mismatch makes
+  the embed fall back to plain template printing, like Prettier. For real
+  code (`@foobar`) we deliberately DIVERGE and keep the verbatim text
+  (Prettier silently deletes it; that's a data-loss bug, not a behavior to
+  port)
+- Placeholder at-rules get Prettier's `isTemplatePlaceholderNode`
+  treatment (`write_placeholder_at_rule` in `at_rule.rs`): verbatim
+  prelude (newlines stay literal), gap comments printed not discarded,
+  name-glued `:` collapses following whitespace to one space, `;` only
+  when the source has one
+- `TopLevelDeclaration` is the ONE recoverable error format() accepts
+  (postcss accepts it; it is the dominant css-in-js shape)
+- Custom property values arrive as raw token streams; they are re-parsed
+  as a plain declaration at the same source offsets (prefix blanked
+  BYTE-wise — multi-byte chars! — prop replaced by `a`s) so the value
+  gets the normal group/break layout (`reparse_custom_property_value`)
+- raffia's `Calc` spans EXCLUDE operand parens; `write_calc_operand`
+  recovers them from the source (children account for unbalanced parens
+  inside the span — see the `need_left`/`need_right` math)
+- A source trailing comma in function args survives for `var()` ONLY
+  (Prettier's `printTrailingComma`)
+- Trailing same-line comments are plain content, NOT `line_suffix`:
+  Prettier counts them towards the line width, so they can break the
+  preceding value group
+- Known remaining diffs (webawesome suite, layout-only): Prettier's fill
+  fit-check (`[item, sep, next]`) breaks inside `var(...)` args in long
+  `calc()`s and inside `::slotted()` after a long `:not(...)`, where our
+  fill breaks after the operator / inside `:not(...)` instead
 
 Layout machinery notes discovered en route:
 
@@ -85,6 +154,26 @@ Layout machinery notes discovered en route:
   with static source widths (`write_commented_value_params` /
   `write_commented_media_params` in `at_rule.rs`, the SassImport path,
   the lead-comment fill in `write_value_groups`)
+  - VERDICT on Prettier's fill semantics (assessed 2026-06-11, keep the
+    sims as-is): it is really TWO separate rules with different merit.
+    (A) "a hardline-bearing chunk never fits → it starts on its own line"
+    is RATIONAL — it keeps a comment visually attached to the item it
+    annotates (`// Comment` ends up on its own line BEFORE the next
+    import path, not dangling after the previous one). The sims reproduce
+    rule A, so they are reasoned behavior, not quirk-for-bytes emulation.
+    (B) the pairwise lookahead's side effect of breaking INSIDE short
+    paren groups (`var(\n --x\n ) * 2`, `::slotted(\n *\n )` — the two
+    accepted webawesome diffs) is IRRATIONAL and we deliberately do NOT
+    follow it. Removing the sims was measured (3 fixtures fail: css
+    112/114, scss 84/85 — all comment-torture tests) and rejected: it
+    would drop rational behavior A for consistency's sake. The principled
+    long-term fix, if ever needed, is to teach rule A ALONE to the core
+    fill fit-check (NOT full Prettier fill) — that retires all three sims
+    and keeps the webawesome layout; it requires a JS-conformance impact
+    experiment first since core fill is shared with `oxc_formatter`.
+    Note the sims sit INSIDE the source-rebuild layer for comment-bearing
+    params; the rebuild itself can never be removed (raffia's AST drops
+    params-embedded comments — removing it loses comments, not layout)
 - Prettier's printer counts a multi-line string doc at its FULL width (no
   newline reset), so after a multi-line `raws.between` the first trailing
   comment always wraps → `ValueContext::tail_break`
@@ -129,8 +218,30 @@ Layout machinery notes discovered en route:
 
 ```sh
 cargo check -p oxc_formatter_css
+cargo test -p oxc_formatter_css                                # fixture snapshots (see below)
 cargo run -p oxc_prettier_conformance                          # pass rates
 cargo run -p oxc_prettier_conformance -- --filter css/atrule   # diff a fixture
 cargo run -p oxc_formatter_css --example css_formatter file.css
 cargo run -p oxc_formatter_css --example parse_debug -- --syntax scss file.scss  # dump raffia AST
 ```
+
+### Fixture tests (`tests/fixtures/format/` and `tests/fixtures/embedded/`)
+
+Cases the Prettier conformance suite does NOT cover live here as insta
+snapshots (same harness as `oxc_formatter_json`/`_graphql`): placeholder
+at-rules, custom-property value re-parsing (incl. the multi-byte-comment
+span regression), calc operand parens, An+B normalization, `:has(>)`
+relative combinators, `var()` trailing commas, group-breaking trailing
+comments, top-level declarations. Parse-error fallback triggers are unit
+tests in `tests/fixtures/mod.rs` (`parse_error_is_err`).
+
+Fixtures under `embedded/` route through `format_to_ir` (the css-in-js
+dispatcher entry, placeholders tolerated) instead of `format()`: value /
+selector / paren-softline / ignore-vanish placeholder cases. The
+`embedded_debug` example formats a file the same way for quick comparison
+(`cargo run -p oxc_formatter_css --example embedded_debug file.scss`).
+
+**Every expected output was verified against `prettier@3.8.3` by hand;
+do the same when adding fixtures** (`npx prettier@3.8.3 --parser <variant>`,
+at both `--print-width 80` and `100` — the harness snapshots both).
+Update snapshots with `cargo insta review` (or `INSTA_UPDATE=always cargo test`).

--- a/crates/oxc_formatter_css/Cargo.toml
+++ b/crates/oxc_formatter_css/Cargo.toml
@@ -25,6 +25,7 @@ oxc_span = { workspace = true }
 raffia = { workspace = true }
 
 [dev-dependencies]
+insta = { workspace = true }
 oxc_formatter_core = { workspace = true, features = ["test_harness"] }
 pico-args = { workspace = true }
 

--- a/crates/oxc_formatter_css/build.rs
+++ b/crates/oxc_formatter_css/build.rs
@@ -1,0 +1,15 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use oxc_formatter_core::test_support::{GenerateConfig, generate_tests};
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = PathBuf::from(out_dir).join("generated_tests.rs");
+
+    let config = GenerateConfig { extensions: &["css", "scss", "less"] };
+
+    generate_tests(&dest_path, Path::new("tests/fixtures"), &config).unwrap();
+}

--- a/crates/oxc_formatter_css/examples/embedded_debug.rs
+++ b/crates/oxc_formatter_css/examples/embedded_debug.rs
@@ -1,0 +1,65 @@
+//! Format a CSS/SCSS/Less fragment through the embedded entry point
+//! (`format_to_ir`), the dispatcher path oxfmt uses for css-in-js.
+//! Unlike `css_formatter`, this tolerates `@prettier-placeholder-N-id`
+//! markers in value/selector position.
+//!
+//! ```sh
+//! cargo run -p oxc_formatter_css --example embedded_debug -- [filename]
+//! ```
+#![expect(clippy::print_stdout, clippy::print_stderr)]
+
+use std::path::Path;
+
+use oxc_allocator::Allocator;
+use oxc_formatter_core::{Document, EmbeddedContext, FormatOptions, Printer, UniqueGroupIdBuilder};
+use oxc_formatter_css::{CssFormatOptions, CssVariant, format_to_ir};
+
+fn main() {
+    let mut args = pico_args::Arguments::from_env();
+    let name = args.free_from_str().unwrap_or_else(|_| "test.scss".to_string());
+    let path = Path::new(&name);
+
+    let source_text = std::fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("Failed to read {}: {err}", path.display()));
+
+    let variant = match path.extension().and_then(|e| e.to_str()) {
+        Some("less") => CssVariant::Less,
+        // The css-in-js dispatcher always parses as SCSS, mirror it.
+        _ => CssVariant::Scss,
+    };
+    // Match Prettier's default print width for side-by-side comparison.
+    let line_width = oxc_formatter_core::LineWidth::try_from(80).unwrap();
+    let options = CssFormatOptions { variant, line_width, ..CssFormatOptions::default() };
+
+    let allocator = Allocator::new();
+    let group_id_builder = UniqueGroupIdBuilder::default();
+    let ctx = EmbeddedContext {
+        allocator: &allocator,
+        group_id_builder: &group_id_builder,
+        dispatcher: None,
+    };
+
+    match format_to_ir(&ctx, &source_text, options) {
+        Ok(elements) => {
+            let document = Document::new(elements, Vec::new());
+            document.propagate_expand();
+            if std::env::var("DUMP_IR").is_ok() {
+                for el in document.elements() {
+                    eprintln!("{el:?}");
+                }
+            }
+            let (elements, tailwind_classes) = document.into_elements_and_tailwind_classes();
+            match Printer::with_capacity(
+                source_text.len(),
+                options.as_print_options(),
+                &tailwind_classes,
+            )
+            .print(elements)
+            {
+                Ok(printed) => println!("{}", printed.into_code()),
+                Err(err) => eprintln!("Print error: {err:?}"),
+            }
+        }
+        Err(diagnostic) => eprintln!("Parse error: {diagnostic:?}"),
+    }
+}

--- a/crates/oxc_formatter_css/src/comments.rs
+++ b/crates/oxc_formatter_css/src/comments.rs
@@ -174,13 +174,8 @@ pub fn flush_leading_comments(value_start: u32, f: &mut CssFormatter<'_, '_>) {
 }
 
 /// If the next pending comment sits on the same line as `prev_end`,
-/// drain it and emit it as a trailing line-suffix comment.
-/// `expand_parent()` keeps the enclosing container multi-line.
-pub fn write_trailing_same_line_comment<'a>(
-    prev_end: u32,
-    upper: u32,
-    f: &mut CssFormatter<'_, 'a>,
-) {
+/// drain it and emit it as a trailing comment.
+pub fn write_trailing_same_line_comment(prev_end: u32, upper: u32, f: &mut CssFormatter<'_, '_>) {
     let Some(comment) = f.context().comments().peek() else { return };
     if comment.span.end > upper {
         return;
@@ -190,11 +185,12 @@ pub fn write_trailing_same_line_comment<'a>(
         return;
     }
     f.context().comments().take_before(comment.span.end);
-    let content = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-        write!(f, space());
-        write_single_comment(comment, f);
-    });
-    write!(f, [line_suffix(&content), expand_parent()]);
+    // Plain content, NOT a line suffix: Prettier prints trailing comments as
+    // regular doc parts, so they count towards the line width during the
+    // preceding value group's fits measurement (`x: min(...); /* long */`
+    // breaks the `min(` group even when the value alone would fit).
+    write!(f, space());
+    write_single_comment(comment, f);
 }
 
 /// Emit comments that sit between the last child of a container and its closing delimiter.

--- a/crates/oxc_formatter_css/src/context.rs
+++ b/crates/oxc_formatter_css/src/context.rs
@@ -15,6 +15,9 @@ pub struct CssFormatContext<'a> {
     in_less_detached: std::cell::Cell<bool>,
     /// Current block nesting depth (rules/at-rules).
     block_depth: std::cell::Cell<u32>,
+    /// The source may contain css-in-js `${}` placeholder markers
+    /// (embedded entry point only); gates the printer's placeholder handling.
+    template_placeholders: bool,
 }
 
 impl<'a> CssFormatContext<'a> {
@@ -22,6 +25,7 @@ impl<'a> CssFormatContext<'a> {
         options: CssFormatOptions,
         source_code: &'a str,
         comments: &'a [CssComment],
+        template_placeholders: bool,
     ) -> Self {
         Self {
             options,
@@ -29,7 +33,13 @@ impl<'a> CssFormatContext<'a> {
             comments: Comments::new(comments),
             in_less_detached: std::cell::Cell::new(false),
             block_depth: std::cell::Cell::new(0),
+            template_placeholders,
         }
+    }
+
+    /// Whether the source may contain css-in-js `${}` placeholder markers.
+    pub fn template_placeholders(&self) -> bool {
+        self.template_placeholders
     }
 
     pub fn block_depth(&self) -> &std::cell::Cell<u32> {

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -29,10 +29,12 @@ pub fn format<'a>(
     options: CssFormatOptions,
 ) -> Result<Formatted<'a, CssFormatContext<'a>>, OxcDiagnostic> {
     let has_bom = source_text.starts_with('\u{feff}');
-    let (stylesheet, source, comments) = parse_stylesheet(allocator, source_text, options)?;
+    let (stylesheet, source, comments) =
+        parse_stylesheet(allocator, source_text, options, /* tolerate_placeholders */ false)?;
     let front_matter = front_matter_end(source).map(|end| &source[..end]);
 
-    let context = CssFormatContext::new(options, source, comments);
+    let context =
+        CssFormatContext::new(options, source, comments, /* template_placeholders */ false);
     let mut state = FormatState::new(context, allocator);
     let mut buffer = VecBuffer::new(&mut state);
 
@@ -63,9 +65,14 @@ pub fn format_to_ir<'a>(
     options: CssFormatOptions,
 ) -> Result<ArenaVec<'a, FormatElement<'a>>, OxcDiagnostic> {
     let allocator = ctx.allocator;
-    let (stylesheet, source, comments) = parse_stylesheet(allocator, source_text, options)?;
+    // The dispatcher input substitutes `${}` interpolations with
+    // `@prettier-placeholder-N-id` markers, which may sit in value or
+    // selector position — tolerate them (raffia fork option).
+    let (stylesheet, source, comments) =
+        parse_stylesheet(allocator, source_text, options, /* tolerate_placeholders */ true)?;
 
-    let context = CssFormatContext::new(options, source, comments);
+    let context =
+        CssFormatContext::new(options, source, comments, /* template_placeholders */ true);
     let mut state = FormatState::new(context, allocator);
     let mut buffer = VecBuffer::new(&mut state);
 
@@ -82,6 +89,7 @@ fn parse_stylesheet<'a>(
     allocator: &'a Allocator,
     source_text: &str,
     options: CssFormatOptions,
+    tolerate_placeholders: bool,
 ) -> Result<(Stylesheet<'a>, &'a str, &'a [CssComment]), OxcDiagnostic> {
     let source_text = source_text.strip_prefix('\u{feff}').unwrap_or(source_text);
     let source: &'a str = allocator.alloc_str(source_text);
@@ -103,11 +111,22 @@ fn parse_stylesheet<'a>(
     let mut comments = vec![];
     let mut parser = ParserBuilder::new(parse_source)
         .syntax(options.variant.to_raffia())
+        .options(raffia::ParserOptions {
+            tolerate_at_keyword_placeholders: tolerate_placeholders,
+            ..raffia::ParserOptions::default()
+        })
         .comments(&mut comments)
         .build();
 
     let stylesheet = parser.parse::<Stylesheet>().map_err(|error| to_diagnostic(&error))?;
-    if let Some(error) = parser.recoverable_errors().first() {
+    // Top-level declarations are recoverable AND accepted by Prettier (postcss
+    // prints them as-is) — the dominant css-in-js shape (`css`display: flex;``),
+    // so they must not bail out. Everything else recoverable still does.
+    if let Some(error) = parser
+        .recoverable_errors()
+        .iter()
+        .find(|error| !matches!(error.kind, raffia::error::ErrorKind::TopLevelDeclaration))
+    {
         return Err(to_diagnostic(error));
     }
     drop(parser);

--- a/crates/oxc_formatter_css/src/lib.rs
+++ b/crates/oxc_formatter_css/src/lib.rs
@@ -18,6 +18,19 @@ mod format;
 mod options;
 mod print;
 
+/// css-in-js `${}` interpolation marker prefix.
+///
+/// The parent (JS) formatter substitutes each interpolation with
+/// `@prettier-placeholder-N-id` before dispatching to [`format_to_ir`].
+/// This is Prettier's wire format — its embed (`replacePlaceholders`)
+/// expects exactly this shape, so the Prettier fallback path relies on it
+/// staying in sync. The producer-side constant lives in `oxc_formatter`'s
+/// `embed/css.rs` (which doesn't depend on this crate); orchestrator-side
+/// consumers (oxfmt) should use these.
+pub const TEMPLATE_PLACEHOLDER_PREFIX: &str = "@prettier-placeholder-";
+/// See [`TEMPLATE_PLACEHOLDER_PREFIX`].
+pub const TEMPLATE_PLACEHOLDER_SUFFIX: &str = "-id";
+
 pub use crate::{
     context::CssFormatContext,
     format::{format, format_to_ir},

--- a/crates/oxc_formatter_css/src/print/at_rule.rs
+++ b/crates/oxc_formatter_css/src/print/at_rule.rs
@@ -4,7 +4,7 @@
 use cow_utils::CowUtils;
 use oxc_formatter_core::{
     Buffer,
-    builders::{group, hard_line_break, indent, soft_line_break_or_space, space, text},
+    builders::{empty_line, group, hard_line_break, indent, soft_line_break_or_space, space, text},
     write,
 };
 use raffia::{
@@ -18,6 +18,7 @@ use raffia::{
 };
 
 use crate::{
+    comments::{Gap, classify_gap},
     format::to_span,
     print::{
         CssFormatter, format_with, scss, selector,
@@ -32,6 +33,16 @@ pub fn write_at_rule<'a>(at_rule: &AtRule<'a>, f: &mut CssFormatter<'_, 'a>) {
     write!(f, "@");
     let name_span = to_span(at_rule.name.span());
     write_maybe_lowercase(source.text_for(&name_span), f);
+
+    // css-in-js `${}` markers at statement position parse as at-rules.
+    // Prettier's `isTemplatePlaceholderNode` rules: the prelude is kept
+    // verbatim (postcss leaves params containing `@` markers as an unparsed
+    // string), the gap after the name maps to nothing/space/hardline/blank
+    // line, and the `;` is printed only when the source has one.
+    if at_rule.name.raw.starts_with("prettier-placeholder") {
+        write_placeholder_at_rule(at_rule, f);
+        return;
+    }
 
     // Comments inside the params: postcss keeps them embedded in the params
     // string / media tokens; reconstruct from the source.
@@ -165,6 +176,73 @@ pub fn write_at_rule<'a>(at_rule: &AtRule<'a>, f: &mut CssFormatter<'_, 'a>) {
         write_block(block, f);
     } else {
         write!(f, ";");
+    }
+}
+
+/// `@prettier-placeholder-N-id` at-rule body: verbatim prelude, source-driven
+/// spacing, `;` only when the source has one. See `write_at_rule`.
+fn write_placeholder_at_rule<'a>(at_rule: &AtRule<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    if let Some(prelude) = &at_rule.prelude {
+        let name_end = to_span(at_rule.name.span()).end;
+        let prelude_span = to_span(prelude.span());
+        let bytes = source.as_bytes();
+
+        let mut pos = name_end;
+        if pos == prelude_span.start && bytes[pos as usize] == b':' {
+            // A `:` glued to the name: postcss folds it into the NAME itself
+            // and Prettier collapses any whitespace after it to one space
+            // (`${foo}:\n${bar}` joins back onto one line).
+            write!(f, ":");
+            pos += 1;
+            if pos < prelude_span.end && bytes[pos as usize].is_ascii_whitespace() {
+                write!(f, space());
+                while pos < prelude_span.end && bytes[pos as usize].is_ascii_whitespace() {
+                    pos += 1;
+                }
+            }
+        } else {
+            // A `;`-less placeholder swallows the FOLLOWING statements into
+            // its prelude, so their leading comments land in this gap; print
+            // them with source line structure instead of discarding them.
+            for &comment in &f.context().comments().take_before(prelude_span.start).to_vec() {
+                write_placeholder_gap(source, pos, comment.span.start, f);
+                crate::comments::write_single_comment(comment, f);
+                pos = comment.span.end;
+            }
+            write_placeholder_gap(source, pos, prelude_span.start, f);
+            pos = prelude_span.start;
+        }
+
+        // The rest is verbatim; embedded newlines stay literal (both Prettier
+        // and the parent template printer treat them as `literalline`s).
+        write!(f, text(source.slice_range(pos, prelude_span.end)));
+        let _ = f.context().comments().take_before(prelude_span.end);
+    }
+    if at_rule.block.is_some() {
+        write_block_or_semicolon(at_rule, f);
+    } else {
+        let end = to_span(at_rule.span()).end;
+        if crate::print::statement::end_with_semicolon(end, f) > end {
+            write!(f, ";");
+        }
+    }
+}
+
+/// Source-driven separator inside a placeholder at-rule (see above).
+fn write_placeholder_gap(
+    source: oxc_formatter_core::SourceText<'_>,
+    start: u32,
+    end: u32,
+    f: &mut CssFormatter<'_, '_>,
+) {
+    if start == end {
+        return;
+    }
+    match classify_gap(source.bytes_range(start, end)) {
+        Gap::None => write!(f, space()),
+        Gap::Line => write!(f, hard_line_break()),
+        Gap::Blank => write!(f, empty_line()),
     }
 }
 

--- a/crates/oxc_formatter_css/src/print/mod.rs
+++ b/crates/oxc_formatter_css/src/print/mod.rs
@@ -113,7 +113,24 @@ pub fn write_statement_sequence_bounded<'a>(
         flush_leading_comments(start, f);
         if suppressed {
             let end = statement::stmt_end(stmt, f);
-            write!(f, oxc_formatter_core::builders::text(source.slice_range(start, end)));
+            // Prettier quirk: an ignored `;`-less at-rule left unclosed at EOF
+            // has no `source.end` in postcss, so `printIgnored` slices an
+            // empty string and the statement VANISHES. We reproduce this for
+            // placeholder at-rules only — there it is load-bearing (the
+            // placeholder count mismatch makes the css-in-js embed fall back
+            // to plain template printing, like Prettier) — but not for real
+            // code, where silently deleting an ignored statement is a bug.
+            let placeholder_vanishes =
+                matches!(
+                    stmt,
+                    raffia::ast::Statement::AtRule(at_rule)
+                        if at_rule.block.is_none()
+                            && at_rule.name.raw.starts_with("prettier-placeholder")
+                ) && !source.slice_range(start, end).trim_end().ends_with(';')
+                    && source[end as usize..].trim().is_empty();
+            if !placeholder_vanishes {
+                write!(f, oxc_formatter_core::builders::text(source.slice_range(start, end)));
+            }
         } else {
             statement::write_statement(stmt, f);
         }

--- a/crates/oxc_formatter_css/src/print/selector.rs
+++ b/crates/oxc_formatter_css/src/print/selector.rs
@@ -14,8 +14,9 @@ use raffia::{
     ast::{
         AttributeSelector, AttributeSelectorMatcherKind, AttributeSelectorValue, Combinator,
         CombinatorKind, ComplexSelector, ComplexSelectorChild, CompoundSelector, InterpolableIdent,
-        NsPrefixKind, PseudoClassSelector, PseudoClassSelectorArgKind, PseudoElementSelector,
-        PseudoElementSelectorArgKind, SelectorList, SimpleSelector, TypeSelector, WqName,
+        NsPrefixKind, Nth, NthIndex, PseudoClassSelector, PseudoClassSelectorArgKind,
+        PseudoElementSelector, PseudoElementSelectorArgKind, SelectorList, SimpleSelector,
+        TypeSelector, WqName,
     },
 };
 
@@ -39,6 +40,25 @@ pub fn write_selector_list<'a>(
     style: SelectorListStyle,
     f: &mut CssFormatter<'_, 'a>,
 ) {
+    // css-in-js `${}` placeholders (raffia fork's
+    // `tolerate_at_keyword_placeholders`): postcss-selector-parser degrades
+    // on at-words — everything from the selector containing the first
+    // placeholder onwards becomes one garbage token soup whose commas no
+    // longer split selectors. Prettier then prints it near-verbatim:
+    // whitespace runs collapse to single spaces and the line never breaks.
+    // Selectors BEFORE the first placeholder still split normally.
+    // Only the embedded entry point can contain placeholders; the gate also
+    // keeps a literal marker inside e.g. an attribute value (`[x="@prettier"]`)
+    // in a standalone file from triggering garbage mode.
+    let placeholder_idx = if f.context().template_placeholders() {
+        let source = f.context().source_text();
+        list.selectors.iter().position(|complex| {
+            source.text_for(&to_span(complex.span())).contains(crate::TEMPLATE_PLACEHOLDER_PREFIX)
+        })
+    } else {
+        None
+    };
+
     let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
         for (i, complex) in list.selectors.iter().enumerate() {
             if i > 0 {
@@ -69,6 +89,22 @@ pub fn write_selector_list<'a>(
             for &comment in f.context().comments().take_before(start) {
                 crate::comments::write_single_comment(comment, f);
                 write!(f, hard_line_break());
+            }
+            if placeholder_idx == Some(i) {
+                let source = f.context().source_text();
+                let end = to_span(list.selectors[list.selectors.len() - 1].span()).end;
+                let raw = source.slice_range(start, end);
+                let mut collapsed = oxc_allocator::StringBuilder::new_in(f.allocator());
+                for (k, word) in raw.split_ascii_whitespace().enumerate() {
+                    if k > 0 {
+                        collapsed.push_str(" ");
+                    }
+                    collapsed.push_str(word);
+                }
+                // Comments inside the chunk are part of the verbatim text.
+                let _ = f.context().comments().take_before(end);
+                write!(f, text(collapsed.into_str()));
+                return;
             }
             write_complex_selector(complex, f);
         }
@@ -286,8 +322,8 @@ fn write_pseudo_class_arg<'a>(kind: &PseudoClassSelectorArgKind<'a>, f: &mut Css
                     write!(f, soft_line_break_or_space());
                 }
                 if let Some(combinator) = &selector.combinator {
+                    // `is_last: false` already appends the space after `>`.
                     write_combinator(combinator, true, false, f);
-                    write!(f, " ");
                 }
                 write_complex_selector(&selector.complex_selector, f);
             }
@@ -305,13 +341,99 @@ fn write_pseudo_class_arg<'a>(kind: &PseudoClassSelectorArgKind<'a>, f: &mut Css
             }
         }
         PseudoClassSelectorArgKind::Ident(ident) => write_interpolable_ident(ident, f),
-        // Nth, Number, LanguageRangeList, TokenSeq, LessExtendList:
+        PseudoClassSelectorArgKind::Nth(nth) => write_nth(nth, f),
+        // Number, LanguageRangeList, TokenSeq, LessExtendList:
         // print the source verbatim (normalized below where needed).
         _ => {
             let span = to_span(kind.span());
             write!(f, text(source.text_for(&span)));
         }
     }
+}
+
+/// `:nth-child()` argument. postcss-selector-parser tokenizes `An+B` so that
+/// a `+` becomes a combinator (printed with one space on both sides) while a
+/// `-` stays glued inside the word; digit-led words land in
+/// `selector-unknown` and get `maybeToLowerCase`d, letter-led ones are tags
+/// and keep their case. `odd`/`even`/integers print verbatim.
+fn write_nth<'a>(nth: &Nth<'a>, f: &mut CssFormatter<'_, 'a>) {
+    let source = f.context().source_text();
+    let index_span = to_span(nth.index.span());
+    let raw = source.text_for(&index_span);
+    match &nth.index {
+        NthIndex::AnPlusB(_) => {
+            let normalized = normalize_an_plus_b(raw);
+            match normalized {
+                Cow::Borrowed(s) => write!(f, text(s)),
+                Cow::Owned(s) => write!(f, text(f.allocator().alloc_str(&s))),
+            }
+        }
+        NthIndex::Odd(_) | NthIndex::Even(_) | NthIndex::Integer(_) => {
+            write!(f, text(raw));
+        }
+    }
+    if let Some(matcher) = &nth.matcher {
+        write!(f, " ");
+        let matcher_span = to_span(matcher.span());
+        if let Some(selector) = &matcher.selector {
+            // The `of` keyword as written, then the selector list.
+            let keyword_end = to_span(selector.span()).start;
+            let keyword = source.slice_range(matcher_span.start, keyword_end).trim_ascii_end();
+            write!(f, [text(keyword), " "]);
+            write_selector_list_inline(selector, f);
+        } else {
+            write!(f, text(source.text_for(&matcher_span)));
+        }
+    }
+}
+
+/// Normalize an `An+B` expression: exactly one space around each `+`
+/// (none before a leading `+`), digit-led segments lowercased, all other
+/// whitespace kept as-is (a glued `-` stays glued).
+fn normalize_an_plus_b(raw: &str) -> Cow<'_, str> {
+    let bytes = raw.as_bytes();
+    if !bytes.iter().any(|&b| b == b'+' || b.is_ascii_uppercase()) {
+        return Cow::Borrowed(raw);
+    }
+
+    let mut out = String::with_capacity(raw.len() + 4);
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'+' {
+            while out.ends_with(' ') {
+                out.pop();
+            }
+            if !out.is_empty() {
+                out.push(' ');
+            }
+            out.push('+');
+            i += 1;
+            while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            if i < bytes.len() {
+                out.push(' ');
+            }
+        } else if b.is_ascii_whitespace() {
+            out.push(b as char);
+            i += 1;
+        } else {
+            let start = i;
+            while i < bytes.len() && !bytes[i].is_ascii_whitespace() && bytes[i] != b'+' {
+                i += 1;
+            }
+            let segment = &raw[start..i];
+            if segment.as_bytes()[0].is_ascii_digit() {
+                for c in segment.chars() {
+                    out.push(c.to_ascii_lowercase());
+                }
+            } else {
+                out.push_str(segment);
+            }
+        }
+    }
+    Cow::Owned(out)
 }
 
 /// Selector list inside pseudo args: `,` + line.

--- a/crates/oxc_formatter_css/src/print/statement.rs
+++ b/crates/oxc_formatter_css/src/print/statement.rs
@@ -305,6 +305,23 @@ fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter<'_, 'a>) {
             // The raw text includes any comments; drop them from the cursor.
             let _ = f.context().comments().take_before(value_end);
         } else {
+            // Custom property values come back from raffia as a raw token
+            // stream (per spec, `<declaration-value>` is any token soup), but
+            // Prettier (postcss) value-parses them like any other declaration,
+            // so `var(...)` etc. get the normal group/break layout.
+            let reparsed = if prop.starts_with("--")
+                && decl
+                    .value
+                    .iter()
+                    .all(|v| matches!(v, raffia::ast::ComponentValue::TokenWithSpan(_)))
+            {
+                reparse_custom_property_value(decl, f)
+            } else {
+                None
+            };
+            let values: &[raffia::ast::ComponentValue<'a>] =
+                reparsed.as_ref().map_or(&decl.value, |d| &d.value);
+
             let ctx = ValueContext {
                 decl_prop: Some(prop_lower),
                 // Prettier applies `removeLines` to `composes` values.
@@ -327,9 +344,9 @@ fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter<'_, 'a>) {
             // `prop: <values> { decls }` — a trailing nested block hugs the
             // declaration; leading values are space-joined flat.
             if let Some(raffia::ast::ComponentValue::SassNestingDeclaration(nesting)) =
-                decl.value.last()
+                values.last()
             {
-                for v in &decl.value[..decl.value.len() - 1] {
+                for v in &values[..values.len() - 1] {
                     value::write_component_value(v, ctx, f);
                     write!(f, space());
                 }
@@ -342,13 +359,13 @@ fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter<'_, 'a>) {
                 let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
                     write!(f, hard_line_break());
                     let inner = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-                        value::write_declaration_value(&decl.value, ctx, f);
+                        value::write_declaration_value(values, ctx, f);
                     });
                     write!(f, oxc_formatter_core::builders::dedent(&inner));
                 });
                 write!(f, indent(&body));
             } else {
-                value::write_declaration_value(&decl.value, ctx, f);
+                value::write_declaration_value(values, ctx, f);
             }
         }
     }
@@ -367,6 +384,53 @@ fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter<'_, 'a>) {
             write!(f, space());
         }
     }
+}
+
+/// Re-parse a custom property's raw token-stream value as a normal
+/// declaration so the value gets the standard group/break layout.
+///
+/// The declaration is rebuilt at the same source offsets — the prefix is
+/// blanked out and the `--name` prop replaced by a same-length plain ident —
+/// so every span in the re-parsed value stays valid against the original
+/// source (Prettier pulls the same offset-preserving trick for
+/// custom-property rule blocks in `parser-postcss.js`).
+///
+/// Returns `None` (caller keeps the token stream) when the value does not
+/// parse as a plain declaration value.
+fn reparse_custom_property_value<'a>(
+    decl: &Declaration<'a>,
+    f: &CssFormatter<'_, 'a>,
+) -> Option<Declaration<'a>> {
+    let source = f.context().source_text();
+    let decl_span = to_span(decl.span());
+    let name_span = to_span(decl.name.span());
+
+    let mut padded = String::with_capacity(decl_span.end as usize);
+    for c in source.slice_range(0, name_span.start).chars() {
+        if c == '\n' || c == '\r' {
+            padded.push(c);
+        } else {
+            // One space per BYTE (not per char): spans are byte offsets, so a
+            // multi-byte char (e.g. `º` in a comment) must keep its width.
+            for _ in 0..c.len_utf8() {
+                padded.push(' ');
+            }
+        }
+    }
+    for _ in name_span.start..name_span.end {
+        padded.push('a');
+    }
+    padded.push_str(source.slice_range(name_span.end, decl_span.end));
+
+    let allocator = f.allocator();
+    let padded: &'a str = allocator.alloc_str(&padded);
+    let syntax = f.options().variant.to_raffia();
+    let mut parser = raffia::ParserBuilder::new(padded).syntax(syntax).build();
+    let reparsed = parser.parse::<Declaration>().ok()?;
+    if !parser.recoverable_errors().is_empty() {
+        return None;
+    }
+    Some(reparsed)
 }
 
 /// Prints a `--prop: { a: b; c: d }` rule-block value by re-flowing the raw

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -776,6 +776,9 @@ pub fn write_comma_group<'a>(
                 _ if ctx.no_break => {
                     filler.entry(&text(" "), &content);
                 }
+                Separator::SoftBreak => {
+                    filler.entry(&soft_line_break(), &content);
+                }
                 _ => {
                     filler.entry(&soft_line_break_or_space(), &content);
                 }
@@ -830,6 +833,8 @@ enum Separator {
     Tight,
     /// Plain space, no break opportunity (word before a math operator).
     Space,
+    /// Breakable, no space when flat (placeholder glued to a paren group).
+    SoftBreak,
     /// Breakable space.
     Line,
     /// Forced line break (grid rows).
@@ -1039,6 +1044,19 @@ fn separator_between(
             let require_space = wordish(Some(curr)) || wordish(values.get(i.wrapping_sub(2)));
             return if gap_empty && !require_space { Separator::Tight } else { Separator::Line };
         }
+    }
+
+    // Prettier: an at-word placeholder glued to a paren group gets a
+    // `softline` (`${fn}(30px)` may break BEFORE the parens, keeping the
+    // paren group intact on the next line).
+    if gap_empty
+        && matches!(raw_token(prev), Some(raffia::token::Token::AtKeyword(_)))
+        && matches!(
+            curr,
+            ComponentValue::SassParenthesizedExpression(_) | ComponentValue::SassMap(_)
+        )
+    {
+        return Separator::SoftBreak;
     }
 
     // Raw token fallbacks (postcss-values would have produced operator/word
@@ -1371,13 +1389,13 @@ fn write_calc<'a>(
     };
 
     let head = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-        write_component_value(&calc.left, ctx, f);
+        write_calc_operand(&calc.left, ctx, f);
         if gap_before_op {
             write!(f, " ");
         }
         write!(f, token(op_str));
         if !gap_after_op {
-            write_component_value(&calc.right, ctx, f);
+            write_calc_operand(&calc.right, ctx, f);
         }
     });
 
@@ -1385,7 +1403,7 @@ fn write_calc<'a>(
         let body = format_with(move |f: &mut CssFormatter<'_, 'a>| {
             let mut filler = f.fill();
             let right = format_with(move |f: &mut CssFormatter<'_, 'a>| {
-                write_component_value(&calc.right, ctx, f);
+                write_calc_operand(&calc.right, ctx, f);
             });
             filler.entry(&soft_line_break_or_space(), &head);
             filler.entry(&soft_line_break_or_space(), &right);
@@ -1394,6 +1412,83 @@ fn write_calc<'a>(
         write!(f, group(&indent(&body)));
     } else {
         head.fmt(f);
+    }
+}
+
+/// A calc operand, restoring ONE pair of parens from the source when present.
+///
+/// raffia folds `(a - b) * c` into nested `Calc` nodes whose spans EXCLUDE
+/// the parens, so they must be recovered from the source (postcss keeps them
+/// as a `value-paren_group` and Prettier preserves them). Only an operand
+/// position can do this safely: at the top of `calc(...)` the function's own
+/// parens are indistinguishable from a redundant pair.
+fn write_calc_operand<'a>(
+    operand: &ComponentValue<'a>,
+    ctx: ValueContext<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    let bytes = source.as_bytes();
+    let span = to_span(operand.span());
+
+    // The span may already contain unbalanced parens belonging to CHILD
+    // operands, whose own pairs also sit outside their spans
+    // (`(a - 1) * b` spans from `a`). Those are reprinted by the child's own
+    // `write_calc_operand` call; the operand has a pair of its OWN only when
+    // a further `(`/`)` exists beyond what the children account for.
+    let mut depth = 0i32;
+    let mut min_depth = 0i32;
+    for &b in &bytes[span.start as usize..span.end as usize] {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                min_depth = min_depth.min(depth);
+            }
+            _ => {}
+        }
+    }
+    // `[need_left x '('] span [need_right x ')']` balances to zero.
+    let need_left = -min_depth;
+    let need_right = depth - min_depth;
+
+    let own_open = {
+        let mut skip = need_left;
+        bytes[..span.start as usize]
+            .iter()
+            .rev()
+            .filter(|b| !b.is_ascii_whitespace())
+            .take_while(|&&b| b == b'(')
+            .any(|_| {
+                if skip == 0 {
+                    return true;
+                }
+                skip -= 1;
+                false
+            })
+    };
+    let own_close = {
+        let mut skip = need_right;
+        bytes[span.end as usize..]
+            .iter()
+            .filter(|b| !b.is_ascii_whitespace())
+            .take_while(|&&b| b == b')')
+            .any(|_| {
+                if skip == 0 {
+                    return true;
+                }
+                skip -= 1;
+                false
+            })
+    };
+    let wrapped = own_open && own_close;
+
+    if wrapped {
+        write!(f, "(");
+    }
+    write_component_value(operand, ctx, f);
+    if wrapped {
+        write!(f, ")");
     }
 }
 
@@ -1441,6 +1536,11 @@ fn write_function<'a>(func: &Function<'a>, ctx: ValueContext<'a>, f: &mut CssFor
     let groups_ref = &groups;
     let r_paren = to_span(func.span()).end.saturating_sub(1);
     let extra_indent = ctx.after_inline_comment;
+    // `var(--baz,)`: an empty fallback is meaningful, so a source trailing
+    // comma is preserved — for `var()` ONLY (Prettier's `printTrailingComma`
+    // checks `isVarFunctionNode`; every other function drops it).
+    let has_trailing_comma = func.args.last().is_some_and(is_comma)
+        && function_name_text(func).eq_ignore_ascii_case("var");
     // Function arguments are "map item" positions (maps break).
     let ctx = ValueContext {
         map_break: true,
@@ -1475,6 +1575,9 @@ fn write_function<'a>(func: &Function<'a>, ctx: ValueContext<'a>, f: &mut CssFor
                 }
             }
             write_comma_group(group_values, ctx, f);
+        }
+        if has_trailing_comma {
+            write!(f, ",");
         }
         // Comments between the last argument and `)` wrap as fill items;
         // `//` comments stay glued to the argument (their hardline follows).

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/options.json
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/options.json
@@ -1,0 +1,1 @@
+[{ "printWidth": 80 }]

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/placeholder-ignore.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/placeholder-ignore.scss
@@ -1,0 +1,5 @@
+color: @prettier-placeholder-0-id;
+/* prettier-ignore */
+@prettier-placeholder-1-id;
+/* prettier-ignore */
+@prettier-placeholder-2-id

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/placeholder-ignore.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/placeholder-ignore.scss.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+color: @prettier-placeholder-0-id;
+/* prettier-ignore */
+@prettier-placeholder-1-id;
+/* prettier-ignore */
+@prettier-placeholder-2-id
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+color: @prettier-placeholder-0-id;
+/* prettier-ignore */
+@prettier-placeholder-1-id;
+/* prettier-ignore */
+
+
+-------------------
+{ printWidth: 100 }
+-------------------
+color: @prettier-placeholder-0-id;
+/* prettier-ignore */
+@prettier-placeholder-1-id;
+/* prettier-ignore */
+
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/placeholder-parens.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/placeholder-parens.scss
@@ -1,0 +1,4 @@
+transform: @prettier-placeholder-0-id(30px);
+transform: @prettier-placeholder-1-id (30px);
+transform: @prettier-placeholder-2-id(@prettier-placeholder-3-idpx);
+some-extra-long-property-name: @prettier-placeholder-4-id(@prettier-placeholder-5-idpx);

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/placeholder-parens.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/placeholder-parens.scss.snap
@@ -1,0 +1,28 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+transform: @prettier-placeholder-0-id(30px);
+transform: @prettier-placeholder-1-id (30px);
+transform: @prettier-placeholder-2-id(@prettier-placeholder-3-idpx);
+some-extra-long-property-name: @prettier-placeholder-4-id(@prettier-placeholder-5-idpx);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+transform: @prettier-placeholder-0-id(30px);
+transform: @prettier-placeholder-1-id (30px);
+transform: @prettier-placeholder-2-id(@prettier-placeholder-3-idpx);
+some-extra-long-property-name: @prettier-placeholder-4-id
+  (@prettier-placeholder-5-idpx);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+transform: @prettier-placeholder-0-id(30px);
+transform: @prettier-placeholder-1-id (30px);
+transform: @prettier-placeholder-2-id(@prettier-placeholder-3-idpx);
+some-extra-long-property-name: @prettier-placeholder-4-id(@prettier-placeholder-5-idpx);
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/selector-placeholders.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/selector-placeholders.scss
@@ -1,0 +1,9 @@
+a.@prettier-placeholder-0-id:focus,a.@prettier-placeholder-1-id:hover {
+  color: red;
+}
+.foo,   .bar    @prettier-placeholder-2-id {
+  color: blue;
+}
+& > :not(.@prettier-placeholder-3-id):not(@prettier-placeholder-4-id) {
+  display: flex;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/selector-placeholders.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/selector-placeholders.scss.snap
@@ -1,0 +1,44 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+a.@prettier-placeholder-0-id:focus,a.@prettier-placeholder-1-id:hover {
+  color: red;
+}
+.foo,   .bar    @prettier-placeholder-2-id {
+  color: blue;
+}
+& > :not(.@prettier-placeholder-3-id):not(@prettier-placeholder-4-id) {
+  display: flex;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+a.@prettier-placeholder-0-id:focus,a.@prettier-placeholder-1-id:hover {
+  color: red;
+}
+.foo,
+.bar @prettier-placeholder-2-id {
+  color: blue;
+}
+& > :not(.@prettier-placeholder-3-id):not(@prettier-placeholder-4-id) {
+  display: flex;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+a.@prettier-placeholder-0-id:focus,a.@prettier-placeholder-1-id:hover {
+  color: red;
+}
+.foo,
+.bar @prettier-placeholder-2-id {
+  color: blue;
+}
+& > :not(.@prettier-placeholder-3-id):not(@prettier-placeholder-4-id) {
+  display: flex;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/value-placeholders.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/value-placeholders.scss
@@ -1,0 +1,5 @@
+border:    1px     @prettier-placeholder-0-id      red;
+grid-area:       area-@prettier-placeholder-1-id;
+foo: @prettier-placeholder-2-id@prettier-placeholder-3-id       @prettier-placeholder-4-id;
+width: @prettier-placeholder-5-id@prettier-placeholder-6-id;
+border: @prettier-placeholder-7-id @prettier-placeholder-8-id solid @prettier-placeholder-9-id;

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/value-placeholders.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/value-placeholders.scss.snap
@@ -1,0 +1,32 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+border:    1px     @prettier-placeholder-0-id      red;
+grid-area:       area-@prettier-placeholder-1-id;
+foo: @prettier-placeholder-2-id@prettier-placeholder-3-id       @prettier-placeholder-4-id;
+width: @prettier-placeholder-5-id@prettier-placeholder-6-id;
+border: @prettier-placeholder-7-id @prettier-placeholder-8-id solid @prettier-placeholder-9-id;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+border: 1px @prettier-placeholder-0-id red;
+grid-area: area-@prettier-placeholder-1-id;
+foo: @prettier-placeholder-2-id@prettier-placeholder-3-id
+  @prettier-placeholder-4-id;
+width: @prettier-placeholder-5-id@prettier-placeholder-6-id;
+border: @prettier-placeholder-7-id @prettier-placeholder-8-id solid
+  @prettier-placeholder-9-id;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+border: 1px @prettier-placeholder-0-id red;
+grid-area: area-@prettier-placeholder-1-id;
+foo: @prettier-placeholder-2-id@prettier-placeholder-3-id @prettier-placeholder-4-id;
+width: @prettier-placeholder-5-id@prettier-placeholder-6-id;
+border: @prettier-placeholder-7-id @prettier-placeholder-8-id solid @prettier-placeholder-9-id;
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/calc-operand-parens.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/calc-operand-parens.css
@@ -1,0 +1,5 @@
+.a {
+  width: calc((100% - 1px) / 2);
+  height: calc((100% - (var(--slides-per-page) - 1) * var(--slide-gap)) / var(--slides-per-page));
+  padding: calc(var(--wa-form-control-padding-block) - ((1lh - 1em) / 2)) var(--wa-form-control-padding-inline);
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/calc-operand-parens.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/calc-operand-parens.css.snap
@@ -1,0 +1,35 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+.a {
+  width: calc((100% - 1px) / 2);
+  height: calc((100% - (var(--slides-per-page) - 1) * var(--slide-gap)) / var(--slides-per-page));
+  padding: calc(var(--wa-form-control-padding-block) - ((1lh - 1em) / 2)) var(--wa-form-control-padding-inline);
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+.a {
+  width: calc((100% - 1px) / 2);
+  height: calc(
+    (100% - (var(--slides-per-page) - 1) * var(--slide-gap)) /
+      var(--slides-per-page)
+  );
+  padding: calc(var(--wa-form-control-padding-block) - ((1lh - 1em) / 2))
+    var(--wa-form-control-padding-inline);
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+.a {
+  width: calc((100% - 1px) / 2);
+  height: calc((100% - (var(--slides-per-page) - 1) * var(--slide-gap)) / var(--slides-per-page));
+  padding: calc(var(--wa-form-control-padding-block) - ((1lh - 1em) / 2))
+    var(--wa-form-control-padding-inline);
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/custom-property-multibyte-comment.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/custom-property-multibyte-comment.css
@@ -1,0 +1,4 @@
+:host {
+  /* The diamond corners are mitred at 22.5º to merge any arrow border. */
+  --arrow-size-diagonal: calc((var(--arrow-size) + var(--arrow-base-offset)) * 0.7071);
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/custom-property-multibyte-comment.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/custom-property-multibyte-comment.css.snap
@@ -1,0 +1,29 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+:host {
+  /* The diamond corners are mitred at 22.5º to merge any arrow border. */
+  --arrow-size-diagonal: calc((var(--arrow-size) + var(--arrow-base-offset)) * 0.7071);
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+:host {
+  /* The diamond corners are mitred at 22.5º to merge any arrow border. */
+  --arrow-size-diagonal: calc(
+    (var(--arrow-size) + var(--arrow-base-offset)) * 0.7071
+  );
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+:host {
+  /* The diamond corners are mitred at 22.5º to merge any arrow border. */
+  --arrow-size-diagonal: calc((var(--arrow-size) + var(--arrow-base-offset)) * 0.7071);
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/custom-property-value-break.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/custom-property-value-break.css
@@ -1,0 +1,6 @@
+:host {
+  /* 80 columns exactly: stays flat (so does Prettier) */
+  --pulse-color: var(--wa-color-border-loud, var(--wa-color-brand-border-loud));
+  /* re-parsed as a normal value: breaks like any declaration */
+  --slide-size: calc((100% - (var(--slides-per-page) - 1) * var(--slide-gap)) / var(--slides-per-page));
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/custom-property-value-break.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/custom-property-value-break.css.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+:host {
+  /* 80 columns exactly: stays flat (so does Prettier) */
+  --pulse-color: var(--wa-color-border-loud, var(--wa-color-brand-border-loud));
+  /* re-parsed as a normal value: breaks like any declaration */
+  --slide-size: calc((100% - (var(--slides-per-page) - 1) * var(--slide-gap)) / var(--slides-per-page));
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+:host {
+  /* 80 columns exactly: stays flat (so does Prettier) */
+  --pulse-color: var(--wa-color-border-loud, var(--wa-color-brand-border-loud));
+  /* re-parsed as a normal value: breaks like any declaration */
+  --slide-size: calc(
+    (100% - (var(--slides-per-page) - 1) * var(--slide-gap)) /
+      var(--slides-per-page)
+  );
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+:host {
+  /* 80 columns exactly: stays flat (so does Prettier) */
+  --pulse-color: var(--wa-color-border-loud, var(--wa-color-brand-border-loud));
+  /* re-parsed as a normal value: breaks like any declaration */
+  --slide-size: calc(
+    (100% - (var(--slides-per-page) - 1) * var(--slide-gap)) / var(--slides-per-page)
+  );
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/nth-an-plus-b.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/nth-an-plus-b.css
@@ -1,0 +1,19 @@
+a:nth-child(n+3) { color: red; }
+b:nth-child(2n+1) { color: red; }
+c:nth-child(-n+3) { color: red; }
+d:nth-child(2n-1) { color: red; }
+e:nth-child(odd) { color: red; }
+f:nth-child(2n) { color: red; }
+g:nth-child( +3n - 2 ) { color: red; }
+h:nth-child(5) { color: red; }
+i:nth-of-type(2N+1) { color: red; }
+j:nth-child(2n + 1 of li.important) { color: red; }
+k:nth-child(2n - 1) { color: red; }
+l:nth-child(2n -1) { color: red; }
+m:nth-child(2n- 1) { color: red; }
+n:nth-child(ODD) { color: red; }
+o:nth-child(N) { color: red; }
+p:nth-child(2N) { color: red; }
+q:nth-last-child(N+3) { color: red; }
+r:nth-child(0n+5) { color: red; }
+s:nth-child(2n+1   of   LI.foo) { color: red; }

--- a/crates/oxc_formatter_css/tests/fixtures/format/nth-an-plus-b.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/nth-an-plus-b.css.snap
@@ -1,0 +1,148 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+a:nth-child(n+3) { color: red; }
+b:nth-child(2n+1) { color: red; }
+c:nth-child(-n+3) { color: red; }
+d:nth-child(2n-1) { color: red; }
+e:nth-child(odd) { color: red; }
+f:nth-child(2n) { color: red; }
+g:nth-child( +3n - 2 ) { color: red; }
+h:nth-child(5) { color: red; }
+i:nth-of-type(2N+1) { color: red; }
+j:nth-child(2n + 1 of li.important) { color: red; }
+k:nth-child(2n - 1) { color: red; }
+l:nth-child(2n -1) { color: red; }
+m:nth-child(2n- 1) { color: red; }
+n:nth-child(ODD) { color: red; }
+o:nth-child(N) { color: red; }
+p:nth-child(2N) { color: red; }
+q:nth-last-child(N+3) { color: red; }
+r:nth-child(0n+5) { color: red; }
+s:nth-child(2n+1   of   LI.foo) { color: red; }
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+a:nth-child(n + 3) {
+  color: red;
+}
+b:nth-child(2n + 1) {
+  color: red;
+}
+c:nth-child(-n + 3) {
+  color: red;
+}
+d:nth-child(2n-1) {
+  color: red;
+}
+e:nth-child(odd) {
+  color: red;
+}
+f:nth-child(2n) {
+  color: red;
+}
+g:nth-child(+ 3n - 2) {
+  color: red;
+}
+h:nth-child(5) {
+  color: red;
+}
+i:nth-of-type(2n + 1) {
+  color: red;
+}
+j:nth-child(2n + 1 of li.important) {
+  color: red;
+}
+k:nth-child(2n - 1) {
+  color: red;
+}
+l:nth-child(2n -1) {
+  color: red;
+}
+m:nth-child(2n- 1) {
+  color: red;
+}
+n:nth-child(ODD) {
+  color: red;
+}
+o:nth-child(N) {
+  color: red;
+}
+p:nth-child(2n) {
+  color: red;
+}
+q:nth-last-child(N + 3) {
+  color: red;
+}
+r:nth-child(0n + 5) {
+  color: red;
+}
+s:nth-child(2n + 1 of LI.foo) {
+  color: red;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+a:nth-child(n + 3) {
+  color: red;
+}
+b:nth-child(2n + 1) {
+  color: red;
+}
+c:nth-child(-n + 3) {
+  color: red;
+}
+d:nth-child(2n-1) {
+  color: red;
+}
+e:nth-child(odd) {
+  color: red;
+}
+f:nth-child(2n) {
+  color: red;
+}
+g:nth-child(+ 3n - 2) {
+  color: red;
+}
+h:nth-child(5) {
+  color: red;
+}
+i:nth-of-type(2n + 1) {
+  color: red;
+}
+j:nth-child(2n + 1 of li.important) {
+  color: red;
+}
+k:nth-child(2n - 1) {
+  color: red;
+}
+l:nth-child(2n -1) {
+  color: red;
+}
+m:nth-child(2n- 1) {
+  color: red;
+}
+n:nth-child(ODD) {
+  color: red;
+}
+o:nth-child(N) {
+  color: red;
+}
+p:nth-child(2n) {
+  color: red;
+}
+q:nth-last-child(N + 3) {
+  color: red;
+}
+r:nth-child(0n + 5) {
+  color: red;
+}
+s:nth-child(2n + 1 of LI.foo) {
+  color: red;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/options.json
+++ b/crates/oxc_formatter_css/tests/fixtures/format/options.json
@@ -1,0 +1,1 @@
+[{ "printWidth": 80 }]

--- a/crates/oxc_formatter_css/tests/fixtures/format/relative-selector-combinator.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/relative-selector-combinator.css
@@ -1,0 +1,6 @@
+[part~="control"]:has(> input:focus-visible:not(:disabled)) {
+  outline: red;
+}
+.a:has(+ .b, ~ .c) {
+  color: red;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/relative-selector-combinator.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/relative-selector-combinator.css.snap
@@ -1,0 +1,33 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+[part~="control"]:has(> input:focus-visible:not(:disabled)) {
+  outline: red;
+}
+.a:has(+ .b, ~ .c) {
+  color: red;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+[part~="control"]:has(> input:focus-visible:not(:disabled)) {
+  outline: red;
+}
+.a:has(+ .b, ~ .c) {
+  color: red;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+[part~="control"]:has(> input:focus-visible:not(:disabled)) {
+  outline: red;
+}
+.a:has(+ .b, ~ .c) {
+  color: red;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/template-placeholder.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/template-placeholder.scss
@@ -1,0 +1,22 @@
+@prettier-placeholder-0-id @prettier-placeholder-1-id
+html {
+  margin: 0;
+}
+
+@prettier-placeholder-2-id:hover {
+  fill: rebeccapurple;
+}
+
+@prettier-placeholder-3-id: @prettier-placeholder-4-id;
+
+@prettier-placeholder-5-id:
+@prettier-placeholder-6-id;
+
+@prettier-placeholder-7-id
+/* a comment */
+
+.aRule {
+  color: red;
+}
+
+@prettier-placeholder-8-id

--- a/crates/oxc_formatter_css/tests/fixtures/format/template-placeholder.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/template-placeholder.scss.snap
@@ -1,0 +1,79 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+@prettier-placeholder-0-id @prettier-placeholder-1-id
+html {
+  margin: 0;
+}
+
+@prettier-placeholder-2-id:hover {
+  fill: rebeccapurple;
+}
+
+@prettier-placeholder-3-id: @prettier-placeholder-4-id;
+
+@prettier-placeholder-5-id:
+@prettier-placeholder-6-id;
+
+@prettier-placeholder-7-id
+/* a comment */
+
+.aRule {
+  color: red;
+}
+
+@prettier-placeholder-8-id
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+@prettier-placeholder-0-id @prettier-placeholder-1-id
+html {
+  margin: 0;
+}
+
+@prettier-placeholder-2-id:hover {
+  fill: rebeccapurple;
+}
+
+@prettier-placeholder-3-id: @prettier-placeholder-4-id;
+
+@prettier-placeholder-5-id: @prettier-placeholder-6-id;
+
+@prettier-placeholder-7-id
+/* a comment */
+
+.aRule {
+  color: red;
+}
+
+@prettier-placeholder-8-id
+
+-------------------
+{ printWidth: 100 }
+-------------------
+@prettier-placeholder-0-id @prettier-placeholder-1-id
+html {
+  margin: 0;
+}
+
+@prettier-placeholder-2-id:hover {
+  fill: rebeccapurple;
+}
+
+@prettier-placeholder-3-id: @prettier-placeholder-4-id;
+
+@prettier-placeholder-5-id: @prettier-placeholder-6-id;
+
+@prettier-placeholder-7-id
+/* a comment */
+
+.aRule {
+  color: red;
+}
+
+@prettier-placeholder-8-id
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/top-level-declaration.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/format/top-level-declaration.scss
@@ -1,0 +1,6 @@
+display: flex;
+color: red;
+
+&:hover {
+  color: blue;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/top-level-declaration.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/top-level-declaration.scss.snap
@@ -1,0 +1,33 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+display: flex;
+color: red;
+
+&:hover {
+  color: blue;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+display: flex;
+color: red;
+
+&:hover {
+  color: blue;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+display: flex;
+color: red;
+
+&:hover {
+  color: blue;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/trailing-comment-breaks-group.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/trailing-comment-breaks-group.css
@@ -1,0 +1,3 @@
+.a {
+  border-radius: min(calc(var(--wa-form-control-toggle-size) * 0.375), var(--wa-border-radius-s)); /* min prevents entirely circular checkbox */
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/trailing-comment-breaks-group.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/trailing-comment-breaks-group.css.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+.a {
+  border-radius: min(calc(var(--wa-form-control-toggle-size) * 0.375), var(--wa-border-radius-s)); /* min prevents entirely circular checkbox */
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+.a {
+  border-radius: min(
+    calc(var(--wa-form-control-toggle-size) * 0.375),
+    var(--wa-border-radius-s)
+  ); /* min prevents entirely circular checkbox */
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+.a {
+  border-radius: min(
+    calc(var(--wa-form-control-toggle-size) * 0.375),
+    var(--wa-border-radius-s)
+  ); /* min prevents entirely circular checkbox */
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/var-trailing-comma.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/var-trailing-comma.css
@@ -1,0 +1,9 @@
+a {
+  color: var(--baz,);
+}
+b {
+  color: var(--baz1, --baz2 , );
+}
+c {
+  margin: min(1px , );
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/var-trailing-comma.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/var-trailing-comma.css.snap
@@ -1,0 +1,42 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+a {
+  color: var(--baz,);
+}
+b {
+  color: var(--baz1, --baz2 , );
+}
+c {
+  margin: min(1px , );
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+a {
+  color: var(--baz,);
+}
+b {
+  color: var(--baz1, --baz2,);
+}
+c {
+  margin: min(1px);
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+a {
+  color: var(--baz,);
+}
+b {
+  color: var(--baz1, --baz2,);
+}
+c {
+  margin: min(1px);
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -1,0 +1,175 @@
+//! Fixture tests for cases the Prettier conformance suite does NOT cover
+//! (discovered while wiring the crate into oxfmt — plan Step 5).
+//!
+//! Every `.css`/`.scss`/`.less` file under `fixtures/format/` is formatted
+//! with each option set from the nearest `options.json` and snapshotted next
+//! to it. Expected outputs were verified against `prettier@3.8.3` by hand;
+//! when adding a fixture, do the same (`npx prettier@3.8.3 --parser <v>`).
+
+use std::path::Path;
+
+use oxc_allocator::Allocator;
+use oxc_formatter_core::{
+    IndentStyle, IndentWidth, LineEnding, LineWidth,
+    test_support::{FixtureFormatter, OptionSet, build_fixture_snapshot},
+};
+use oxc_formatter_css::{CssFormatOptions, CssVariant, format};
+
+struct CssHarness;
+
+impl FixtureFormatter for CssHarness {
+    type Options = CssFormatOptions;
+
+    fn parse_options(json: &OptionSet) -> Self::Options {
+        let mut options = CssFormatOptions::default();
+
+        for (key, value) in json {
+            match key.as_str() {
+                "printWidth" => {
+                    if let Some(n) = value.as_u64()
+                        && let Ok(width) = LineWidth::try_from(u16::try_from(n).unwrap())
+                    {
+                        options.line_width = width;
+                    }
+                }
+                "tabWidth" => {
+                    if let Some(n) = value.as_u64()
+                        && let Ok(width) = IndentWidth::try_from(u8::try_from(n).unwrap())
+                    {
+                        options.indent_width = width;
+                    }
+                }
+                "useTabs" => {
+                    if let Some(b) = value.as_bool() {
+                        options.indent_style =
+                            if b { IndentStyle::Tab } else { IndentStyle::Space };
+                    }
+                }
+                "endOfLine" => {
+                    if let Some(s) = value.as_str() {
+                        options.line_ending = match s {
+                            "lf" => LineEnding::Lf,
+                            "crlf" => LineEnding::Crlf,
+                            "cr" => LineEnding::Cr,
+                            _ => LineEnding::default(),
+                        };
+                    }
+                }
+                "singleQuote" => {
+                    if let Some(b) = value.as_bool() {
+                        options.single_quote = b.into();
+                    }
+                }
+                "trailingComma" => {
+                    if let Some(s) = value.as_str() {
+                        options.trailing_commas = match s {
+                            "none" => oxc_formatter_css::TrailingCommas::Never,
+                            _ => oxc_formatter_css::TrailingCommas::Always,
+                        };
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        options
+    }
+
+    fn format(source: &str, path: &Path, options: &Self::Options) -> String {
+        // The dialect comes from the fixture extension, like oxfmt's classifier.
+        let variant = match path.extension().and_then(|e| e.to_str()) {
+            Some("scss") => CssVariant::Scss,
+            Some("less") => CssVariant::Less,
+            _ => CssVariant::Css,
+        };
+        let options = CssFormatOptions { variant, ..*options };
+
+        // Fixtures under `embedded/` exercise the dispatcher entry point
+        // (`format_to_ir`, css-in-js), which tolerates
+        // `@prettier-placeholder-N-id` markers in value/selector position.
+        if path.components().any(|c| c.as_os_str() == "embedded") {
+            return format_embedded(source, options);
+        }
+
+        let allocator = Allocator::default();
+        format(&allocator, source, options)
+            .expect("format should succeed")
+            .print()
+            .expect("print should succeed")
+            .into_code()
+    }
+}
+
+/// Format through `format_to_ir` and print the raw IR, mirroring what the
+/// oxfmt dispatcher + parent template printing do (minus `${}` substitution).
+fn format_embedded(source: &str, options: CssFormatOptions) -> String {
+    use oxc_formatter_core::{Document, EmbeddedContext, FormatOptions, Printer};
+
+    let allocator = Allocator::default();
+    let group_id_builder = oxc_formatter_core::UniqueGroupIdBuilder::default();
+    let ctx = EmbeddedContext {
+        allocator: &allocator,
+        group_id_builder: &group_id_builder,
+        dispatcher: None,
+    };
+    let elements =
+        oxc_formatter_css::format_to_ir(&ctx, source, options).expect("format should succeed");
+    let document = Document::new(elements, Vec::new());
+    document.propagate_expand();
+    let (elements, tailwind_classes) = document.into_elements_and_tailwind_classes();
+    let mut code =
+        Printer::with_capacity(source.len(), options.as_print_options(), &tailwind_classes)
+            .print(elements)
+            .expect("print should succeed")
+            .into_code();
+    // The embedded entry point emits no trailing newline (the parent owns it);
+    // add one so snapshots stay diff-friendly.
+    code.push('\n');
+    code
+}
+
+fn test_file(path: &Path) {
+    // `insta::assert_snapshot!` is invoked from this file so the snapshot's
+    // `source:` header records this consumer crate, not the shared harness.
+    let snap = build_fixture_snapshot::<CssHarness>(path);
+    insta::with_settings!({
+        snapshot_path => snap.path,
+        prepend_module_to_snapshot => false,
+        snapshot_suffix => "",
+        omit_expression => true,
+    }, {
+        insta::assert_snapshot!(snap.name, snap.body);
+    });
+}
+
+// Include auto-generated test functions from build.rs
+include!(concat!(env!("OUT_DIR"), "/generated_tests.rs"));
+
+// ---
+
+/// Any parse error must surface as `Err` (the oxfmt Prettier-fallback
+/// trigger), including raffia's recoverable ones — EXCEPT top-level
+/// declarations, which postcss accepts (see `top-level-declaration.scss`).
+#[test]
+fn parse_error_is_err() {
+    let allocator = Allocator::default();
+    let css = CssFormatOptions::default();
+    let scss = CssFormatOptions { variant: CssVariant::Scss, ..css };
+    for (source, options) in [
+        // Unclosed block (postcss also rejects this).
+        ("a {\n  color: red;\n", css),
+        // IE star hack: postcss tolerates it, raffia does not -> fallback.
+        ("a { *zoom: 1; }", css),
+        // css-in-js `${}` markers in value position...
+        ("a { color: @prettier-placeholder-0-id; }", scss),
+        // ...and in selector position stay errors in the STANDALONE entry
+        // (`format_to_ir` tolerates them via the raffia fork option;
+        // see `fixtures/embedded/`).
+        (".a-@prettier-placeholder-0-id {\n}", scss),
+        // `2N-1` with a glued minus is invalid An+B for raffia
+        // (postcss-selector-parser accepts and lowercases it).
+        ("a:nth-child(2N-1) { color: red; }", css),
+    ] {
+        assert!(format(&allocator, source, options).is_err(), "{source:?} should fail to format");
+    }
+}

--- a/crates/oxc_formatter_css/tests/mod.rs
+++ b/crates/oxc_formatter_css/tests/mod.rs
@@ -1,0 +1,1 @@
+mod fixtures;


### PR DESCRIPTION
- Use `oxc_formatter_css` from Oxfmt to handle CSS/LESS/SCSS files
- css-in-js is also handled by `oxc_formatter_css`
  - But it will fallback to Prettier if formatting failed
  - No fallback for no-embedded path
- At the point of this PR, it will fallback to Prettier when tailwind is required to format

NOTE: Both fallback will be removed in later PR.

In that sense, as a result of this series of PRs, Oxfmt's CSS support will no longer be 100% compatible compared to Prettier.

Since the parsers used are also different, it will no longer be possible to support certain postcss-plugin-specific syntax, invalid syntax or legacy syntax.

> [!WARNING]
> TODO: Move fork under `oxc-project` org and replace refs