### PR TITLE
refactor(oxfmt)!: remove prettier fallback for css-in-js failure

### DIFF
--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -45,10 +45,9 @@ NOTE: Some Tier 1 formatters can fallback to Prettier with NAPI CLI.
 e.g. `oxc_formatter_graphql` (uses `apollo-parser`) only covers the stable GraphQL spec.
 When it returns an error (e.g. draft-spec syntax that Prettier's `graphql-js` accepts), the format step retries via Prettier.
 
-`oxc_formatter_css` (uses `raffia`) is different: standalone css/scss/less files have NO parse-error fallback.
-`raffia` covers the stable grammar, and what it rejects is genuinely broken CSS or the tail of postcss's error tolerance (e.g. IE star hacks), reported as diagnostics.
+`oxc_formatter_css` (uses `raffia`) is different: NO CSS ever reaches Prettier. Standalone css/scss/less parse errors are reported as diagnostics (`raffia` covers the stable grammar; what it rejects is genuinely broken CSS or the tail of postcss's error tolerance, e.g. IE star hacks), and a css-in-js dispatch error makes the parent print the template literal as-is — the same thing Prettier does when its embed throws.
 
-Embedded languages (e.g. css-in-js) go through `src/core/external_formatter.rs`, which assembles a `FormatDispatcher` (defined in `oxc_formatter_core`) that maps each language to a Rust formatter where implemented (currently GraphQL and CSS/SCSS/Less) and to the Prettier Doc→IR path otherwise.
+Embedded languages (e.g. css-in-js) go through `src/core/external_formatter.rs`, which assembles a `FormatDispatcher` (defined in `oxc_formatter_core`) that maps each language to a Rust formatter where implemented (currently GraphQL with Prettier fallback, and CSS/SCSS/Less with none) and to the Prettier Doc→IR path otherwise.
 
 JSDoc fenced code blocks use a separate string-in/string-out channel (the `embedded_callback` in the same file, NOT the dispatcher): css/scss/less/graphql format via the Rust crates (variant derived from the fence language), unimplemented languages go to Prettier, and parse errors keep the block verbatim = no Prettier fallback, no diagnostics (it's inside a comment).
 

--- a/apps/oxfmt/src/core/config/mod.rs
+++ b/apps/oxfmt/src/core/config/mod.rs
@@ -650,10 +650,10 @@ mod tests_slow_path_validation {
     #[cfg(feature = "napi")]
     fn resolve_for_api_rejects_invalid_value_for_external_formatter() {
         let kind = FileKind::ExternalFormatter {
-            path: Arc::from(PathBuf::from("style.css").as_path()),
-            parser_name: "css",
+            path: Arc::from(PathBuf::from("page.vue").as_path()),
+            parser_name: "vue",
             supports_tailwind: true,
-            supports_oxfmt: false,
+            supports_oxfmt: true,
             supports_svelte: false,
         };
         let err = resolve_for_api(serde_json::json!({ "printWidth": 1000 }), kind, Path::new("."))

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -337,17 +337,17 @@ impl ExternalFormatter {
                                 );
                                 prettier_fallback(ctx, language, texts)
                             }),
-                        // Rust implementation; Prettier fallback on parse errors.
+                        // Rust implementation; NO Prettier fallback (plan Step 5-3).
                         // Since the raffia fork accepts `${}` placeholders in
-                        // value/selector position (plan Step 6), this is a pure
-                        // safety net: what still errors is garbage that
-                        // Prettier's embed cannot format either.
+                        // value/selector position, what still errors is garbage
+                        // that Prettier's embed cannot format either — `Err`
+                        // makes the parent print the template as-is, which is
+                        // exactly what Prettier does when its embed throws.
                         "css" | "scss" | "less" => {
-                            format_css_to_irs(ctx, texts, css_options).or_else(|err| {
+                            format_css_to_irs(ctx, texts, css_options).inspect_err(|err| {
                                 debug!(
-                                    "`oxc_formatter_css` failed, falling back to Prettier: {err}"
+                                    "`oxc_formatter_css` failed, template stays as-is: {err}"
                                 );
-                                prettier_fallback(ctx, language, texts)
                             })
                         }
                         // Everything else: Prettier fallback (Doc→IR path)
@@ -571,7 +571,10 @@ fn build_prettier_fallback(
 }
 
 /// Mapping from language identifiers to Prettier `parser` names.
-/// This is the single source of truth for supported embedded languages.
+/// This is the single source of truth for embedded languages that can still
+/// reach Prettier; languages fully served by a Rust crate are absent
+/// (css/scss/less since plan Step 5-3 — their dispatcher branch has no
+/// fallback and the JSDoc channel formats them in Rust, both before this map).
 ///
 /// Language identifiers come from two sources:
 /// - xxx-in-js `(Tagged)TemplateLiteral` (`embed/*.rs`)
@@ -582,7 +585,6 @@ fn build_prettier_fallback(
 /// This function is the only place that maps them to Prettier-specific parsers.
 fn language_to_prettier_parser(language: &str) -> Option<&'static str> {
     match language {
-        "css" | "scss" | "less" => Some("scss"),
         "graphql" | "gql" => Some("graphql"),
         "html" => Some("html"),
         "angular" => Some("angular"),

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -602,8 +602,8 @@ impl SourceFormatter {
         // and both share the same `to_core_options()` validation.
         let graphql_options = to_oxc_formatter_graphql(config)
             .expect("config was already validated when building `JsFormatOptions`");
-        // CSS-in-JS is always parsed as SCSS, mirroring Prettier's embed
-        // (`language_to_prettier_parser` maps css/scss/less to the `scss` parser).
+        // CSS-in-JS is always parsed as SCSS (Prettier's embed uses the
+        // `scss` parser for all of css/scss/less template tags).
         let css_options = to_oxc_formatter_css(config, CssVariant::Scss)
             .expect("config was already validated when building `JsFormatOptions`");
 

--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 use serde_json::Value;
 
 use oxc_allocator::{Allocator, ArenaStringBuilder, ArenaVec};
-use oxc_formatter::{CssEmbedMeta, HtmlEmbedMeta};
+use oxc_formatter::HtmlEmbedMeta;
 use oxc_formatter_core::{
     Align, Condition, DedentMode, DispatchResult, FormatElement, Group, GroupId, GroupMode,
     IndentWidth, LineMode, PrintMode, Tag, TextWidth, UniqueGroupIdBuilder,
@@ -20,8 +20,8 @@ const NEGATIVE_INFINITY_MARKER: &str = "__NEGATIVE_INFINITY__";
 ///
 /// Handles language-specific processing:
 /// - GraphQL: converts each doc independently → one IR per doc
-/// - CSS, HTML: merges consecutive Text nodes, counts placeholders →
-///   single IR + [`CssEmbedMeta`] / [`HtmlEmbedMeta`]
+/// - HTML: merges consecutive Text nodes, counts placeholders →
+///   single IR + [`HtmlEmbedMeta`]
 ///
 /// All Doc JSONs use a uniform `[doc, metadata]` envelope from the JS side.
 pub fn to_format_elements_for_template<'a>(
@@ -70,27 +70,8 @@ pub fn to_format_elements_for_template<'a>(
                 .collect::<Result<Vec<_>, String>>()?;
             Ok(DispatchResult { docs: irs, tailwind_classes: Vec::new(), meta: None })
         }
-        "css" => {
-            let (mut ir, _) = convert(
-                doc_jsons.into_iter().next().expect("Doc JSON for CSS"),
-                allocator,
-                group_id_builder,
-            )?;
-            let placeholder_count = postprocess(
-                &mut ir,
-                allocator,
-                // CSS uses `.raw` values, so no template char escaping needed
-                TemplateEscape::None,
-                Some((TEMPLATE_PLACEHOLDER_PREFIX, TEMPLATE_PLACEHOLDER_SUFFIX)),
-            );
-            Ok(DispatchResult {
-                docs: vec![ir],
-                // Prettier's plugin sorts `@apply` in-place during its own
-                // formatting, so the Doc path never carries classes to remap.
-                tailwind_classes: Vec::new(),
-                meta: Some(Box::new(CssEmbedMeta { placeholder_count })),
-            })
-        }
+        // NOTE: no "css" arm — css/scss/less never reach the Prettier Doc
+        // path since plan Step 5-3 (the dispatcher branch is Rust-only).
         "html" | "angular" => {
             let (mut ir, metadata) = convert(
                 doc_jsons.into_iter().next().expect("Doc JSON for HTML"),
@@ -568,8 +549,6 @@ fn extract_group_id(
 
 #[derive(Clone, Copy)]
 enum TemplateEscape {
-    /// No escaping
-    None,
     /// Full escaping: `\` → `\\`, `` ` `` → `` \` ``, `${` → `\${`.
     Full,
     /// Raw backtick escaping: `(\\*)\`` → `$1$1\\\``.
@@ -635,7 +614,6 @@ fn postprocess<'a>(
                 sb.into_str()
             };
             let text = match escape {
-                TemplateEscape::None => text,
                 TemplateEscape::Full => escape_template_characters(text, allocator),
                 TemplateEscape::RawBacktick => escape_backticks_raw_str(text, allocator),
             };

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -37,15 +37,14 @@ debug_assert). Params containing comments fall back to the normal printers
 ### Error semantics
 
 `format()` / `format_to_ir()` return `Err` on ANY parse error, including
-raffia's recoverable ones (`parser.recoverable_errors()`) — except
-`TopLevelDeclaration`, which postcss accepts (the dominant css-in-js shape).
-What oxfmt does with the `Err` differs by entry point: standalone files
-report it as a diagnostic (NO Prettier fallback), while the css-in-js
-dispatcher falls back to Prettier. Since the raffia fork (plan Step 6),
-value/selector-position `${}` placeholders parse on the Rust path, so that
-fallback is a pure safety net: what still `Err`s is garbage Prettier can't
-format either (e.g. `foo\n${a}\n${b}` bare words — Prettier's embed throws
-too and the template prints as-is).
+raffia's recoverable ones (`parser.recoverable_errors()`).
+Except `TopLevelDeclaration`, which postcss accepts (the dominant css-in-js shape).
+
+NOTHING falls back to Prettier: standalone files report the
+`Err` as a diagnostic, and a css-in-js dispatch `Err` makes the parent print
+the template as-is.
+Since the raffia fork, value/selector-position `${}` placeholders parse on the Rust path,
+so what still `Err`s is garbage Prettier's embed throws on too (e.g. `foo\n${a}\n${b}` bare words).
 
 ### Architecture notes (Prettier mapping)
 


### PR DESCRIPTION
- Removed last remaining Prettier fallback path for css-in-js failure case
- In our Rust formatter host paths, Prettier is not used for CSS/LESS/SCSS anymore