### PR TITLE
feat(linter): support forbid-dom-props disallowedValues

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -4297,7 +4297,7 @@ export interface ForbidDomPropsConfig {
    * An array of prop names or objects that are forbidden on DOM elements.
    *
    * Each array element can be a string with the property name, or an object
-   * with `propName`, an optional `disallowedFor` array of DOM node names,
+   * with `propName`, optional `disallowedFor` and `disallowedValues` arrays,
    * and an optional custom `message`.
    *
    * Examples:
@@ -4305,11 +4305,12 @@ export interface ForbidDomPropsConfig {
    * - `["error", { "forbid": ["id", "style"] }]`
    * - `["error", { "forbid": [{ "propName": "className", "message": "Use class instead" }] }]`
    * - `["error", { "forbid": [{ "propName": "style", "disallowedFor": ["div", "span"] }] }]`
+   * - `["error", { "forbid": [{ "propName": "data-testid", "disallowedValues": ["legacy"] }] }]`
    */
   forbid?: ForbidDomPropsItem[];
 }
 /**
- * A prop with optional `disallowedFor` DOM node list and custom `message`.
+ * A prop with optional `disallowedFor` DOM node list, `disallowedValues` list, and custom `message`.
  */
 export interface PropWithOptions {
   /**
@@ -4318,6 +4319,11 @@ export interface PropWithOptions {
    * DOM elements.
    */
   disallowedFor?: string[];
+  /**
+   * A list of prop values for which this prop is forbidden. If omitted,
+   * the prop is forbidden for any value.
+   */
+  disallowedValues?: string[];
   /**
    * A custom message to display when this prop is used.
    */

--- a/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
@@ -17,10 +17,17 @@ use crate::{
 fn forbid_dom_props_diagnostic(
     span: Span,
     property: &str,
+    property_value: Option<&str>,
     message: Option<&String>,
 ) -> OxcDiagnostic {
     if let Some(message) = message {
         return OxcDiagnostic::warn(message.clone()).with_label(span);
+    }
+    if let Some(property_value) = property_value {
+        return OxcDiagnostic::warn(format!(
+            "Prop \"{property}\" with value \"{property_value}\" is forbidden on DOM Nodes"
+        ))
+        .with_label(span);
     }
     OxcDiagnostic::warn(format!("Prop \"{property}\" is forbidden on DOM Nodes")).with_label(span)
 }
@@ -28,6 +35,7 @@ fn forbid_dom_props_diagnostic(
 #[derive(Debug, Default, Clone)]
 struct ForbidPropOptions {
     disallowed_for: FxHashSet<CompactStr>,
+    disallowed_values: Option<FxHashSet<CompactStr>>,
     message: Option<String>,
 }
 
@@ -49,6 +57,7 @@ impl From<ForbidDomPropsConfig> for ForbidDomProps {
                 ForbidDomPropsItem::PropWithOptions(PropWithOptions {
                     prop_name,
                     disallowed_for,
+                    disallowed_values,
                     message,
                 }) => {
                     forbid.insert(
@@ -58,6 +67,8 @@ impl From<ForbidDomPropsConfig> for ForbidDomProps {
                                 .unwrap_or_default()
                                 .into_iter()
                                 .collect(),
+                            disallowed_values: disallowed_values
+                                .map(|values| values.into_iter().collect()),
                             message,
                         },
                     );
@@ -74,11 +85,12 @@ impl From<ForbidDomPropsConfig> for ForbidDomProps {
 pub enum ForbidDomPropsItem {
     /// A prop name to forbid on all DOM elements.
     PropName(CompactStr),
-    /// A prop with optional `disallowedFor` DOM node list and custom `message`.
+    /// A prop with optional `disallowedFor` DOM node list, `disallowedValues` list,
+    /// and custom `message`.
     PropWithOptions(PropWithOptions),
 }
 
-/// A prop with optional `disallowedFor` DOM node list and custom `message`.
+/// A prop with optional `disallowedFor` DOM node list, `disallowedValues` list, and custom `message`.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropWithOptions {
@@ -88,6 +100,9 @@ pub struct PropWithOptions {
     /// prop is forbidden. If empty or omitted, the prop is forbidden on all
     /// DOM elements.
     disallowed_for: Option<Vec<CompactStr>>,
+    /// A list of prop values for which this prop is forbidden. If omitted,
+    /// the prop is forbidden for any value.
+    disallowed_values: Option<Vec<CompactStr>>,
     /// A custom message to display when this prop is used.
     message: Option<String>,
 }
@@ -99,7 +114,7 @@ pub struct ForbidDomPropsConfig {
     /// An array of prop names or objects that are forbidden on DOM elements.
     ///
     /// Each array element can be a string with the property name, or an object
-    /// with `propName`, an optional `disallowedFor` array of DOM node names,
+    /// with `propName`, optional `disallowedFor` and `disallowedValues` arrays,
     /// and an optional custom `message`.
     ///
     /// Examples:
@@ -107,6 +122,7 @@ pub struct ForbidDomPropsConfig {
     /// - `["error", { "forbid": ["id", "style"] }]`
     /// - `["error", { "forbid": [{ "propName": "className", "message": "Use class instead" }] }]`
     /// - `["error", { "forbid": [{ "propName": "style", "disallowedFor": ["div", "span"] }] }]`
+    /// - `["error", { "forbid": [{ "propName": "data-testid", "disallowedValues": ["legacy"] }] }]`
     forbid: Vec<ForbidDomPropsItem>,
 }
 
@@ -176,9 +192,24 @@ impl Rule for ForbidDomProps {
                     {
                         continue;
                     }
+                    let property_value = if let Some(disallowed_values) = &options.disallowed_values
+                    {
+                        let Some(value) =
+                            attr.value.as_ref().and_then(|value| value.as_string_literal())
+                        else {
+                            continue;
+                        };
+                        if !disallowed_values.contains(value.value.as_str()) {
+                            continue;
+                        }
+                        Some(value.value.as_str())
+                    } else {
+                        None
+                    };
                     ctx.diagnostic(forbid_dom_props_diagnostic(
                         attr_ident.span,
                         prop_name,
+                        property_value,
                         options.message.as_ref(),
                     ));
                 }
@@ -280,6 +311,56 @@ fn test() {
                 serde_json::json!([{ "forbid": [{"propName": "otherProp","disallowedFor": ["span"],},],},]),
             ),
         ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div someProp="otherValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([{ "forbid": [{"propName": "someProp", "disallowedValues": ["someValue"]}] }]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <Foo someProp="someValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([{ "forbid": [{"propName": "someProp", "disallowedValues": ["someValue"]}] }]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div someProp="someValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([{ "forbid": [{"propName": "someProp", "disallowedValues": []}] }]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div someProp="someValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([{ "forbid": [{"propName": "someProp", "disallowedValues": ["someValue"], "disallowedFor": ["span"]}] }]),
+            ),
+        ),
+        (
+            r"
+                    const First = (props) => (
+                      <div someProp />
+                    );
+                  ",
+            Some(
+                serde_json::json!([{ "forbid": [{"propName": "someProp", "disallowedValues": ["someValue"]}] }]),
+            ),
+        ),
     ];
 
     let fail = vec![
@@ -371,6 +452,36 @@ fn test() {
                   "#,
             Some(
                 serde_json::json!([{"forbid": [{"propName": "className","disallowedFor": ["div", "span"],"message": "Please use class instead of ClassName",},{ "propName": "otherProp", "message": "Avoid using otherProp" },],},]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div someProp="someValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([{ "forbid": [{"propName": "someProp", "disallowedValues": ["someValue"]}] }]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <span someProp="someValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([{ "forbid": [{"propName": "someProp", "disallowedValues": ["someValue"], "disallowedFor": ["span"]}] }]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <p thirdProp="baz" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([{ "forbid": [{"propName": "thirdProp", "disallowedValues": ["bar", "baz"], "disallowedFor": ["p"], "message": "Do not use thirdProp with values bar and baz on p"}] }]),
             ),
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/react_forbid_dom_props.snap
+++ b/crates/oxc_linter/src/snapshots/react_forbid_dom_props.snap
@@ -105,3 +105,27 @@ source: crates/oxc_linter/src/tester.rs
    ·                                              ─────────
  7 │                       </div>
    ╰────
+
+  ⚠ react(forbid-dom-props): Prop "someProp" with value "someValue" is forbidden on DOM Nodes
+   ╭─[forbid_dom_props.tsx:3:28]
+ 2 │                     const First = (props) => (
+ 3 │                       <div someProp="someValue" />
+   ·                            ────────
+ 4 │                     );
+   ╰────
+
+  ⚠ react(forbid-dom-props): Prop "someProp" with value "someValue" is forbidden on DOM Nodes
+   ╭─[forbid_dom_props.tsx:3:29]
+ 2 │                     const First = (props) => (
+ 3 │                       <span someProp="someValue" />
+   ·                             ────────
+ 4 │                     );
+   ╰────
+
+  ⚠ react(forbid-dom-props): Do not use thirdProp with values bar and baz on p
+   ╭─[forbid_dom_props.tsx:3:26]
+ 2 │                     const First = (props) => (
+ 3 │                       <p thirdProp="baz" />
+   ·                          ─────────
+ 4 │                     );
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10344,12 +10344,12 @@
       "type": "object",
       "properties": {
         "forbid": {
-          "description": "An array of prop names or objects that are forbidden on DOM elements.\n\nEach array element can be a string with the property name, or an object\nwith `propName`, an optional `disallowedFor` array of DOM node names,\nand an optional custom `message`.\n\nExamples:\n\n- `[\"error\", { \"forbid\": [\"id\", \"style\"] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"className\", \"message\": \"Use class instead\" }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"style\", \"disallowedFor\": [\"div\", \"span\"] }] }]`",
+          "description": "An array of prop names or objects that are forbidden on DOM elements.\n\nEach array element can be a string with the property name, or an object\nwith `propName`, optional `disallowedFor` and `disallowedValues` arrays,\nand an optional custom `message`.\n\nExamples:\n\n- `[\"error\", { \"forbid\": [\"id\", \"style\"] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"className\", \"message\": \"Use class instead\" }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"style\", \"disallowedFor\": [\"div\", \"span\"] }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"data-testid\", \"disallowedValues\": [\"legacy\"] }] }]`",
           "type": "array",
           "items": {
             "$ref": "#/definitions/ForbidDomPropsItem"
           },
-          "markdownDescription": "An array of prop names or objects that are forbidden on DOM elements.\n\nEach array element can be a string with the property name, or an object\nwith `propName`, an optional `disallowedFor` array of DOM node names,\nand an optional custom `message`.\n\nExamples:\n\n- `[\"error\", { \"forbid\": [\"id\", \"style\"] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"className\", \"message\": \"Use class instead\" }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"style\", \"disallowedFor\": [\"div\", \"span\"] }] }]`"
+          "markdownDescription": "An array of prop names or objects that are forbidden on DOM elements.\n\nEach array element can be a string with the property name, or an object\nwith `propName`, optional `disallowedFor` and `disallowedValues` arrays,\nand an optional custom `message`.\n\nExamples:\n\n- `[\"error\", { \"forbid\": [\"id\", \"style\"] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"className\", \"message\": \"Use class instead\" }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"style\", \"disallowedFor\": [\"div\", \"span\"] }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"data-testid\", \"disallowedValues\": [\"legacy\"] }] }]`"
         }
       },
       "additionalProperties": false,
@@ -10364,13 +10364,13 @@
           "markdownDescription": "A prop name to forbid on all DOM elements."
         },
         {
-          "description": "A prop with optional `disallowedFor` DOM node list and custom `message`.",
+          "description": "A prop with optional `disallowedFor` DOM node list, `disallowedValues` list,\nand custom `message`.",
           "allOf": [
             {
               "$ref": "#/definitions/PropWithOptions"
             }
           ],
-          "markdownDescription": "A prop with optional `disallowedFor` DOM node list and custom `message`."
+          "markdownDescription": "A prop with optional `disallowedFor` DOM node list, `disallowedValues` list,\nand custom `message`."
         }
       ],
       "markdownDescription": "A forbidden prop, either as a plain prop name string or with options."
@@ -16097,7 +16097,7 @@
       "additionalProperties": false
     },
     "PropWithOptions": {
-      "description": "A prop with optional `disallowedFor` DOM node list and custom `message`.",
+      "description": "A prop with optional `disallowedFor` DOM node list, `disallowedValues` list, and custom `message`.",
       "type": "object",
       "required": [
         "propName"
@@ -16111,6 +16111,14 @@
           },
           "markdownDescription": "A list of DOM element names (e.g. `[\"div\", \"span\"]`) on which this\nprop is forbidden. If empty or omitted, the prop is forbidden on all\nDOM elements."
         },
+        "disallowedValues": {
+          "description": "A list of prop values for which this prop is forbidden. If omitted,\nthe prop is forbidden for any value.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "A list of prop values for which this prop is forbidden. If omitted,\nthe prop is forbidden for any value."
+        },
         "message": {
           "description": "A custom message to display when this prop is used.",
           "type": "string",
@@ -16123,7 +16131,7 @@
         }
       },
       "additionalProperties": false,
-      "markdownDescription": "A prop with optional `disallowedFor` DOM node list and custom `message`."
+      "markdownDescription": "A prop with optional `disallowedFor` DOM node list, `disallowedValues` list, and custom `message`."
     },
     "RadixType": {
       "oneOf": [

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -1617,7 +1617,7 @@ type: `array`
 An array of prop names or objects that are forbidden on DOM elements.
 
 Each array element can be a string with the property name, or an object
-with `propName`, an optional `disallowedFor` array of DOM node names,
+with `propName`, optional `disallowedFor` and `disallowedValues` arrays,
 and an optional custom `message`.
 
 Examples:
@@ -1625,6 +1625,7 @@ Examples:
 - `["error", { "forbid": ["id", "style"] }]`
 - `["error", { "forbid": [{ "propName": "className", "message": "Use class instead" }] }]`
 - `["error", { "forbid": [{ "propName": "style", "disallowedFor": ["div", "span"] }] }]`
+- `["error", { "forbid": [{ "propName": "data-testid", "disallowedValues": ["legacy"] }] }]`
 
 
 #### forbid[n]
@@ -1643,6 +1644,15 @@ type: `string[]`
 A list of DOM element names (e.g. `["div", "span"]`) on which this
 prop is forbidden. If empty or omitted, the prop is forbidden on all
 DOM elements.
+
+
+##### forbid[n].disallowedValues
+
+type: `string[]`
+
+
+A list of prop values for which this prop is forbidden. If omitted,
+the prop is forbidden for any value.
 
 
 ##### forbid[n].message


### PR DESCRIPTION
Closes #23049.

## Summary
- support `disallowedValues` in `react/forbid-dom-props` object config
- only report a prop when the DOM tag and configured literal value both match
- include `disallowedValues` in generated JSON schema and TypeScript config types

## Test
- `cargo fmt -p oxc_linter`
- `cargo test -p oxc_linter forbid_dom_props --lib`
- `cargo test -p oxc_linter --features ruledocs forbid_dom_props --lib`
- `cargo test -p website_linter test_schema_json`
- `git diff --check`

## AI Assistance

This PR was prepared with AI assistance. I reviewed the generated changes and test results, and I am responsible for the contribution.
