### PR TITLE
refactor(formatter_css): update `oxc_formatter_css` to support `sortTailwindcss` option

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -50,7 +50,9 @@ When it returns an error (e.g. draft-spec syntax that Prettier's `graphql-js` ac
 
 Embedded languages (e.g. css-in-js) go through `src/core/external_formatter.rs`, which assembles a `FormatDispatcher` (defined in `oxc_formatter_core`) that maps each language to a Rust formatter where implemented (currently GraphQL and CSS/SCSS/Less) and to the Prettier Doc→IR path otherwise.
 
-JSDoc fenced code blocks (` ```css ` etc.) use a separate string-in/string-out channel (the `embedded_callback` in the same file, NOT the dispatcher): css/scss/less/graphql format via the Rust crates (variant derived from the fence language), unimplemented languages go to Prettier, and parse errors keep the block verbatim — no Prettier fallback, no diagnostics (it's inside a comment). CSS stays on the Prettier path while Tailwind sorting is enabled (`@apply`).
+JSDoc fenced code blocks use a separate string-in/string-out channel (the `embedded_callback` in the same file, NOT the dispatcher): css/scss/less/graphql format via the Rust crates (variant derived from the fence language), unimplemented languages go to Prettier, and parse errors keep the block verbatim = no Prettier fallback, no diagnostics (it's inside a comment).
+
+Tailwind class sorting (`sortTailwindcss`) splits responsibilities: Rust collects classes (`className` etc. in JS/TS, `@apply` in CSS — incl. css-in-js and JSDoc fenced blocks) into `FormatElement::TailwindClass`, and the JS side sorts them in one batch (`sortTailwindClasses` → tailwind's `getClassOrder`, which needs the resolved Tailwind config). Across embedded boundaries the child's classes travel in `DispatchResult::tailwind_classes` and the parent merges them with `DispatchResult::remap_tailwind_into` (defined in `oxc_formatter_core`; a forgotten merge trips a printer `debug_assert` instead of silently dropping classes). No CSS goes to Prettier for this; the pure Rust build never collects (no sorter available).
 
 Consequently, managing these various formatter implementations and handling their respective options are also part of Oxfmt's responsibilities.
 

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -260,6 +260,8 @@ impl ExternalFormatter {
         let embedded_callback: Option<EmbeddedFormatterCallback> = if needs_embedded {
             let format_embedded = Arc::clone(&self.format_embedded);
             let options_for_embedded = options.clone();
+            let sort_tailwind =
+                tailwind_enabled.then(|| Arc::clone(&self.sort_tailwindcss_classes));
             Some(Arc::new(move |language: &str, code: &str| {
                 // Rust implementations first (JSDoc fenced code blocks).
                 // Unlike the dispatcher there is NO Prettier fallback: on `Err`
@@ -269,11 +271,18 @@ impl ExternalFormatter {
                     "graphql" | "gql" => {
                         return format_graphql_embedded(code, graphql_options);
                     }
-                    // `@apply` class sorting only happens in
-                    // `prettier-plugin-tailwindcss`, so css must stay on the
-                    // Prettier path while it is enabled.
-                    "css" | "scss" | "less" if !tailwind_enabled => {
-                        return format_css_embedded(code, language, css_options);
+                    "css" | "scss" | "less" => {
+                        // `options_for_embedded` already carries the Tailwind
+                        // plugin payload (filepath, config paths) the JS-side
+                        // sorter resolves the class order from.
+                        return match &sort_tailwind {
+                            Some(sort) => {
+                                let sorter =
+                                    |classes: Vec<String>| sort(&options_for_embedded, classes);
+                                format_css_embedded(code, language, css_options, Some(&sorter))
+                            }
+                            None => format_css_embedded(code, language, css_options, None),
+                        };
                     }
                     _ => {}
                 }
@@ -310,8 +319,6 @@ impl ExternalFormatter {
         // Rust implementations replace branches one by one;
         // the rest go through the Prettier Doc→IR fallback.
         let dispatcher: Option<FormatDispatcher> = if needs_embedded {
-            // `@apply` class sorting only happens in `prettier-plugin-tailwindcss`,
-            // so css-in-js must stay on the Prettier path while it is enabled.
             let prettier_fallback =
                 build_prettier_fallback(Arc::clone(&self.format_embedded_doc), options.clone());
             Some(Arc::new(
@@ -335,7 +342,7 @@ impl ExternalFormatter {
                         // value/selector position (plan Step 6), this is a pure
                         // safety net: what still errors is garbage that
                         // Prettier's embed cannot format either.
-                        "css" | "scss" | "less" if !tailwind_enabled => {
+                        "css" | "scss" | "less" => {
                             format_css_to_irs(ctx, texts, css_options).or_else(|err| {
                                 debug!(
                                     "`oxc_formatter_css` failed, falling back to Prettier: {err}"
@@ -413,6 +420,7 @@ fn format_css_embedded(
     code: &str,
     language: &str,
     options: CssFormatOptions,
+    sorter: Option<oxc_formatter_css::TailwindSorter<'_>>,
 ) -> Result<String, String> {
     debug_span!("oxfmt::external::format_css_embedded", language = language).in_scope(|| {
         let variant = match language {
@@ -422,8 +430,8 @@ fn format_css_embedded(
         };
         let options = CssFormatOptions { variant, ..options };
         let allocator = Allocator::default();
-        let formatted =
-            oxc_formatter_css::format(&allocator, code, options).map_err(|err| err.to_string())?;
+        let formatted = oxc_formatter_css::format(&allocator, code, options, sorter)
+            .map_err(|err| err.to_string())?;
         print_embedded_block(formatted)
     })
 }
@@ -466,7 +474,7 @@ fn format_graphql_to_irs<'a>(
             })
         })
         .collect::<Result<Vec<_>, String>>()?;
-    Ok(DispatchResult { docs, meta: None })
+    Ok(DispatchResult { docs, tailwind_classes: Vec::new(), meta: None })
 }
 
 /// Format the single joined CSS text (placeholders included) via
@@ -489,7 +497,7 @@ fn format_css_to_irs<'a>(
         return Err(format!("CSS dispatch expects exactly one text, got {}", texts.len()));
     };
     debug_span!("oxfmt::external::format_css_to_ir").in_scope(|| {
-        let mut ir =
+        let (mut ir, tailwind_classes) =
             oxc_formatter_css::format_to_ir(ctx, text, options).map_err(|err| err.to_string())?;
         let placeholder_count = from_prettier_doc::merge_texts_and_count_css_placeholders(
             &mut ir,
@@ -498,6 +506,7 @@ fn format_css_to_irs<'a>(
         );
         Ok(DispatchResult {
             docs: vec![ir],
+            tailwind_classes,
             meta: Some(Box::new(CssEmbedMeta { placeholder_count })),
         })
     })

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -73,8 +73,8 @@ pub enum FormatStrategy {
     },
     /// For CSS/SCSS/Less files formatted by `oxc_formatter_css`.
     /// Parse errors are surfaced as diagnostics — no Prettier fallback.
-    /// `config` is retained (napi only) solely to route to Prettier up front
-    /// when it enables Tailwind class sorting (not implemented in Rust yet).
+    /// `config` is retained (napi only) to build the JS-side Tailwind class
+    /// sorter options when Tailwind sorting is enabled.
     OxcFormatterCss {
         path: Arc<Path>,
         format_options: Box<CssFormatOptions>,
@@ -494,9 +494,10 @@ impl SourceFormatter {
     /// (e.g. IE star hacks). Both the napi and pure builds report the
     /// diagnostic as-is.
     ///
-    /// When the config enables Tailwind class sorting (`@apply` sorting lives in
-    /// `prettier-plugin-tailwindcss`, not implemented in Rust yet), the napi
-    /// build routes to Prettier up front to keep the sorting behavior.
+    /// When the config enables Tailwind class sorting, the napi build passes
+    /// a JS-side sorter for the `@apply` classes the formatter collects
+    /// (the order itself comes from the Tailwind config, which only the JS
+    /// side can resolve). The pure build never collects classes.
     #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter_css", skip_all)]
     fn format_by_oxc_formatter_css(
         &self,
@@ -506,25 +507,17 @@ impl SourceFormatter {
         #[cfg(feature = "napi")] config: &FormatConfig,
     ) -> Result<String, OxcDiagnostic> {
         #[cfg(feature = "napi")]
-        if config.is_tailwind_enabled() {
-            let parser_name = match format_options.variant {
-                CssVariant::Css => "css",
-                CssVariant::Scss => "scss",
-                CssVariant::Less => "less",
-            };
-            return self.format_by_external_formatter(
-                source_text,
-                path,
-                parser_name,
-                config,
-                /* supports_tailwind */ true,
-                /* supports_oxfmt */ false,
-                /* supports_svelte */ false,
-            );
-        }
+        let sorter = self.tailwind_sorter(config, path);
+        #[cfg(not(feature = "napi"))]
+        let sorter: Option<fn(Vec<String>) -> Vec<String>> = None;
 
         let allocator = self.allocator_pool.get();
-        let formatted = oxc_formatter_css::format(&allocator, source_text, format_options)?;
+        let formatted = oxc_formatter_css::format(
+            &allocator,
+            source_text,
+            format_options,
+            sorter.as_ref().map(|s| s as &dyn Fn(Vec<String>) -> Vec<String>),
+        )?;
         let printed = formatted.print().map_err(|err| {
             OxcDiagnostic::error(format!(
                 "Failed to print formatted CSS: {}\n{err}",
@@ -558,6 +551,34 @@ impl SourceFormatter {
         self
     }
 
+    /// Build the Prettier options JSON shared by the embedded callbacks and
+    /// the Tailwind sorter: resolved config + `filepath` + the Tailwind
+    /// plugin payload (which the JS-side sorter resolves the class order from).
+    fn build_external_options(config: &FormatConfig, path: &Path) -> serde_json::Value {
+        let mut external_options = to_prettier(config);
+        inject_filepath(&mut external_options, path);
+        inject_tailwind_plugin_payload(&mut external_options, config);
+        external_options
+    }
+
+    /// Build the JS-side Tailwind class sorter for `oxc_formatter_css`'s
+    /// `@apply` collection, or `None` when the config does not enable it.
+    fn tailwind_sorter(
+        &self,
+        config: &FormatConfig,
+        path: &Path,
+    ) -> Option<impl Fn(Vec<String>) -> Vec<String>> {
+        config.is_tailwind_enabled().then(|| {
+            let external_formatter = self
+                .external_formatter
+                .as_ref()
+                .expect("`external_formatter` must exist when `napi` feature is enabled");
+            let sort = std::sync::Arc::clone(&external_formatter.sort_tailwindcss_classes);
+            let external_options = Self::build_external_options(config, path);
+            move |classes: Vec<String>| sort(&external_options, classes)
+        })
+    }
+
     /// Build external callbacks for `oxc_formatter` from the NAPI external formatter.
     ///
     /// Tailwind is always considered "capable" here because `oxc_formatter`
@@ -574,9 +595,7 @@ impl SourceFormatter {
             .as_ref()
             .expect("`external_formatter` must exist when `napi` feature is enabled");
 
-        let mut external_options = to_prettier(config);
-        inject_filepath(&mut external_options, path);
-        inject_tailwind_plugin_payload(&mut external_options, config);
+        let external_options = Self::build_external_options(config, path);
 
         // Dual mapping of the same resolved config for the dispatcher's Rust branches.
         // Cannot fail here: building `JsFormatOptions` from this config already succeeded,

--- a/apps/oxfmt/src/core/options/to_oxc_formatter_css.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter_css.rs
@@ -39,6 +39,13 @@ pub fn to_oxc_formatter_css(
             TrailingCommaConfig::None => TrailingCommas::Never,
         };
     }
+    // [Oxfmt] sortTailwindcss: collect `@apply` classes for batch sorting.
+    // The sorter itself is JS-side, so this stays off in the pure Rust build
+    // (classes would print as-is anyway, but skipping collection is cheaper).
+    #[cfg(feature = "napi")]
+    {
+        options.sort_tailwindcss = config.is_tailwind_enabled();
+    }
 
     Ok(options)
 }

--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -68,7 +68,7 @@ pub fn to_format_elements_for_template<'a>(
                     Ok(ir)
                 })
                 .collect::<Result<Vec<_>, String>>()?;
-            Ok(DispatchResult { docs: irs, meta: None })
+            Ok(DispatchResult { docs: irs, tailwind_classes: Vec::new(), meta: None })
         }
         "css" => {
             let (mut ir, _) = convert(
@@ -85,6 +85,9 @@ pub fn to_format_elements_for_template<'a>(
             );
             Ok(DispatchResult {
                 docs: vec![ir],
+                // Prettier's plugin sorts `@apply` in-place during its own
+                // formatting, so the Doc path never carries classes to remap.
+                tailwind_classes: Vec::new(),
                 meta: Some(Box::new(CssEmbedMeta { placeholder_count })),
             })
         }
@@ -105,6 +108,7 @@ pub fn to_format_elements_for_template<'a>(
             );
             Ok(DispatchResult {
                 docs: vec![ir],
+                tailwind_classes: Vec::new(),
                 meta: Some(Box::new(HtmlEmbedMeta {
                     placeholder_count,
                     has_multiple_root_elements: html_has_multiple_root_elements,
@@ -124,7 +128,7 @@ pub fn to_format_elements_for_template<'a>(
                 TemplateEscape::RawBacktick,
                 None,
             );
-            Ok(DispatchResult { docs: vec![ir], meta: None })
+            Ok(DispatchResult { docs: vec![ir], tailwind_classes: Vec::new(), meta: None })
         }
         _ => unreachable!("Unsupported embedded_doc language: {language}"),
     }

--- a/apps/oxfmt/test/api/sort_tailwindcss.test.ts
+++ b/apps/oxfmt/test/api/sort_tailwindcss.test.ts
@@ -1245,4 +1245,67 @@ describe("Tailwind CSS Sorting in CSS (@apply)", () => {
     expect(result.code).toContain("@apply flex p-4;");
     expect(result.errors).toStrictEqual([]);
   });
+
+  // The cases below mirror prettier-plugin-tailwindcss's `transformCss`;
+  // every expected output was verified against prettier@3.8.3 + the plugin.
+  it("should keep a !important tail unsorted", async () => {
+    const input = `.y { @apply p-4 flex !important; }`;
+
+    const result = await format("test.css", input, { sortTailwindcss: {} });
+
+    expect(result.code).toContain("@apply flex p-4 !important;");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should keep a SCSS #{!important} interpolation tail unsorted", async () => {
+    const input = `.s { @apply p-4 flex #{!important}; }`;
+
+    const result = await format("test.scss", input, { sortTailwindcss: {} });
+
+    expect(result.code).toContain("@apply flex p-4 #{!important};");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it('should sort inside a Less ~"..." escaped-string wrapper', async () => {
+    const input = `.z { @apply ~"p-4 flex"; }`;
+
+    const result = await format("test.less", input, { sortTailwindcss: {} });
+
+    expect(result.code).toContain('@apply ~"flex p-4";');
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should dedup and collapse whitespace via the sorter", async () => {
+    const input = `.d { @apply  p-4   flex  p-4; }`;
+
+    const result = await format("test.css", input, { sortTailwindcss: {} });
+
+    expect(result.code).toContain("@apply flex p-4;");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should sort @apply inside css-in-js template literals", async () => {
+    const input = ["const A = styled.div`", "  @apply p-4 flex;", "  color: red;", "`;"].join("\n");
+
+    const result = await format("test.ts", input, { sortTailwindcss: {} });
+
+    expect(result.code).toContain("@apply flex p-4;");
+    expect(result.errors).toStrictEqual([]);
+  });
+
+  it("should sort @apply in fenced css blocks in JSDoc", async () => {
+    const input = [
+      "/**",
+      " * ```css",
+      " * .c { @apply p-4 flex; }",
+      " * ```",
+      " */",
+      "export const C = 1;",
+    ].join("\n");
+
+    const result = await format("test.ts", input, { sortTailwindcss: {}, jsdoc: {} });
+
+    expect(result.code).toContain("@apply flex p-4;");
+    expect(result.errors).toStrictEqual([]);
+  });
 });

--- a/crates/oxc_formatter/src/formatter/context.rs
+++ b/crates/oxc_formatter/src/formatter/context.rs
@@ -123,6 +123,14 @@ impl std::fmt::Debug for JsFormatContext<'_> {
     }
 }
 
+/// Lets embedded children's classes merge into this context's index space
+/// (`DispatchResult::remap_tailwind_into` at each embed site).
+impl oxc_formatter_core::TailwindCollector for JsFormatContext<'_> {
+    fn add_class(&mut self, class: String) -> usize {
+        self.add_tailwind_class(class)
+    }
+}
+
 impl oxc_formatter_core::FormatContext for JsFormatContext<'_> {
     type Options = JsFormatOptions;
 

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -39,7 +39,7 @@ pub(super) fn format_css_doc<'a>(
 
         let allocator = f.allocator();
         let group_id_builder = f.group_id_builder();
-        let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
+        let Some(Ok(mut result)) = f.context().external_callbacks().dispatch_embedded(
             allocator,
             group_id_builder,
             "css",
@@ -47,6 +47,7 @@ pub(super) fn format_css_doc<'a>(
         ) else {
             return false;
         };
+        result.remap_tailwind_into(f.context_mut());
         let Some(ir) = result.into_single_doc() else {
             return false;
         };
@@ -75,7 +76,7 @@ pub(super) fn format_css_doc<'a>(
     // Phase 2: Format via the dispatcher (IR path)
     let allocator = f.allocator();
     let group_id_builder = f.group_id_builder();
-    let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
+    let Some(Ok(mut result)) = f.context().external_callbacks().dispatch_embedded(
         allocator,
         group_id_builder,
         "css",
@@ -91,9 +92,6 @@ pub(super) fn format_css_doc<'a>(
     else {
         return false;
     };
-    let Some(ir) = result.into_single_doc() else {
-        return false;
-    };
 
     // Verify all placeholders survived SCSS formatting.
     // Some edge cases (e.g. `/* prettier-ignore */` before a placeholder without semicolon)
@@ -104,6 +102,11 @@ pub(super) fn format_css_doc<'a>(
     if placeholder_count != expressions.len() {
         return false;
     }
+
+    result.remap_tailwind_into(f.context_mut());
+    let Some(ir) = result.into_single_doc() else {
+        return false;
+    };
 
     // Phase 3: Replace placeholders in IR with expressions
     let indent_width = f.options().indent_width;

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -55,7 +55,7 @@ pub(super) fn format_html_doc<'a>(
 
         let allocator = f.allocator();
         let group_id_builder = f.group_id_builder();
-        let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
+        let Some(Ok(mut result)) = f.context().external_callbacks().dispatch_embedded(
             allocator,
             group_id_builder,
             embedded_language,
@@ -63,6 +63,10 @@ pub(super) fn format_html_doc<'a>(
         ) else {
             return false;
         };
+        // No-op today (the Prettier Doc path never carries classes), but the
+        // boundary contract is "merge at every embed site" — a Rust HTML
+        // formatter collecting `class` attributes will rely on this.
+        result.remap_tailwind_into(f.context_mut());
         let Some(html_has_multiple_root_elements) = result
             .meta
             .as_ref()
@@ -115,7 +119,7 @@ pub(super) fn format_html_doc<'a>(
     // Phase 2: Format via the dispatcher (IR path)
     let allocator = f.allocator();
     let group_id_builder = f.group_id_builder();
-    let Some(Ok(result)) = f.context().external_callbacks().dispatch_embedded(
+    let Some(Ok(mut result)) = f.context().external_callbacks().dispatch_embedded(
         allocator,
         group_id_builder,
         embedded_language,
@@ -134,6 +138,8 @@ pub(super) fn format_html_doc<'a>(
         // but it also requires placeholder replacement, which is non-trivial.
         return format_js_in_html_as_fallback(joined, &expressions, f);
     };
+    // See the Phase 0 note: no-op today, load-bearing once HTML is Rust.
+    result.remap_tailwind_into(f.context_mut());
     let Some((placeholder_count, html_has_multiple_root_elements)) = result
         .meta
         .as_ref()

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -60,6 +60,11 @@ pub struct DispatchResult<'a> {
     /// One IR per input text (usually one; GraphQL returns one per quasi).
     /// Each IR is arena-allocated alongside its elements.
     pub docs: Vec<ArenaVec<'a, FormatElement<'a>>>,
+    /// Pre-sort Tailwind classes referenced by the docs'
+    /// `FormatElement::TailwindClass` indices (0-based, local to this result).
+    /// The receiving parent MUST merge them into its own class space via
+    /// [`Self::remap_tailwind_into`] — the printer asserts on dangling indices.
+    pub tailwind_classes: Vec<String>,
     /// Child→parent language-specific metadata; the parent downcasts it
     /// (e.g. placeholder survival counts for CSS/HTML).
     pub meta: Option<Box<dyn Any>>,
@@ -71,21 +76,50 @@ impl<'a> DispatchResult<'a> {
     pub fn into_single_doc(self) -> Option<ArenaVec<'a, FormatElement<'a>>> {
         self.docs.into_iter().next()
     }
-}
 
-/// Collector sharing one Tailwind class index space across embedded boundaries.
-///
-/// `FormatElement::TailwindClass(usize)` holds pre-sort class strings by index;
-/// sorting happens in one batch after the entry formatter completes. Parent and
-/// child must allocate indices from the same collector to avoid collisions.
-pub trait TailwindCollector {
-    /// Register a class string, returning its index in the shared space.
-    fn add_class(&mut self, class: String) -> usize;
-}
-
-/// No-op collector for languages without Tailwind support (JSON, GraphQL, …).
-impl TailwindCollector for () {
-    fn add_class(&mut self, _class: String) -> usize {
-        0
+    /// Move the child's pre-sort Tailwind classes into the parent's class
+    /// space and shift the docs' `TailwindClass` indices to match.
+    ///
+    /// Call this once per received dispatch result (a no-op when the child
+    /// collected nothing). The entry formatter's document then sorts all
+    /// collected classes in one host-supplied batch.
+    pub fn remap_tailwind_into(&mut self, collector: &mut dyn TailwindCollector) {
+        let mut classes = std::mem::take(&mut self.tailwind_classes).into_iter();
+        let Some(first) = classes.next() else {
+            return;
+        };
+        // The collector hands out consecutive indices, so the first one is
+        // the base offset for every local index.
+        let base = collector.add_class(first);
+        for class in classes {
+            collector.add_class(class);
+        }
+        for doc in &mut self.docs {
+            for element in doc.iter_mut() {
+                if let FormatElement::TailwindClass(index) = element {
+                    *index += base;
+                }
+            }
+        }
     }
+}
+
+/// Index-space provider for batched Tailwind class sorting.
+///
+/// `FormatElement::TailwindClass(usize)` holds pre-sort class strings by
+/// index; sorting happens in one host-supplied batch when the entry
+/// formatter's document is finalized. A child formatter collects classes
+/// locally (0-based) and returns them in [`DispatchResult::tailwind_classes`];
+/// the receiving parent implements this trait on its format context and
+/// merges them with [`DispatchResult::remap_tailwind_into`].
+///
+/// NOTE: an alternative design — threading one shared collector through
+/// [`EmbeddedContext`] so children allocate parent indices directly — was
+/// considered and deferred: it needs interior mutability plumbing through
+/// every format context for no current gain. Revisit if deep embedding nests
+/// (e.g. css-in-html-in-js at plan Step 8/9) make per-boundary remapping
+/// burdensome.
+pub trait TailwindCollector {
+    /// Register a class string, returning its index in the collector's space.
+    fn add_class(&mut self, class: String) -> usize;
 }

--- a/crates/oxc_formatter_core/src/printer/mod.rs
+++ b/crates/oxc_formatter_core/src/printer/mod.rs
@@ -323,7 +323,17 @@ impl<'a> Printer<'a> {
                 stack.pop(tag.kind())?;
             }
             FormatElement::TailwindClass(index) => {
-                if let Some(text) = self.state.sorted_tailwind_classes.get(*index) {
+                let text = self.state.sorted_tailwind_classes.get(*index);
+                // A dangling index silently DELETES the class list from the
+                // output, so fail loudly in debug builds instead.
+                debug_assert!(
+                    text.is_some(),
+                    "TailwindClass index {index} out of bounds ({} classes) — \
+                     was the embedded IR remapped into the parent's class space \
+                     (`DispatchResult::remap_tailwind_into`)?",
+                    self.state.sorted_tailwind_classes.len(),
+                );
+                if let Some(text) = text {
                     let width = TextWidth::from_text(text, self.options.indent_width);
                     self.print_text(Text::Text { text, width });
                 }

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -18,6 +18,22 @@ Prettier compatible CSS/SCSS/Less formatter, using the `oxc_formatter_core` APIs
     decisions, do not invent new ones
 - Two entry points: `format()` (standalone) and `format_to_ir()` (embedded/dispatcher)
 
+### Tailwind `@apply` sorting (`CssFormatOptions::sort_tailwindcss`)
+
+Ports prettier-plugin-tailwindcss's `transformCss`: the ONLY CSS construct it
+sorts is `@apply` params (`name == "apply"`, case-sensitive). This crate only
+COLLECTS — `write_apply_prelude` (at_rule.rs) splits off the `!important` tail
+(`/\s+(?:!important|#{(['"]*)!important\1})\s*$/`, see `split_important_tail`)
+and Less `~"..."` wrappers, then emits the class list as one
+`FormatElement::TailwindClass(index)`. Sorting (order, dedup, whitespace
+collapse, `{{` skip) is the host-supplied sorter's job: `format()` takes an
+`Option<TailwindSorter>` and bakes the result into the `Document`;
+`format_to_ir()` returns `(IR, Vec<String>)` and the classes travel to the
+parent in `DispatchResult::tailwind_classes`, where the parent merges them
+with `DispatchResult::remap_tailwind_into` (a dangling index trips a printer
+debug_assert). Params containing comments fall back to the normal printers
+(sorting would corrupt them).
+
 ### Error semantics
 
 `format()` / `format_to_ir()` return `Err` on ANY parse error, including

--- a/crates/oxc_formatter_css/examples/css_formatter.rs
+++ b/crates/oxc_formatter_css/examples/css_formatter.rs
@@ -27,7 +27,7 @@ fn main() {
     let options = CssFormatOptions { variant, ..CssFormatOptions::default() };
 
     let allocator = Allocator::new();
-    match format(&allocator, &source_text, options) {
+    match format(&allocator, &source_text, options, None) {
         Ok(formatted) => {
             if std::env::var("DUMP_IR").is_ok() {
                 for el in formatted.document().elements() {

--- a/crates/oxc_formatter_css/examples/embedded_debug.rs
+++ b/crates/oxc_formatter_css/examples/embedded_debug.rs
@@ -40,7 +40,7 @@ fn main() {
     };
 
     match format_to_ir(&ctx, &source_text, options) {
-        Ok(elements) => {
+        Ok((elements, _tailwind_classes)) => {
             let document = Document::new(elements, Vec::new());
             document.propagate_expand();
             if std::env::var("DUMP_IR").is_ok() {

--- a/crates/oxc_formatter_css/src/context.rs
+++ b/crates/oxc_formatter_css/src/context.rs
@@ -18,6 +18,9 @@ pub struct CssFormatContext<'a> {
     /// The source may contain css-in-js `${}` placeholder markers
     /// (embedded entry point only); gates the printer's placeholder handling.
     template_placeholders: bool,
+    /// Pre-sort `@apply` class strings indexed by `FormatElement::TailwindClass`.
+    /// Sorting happens in one host-supplied batch after IR construction.
+    tailwind_classes: Vec<String>,
 }
 
 impl<'a> CssFormatContext<'a> {
@@ -34,7 +37,21 @@ impl<'a> CssFormatContext<'a> {
             in_less_detached: std::cell::Cell::new(false),
             block_depth: std::cell::Cell::new(0),
             template_placeholders,
+            tailwind_classes: Vec::new(),
         }
+    }
+
+    /// Register an `@apply` class string for batch sorting,
+    /// returning its `FormatElement::TailwindClass` index.
+    pub fn add_tailwind_class(&mut self, class: String) -> usize {
+        let index = self.tailwind_classes.len();
+        self.tailwind_classes.push(class);
+        index
+    }
+
+    /// Takes the collected class strings, leaving an empty list.
+    pub fn take_tailwind_classes(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.tailwind_classes)
     }
 
     /// Whether the source may contain css-in-js `${}` placeholder markers.

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -15,7 +15,15 @@ use crate::{
     print::{self, CssFormatter},
 };
 
+/// Host-supplied batch sorter for `@apply` Tailwind classes
+/// (one pre-sort string in, one sorted string out, index-aligned).
+pub type TailwindSorter<'s> = &'s dyn Fn(Vec<String>) -> Vec<String>;
+
 /// Parse `source_text` as a stylesheet and build its formatter IR.
+///
+/// `sort_tailwind_classes` sorts the `@apply` classes collected when
+/// [`CssFormatOptions::sort_tailwindcss`] is on; `None` (or an unset option)
+/// prints them as-is.
 ///
 /// # Errors
 /// Returns an [`OxcDiagnostic`] when the parse produces any error, including
@@ -27,6 +35,7 @@ pub fn format<'a>(
     allocator: &'a Allocator,
     source_text: &str,
     options: CssFormatOptions,
+    sort_tailwind_classes: Option<TailwindSorter<'_>>,
 ) -> Result<Formatted<'a, CssFormatContext<'a>>, OxcDiagnostic> {
     let has_bom = source_text.starts_with('\u{feff}');
     let (stylesheet, source, comments) =
@@ -41,9 +50,15 @@ pub fn format<'a>(
     write!(&mut buffer, FormatCssRoot { stylesheet: &stylesheet, has_bom, front_matter });
 
     let elements = buffer.into_vec();
-    let context = state.into_context();
+    let mut context = state.into_context();
 
-    let ir = Document::new(elements, Vec::new());
+    let tailwind_classes = context.take_tailwind_classes();
+    let sorted_tailwind_classes = match sort_tailwind_classes {
+        Some(sorter) if !tailwind_classes.is_empty() => sorter(tailwind_classes),
+        _ => tailwind_classes,
+    };
+
+    let ir = Document::new(elements, sorted_tailwind_classes);
     ir.propagate_expand();
 
     Ok(Formatted::new(ir, context))
@@ -57,13 +72,19 @@ pub fn format<'a>(
 /// - emits neither a BOM nor the trailing newline
 /// - skips `propagate_expand()`, which the parent runs on the merged document
 ///
+/// Also returns the pre-sort `@apply` Tailwind classes the IR's
+/// `TailwindClass(index)` elements refer to (empty unless
+/// [`CssFormatOptions::sort_tailwindcss`] is on). The parent document owns
+/// the batch sort, so the caller must re-index the elements into the parent's
+/// class space (e.g. `oxc_formatter`'s CSS embed via `CssEmbedMeta`).
+///
 /// # Errors
 /// Same as [`format()`].
 pub fn format_to_ir<'a>(
     ctx: &EmbeddedContext<'a, '_>,
     source_text: &str,
     options: CssFormatOptions,
-) -> Result<ArenaVec<'a, FormatElement<'a>>, OxcDiagnostic> {
+) -> Result<(ArenaVec<'a, FormatElement<'a>>, Vec<String>), OxcDiagnostic> {
     let allocator = ctx.allocator;
     // The dispatcher input substitutes `${}` interpolations with
     // `@prettier-placeholder-N-id` markers, which may sit in value or
@@ -78,7 +99,10 @@ pub fn format_to_ir<'a>(
 
     write!(&mut buffer, FormatCssEmbedded { stylesheet: &stylesheet });
 
-    Ok(buffer.into_vec())
+    let elements = buffer.into_vec();
+    let tailwind_classes = state.context_mut().take_tailwind_classes();
+
+    Ok((elements, tailwind_classes))
 }
 
 /// Parse the source into an AST and collect comments, bailing out on any error.

--- a/crates/oxc_formatter_css/src/lib.rs
+++ b/crates/oxc_formatter_css/src/lib.rs
@@ -7,7 +7,8 @@
 //! use oxc_formatter_css::{CssFormatOptions, format};
 //!
 //! let allocator = Allocator::new();
-//! let formatted = format(&allocator, "a { color: red }", CssFormatOptions::default()).unwrap();
+//! let formatted =
+//!     format(&allocator, "a { color: red }", CssFormatOptions::default(), None).unwrap();
 //! let out = formatted.print().unwrap().into_code();
 //! assert_eq!(out, "a {\n  color: red;\n}\n");
 //! ```
@@ -33,6 +34,6 @@ pub const TEMPLATE_PLACEHOLDER_SUFFIX: &str = "-id";
 
 pub use crate::{
     context::CssFormatContext,
-    format::{format, format_to_ir},
+    format::{TailwindSorter, format, format_to_ir},
     options::{CssFormatOptions, CssVariant, SingleQuote, TrailingCommas},
 };

--- a/crates/oxc_formatter_css/src/options.rs
+++ b/crates/oxc_formatter_css/src/options.rs
@@ -51,6 +51,10 @@ pub struct CssFormatOptions {
     pub single_quote: SingleQuote,
     // Used by: SCSS (maps only)
     pub trailing_commas: TrailingCommas,
+    /// Collect `@apply` classes as `FormatElement::TailwindClass` for batch
+    /// sorting (the sort itself is host-supplied). Mirrors
+    /// `prettier-plugin-tailwindcss`'s CSS transform.
+    pub sort_tailwindcss: bool,
 }
 
 impl CssFormatOptions {

--- a/crates/oxc_formatter_css/src/print/at_rule.rs
+++ b/crates/oxc_formatter_css/src/print/at_rule.rs
@@ -3,7 +3,7 @@
 
 use cow_utils::CowUtils;
 use oxc_formatter_core::{
-    Buffer,
+    Buffer, FormatElement,
     builders::{empty_line, group, hard_line_break, indent, soft_line_break_or_space, space, text},
     write,
 };
@@ -60,6 +60,24 @@ pub fn write_at_rule<'a>(at_rule: &AtRule<'a>, f: &mut CssFormatter<'_, 'a>) {
         .comments()
         .peek()
         .is_some_and(|c| c.span.start >= name_span.end && c.span.end <= region_end);
+
+    // `@apply` with Tailwind sorting enabled: the class list becomes one
+    // `TailwindClass` element, sorted in a host-supplied batch after IR
+    // construction (mirrors prettier-plugin-tailwindcss's `transformCss`,
+    // which matches `name === "apply"` case-sensitively). Params containing
+    // comments are left to the normal printers — sorting would corrupt them.
+    if f.options().sort_tailwindcss
+        && at_rule.name.raw == "apply"
+        && at_rule.block.is_none()
+        && !has_params_comments
+        && let Some(prelude) = &at_rule.prelude
+    {
+        let prelude_span = to_span(prelude.span());
+        if write_apply_prelude(source.text_for(&prelude_span), f) {
+            write!(f, ";");
+            return;
+        }
+    }
     // `//` comments have their own layout rules (e.g. less `selector(...)`)
     // handled by the structural printers below.
     let has_inline_params_comment = f
@@ -177,6 +195,66 @@ pub fn write_at_rule<'a>(at_rule: &AtRule<'a>, f: &mut CssFormatter<'_, 'a>) {
     } else {
         write!(f, ";");
     }
+}
+
+/// Emits `@apply` params with the sortable class list as a single
+/// `FormatElement::TailwindClass`. Returns `false` (nothing written) when
+/// there is nothing sortable, leaving the caller on the normal path.
+///
+/// Ports prettier-plugin-tailwindcss's `transformCss` pre-processing; the
+/// sorter itself (ordering, dedup, whitespace collapse) is host-supplied:
+/// - a `!important` tail (incl. SCSS `#{!important}` interpolation forms)
+///   is kept out of the sortable part and re-attached verbatim
+/// - a Less `~"..."` / `~'...'` escaped-string wrapper is kept and only the
+///   inside is sorted (and a `!important` inside it is NOT special)
+fn write_apply_prelude<'a>(raw: &'a str, f: &mut CssFormatter<'_, 'a>) -> bool {
+    let raw = raw.trim();
+
+    let (wrapper, class_list, important_tail) =
+        if let Some(inner) = raw.strip_prefix("~\"").and_then(|r| r.strip_suffix('"')) {
+            (Some("\""), inner, None)
+        } else if let Some(inner) = raw.strip_prefix("~'").and_then(|r| r.strip_suffix('\'')) {
+            (Some("'"), inner, None)
+        } else {
+            match split_important_tail(raw) {
+                Some((classes, tail)) => (None, classes, Some(tail)),
+                None => (None, raw, None),
+            }
+        };
+
+    let class_list = class_list.trim();
+    if class_list.is_empty() {
+        return false;
+    }
+
+    write!(f, space());
+    if let Some(quote) = wrapper {
+        write!(f, "~");
+        write!(f, text(quote));
+    }
+    let index = f.context_mut().add_tailwind_class(class_list.to_string());
+    f.write_element(FormatElement::TailwindClass(index));
+    if let Some(quote) = wrapper {
+        write!(f, text(quote));
+    }
+    if let Some(tail) = important_tail {
+        write!(f, [space(), text(tail)]);
+    }
+    true
+}
+
+/// Splits off the `!important` tail the Tailwind plugin ignores when sorting:
+/// `/\s+(?:!important|#{(['"]*)!important\1})\s*$/` (whitespace before the
+/// tail is required; matching is case-sensitive like the plugin's).
+/// Returns `(class part, tail text)` when present.
+fn split_important_tail(raw: &str) -> Option<(&str, &str)> {
+    let trimmed = raw.trim_end();
+    ["!important", "#{!important}", "#{'!important'}", "#{\"!important\"}"].iter().find_map(
+        |tail| {
+            let classes = trimmed.strip_suffix(tail)?;
+            classes.ends_with(char::is_whitespace).then_some((classes, *tail))
+        },
+    )
 }
 
 /// `@prettier-placeholder-N-id` at-rule body: verbatim prelude, source-driven
@@ -1551,5 +1629,31 @@ fn write_supports_in_parens<'a>(in_parens: &SupportsInParens<'a>, f: &mut CssFor
             let func_value = raffia::ast::ComponentValue::Function(func.clone());
             value::write_component_value(&func_value, ValueContext::default(), f);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_important_tail;
+
+    #[test]
+    fn important_tail_forms() {
+        // Plugin regex: /\s+(?:!important|#{(['"]*)!important\1})\s*$/
+        assert_eq!(split_important_tail("p-4 flex !important"), Some(("p-4 flex ", "!important")));
+        assert_eq!(split_important_tail("p-4 #{!important}"), Some(("p-4 ", "#{!important}")));
+        assert_eq!(split_important_tail("p-4 #{'!important'}"), Some(("p-4 ", "#{'!important'}")));
+        assert_eq!(
+            split_important_tail("p-4 #{\"!important\"}"),
+            Some(("p-4 ", "#{\"!important\"}"))
+        );
+        // Trailing whitespace after the tail is fine (`\s*$`).
+        assert_eq!(split_important_tail("p-4 !important  "), Some(("p-4 ", "!important")));
+        // Whitespace BEFORE the tail is required (`\s+`).
+        assert_eq!(split_important_tail("p-4!important"), None);
+        assert_eq!(split_important_tail("!important"), None);
+        // Case-sensitive, like the plugin.
+        assert_eq!(split_important_tail("p-4 !IMPORTANT"), None);
+        // Not at the end -> not a tail.
+        assert_eq!(split_important_tail("p-4 !important flex"), None);
     }
 }

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -92,7 +92,7 @@ impl FixtureFormatter for CssHarness {
         }
 
         let allocator = Allocator::default();
-        format(&allocator, source, options)
+        format(&allocator, source, options, None)
             .expect("format should succeed")
             .print()
             .expect("print should succeed")
@@ -113,7 +113,7 @@ fn format_embedded(source: &str, options: CssFormatOptions) -> String {
         dispatcher: None,
     };
     let elements =
-        oxc_formatter_css::format_to_ir(&ctx, source, options).expect("format should succeed");
+        oxc_formatter_css::format_to_ir(&ctx, source, options).expect("format should succeed").0;
     let document = Document::new(elements, Vec::new());
     document.propagate_expand();
     let (elements, tailwind_classes) = document.into_elements_and_tailwind_classes();
@@ -170,6 +170,9 @@ fn parse_error_is_err() {
         // (postcss-selector-parser accepts and lowercases it).
         ("a:nth-child(2N-1) { color: red; }", css),
     ] {
-        assert!(format(&allocator, source, options).is_err(), "{source:?} should fail to format");
+        assert!(
+            format(&allocator, source, options, None).is_err(),
+            "{source:?} should fail to format"
+        );
     }
 }

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -487,7 +487,8 @@ impl TestRunner {
 
     fn run_css_formatter(source_text: &str, format_options: CssFormatOptions) -> Option<String> {
         let allocator = Allocator::default();
-        let formatted = oxc_formatter_css::format(&allocator, source_text, format_options).ok()?;
+        let formatted =
+            oxc_formatter_css::format(&allocator, source_text, format_options, None).ok()?;
         let printed = formatted.print().ok()?;
         Some(printed.into_code())
     }


### PR DESCRIPTION
- Before this PR: If `sortTailwindcss` option is enabled for CSS/LESS/SCSS, it was formatted by Prettier
- After this PR: `oxc_formatter_css` also handles `sortTailwindcss` as like `oxc_formatter` does