### PR TITLE
refactor(oxfmt): use unified embedded ir results

### DIFF
--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -11,10 +11,10 @@ use tracing::{debug, debug_span};
 
 use oxc_allocator::Allocator;
 use oxc_formatter::{
-    CssEmbedMeta, EmbeddedFormatterCallback, ExternalCallbacks, JsFormatOptions, TailwindCallback,
+    EmbeddedFormatterCallback, ExternalCallbacks, JsFormatOptions, TailwindCallback,
 };
 use oxc_formatter_core::{
-    DispatchResult, EmbeddedContext, FormatContext, FormatDispatcher, Formatted,
+    DispatchResult, EmbeddedContext, EmbeddedIr, FormatContext, FormatDispatcher, Formatted,
 };
 use oxc_formatter_css::{CssFormatOptions, CssVariant};
 use oxc_formatter_graphql::GraphqlFormatOptions;
@@ -463,22 +463,22 @@ fn format_graphql_to_irs<'a>(
         .iter()
         .map(|text| {
             debug_span!("oxfmt::external::format_graphql_to_ir").in_scope(|| {
-                let mut ir = oxc_formatter_graphql::format_to_ir(ctx, text, options)
+                let mut embedded = oxc_formatter_graphql::format_to_ir(ctx, text, options)
                     .map_err(|err| err.to_string())?;
                 from_prettier_doc::escape_template_characters_in_ir(
-                    &mut ir,
+                    &mut embedded.ir,
                     ctx.allocator,
                     options.indent_width,
                 );
-                Ok(ir)
+                Ok(embedded.ir)
             })
         })
         .collect::<Result<Vec<_>, String>>()?;
-    Ok(DispatchResult { docs, tailwind_classes: Vec::new(), meta: None })
+    Ok(DispatchResult { docs, tailwind_classes: Vec::new(), placeholder_count: None, meta: None })
 }
 
 /// Format the single joined CSS text (placeholders included) via
-/// `oxc_formatter_css`, returning one IR plus [`CssEmbedMeta`]
+/// `oxc_formatter_css`, returning one IR plus the surviving placeholder count
 /// (the dispatcher contract for CSS, mirroring the Prettier Doc path).
 ///
 /// CSS-in-js uses `.raw` template values, so unlike GraphQL no template-char
@@ -497,7 +497,7 @@ fn format_css_to_irs<'a>(
         return Err(format!("CSS dispatch expects exactly one text, got {}", texts.len()));
     };
     debug_span!("oxfmt::external::format_css_to_ir").in_scope(|| {
-        let (mut ir, tailwind_classes) =
+        let EmbeddedIr { mut ir, tailwind_classes } =
             oxc_formatter_css::format_to_ir(ctx, text, options).map_err(|err| err.to_string())?;
         let placeholder_count = from_prettier_doc::merge_texts_and_count_css_placeholders(
             &mut ir,
@@ -507,7 +507,8 @@ fn format_css_to_irs<'a>(
         Ok(DispatchResult {
             docs: vec![ir],
             tailwind_classes,
-            meta: Some(Box::new(CssEmbedMeta { placeholder_count })),
+            placeholder_count: Some(placeholder_count),
+            meta: None,
         })
     })
 }

--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -21,7 +21,7 @@ const NEGATIVE_INFINITY_MARKER: &str = "__NEGATIVE_INFINITY__";
 /// Handles language-specific processing:
 /// - GraphQL: converts each doc independently → one IR per doc
 /// - HTML: merges consecutive Text nodes, counts placeholders →
-///   single IR + [`HtmlEmbedMeta`]
+///   single IR + placeholder count + [`HtmlEmbedMeta`]
 ///
 /// All Doc JSONs use a uniform `[doc, metadata]` envelope from the JS side.
 pub fn to_format_elements_for_template<'a>(
@@ -68,7 +68,12 @@ pub fn to_format_elements_for_template<'a>(
                     Ok(ir)
                 })
                 .collect::<Result<Vec<_>, String>>()?;
-            Ok(DispatchResult { docs: irs, tailwind_classes: Vec::new(), meta: None })
+            Ok(DispatchResult {
+                docs: irs,
+                tailwind_classes: Vec::new(),
+                placeholder_count: None,
+                meta: None,
+            })
         }
         // NOTE: no "css" arm — css/scss/less never reach the Prettier Doc
         // path since plan Step 5-3 (the dispatcher branch is Rust-only).
@@ -90,8 +95,8 @@ pub fn to_format_elements_for_template<'a>(
             Ok(DispatchResult {
                 docs: vec![ir],
                 tailwind_classes: Vec::new(),
+                placeholder_count: Some(placeholder_count),
                 meta: Some(Box::new(HtmlEmbedMeta {
-                    placeholder_count,
                     has_multiple_root_elements: html_has_multiple_root_elements,
                 })),
             })
@@ -109,7 +114,12 @@ pub fn to_format_elements_for_template<'a>(
                 TemplateEscape::RawBacktick,
                 None,
             );
-            Ok(DispatchResult { docs: vec![ir], tailwind_classes: Vec::new(), meta: None })
+            Ok(DispatchResult {
+                docs: vec![ir],
+                tailwind_classes: Vec::new(),
+                placeholder_count: None,
+                meta: None,
+            })
         }
         _ => unreachable!("Unsupported embedded_doc language: {language}"),
     }

--- a/crates/oxc_formatter/src/external_formatter.rs
+++ b/crates/oxc_formatter/src/external_formatter.rs
@@ -10,23 +10,15 @@ use super::formatter::UniqueGroupIdBuilder;
 pub type EmbeddedFormatterCallback =
     Arc<dyn Fn(&str, &str) -> Result<String, String> + Send + Sync>;
 
-/// Child→parent metadata for CSS formatted as an embedded child.
-///
-/// NOTE: Belongs to the CSS formatter crate once it exists
-/// (see `refactor-oxfmt-architecture.md`); lives here until then because
-/// both the producer (oxfmt's dispatcher) and the consumer (`embed/css.rs`)
-/// can reach this crate.
-pub struct CssEmbedMeta {
-    /// How many `@prettier-placeholder-N-id` patterns survived formatting.
-    pub placeholder_count: usize,
-}
-
 /// Child→parent metadata for HTML/Angular formatted as an embedded child.
 ///
-/// NOTE: Belongs to the HTML formatter crate once it exists (same as [`CssEmbedMeta`]).
+/// NOTE: This lives here permanently, NOT in a future HTML formatter crate:
+/// the consumer is this crate's `embed/html.rs` (the JS side of html-in-js),
+/// and `oxc_formatter` must never depend on language crates. Cross-language
+/// contract fields (placeholder counts, Tailwind classes) are first-class on
+/// `DispatchResult` in `oxc_formatter_core` instead; only what is truly
+/// specific to the JS↔HTML pair stays here as `dyn Any` metadata.
 pub struct HtmlEmbedMeta {
-    /// How many `PRETTIER_HTML_PLACEHOLDER_N_0_IN_JS` patterns survived formatting.
-    pub placeholder_count: usize,
     /// Whether the parsed HTML has more than one root element.
     /// Used to decide whether to `indent` the template content.
     pub has_multiple_root_elements: Option<bool>,

--- a/crates/oxc_formatter/src/lib.rs
+++ b/crates/oxc_formatter/src/lib.rs
@@ -25,7 +25,7 @@ use oxc_span::SourceType;
 // or the special-purpose AST-in `format_program`.
 pub(crate) use crate::ast_nodes::{AstNode, AstNodes};
 pub use crate::external_formatter::{
-    CssEmbedMeta, EmbeddedFormatterCallback, ExternalCallbacks, HtmlEmbedMeta, TailwindCallback,
+    EmbeddedFormatterCallback, ExternalCallbacks, HtmlEmbedMeta, TailwindCallback,
 };
 // `JsFormatContext` is public solely as the type parameter of the `Formatted`
 // returned by `format` / `format_fragment`.

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -4,7 +4,6 @@ use oxc_span::GetSpan;
 
 use crate::{
     ast_nodes::AstNode,
-    external_formatter::CssEmbedMeta,
     format_args,
     formatter::{FormatElement, prelude::*},
     write,
@@ -84,12 +83,7 @@ pub(super) fn format_css_doc<'a>(
     ) else {
         return false;
     };
-    let Some(placeholder_count) = result
-        .meta
-        .as_ref()
-        .and_then(|meta| meta.downcast_ref::<CssEmbedMeta>())
-        .map(|meta| meta.placeholder_count)
-    else {
+    let Some(placeholder_count) = result.placeholder_count else {
         return false;
     };
 

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -140,11 +140,14 @@ pub(super) fn format_html_doc<'a>(
     };
     // See the Phase 0 note: no-op today, load-bearing once HTML is Rust.
     result.remap_tailwind_into(f.context_mut());
-    let Some((placeholder_count, html_has_multiple_root_elements)) = result
+    let Some(placeholder_count) = result.placeholder_count else {
+        return false;
+    };
+    let Some(html_has_multiple_root_elements) = result
         .meta
         .as_ref()
         .and_then(|meta| meta.downcast_ref::<HtmlEmbedMeta>())
-        .map(|meta| (meta.placeholder_count, meta.has_multiple_root_elements))
+        .map(|meta| meta.has_multiple_root_elements)
     else {
         return false;
     };

--- a/crates/oxc_formatter_core/AGENTS.md
+++ b/crates/oxc_formatter_core/AGENTS.md
@@ -37,7 +37,11 @@ formatter's IR be built inside another's document (e.g. graphql-in-js):
 - The orchestrator (oxfmt) assembles the dispatcher, mapping language names to
   formatter implementations (or a Prettier fallback); formatter crates only invoke it
 - Parent and child share one arena and one `GroupId` space through `EmbeddedContext`
-- Language-pair specific data crosses the boundary as `dyn Any` only —
+- A language crate's `format_to_ir` entry returns `EmbeddedIr` (IR + pre-sort
+  Tailwind classes) — one shape for every child language, no per-crate tuples
+- Cross-language contract data is first-class on `DispatchResult`
+  (`tailwind_classes`, `placeholder_count`); only truly language-pair specific
+  data crosses as `dyn Any` (e.g. HTML's `has_multiple_root_elements`) —
   core never learns concrete languages
 
 ### What belongs in core (the boundary)

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -7,8 +7,10 @@
 //! mapping a language name to a formatter implementation (or a fallback).
 //!
 //! Core only carries the shared plumbing (arena, group-id space, recursion
-//! handle) plus `dyn Any` passthroughs for language-pair specific data;
-//! it knows nothing about any concrete language.
+//! handle) and the cross-language contract fields ([`DispatchResult`]'s
+//! `tailwind_classes` / `placeholder_count`); anything truly language-pair
+//! specific crosses as a `dyn Any` passthrough. Core knows nothing about any
+//! concrete language.
 
 use std::any::Any;
 use std::sync::Arc;
@@ -55,6 +57,21 @@ pub type FormatDispatcher = Arc<
         + Sync,
 >;
 
+/// IR built by a language crate's embedded entry point (`format_to_ir`) for
+/// ONE input text. The orchestrator's dispatcher assembles one or more of
+/// these into a [`DispatchResult`].
+///
+/// Every language crate's `format_to_ir` returns this shape, so a new child
+/// language only has to fill in the fields (no per-crate tuple conventions).
+pub struct EmbeddedIr<'a> {
+    /// The formatter IR, arena-allocated alongside its elements.
+    pub ir: ArenaVec<'a, FormatElement<'a>>,
+    /// Pre-sort Tailwind classes referenced by the IR's
+    /// `FormatElement::TailwindClass` indices (0-based, local to this IR).
+    /// Empty unless the language collects classes (e.g. CSS `@apply`).
+    pub tailwind_classes: Vec<String>,
+}
+
 /// Result of a [`FormatDispatcher`] call.
 pub struct DispatchResult<'a> {
     /// One IR per input text (usually one; GraphQL returns one per quasi).
@@ -65,8 +82,13 @@ pub struct DispatchResult<'a> {
     /// The receiving parent MUST merge them into its own class space via
     /// [`Self::remap_tailwind_into`] — the printer asserts on dangling indices.
     pub tailwind_classes: Vec<String>,
+    /// How many host-substituted placeholder markers (standing in for `${}`
+    /// interpolations) survived formatting. The parent compares this against
+    /// its expression count to decide whether it can splice them back in.
+    /// `None` when the language pair doesn't use placeholders.
+    pub placeholder_count: Option<usize>,
     /// Child→parent language-specific metadata; the parent downcasts it
-    /// (e.g. placeholder survival counts for CSS/HTML).
+    /// (e.g. HTML's `has_multiple_root_elements`).
     pub meta: Option<Box<dyn Any>>,
 }
 

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -43,7 +43,9 @@ pub use buffer::{
     VecBuffer,
 };
 pub use diagnostics::{ActualStart, FormatError, InvalidDocumentError, PrintError};
-pub use embedded::{DispatchResult, EmbeddedContext, FormatDispatcher, TailwindCollector};
+pub use embedded::{
+    DispatchResult, EmbeddedContext, EmbeddedIr, FormatDispatcher, TailwindCollector,
+};
 pub use format::{Format, write};
 pub use format_element::debug::DisplayDocument;
 pub use format_element::document::Document;

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -28,7 +28,7 @@ and Less `~"..."` wrappers, then emits the class list as one
 `FormatElement::TailwindClass(index)`. Sorting (order, dedup, whitespace
 collapse, `{{` skip) is the host-supplied sorter's job: `format()` takes an
 `Option<TailwindSorter>` and bakes the result into the `Document`;
-`format_to_ir()` returns `(IR, Vec<String>)` and the classes travel to the
+`format_to_ir()` returns an `EmbeddedIr` and its classes travel to the
 parent in `DispatchResult::tailwind_classes`, where the parent merges them
 with `DispatchResult::remap_tailwind_into` (a dangling index trips a printer
 debug_assert). Params containing comments fall back to the normal printers

--- a/crates/oxc_formatter_css/examples/embedded_debug.rs
+++ b/crates/oxc_formatter_css/examples/embedded_debug.rs
@@ -40,8 +40,8 @@ fn main() {
     };
 
     match format_to_ir(&ctx, &source_text, options) {
-        Ok((elements, _tailwind_classes)) => {
-            let document = Document::new(elements, Vec::new());
+        Ok(embedded) => {
+            let document = Document::new(embedded.ir, Vec::new());
             document.propagate_expand();
             if std::env::var("DUMP_IR").is_ok() {
                 for el in document.elements() {

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
-    Buffer, Document, EmbeddedContext, Format, FormatElement, FormatState, Formatted, VecBuffer,
+    Buffer, Document, EmbeddedContext, EmbeddedIr, Format, FormatState, Formatted, VecBuffer,
     builders::{empty_line, hard_line_break, text},
     write,
 };
@@ -72,11 +72,11 @@ pub fn format<'a>(
 /// - emits neither a BOM nor the trailing newline
 /// - skips `propagate_expand()`, which the parent runs on the merged document
 ///
-/// Also returns the pre-sort `@apply` Tailwind classes the IR's
-/// `TailwindClass(index)` elements refer to (empty unless
+/// The returned [`EmbeddedIr`] also carries the pre-sort `@apply` Tailwind
+/// classes the IR's `TailwindClass(index)` elements refer to (empty unless
 /// [`CssFormatOptions::sort_tailwindcss`] is on). The parent document owns
 /// the batch sort, so the caller must re-index the elements into the parent's
-/// class space (e.g. `oxc_formatter`'s CSS embed via `CssEmbedMeta`).
+/// class space (`DispatchResult::remap_tailwind_into`).
 ///
 /// # Errors
 /// Same as [`format()`].
@@ -84,7 +84,7 @@ pub fn format_to_ir<'a>(
     ctx: &EmbeddedContext<'a, '_>,
     source_text: &str,
     options: CssFormatOptions,
-) -> Result<(ArenaVec<'a, FormatElement<'a>>, Vec<String>), OxcDiagnostic> {
+) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
     let allocator = ctx.allocator;
     // The dispatcher input substitutes `${}` interpolations with
     // `@prettier-placeholder-N-id` markers, which may sit in value or
@@ -102,7 +102,7 @@ pub fn format_to_ir<'a>(
     let elements = buffer.into_vec();
     let tailwind_classes = state.context_mut().take_tailwind_classes();
 
-    Ok((elements, tailwind_classes))
+    Ok(EmbeddedIr { ir: elements, tailwind_classes })
 }
 
 /// Parse the source into an AST and collect comments, bailing out on any error.

--- a/crates/oxc_formatter_css/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_css/tests/fixtures/mod.rs
@@ -112,9 +112,9 @@ fn format_embedded(source: &str, options: CssFormatOptions) -> String {
         group_id_builder: &group_id_builder,
         dispatcher: None,
     };
-    let elements =
-        oxc_formatter_css::format_to_ir(&ctx, source, options).expect("format should succeed").0;
-    let document = Document::new(elements, Vec::new());
+    let embedded =
+        oxc_formatter_css::format_to_ir(&ctx, source, options).expect("format should succeed");
+    let document = Document::new(embedded.ir, Vec::new());
     document.propagate_expand();
     let (elements, tailwind_classes) = document.into_elements_and_tailwind_classes();
     let mut code =

--- a/crates/oxc_formatter_graphql/src/format.rs
+++ b/crates/oxc_formatter_graphql/src/format.rs
@@ -2,7 +2,7 @@ use apollo_parser::{Parser, SyntaxKind, cst, cst::CstNode};
 use oxc_allocator::{Allocator, ArenaVec};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_formatter_core::{
-    Buffer, Document, EmbeddedContext, Format, FormatElement, FormatState, Formatted, VecBuffer,
+    Buffer, Document, EmbeddedContext, EmbeddedIr, Format, FormatState, Formatted, VecBuffer,
     builders::{hard_line_break, text},
     write,
 };
@@ -63,7 +63,7 @@ pub fn format_to_ir<'a>(
     ctx: &EmbeddedContext<'a, '_>,
     source_text: &str,
     options: GraphqlFormatOptions,
-) -> Result<ArenaVec<'a, FormatElement<'a>>, OxcDiagnostic> {
+) -> Result<EmbeddedIr<'a>, OxcDiagnostic> {
     let allocator = ctx.allocator;
     let (document, source, comments) = parse_document(allocator, source_text)?;
 
@@ -73,7 +73,8 @@ pub fn format_to_ir<'a>(
 
     write!(&mut buffer, FormatGraphqlEmbedded { document: &document });
 
-    Ok(buffer.into_vec())
+    // GraphQL never collects Tailwind classes.
+    Ok(EmbeddedIr { ir: buffer.into_vec(), tailwind_classes: Vec::new() })
 }
 
 /// Parse the source into a CST and collect comment trivia,


### PR DESCRIPTION
- Add `EmbeddedIr` struct in `oxc_formatter_core`
- Each `format_to_ir` implementation returns this as unified result