### PR TITLE
fix(lsp): use protocol line breaks for positions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2852,7 +2852,6 @@ dependencies = [
  "oxc-toml",
  "oxc_allocator",
  "oxc_config",
- "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_formatter",
  "oxc_formatter_core",

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -29,7 +29,6 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true, features = ["pool"] }
 oxc_config = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["rope"] }
 oxc_diagnostics = { workspace = true }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }

--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -4,12 +4,12 @@ use std::{
 };
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use tower_lsp_server::ls_types::{Pattern, Position, Range, ServerCapabilities, TextEdit, Uri};
+use tower_lsp_server::ls_types::{Pattern, Range, ServerCapabilities, TextEdit, Uri};
 use tracing::{debug, error, warn};
 
-use oxc_data_structures::rope::{Rope, get_line_column};
 use oxc_language_server::{
     Capabilities, LanguageId, TextDocument, Tool, ToolBuilder, ToolRestartChanges,
+    offset_to_position,
 };
 
 use crate::core::{
@@ -249,15 +249,11 @@ impl Tool for ServerFormatter {
                 }
 
                 let (start, end, replacement) = compute_minimal_text_edit(source_text, &code);
-                let rope = Rope::from(source_text);
-                let (start_line, start_character) = get_line_column(&rope, start, source_text);
-                let (end_line, end_character) = get_line_column(&rope, end, source_text);
+                let start_position = offset_to_position(source_text, start);
+                let end_position = offset_to_position(source_text, end);
 
                 Ok(vec![TextEdit::new(
-                    Range::new(
-                        Position::new(start_line, start_character),
-                        Position::new(end_line, end_character),
-                    ),
+                    Range::new(start_position, end_position),
                     replacement.to_string(),
                 )])
             }
@@ -515,6 +511,7 @@ mod tests_builder {
 #[cfg(test)]
 mod tests {
     use super::compute_minimal_text_edit;
+    use oxc_language_server::offset_to_position;
 
     #[test]
     #[should_panic(expected = "assertion failed")]
@@ -575,6 +572,20 @@ mod tests {
         let (start, end, replacement) = compute_minimal_text_edit(src, formatted);
         // Replace 😀 with 😃
         assert_eq!((start, end, replacement), (1, 5, "😃"));
+    }
+
+    #[test]
+    fn test_lsp_edit_range_ignores_unicode_line_separators() {
+        let src = "a\u{2028}b\u{2029}c \nnext";
+        let formatted = "a\u{2028}b\u{2029}c\nnext";
+        let (start, end, replacement) = compute_minimal_text_edit(src, formatted);
+
+        let start_position = offset_to_position(src, start);
+        let end_position = offset_to_position(src, end);
+
+        assert_eq!((start_position.line, start_position.character), (0, 5));
+        assert_eq!((end_position.line, end_position.character), (0, 6));
+        assert_eq!(replacement, "");
     }
 
     #[test]

--- a/apps/oxlint/src/lsp/error_with_position.rs
+++ b/apps/oxlint/src/lsp/error_with_position.rs
@@ -6,8 +6,9 @@ use tower_lsp_server::ls_types::{
     NumberOrString, Position, Range, Uri,
 };
 
-use oxc_data_structures::rope::{Rope, get_line_column};
+use oxc_data_structures::rope::Rope;
 use oxc_diagnostics::{OxcCode, Severity};
+use oxc_language_server::offset_to_position as lsp_offset_to_position;
 use oxc_linter::{
     AllowWarnDeny, DisableDirectives, Fix, FixKind, Message, PossibleFixes, RuleCommentType,
 };
@@ -404,9 +405,8 @@ fn build_unused_disable_diagnostic_report(
     }
 }
 
-pub fn offset_to_position(rope: &Rope, offset: u32, source_text: &str) -> Position {
-    let (line, column) = get_line_column(rope, offset, source_text);
-    Position::new(line, column)
+pub fn offset_to_position(_rope: &Rope, offset: u32, source_text: &str) -> Position {
+    lsp_offset_to_position(source_text, offset)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -833,6 +833,14 @@ mod test {
         assert_position(source, 14, (1, 3));
         assert_position(source, 18, (1, 5));
         assert_position(source, 19, (1, 6));
+    }
+
+    #[test]
+    fn unicode_line_and_paragraph_separators_are_not_lsp_line_breaks() {
+        let source = "a\u{2028}b\nc\u{2029}d";
+        assert_position(source, source.find('b').unwrap() as u32, (0, 2));
+        assert_position(source, source.find('c').unwrap() as u32, (1, 0));
+        assert_position(source, source.find('d').unwrap() as u32, (1, 2));
     }
 
     #[test]

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -9,6 +9,7 @@ mod capabilities;
 mod file_system;
 mod language_id;
 mod options;
+mod position;
 #[cfg(test)]
 mod tests;
 mod tool;
@@ -17,6 +18,7 @@ mod worker_manager;
 
 pub use crate::capabilities::{Capabilities, DiagnosticMode};
 pub use crate::language_id::LanguageId;
+pub use crate::position::offset_to_position;
 pub use crate::tool::{DiagnosticResult, Tool, ToolBuilder, ToolRestartChanges};
 pub use crate::worker::WorkspaceWorker;
 pub use crate::worker_manager::WorkerManager;

--- a/crates/oxc_language_server/src/position.rs
+++ b/crates/oxc_language_server/src/position.rs
@@ -1,0 +1,88 @@
+use tower_lsp_server::ls_types::Position;
+
+/// Convert a UTF-8 byte offset to an LSP position.
+///
+/// LSP positions use zero-based line numbers and UTF-16 character offsets. The
+/// protocol only treats CR, LF, and CRLF as line breaks, so Unicode line and
+/// paragraph separators must remain ordinary characters here.
+///
+/// # Panics
+///
+/// Panics if `offset` is out of bounds, does not point to a UTF-8 character
+/// boundary in `source_text`, or the computed LSP character offset does not fit
+/// in `u32`.
+pub fn offset_to_position(source_text: &str, offset: u32) -> Position {
+    let offset = usize::try_from(offset).expect("offset must fit in usize");
+    assert!(offset <= source_text.len(), "offset out of bounds");
+    assert!(source_text.is_char_boundary(offset), "offset is not a char boundary");
+
+    let bytes = source_text.as_bytes();
+    let mut line = 0;
+    let mut line_start = 0;
+    let mut i = 0;
+
+    while i < offset {
+        match bytes[i] {
+            b'\r' => {
+                i += if i + 1 < offset && bytes[i + 1] == b'\n' { 2 } else { 1 };
+                line += 1;
+                line_start = i;
+            }
+            b'\n' => {
+                i += 1;
+                line += 1;
+                line_start = i;
+            }
+            _ => {
+                let ch = source_text[i..].chars().next().expect("valid char boundary");
+                i += ch.len_utf8();
+            }
+        }
+    }
+
+    let character = u32::try_from(source_text[line_start..offset].encode_utf16().count())
+        .expect("LSP character offset must fit in u32");
+    Position::new(line, character)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::offset_to_position;
+
+    fn assert_position(source_text: &str, offset: usize, expected: (u32, u32)) {
+        let position = offset_to_position(
+            source_text,
+            u32::try_from(offset).expect("test offset must fit in u32"),
+        );
+        assert_eq!((position.line, position.character), expected);
+    }
+
+    #[test]
+    fn uses_lsp_line_breaks() {
+        let source = "a\u{2028}b\nc\u{2029}d";
+
+        assert_position(source, source.find('b').unwrap(), (0, 2));
+        assert_position(source, source.find('c').unwrap(), (1, 0));
+        assert_position(source, source.find('d').unwrap(), (1, 2));
+    }
+
+    #[test]
+    fn treats_crlf_as_one_line_break() {
+        let source = "a\r\nb";
+
+        assert_position(source, source.find('b').unwrap(), (1, 0));
+    }
+
+    #[test]
+    fn reports_utf16_character_offsets() {
+        let source = "😀a";
+
+        assert_position(source, source.find('a').unwrap(), (0, 2));
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn panics_for_out_of_bounds_offset() {
+        offset_to_position("foo", 100);
+    }
+}

--- a/crates/oxc_language_server/src/position.rs
+++ b/crates/oxc_language_server/src/position.rs
@@ -58,31 +58,93 @@ mod tests {
     }
 
     #[test]
-    fn uses_lsp_line_breaks() {
-        let source = "a\u{2028}b\nc\u{2029}d";
+    fn test_line_break() {
+        for nl in ["\n", "\r", "\r\n"] {
+            let source = format!("a{}b", nl);
+            assert_position(&source, source.find('b').unwrap(), (1, 0));
+        }
 
-        assert_position(source, source.find('b').unwrap(), (0, 2));
-        assert_position(source, source.find('c').unwrap(), (1, 0));
-        assert_position(source, source.find('d').unwrap(), (1, 2));
-    }
-
-    #[test]
-    fn treats_crlf_as_one_line_break() {
-        let source = "a\r\nb";
-
-        assert_position(source, source.find('b').unwrap(), (1, 0));
-    }
-
-    #[test]
-    fn reports_utf16_character_offsets() {
-        let source = "😀a";
-
-        assert_position(source, source.find('a').unwrap(), (0, 2));
+        for nl in ["\u{2028}", "\u{2029}"] {
+            let source = format!("a{}b", nl);
+            assert_position(&source, source.find('b').unwrap(), (0, 2));
+        }
     }
 
     #[test]
     #[should_panic(expected = "out of bounds")]
     fn panics_for_out_of_bounds_offset() {
         offset_to_position("foo", 100);
+    }
+
+    #[test]
+    fn empty_file() {
+        assert_position("", 0, (0, 0));
+    }
+
+    #[test]
+    fn first_line_start() {
+        assert_position("foo\nbar\n", 0, (0, 0));
+    }
+
+    #[test]
+    fn first_line_middle() {
+        assert_position("blahblahblah\noops\n", 5, (0, 5));
+    }
+
+    #[test]
+    fn later_line_start() {
+        assert_position("foo\nbar\nblahblahblah", 8, (2, 0));
+    }
+
+    #[test]
+    fn later_line_middle() {
+        assert_position("foo\nbar\nblahblahblah", 12, (2, 4));
+    }
+
+    #[test]
+    fn after_2_byte_unicode() {
+        assert_eq!("£".len(), 2);
+        assert_eq!(utf16_len("£"), 1);
+        assert_position("£abc", 4, (0, 3));
+    }
+
+    #[test]
+    fn after_3_byte_unicode() {
+        assert_eq!("अ".len(), 3);
+        assert_eq!(utf16_len("अ"), 1);
+        assert_position("अabc", 5, (0, 3));
+    }
+
+    #[test]
+    fn after_4_byte_unicode() {
+        assert_eq!("🍄".len(), 4);
+        assert_eq!(utf16_len("🍄"), 2);
+        assert_position("🍄abc", 6, (0, 4));
+    }
+
+    #[test]
+    fn after_2_byte_unicode_on_previous_line() {
+        assert_eq!("£".len(), 2);
+        assert_eq!(utf16_len("£"), 1);
+        assert_position("£\nabc", 4, (1, 1));
+    }
+
+    #[test]
+    fn after_3_byte_unicode_on_previous_line() {
+        assert_eq!("अ".len(), 3);
+        assert_eq!(utf16_len("अ"), 1);
+        assert_position("अ\nabc", 5, (1, 1));
+    }
+
+    #[test]
+    fn after_4_byte_unicode_on_previous_line() {
+        assert_eq!("🍄".len(), 4);
+        assert_eq!(utf16_len("🍄"), 2);
+        assert_position("🍄\nabc", 6, (1, 1));
+    }
+
+    #[cfg(test)]
+    fn utf16_len(s: &str) -> usize {
+        s.encode_utf16().count()
     }
 }

--- a/crates/oxc_language_server/src/position.rs
+++ b/crates/oxc_language_server/src/position.rs
@@ -60,12 +60,12 @@ mod tests {
     #[test]
     fn test_line_break() {
         for nl in ["\n", "\r", "\r\n"] {
-            let source = format!("a{}b", nl);
+            let source = format!("a{nl}b");
             assert_position(&source, source.find('b').unwrap(), (1, 0));
         }
 
         for nl in ["\u{2028}", "\u{2029}"] {
-            let source = format!("a{}b", nl);
+            let source = format!("a{nl}b");
             assert_position(&source, source.find('b').unwrap(), (0, 2));
         }
     }


### PR DESCRIPTION
Fixes #23314

## Summary

- add an LSP-specific UTF-8 byte offset to `Position` converter
- use it for oxfmt formatter `TextEdit` ranges
- route oxlint LSP positions through the same converter

## Details

The existing conversion used the shared rope helper, which treats Unicode line
and paragraph separators as line breaks. That is correct for some JavaScript
source-location semantics, but LSP only treats CR, LF, and CRLF as line breaks.

This keeps the shared rope helper unchanged and isolates the protocol-specific
behavior in `oxc_language_server`.

## Tests

- `cargo fmt --all`
- `cargo test -p oxc_language_server position --lib`
- `cargo test -p oxfmt --lib lsp::server_formatter`
- `cargo test -p oxlint --lib lsp::error_with_position`
- `cargo clippy -p oxc_language_server -p oxfmt -p oxlint --lib --tests --no-deps -- -D warnings`
- `git diff --check`


## AI Assistance

This PR was prepared with AI assistance. I reviewed the generated changes and test results, and I am responsible for the contribution.
