### PR TITLE
fix(linter): print js plugin rules in config

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -313,7 +313,12 @@ impl CliRunner {
         .with_filters(&filters);
 
         if misc_options.print_config {
-            return crate::mode::run_print_config(&config_builder, root_config, stdout);
+            return crate::mode::run_print_config(
+                &config_builder,
+                root_config,
+                &external_plugin_store,
+                stdout,
+            );
         }
 
         let lint_config = match config_builder.build(&mut external_plugin_store) {

--- a/apps/oxlint/src/mode/print_config.rs
+++ b/apps/oxlint/src/mode/print_config.rs
@@ -1,13 +1,14 @@
-use oxc_linter::{ConfigStoreBuilder, Oxlintrc};
+use oxc_linter::{ConfigStoreBuilder, ExternalPluginStore, Oxlintrc};
 
 use crate::{cli::CliRunResult, lint::print_and_flush_stdout};
 
 pub fn run_print_config(
     store_builder: &ConfigStoreBuilder,
     oxlintrc: Oxlintrc,
+    external_plugin_store: &ExternalPluginStore,
     stdout: &mut dyn std::io::Write,
 ) -> CliRunResult {
-    let config_file = store_builder.resolve_final_config_file(oxlintrc);
+    let config_file = store_builder.resolve_final_config_file(oxlintrc, external_plugin_store);
     print_and_flush_stdout(stdout, &config_file);
     print_and_flush_stdout(stdout, "\n");
 

--- a/apps/oxlint/test/fixtures/print_config_js_plugin_rules/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/print_config_js_plugin_rules/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "categories": {
+    "correctness": "off"
+  },
+  "jsPlugins": ["./plugin.ts"],
+  "rules": {
+    "no-debugger": "warn",
+    "print-config-plugin/with-options": ["error", { "mode": "strict" }]
+  }
+}

--- a/apps/oxlint/test/fixtures/print_config_js_plugin_rules/files/test.js
+++ b/apps/oxlint/test/fixtures/print_config_js_plugin_rules/files/test.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/print_config_js_plugin_rules/options.json
+++ b/apps/oxlint/test/fixtures/print_config_js_plugin_rules/options.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--print-config"]
+}

--- a/apps/oxlint/test/fixtures/print_config_js_plugin_rules/output.snap.md
+++ b/apps/oxlint/test/fixtures/print_config_js_plugin_rules/output.snap.md
@@ -1,0 +1,71 @@
+# Exit code
+0
+
+# stdout
+```
+{
+  "plugins": [
+    "unicorn",
+    "typescript",
+    "oxc"
+  ],
+  "jsPlugins": [
+    "./plugin.ts"
+  ],
+  "categories": {
+    "correctness": "allow"
+  },
+  "rules": {
+    "no-debugger": "warn",
+    "print-config-plugin/with-options": [
+      "deny",
+      [
+        {
+          "mode": "strict"
+        }
+      ]
+    ]
+  },
+  "settings": {
+    "jsx-a11y": {
+      "polymorphicPropName": null,
+      "components": {},
+      "attributes": {}
+    },
+    "next": {
+      "rootDir": []
+    },
+    "react": {
+      "formComponents": [],
+      "linkComponents": [],
+      "version": null,
+      "componentWrapperFunctions": []
+    },
+    "jsdoc": {
+      "ignorePrivate": false,
+      "ignoreInternal": false,
+      "ignoreReplacesDocs": true,
+      "overrideReplacesDocs": true,
+      "augmentsExtendsReplacesDocs": false,
+      "implementsReplacesDocs": false,
+      "exemptDestructuredRootsFromChecks": false,
+      "tagNamePreference": {}
+    },
+    "vitest": {
+      "typecheck": false
+    },
+    "jest": {
+      "version": null
+    }
+  },
+  "env": {
+    "builtin": true
+  },
+  "globals": {},
+  "ignorePatterns": []
+}
+```
+
+# stderr
+```
+```

--- a/apps/oxlint/test/fixtures/print_config_js_plugin_rules/plugin.ts
+++ b/apps/oxlint/test/fixtures/print_config_js_plugin_rules/plugin.ts
@@ -1,0 +1,16 @@
+import type { Plugin } from "#oxlint/plugins";
+
+const plugin: Plugin = {
+  meta: {
+    name: "print-config-plugin",
+  },
+  rules: {
+    "with-options": {
+      create() {
+        return {};
+      },
+    },
+  },
+};
+
+export default plugin;

--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -559,7 +559,11 @@ impl ConfigStoreBuilder {
 
     /// # Panics
     /// This function will panic if the `oxlintrc` is not valid JSON.
-    pub fn resolve_final_config_file(&self, oxlintrc: Oxlintrc) -> String {
+    pub fn resolve_final_config_file(
+        &self,
+        oxlintrc: Oxlintrc,
+        external_plugin_store: &ExternalPluginStore,
+    ) -> String {
         let mut oxlintrc = oxlintrc;
         let previous_rules = std::mem::take(&mut oxlintrc.rules);
 
@@ -569,7 +573,7 @@ impl ConfigStoreBuilder {
             .map(|r| (get_name(&r.plugin_name, &r.rule_name), r))
             .collect::<rustc_hash::FxHashMap<_, _>>();
 
-        let new_rules = self
+        let mut new_rules = self
             .rules
             .iter()
             .sorted_unstable_by_key(|(r, _)| (r.plugin_name(), r.name()))
@@ -582,7 +586,23 @@ impl ConfigStoreBuilder {
                     .map(|r| r.config.clone())
                     .unwrap_or_default(),
             })
-            .collect();
+            .collect::<Vec<_>>();
+
+        new_rules.extend(self.external_rules.iter().map(
+            |(external_rule_id, (options_id, severity))| {
+                let (plugin_name, rule_name, config) =
+                    external_plugin_store.resolve_rule_config(*external_rule_id, *options_id);
+                ESLintRule {
+                    plugin_name: plugin_name.to_string(),
+                    rule_name: rule_name.to_string(),
+                    severity: *severity,
+                    config: config.clone(),
+                }
+            },
+        ));
+        new_rules.sort_unstable_by(|a, b| {
+            a.plugin_name.cmp(&b.plugin_name).then_with(|| a.rule_name.cmp(&b.rule_name))
+        });
 
         oxlintrc.plugins = Some(self.config.plugins);
         oxlintrc.settings.clone_from(&self.config.settings);
@@ -1682,6 +1702,43 @@ mod test {
         let err = builder.build(&mut external_plugin_store).unwrap_err();
 
         assert_eq!(err.to_string(), "Rule 'no-console-typo' not found in plugin 'eslint'");
+    }
+
+    #[test]
+    fn test_print_config_includes_external_rules() {
+        let mut external_plugin_store = ExternalPluginStore::default();
+        external_plugin_store.register_plugin(
+            PathBuf::from("path/to/custom-plugin"),
+            "custom".to_string(),
+            0,
+            vec!["my-rule".to_string()],
+        );
+
+        let rule_id = external_plugin_store.lookup_rule_id("custom", "my-rule").unwrap();
+        let options = smallvec::smallvec![serde_json::json!({ "mode": "strict" })];
+        let options_id = external_plugin_store.add_options(rule_id, &options);
+
+        let mut builder = ConfigStoreBuilder::empty();
+        builder.external_rules.insert(rule_id, (options_id, AllowWarnDeny::Deny));
+
+        let oxlintrc = serde_json::from_str(
+            r#"
+            {
+                "jsPlugins": ["./plugin.ts"],
+                "rules": {
+                    "custom/my-rule": "warn"
+                }
+            }
+            "#,
+        )
+        .unwrap();
+        let config_file = builder.resolve_final_config_file(oxlintrc, &external_plugin_store);
+        let config: serde_json::Value = serde_json::from_str(&config_file).unwrap();
+
+        assert_eq!(
+            config["rules"]["custom/my-rule"],
+            serde_json::json!(["deny", [{ "mode": "strict" }]])
+        );
     }
 
     fn config_store_from_path(path: &str) -> Config {

--- a/crates/oxc_linter/src/external_plugin_store.rs
+++ b/crates/oxc_linter/src/external_plugin_store.rs
@@ -144,6 +144,19 @@ impl ExternalPluginStore {
         (&plugin.name, &external_rule.name)
     }
 
+    pub fn resolve_rule_config(
+        &self,
+        external_rule_id: ExternalRuleId,
+        options_id: ExternalOptionsId,
+    ) -> (/* plugin name */ &str, /* rule name */ &str, &SmallVec<[serde_json::Value; 1]>) {
+        let (plugin_name, rule_name) = self.resolve_plugin_rule_names(external_rule_id);
+        let (options_rule_id, options) = &self.options[options_id];
+        debug_assert!(
+            *options_rule_id == ExternalRuleId::DUMMY || *options_rule_id == external_rule_id
+        );
+        (plugin_name, rule_name, options)
+    }
+
     /// Add options to the store and return its [`ExternalOptionsId`].
     /// If `options` is empty, returns [`ExternalOptionsId::NONE`] without adding to the store.
     pub fn add_options(


### PR DESCRIPTION
Closes #22117.

## Problem

`oxlint --print-config` preserved the `jsPlugins` field, but silently dropped rules that came from those JS plugins. Linting still worked because external rules were resolved for the normal lint path; the bug was specific to the printed config output.

## Root cause

`ConfigStoreBuilder::resolve_final_config_file` rebuilt the printed `rules` object from `ConfigStoreBuilder.rules`, which only contains built-in rules. JS plugin rules live in `ConfigStoreBuilder.external_rules`, with their names and options stored in `ExternalPluginStore`, so they were never serialized back into the printed config.

## Changes

- Pass `ExternalPluginStore` into the print-config path.
- Add a small `ExternalPluginStore::resolve_rule_config` helper to recover an external rule's plugin name, rule name, and options.
- Merge `external_rules` into the final printed `rules` list and sort the combined output by plugin/rule name.
- Add a CLI fixture that prints a config containing a JS plugin rule with options.

## Checks

- `cargo fmt -p oxc_linter -p oxlint`
- `cargo test -p oxc_linter test_print_config_includes_external_rules --lib`
- `cargo test -p oxc_linter test_print_config --lib`
- `cargo test -p oxlint test_print_config`
- `pnpm --filter oxlint-app build-test`
- `pnpm --filter oxlint-app test -- -t "fixture: print_config_js_plugin_rules"`
- `pnpm --filter oxlint-app test -- -t "fixture: print_config"`
- `git diff --check`


## AI Assistance

This PR was prepared with AI assistance. I reviewed the generated changes and test results, and I am responsible for the contribution.
