### PR TITLE
fix(linter): apply CLI severity filters to JS plugin rules

### DIFF
--- a/apps/oxlint/src/config_loader.rs
+++ b/apps/oxlint/src/config_loader.rs
@@ -477,7 +477,7 @@ impl<'a> ConfigLoader<'a> {
             let extended_paths = builder.extended_paths.clone();
 
             match builder
-                .with_filters(self.filters)
+                .with_filters_and_external_rules(self.filters, self.external_plugin_store)
                 .build(self.external_plugin_store)
                 .map_err(|e| ConfigLoadError::Build { path: path.clone(), error: e.to_string() })
             {

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -310,7 +310,7 @@ impl CliRunner {
                 return CliRunResult::InvalidOptionConfig;
             }
         }
-        .with_filters(&filters);
+        .with_filters_and_external_rules(&filters, &external_plugin_store);
 
         if misc_options.print_config {
             return crate::mode::run_print_config(&config_builder, root_config, stdout);

--- a/apps/oxlint/test/fixtures/js_plugin_cli_filter/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/js_plugin_cli_filter/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "jsPlugins": [{ "name": "custom", "specifier": "./plugin.js" }],
+  "rules": {
+    "custom/rule": "warn"
+  }
+}

--- a/apps/oxlint/test/fixtures/js_plugin_cli_filter/files/index.js
+++ b/apps/oxlint/test/fixtures/js_plugin_cli_filter/files/index.js
@@ -1,0 +1,2 @@
+const value = 1;
+console.log(value);

--- a/apps/oxlint/test/fixtures/js_plugin_cli_filter/options.json
+++ b/apps/oxlint/test/fixtures/js_plugin_cli_filter/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["-A", "all", "-D", "custom/rule"]
+}

--- a/apps/oxlint/test/fixtures/js_plugin_cli_filter/output.snap.md
+++ b/apps/oxlint/test/fixtures/js_plugin_cli_filter/output.snap.md
@@ -1,0 +1,18 @@
+# Exit code
+1
+
+# stdout
+```
+  x custom(rule): custom rule diagnostic
+   ,-[files/index.js:1:1]
+ 1 | ,-> const value = 1;
+ 2 | `-> console.log(value);
+   `----
+
+Found 0 warnings and 1 error.
+Finished in Xms on 1 file with 1 rules using X threads.
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/js_plugin_cli_filter/plugin.js
+++ b/apps/oxlint/test/fixtures/js_plugin_cli_filter/plugin.js
@@ -1,0 +1,16 @@
+export default {
+  rules: {
+    rule: {
+      create(context) {
+        return {
+          Program(node) {
+            context.report({
+              node,
+              message: "custom rule diagnostic",
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -377,7 +377,27 @@ impl ConfigStoreBuilder {
         self
     }
 
+    pub fn with_filters_and_external_rules<'a, I: IntoIterator<Item = &'a LintFilter>>(
+        mut self,
+        filters: I,
+        external_plugin_store: &ExternalPluginStore,
+    ) -> Self {
+        for filter in filters {
+            self = self.with_filter_inner(filter, Some(external_plugin_store));
+        }
+        self
+    }
+
     pub fn with_filter(mut self, filter: &LintFilter) -> Self {
+        self = self.with_filter_inner(filter, None);
+        self
+    }
+
+    fn with_filter_inner(
+        mut self,
+        filter: &LintFilter,
+        external_plugin_store: Option<&ExternalPluginStore>,
+    ) -> Self {
         let (severity, filter) = filter.into();
 
         match severity {
@@ -388,6 +408,12 @@ impl ConfigStoreBuilder {
                 LintFilterKind::Rule(plugin, rule) => {
                     let (plugin, rule) = super::rules::unalias_plugin_name(plugin, rule);
                     self.upsert_where(severity, |r| r.plugin_name() == plugin && r.name() == rule);
+                    self.upsert_external_rule_filter(
+                        severity,
+                        &plugin,
+                        &rule,
+                        external_plugin_store,
+                    );
                 }
                 LintFilterKind::Generic(name) => self.upsert_where(severity, |r| r.name() == name),
                 LintFilterKind::All => {
@@ -401,6 +427,7 @@ impl ConfigStoreBuilder {
                 LintFilterKind::Rule(plugin, rule) => {
                     let (plugin, rule) = super::rules::unalias_plugin_name(plugin, rule);
                     self.rules.retain(|r, _| r.plugin_name() != plugin || r.name() != rule);
+                    self.remove_external_rule_filter(&plugin, &rule, external_plugin_store);
                 }
                 LintFilterKind::Generic(name) => self.rules.retain(|rule, _| rule.name() != name),
                 LintFilterKind::All => self.rules.clear(),
@@ -408,6 +435,42 @@ impl ConfigStoreBuilder {
         }
 
         self
+    }
+
+    fn upsert_external_rule_filter(
+        &mut self,
+        severity: AllowWarnDeny,
+        plugin: &str,
+        rule: &str,
+        external_plugin_store: Option<&ExternalPluginStore>,
+    ) {
+        let Some(external_plugin_store) = external_plugin_store else { return };
+        if !external_plugin_store.is_enabled() {
+            return;
+        }
+
+        if let Ok(external_rule_id) = external_plugin_store.lookup_rule_id(plugin, rule) {
+            self.external_rules
+                .entry(external_rule_id)
+                .and_modify(|(_, existing_severity)| *existing_severity = severity)
+                .or_insert((ExternalOptionsId::NONE, severity));
+        }
+    }
+
+    fn remove_external_rule_filter(
+        &mut self,
+        plugin: &str,
+        rule: &str,
+        external_plugin_store: Option<&ExternalPluginStore>,
+    ) {
+        let Some(external_plugin_store) = external_plugin_store else { return };
+        if !external_plugin_store.is_enabled() {
+            return;
+        }
+
+        if let Ok(external_rule_id) = external_plugin_store.lookup_rule_id(plugin, rule) {
+            self.external_rules.remove(&external_rule_id);
+        }
     }
 
     /// Warn/Deny a let of rules based on some predicate. Rules already in `self.rules` get
@@ -935,6 +998,45 @@ mod test {
 
             assert_eq!(*severity, AllowWarnDeny::Warn);
         }
+    }
+
+    #[test]
+    fn test_filter_external_rule() {
+        let mut external_plugin_store = ExternalPluginStore::new(true);
+        external_plugin_store.register_plugin(
+            PathBuf::from("path/to/custom-plugin"),
+            "custom".to_string(),
+            0,
+            vec!["my-rule".to_string()],
+        );
+
+        let external_rule_id = external_plugin_store.lookup_rule_id("custom", "my-rule").unwrap();
+        let options = smallvec::smallvec![serde_json::json!({ "foo": true })];
+        let options_id = external_plugin_store.add_options(external_rule_id, &options);
+
+        let mut builder = ConfigStoreBuilder::empty();
+        builder.external_rules.insert(external_rule_id, (options_id, AllowWarnDeny::Warn));
+
+        let builder = builder.with_filters_and_external_rules(
+            [&LintFilter::new(AllowWarnDeny::Deny, "custom/my-rule").unwrap()],
+            &external_plugin_store,
+        );
+
+        assert_eq!(
+            builder.external_rules.get(&external_rule_id),
+            Some(&(options_id, AllowWarnDeny::Deny)),
+            "CLI severity filters should preserve JS plugin rule options"
+        );
+
+        let builder = builder.with_filters_and_external_rules(
+            [&LintFilter::new(AllowWarnDeny::Allow, "custom/my-rule").unwrap()],
+            &external_plugin_store,
+        );
+
+        assert!(
+            !builder.external_rules.contains_key(&external_rule_id),
+            "Allowing a JS plugin rule should remove it from configured external rules"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #22730

## Summary

- apply CLI rule filters to external JS plugin rules when the filter is fully qualified, e.g. `-D custom/rule`
- preserve existing JS plugin rule options when only the CLI filter changes severity
- allow `-A custom/rule` to remove configured JS plugin rules
- add an oxlint e2e fixture covering a JS plugin rule promoted from warn to error by `-D`

## Root Cause

Config-file rule parsing already populated both built-in rules and `external_rules`, but the CLI filter path only updated built-in rules through `ConfigStoreBuilder::with_filter`. As a result, `-D import-js/order` never reached the JS plugin rule table.

## Tests

- `cargo fmt -p oxc_linter -p oxlint`
- `cargo test -p oxc_linter test_filter_external_rule --lib`
- `cargo test -p oxc_linter test_filter_ --lib`
- `pnpm --filter oxlint-app build-test`
- `pnpm --filter oxlint-app test -- -t "fixture: js_plugin_cli_filter"`
- `git diff --check`

## AI Assistance

This PR was prepared with AI assistance. I reviewed the generated changes and test results, and I am responsible for the contribution.
