### PR TITLE
fix(linter): clamp JS plugin report loc offsets

### DIFF
--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -368,11 +368,7 @@ function getOffsetFromLineColumn(lineCol: LineColumn): number {
   const lineOffset = lineStartIndices[line - 1];
   const offset = lineOffset + column;
 
-  // Ensure offset is within bounds.
-  // Do this here on JS side to prevent a NAPI error when converting to `u32` on Rust side.
-  if (offset < 0 || offset > sourceText.length) {
-    throw new RangeError("Line/column pair translates to an out of range offset");
-  }
-
-  return offset;
+  // Clamp to source bounds. Some ESLint rules intentionally report columns before
+  // the line start or after the line end, and Rust requires a valid `u32` offset.
+  return Math.max(0, Math.min(offset, sourceText.length));
 }

--- a/apps/oxlint/src-js/plugins/report.ts
+++ b/apps/oxlint/src-js/plugins/report.ts
@@ -328,10 +328,9 @@ export function replacePlaceholders(message: string, data: DiagnosticData): stri
  * produce `column: -1` in some cases.
  *
  * @param lineCol - A line/column location.
- * @returns The character index of the location in the file.
- * @throws {TypeError} If `lineCol` is not an object with a integer `line` and `column`.
+ * @returns The character index of the location in the file, clamped to the source bounds.
+ * @throws {TypeError} If `lineCol` is not an object with an integer `line` and `column`.
  * @throws {RangeError} If `line` is less than or equal to 0, or greater than the number of lines in the source text.
- * @throws {RangeError} If computed offset is out of range of the source text.
  */
 function getOffsetFromLineColumn(lineCol: LineColumn): number {
   const { line, column } = lineCol;

--- a/apps/oxlint/test/fixtures/diagnostic_loc_negative_column/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/diagnostic_loc_negative_column/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+  "jsPlugins": ["./plugin.ts"],
+  "categories": { "correctness": "off" },
+  "rules": {
+    "negative-loc/no-bugger": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/diagnostic_loc_negative_column/files/index.js
+++ b/apps/oxlint/test/fixtures/diagnostic_loc_negative_column/files/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/diagnostic_loc_negative_column/output.snap.md
+++ b/apps/oxlint/test/fixtures/diagnostic_loc_negative_column/output.snap.md
@@ -1,0 +1,18 @@
+# Exit code
+1
+
+# stdout
+```
+  x negative-loc(no-bugger): Column before file start!
+   ,-[files/index.js:1:1]
+ 1 | debugger;
+   : ^
+   `----
+
+Found 0 warnings and 1 error.
+Finished in Xms on 1 file with 1 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/diagnostic_loc_negative_column/plugin.ts
+++ b/apps/oxlint/test/fixtures/diagnostic_loc_negative_column/plugin.ts
@@ -1,0 +1,26 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: {
+    name: "negative-loc",
+  },
+  rules: {
+    "no-bugger": {
+      create(context) {
+        return {
+          Program() {
+            context.report({
+              message: "Column before file start!",
+              loc: {
+                start: { line: 1, column: -1 },
+                end: { line: 1, column: 1 },
+              },
+            });
+          },
+        };
+      },
+    },
+  },
+};
+
+export default plugin;


### PR DESCRIPTION
## Summary

- clamp JS plugin `context.report({ loc })` offsets to the source bounds after applying out-of-range columns
- add a regression fixture for `line: 1, column: -1` so plugin reports no longer throw before reaching Rust

## Root cause

`report.ts` already allows ESLint-compatible out-of-range columns, including `column: -1`. However, on line 1 the computed absolute offset becomes negative before Rust serialization, so `context.report` still throws `RangeError: Line/column pair translates to an out of range offset`. Clamping the computed offset keeps the relaxed column behavior while still sending Rust a valid range index.

Fixes #23330.

## Checks

- `pnpm --filter oxlint-app build-js`
- `env -u CODEX_CI -u CODEX_THREAD_ID -u CODEX_SANDBOX -u AI_AGENT -u NO_COLOR TERM=xterm-256color pnpm --filter oxlint-app exec vitest --dir ./test run test/e2e.test.ts -t "fixture: diagnostic_loc"`
- `git diff --check`

Note: the full local `test/e2e.test.ts` run still has existing snapshot-order differences in unrelated fixtures on this machine, but the targeted regression fixture passes.

## AI Assistance

This PR was prepared with AI assistance. I reviewed the generated changes and test results, and I am responsible for the contribution.
