### PR TITLE
feat(linter): support jest globalPackage setting

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -6441,6 +6441,12 @@ export interface OxlintPluginSettings {
  */
 export interface JestPluginSettings {
   /**
+   * Package to treat as the source of Jest globals.
+   *
+   * This matches `eslint-plugin-jest`'s `settings.jest.globalPackage` option.
+   */
+  globalPackage?: string;
+  /**
    * Jest version — accepts a number (`29`) or a semver string (`"29.1.0"` or `"v29.1.0"`),
    * storing only the major version.
    * ::: warning

--- a/apps/oxlint/src/snapshots/_-c fixtures__cli__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__cli__print_config__ban_rules__eslintrc.json -A all -D eqeqeq --print-config@oxlint.snap
@@ -49,6 +49,7 @@ working directory:
       "typecheck": false
     },
     "jest": {
+      "globalPackage": null,
       "version": null
     }
   },

--- a/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_-A all --print-config@oxlint.snap
@@ -42,6 +42,7 @@ working directory: fixtures
       "typecheck": false
     },
     "jest": {
+      "globalPackage": null,
       "version": null
     }
   },

--- a/apps/oxlint/test/fixtures/print_config_js_config_extends/output.snap.md
+++ b/apps/oxlint/test/fixtures/print_config_js_config_extends/output.snap.md
@@ -45,6 +45,7 @@
       "typecheck": false
     },
     "jest": {
+      "globalPackage": null,
       "version": null
     }
   },

--- a/crates/oxc_linter/src/config/settings/jest.rs
+++ b/crates/oxc_linter/src/config/settings/jest.rs
@@ -10,6 +10,12 @@ use serde::{Deserialize, Deserializer, Serialize};
 /// configuration for a full reference.
 #[derive(Debug, Clone, Deserialize, Default, Serialize, JsonSchema, PartialEq, Eq)]
 pub struct JestPluginSettings {
+    /// Package to treat as the source of Jest globals.
+    ///
+    /// This matches `eslint-plugin-jest`'s `settings.jest.globalPackage` option.
+    #[serde(default, rename = "globalPackage")]
+    pub global_package: Option<String>,
+
     /// Jest version — accepts a number (`29`) or a semver string (`"29.1.0"` or `"v29.1.0"`),
     /// storing only the major version.
     /// ::: warning
@@ -18,6 +24,16 @@ pub struct JestPluginSettings {
     #[serde(default, deserialize_with = "jest_version_deserialize")]
     #[schemars(with = "Option<JestVersionSchema>")]
     pub version: Option<usize>,
+}
+
+impl JestPluginSettings {
+    /// The default package providing Jest globals.
+    pub const DEFAULT_GLOBAL_PACKAGE: &'static str = "@jest/globals";
+
+    /// Return the configured package to treat as the source of Jest globals.
+    pub fn global_package(&self) -> &str {
+        self.global_package.as_deref().unwrap_or(Self::DEFAULT_GLOBAL_PACKAGE)
+    }
 }
 
 #[derive(JsonSchema)]

--- a/crates/oxc_linter/src/config/settings/mod.rs
+++ b/crates/oxc_linter/src/config/settings/mod.rs
@@ -323,6 +323,22 @@ mod test {
     }
 
     #[test]
+    fn test_jest_global_package_settings() {
+        let json_value = serde_json::json!({
+            "jest": {
+                "globalPackage": "bun:test"
+            }
+        });
+
+        let settings = OxlintSettings::deserialize(&json_value).unwrap();
+
+        assert_eq!(settings.jest.global_package(), "bun:test");
+
+        let raw_json = settings.json.unwrap();
+        assert_eq!(raw_json["jest"]["globalPackage"], "bun:test");
+    }
+
+    #[test]
     fn test_major_version_jest_as_string_settings() {
         let json_value = serde_json::json!({
             "jest": {

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -481,8 +481,8 @@ impl<'a> ContextHost<'a> {
             // let mut test_flags = FrameworkFlags::empty();
 
             let vitest_like = has_vitest_imports(self.module_record());
-            let jest_like =
-                is_jestlike_file(&self.file_path) || has_jest_imports(self.module_record());
+            let jest_like = is_jestlike_file(&self.file_path)
+                || has_jest_imports(self.module_record(), self.settings().jest.global_package());
 
             self.frameworks.set(FrameworkFlags::Vitest, vitest_like);
             self.frameworks.set(FrameworkFlags::Jest, jest_like);

--- a/crates/oxc_linter/src/frameworks.rs
+++ b/crates/oxc_linter/src/frameworks.rs
@@ -100,8 +100,8 @@ pub fn has_vitest_imports(module_record: &ModuleRecord) -> bool {
 }
 
 #[cfg(not(test))]
-pub fn has_jest_imports(module_record: &ModuleRecord) -> bool {
-    module_record.import_entries.iter().any(|entry| entry.module_request.name() == "@jest/globals")
+pub fn has_jest_imports(module_record: &ModuleRecord, global_package: &str) -> bool {
+    module_record.import_entries.iter().any(|entry| entry.module_request.name() == global_package)
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -103,7 +103,7 @@ use crate::{
     loader::LINT_PARTIAL_LOADER_EXTENSIONS,
     rules::RuleEnum,
     timing::{RuleTimingRecorder, RuleTimingStat},
-    utils::iter_possible_jest_call_node,
+    utils::iter_possible_jest_call_node_with_global_package,
 };
 
 #[cfg(target_pointer_width = "64")]
@@ -189,6 +189,7 @@ fn execute_rules<'a, const TIMINGS: bool>(
     rules: &[(&RuleEnum, LintContext<'a>)],
     semantic: &Semantic<'a>,
     should_run_on_jest_node: bool,
+    jest_global_package: &str,
     with_runtime_optimization: bool,
     mut timing_recorder: Option<&mut RuleTimingRecorder>,
 ) {
@@ -235,7 +236,9 @@ fn execute_rules<'a, const TIMINGS: bool>(
             }
 
             if should_run_on_jest_node {
-                for jest_node in iter_possible_jest_call_node(semantic) {
+                for jest_node in
+                    iter_possible_jest_call_node_with_global_package(semantic, jest_global_package)
+                {
                     for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
                         if rule.run_info().is_run_on_jest_node_implemented() {
                             let timing_stat =
@@ -259,7 +262,10 @@ fn execute_rules<'a, const TIMINGS: bool>(
             }
 
             if should_run_on_jest_node {
-                for jest_node in iter_possible_jest_call_node(semantic) {
+                for jest_node in iter_possible_jest_call_node_with_global_package(
+                    semantic,
+                    jest_global_package,
+                ) {
                     let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
                     rule.run_on_jest_node::<TIMINGS>(&jest_node, ctx, timing_stat);
                 }
@@ -401,11 +407,13 @@ impl Linter {
 
             let should_run_on_jest_node =
                 ctx_host.plugins().has_test() && ctx_host.frameworks().is_test();
+            let jest_global_package = ctx_host.settings().jest.global_package();
 
             execute_rules::<TIMINGS>(
                 &rules,
                 semantic,
                 should_run_on_jest_node,
+                jest_global_package,
                 true,
                 timing_recorder.as_mut(),
             );
@@ -413,7 +421,14 @@ impl Linter {
             #[cfg(debug_assertions)]
             {
                 let diagnostics_after_optimized = ctx_host.diagnostic_count();
-                execute_rules::<false>(&rules, semantic, should_run_on_jest_node, false, None);
+                execute_rules::<false>(
+                    &rules,
+                    semantic,
+                    should_run_on_jest_node,
+                    jest_global_package,
+                    false,
+                    None,
+                );
                 let diagnostics_after_unoptimized = ctx_host.diagnostic_count();
                 ctx_host.get_diagnostics(|diagnostics| {
                     let optimized_diagnostics = &diagnostics[current_diagnostic_index..diagnostics_after_optimized];

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -262,10 +262,9 @@ fn execute_rules<'a, const TIMINGS: bool>(
             }
 
             if should_run_on_jest_node {
-                for jest_node in iter_possible_jest_call_node_with_global_package(
-                    semantic,
-                    jest_global_package,
-                ) {
+                for jest_node in
+                    iter_possible_jest_call_node_with_global_package(semantic, jest_global_package)
+                {
                     let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
                     rule.run_on_jest_node::<TIMINGS>(&jest_node, ctx, timing_stat);
                 }

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -98,3 +98,21 @@ fn test() {
         .with_jest_plugin(true)
         .test_and_snapshot();
 }
+
+#[test]
+fn test_global_package_setting() {
+    use crate::tester::Tester;
+
+    fn settings() -> serde_json::Value {
+        serde_json::json!({ "settings": { "jest": { "globalPackage": "bun:test" } } })
+    }
+
+    let pass = vec![("import { test } from 'bun:test'; test.skip('something');", None, None)];
+    let fail =
+        vec![("import { test } from 'bun:test'; test.skip('something');", None, Some(settings()))];
+
+    Tester::new(NoDisabledTests::NAME, NoDisabledTests::PLUGIN, pass, fail)
+        .with_jest_plugin(true)
+        .with_snapshot_suffix("global_package")
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_assertions.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_assertions.rs
@@ -60,7 +60,8 @@ impl Rule for PreferExpectAssertions {
         // Resolve the file-level expect local name once (e.g. `"expect"` or `"e"`
         // for `import { expect as e }`). Per-callback vitest fixture overrides
         // are handled in `resolve_expect_source`.
-        let file_expect_prefix = resolve_expect_local_name(ctx, &["@jest/globals"]);
+        let file_expect_prefix =
+            resolve_expect_local_name(ctx, &[ctx.settings().jest.global_package()]);
 
         let mut covered_describe_ids: Vec<NodeId> = Vec::new();
 
@@ -1602,5 +1603,50 @@ fn test() {
         .expect_fix(fix_multi_statement)
         .expect_fix(fix_has_assertions_callback_arg)
         .expect_fix(fix_remove_args)
+        .test_and_snapshot();
+}
+
+#[test]
+fn test_global_package_setting() {
+    use crate::tester::Tester;
+
+    fn settings() -> serde_json::Value {
+        serde_json::json!({ "settings": { "jest": { "globalPackage": "bun:test" } } })
+    }
+
+    let pass = vec![(
+        r#"import { expect as e, test } from 'bun:test';
+            test("passes", () => {
+              e.assertions(1);
+              e(true).toBe(true);
+            });"#,
+        None,
+        Some(settings()),
+    )];
+    let fail = vec![(
+        r#"import { expect as e, test } from 'bun:test';
+            test("fails", () => {
+              e(true).toBe(true);
+            });"#,
+        None,
+        Some(settings()),
+    )];
+    let fix = vec![(
+        r#"import { expect as e, test } from 'bun:test';
+            test("fails", () => {
+              e(true).toBe(true);
+            });"#,
+        r#"import { expect as e, test } from 'bun:test';
+            test("fails", () => {e.hasAssertions();
+              e(true).toBe(true);
+            });"#,
+        None,
+        Some(settings()),
+    )];
+
+    Tester::new(PreferExpectAssertions::NAME, PreferExpectAssertions::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .with_jest_plugin(true)
+        .with_snapshot_suffix("global_package")
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_importing_jest_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_importing_jest_globals.rs
@@ -21,9 +21,13 @@ use crate::{
     },
 };
 
-fn prefer_importing_jest_globals_diagnostic(span: Span, globals: &str) -> OxcDiagnostic {
+fn prefer_importing_jest_globals_diagnostic(
+    span: Span,
+    globals: &str,
+    import_source: &str,
+) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
-        "Import the following Jest functions from `@jest/globals`: {globals}"
+        "Import the following Jest functions from `{import_source}`: {globals}"
     ))
     .with_label(span)
 }
@@ -88,8 +92,6 @@ impl JestFnType {
     }
 }
 
-const IMPORT_SOURCE: &str = "@jest/globals";
-
 declare_oxc_lint!(
     /// ### What it does
     ///
@@ -135,6 +137,7 @@ impl Rule for PreferImportingJestGlobals {
     }
 
     fn run_once(&self, ctx: &LintContext) {
+        let import_source = ctx.settings().jest.global_package();
         let mut functions_to_import: FxHashSet<String> = FxHashSet::default();
         let mut reporting_span: Option<Span> = None;
 
@@ -174,8 +177,9 @@ impl Rule for PreferImportingJestGlobals {
             prefer_importing_jest_globals_diagnostic(
                 span,
                 &functions_to_import.iter().sorted().join(", "),
+                import_source,
             ),
-            |fixer| build_fix(ctx, &fixer, &mut functions_to_import),
+            |fixer| build_fix(ctx, &fixer, &mut functions_to_import, import_source),
         );
     }
 }
@@ -184,22 +188,23 @@ fn build_fix<'a>(
     ctx: &LintContext<'a>,
     fixer: &RuleFixer<'_, 'a>,
     functions_to_import: &mut FxHashSet<String>,
+    import_source: &str,
 ) -> RuleFix {
     let program = ctx.nodes().program();
     let is_module = ctx.source_type().is_module();
 
-    // 1. Merge with existing `import ... from '@jest/globals'`
-    if let Some(fix) = try_merge_esm_import(ctx, fixer, functions_to_import) {
+    // 1. Merge with existing `import ...` from the configured globals package.
+    if let Some(fix) = try_merge_esm_import(ctx, fixer, functions_to_import, import_source) {
         return fix;
     }
 
-    // 2. Merge with existing `const { ... } = require('@jest/globals')`
-    if let Some(fix) = try_merge_cjs_require(ctx, fixer, functions_to_import) {
+    // 2. Merge with existing `require(...)` from the configured globals package.
+    if let Some(fix) = try_merge_cjs_require(ctx, fixer, functions_to_import, import_source) {
         return fix;
     }
 
     // 3. Create a new import/require
-    let text = create_import_text(is_module, functions_to_import);
+    let text = create_import_text(is_module, functions_to_import, import_source);
 
     if let Some(directive) = program.directives.last() {
         return fixer.insert_text_after_range(directive.span, format!("\n{text}"));
@@ -210,29 +215,34 @@ fn build_fix<'a>(
     fixer.insert_text_before_range(Span::empty(0), format!("{text}\n"))
 }
 
-fn create_import_text(is_module: bool, functions: &FxHashSet<String>) -> String {
+fn create_import_text(
+    is_module: bool,
+    functions: &FxHashSet<String>,
+    import_source: &str,
+) -> String {
     let sorted = functions.iter().sorted().join(", ");
     if is_module {
-        format!("import {{ {sorted} }} from '{IMPORT_SOURCE}';")
+        format!("import {{ {sorted} }} from '{import_source}';")
     } else {
-        format!("const {{ {sorted} }} = require('{IMPORT_SOURCE}');")
+        format!("const {{ {sorted} }} = require('{import_source}');")
     }
 }
 
-/// Merge with existing `import ... from '@jest/globals'` and replace it entirely.
+/// Merge with an existing import from the configured globals package and replace it entirely.
 /// Uses `module_record` to find import entries and their statement span.
 fn try_merge_esm_import<'a>(
     ctx: &LintContext<'a>,
     fixer: &RuleFixer<'_, 'a>,
     functions_to_import: &mut FxHashSet<String>,
+    import_source: &str,
 ) -> Option<RuleFix> {
     let module_record = ctx.module_record();
 
-    // Find the first `@jest/globals` import statement span
+    // Find the first matching import statement span.
     let first_span = module_record
         .import_entries
         .iter()
-        .find(|e| e.module_request.name() == IMPORT_SOURCE && !e.is_type)?
+        .find(|e| e.module_request.name() == import_source && !e.is_type)?
         .statement_span;
 
     // Merge only entries belonging to that same import statement
@@ -258,15 +268,16 @@ fn try_merge_esm_import<'a>(
         }
     }
 
-    Some(fixer.replace(first_span, create_import_text(true, functions_to_import)))
+    Some(fixer.replace(first_span, create_import_text(true, functions_to_import, import_source)))
 }
 
-/// Merge with existing `const { ... } = require('@jest/globals')` and replace it entirely.
+/// Merge with an existing require from the configured globals package and replace it entirely.
 /// Uses semantic analysis to find `require` references instead of iterating the AST.
 fn try_merge_cjs_require<'a>(
     ctx: &LintContext<'a>,
     fixer: &RuleFixer<'_, 'a>,
     functions_to_import: &mut FxHashSet<String>,
+    import_source: &str,
 ) -> Option<RuleFix> {
     let is_module = ctx.source_type().is_module();
     let alias_sep = if is_module { " as " } else { ": " };
@@ -279,7 +290,7 @@ fn try_merge_cjs_require<'a>(
         let AstKind::CallExpression(call) = call_node.kind() else { continue };
 
         let is_jest_require =
-            call.arguments.len() == 1 && is_string_arg_matching(&call.arguments[0], IMPORT_SOURCE);
+            call.arguments.len() == 1 && is_string_arg_matching(&call.arguments[0], import_source);
 
         if !is_jest_require {
             continue;
@@ -320,9 +331,10 @@ fn try_merge_cjs_require<'a>(
         // VariableDeclaration is the direct parent of VariableDeclarator
         let var_decl_node = ctx.nodes().parent_node(var_declarator_node.id());
 
-        return Some(
-            fixer.replace(var_decl_node.span(), create_import_text(is_module, functions_to_import)),
-        );
+        return Some(fixer.replace(
+            var_decl_node.span(),
+            create_import_text(is_module, functions_to_import, import_source),
+        ));
     }
 
     None
@@ -1064,5 +1076,37 @@ fn test() {
     Tester::new(PreferImportingJestGlobals::NAME, PreferImportingJestGlobals::PLUGIN, pass, fail)
         .expect_fix(fix)
         .with_jest_plugin(true)
+        .test_and_snapshot();
+}
+
+#[test]
+fn test_global_package_setting() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    fn settings() -> serde_json::Value {
+        serde_json::json!({ "settings": { "jest": { "globalPackage": "bun:test" } } })
+    }
+
+    let pass = vec![(
+        "import { expect, test } from 'bun:test'; test('foo', () => { expect(true).toBeDefined(); });",
+        None,
+        Some(settings()),
+    )];
+    let fail =
+        vec![("test('foo', () => { expect(true).toBeDefined(); });", None, Some(settings()))];
+    let fix = vec![(
+        "test('foo', () => { expect(true).toBeDefined(); });",
+        "import { expect, test } from 'bun:test';\ntest('foo', () => { expect(true).toBeDefined(); });",
+        None,
+        Some(PathBuf::from("test.mjs")),
+        Some(settings()),
+    )];
+
+    Tester::new(PreferImportingJestGlobals::NAME, PreferImportingJestGlobals::PLUGIN, pass, fail)
+        .expect_fix(fix)
+        .with_jest_plugin(true)
+        .with_snapshot_suffix("global_package")
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_large_snapshots.rs
@@ -169,7 +169,7 @@ impl NoLargeSnapshotsConfig {
                 }
             }
         } else {
-            for possible_jest_node in iter_possible_jest_call_node(ctx.semantic()) {
+            for possible_jest_node in iter_possible_jest_call_node(ctx) {
                 self.run(&possible_jest_node, ctx);
             }
         }

--- a/crates/oxc_linter/src/snapshots/jest_no_disabled_tests@global_package.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_disabled_tests@global_package.snap
@@ -1,0 +1,11 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ jest(no-disabled-tests): Test is missing function argument
+   ╭─[no_disabled_tests.tsx:1:34]
+ 1 │ import { test } from 'bun:test'; test.skip('something');
+   ·                                  ──────────────────────
+   ╰────
+  help: Add function argument

--- a/crates/oxc_linter/src/snapshots/jest_prefer_expect_assertions@global_package.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_expect_assertions@global_package.snap
@@ -1,0 +1,13 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ jest(prefer-expect-assertions): Every test should have either `e.assertions(<number of assertions>)` or `e.hasAssertions()` as its first expression.
+   ╭─[prefer_expect_assertions.tsx:2:13]
+ 1 │     import { expect as e, test } from 'bun:test';
+ 2 │ ╭─▶             test("fails", () => {
+ 3 │ │                 e(true).toBe(true);
+ 4 │ ╰─▶             });
+   ╰────
+  help: Add `e.hasAssertions()` or `e.assertions(<number>)` as the first statement in the test.

--- a/crates/oxc_linter/src/snapshots/jest_prefer_importing_jest_globals@global_package.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_importing_jest_globals@global_package.snap
@@ -1,0 +1,12 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ jest(prefer-importing-jest-globals): Import the following Jest functions from `bun:test`: expect, test
+   ╭─[prefer_importing_jest_globals.tsx:1:1]
+ 1 │ test('foo', () => { expect(true).toBeDefined(); });
+   · ────
+   ╰────
+  help: Insert `const { expect, test } = require('bun:test');
+        `

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -164,13 +164,24 @@ pub struct PossibleJestNode<'a, 'b> {
 pub fn collect_possible_jest_call_node<'a, 'c>(
     ctx: &'c LintContext<'a>,
 ) -> Vec<PossibleJestNode<'a, 'c>> {
-    iter_possible_jest_call_node(ctx.semantic()).collect()
+    iter_possible_jest_call_node(ctx).collect()
 }
 
 /// Iterate over all possible Jest fn Call Expression,
 /// for `expect(1).toBe(1)`, the result will be an iter over node `expect(1)` and node `expect(1).toBe(1)`.
 pub fn iter_possible_jest_call_node<'a, 'c>(
+    ctx: &'c LintContext<'a>,
+) -> impl Iterator<Item = PossibleJestNode<'a, 'c>> + 'c {
+    iter_possible_jest_call_node_with_global_package(
+        ctx.semantic(),
+        ctx.settings().jest.global_package(),
+    )
+}
+
+/// Iterate over all possible Jest fn Call Expression for a pre-resolved Jest globals package.
+pub fn iter_possible_jest_call_node_with_global_package<'a, 'c>(
     semantic: &'c Semantic<'a>,
+    jest_global_package: &'c str,
 ) -> impl Iterator<Item = PossibleJestNode<'a, 'c>> + 'c {
     // Some people may write codes like below, we need lookup imported test function and global test function.
     // ```
@@ -180,11 +191,12 @@ pub fn iter_possible_jest_call_node<'a, 'c>(
     //     expect(1 + 2).toEqual(3);
     // });
     // ```
-    let reference_id_with_original_list = collect_ids_referenced_to_import(semantic).chain(
-        collect_ids_referenced_to_global(semantic)
-            // set the original of global test function to None
-            .map(|id| (id, None)),
-    );
+    let reference_id_with_original_list =
+        collect_ids_referenced_to_import(semantic, jest_global_package).chain(
+            collect_ids_referenced_to_global(semantic)
+                // set the original of global test function to None
+                .map(|id| (id, None)),
+        );
 
     // get the longest valid chain of Jest Call Expression
     reference_id_with_original_list.flat_map(move |(reference_id, original)| {
@@ -215,6 +227,7 @@ pub fn iter_possible_jest_call_node<'a, 'c>(
 
 fn collect_ids_referenced_to_import<'a, 'c>(
     semantic: &'c Semantic<'a>,
+    jest_global_package: &'c str,
 ) -> impl Iterator<Item = (ReferenceId, Option<&'a str>)> + 'c {
     semantic
         .scoping()
@@ -230,10 +243,7 @@ fn collect_ids_referenced_to_import<'a, 'c>(
                 };
                 let name = semantic.scoping().symbol_name(symbol_id);
 
-                if matches!(
-                    import_decl.source.value.as_str(),
-                    "@jest/globals" | "vitest" | "vite-plus/test"
-                ) {
+                if is_jest_import_source(import_decl.source.value.as_str(), jest_global_package) {
                     let original = find_original_name(import_decl, name);
                     let ret = reference_ids
                         .iter()
@@ -246,6 +256,10 @@ fn collect_ids_referenced_to_import<'a, 'c>(
             None
         })
         .flatten()
+}
+
+fn is_jest_import_source(source: &str, jest_global_package: &str) -> bool {
+    source == jest_global_package || matches!(source, "vitest" | "vite-plus/test")
 }
 
 /// Find name in the Import Declaration, not use name because of lifetime not long enough.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -141,6 +141,7 @@
           "typecheck": false
         },
         "jest": {
+          "globalPackage": null,
           "version": null
         }
       },
@@ -11796,6 +11797,12 @@
       "description": "Configure Jest plugin rules.\n\nSee [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s\nconfiguration for a full reference.",
       "type": "object",
       "properties": {
+        "globalPackage": {
+          "description": "Package to treat as the source of Jest globals.\n\nThis matches `eslint-plugin-jest`'s `settings.jest.globalPackage` option.",
+          "default": null,
+          "type": "string",
+          "markdownDescription": "Package to treat as the source of Jest globals.\n\nThis matches `eslint-plugin-jest`'s `settings.jest.globalPackage` option."
+        },
         "version": {
           "description": "Jest version — accepts a number (`29`) or a semver string (`\"29.1.0\"` or `\"v29.1.0\"`),\nstoring only the major version.\n::: warning\nUsing this config will override the `no-deprecated-functions` config set.\n:::",
           "default": null,
@@ -16305,6 +16312,7 @@
       "properties": {
         "jest": {
           "default": {
+            "globalPackage": null,
             "version": null
           },
           "allOf": [

--- a/tasks/website_linter/src/snapshots/schema_markdown.snap
+++ b/tasks/website_linter/src/snapshots/schema_markdown.snap
@@ -723,6 +723,17 @@ See [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest)'s
 configuration for a full reference.
 
 
+#### settings.jest.globalPackage
+
+type: `string`
+
+default: `null`
+
+Package to treat as the source of Jest globals.
+
+This matches `eslint-plugin-jest`'s `settings.jest.globalPackage` option.
+
+
 #### settings.jest.version
 
 type: `integer | string`


### PR DESCRIPTION
## Summary

- add `settings.jest.globalPackage` support, defaulting to `@jest/globals`
- thread the configured package through Jest framework detection and shared Jest call collection
- use the configured package in `prefer-importing-jest-globals` diagnostics/fixes and `prefer-expect-assertions` alias resolution
- update generated oxlint configuration schema and TypeScript config types

Closes #23290.

## Testing

- `cargo fmt --all`
- `cargo test -p oxc_linter settings::test::test_jest_global_package_settings --lib`
- `cargo test -p oxc_linter no_disabled_tests::test_global_package_setting --lib`
- `cargo test -p oxc_linter prefer_importing_jest_globals::test_global_package_setting --lib`
- `cargo test -p oxc_linter prefer_expect_assertions::test_global_package_setting --lib`
- `cargo test -p oxc_linter jest --lib`
- `cargo lintgen`
- `cargo run -p website_linter schema-json > npm/oxlint/configuration_schema.json`
- `pnpm --filter oxlint-app generate-config-types`
- `cargo clippy -p oxc_linter --lib --tests --no-deps -- -D warnings -A clippy::collapsible_match`
- `git diff --check`

## AI Assistance

This PR was prepared with AI assistance. I reviewed the generated changes and test results, and I am responsible for the contribution.
