### PR TITLE
feat(oxfmt,formatter_graphql)!: support draft syntax with removing prettier fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,8 +32,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 [[package]]
 name = "apollo-parser"
 version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f6e2be4b3474e5890d34d3e483d49ec9b5cbf9e358bc62c9cc5423376df54b"
+source = "git+https://github.com/leaysgur/apollo-rs?rev=64bbb246a146575d583c3c17c18c46454cec62ae#64bbb246a146575d583c3c17c18c46454cec62ae"
 dependencies = [
  "memchr",
  "rowan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,7 @@ oxc_sourcemap = "8.0.2" # Source map generation
 
 #
 allocator-api2 = "=0.2.21" # Allocator trait
-apollo-parser = "0.8.6" # GraphQL parser (lossless CST)
+apollo-parser = { git = "https://github.com/leaysgur/apollo-rs", rev = "64bbb246a146575d583c3c17c18c46454cec62ae" } # GraphQL parser (lossless CST; fork of 0.8.6: adds opt-in 2025 descriptions + legacy fragment variables)
 base64 = "0.22.1" # Base64 encoding
 bitflags = "2.10.0" # Bitflag types
 bpaf = "0.9.20" # CLI parser

--- a/apps/oxfmt/AGENTS.md
+++ b/apps/oxfmt/AGENTS.md
@@ -40,14 +40,11 @@ Oxfmt utilizes different implementations depending on the file extension and fil
 - Tier 3: Delegations to Prettier via NAPI-JS calls (e.g., for Vue or Markdown)
 - Tier 4: Delegations to Prettier that require additional plugins (e.g., for Svelte)
 
-NOTE: Some Tier 1 formatters can fallback to Prettier with NAPI CLI.
+NOTE: Tier 1 formatters never fall back to Prettier.
 
-e.g. `oxc_formatter_graphql` (uses `apollo-parser`) only covers the stable GraphQL spec.
-When it returns an error (e.g. draft-spec syntax that Prettier's `graphql-js` accepts), the format step retries via Prettier.
+`oxc_formatter_css` (uses a `raffia` fork) and `oxc_formatter_graphql` (uses an `apollo-parser` fork) both cover everything the bundled Prettier can parse for their language (raffia: the stable grammar + `${}` placeholders; apollo-parser: October 2021 spec + 2025 descriptions + legacy fragment variables = graphql-js 16.12 coverage). Standalone parse errors are reported as diagnostics — what the forks reject is genuinely broken input or, for CSS, the tail of postcss's error tolerance (e.g. IE star hacks). An embedded (xxx-in-js) dispatch error makes the parent print the template literal as-is — the same thing Prettier does when its embed throws.
 
-`oxc_formatter_css` (uses `raffia`) is different: NO CSS ever reaches Prettier. Standalone css/scss/less parse errors are reported as diagnostics (`raffia` covers the stable grammar; what it rejects is genuinely broken CSS or the tail of postcss's error tolerance, e.g. IE star hacks), and a css-in-js dispatch error makes the parent print the template literal as-is — the same thing Prettier does when its embed throws.
-
-Embedded languages (e.g. css-in-js) go through `src/core/external_formatter.rs`, which assembles a `FormatDispatcher` (defined in `oxc_formatter_core`) that maps each language to a Rust formatter where implemented (currently GraphQL with Prettier fallback, and CSS/SCSS/Less with none) and to the Prettier Doc→IR path otherwise.
+Embedded languages (e.g. css-in-js) go through `src/core/external_formatter.rs`, which assembles a `FormatDispatcher` (defined in `oxc_formatter_core`) that maps each language to a Rust formatter where implemented (currently GraphQL and CSS/SCSS/Less, both without Prettier fallback) and to the Prettier Doc→IR path otherwise.
 
 JSDoc fenced code blocks use a separate string-in/string-out channel (the `embedded_callback` in the same file, NOT the dispatcher): css/scss/less/graphql format via the Rust crates (variant derived from the fence language), unimplemented languages go to Prettier, and parse errors keep the block verbatim = no Prettier fallback, no diagnostics (it's inside a comment).
 

--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -327,15 +327,16 @@ impl ExternalFormatter {
                       texts: &[&str],
                       _parent_context| {
                     match language {
-                        // Rust implementation; Prettier fallback on parse errors
-                        // (apollo-parser covers the stable spec only, while
-                        // Prettier's graphql-js also accepts draft-level syntax)
+                        // Rust implementation; NO Prettier fallback.
+                        // The apollo-parser fork covers everything Prettier's
+                        // graphql-js 16.12 accepts, so what still errors is
+                        // garbage that Prettier's embed cannot format either —
+                        // `Err` makes the parent print the template as-is.
                         "graphql" | "gql" => format_graphql_to_irs(ctx, texts, graphql_options)
-                            .or_else(|err| {
+                            .inspect_err(|err| {
                                 debug!(
-                                    "`oxc_formatter_graphql` failed, falling back to Prettier: {err}"
+                                    "`oxc_formatter_graphql` failed, template stays as-is: {err}"
                                 );
-                                prettier_fallback(ctx, language, texts)
                             }),
                         // Rust implementation; NO Prettier fallback (plan Step 5-3).
                         // Since the raffia fork accepts `${}` placeholders in
@@ -343,13 +344,10 @@ impl ExternalFormatter {
                         // that Prettier's embed cannot format either — `Err`
                         // makes the parent print the template as-is, which is
                         // exactly what Prettier does when its embed throws.
-                        "css" | "scss" | "less" => {
-                            format_css_to_irs(ctx, texts, css_options).inspect_err(|err| {
-                                debug!(
-                                    "`oxc_formatter_css` failed, template stays as-is: {err}"
-                                );
-                            })
-                        }
+                        "css" | "scss" | "less" => format_css_to_irs(ctx, texts, css_options)
+                            .inspect_err(|err| {
+                                debug!("`oxc_formatter_css` failed, template stays as-is: {err}");
+                            }),
                         // Everything else: Prettier fallback (Doc→IR path)
                         _ => prettier_fallback(ctx, language, texts),
                     }
@@ -452,8 +450,8 @@ fn print_embedded_block<C: FormatContext>(formatted: Formatted<'_, C>) -> Result
 /// Template-literal characters in the output are re-escaped because the parent
 /// re-inserts the IR into a JS template literal built from `.cooked` values.
 ///
-/// Any parse error fails the whole batch so the caller can fall back to
-/// Prettier for all texts at once (an embedded template is all-or-nothing).
+/// Any parse error fails the whole batch (an embedded template is
+/// all-or-nothing): `Err` makes the parent print the template as-is.
 fn format_graphql_to_irs<'a>(
     ctx: &EmbeddedContext<'a, '_>,
     texts: &[&str],
@@ -574,7 +572,7 @@ fn build_prettier_fallback(
 /// Mapping from language identifiers to Prettier `parser` names.
 /// This is the single source of truth for embedded languages that can still
 /// reach Prettier; languages fully served by a Rust crate are absent
-/// (css/scss/less since plan Step 5-3 — their dispatcher branch has no
+/// (css/scss/less and graphql/gql — their dispatcher branches have no
 /// fallback and the JSDoc channel formats them in Rust, both before this map).
 ///
 /// Language identifiers come from two sources:
@@ -586,7 +584,6 @@ fn build_prettier_fallback(
 /// This function is the only place that maps them to Prettier-specific parsers.
 fn language_to_prettier_parser(language: &str) -> Option<&'static str> {
     match language {
-        "graphql" | "gql" => Some("graphql"),
         "html" => Some("html"),
         "angular" => Some("angular"),
         "markdown" | "md" => Some("markdown"),

--- a/apps/oxfmt/src/core/format.rs
+++ b/apps/oxfmt/src/core/format.rs
@@ -62,13 +62,10 @@ pub enum FormatStrategy {
         insert_final_newline: bool,
     },
     /// For GraphQL files formatted by `oxc_formatter_graphql`.
-    /// `config` is retained (napi only) so the format step can fall back to Prettier
-    /// when the Rust parser rejects the input (e.g. draft-spec syntax).
+    /// Parse errors are surfaced as diagnostics — no Prettier fallback.
     OxcFormatterGraphql {
         path: Arc<Path>,
         format_options: Box<GraphqlFormatOptions>,
-        #[cfg(feature = "napi")]
-        config: Box<FormatConfig>,
         insert_final_newline: bool,
     },
     /// For CSS/SCSS/Less files formatted by `oxc_formatter_css`.
@@ -162,8 +159,6 @@ impl FormatStrategy {
             FileKind::OxcFormatterGraphql { path } => Self::OxcFormatterGraphql {
                 path,
                 format_options: Box::new(to_oxc_formatter_graphql(&config)?),
-                #[cfg(feature = "napi")]
-                config: Box::new(config),
                 insert_final_newline,
             },
             FileKind::OxcFormatterCss { path, variant } => Self::OxcFormatterCss {
@@ -269,20 +264,8 @@ impl SourceFormatter {
                 ),
                 insert_final_newline,
             ),
-            FormatStrategy::OxcFormatterGraphql {
-                path,
-                format_options,
-                #[cfg(feature = "napi")]
-                config,
-                insert_final_newline,
-            } => (
-                self.format_by_oxc_formatter_graphql(
-                    source_text,
-                    &path,
-                    *format_options,
-                    #[cfg(feature = "napi")]
-                    &config,
-                ),
+            FormatStrategy::OxcFormatterGraphql { path, format_options, insert_final_newline } => (
+                self.format_by_oxc_formatter_graphql(source_text, &path, *format_options),
                 insert_final_newline,
             ),
             FormatStrategy::OxcFormatterCss {
@@ -445,50 +428,32 @@ impl SourceFormatter {
 
     /// Format GraphQL source using `oxc_formatter_graphql`.
     ///
-    /// apollo-parser covers the stable GraphQL spec only, while Prettier (graphql-js)
-    /// also accepts draft-level syntax. So when the Rust formatter returns `Err`
-    /// (parse error or internal failure), the napi build falls back to Prettier;
-    /// if Prettier also fails, its error is reported.
-    /// The pure Rust build has no fallback and reports the diagnostic as-is.
+    /// There is NO Prettier fallback on parse errors: the apollo-parser fork
+    /// covers everything Prettier's graphql-js 16.12 accepts (conformance 100%,
+    /// 0 skipped), so what it rejects is genuinely broken GraphQL that Prettier
+    /// cannot format either. Both the napi and pure builds report the
+    /// diagnostic as-is.
     #[instrument(level = "debug", name = "oxfmt::format::oxc_formatter_graphql", skip_all)]
     fn format_by_oxc_formatter_graphql(
         &self,
         source_text: &str,
         path: &Path,
         format_options: GraphqlFormatOptions,
-        #[cfg(feature = "napi")] config: &FormatConfig,
     ) -> Result<String, OxcDiagnostic> {
-        let result = (|| -> Result<String, OxcDiagnostic> {
-            let allocator = self.allocator_pool.get();
-            let formatted = oxc_formatter_graphql::format(&allocator, source_text, format_options)?;
-            let printed = formatted.print().map_err(|err| {
-                OxcDiagnostic::error(format!(
-                    "Failed to print formatted GraphQL: {}\n{err}",
-                    path.display()
-                ))
-            })?;
-            Ok(printed.into_code())
-        })();
-
-        #[cfg(feature = "napi")]
-        let result = result.or_else(|_| {
-            self.format_by_external_formatter(
-                source_text,
-                path,
-                "graphql",
-                config,
-                /* supports_tailwind */ false,
-                /* supports_oxfmt */ false,
-                /* supports_svelte */ false,
-            )
-        });
-
-        result
+        let allocator = self.allocator_pool.get();
+        let formatted = oxc_formatter_graphql::format(&allocator, source_text, format_options)?;
+        let printed = formatted.print().map_err(|err| {
+            OxcDiagnostic::error(format!(
+                "Failed to print formatted GraphQL: {}\n{err}",
+                path.display()
+            ))
+        })?;
+        Ok(printed.into_code())
     }
 
     /// Format CSS/SCSS/Less source using `oxc_formatter_css`.
     ///
-    /// Unlike GraphQL, there is NO Prettier fallback on parse errors: raffia
+    /// There is NO Prettier fallback on parse errors: raffia
     /// covers the stable grammar (conformance 100%), and what it rejects is
     /// genuinely broken CSS or the tail of postcss's error tolerance
     /// (e.g. IE star hacks). Both the napi and pure builds report the

--- a/apps/oxfmt/src/core/support.rs
+++ b/apps/oxfmt/src/core/support.rs
@@ -98,9 +98,9 @@ pub enum FileKind {
     /// by `oxc_formatter_json` with the `json-stringify` variant.
     OxcFormatterJsonPackageJson { path: Arc<Path> },
     /// GraphQL files formatted by `oxc_formatter_graphql`.
-    /// On parse error, the format step falls back to Prettier (`napi` feature only):
-    /// apollo-parser covers the stable spec, while Prettier (graphql-js) also
-    /// accepts draft-level syntax.
+    /// Parse errors are surfaced as diagnostics — no Prettier fallback
+    /// (the apollo-parser fork covers everything Prettier's graphql-js 16.12
+    /// accepts; what it rejects is genuinely broken GraphQL).
     OxcFormatterGraphql { path: Arc<Path> },
     /// CSS/SCSS/Less files formatted by `oxc_formatter_css`.
     /// Parse errors are surfaced as diagnostics — no Prettier fallback

--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -19,9 +19,9 @@ const NEGATIVE_INFINITY_MARKER: &str = "__NEGATIVE_INFINITY__";
 /// Converts parsed Prettier Doc JSON values into a [`DispatchResult`].
 ///
 /// Handles language-specific processing:
-/// - GraphQL: converts each doc independently → one IR per doc
 /// - HTML: merges consecutive Text nodes, counts placeholders →
 ///   single IR + placeholder count + [`HtmlEmbedMeta`]
+/// - Markdown: single doc with raw-backtick escaping
 ///
 /// All Doc JSONs use a uniform `[doc, metadata]` envelope from the JS side.
 pub fn to_format_elements_for_template<'a>(
@@ -53,30 +53,8 @@ pub fn to_format_elements_for_template<'a>(
     }
 
     match language {
-        "graphql" => {
-            let irs = doc_jsons
-                .into_iter()
-                .map(|envelope| {
-                    let (mut ir, _) = convert(envelope, allocator, group_id_builder)?;
-                    postprocess(
-                        &mut ir,
-                        allocator,
-                        // GraphQL uses `.cooked` values, so template chars need escaping
-                        TemplateEscape::Full,
-                        None,
-                    );
-                    Ok(ir)
-                })
-                .collect::<Result<Vec<_>, String>>()?;
-            Ok(DispatchResult {
-                docs: irs,
-                tailwind_classes: Vec::new(),
-                placeholder_count: None,
-                meta: None,
-            })
-        }
-        // NOTE: no "css" arm — css/scss/less never reach the Prettier Doc
-        // path since plan Step 5-3 (the dispatcher branch is Rust-only).
+        // NOTE: no "css" / "graphql" arms — those languages never reach the
+        // Prettier Doc path (their dispatcher branches are Rust-only).
         "html" | "angular" => {
             let (mut ir, metadata) = convert(
                 doc_jsons.into_iter().next().expect("Doc JSON for HTML"),

--- a/apps/oxfmt/test/api/graphql.test.ts
+++ b/apps/oxfmt/test/api/graphql.test.ts
@@ -41,23 +41,29 @@ describe("GraphQL files (oxc_formatter_graphql)", () => {
     `);
   });
 
-  it("should fall back to Prettier for draft-spec syntax apollo-parser rejects", async () => {
-    // Fragment arguments are graphql-js experimental syntax, not in the stable spec
-    const source = `fragment F($x: Int) on T { f(arg: $x) }`;
+  it("should format legacy fragment variables and descriptions in Rust", async () => {
+    // Formerly Prettier-fallback territory; the apollo-parser fork
+    // now covers everything Prettier's graphql-js 16.12 accepts.
+    const source = `"Frag description" fragment F("var description" $x: Int) on T { f(arg: $x) }`;
     const result = await format("draft.graphql", source);
+    expect(result.errors).toHaveLength(0);
     expect(result.code).toMatchInlineSnapshot(`
-      "fragment F($x: Int) on T {
+      ""Frag description"
+      fragment F(
+        "var description"
+        $x: Int
+      ) on T {
         f(arg: $x)
       }
       "
     `);
   });
 
-  it("should report Prettier's error when both parsers fail", async () => {
+  it("should report a diagnostic on parse errors (no Prettier fallback)", async () => {
     const source = `query {{{`;
     const result = await format("broken.graphql", source);
     expect(result.code).toBe(source);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0].message).toMatch(/Syntax Error/);
+    expect(result.errors[0].message).toMatch(/Syntax error/);
   });
 });

--- a/apps/oxfmt/test/api/jsdoc.test.ts
+++ b/apps/oxfmt/test/api/jsdoc.test.ts
@@ -111,8 +111,8 @@ describe("JSDoc", () => {
     // Parse errors inside comments are NOT diagnostics and do NOT fall back
     // to Prettier: the block stays as-is.
     // - css: genuinely broken
-    // - graphql: draft-spec syntax (fragment variable definitions) that
-    //   apollo-parser rejects
+    // - graphql: draft-spec syntax (fragment spread arguments, graphql-js 17)
+    //   that the apollo-parser fork does not cover yet
     const source = `
 /**
  * \`\`\`css
@@ -120,7 +120,7 @@ describe("JSDoc", () => {
  * \`\`\`
  *
  * \`\`\`graphql
- * fragment F($x: Int) on T { f }
+ * fragment F on T { ...G(x: 1) }
  * \`\`\`
  */
 `.trim();

--- a/crates/oxc_formatter_graphql/AGENTS.md
+++ b/crates/oxc_formatter_graphql/AGENTS.md
@@ -12,11 +12,23 @@ Prettier compatible GraphQL formatter (`oxfmt`'s Tier 1 backend), using the `oxc
   - `format_to_ir()`: embedded use via the dispatcher (graphql-in-js); allocates
     from the shared `EmbeddedContext` arena, emits no BOM / trailing newline,
     and leaves `propagate_expand()` to the parent document
-- Parses with [apollo-parser](https://docs.rs/apollo-parser) (rowan-based lossless CST)
-  - Spec coverage: **October 2021 GraphQL spec only**
-  - Prettier parses with `graphql-js`, which also accepts draft-level syntax
-    (e.g. experimental fragment arguments, directives on directive definitions)
-  - Such input makes `format()` return `Err`; `oxfmt` then falls back to Prettier (napi build)
+- Parses with a [fork of apollo-parser](https://github.com/leaysgur/apollo-rs)
+  (rowan-based lossless CST), pinned via `rev` in the workspace `Cargo.toml`
+  - Base: 0.8.6 (October 2021 spec). The fork adds, behind **opt-in** parser
+    flags, what Prettier's graphql-js 16.12 also accepts: **executable
+    descriptions** on operation / fragment / variable definitions
+    (Sep2025 spec, graphql-spec #1170) and **legacy fragment variables**
+    (`fragment F($x: Int) on T`). Both default to off; `format.rs` enables them
+    explicitly via `allow_executable_descriptions` /
+    `allow_legacy_fragment_variables` on `Parser`
+  - NOT covered by the fork (graphql-js 17 syntax): fragment spread arguments
+    (`...F(x: 1)`), directives on directive definitions, directive extensions.
+    Prettier 3.8.4 (stable) also rejects these, but Prettier main already
+    handles directives-on-directives (#19171) and fragment arguments (#19297) —
+    see the Roadmap below; following main here is future work
+  - Remaining parse errors make `format()` return `Err`; there is NO Prettier
+    fallback (oxfmt reports a diagnostic for standalone files, and an embedded
+    dispatch error makes the parent print the template as-is)
 - The canonical reference is Prettier's `src/language-graphql/printer-graphql.js`
   — port its layout decisions, do not invent new ones
 
@@ -27,7 +39,8 @@ Prettier compatible GraphQL formatter (`oxfmt`'s Tier 1 backend), using the `oxc
 - apollo-parser is error-tolerant (returns a CST even for invalid input),
   but any parse error bails out; never format a broken CST
 - print-stage internal errors are also `Err`
-- The caller (oxfmt) decides what happens next (report, or Prettier fallback)
+- The caller (oxfmt) decides what happens next
+  (diagnostics for standalone files, template-as-is for embedded)
 
 ### Comments
 
@@ -58,6 +71,36 @@ the printer collapses consecutive line breaks, so they are emitted as raw `\n` t
   Counting raw newlines would over-report when tokens (e.g. the `&` between two `implements` comments, or an insignificant comma) sit on their own line.
 - A cooked `\r` escape in a string value is re-emitted as `\r`
   (Prettier emits a raw CR byte, which the core `text()` builder forbids; the string VALUE is identical).
+- Known divergence: a trailing comment on the same line as a description
+  (`"desc" # comment`) moves to the next flush point (Prettier keeps it inline).
+  Pre-existing behavior of the positional comment cursor, affects type-system
+  descriptions too; no conformance test covers this shape.
+
+## Roadmap / TODO (graphql-js 17 / Prettier main)
+
+The guiding axis is **Prettier compatibility, not spec compliance**: match the
+syntax that the graphql-js version Prettier depends on can format
+(Prettier stable = graphql-js 16, Prettier main = graphql-js 17). Directive
+applications like `@oneOf` / `@defer` need no work — apollo-parser 0.8.6 already
+parses them.
+
+These are in Prettier's unreleased changelog (main has them, next stable will).
+Spec ratification is 2026+ at the earliest (RFC #1206 etc. still in flux).
+
+- **Prettier [#18582](https://github.com/prettier/prettier/blob/main/changelog_unreleased/graphql/18582.md)**:
+  allow `implements` lists to break. We currently implement **never break**
+  (see `tests/fixtures/format/implements-width.graphql`), so this is a layout
+  divergence that will become incompatible — not a new-syntax item, lands sooner.
+- **Prettier [#19171](https://github.com/prettier/prettier/blob/main/changelog_unreleased/graphql/19171.md)**:
+  directives on directive definitions (`directive @a @b on QUERY`) + `extend
+directive`. graphql-js 17 graduated this to default (no option).
+- **Prettier [#19297](https://github.com/prettier/prettier/blob/main/changelog_unreleased/graphql/19297.md)**:
+  fragment arguments (`...F(size: $size)`). graphql-js 17 still gates it behind
+  `experimentalFragmentArguments`; it replaces the v16 `allowLegacyFragmentVariables`
+  (definition-side, parser-only), which v17 removed.
+
+Adding any of these to the fork needs new grammar in apollo-parser (unlike
+`@oneOf`, these are genuinely new syntax).
 
 ## Verification
 
@@ -75,7 +118,9 @@ covering what the Prettier conformance suite does not:
 string escape re-encoding (incl. the `\r` divergence), empty `[]` / `{}` values,
 the full set of type-system extensions, insignificant-comma trivia,
 trailing comments at various positions,
-and width-overflowing `implements` lists (which never break).
+width-overflowing `implements` lists (which never break),
+and executable descriptions + legacy fragment variables
+(comment / blank-line / width edges beyond the conformance fixtures).
 `build.rs` auto-generates a test case from every `.graphql` file using the core
 `test_support` harness. Unit tests in `tests/fixtures/mod.rs` cover parse-error
 `Err` semantics and BOM preservation; `src/comments.rs` has `classify_gap` tests

--- a/crates/oxc_formatter_graphql/src/format.rs
+++ b/crates/oxc_formatter_graphql/src/format.rs
@@ -87,7 +87,12 @@ fn parse_document<'a>(
 ) -> Result<(cst::Document, &'a str, &'a [Span]), OxcDiagnostic> {
     let source: &'a str = allocator.alloc_str(source_text);
 
-    let tree = Parser::new(source).parse();
+    // The fork gates these behind opt-in flags; enable both to keep parsing the
+    // graphql-js 16 syntax (executable descriptions + legacy fragment variables).
+    let tree = Parser::new(source)
+        .allow_executable_descriptions(true)
+        .allow_legacy_fragment_variables(true)
+        .parse();
     if let Some(error) = tree.errors().next() {
         let start = u32::try_from(error.index()).unwrap_or(0);
         let len = u32::try_from(error.data().len()).unwrap_or(0);

--- a/crates/oxc_formatter_graphql/src/print/common.rs
+++ b/crates/oxc_formatter_graphql/src/print/common.rs
@@ -176,6 +176,7 @@ fn write_variable_definition(
     variable_definition: &cst::VariableDefinition,
     f: &mut GraphqlFormatter<'_, '_>,
 ) {
+    write_description(variable_definition.description(), f);
     if let Some(variable) = variable_definition.variable() {
         write_variable(&variable, f);
     }

--- a/crates/oxc_formatter_graphql/src/print/definition.rs
+++ b/crates/oxc_formatter_graphql/src/print/definition.rs
@@ -115,6 +115,8 @@ fn write_operation_definition(
     operation: &cst::OperationDefinition,
     f: &mut GraphqlFormatter<'_, '_>,
 ) {
+    common::write_description(operation.description(), f);
+
     let has_operation = operation.operation_type().is_some();
     let has_name = operation.name().is_some();
 
@@ -142,12 +144,15 @@ fn write_operation_definition(
 }
 
 fn write_fragment_definition(fragment: &cst::FragmentDefinition, f: &mut GraphqlFormatter<'_, '_>) {
+    common::write_description(fragment.description(), f);
     write!(f, "fragment ");
     if let Some(fragment_name) = fragment.fragment_name()
         && let Some(name) = fragment_name.name()
     {
         common::write_name(&name, f);
     }
+    // Legacy fragment variables (graphql-js `allowLegacyFragmentVariables`).
+    common::write_variable_definitions(fragment.variable_definitions(), f);
     if let Some(type_condition) = fragment.type_condition()
         && let Some(named) = type_condition.named_type()
     {

--- a/crates/oxc_formatter_graphql/tests/fixtures/format/executable-descriptions.graphql
+++ b/crates/oxc_formatter_graphql/tests/fixtures/format/executable-descriptions.graphql
@@ -1,0 +1,46 @@
+# Descriptions on executable definitions (GraphQL 2025 spec, graphql-js 16.12+)
+# and legacy fragment variables (graphql-js allowLegacyFragmentVariables).
+"Op description"
+query q {
+  f
+}
+
+"""
+Block description
+"""
+mutation m @dir {
+  f
+}
+
+"desc"   query withVars("var desc" $x: Int, "another"
+$y: String = "z" @upper) {
+  f
+}
+
+"Fragment description"
+fragment F($a: Int = 1, "b desc" $b: [B!]!) on T {
+  f
+}
+
+fragment G($veryLongVariableName: SomeLongTypeName = DEFAULT, "described" $another: AlsoQuiteLongTypeName) on SomeType @dir {
+  f
+}
+
+query noDesc(
+  "single line stays"
+  $x: Int
+  """
+  block forces line
+  """
+  $y: Int
+) {
+  f
+}
+
+fragment H(
+  # leading comment in vars
+  "a desc"
+  $a: Int # trailing var comment
+) on T {
+  f
+}

--- a/crates/oxc_formatter_graphql/tests/fixtures/format/executable-descriptions.graphql.snap
+++ b/crates/oxc_formatter_graphql/tests/fixtures/format/executable-descriptions.graphql.snap
@@ -1,0 +1,179 @@
+---
+source: crates/oxc_formatter_graphql/tests/fixtures/mod.rs
+---
+==================== Input ====================
+# Descriptions on executable definitions (GraphQL 2025 spec, graphql-js 16.12+)
+# and legacy fragment variables (graphql-js allowLegacyFragmentVariables).
+"Op description"
+query q {
+  f
+}
+
+"""
+Block description
+"""
+mutation m @dir {
+  f
+}
+
+"desc"   query withVars("var desc" $x: Int, "another"
+$y: String = "z" @upper) {
+  f
+}
+
+"Fragment description"
+fragment F($a: Int = 1, "b desc" $b: [B!]!) on T {
+  f
+}
+
+fragment G($veryLongVariableName: SomeLongTypeName = DEFAULT, "described" $another: AlsoQuiteLongTypeName) on SomeType @dir {
+  f
+}
+
+query noDesc(
+  "single line stays"
+  $x: Int
+  """
+  block forces line
+  """
+  $y: Int
+) {
+  f
+}
+
+fragment H(
+  # leading comment in vars
+  "a desc"
+  $a: Int # trailing var comment
+) on T {
+  f
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+# Descriptions on executable definitions (GraphQL 2025 spec, graphql-js 16.12+)
+# and legacy fragment variables (graphql-js allowLegacyFragmentVariables).
+"Op description"
+query q {
+  f
+}
+
+"""
+Block description
+"""
+mutation m @dir {
+  f
+}
+
+"desc"
+query withVars(
+  "var desc"
+  $x: Int
+  "another"
+  $y: String = "z" @upper
+) {
+  f
+}
+
+"Fragment description"
+fragment F(
+  $a: Int = 1
+  "b desc"
+  $b: [B!]!
+) on T {
+  f
+}
+
+fragment G(
+  $veryLongVariableName: SomeLongTypeName = DEFAULT
+  "described"
+  $another: AlsoQuiteLongTypeName
+) on SomeType @dir {
+  f
+}
+
+query noDesc(
+  "single line stays"
+  $x: Int
+  """
+  block forces line
+  """
+  $y: Int
+) {
+  f
+}
+
+fragment H(
+  # leading comment in vars
+  "a desc"
+  $a: Int # trailing var comment
+) on T {
+  f
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+# Descriptions on executable definitions (GraphQL 2025 spec, graphql-js 16.12+)
+# and legacy fragment variables (graphql-js allowLegacyFragmentVariables).
+"Op description"
+query q {
+  f
+}
+
+"""
+Block description
+"""
+mutation m @dir {
+  f
+}
+
+"desc"
+query withVars(
+  "var desc"
+  $x: Int
+  "another"
+  $y: String = "z" @upper
+) {
+  f
+}
+
+"Fragment description"
+fragment F(
+  $a: Int = 1
+  "b desc"
+  $b: [B!]!
+) on T {
+  f
+}
+
+fragment G(
+  $veryLongVariableName: SomeLongTypeName = DEFAULT
+  "described"
+  $another: AlsoQuiteLongTypeName
+) on SomeType @dir {
+  f
+}
+
+query noDesc(
+  "single line stays"
+  $x: Int
+  """
+  block forces line
+  """
+  $y: Int
+) {
+  f
+}
+
+fragment H(
+  # leading comment in vars
+  "a desc"
+  $a: Int # trailing var comment
+) on T {
+  f
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_graphql/tests/fixtures/mod.rs
+++ b/crates/oxc_formatter_graphql/tests/fixtures/mod.rs
@@ -97,8 +97,9 @@ fn parse_error_is_err() {
         "query {{{",
         "",
         "# comments-only",
-        // Draft-spec syntax that Prettier (graphql-js) accepts but apollo-parser does not.
-        "fragment F($x: Int) on T { f }",
+        // Draft-spec syntax that Prettier main (graphql-js 17) accepts
+        // but the apollo-parser fork does not (yet): fragment spread arguments.
+        "fragment F on T { ...G(x: 1) }",
     ] {
         assert!(
             format(&allocator, source, GraphqlFormatOptions::default()).is_err(),

--- a/tasks/prettier_conformance/snapshots/prettier.graphql.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.graphql.snap.md
@@ -1,16 +1,6 @@
-graphql compatibility: 53/53 (100.00%), 7 files skipped
+graphql compatibility: 53/53 (100.00%), 0 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-
-# Skipped (parse error, TODO: should be ignored or supported)
-
-- graphql/descriptions/fragment-with-variable-description(legacy).graphql
-- graphql/descriptions/fragment.graphql
-- graphql/descriptions/nameless-query-with-description.graphql
-- graphql/descriptions/operation-and-variable-definition-descriptions.graphql
-- graphql/descriptions/variable-definition-with-description-default value-and-directives.graphql
-- graphql/fragment-variables/fragment_variables.graphql
-- graphql/kitchen-sink/kitchen-sink-2.graphql


### PR DESCRIPTION
- Fork `apollo-rs` to be compatible with Prettier(`latest` for now)
  - https://github.com/leaysgur/apollo-rs
- By doing this, Prettier fallback is no longer needed
- And now all prettier_conformance are passed, no parse error skip

> [!WARNING]
> TODO: Move fork under `oxc-project` org and replace refs