### PR TITLE
feat(linter): support filename-case checkDirectories

### DIFF
--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -160,6 +160,8 @@ pub struct ContextHost<'a> {
     pub(crate) fix: FixKind,
     /// Path to the file being linted.
     pub(super) file_path: Box<Path>,
+    /// Current working directory used to resolve linted paths.
+    pub(super) cwd: Box<Path>,
     /// Extension of the file being linted.
     file_extension: Option<Box<OsStr>>,
     /// Global linter configuration, such as globals to include and the target
@@ -180,6 +182,7 @@ impl<'a> ContextHost<'a> {
     /// If `sub_hosts` is empty.
     pub fn new<P: AsRef<Path>>(
         file_path: P,
+        cwd: &Path,
         sub_hosts: Vec<ContextSubHost<'a>>,
         options: LintOptions,
         config: Arc<LintConfig>,
@@ -192,6 +195,7 @@ impl<'a> ContextHost<'a> {
         );
 
         let file_path = file_path.as_ref().to_path_buf().into_boxed_path();
+        let cwd = cwd.to_path_buf().into_boxed_path();
         let file_extension = file_path.extension().map(|ext| ext.to_owned().into_boxed_os_str());
 
         Self {
@@ -200,6 +204,7 @@ impl<'a> ContextHost<'a> {
             diagnostics: RefCell::new(Vec::with_capacity(DIAGNOSTICS_INITIAL_CAPACITY)),
             fix: options.fix,
             file_path,
+            cwd,
             file_extension,
             config,
             frameworks: options.framework_hints,
@@ -262,6 +267,10 @@ impl<'a> ContextHost<'a> {
     #[inline]
     pub fn file_path(&self) -> &Path {
         &self.file_path
+    }
+
+    pub fn cwd(&self) -> &Path {
+        &self.cwd
     }
 
     /// Extension of the file currently being linted, without the leading dot.

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -194,6 +194,12 @@ impl<'a> LintContext<'a> {
         &self.parent.file_path
     }
 
+    /// Current working directory for this lint run.
+    #[inline]
+    pub fn cwd(&self) -> &Path {
+        self.parent.cwd()
+    }
+
     /// Extension of the file currently being linted, without the leading dot.
     #[inline]
     pub fn file_extension(&self) -> Option<&OsStr> {

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -269,6 +269,7 @@ pub struct Linter {
     config: ConfigStore,
     external_linter: Option<ExternalLinter>,
     workspace_uri: Option<Box<str>>,
+    cwd: Option<Box<Path>>,
 }
 
 impl Linter {
@@ -277,13 +278,23 @@ impl Linter {
         config: ConfigStore,
         external_linter: Option<ExternalLinter>,
     ) -> Self {
-        Self { options, config, external_linter, workspace_uri: None }
+        Self { options, config, external_linter, workspace_uri: None, cwd: None }
     }
 
     #[must_use]
     pub fn with_workspace_uri(mut self, workspace_uri: Option<&str>) -> Self {
         self.workspace_uri = workspace_uri.map(Box::from);
         self
+    }
+
+    #[must_use]
+    pub fn with_cwd(mut self, cwd: &Path) -> Self {
+        self.cwd = Some(cwd.to_path_buf().into_boxed_path());
+        self
+    }
+
+    fn cwd(&self) -> &Path {
+        self.cwd.as_deref().unwrap_or_else(|| Path::new(""))
     }
 
     /// Set the kind of auto fixes to apply.
@@ -350,7 +361,8 @@ impl Linter {
         let ResolvedLinterState { rules, config, external_rules } = self.config.resolve(path);
         let mut timing_recorder = TIMINGS.then(|| RuleTimingRecorder::with_capacity(rules.len()));
 
-        let mut ctx_host = Rc::new(ContextHost::new(path, context_sub_hosts, self.options, config));
+        let mut ctx_host =
+            Rc::new(ContextHost::new(path, self.cwd(), context_sub_hosts, self.options, config));
 
         #[cfg(debug_assertions)]
         let mut current_diagnostic_index = 0;

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -1,3 +1,5 @@
+use std::path::{Component, Path};
+
 use convert_case::{Boundary, Case, Converter};
 use cow_utils::CowUtils;
 use lazy_regex::Regex;
@@ -37,6 +39,7 @@ pub struct FilenameCaseConfig {
     pascal_case: bool,
     ignore: Vec<Regex>,
     multiple_file_extensions: bool,
+    check_directories: bool,
 }
 
 impl Default for FilenameCaseConfig {
@@ -48,6 +51,7 @@ impl Default for FilenameCaseConfig {
             pascal_case: false,
             ignore: vec![],
             multiple_file_extensions: true,
+            check_directories: true,
         }
     }
 }
@@ -88,7 +92,7 @@ pub struct FilenameCaseConfigJson {
     /// }
     /// ```
     case: Option<FilenameCaseJsonOptions>,
-    /// An array of regular expression patterns for filenames to ignore.
+    /// An array of regular expression patterns for path segments to ignore.
     ///
     /// You can set the `ignore` option like this:
     /// ```json
@@ -107,11 +111,20 @@ pub struct FilenameCaseConfigJson {
     /// parts of the extension rather than parts of the filename.
     #[serde(default = "default_true")]
     multiple_file_extensions: bool,
+    /// Whether to check directory names. Filenames are always checked.
+    #[serde(default = "default_true")]
+    check_directories: bool,
 }
 
 impl Default for FilenameCaseConfigJson {
     fn default() -> Self {
-        Self { cases: None, case: None, ignore: vec![], multiple_file_extensions: true }
+        Self {
+            cases: None,
+            case: None,
+            ignore: vec![],
+            multiple_file_extensions: true,
+            check_directories: true,
+        }
     }
 }
 
@@ -137,6 +150,12 @@ enum FilenameCaseJsonOptions {
     CamelCase,
     SnakeCase,
     PascalCase,
+}
+
+#[derive(Clone, Copy)]
+enum PathSegmentKind {
+    Directory,
+    Filename,
 }
 
 declare_oxc_lint!(
@@ -195,6 +214,7 @@ impl Rule for FilenameCase {
         let mut config = FilenameCaseConfig {
             ignore: json.ignore,
             multiple_file_extensions: json.multiple_file_extensions,
+            check_directories: json.check_directories,
             ..Default::default()
         };
 
@@ -222,22 +242,61 @@ impl Rule for FilenameCase {
             return;
         }
 
-        let filename = if self.multiple_file_extensions {
-            raw_filename.split('.').next()
-        } else {
-            raw_filename.rsplit_once('.').map(|(before, _)| before)
-        };
-
-        let filename = filename.unwrap_or(raw_filename);
-
-        // Ignore files named "index" — they are often used as module entry points and
-        // cannot reliably be renamed to other casings (e.g. "Index.js"), so allow them
-        // regardless of the configured filename case.
-        if filename.eq_ignore_ascii_case("index") {
+        let path_segments = path_segments(ctx.file_path(), ctx.cwd(), raw_filename);
+        if path_segments.iter().any(|segment| self.ignore.iter().any(|r| r.is_match(segment))) {
             return;
         }
 
-        let trimmed_filename = filename.trim_matches('_');
+        if self.check_directories {
+            for directory in path_segments.iter().take(path_segments.len().saturating_sub(1)) {
+                if directory.starts_with(['.', '$']) {
+                    continue;
+                }
+
+                if !self.check_segment(ctx, directory, PathSegmentKind::Directory) {
+                    return;
+                }
+            }
+        }
+
+        self.check_segment(ctx, raw_filename, PathSegmentKind::Filename);
+    }
+
+    fn should_run(&self, ctx: &ContextHost<'_>) -> bool {
+        ctx.is_first_sub_host()
+    }
+}
+
+impl FilenameCase {
+    fn check_segment(
+        &self,
+        ctx: &LintContext<'_>,
+        raw_segment: &str,
+        kind: PathSegmentKind,
+    ) -> bool {
+        let segment = match kind {
+            PathSegmentKind::Directory => raw_segment,
+            PathSegmentKind::Filename => {
+                let filename = if self.multiple_file_extensions {
+                    raw_segment.split('.').next()
+                } else {
+                    raw_segment.rsplit_once('.').map(|(before, _)| before)
+                };
+
+                let filename = filename.unwrap_or(raw_segment);
+
+                // Ignore files named "index" — they are often used as module entry points and
+                // cannot reliably be renamed to other casings (e.g. "Index.js"), so allow them
+                // regardless of the configured filename case.
+                if filename.eq_ignore_ascii_case("index") {
+                    return true;
+                }
+
+                filename
+            }
+        };
+
+        let trimmed_segment = segment.trim_matches('_');
 
         let cases = [
             (self.camel_case, Case::Camel, "camelCase"),
@@ -253,8 +312,8 @@ impl Rule for FilenameCase {
                     .remove_boundaries(&[Boundary::LowerDigit, Boundary::DigitLower]);
                 let converter = converter.to_case(case);
 
-                if converter.convert(trimmed_filename) == trimmed_filename {
-                    return;
+                if converter.convert(trimmed_segment) == trimmed_segment {
+                    return true;
                 }
 
                 valid_cases.push((converter, name));
@@ -263,33 +322,69 @@ impl Rule for FilenameCase {
 
         let valid_cases_len = valid_cases.len();
 
-        let mut message = String::from("Filename should be in ");
-        let mut help_message = String::from("Rename the file to ");
+        let (message_subject, help_subject) = match kind {
+            PathSegmentKind::Directory => ("Directory name", "directory"),
+            PathSegmentKind::Filename => ("Filename", "file"),
+        };
+
+        let mut message = format!("{message_subject} should be in ");
+        let mut help_message = format!("Rename the {help_subject} to ");
 
         for (i, (converter, name)) in valid_cases.into_iter().enumerate() {
-            let filename = format!(
+            let replacement = format!(
                 "'{}'",
-                raw_filename.cow_replace(trimmed_filename, &converter.convert(trimmed_filename))
+                raw_segment.cow_replace(trimmed_segment, &converter.convert(trimmed_segment))
             );
 
-            let (name, filename) = if i == 0 {
-                (name, filename.as_ref())
+            let (name, replacement) = if i == 0 {
+                (name, replacement.as_ref())
             } else if i == valid_cases_len - 1 {
-                (&*format!(", or {name}"), &*format!(", or {filename}"))
+                (&*format!(", or {name}"), &*format!(", or {replacement}"))
             } else {
-                (&*format!(", {name}"), &*format!(", {filename}"))
+                (&*format!(", {name}"), &*format!(", {replacement}"))
             };
 
             message.push_str(name);
-            help_message.push_str(filename);
+            help_message.push_str(replacement);
         }
 
         ctx.diagnostic(filename_case_diagnostic(message, help_message));
+        false
+    }
+}
+
+fn path_segments<'a>(path: &'a Path, cwd: &Path, raw_filename: &'a str) -> Vec<&'a str> {
+    let Some(relative_path) = path_inside_cwd(path, cwd) else {
+        return vec![raw_filename];
+    };
+
+    let segments = relative_path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(segment) => segment.to_str(),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    if segments.is_empty() { vec![raw_filename] } else { segments }
+}
+
+fn path_inside_cwd<'a>(path: &'a Path, cwd: &Path) -> Option<&'a Path> {
+    if cwd.as_os_str().is_empty() && path.is_absolute() {
+        return None;
     }
 
-    fn should_run(&self, ctx: &ContextHost<'_>) -> bool {
-        ctx.is_first_sub_host()
+    if path.is_absolute() {
+        return path.strip_prefix(cwd).ok();
     }
+
+    if path.components().any(|component| {
+        matches!(component, Component::ParentDir | Component::Prefix(_) | Component::RootDir)
+    }) {
+        return None;
+    }
+
+    Some(path)
 }
 
 #[test]
@@ -346,12 +441,15 @@ fn test() {
         ("", Some(options), None, Some(PathBuf::from(path)))
     }
 
+    let outside_cwd = std::env::current_dir().unwrap().join("fixtures/FooBar/file.js");
+
     let pass = vec![
         // Default is to allow kebab-case
         ("", None, None, Some(PathBuf::from("foo-bar.tsx"))),
         ("", None, None, Some(PathBuf::from("src/foo-bar.tsx"))),
         ("", None, None, Some(PathBuf::from("src/bar/foo-bar.js"))),
         ("", None, None, Some(PathBuf::from("src/bar/foo.js"))),
+        ("", None, None, Some(outside_cwd)),
         // Specific cases
         test_case("src/foo/bar.js", "camelCase"),
         test_case("src/foo/fooBar.js", "camelCase"),
@@ -374,13 +472,13 @@ fn test() {
         test_case("src/foo/foo-bar.test-utils.js", "kebabCase"),
         test_case("src/foo/foo-bar.test_utils.js", "kebabCase"),
         test_case("src/foo/.test_utils.js", "kebabCase"),
-        test_case("src/foo/Foo.js", "pascalCase"),
-        test_case("src/foo/FooBar.js", "pascalCase"),
-        test_case("src/foo/Foo.test.js", "pascalCase"),
-        test_case("src/foo/FooBar.test.js", "pascalCase"),
-        test_case("src/foo/FooBar.test-utils.js", "pascalCase"),
-        test_case("src/foo/FooBar.test_utils.js", "pascalCase"),
-        test_case("src/foo/.test_utils.js", "pascalCase"),
+        test_case("Src/Foo/Foo.js", "pascalCase"),
+        test_case("Src/Foo/FooBar.js", "pascalCase"),
+        test_case("Src/Foo/Foo.test.js", "pascalCase"),
+        test_case("Src/Foo/FooBar.test.js", "pascalCase"),
+        test_case("Src/Foo/FooBar.test-utils.js", "pascalCase"),
+        test_case("Src/Foo/FooBar.test_utils.js", "pascalCase"),
+        test_case("Src/Foo/.test_utils.js", "pascalCase"),
         test_case("spec/iss47Spec.js", "camelCase"),
         test_case("spec/iss47Spec100.js", "camelCase"),
         test_case("spec/i18n.js", "camelCase"),
@@ -392,9 +490,9 @@ fn test() {
         test_case("spec/iss_47_spec.js", "snakeCase"),
         test_case("spec/iss47_100spec.js", "snakeCase"),
         test_case("spec/i18n.js", "snakeCase"),
-        test_case("spec/Iss47Spec.js", "pascalCase"),
-        test_case("spec/Iss47.100spec.js", "pascalCase"),
-        test_case("spec/I18n.js", "pascalCase"),
+        test_case("Spec/Iss47Spec.js", "pascalCase"),
+        test_case("Spec/Iss47.100spec.js", "pascalCase"),
+        test_case("Spec/I18n.js", "pascalCase"),
         test_case("", "camelCase"),
         test_case("", "snakeCase"),
         test_case("", "kebabCase"),
@@ -405,9 +503,9 @@ fn test() {
         test_case("src/foo/___foo_bar.js", "snakeCase"),
         test_case("src/foo/_foo-bar.js", "kebabCase"),
         test_case("src/foo/___foo-bar.js", "kebabCase"),
-        test_case("src/foo/_FooBar.js", "pascalCase"),
-        test_case("src/foo/___FooBar.js", "pascalCase"),
-        test_case("src/foo/$foo.js", "pascalCase"),
+        test_case("Src/Foo/_FooBar.js", "pascalCase"),
+        test_case("Src/Foo/___FooBar.js", "pascalCase"),
+        test_case("Src/Foo/$foo.js", "pascalCase"),
         test_case("src/foo/[fooBar].js", "camelCase"),
         test_case("src/foo/{foo_bar}.js", "snakeCase"),
         test_cases("src/foo/foo-bar.js", []),
@@ -545,6 +643,18 @@ fn test() {
             "src/foo/foo_bar.test_utils.js",
             serde_json::json!([{ "case": "snakeCase", "multipleFileExtensions": false }]),
         ),
+        test_case_with_options(
+            "src/FooBar/file.js",
+            serde_json::json!([{ "checkDirectories": false }]),
+        ),
+        test_case_with_options(
+            "src/FooBar/file.js",
+            serde_json::json!([{ "case": "kebabCase", "checkDirectories": false }]),
+        ),
+        test_case_with_options(
+            "src/meta/BadName.js",
+            serde_json::json!([{ "case": "kebabCase", "ignore": ["^meta$"] }]),
+        ),
         // Ensure all `index` files are allowed, despite being in non-conforming case.
         test_case("index.js", "camelCase"),
         test_case("index.js", "snakeCase"),
@@ -590,21 +700,28 @@ fn test() {
         test_case("test/foo/fooBar.js", "kebabCase"),
         test_case("test/foo/fooBar.test.js", "kebabCase"),
         test_case("test/foo/fooBar.testUtils.js", "kebabCase"),
-        test_case("test/foo/fooBar.js", "pascalCase"),
-        test_case("test/foo/foo_bar.test.js", "pascalCase"),
-        test_case("test/foo/foo-bar.test-utils.js", "pascalCase"),
+        test_case("Test/Foo/fooBar.js", "pascalCase"),
+        test_case("Test/Foo/foo_bar.test.js", "pascalCase"),
+        test_case("Test/Foo/foo-bar.test-utils.js", "pascalCase"),
         test_case("src/foo/_FOO-BAR.js", "camelCase"),
         test_case("src/foo/___FOO-BAR.js", "camelCase"),
         test_case("src/foo/_FOO-BAR.js", "snakeCase"),
         test_case("src/foo/___FOO-BAR.js", "snakeCase"),
         test_case("src/foo/_FOO-BAR.js", "kebabCase"),
         test_case("src/foo/___FOO-BAR.js", "kebabCase"),
-        test_case("src/foo/_FOO-BAR.js", "pascalCase"),
-        test_case("src/foo/___FOO-BAR.js", "pascalCase"),
+        test_case("Src/Foo/_FOO-BAR.js", "pascalCase"),
+        test_case("Src/Foo/___FOO-BAR.js", "pascalCase"),
         test_cases("src/foo/foo_bar.js", []),
         test_cases("src/foo/foo-bar.js", ["camelCase", "pascalCase"]),
         test_cases("src/foo/_foo_bar.js", ["camelCase", "pascalCase", "kebabCase"]),
         test_cases("src/foo/_FOO-BAR.js", ["snakeCase"]),
+        test_case("src/FooBar/file.js", ""),
+        test_cases("src/foo-bar/file.js", ["camelCase", "pascalCase"]),
+        test_case_with_options(
+            "src/FooBar/foo_bar.js",
+            serde_json::json!([{ "case": "kebabCase", "checkDirectories": false }]),
+        ),
+        test_case("src/FooBar/index.js", ""),
         test_case("src/foo/[foo_bar].js", ""),
         test_case("src/foo/$foo_bar.js", ""),
         test_case("src/foo/$fooBar.js", ""),

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -199,6 +199,9 @@ impl RuntimeFileSystem for OsFileSystem {
 
 impl Runtime {
     pub(super) fn new(linter: Linter, options: LintServiceOptions) -> Self {
+        let LintServiceOptions { cwd, tsconfig, cross_module } = options;
+        let linter = linter.with_cwd(&cwd);
+
         // If global thread pool wasn't already initialized, do it now.
         // This "locks" config for the thread pool, which ensures `rayon::current_num_threads()`
         // cannot change from now on.
@@ -234,7 +237,7 @@ impl Runtime {
         // * If no JS plugins, use standard allocators for parsing/linting.
         #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
         let (allocator_pool, js_allocator_pool) = if linter.has_external_linter() {
-            if options.cross_module {
+            if cross_module {
                 (
                     AllocatorPool::new(thread_count),
                     Some(AllocatorPool::new_fixed_size(thread_count)),
@@ -249,13 +252,13 @@ impl Runtime {
         #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
         let allocator_pool = AllocatorPool::new(thread_count);
 
-        let resolver = options.cross_module.then(|| Self::get_resolver(options.tsconfig));
+        let resolver = cross_module.then(|| Self::get_resolver(tsconfig));
 
         Self {
             allocator_pool,
             #[cfg(all(target_pointer_width = "64", target_endian = "little"))]
             js_allocator_pool,
-            cwd: options.cwd,
+            cwd,
             linter,
             resolver,
             modules_by_path: papaya::HashMap::builder()

--- a/crates/oxc_linter/src/snapshots/unicorn_filename_case.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_filename_case.snap
@@ -132,6 +132,26 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Rename the file to '_foo_bar.js'
 
+  ⚠ unicorn(filename-case): Directory name should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the directory to 'foo-bar'
+
+  ⚠ unicorn(filename-case): Directory name should be in camelCase, or PascalCase
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the directory to 'fooBar', or 'FooBar'
+
+  ⚠ unicorn(filename-case): Filename should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the file to 'foo-bar.js'
+
+  ⚠ unicorn(filename-case): Directory name should be in kebab-case
+   ╭─[filename_case.tsx:1:1]
+   ╰────
+  help: Rename the directory to 'foo-bar'
+
   ⚠ unicorn(filename-case): Filename should be in kebab-case
    ╭─[filename_case.tsx:1:1]
    ╰────

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -371,6 +371,7 @@ mod test {
             let semantic = SemanticBuilder::new_linter().build(program).semantic;
             Rc::new(ContextHost::new(
                 path,
+                std::path::Path::new(""),
                 vec![ContextSubHost::new(
                     semantic,
                     Arc::new(ModuleRecord::default()),

--- a/crates/oxc_linter/src/utils/regex.rs
+++ b/crates/oxc_linter/src/utils/regex.rs
@@ -266,6 +266,7 @@ mod test {
         let semantic = SemanticBuilder::new_linter().build(program).semantic;
         let ctx = Rc::new(ContextHost::new(
             "test.js",
+            std::path::Path::new(""),
             vec![ContextSubHost::new(
                 semantic,
                 Arc::new(ModuleRecord::default()),


### PR DESCRIPTION
Closes #23248

## Summary

- add `checkDirectories` support to `unicorn/filename-case`
- check path segments relative to the lint cwd, while files outside cwd continue to check only the basename
- keep `checkDirectories: false` limited to directory checks; filenames are still checked
- update `filename-case` rule tests and snapshots for directory diagnostics

## Test

- `cargo test -p oxc_linter filename_case --lib`
- `cargo test -p oxc_linter --features ruledocs filename_case --lib`
- `git diff --check`

## AI Assistance

This PR was prepared with AI assistance. I reviewed the generated changes and test results, and I am responsible for the contribution.
