### PR TITLE
fix(linter/unicorn/prefer-string-starts-ends-with): mark rule as deprecated

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -31,6 +31,10 @@ declare_oxc_lint!(
     ///
     /// Prefer [`String#startsWith()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith) and [`String#endsWith()`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) over using a regex with `/^foo/` or `/foo$/`.
     ///
+    /// ::: warning
+    /// This rule is deprecated. Prefer the type-aware [`typescript/prefer-string-starts-ends-with`](https://oxc.rs/docs/guide/usage/linter/rules/typescript/prefer-string-starts-ends-with.html) rule instead.
+    /// :::
+    ///
     /// ### Why is this bad?
     ///
     /// Using `String#startsWith()` and `String#endsWith()` is more readable and performant as it does not need to parse a regex.


### PR DESCRIPTION
## Summary
- Mark `unicorn/prefer-string-starts-ends-with` as deprecated in the rule documentation.
- Point users to the type-aware `typescript/prefer-string-starts-ends-with` replacement.

## Reasoning
The Unicorn rule is still kept for compatibility, but it should no longer be the preferred rule. The type-aware TypeScript rule can use type information and covers string boundary checks more reliably than the Unicorn regex-focused rule, so the docs should steer users toward that rule without removing the existing Unicorn rule.

Fixes #23303
