### PR TITLE
feat(linter/vue): implement no-dupe-keys rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1651,7 +1651,7 @@ export interface DummyRuleMap {
   "vue/no-deprecated-model-definition"?: RuleNoConfig | [AllowWarnDeny, NoDeprecatedModelDefinitionConfig];
   "vue/no-deprecated-props-default-this"?: RuleNoConfig;
   "vue/no-deprecated-vue-config-keycodes"?: RuleNoConfig;
-  "vue/no-dupe-keys"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConfigElement0];
+  "vue/no-dupe-keys"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoDupeKeysConfig];
   "vue/no-export-in-script-setup"?: RuleNoConfig;
   "vue/no-expose-after-await"?: RuleNoConfig;
   "vue/no-import-compiler-macros"?: RuleNoConfig;
@@ -6044,7 +6044,9 @@ export interface NoDeprecatedModelDefinitionConfig {
    */
   allowVue3Compat?: boolean;
 }
-export interface ConfigElement0 {}
+export interface NoDupeKeysConfig {
+  groups?: string[];
+}
 export interface NoReservedComponentNames {
   /**
    * Disallow Vue 3 built-in component names (e.g. `Teleport`, `Suspense`).

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1651,7 +1651,7 @@ export interface DummyRuleMap {
   "vue/no-deprecated-model-definition"?: RuleNoConfig | [AllowWarnDeny, NoDeprecatedModelDefinitionConfig];
   "vue/no-deprecated-props-default-this"?: RuleNoConfig;
   "vue/no-deprecated-vue-config-keycodes"?: RuleNoConfig;
-  "vue/no-dupe-keys"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoDupeKeysConfig];
+  "vue/no-dupe-keys"?: RuleNoConfig | [AllowWarnDeny, NoDupeKeysConfig];
   "vue/no-export-in-script-setup"?: RuleNoConfig;
   "vue/no-expose-after-await"?: RuleNoConfig;
   "vue/no-import-compiler-macros"?: RuleNoConfig;

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1651,6 +1651,7 @@ export interface DummyRuleMap {
   "vue/no-deprecated-model-definition"?: RuleNoConfig | [AllowWarnDeny, NoDeprecatedModelDefinitionConfig];
   "vue/no-deprecated-props-default-this"?: RuleNoConfig;
   "vue/no-deprecated-vue-config-keycodes"?: RuleNoConfig;
+  "vue/no-dupe-keys"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConfigElement0];
   "vue/no-export-in-script-setup"?: RuleNoConfig;
   "vue/no-expose-after-await"?: RuleNoConfig;
   "vue/no-import-compiler-macros"?: RuleNoConfig;
@@ -6043,6 +6044,7 @@ export interface NoDeprecatedModelDefinitionConfig {
    */
   allowVue3Compat?: boolean;
 }
+export interface ConfigElement0 {}
 export interface NoReservedComponentNames {
   /**
    * Disallow Vue 3 built-in component names (e.g. `Teleport`, `Suspense`).

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -6045,6 +6045,10 @@ export interface NoDeprecatedModelDefinitionConfig {
   allowVue3Compat?: boolean;
 }
 export interface NoDupeKeysConfig {
+  /**
+   * Additional group names to search for duplicate keys in, on top of the
+   * built-in `props`, `computed`, `data`, `methods` and `setup` groups.
+   */
   groups?: string[];
 }
 export interface NoReservedComponentNames {

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5091,6 +5091,12 @@ impl RuleRunner
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vue::no_dupe_keys::NoDupeKeys {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ObjectExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+}
+
 impl RuleRunner for crate::rules::vue::no_export_in_script_setup::NoExportInScriptSetup {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5093,8 +5093,8 @@ impl RuleRunner
 
 impl RuleRunner for crate::rules::vue::no_dupe_keys::NoDupeKeys {
     const NODE_TYPES: Option<&AstTypesBitset> =
-        Some(&AstTypesBitset::from_types(&[AstType::ObjectExpression]));
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ObjectExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::vue::no_export_in_script_setup::NoExportInScriptSetup {

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -813,6 +813,7 @@ pub use crate::rules::vue::no_deprecated_events_api::NoDeprecatedEventsApi as Vu
 pub use crate::rules::vue::no_deprecated_model_definition::NoDeprecatedModelDefinition as VueNoDeprecatedModelDefinition;
 pub use crate::rules::vue::no_deprecated_props_default_this::NoDeprecatedPropsDefaultThis as VueNoDeprecatedPropsDefaultThis;
 pub use crate::rules::vue::no_deprecated_vue_config_keycodes::NoDeprecatedVueConfigKeycodes as VueNoDeprecatedVueConfigKeycodes;
+pub use crate::rules::vue::no_dupe_keys::NoDupeKeys as VueNoDupeKeys;
 pub use crate::rules::vue::no_export_in_script_setup::NoExportInScriptSetup as VueNoExportInScriptSetup;
 pub use crate::rules::vue::no_expose_after_await::NoExposeAfterAwait as VueNoExposeAfterAwait;
 pub use crate::rules::vue::no_import_compiler_macros::NoImportCompilerMacros as VueNoImportCompilerMacros;
@@ -1663,6 +1664,7 @@ pub enum RuleEnum {
     VueNoDeprecatedModelDefinition(VueNoDeprecatedModelDefinition),
     VueNoDeprecatedPropsDefaultThis(VueNoDeprecatedPropsDefaultThis),
     VueNoDeprecatedVueConfigKeycodes(VueNoDeprecatedVueConfigKeycodes),
+    VueNoDupeKeys(VueNoDupeKeys),
     VueNoExportInScriptSetup(VueNoExportInScriptSetup),
     VueNoExposeAfterAwait(VueNoExposeAfterAwait),
     VueNoImportCompilerMacros(VueNoImportCompilerMacros),
@@ -2601,7 +2603,8 @@ const VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID: usize =
     VUE_NO_DEPRECATED_MODEL_DEFINITION_ID + 1usize;
 const VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID: usize =
     VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID + 1usize;
-const VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID: usize = VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID + 1usize;
+const VUE_NO_DUPE_KEYS_ID: usize = VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID + 1usize;
+const VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID: usize = VUE_NO_DUPE_KEYS_ID + 1usize;
 const VUE_NO_EXPOSE_AFTER_AWAIT_ID: usize = VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID + 1usize;
 const VUE_NO_IMPORT_COMPILER_MACROS_ID: usize = VUE_NO_EXPOSE_AFTER_AWAIT_ID + 1usize;
 const VUE_NO_LIFECYCLE_AFTER_AWAIT_ID: usize = VUE_NO_IMPORT_COMPILER_MACROS_ID + 1usize;
@@ -3566,6 +3569,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(_) => VUE_NO_DEPRECATED_MODEL_DEFINITION_ID,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VUE_NO_DEPRECATED_PROPS_DEFAULT_THIS_ID,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VUE_NO_DEPRECATED_VUE_CONFIG_KEYCODES_ID,
+            Self::VueNoDupeKeys(_) => VUE_NO_DUPE_KEYS_ID,
             Self::VueNoExportInScriptSetup(_) => VUE_NO_EXPORT_IN_SCRIPT_SETUP_ID,
             Self::VueNoExposeAfterAwait(_) => VUE_NO_EXPOSE_AFTER_AWAIT_ID,
             Self::VueNoImportCompilerMacros(_) => VUE_NO_IMPORT_COMPILER_MACROS_ID,
@@ -4516,6 +4520,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::NAME,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::NAME,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::NAME,
+            Self::VueNoDupeKeys(_) => VueNoDupeKeys::NAME,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::NAME,
             Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::NAME,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::NAME,
@@ -5524,6 +5529,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::CATEGORY,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::CATEGORY,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::CATEGORY,
+            Self::VueNoDupeKeys(_) => VueNoDupeKeys::CATEGORY,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::CATEGORY,
             Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::CATEGORY,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::CATEGORY,
@@ -6475,6 +6481,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::FIX,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::FIX,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::FIX,
+            Self::VueNoDupeKeys(_) => VueNoDupeKeys::FIX,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::FIX,
             Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::FIX,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::FIX,
@@ -7686,6 +7693,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedVueConfigKeycodes(_) => {
                 VueNoDeprecatedVueConfigKeycodes::documentation()
             }
+            Self::VueNoDupeKeys(_) => VueNoDupeKeys::documentation(),
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::documentation(),
             Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::documentation(),
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::documentation(),
@@ -10038,6 +10046,9 @@ impl RuleEnum {
                 VueNoDeprecatedVueConfigKeycodes::config_schema(generator)
                     .or_else(|| VueNoDeprecatedVueConfigKeycodes::schema(generator))
             }
+            Self::VueNoDupeKeys(_) => {
+                VueNoDupeKeys::config_schema(generator).or_else(|| VueNoDupeKeys::schema(generator))
+            }
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::config_schema(generator)
                 .or_else(|| VueNoExportInScriptSetup::schema(generator)),
             Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::config_schema(generator)
@@ -10921,6 +10932,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(_) => "vue",
             Self::VueNoDeprecatedPropsDefaultThis(_) => "vue",
             Self::VueNoDeprecatedVueConfigKeycodes(_) => "vue",
+            Self::VueNoDupeKeys(_) => "vue",
             Self::VueNoExportInScriptSetup(_) => "vue",
             Self::VueNoExposeAfterAwait(_) => "vue",
             Self::VueNoImportCompilerMacros(_) => "vue",
@@ -13550,6 +13562,9 @@ impl RuleEnum {
                     VueNoDeprecatedVueConfigKeycodes::from_configuration(value)?,
                 ))
             }
+            Self::VueNoDupeKeys(_) => {
+                Ok(Self::VueNoDupeKeys(VueNoDupeKeys::from_configuration(value)?))
+            }
             Self::VueNoExportInScriptSetup(_) => Ok(Self::VueNoExportInScriptSetup(
                 VueNoExportInScriptSetup::from_configuration(value)?,
             )),
@@ -14450,6 +14465,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.to_configuration(),
+            Self::VueNoDupeKeys(rule) => rule.to_configuration(),
             Self::VueNoExportInScriptSetup(rule) => rule.to_configuration(),
             Self::VueNoExposeAfterAwait(rule) => rule.to_configuration(),
             Self::VueNoImportCompilerMacros(rule) => rule.to_configuration(),
@@ -15296,6 +15312,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedModelDefinition(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run(node, ctx),
+                Self::VueNoDupeKeys(rule) => rule.run(node, ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run(node, ctx),
                 Self::VueNoExposeAfterAwait(rule) => rule.run(node, ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run(node, ctx),
@@ -16135,6 +16152,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedModelDefinition(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run(node, ctx),
+                Self::VueNoDupeKeys(rule) => rule.run(node, ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run(node, ctx),
                 Self::VueNoExposeAfterAwait(rule) => rule.run(node, ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run(node, ctx),
@@ -16981,6 +16999,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedModelDefinition(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_once(ctx),
+                Self::VueNoDupeKeys(rule) => rule.run_once(ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run_once(ctx),
                 Self::VueNoExposeAfterAwait(rule) => rule.run_once(ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run_once(ctx),
@@ -17820,6 +17839,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedModelDefinition(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_once(ctx),
+                Self::VueNoDupeKeys(rule) => rule.run_once(ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run_once(ctx),
                 Self::VueNoExposeAfterAwait(rule) => rule.run_once(ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run_once(ctx),
@@ -18925,6 +18945,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::VueNoDupeKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoExposeAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20024,6 +20045,7 @@ impl RuleEnum {
                 Self::VueNoDeprecatedVueConfigKeycodes(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
+                Self::VueNoDupeKeys(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoExportInScriptSetup(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoExposeAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoImportCompilerMacros(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20863,6 +20885,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.should_run(ctx),
+            Self::VueNoDupeKeys(rule) => rule.should_run(ctx),
             Self::VueNoExportInScriptSetup(rule) => rule.should_run(ctx),
             Self::VueNoExposeAfterAwait(rule) => rule.should_run(ctx),
             Self::VueNoImportCompilerMacros(rule) => rule.should_run(ctx),
@@ -22071,6 +22094,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedVueConfigKeycodes(_) => {
                 VueNoDeprecatedVueConfigKeycodes::IS_TSGOLINT_RULE
             }
+            Self::VueNoDupeKeys(_) => VueNoDupeKeys::IS_TSGOLINT_RULE,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::IS_TSGOLINT_RULE,
             Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::IS_TSGOLINT_RULE,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::IS_TSGOLINT_RULE,
@@ -23083,6 +23107,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::VERSION,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::VERSION,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::VERSION,
+            Self::VueNoDupeKeys(_) => VueNoDupeKeys::VERSION,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::VERSION,
             Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::VERSION,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::VERSION,
@@ -24130,6 +24155,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedVueConfigKeycodes(_) => {
                 VueNoDeprecatedVueConfigKeycodes::HAS_CONFIG
             }
+            Self::VueNoDupeKeys(_) => VueNoDupeKeys::HAS_CONFIG,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::HAS_CONFIG,
             Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::HAS_CONFIG,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::HAS_CONFIG,
@@ -25082,6 +25108,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(_) => VueNoDeprecatedModelDefinition::INFO,
             Self::VueNoDeprecatedPropsDefaultThis(_) => VueNoDeprecatedPropsDefaultThis::INFO,
             Self::VueNoDeprecatedVueConfigKeycodes(_) => VueNoDeprecatedVueConfigKeycodes::INFO,
+            Self::VueNoDupeKeys(_) => VueNoDupeKeys::INFO,
             Self::VueNoExportInScriptSetup(_) => VueNoExportInScriptSetup::INFO,
             Self::VueNoExposeAfterAwait(_) => VueNoExposeAfterAwait::INFO,
             Self::VueNoImportCompilerMacros(_) => VueNoImportCompilerMacros::INFO,
@@ -25925,6 +25952,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(rule) => rule.types_info(),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.types_info(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.types_info(),
+            Self::VueNoDupeKeys(rule) => rule.types_info(),
             Self::VueNoExportInScriptSetup(rule) => rule.types_info(),
             Self::VueNoExposeAfterAwait(rule) => rule.types_info(),
             Self::VueNoImportCompilerMacros(rule) => rule.types_info(),
@@ -26761,6 +26789,7 @@ impl RuleEnum {
             Self::VueNoDeprecatedModelDefinition(rule) => rule.run_info(),
             Self::VueNoDeprecatedPropsDefaultThis(rule) => rule.run_info(),
             Self::VueNoDeprecatedVueConfigKeycodes(rule) => rule.run_info(),
+            Self::VueNoDupeKeys(rule) => rule.run_info(),
             Self::VueNoExportInScriptSetup(rule) => rule.run_info(),
             Self::VueNoExposeAfterAwait(rule) => rule.run_info(),
             Self::VueNoImportCompilerMacros(rule) => rule.run_info(),
@@ -27731,6 +27760,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueNoDeprecatedModelDefinition(VueNoDeprecatedModelDefinition::default()),
         RuleEnum::VueNoDeprecatedPropsDefaultThis(VueNoDeprecatedPropsDefaultThis::default()),
         RuleEnum::VueNoDeprecatedVueConfigKeycodes(VueNoDeprecatedVueConfigKeycodes::default()),
+        RuleEnum::VueNoDupeKeys(VueNoDupeKeys::default()),
         RuleEnum::VueNoExportInScriptSetup(VueNoExportInScriptSetup::default()),
         RuleEnum::VueNoExposeAfterAwait(VueNoExposeAfterAwait::default()),
         RuleEnum::VueNoImportCompilerMacros(VueNoImportCompilerMacros::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -863,6 +863,7 @@ pub(crate) mod vue {
     pub mod no_deprecated_model_definition;
     pub mod no_deprecated_props_default_this;
     pub mod no_deprecated_vue_config_keycodes;
+    pub mod no_dupe_keys;
     pub mod no_export_in_script_setup;
     pub mod no_expose_after_await;
     pub mod no_import_compiler_macros;

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -297,11 +297,18 @@ fn literal_element_name<'a>(expr: &Expression<'a>) -> Option<Cow<'a, str>> {
     }
 }
 
-/// `PropertyKey::static_name`, except numeric keys are formatted like JS `String(n)`
-/// (`1e-7` → "1e-7", not "0.0000001") to match upstream `getStaticPropertyName`.
+/// `PropertyKey::static_name` adjusted to upstream `getStaticPropertyName` semantics:
+/// numeric keys are formatted like JS `String(n)` (`1e-7` → "1e-7", not "0.0000001"),
+/// a computed `[true]` key is named "true", and a computed `[null]` key has no name
+/// (upstream's `getStringLiteralValue` bails on `value == null`; a plain `null` key
+/// is an identifier, not this variant).
 fn static_key_name<'a>(key: &PropertyKey<'a>) -> Option<Cow<'a, str>> {
     match key {
         PropertyKey::NumericLiteral(n) => Some(Cow::Owned(n.value.to_js_string())),
+        PropertyKey::BooleanLiteral(b) => {
+            Some(Cow::Borrowed(if b.value { "true" } else { "false" }))
+        }
+        PropertyKey::NullLiteral(_) => None,
         _ => key.static_name(),
     }
 }
@@ -1160,6 +1167,17 @@ const foo = reactive(defineProps(['foo']))
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        // a computed `[null]` key has no static name upstream
+        (
+            r"
+<script>
+export default { props: { [null]: String }, data () { return { 'null': 1 } } }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     let fail = vec![
@@ -1785,6 +1803,28 @@ export default { props: [1, true], data () { return { 1: 'x', true: 'y' } } }
             r"
 <script>
 export default { props: { 1e-7: String }, data () { return { '1e-7': 1 } } }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // a plain `null` key is an identifier and is a real key name
+        (
+            r"
+<script>
+export default { data () { return { null: 1, null: 2 } } }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // a computed `[true]` key is stringified like JS String(value)
+        (
+            r"
+<script>
+export default { props: { [true]: String }, data () { return { 'true': 1 } } }
 </script>
 ",
             None,

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -35,6 +35,8 @@ fn duplicate_key_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct NoDupeKeysConfig {
+    /// Additional group names to search for duplicate keys in, on top of the
+    /// built-in `props`, `computed`, `data`, `methods` and `setup` groups.
     groups: Vec<String>,
 }
 
@@ -179,7 +181,7 @@ fn collect_group_keys<'a>(
     ctx: &LintContext<'a>,
 ) {
     // Only unwrap parens: espree has no paren nodes, so upstream sees through them,
-    // but a TS `as`-wrapped value is skipped by upstream and must stay skipped here.
+    // while a TS `as`-wrapped value is opaque to upstream and must stay opaque here.
     match value.without_parentheses() {
         Expression::ArrayExpression(arr) => {
             for el in &arr.elements {

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -136,9 +136,11 @@ impl Rule for NoDupeKeys {
             let span = match decl.kind() {
                 AstKind::VariableDeclarator(d) => {
                     if d.init.as_ref().is_some_and(|init| {
-                        // Initialised directly from defineProps / withDefaults(defineProps(...))
-                        is_define_props_initializer(init, define_props_call)
-                            // Initialiser references the props object or any destructured binding
+                        // The defineProps call itself counts as a props reference upstream,
+                        // so any initializer containing it (e.g. `reactive(defineProps(...))`)
+                        // is exempt, as is one referencing the props object or any
+                        // destructured binding.
+                        init.span().contains_inclusive(define_props_call.span)
                             || is_inside_props_reference(init, &props_symbol_ids, ctx)
                     }) {
                         continue;
@@ -1130,6 +1132,18 @@ export default { props: ['foo'], data () { return { foo: 1 } as any } }
             r"
 <script>
 export default { props: { '0.0000001': String }, data () { return { 1e-7: 1 } } }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // an initializer containing the defineProps call itself is exempt
+        // (upstream includes the call node in propReferences)
+        (
+            r"
+<script setup>
+const foo = reactive(defineProps(['foo']))
 </script>
 ",
             None,

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -128,11 +128,11 @@ impl Rule for NoDupeKeys {
             return;
         }
         let renamed = collect_renamed_props(define_props_call, ctx);
-        // Obtain the symbol bound to `const xxx = defineProps(...)` once for O(1) span checks
-        let props_symbol_id = find_props_symbol_id(define_props_call, ctx);
+        // Collect all symbols bound by defineProps (simple binding + destructured) for span checks
+        let props_symbol_ids = find_props_symbol_ids(define_props_call, ctx);
         let root_scope_id = ctx.scoping().root_scope_id();
 
-        for (prop_name, _) in &props {
+        for prop_name in &props {
             if renamed.contains(prop_name.as_str()) {
                 continue;
             }
@@ -148,10 +148,8 @@ impl Rule for NoDupeKeys {
                     if d.init.as_ref().is_some_and(|init| {
                         // Initialised directly from defineProps / withDefaults(defineProps(...))
                         is_define_props_initializer(init, define_props_call)
-                            // Initialiser references the props object (e.g. computed(() => props.foo))
-                            || props_symbol_id.is_some_and(|sid| {
-                                is_inside_props_reference(init, sid, ctx)
-                            })
+                            // Initialiser references the props object or any destructured binding
+                            || is_inside_props_reference(init, &props_symbol_ids, ctx)
                     }) {
                         continue;
                     }
@@ -159,7 +157,7 @@ impl Rule for NoDupeKeys {
                 }
                 _ => decl.kind().span(),
             };
-            ctx.diagnostic(duplicate_key_diagnostic(span, prop_name));
+            ctx.diagnostic(duplicate_key_diagnostic(span, prop_name.as_ref()));
         }
     }
 }
@@ -171,11 +169,20 @@ fn collect_group_keys<'a>(
     seen: &mut FxHashSet<String>,
     ctx: &LintContext<'a>,
 ) {
-    match value {
+    match value.get_inner_expression() {
         Expression::ArrayExpression(arr) => {
             for el in &arr.elements {
-                if let ArrayExpressionElement::StringLiteral(s) = el {
-                    report_or_add(s.value.as_str(), s.span, seen, ctx);
+                match el {
+                    ArrayExpressionElement::StringLiteral(s) => {
+                        report_or_add(s.value.as_str(), s.span, seen, ctx);
+                    }
+                    ArrayExpressionElement::TemplateLiteral(t) if t.expressions.is_empty() => {
+                        if let Some(cooked) = t.quasis.first().and_then(|q| q.value.cooked.as_ref())
+                        {
+                            report_or_add(cooked.as_str(), t.span, seen, ctx);
+                        }
+                    }
+                    _ => {}
                 }
             }
         }
@@ -277,39 +284,73 @@ fn find_define_props_call<'a>(
     None
 }
 
-/// Find the `SymbolId` of the variable bound to `const xxx = defineProps(...)`.
-fn find_props_symbol_id(
-    call: &oxc_ast::ast::CallExpression,
-    ctx: &LintContext,
-) -> Option<SymbolId> {
+/// Collect all `SymbolId`s bound by a defineProps assignment, including destructured bindings.
+/// Handles `const props = defineProps(...)`, `const { foo } = defineProps(...)`, etc.
+fn find_props_symbol_ids(call: &oxc_ast::ast::CallExpression, ctx: &LintContext) -> Vec<SymbolId> {
+    let mut ids = Vec::new();
     for node in ctx.nodes() {
         let AstKind::VariableDeclarator(decl) = node.kind() else { continue };
         if !decl.init.as_ref().is_some_and(|init| is_define_props_initializer(init, call)) {
             continue;
         }
-        if let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &decl.id {
-            return id.symbol_id.get();
-        }
+        collect_binding_symbol_ids(&decl.id, &mut ids);
     }
-    None
+    ids
 }
 
-/// True if any reference to `symbol_id` falls within `init`'s span.
-fn is_inside_props_reference(init: &Expression, symbol_id: SymbolId, ctx: &LintContext) -> bool {
+fn collect_binding_symbol_ids(pattern: &oxc_ast::ast::BindingPattern, ids: &mut Vec<SymbolId>) {
+    use oxc_ast::ast::BindingPattern;
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => {
+            if let Some(sym) = id.symbol_id.get() {
+                ids.push(sym);
+            }
+        }
+        BindingPattern::ObjectPattern(obj) => {
+            for prop in &obj.properties {
+                collect_binding_symbol_ids(&prop.value, ids);
+            }
+            if let Some(rest) = &obj.rest {
+                collect_binding_symbol_ids(&rest.argument, ids);
+            }
+        }
+        BindingPattern::ArrayPattern(arr) => {
+            for el in arr.elements.iter().flatten() {
+                collect_binding_symbol_ids(el, ids);
+            }
+            if let Some(rest) = &arr.rest {
+                collect_binding_symbol_ids(&rest.argument, ids);
+            }
+        }
+        BindingPattern::AssignmentPattern(assign) => {
+            collect_binding_symbol_ids(&assign.left, ids);
+        }
+    }
+}
+
+/// True if any reference to one of `symbol_ids` falls within `init`'s span.
+fn is_inside_props_reference(
+    init: &Expression,
+    symbol_ids: &[SymbolId],
+    ctx: &LintContext,
+) -> bool {
+    if symbol_ids.is_empty() {
+        return false;
+    }
     let init_span = init.span();
-    ctx.semantic().symbol_references(symbol_id).any(|reference| {
-        let ref_span = ctx.nodes().get_node(reference.node_id()).kind().span();
-        init_span.start <= ref_span.start && ref_span.end <= init_span.end
+    symbol_ids.iter().any(|&symbol_id| {
+        ctx.semantic().symbol_references(symbol_id).any(|reference| {
+            let ref_span = ctx.nodes().get_node(reference.node_id()).kind().span();
+            init_span.start <= ref_span.start && ref_span.end <= init_span.end
+        })
     })
 }
 
-/// Collects (prop_name, span) pairs from a `defineProps(...)` call.
-/// Returns owned Strings to avoid lifetime issues with `static_name()` → `Cow`.
 fn collect_prop_names_from_call<'a>(
     call: &'a oxc_ast::ast::CallExpression<'a>,
     ctx: &LintContext<'a>,
-) -> Vec<(String, Span)> {
-    let mut props: Vec<(String, Span)> = Vec::new();
+) -> Vec<String> {
+    let mut props: Vec<String> = Vec::new();
     if let Some(arg) = call.arguments.first().and_then(|a| a.as_expression()) {
         match arg {
             Expression::ObjectExpression(obj) => {
@@ -317,14 +358,24 @@ fn collect_prop_names_from_call<'a>(
                     if let ObjectPropertyKind::ObjectProperty(p) = prop_kind
                         && let Some(name) = p.key.static_name()
                     {
-                        props.push((name.into_owned(), p.key.span()));
+                        props.push(name.into_owned());
                     }
                 }
             }
             Expression::ArrayExpression(arr) => {
                 for el in &arr.elements {
-                    if let ArrayExpressionElement::StringLiteral(s) = el {
-                        props.push((s.value.to_string(), s.span));
+                    match el {
+                        ArrayExpressionElement::StringLiteral(s) => {
+                            props.push(s.value.to_string());
+                        }
+                        ArrayExpressionElement::TemplateLiteral(t) if t.expressions.is_empty() => {
+                            if let Some(cooked) =
+                                t.quasis.first().and_then(|q| q.value.cooked.as_ref())
+                            {
+                                props.push(cooked.to_string());
+                            }
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -339,7 +390,7 @@ fn collect_prop_names_from_call<'a>(
 fn collect_ts_type_prop_names<'a>(
     call: &'a oxc_ast::ast::CallExpression<'a>,
     ctx: &LintContext<'a>,
-    out: &mut Vec<(String, Span)>,
+    out: &mut Vec<String>,
 ) {
     let Some(type_params) = &call.type_arguments else { return };
     let Some(first_type) = type_params.params.first() else { return };
@@ -350,7 +401,7 @@ fn collect_ts_type_prop_names<'a>(
             _ => return,
         };
         if let Some(name) = key.static_name() {
-            out.push((name.into_owned(), key.span()));
+            out.push(name.into_owned());
         }
     });
 }
@@ -1033,6 +1084,18 @@ const foo = 1
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        // new-1: destructured prop binding referenced in initializer must be exempted
+        (
+            r"
+<script setup>
+const { foo } = defineProps(['foo', 'bar'])
+const bar = computed(() => foo + 1)
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     let fail = vec![
@@ -1554,6 +1617,40 @@ export default {
   props: { 1: String },
   data () { return { 1: 'x' } }
 }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // fix-8c: group value itself wrapped in parens
+        (
+            r"
+<script>
+export default { props: ['foo'], data: ({ foo: null }) }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // new-2a: template literal in array prop list (Options API)
+        (
+            r"
+<script>
+export default { props: [`foo`], data() { return { foo: 1 } } }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // new-2b: template literal in defineProps array (script setup)
+        (
+            r"
+<script setup>
+defineProps([`foo`])
+const foo = 1
 </script>
 ",
             None,

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -35,7 +35,7 @@ pub struct NoDupeKeysConfig {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct NoDupeKeys(NoDupeKeysConfig);
+pub struct NoDupeKeys(Box<NoDupeKeysConfig>);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -93,7 +93,7 @@ impl Rule for NoDupeKeys {
         } else {
             serde_json::from_value(value)?
         };
-        Ok(Self(config))
+        Ok(Self(Box::new(config)))
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -5,12 +5,13 @@ use serde::{Deserialize, Serialize};
 use oxc_ast::{
     AstKind,
     ast::{
-        ArrayExpressionElement, Expression, ImportDeclarationSpecifier, ObjectExpression,
-        ObjectPropertyKind, PropertyKey, PropertyKind, Statement, TSSignature,
+        ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind, PropertyKind,
+        Statement, TSSignature,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -18,7 +19,7 @@ use crate::{
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::Rule,
-    utils::{find_property, for_each_define_props_type_signature, is_vue_component_options_object},
+    utils::{for_each_define_props_type_signature, is_vue_component_options_object},
 };
 
 fn duplicate_key_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
@@ -102,10 +103,18 @@ impl Rule for NoDupeKeys {
             return;
         }
         let extra_groups = &self.0.groups;
-        let mut seen: Vec<(&str, Span)> = Vec::new();
-        for group in GROUP_NAMES.iter().copied().chain(extra_groups.iter().map(String::as_str)) {
-            let Some(group_prop) = find_property(obj, group) else { continue };
-            collect_group_keys(&group_prop.value, &mut seen, ctx);
+        // dedup: user-supplied group names may overlap with built-in names
+        let groups: FxHashSet<&str> =
+            GROUP_NAMES.iter().copied().chain(extra_groups.iter().map(String::as_str)).collect();
+        let mut seen: FxHashSet<String> = FxHashSet::default();
+        // Walk all properties in source order so duplicate group names are both visited
+        for prop_kind in &obj.properties {
+            let ObjectPropertyKind::ObjectProperty(prop) = prop_kind else { continue };
+            let Some(group_name) = prop.key.static_name() else { continue };
+            if !groups.contains(group_name.as_ref()) {
+                continue;
+            }
+            collect_group_keys(&prop.value, &mut seen, ctx);
         }
     }
 
@@ -113,61 +122,44 @@ impl Rule for NoDupeKeys {
         if ctx.frameworks_options() != FrameworkOptions::VueSetup {
             return;
         }
-        let Some(define_props_node) = find_define_props_call(ctx) else { return };
-        let props = collect_prop_names_from_call(define_props_node, ctx);
+        let Some(define_props_call) = find_define_props_call(ctx) else { return };
+        let props = collect_prop_names_from_call(define_props_call, ctx);
         if props.is_empty() {
             return;
         }
-        let renamed = collect_renamed_props(define_props_node, ctx);
+        let renamed = collect_renamed_props(define_props_call, ctx);
+        // Obtain the symbol bound to `const xxx = defineProps(...)` once for O(1) span checks
+        let props_symbol_id = find_props_symbol_id(define_props_call, ctx);
+        let root_scope_id = ctx.scoping().root_scope_id();
 
-        for node in ctx.nodes() {
-            if !is_script_setup_top_level(node.id(), ctx) {
+        for (prop_name, _) in &props {
+            if renamed.contains(prop_name.as_str()) {
                 continue;
             }
-            match node.kind() {
-                AstKind::VariableDeclarator(decl) => {
-                    if decl
-                        .init
-                        .as_ref()
-                        .is_some_and(|init| is_define_props_initializer(init, define_props_node))
-                    {
+            // Only look in the module (root) scope — nested function/block bindings are invisible
+            let Some(symbol_id) =
+                ctx.scoping().get_binding(root_scope_id, prop_name.as_str().into())
+            else {
+                continue;
+            };
+            let decl = ctx.semantic().symbol_declaration(symbol_id);
+            let span = match decl.kind() {
+                AstKind::VariableDeclarator(d) => {
+                    if d.init.as_ref().is_some_and(|init| {
+                        // Initialised directly from defineProps / withDefaults(defineProps(...))
+                        is_define_props_initializer(init, define_props_call)
+                            // Initialiser references the props object (e.g. computed(() => props.foo))
+                            || props_symbol_id.is_some_and(|sid| {
+                                is_inside_props_reference(init, sid, ctx)
+                            })
+                    }) {
                         continue;
                     }
-                    if decl
-                        .init
-                        .as_ref()
-                        .is_some_and(|init| is_props_access(init, define_props_node, ctx))
-                    {
-                        continue;
-                    }
-                    let Some(bound_name) = bound_name_of_declarator(decl) else { continue };
-                    check_prop_duplicate(bound_name, decl.id.span(), &props, &renamed, ctx);
+                    d.id.span()
                 }
-                AstKind::Function(func)
-                    if func.r#type == oxc_ast::ast::FunctionType::FunctionDeclaration =>
-                {
-                    let Some(id) = &func.id else { continue };
-                    check_prop_duplicate(id.name.as_str(), id.span, &props, &renamed, ctx);
-                }
-                AstKind::ImportDeclaration(import) => {
-                    let Some(specifiers) = &import.specifiers else { continue };
-                    for specifier in specifiers {
-                        let (name, span) = match specifier {
-                            ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
-                                (s.local.name.as_str(), s.local.span)
-                            }
-                            ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => {
-                                (s.local.name.as_str(), s.local.span)
-                            }
-                            ImportDeclarationSpecifier::ImportSpecifier(s) => {
-                                (s.local.name.as_str(), s.local.span)
-                            }
-                        };
-                        check_prop_duplicate(name, span, &props, &renamed, ctx);
-                    }
-                }
-                _ => {}
-            }
+                _ => decl.kind().span(),
+            };
+            ctx.diagnostic(duplicate_key_diagnostic(span, prop_name));
         }
     }
 }
@@ -176,7 +168,7 @@ const GROUP_NAMES: &[&str] = &["props", "computed", "data", "methods", "setup"];
 
 fn collect_group_keys<'a>(
     value: &'a Expression<'a>,
-    seen: &mut Vec<(&'a str, Span)>,
+    seen: &mut FxHashSet<String>,
     ctx: &LintContext<'a>,
 ) {
     match value {
@@ -194,7 +186,9 @@ fn collect_group_keys<'a>(
             if let Some(body) = &func.body {
                 for stmt in &body.statements {
                     if let Statement::ReturnStatement(ret) = stmt
-                        && let Some(Expression::ObjectExpression(ret_obj)) = &ret.argument
+                        && let Some(ret_expr) = &ret.argument
+                        && let Expression::ObjectExpression(ret_obj) =
+                            ret_expr.get_inner_expression()
                     {
                         collect_object_keys(ret_obj, seen, ctx);
                     }
@@ -211,7 +205,9 @@ fn collect_group_keys<'a>(
             } else {
                 for stmt in &arrow.body.statements {
                     if let Statement::ReturnStatement(ret) = stmt
-                        && let Some(Expression::ObjectExpression(ret_obj)) = &ret.argument
+                        && let Some(ret_expr) = &ret.argument
+                        && let Expression::ObjectExpression(ret_obj) =
+                            ret_expr.get_inner_expression()
                     {
                         collect_object_keys(ret_obj, seen, ctx);
                     }
@@ -224,98 +220,87 @@ fn collect_group_keys<'a>(
 
 fn collect_object_keys<'a>(
     obj: &'a ObjectExpression<'a>,
-    seen: &mut Vec<(&'a str, Span)>,
+    seen: &mut FxHashSet<String>,
     ctx: &LintContext<'a>,
 ) {
-    let getter_names: Vec<&str> = obj
+    let getter_names: FxHashSet<String> = obj
         .properties
         .iter()
         .filter_map(|p| {
             let ObjectPropertyKind::ObjectProperty(prop) = p else { return None };
-            if prop.kind == PropertyKind::Get { static_key_name(&prop.key) } else { None }
+            if prop.kind == PropertyKind::Get {
+                prop.key.static_name().map(std::borrow::Cow::into_owned)
+            } else {
+                None
+            }
         })
         .collect();
 
-    let mut used_getters: Vec<&str> = Vec::new();
+    let mut used_getters: FxHashSet<String> = FxHashSet::default();
 
     for prop_kind in &obj.properties {
         let ObjectPropertyKind::ObjectProperty(prop) = prop_kind else { continue };
-        let Some(name) = static_key_name(&prop.key) else { continue };
+        let Some(name) = prop.key.static_name() else { continue };
+        let name_str = name.as_ref();
 
         if prop.kind == PropertyKind::Set
-            && let Some(&getter) = getter_names.iter().find(|&&g| g == name)
-            && !used_getters.contains(&getter)
+            && getter_names.contains(name_str)
+            && !used_getters.contains(name_str)
         {
-            used_getters.push(getter);
+            used_getters.insert(name_str.to_string());
             continue;
         }
 
-        report_or_add(name, prop.key.span(), seen, ctx);
+        report_or_add(name_str, prop.key.span(), seen, ctx);
     }
 }
 
-fn report_or_add<'a>(
-    name: &'a str,
-    span: Span,
-    seen: &mut Vec<(&'a str, Span)>,
-    ctx: &LintContext,
-) {
-    if seen.iter().any(|(n, _)| *n == name) {
+fn report_or_add(name: &str, span: Span, seen: &mut FxHashSet<String>, ctx: &LintContext) {
+    if !seen.insert(name.to_string()) {
         ctx.diagnostic(duplicate_key_diagnostic(span, name));
-    } else {
-        seen.push((name, span));
-    }
-}
-
-fn static_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
-    match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
-        PropertyKey::StringLiteral(s) => Some(s.value.as_str()),
-        _ => None,
     }
 }
 
 // ---- script setup helpers ----
-
-/// True when the node is at the top level of a `<script setup>` block
-/// (i.e., not nested inside a function body).
-fn is_script_setup_top_level(node_id: oxc_semantic::NodeId, ctx: &LintContext) -> bool {
-    for ancestor in ctx.nodes().ancestors(node_id).skip(1) {
-        match ancestor.kind() {
-            AstKind::Program(_) => return true,
-            AstKind::FunctionBody(_) => return false,
-            _ => {}
-        }
-    }
-    true
-}
-
-fn check_prop_duplicate(
-    name: &str,
-    span: Span,
-    props: &[(String, Span)],
-    renamed: &FxHashSet<String>,
-    ctx: &LintContext,
-) {
-    if renamed.contains(name) {
-        return;
-    }
-    if props.iter().any(|(p, _)| p.as_str() == name) {
-        ctx.diagnostic(duplicate_key_diagnostic(span, name));
-    }
-}
 
 fn find_define_props_call<'a>(
     ctx: &LintContext<'a>,
 ) -> Option<&'a oxc_ast::ast::CallExpression<'a>> {
     for node in ctx.nodes() {
         if let AstKind::CallExpression(call) = node.kind()
+            && matches!(call.callee, Expression::Identifier(_))
             && call.callee_name() == Some("defineProps")
         {
             return Some(call);
         }
     }
     None
+}
+
+/// Find the `SymbolId` of the variable bound to `const xxx = defineProps(...)`.
+fn find_props_symbol_id(
+    call: &oxc_ast::ast::CallExpression,
+    ctx: &LintContext,
+) -> Option<SymbolId> {
+    for node in ctx.nodes() {
+        let AstKind::VariableDeclarator(decl) = node.kind() else { continue };
+        if !decl.init.as_ref().is_some_and(|init| is_define_props_initializer(init, call)) {
+            continue;
+        }
+        if let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &decl.id {
+            return id.symbol_id.get();
+        }
+    }
+    None
+}
+
+/// True if any reference to `symbol_id` falls within `init`'s span.
+fn is_inside_props_reference(init: &Expression, symbol_id: SymbolId, ctx: &LintContext) -> bool {
+    let init_span = init.span();
+    ctx.semantic().symbol_references(symbol_id).any(|reference| {
+        let ref_span = ctx.nodes().get_node(reference.node_id()).kind().span();
+        init_span.start <= ref_span.start && ref_span.end <= init_span.end
+    })
 }
 
 /// Collects (prop_name, span) pairs from a `defineProps(...)` call.
@@ -330,9 +315,9 @@ fn collect_prop_names_from_call<'a>(
             Expression::ObjectExpression(obj) => {
                 for prop_kind in &obj.properties {
                     if let ObjectPropertyKind::ObjectProperty(p) = prop_kind
-                        && let Some(name) = static_key_name(&p.key)
+                        && let Some(name) = p.key.static_name()
                     {
-                        props.push((name.to_string(), p.key.span()));
+                        props.push((name.into_owned(), p.key.span()));
                     }
                 }
             }
@@ -371,6 +356,7 @@ fn collect_ts_type_prop_names<'a>(
 }
 
 /// Prop names that are renamed in `const { foo: bar } = defineProps(...)` — `foo` is renamed.
+/// withDefaults wrapping is also handled so `const { foo: bar } = withDefaults(defineProps<...>(), ...)` works.
 fn collect_renamed_props(
     call: &oxc_ast::ast::CallExpression,
     ctx: &LintContext,
@@ -378,7 +364,7 @@ fn collect_renamed_props(
     let mut renamed = FxHashSet::default();
     for node in ctx.nodes() {
         let AstKind::VariableDeclarator(decl) = node.kind() else { continue };
-        if !decl.init.as_ref().is_some_and(|init| is_exact_define_props(init, call)) {
+        if !decl.init.as_ref().is_some_and(|init| is_define_props_initializer(init, call)) {
             continue;
         }
         if let oxc_ast::ast::BindingPattern::ObjectPattern(pat) = &decl.id {
@@ -395,14 +381,6 @@ fn collect_renamed_props(
     renamed
 }
 
-fn bound_name_of_declarator<'a>(decl: &'a oxc_ast::ast::VariableDeclarator<'a>) -> Option<&'a str> {
-    if let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &decl.id {
-        Some(id.name.as_str())
-    } else {
-        None
-    }
-}
-
 fn is_define_props_initializer<'a>(
     init: &'a Expression<'a>,
     call: &'a oxc_ast::ast::CallExpression<'a>,
@@ -410,7 +388,8 @@ fn is_define_props_initializer<'a>(
     match init {
         Expression::CallExpression(c) => {
             std::ptr::eq(c.as_ref(), call)
-                || (c.callee_name() == Some("withDefaults")
+                || (matches!(c.callee, Expression::Identifier(_))
+                    && c.callee_name() == Some("withDefaults")
                     && c.arguments
                         .first()
                         .and_then(|a| a.as_expression())
@@ -418,58 +397,6 @@ fn is_define_props_initializer<'a>(
         }
         _ => false,
     }
-}
-
-fn is_exact_define_props<'a>(
-    init: &'a Expression<'a>,
-    call: &'a oxc_ast::ast::CallExpression<'a>,
-) -> bool {
-    matches!(init, Expression::CallExpression(c) if std::ptr::eq(c.as_ref(), call))
-}
-
-fn is_props_access<'a>(
-    init: &'a Expression<'a>,
-    define_props_call: &'a oxc_ast::ast::CallExpression<'a>,
-    ctx: &LintContext<'a>,
-) -> bool {
-    let props_var_name = find_props_variable_name(define_props_call, ctx);
-    match init {
-        Expression::StaticMemberExpression(m) => {
-            is_props_identifier(&m.object, props_var_name.as_deref())
-        }
-        Expression::ComputedMemberExpression(m) => {
-            is_props_identifier(&m.object, props_var_name.as_deref())
-        }
-        Expression::CallExpression(c) => {
-            matches!(c.callee_name(), Some("toRefs" | "toRef"))
-                && c.arguments
-                    .first()
-                    .and_then(|a| a.as_expression())
-                    .is_some_and(|a| is_props_identifier(a, props_var_name.as_deref()))
-        }
-        _ => false,
-    }
-}
-
-fn find_props_variable_name(
-    call: &oxc_ast::ast::CallExpression,
-    ctx: &LintContext,
-) -> Option<String> {
-    for node in ctx.nodes() {
-        let AstKind::VariableDeclarator(decl) = node.kind() else { continue };
-        if !decl.init.as_ref().is_some_and(|i| is_define_props_initializer(i, call)) {
-            continue;
-        }
-        if let Some(name) = bound_name_of_declarator(decl) {
-            return Some(name.to_string());
-        }
-    }
-    None
-}
-
-fn is_props_identifier(expr: &Expression, props_name: Option<&str>) -> bool {
-    let Some(name) = props_name else { return false };
-    matches!(expr, Expression::Identifier(id) if id.name.as_str() == name)
 }
 
 #[test]
@@ -1028,6 +955,84 @@ const bar = 'hello'
         ),
         // External import types (import { Props } from './x') require cross-file TS type
         // resolution which is not supported; skipping this case.
+
+        // fix-2a: nested function's binding is not in root scope — no false positive
+        (
+            r"
+<script setup>
+defineProps({foo: String})
+function outer() {
+  function foo() {}
+}
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // fix-2b: block-scoped const is not in root scope — no false positive
+        (
+            r"
+<script setup>
+defineProps(['foo'])
+{
+  const foo = 1
+}
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // fix-1: built-in group name in groups option must not double-report
+        (
+            r"
+<script>
+export default {
+  props: ['foo', 'bar']
+}
+</script>
+",
+            Some(serde_json::json!([{ "groups": ["props"] }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // fix-3: initializer that references the props variable should be skipped
+        (
+            r"
+<script setup>
+const props = defineProps(['foo'])
+const foo = computed(() => props.foo)
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // fix-4: withDefaults wrapping defineProps — rename collected correctly
+        (
+            r#"
+<script setup lang="ts">
+const { foo: renamedFoo } = withDefaults(defineProps<{foo?: string}>(), {foo: 'x'})
+const foo = 1
+</script>
+"#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // fix-5: member-expression callee (utils.defineProps) must not be treated as defineProps
+        (
+            r"
+<script setup>
+const p = utils.defineProps({ foo: String })
+const foo = 1
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     let fail = vec![
@@ -1487,6 +1492,74 @@ const bar = 'bar'
         ),
         // External import type case (import { Props1 as Props } from './test01') requires
         // cross-file TS type resolution which is not supported; skipping this case.
+
+        // fix-7a: class declaration at root scope conflicts with prop name
+        (
+            r"
+<script setup>
+defineProps({ Foo: String })
+class Foo {}
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // fix-7b: destructuring binding at root scope conflicts with prop name
+        (
+            r"
+<script setup>
+defineProps({ foo: String })
+const { foo } = useSomething()
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // fix-6: duplicate group name (second data) — second occurrence must be reported
+        (
+            r"
+<script>
+export default {
+  props: ['foo'],
+  data () { return {} },
+  data () { return { foo: 1 } }
+}
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // fix-8a: return value wrapped in parens should still be detected
+        (
+            r"
+<script>
+export default {
+  props: ['foo'],
+  data () { return ({ foo: null }) }
+}
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // fix-8b: numeric property key
+        (
+            r"
+<script>
+export default {
+  props: { 1: String },
+  data () { return { 1: 'x' } }
+}
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     Tester::new(NoDupeKeys::NAME, NoDupeKeys::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -107,7 +107,7 @@ impl NoDupeKeys {
         obj: &'a ObjectExpression<'a>,
         ctx: &LintContext<'a>,
     ) {
-        if !is_vue_component_options_object(node, ctx) {
+        if !is_vue_component_options_object(node, ctx) && !has_vue_component_annotation(node, ctx) {
             return;
         }
         let extra_groups = &self.0.groups;
@@ -152,6 +152,9 @@ fn check_define_props<'a>(node: &AstNode<'a>, call: &'a CallExpression<'a>, ctx:
         else {
             continue;
         };
+        if !ctx.scoping().symbol_flags(symbol_id).can_be_referenced_by_value() {
+            continue;
+        }
         let decl = ctx.semantic().symbol_declaration(symbol_id);
         let span = match decl.kind() {
             AstKind::VariableDeclarator(d) => {
@@ -174,6 +177,31 @@ fn check_define_props<'a>(node: &AstNode<'a>, call: &'a CallExpression<'a>, ctx:
 }
 
 const GROUP_NAMES: &[&str] = &["props", "computed", "data", "methods", "setup"];
+
+fn has_vue_component_annotation(node: &AstNode, ctx: &LintContext) -> bool {
+    let mut target_start = node.kind().span().start;
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        if matches!(
+            ancestor.kind(),
+            AstKind::ExportDefaultDeclaration(_)
+                | AstKind::ExportNamedDeclaration(_)
+                | AstKind::ExpressionStatement(_)
+                | AstKind::VariableDeclaration(_)
+        ) {
+            target_start = ancestor.kind().span().start;
+        }
+    }
+
+    for comment in ctx.comments_range(..target_start).rev() {
+        if comment.attached_to != target_start {
+            break;
+        }
+        if comment.content_span().source_text(ctx.source_text()).trim() == "@vue/component" {
+            return true;
+        }
+    }
+    false
+}
 
 fn collect_group_keys<'a>(
     value: &'a Expression<'a>,
@@ -911,6 +939,23 @@ fn test() {
             Some(PathBuf::from("test.vue")),
         ),
         (
+            r#"
+<script setup lang="ts">
+defineProps<{
+  Foo: string;
+  Bar: string;
+  Baz: string;
+}>();
+interface Foo {}
+type Bar = string
+import type { Baz } from './types'
+</script>
+"#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
             r"
 <script setup>
 const props = defineProps(['foo', 'bar'])
@@ -1464,6 +1509,22 @@ export default { props: { [null]: String }, data () { return { 'null': 1 } } }
         })
       ",
             Some(serde_json::json!([{ "groups": ["foo"] }])),
+            None,
+            Some(PathBuf::from("test.js")),
+        ),
+        (
+            r"
+        // @vue/component
+        export const comp = {
+          props: ['foo'],
+          data () {
+            return {
+              foo: null
+            }
+          }
+        }
+      ",
+            None,
             None,
             Some(PathBuf::from("test.js")),
         ),

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use rustc_hash::FxHashSet;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -5,20 +7,21 @@ use serde::{Deserialize, Serialize};
 use oxc_ast::{
     AstKind,
     ast::{
-        ArrayExpressionElement, Expression, ObjectExpression, ObjectPropertyKind, PropertyKind,
-        Statement, TSSignature,
+        BindingPattern, CallExpression, Expression, ObjectExpression, ObjectPropertyKind,
+        PropertyKey, PropertyKind, Statement, TSSignature,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::{GetSpan, Span};
+use oxc_syntax::number::ToJsString;
 
 use crate::{
     AstNode,
     context::LintContext,
     frameworks::FrameworkOptions,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{for_each_define_props_type_signature, is_vue_component_options_object},
 };
 
@@ -83,18 +86,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDupeKeys {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let config: NoDupeKeysConfig = if value.is_null() {
-            NoDupeKeysConfig::default()
-        } else if let Some(arr) = value.as_array() {
-            if arr.is_empty() {
-                NoDupeKeysConfig::default()
-            } else {
-                serde_json::from_value(arr[0].clone())?
-            }
-        } else {
-            serde_json::from_value(value)?
-        };
-        Ok(Self(Box::new(config)))
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -106,11 +98,11 @@ impl Rule for NoDupeKeys {
         // dedup: user-supplied group names may overlap with built-in names
         let groups: FxHashSet<&str> =
             GROUP_NAMES.iter().copied().chain(extra_groups.iter().map(String::as_str)).collect();
-        let mut seen: FxHashSet<String> = FxHashSet::default();
+        let mut seen: FxHashSet<Cow<'a, str>> = FxHashSet::default();
         // Walk all properties in source order so duplicate group names are both visited
         for prop_kind in &obj.properties {
             let ObjectPropertyKind::ObjectProperty(prop) = prop_kind else { continue };
-            let Some(group_name) = prop.key.static_name() else { continue };
+            let Some(group_name) = static_key_name(&prop.key) else { continue };
             if !groups.contains(group_name.as_ref()) {
                 continue;
             }
@@ -127,18 +119,16 @@ impl Rule for NoDupeKeys {
         if props.is_empty() {
             return;
         }
-        let renamed = collect_renamed_props(define_props_call, ctx);
-        // Collect all symbols bound by defineProps (simple binding + destructured) for span checks
-        let props_symbol_ids = find_props_symbol_ids(define_props_call, ctx);
+        let (props_symbol_ids, renamed) = collect_props_bindings(define_props_call, ctx);
         let root_scope_id = ctx.scoping().root_scope_id();
 
         for prop_name in &props {
-            if renamed.contains(prop_name.as_str()) {
+            if renamed.contains(prop_name.as_ref()) {
                 continue;
             }
             // Only look in the module (root) scope — nested function/block bindings are invisible
             let Some(symbol_id) =
-                ctx.scoping().get_binding(root_scope_id, prop_name.as_str().into())
+                ctx.scoping().get_binding(root_scope_id, prop_name.as_ref().into())
             else {
                 continue;
             };
@@ -166,23 +156,20 @@ const GROUP_NAMES: &[&str] = &["props", "computed", "data", "methods", "setup"];
 
 fn collect_group_keys<'a>(
     value: &'a Expression<'a>,
-    seen: &mut FxHashSet<String>,
+    seen: &mut FxHashSet<Cow<'a, str>>,
     ctx: &LintContext<'a>,
 ) {
-    match value.get_inner_expression() {
+    // Only unwrap parens: espree has no paren nodes, so upstream sees through them,
+    // but a TS `as`-wrapped value is skipped by upstream and must stay skipped here.
+    match value.without_parentheses() {
         Expression::ArrayExpression(arr) => {
             for el in &arr.elements {
-                match el {
-                    ArrayExpressionElement::StringLiteral(s) => {
-                        report_or_add(s.value.as_str(), s.span, seen, ctx);
-                    }
-                    ArrayExpressionElement::TemplateLiteral(t) if t.expressions.is_empty() => {
-                        if let Some(cooked) = t.quasis.first().and_then(|q| q.value.cooked.as_ref())
-                        {
-                            report_or_add(cooked.as_str(), t.span, seen, ctx);
-                        }
-                    }
-                    _ => {}
+                let Some(expr) = el.as_expression() else { continue };
+                let expr = expr.without_parentheses();
+                if let Some(name) = literal_element_name(expr)
+                    && !name.is_empty()
+                {
+                    report_or_add(name, expr.span(), seen, ctx);
                 }
             }
         }
@@ -191,88 +178,116 @@ fn collect_group_keys<'a>(
         }
         Expression::FunctionExpression(func) => {
             if let Some(body) = &func.body {
-                for stmt in &body.statements {
-                    if let Statement::ReturnStatement(ret) = stmt
-                        && let Some(ret_expr) = &ret.argument
-                        && let Expression::ObjectExpression(ret_obj) =
-                            ret_expr.get_inner_expression()
-                    {
-                        collect_object_keys(ret_obj, seen, ctx);
-                    }
-                }
+                collect_returned_object_keys(&body.statements, seen, ctx);
             }
         }
         Expression::ArrowFunctionExpression(arrow) => {
             if arrow.expression {
                 if let Some(Statement::ExpressionStatement(es)) = arrow.body.statements.first()
-                    && let Expression::ObjectExpression(obj) = es.expression.get_inner_expression()
+                    && let Expression::ObjectExpression(obj) = es.expression.without_parentheses()
                 {
                     collect_object_keys(obj, seen, ctx);
                 }
             } else {
-                for stmt in &arrow.body.statements {
-                    if let Statement::ReturnStatement(ret) = stmt
-                        && let Some(ret_expr) = &ret.argument
-                        && let Expression::ObjectExpression(ret_obj) =
-                            ret_expr.get_inner_expression()
-                    {
-                        collect_object_keys(ret_obj, seen, ctx);
-                    }
-                }
+                collect_returned_object_keys(&arrow.body.statements, seen, ctx);
             }
         }
         _ => {}
     }
 }
 
-fn collect_object_keys<'a>(
-    obj: &'a ObjectExpression<'a>,
-    seen: &mut FxHashSet<String>,
+fn collect_returned_object_keys<'a>(
+    statements: &'a [Statement<'a>],
+    seen: &mut FxHashSet<Cow<'a, str>>,
     ctx: &LintContext<'a>,
 ) {
-    let getter_names: FxHashSet<String> = obj
-        .properties
-        .iter()
-        .filter_map(|p| {
-            let ObjectPropertyKind::ObjectProperty(prop) = p else { return None };
-            if prop.kind == PropertyKind::Get {
-                prop.key.static_name().map(std::borrow::Cow::into_owned)
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    let mut used_getters: FxHashSet<String> = FxHashSet::default();
-
-    for prop_kind in &obj.properties {
-        let ObjectPropertyKind::ObjectProperty(prop) = prop_kind else { continue };
-        let Some(name) = prop.key.static_name() else { continue };
-        let name_str = name.as_ref();
-
-        if prop.kind == PropertyKind::Set
-            && getter_names.contains(name_str)
-            && !used_getters.contains(name_str)
+    for stmt in statements {
+        if let Statement::ReturnStatement(ret) = stmt
+            && let Some(ret_expr) = &ret.argument
+            && let Expression::ObjectExpression(ret_obj) = ret_expr.without_parentheses()
         {
-            used_getters.insert(name_str.to_string());
-            continue;
+            collect_object_keys(ret_obj, seen, ctx);
         }
-
-        report_or_add(name_str, prop.key.span(), seen, ctx);
     }
 }
 
-fn report_or_add(name: &str, span: Span, seen: &mut FxHashSet<String>, ctx: &LintContext) {
-    if !seen.insert(name.to_string()) {
-        ctx.diagnostic(duplicate_key_diagnostic(span, name));
+fn collect_object_keys<'a>(
+    obj: &'a ObjectExpression<'a>,
+    seen: &mut FxHashSet<Cow<'a, str>>,
+    ctx: &LintContext<'a>,
+) {
+    let getter_names: FxHashSet<Cow<'a, str>> = obj
+        .properties
+        .iter()
+        .filter_map(|p| {
+            let prop = p.as_property()?;
+            if prop.kind == PropertyKind::Get { static_key_name(&prop.key) } else { None }
+        })
+        .collect();
+
+    let mut used_getters: FxHashSet<Cow<'a, str>> = FxHashSet::default();
+
+    for prop_kind in &obj.properties {
+        let ObjectPropertyKind::ObjectProperty(prop) = prop_kind else { continue };
+        let Some(name) = static_key_name(&prop.key) else { continue };
+        // upstream skips empty names (`if (name)`)
+        if name.is_empty() {
+            continue;
+        }
+
+        if prop.kind == PropertyKind::Set
+            && getter_names.contains(name.as_ref())
+            && !used_getters.contains(name.as_ref())
+        {
+            used_getters.insert(name);
+            continue;
+        }
+
+        report_or_add(name, prop.key.span(), seen, ctx);
+    }
+}
+
+fn report_or_add<'a>(
+    name: Cow<'a, str>,
+    span: Span,
+    seen: &mut FxHashSet<Cow<'a, str>>,
+    ctx: &LintContext<'a>,
+) {
+    if seen.contains(name.as_ref()) {
+        ctx.diagnostic(duplicate_key_diagnostic(span, &name));
+    } else {
+        seen.insert(name);
+    }
+}
+
+/// Mirrors upstream `getStringLiteralValue`: the prop-name string of a literal array element.
+/// Non-string literals are stringified like JS `String(value)`; `null` has no name.
+fn literal_element_name<'a>(expr: &Expression<'a>) -> Option<Cow<'a, str>> {
+    match expr {
+        Expression::StringLiteral(s) => Some(Cow::Borrowed(s.value.as_str())),
+        Expression::TemplateLiteral(t) => t.single_quasi().map(Into::into),
+        Expression::NumericLiteral(n) => Some(Cow::Owned(n.value.to_js_string())),
+        Expression::BooleanLiteral(b) => {
+            Some(Cow::Borrowed(if b.value { "true" } else { "false" }))
+        }
+        Expression::BigIntLiteral(b) => Some(Cow::Borrowed(b.value.as_str())),
+        Expression::RegExpLiteral(r) => Some(Cow::Owned(r.regex.to_string())),
+        _ => None,
+    }
+}
+
+/// `PropertyKey::static_name`, except numeric keys are formatted like JS `String(n)`
+/// (`1e-7` → "1e-7", not "0.0000001") to match upstream `getStaticPropertyName`.
+fn static_key_name<'a>(key: &PropertyKey<'a>) -> Option<Cow<'a, str>> {
+    match key {
+        PropertyKey::NumericLiteral(n) => Some(Cow::Owned(n.value.to_js_string())),
+        _ => key.static_name(),
     }
 }
 
 // ---- script setup helpers ----
 
-fn find_define_props_call<'a>(
-    ctx: &LintContext<'a>,
-) -> Option<&'a oxc_ast::ast::CallExpression<'a>> {
+fn find_define_props_call<'a>(ctx: &LintContext<'a>) -> Option<&'a CallExpression<'a>> {
     for node in ctx.nodes() {
         if let AstKind::CallExpression(call) = node.kind()
             && matches!(call.callee, Expression::Identifier(_))
@@ -284,22 +299,36 @@ fn find_define_props_call<'a>(
     None
 }
 
-/// Collect all `SymbolId`s bound by a defineProps assignment, including destructured bindings.
-/// Handles `const props = defineProps(...)`, `const { foo } = defineProps(...)`, etc.
-fn find_props_symbol_ids(call: &oxc_ast::ast::CallExpression, ctx: &LintContext) -> Vec<SymbolId> {
+/// Collect everything bound by `const ... = defineProps(...)` declarators in one pass:
+/// every bound `SymbolId` (for initializer reference checks) and the prop names renamed
+/// via `const { foo: bar } = defineProps(...)`.
+fn collect_props_bindings<'a>(
+    call: &CallExpression<'a>,
+    ctx: &LintContext<'a>,
+) -> (Vec<SymbolId>, FxHashSet<Cow<'a, str>>) {
     let mut ids = Vec::new();
+    let mut renamed = FxHashSet::default();
     for node in ctx.nodes() {
         let AstKind::VariableDeclarator(decl) = node.kind() else { continue };
         if !decl.init.as_ref().is_some_and(|init| is_define_props_initializer(init, call)) {
             continue;
         }
         collect_binding_symbol_ids(&decl.id, &mut ids);
+        if let BindingPattern::ObjectPattern(pat) = &decl.id {
+            for prop in &pat.properties {
+                if let Some(key_name) = static_key_name(&prop.key)
+                    && let BindingPattern::BindingIdentifier(val) = &prop.value
+                    && key_name.as_ref() != val.name.as_str()
+                {
+                    renamed.insert(key_name);
+                }
+            }
+        }
     }
-    ids
+    (ids, renamed)
 }
 
-fn collect_binding_symbol_ids(pattern: &oxc_ast::ast::BindingPattern, ids: &mut Vec<SymbolId>) {
-    use oxc_ast::ast::BindingPattern;
+fn collect_binding_symbol_ids(pattern: &BindingPattern, ids: &mut Vec<SymbolId>) {
     match pattern {
         BindingPattern::BindingIdentifier(id) => {
             if let Some(sym) = id.symbol_id.get() {
@@ -314,14 +343,8 @@ fn collect_binding_symbol_ids(pattern: &oxc_ast::ast::BindingPattern, ids: &mut 
                 collect_binding_symbol_ids(&rest.argument, ids);
             }
         }
-        BindingPattern::ArrayPattern(arr) => {
-            for el in arr.elements.iter().flatten() {
-                collect_binding_symbol_ids(el, ids);
-            }
-            if let Some(rest) = &arr.rest {
-                collect_binding_symbol_ids(&rest.argument, ids);
-            }
-        }
+        // upstream's extractReferences does not descend into array patterns
+        BindingPattern::ArrayPattern(_) => {}
         BindingPattern::AssignmentPattern(assign) => {
             collect_binding_symbol_ids(&assign.left, ids);
         }
@@ -347,35 +370,26 @@ fn is_inside_props_reference(
 }
 
 fn collect_prop_names_from_call<'a>(
-    call: &'a oxc_ast::ast::CallExpression<'a>,
+    call: &'a CallExpression<'a>,
     ctx: &LintContext<'a>,
-) -> Vec<String> {
-    let mut props: Vec<String> = Vec::new();
+) -> Vec<Cow<'a, str>> {
+    let mut props: Vec<Cow<'a, str>> = Vec::new();
     if let Some(arg) = call.arguments.first().and_then(|a| a.as_expression()) {
-        match arg {
+        match arg.without_parentheses() {
             Expression::ObjectExpression(obj) => {
                 for prop_kind in &obj.properties {
                     if let ObjectPropertyKind::ObjectProperty(p) = prop_kind
-                        && let Some(name) = p.key.static_name()
+                        && let Some(name) = static_key_name(&p.key)
                     {
-                        props.push(name.into_owned());
+                        props.push(name);
                     }
                 }
             }
             Expression::ArrayExpression(arr) => {
                 for el in &arr.elements {
-                    match el {
-                        ArrayExpressionElement::StringLiteral(s) => {
-                            props.push(s.value.to_string());
-                        }
-                        ArrayExpressionElement::TemplateLiteral(t) if t.expressions.is_empty() => {
-                            if let Some(cooked) =
-                                t.quasis.first().and_then(|q| q.value.cooked.as_ref())
-                            {
-                                props.push(cooked.to_string());
-                            }
-                        }
-                        _ => {}
+                    let Some(expr) = el.as_expression() else { continue };
+                    if let Some(name) = literal_element_name(expr.without_parentheses()) {
+                        props.push(name);
                     }
                 }
             }
@@ -388,9 +402,9 @@ fn collect_prop_names_from_call<'a>(
 }
 
 fn collect_ts_type_prop_names<'a>(
-    call: &'a oxc_ast::ast::CallExpression<'a>,
+    call: &'a CallExpression<'a>,
     ctx: &LintContext<'a>,
-    out: &mut Vec<String>,
+    out: &mut Vec<Cow<'a, str>>,
 ) {
     let Some(type_params) = &call.type_arguments else { return };
     let Some(first_type) = type_params.params.first() else { return };
@@ -400,42 +414,13 @@ fn collect_ts_type_prop_names<'a>(
             TSSignature::TSMethodSignature(s) => &s.key,
             _ => return,
         };
-        if let Some(name) = key.static_name() {
-            out.push(name.into_owned());
+        if let Some(name) = static_key_name(key) {
+            out.push(name);
         }
     });
 }
 
-/// Prop names that are renamed in `const { foo: bar } = defineProps(...)` — `foo` is renamed.
-/// withDefaults wrapping is also handled so `const { foo: bar } = withDefaults(defineProps<...>(), ...)` works.
-fn collect_renamed_props(
-    call: &oxc_ast::ast::CallExpression,
-    ctx: &LintContext,
-) -> FxHashSet<String> {
-    let mut renamed = FxHashSet::default();
-    for node in ctx.nodes() {
-        let AstKind::VariableDeclarator(decl) = node.kind() else { continue };
-        if !decl.init.as_ref().is_some_and(|init| is_define_props_initializer(init, call)) {
-            continue;
-        }
-        if let oxc_ast::ast::BindingPattern::ObjectPattern(pat) = &decl.id {
-            for prop in &pat.properties {
-                if let Some(key_name) = prop.key.static_name()
-                    && let oxc_ast::ast::BindingPattern::BindingIdentifier(val) = &prop.value
-                    && key_name.as_ref() != val.name.as_str()
-                {
-                    renamed.insert(key_name.into_owned());
-                }
-            }
-        }
-    }
-    renamed
-}
-
-fn is_define_props_initializer<'a>(
-    init: &'a Expression<'a>,
-    call: &'a oxc_ast::ast::CallExpression<'a>,
-) -> bool {
+fn is_define_props_initializer<'a>(init: &'a Expression<'a>, call: &'a CallExpression<'a>) -> bool {
     match init {
         Expression::CallExpression(c) => {
             std::ptr::eq(c.as_ref(), call)
@@ -1096,6 +1081,61 @@ const bar = computed(() => foo + 1)
             None,
             Some(PathBuf::from("test.vue")),
         ),
+        // empty template literal names are ignored (upstream `if (name)` guard)
+        (
+            r"
+<script>
+export default { props: [``, ``] }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // empty string keys are ignored (upstream `if (name)` guard)
+        (
+            r"
+<script>
+export default { data () { return { '': 1, '': 2 } } }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // TS as-expression group value is skipped — only parentheses are transparent
+        (
+            r#"
+<script lang="ts">
+export default { props: ['foo'], data: ({ foo: null } as any) }
+</script>
+"#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // TS as-expression return argument is skipped
+        (
+            r#"
+<script lang="ts">
+export default { props: ['foo'], data () { return { foo: 1 } as any } }
+</script>
+"#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // numeric keys compare using JS number formatting ('1e-7', not '0.0000001')
+        (
+            r"
+<script>
+export default { props: { '0.0000001': String }, data () { return { 1e-7: 1 } } }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
     ];
 
     let fail = vec![
@@ -1651,6 +1691,76 @@ export default { props: [`foo`], data() { return { foo: 1 } } }
 <script setup>
 defineProps([`foo`])
 const foo = 1
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // array-destructured defineProps binding does not exempt initializers
+        // (upstream extractReferences ignores array patterns)
+        (
+            r"
+<script setup>
+const [a] = defineProps(['foo', 'bar'])
+const foo = computed(() => a)
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // parenthesized defineProps argument
+        (
+            r"
+<script setup>
+defineProps((['foo']))
+const foo = 1
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // parenthesized array element in a group
+        (
+            r"
+<script>
+export default { props: [('foo')], data () { return { foo: 1 } } }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // parenthesized element in defineProps array
+        (
+            r"
+<script setup>
+defineProps([('foo')])
+const foo = 1
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // non-string literal array elements are stringified like JS String(value)
+        (
+            r"
+<script>
+export default { props: [1, true], data () { return { 1: 'x', true: 'y' } } }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // numeric keys use JS exponent formatting ('1e-7', not '0.0000001')
+        (
+            r"
+<script>
+export default { props: { 1e-7: String }, data () { return { '1e-7': 1 } } }
 </script>
 ",
             None,

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -1,0 +1,1543 @@
+use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use oxc_ast::{
+    AstKind,
+    ast::{
+        ArrayExpressionElement, Expression, ImportDeclarationSpecifier, ObjectExpression,
+        ObjectPropertyKind, PropertyKey, PropertyKind, Statement,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    frameworks::FrameworkOptions,
+    rule::Rule,
+    utils::{find_property, is_vue_component_options_object},
+};
+
+fn duplicate_key_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "Duplicate key '{name}'. May cause name collision in script or template tag."
+    ))
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct NoDupeKeysConfig {
+    groups: Vec<String>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct NoDupeKeys(NoDupeKeysConfig);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow duplication of field names.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Duplicate keys in Vue component options (props, data, computed, methods, setup)
+    /// can cause unexpected behavior because they may overwrite each other at runtime,
+    /// and they cause name collisions in the template.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   props: ['foo'],
+    ///   computed: {
+    ///     foo() {}
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   props: ['foo'],
+    ///   computed: {
+    ///     bar() {}
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    NoDupeKeys,
+    vue,
+    correctness,
+    version = "next",
+    config = NoDupeKeys,
+);
+
+impl Rule for NoDupeKeys {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let config: NoDupeKeysConfig = if value.is_null() {
+            NoDupeKeysConfig::default()
+        } else if let Some(arr) = value.as_array() {
+            if arr.is_empty() {
+                NoDupeKeysConfig::default()
+            } else {
+                serde_json::from_value(arr[0].clone())?
+            }
+        } else {
+            serde_json::from_value(value)?
+        };
+        Ok(Self(config))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ObjectExpression(obj) = node.kind() else { return };
+        if !is_vue_component_options_object(node, ctx) {
+            return;
+        }
+        let extra_groups = &self.0.groups;
+        let mut seen: Vec<(&str, Span)> = Vec::new();
+        for group in GROUP_NAMES.iter().copied().chain(extra_groups.iter().map(String::as_str)) {
+            let Some(group_prop) = find_property(obj, group) else { continue };
+            collect_group_keys(&group_prop.value, &mut seen, ctx);
+        }
+    }
+
+    fn run_once(&self, ctx: &LintContext) {
+        if ctx.frameworks_options() != FrameworkOptions::VueSetup {
+            return;
+        }
+        let Some(define_props_node) = find_define_props_call(ctx) else { return };
+        let props = collect_prop_names_from_call(define_props_node, ctx);
+        if props.is_empty() {
+            return;
+        }
+        let renamed = collect_renamed_props(define_props_node, ctx);
+
+        for node in ctx.nodes() {
+            if !is_script_setup_top_level(node.id(), ctx) {
+                continue;
+            }
+            match node.kind() {
+                AstKind::VariableDeclarator(decl) => {
+                    if decl
+                        .init
+                        .as_ref()
+                        .is_some_and(|init| is_define_props_initializer(init, define_props_node))
+                    {
+                        continue;
+                    }
+                    if decl
+                        .init
+                        .as_ref()
+                        .is_some_and(|init| is_props_access(init, define_props_node, ctx))
+                    {
+                        continue;
+                    }
+                    let Some(bound_name) = bound_name_of_declarator(decl) else { continue };
+                    check_prop_duplicate(bound_name, decl.id.span(), &props, &renamed, ctx);
+                }
+                AstKind::Function(func)
+                    if func.r#type == oxc_ast::ast::FunctionType::FunctionDeclaration =>
+                {
+                    let Some(id) = &func.id else { continue };
+                    check_prop_duplicate(id.name.as_str(), id.span, &props, &renamed, ctx);
+                }
+                AstKind::ImportDeclaration(import) => {
+                    let Some(specifiers) = &import.specifiers else { continue };
+                    for specifier in specifiers {
+                        let (name, span) = match specifier {
+                            ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => {
+                                (s.local.name.as_str(), s.local.span)
+                            }
+                            ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => {
+                                (s.local.name.as_str(), s.local.span)
+                            }
+                            ImportDeclarationSpecifier::ImportSpecifier(s) => {
+                                (s.local.name.as_str(), s.local.span)
+                            }
+                        };
+                        check_prop_duplicate(name, span, &props, &renamed, ctx);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+const GROUP_NAMES: &[&str] = &["props", "computed", "data", "methods", "setup"];
+
+fn collect_group_keys<'a>(
+    value: &'a Expression<'a>,
+    seen: &mut Vec<(&'a str, Span)>,
+    ctx: &LintContext<'a>,
+) {
+    match value {
+        Expression::ArrayExpression(arr) => {
+            for el in &arr.elements {
+                if let ArrayExpressionElement::StringLiteral(s) = el {
+                    report_or_add(s.value.as_str(), s.span, seen, ctx);
+                }
+            }
+        }
+        Expression::ObjectExpression(obj) => {
+            collect_object_keys(obj, seen, ctx);
+        }
+        Expression::FunctionExpression(func) => {
+            if let Some(body) = &func.body {
+                for stmt in &body.statements {
+                    if let Statement::ReturnStatement(ret) = stmt
+                        && let Some(Expression::ObjectExpression(ret_obj)) = &ret.argument
+                    {
+                        collect_object_keys(ret_obj, seen, ctx);
+                    }
+                }
+            }
+        }
+        Expression::ArrowFunctionExpression(arrow) => {
+            if arrow.expression {
+                if let Some(Statement::ExpressionStatement(es)) = arrow.body.statements.first()
+                    && let Expression::ObjectExpression(obj) = es.expression.get_inner_expression()
+                {
+                    collect_object_keys(obj, seen, ctx);
+                }
+            } else {
+                for stmt in &arrow.body.statements {
+                    if let Statement::ReturnStatement(ret) = stmt
+                        && let Some(Expression::ObjectExpression(ret_obj)) = &ret.argument
+                    {
+                        collect_object_keys(ret_obj, seen, ctx);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_object_keys<'a>(
+    obj: &'a ObjectExpression<'a>,
+    seen: &mut Vec<(&'a str, Span)>,
+    ctx: &LintContext<'a>,
+) {
+    let getter_names: Vec<&str> = obj
+        .properties
+        .iter()
+        .filter_map(|p| {
+            let ObjectPropertyKind::ObjectProperty(prop) = p else { return None };
+            if prop.kind == PropertyKind::Get { static_key_name(&prop.key) } else { None }
+        })
+        .collect();
+
+    let mut used_getters: Vec<&str> = Vec::new();
+
+    for prop_kind in &obj.properties {
+        let ObjectPropertyKind::ObjectProperty(prop) = prop_kind else { continue };
+        let Some(name) = static_key_name(&prop.key) else { continue };
+
+        if prop.kind == PropertyKind::Set
+            && let Some(&getter) = getter_names.iter().find(|&&g| g == name)
+            && !used_getters.contains(&getter)
+        {
+            used_getters.push(getter);
+            continue;
+        }
+
+        report_or_add(name, prop.key.span(), seen, ctx);
+    }
+}
+
+fn report_or_add<'a>(
+    name: &'a str,
+    span: Span,
+    seen: &mut Vec<(&'a str, Span)>,
+    ctx: &LintContext,
+) {
+    if seen.iter().any(|(n, _)| *n == name) {
+        ctx.diagnostic(duplicate_key_diagnostic(span, name));
+    } else {
+        seen.push((name, span));
+    }
+}
+
+fn static_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(s) => Some(s.value.as_str()),
+        _ => None,
+    }
+}
+
+// ---- script setup helpers ----
+
+/// True when the node is at the top level of a `<script setup>` block
+/// (i.e., not nested inside a function body).
+fn is_script_setup_top_level(node_id: oxc_semantic::NodeId, ctx: &LintContext) -> bool {
+    for ancestor in ctx.nodes().ancestors(node_id).skip(1) {
+        match ancestor.kind() {
+            AstKind::Program(_) => return true,
+            AstKind::FunctionBody(_) => return false,
+            _ => {}
+        }
+    }
+    true
+}
+
+fn check_prop_duplicate(
+    name: &str,
+    span: Span,
+    props: &[(String, Span)],
+    renamed: &FxHashSet<String>,
+    ctx: &LintContext,
+) {
+    if renamed.contains(name) {
+        return;
+    }
+    if props.iter().any(|(p, _)| p.as_str() == name) {
+        ctx.diagnostic(duplicate_key_diagnostic(span, name));
+    }
+}
+
+fn find_define_props_call<'a>(
+    ctx: &LintContext<'a>,
+) -> Option<&'a oxc_ast::ast::CallExpression<'a>> {
+    for node in ctx.nodes() {
+        if let AstKind::CallExpression(call) = node.kind()
+            && call.callee_name() == Some("defineProps")
+        {
+            return Some(call);
+        }
+    }
+    None
+}
+
+/// Collects (prop_name, span) pairs from a `defineProps(...)` call.
+/// Returns owned Strings to avoid lifetime issues with `static_name()` → `Cow`.
+fn collect_prop_names_from_call(
+    call: &oxc_ast::ast::CallExpression,
+    ctx: &LintContext,
+) -> Vec<(String, Span)> {
+    let mut props: Vec<(String, Span)> = Vec::new();
+    if let Some(arg) = call.arguments.first().and_then(|a| a.as_expression()) {
+        match arg {
+            Expression::ObjectExpression(obj) => {
+                for prop_kind in &obj.properties {
+                    if let ObjectPropertyKind::ObjectProperty(p) = prop_kind
+                        && let Some(name) = static_key_name(&p.key)
+                    {
+                        props.push((name.to_string(), p.key.span()));
+                    }
+                }
+            }
+            Expression::ArrayExpression(arr) => {
+                for el in &arr.elements {
+                    if let ArrayExpressionElement::StringLiteral(s) = el {
+                        props.push((s.value.to_string(), s.span));
+                    }
+                }
+            }
+            _ => {}
+        }
+    } else {
+        collect_ts_type_prop_names(call, ctx, &mut props);
+    }
+    props
+}
+
+fn collect_ts_type_prop_names(
+    call: &oxc_ast::ast::CallExpression,
+    ctx: &LintContext,
+    out: &mut Vec<(String, Span)>,
+) {
+    let Some(type_params) = &call.type_arguments else { return };
+    let Some(first_type) = type_params.params.first() else { return };
+    collect_ts_type_keys(first_type, ctx, out);
+}
+
+fn collect_ts_type_keys(
+    ts_type: &oxc_ast::ast::TSType,
+    ctx: &LintContext,
+    out: &mut Vec<(String, Span)>,
+) {
+    use oxc_ast::ast::{TSSignature, TSType, TSTypeName};
+    match ts_type {
+        TSType::TSTypeLiteral(lit) => {
+            for member in &lit.members {
+                let key = match member {
+                    TSSignature::TSPropertySignature(s) => &s.key,
+                    TSSignature::TSMethodSignature(s) => &s.key,
+                    _ => continue,
+                };
+                if let Some(name) = key.static_name() {
+                    out.push((name.into_owned(), key.span()));
+                }
+            }
+        }
+        TSType::TSTypeReference(r) => {
+            let TSTypeName::IdentifierReference(id) = &r.type_name else { return };
+            let Some(reference_id) = id.reference_id.get() else { return };
+            let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id() else {
+                return;
+            };
+            let decl_node = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
+            match decl_node.kind() {
+                AstKind::TSInterfaceDeclaration(iface) => {
+                    for member in &iface.body.body {
+                        let key = match member {
+                            TSSignature::TSPropertySignature(s) => &s.key,
+                            TSSignature::TSMethodSignature(s) => &s.key,
+                            _ => continue,
+                        };
+                        if let Some(name) = key.static_name() {
+                            out.push((name.into_owned(), key.span()));
+                        }
+                    }
+                }
+                AstKind::TSTypeAliasDeclaration(alias) => {
+                    collect_ts_type_keys(&alias.type_annotation, ctx, out);
+                }
+                _ => {}
+            }
+        }
+        TSType::TSIntersectionType(t) => {
+            for ty in &t.types {
+                collect_ts_type_keys(ty, ctx, out);
+            }
+        }
+        TSType::TSUnionType(t) => {
+            for ty in &t.types {
+                collect_ts_type_keys(ty, ctx, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Prop names that are renamed in `const { foo: bar } = defineProps(...)` — `foo` is renamed.
+fn collect_renamed_props(
+    call: &oxc_ast::ast::CallExpression,
+    ctx: &LintContext,
+) -> FxHashSet<String> {
+    let mut renamed = FxHashSet::default();
+    for node in ctx.nodes() {
+        let AstKind::VariableDeclarator(decl) = node.kind() else { continue };
+        if !decl.init.as_ref().is_some_and(|init| is_exact_define_props(init, call)) {
+            continue;
+        }
+        if let oxc_ast::ast::BindingPattern::ObjectPattern(pat) = &decl.id {
+            for prop in &pat.properties {
+                if let Some(key_name) = prop.key.static_name()
+                    && let oxc_ast::ast::BindingPattern::BindingIdentifier(val) = &prop.value
+                    && key_name.as_ref() != val.name.as_str()
+                {
+                    renamed.insert(key_name.into_owned());
+                }
+            }
+        }
+    }
+    renamed
+}
+
+fn bound_name_of_declarator<'a>(decl: &'a oxc_ast::ast::VariableDeclarator<'a>) -> Option<&'a str> {
+    if let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &decl.id {
+        Some(id.name.as_str())
+    } else {
+        None
+    }
+}
+
+fn is_define_props_initializer<'a>(
+    init: &'a Expression<'a>,
+    call: &'a oxc_ast::ast::CallExpression<'a>,
+) -> bool {
+    match init {
+        Expression::CallExpression(c) => {
+            std::ptr::eq(c.as_ref(), call)
+                || (c.callee_name() == Some("withDefaults")
+                    && c.arguments
+                        .first()
+                        .and_then(|a| a.as_expression())
+                        .is_some_and(|a| is_define_props_initializer(a, call)))
+        }
+        _ => false,
+    }
+}
+
+fn is_exact_define_props<'a>(
+    init: &'a Expression<'a>,
+    call: &'a oxc_ast::ast::CallExpression<'a>,
+) -> bool {
+    matches!(init, Expression::CallExpression(c) if std::ptr::eq(c.as_ref(), call))
+}
+
+fn is_props_access<'a>(
+    init: &'a Expression<'a>,
+    define_props_call: &'a oxc_ast::ast::CallExpression<'a>,
+    ctx: &LintContext<'a>,
+) -> bool {
+    let props_var_name = find_props_variable_name(define_props_call, ctx);
+    match init {
+        Expression::StaticMemberExpression(m) => {
+            is_props_identifier(&m.object, props_var_name.as_deref())
+        }
+        Expression::ComputedMemberExpression(m) => {
+            is_props_identifier(&m.object, props_var_name.as_deref())
+        }
+        Expression::CallExpression(c) => {
+            matches!(c.callee_name(), Some("toRefs" | "toRef"))
+                && c.arguments
+                    .first()
+                    .and_then(|a| a.as_expression())
+                    .is_some_and(|a| is_props_identifier(a, props_var_name.as_deref()))
+        }
+        _ => false,
+    }
+}
+
+fn find_props_variable_name(
+    call: &oxc_ast::ast::CallExpression,
+    ctx: &LintContext,
+) -> Option<String> {
+    for node in ctx.nodes() {
+        let AstKind::VariableDeclarator(decl) = node.kind() else { continue };
+        if !decl.init.as_ref().is_some_and(|i| is_define_props_initializer(i, call)) {
+            continue;
+        }
+        if let Some(name) = bound_name_of_declarator(decl) {
+            return Some(name.to_string());
+        }
+    }
+    None
+}
+
+fn is_props_identifier(expr: &Expression, props_name: Option<&str>) -> bool {
+    let Some(name) = props_name else { return false };
+    matches!(expr, Expression::Identifier(id) if id.name.as_str() == name)
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            r"
+<script>
+        export default {
+          props: ['foo'],
+          computed: {
+            bar () {
+            }
+          },
+          data () {
+            return {
+              dat: null
+            }
+          },
+          data () {
+            return
+          },
+          methods: {
+            _foo () {},
+            test () {
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          props: ['foo'],
+          data () {
+            return {
+              dat: null
+            }
+          },
+          data () {
+            return
+          },
+          methods: {
+            _foo () {},
+            test () {
+            }
+          },
+          setup () {
+            const _foo = () => {}
+            const dat = ref(null)
+            const bar = computed(() => 'bar')
+
+            return {
+              bar
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          props: ['foo'],
+          computed: {
+            bar () {
+            }
+          },
+          data: () => {
+            return {
+              dat: null
+            }
+          },
+          data: () => {
+            return
+          },
+          methods: {
+            _foo () {},
+            test () {
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          props: ['foo'],
+          computed: {
+            bar () {
+            }
+          },
+          data: () => ({
+            dat: null
+          }),
+          data: () => {
+            return
+          },
+          methods: {
+            _foo () {},
+            test () {
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          ...foo(),
+          props: {
+            ...foo(),
+            foo: String
+          },
+          computed: {
+            ...mapGetters({
+              test: 'getTest'
+            }),
+            bar: {
+              get () {
+              }
+            }
+          },
+          data: {
+            ...foo(),
+            dat: null
+          },
+          methods: {
+            ...foo(),
+            test () {
+            }
+          },
+          data () {
+            return {
+              ...dat
+            }
+          },
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          ...foo(),
+          props: {
+            ...foo(),
+            foo: String
+          },
+          computed: {
+            ...mapGetters({
+              test: 'getTest'
+            }),
+            bar: {
+              get () {
+              }
+            }
+          },
+          data: {
+            ...foo(),
+            dat: null
+          },
+          methods: {
+            ...foo(),
+            test () {
+            }
+          },
+          data () {
+            return {
+              ...dat
+            }
+          },
+          setup () {
+            const com = computed(() => 1)
+
+            return {
+              ...foo(),
+              com
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          ...foo(),
+          props: {
+            ...foo(),
+            foo: String
+          },
+          computed: {
+            ...mapGetters({
+              test: 'getTest'
+            }),
+            bar: {
+              get () {
+              }
+            }
+          },
+          data: {
+            ...foo(),
+            dat: null
+          },
+          methods: {
+            ...foo(),
+            test () {
+            }
+          },
+          data: () => {
+            return {
+              ...dat
+            }
+          },
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          ...foo(),
+          props: {
+            ...foo(),
+            foo: String
+          },
+          computed: {
+            ...mapGetters({
+              test: 'getTest'
+            }),
+            bar: {
+              get () {
+              }
+            }
+          },
+          data: {
+            ...foo(),
+            dat: null
+          },
+          methods: {
+            ...foo(),
+            test () {
+            }
+          },
+          data: () => ({
+            ...dat
+          }),
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+        // @vue/component
+        export const compA = {
+          props: {
+            propA: String
+          }
+        }
+
+        // @vue/component
+        export const compB = {
+          props: {
+            propA: String
+          }
+        }
+      ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ),
+        (
+            r"
+<script>
+        // @vue/component
+        export const compA = {
+          props: {
+            propA: String
+          },
+          setup (props) {
+            const com = computed(() => props.propA)
+
+            return {
+              com
+            }
+          }
+        }
+
+        // @vue/component
+        export const compB = {
+          props: {
+            propA: String
+          },
+          setup (props) {
+            const com = computed(() => props.propA)
+
+            return {
+              com
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+      export default {
+        data () {
+          return {
+            get foo() {
+              return foo
+            },
+            set foo(v) {
+              foo = v
+            }
+          }
+        }
+      }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+      export default {
+        data () {
+          return {
+            set foo(v) {
+              foo = v
+            },
+            get foo() {
+              return foo
+            }
+          }
+        }
+      }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+      export default {
+        data () {
+          return {
+            get foo() {
+              return foo
+            },
+            bar,
+            set foo(v) {
+              foo = v
+            }
+          }
+        }
+      }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          asyncData() {
+            return {
+              foo: 1
+            }
+          },
+          data() {
+            return {
+              foo: 2
+            }
+          },
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+  defineProps({
+    foo: String,
+  })
+  const bar = 0
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+<script setup lang="ts">
+  defineProps<{
+    foo: string;
+  }>();
+
+  const bar = 0
+</script>
+"#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+const props = defineProps(['foo', 'bar'])
+const { foo, bar } = props
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+const props = defineProps(['foo', 'bar'])
+const foo = props.foo
+const bar = props.bar
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+import {toRefs} from 'vue'
+const props = defineProps(['foo', 'bar'])
+const { foo, bar } = toRefs(props)
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+import {toRef} from 'vue'
+const props = defineProps(['foo', 'bar'])
+const foo = toRef(props, 'foo')
+const bar = toRef(props, 'bar')
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+const {foo,bar} = defineProps(['foo', 'bar'])
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+const {foo=42,bar='abc'} = defineProps(['foo', 'bar'])
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    foo?: string | number
+  }>(),
+  {
+    foo: "Foo",
+  }
+);
+const foo = props.foo
+</script>
+"#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+const { foo: renamedFoo, bar: renamedBar } = defineProps(['foo', 'bar'])
+const foo = 42
+const bar = 'hello'
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // External import types (import { Props } from './x') require cross-file TS type
+        // resolution which is not supported; skipping this case.
+    ];
+
+    let fail = vec![
+        (
+            r"
+<script>
+        export default {
+          props: ['foo'],
+          computed: {
+            foo () {
+            }
+          },
+          data () {
+            return {
+              foo: null
+            }
+          },
+          methods: {
+            foo () {
+            }
+          },
+          setup () {
+            const foo = ref(1)
+
+            return {
+              foo
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          props: ['foo'],
+          computed: {
+            foo () {
+            }
+          },
+          data: () => {
+            return {
+              foo: null
+            }
+          },
+          methods: {
+            foo () {
+            }
+          },
+          setup: () => {
+            const foo = computed(() => 0)
+
+            return {
+              foo
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          props: ['foo'],
+          computed: {
+            foo () {
+            }
+          },
+          data: () => ({
+            foo: null
+          }),
+          methods: {
+            foo () {
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          props: {
+            foo: String
+          },
+          computed: {
+            foo: {
+              get () {
+              }
+            }
+          },
+          data: {
+            foo: null
+          },
+          methods: {
+            foo () {
+            }
+          },
+          setup (props) {
+            const foo = computed(() => props.foo)
+
+            return {
+              foo
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+        new Vue({
+          foo: {
+            bar: String
+          },
+          data: {
+            bar: null
+          },
+        })
+      ",
+            Some(serde_json::json!([{ "groups": ["foo"] }])),
+            None,
+            Some(PathBuf::from("test.js")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          methods: {
+            foo () {
+              return 0
+            }
+          },
+          setup () {
+            const foo = () => 0
+
+            return {
+              foo
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          methods: {
+            foo () {
+              return 0
+            }
+          },
+          setup () {
+            return {
+              foo: () => 0
+            }
+          }
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          methods: {
+            foo () {
+              return 0
+            }
+          },
+          setup: () => ({
+            foo: () => 0
+          })
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          computed: {
+            foo () {
+              return 0
+            }
+          },
+          setup: () => ({
+            foo: computed(() => 0)
+          })
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          data() {
+            return {
+              foo: 0
+            }
+          },
+          setup: () => ({
+            foo: ref(0)
+          })
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+        export default {
+          data() {
+            return {
+              foo: 0
+            }
+          },
+          setup: () => ({
+            foo: 0
+          })
+        }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+        defineComponent({
+          foo: {
+            bar: String
+          },
+          data: {
+            bar: null
+          },
+        })
+      ",
+            Some(serde_json::json!([{ "groups": ["foo"] }])),
+            None,
+            Some(PathBuf::from("test.js")),
+        ),
+        (
+            r"
+        export default defineComponent({
+          foo: {
+            bar: String
+          },
+          data: {
+            bar: null
+          },
+        })
+      ",
+            Some(serde_json::json!([{ "groups": ["foo"] }])),
+            None,
+            Some(PathBuf::from("test.js")),
+        ),
+        (
+            r"
+<script>
+      export default {
+        props: ['foo'],
+        data () {
+          return {
+            get foo() {
+              return foo
+            },
+            set foo(v) {
+              foo = v
+            }
+          }
+        }
+      }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+      export default {
+        props: ['foo'],
+        data () {
+          return {
+            set foo(v) {},
+            get foo() {}
+          }
+        }
+      }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+      export default {
+        props: ['foo'],
+        data () {
+          return {
+            set foo(v) {}
+          }
+        }
+      }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+      export default {
+        data () {
+          return {
+            get foo() {},
+            set foo(v) {},
+            get foo() {},
+          }
+        }
+      }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script>
+      export default {
+        data () {
+          return {
+            get foo() {},
+            set foo(v) {},
+            set foo(v) {},
+          }
+        }
+      }
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+  defineProps({
+    foo: String,
+  })
+  const foo = 0
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+  import { Foo } from './Foo.vue';
+  import baz from './baz';
+
+  defineProps({
+    foo: String,
+    bar: String,
+    baz: String,
+  });
+
+  function foo() {
+    const baz = 'baz';
+  }
+  const bar = () => 'bar';
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r#"
+<script setup lang="ts">
+defineProps<{
+  foo: string;
+  bar: string;
+}>();
+
+const foo = 'foo';
+const bar = 'bar';
+</script>
+"#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+const props = defineProps(['foo', 'bar'])
+const { foo } = props
+const bar = 42
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        (
+            r"
+<script setup>
+const { foo: renamedFoo } = defineProps(['foo', 'bar'])
+const foo = 'foo'
+const bar = 'bar'
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // External import type case (import { Props1 as Props } from './test01') requires
+        // cross-file TS type resolution which is not supported; skipping this case.
+    ];
+
+    Tester::new(NoDupeKeys::NAME, NoDupeKeys::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -90,7 +90,21 @@ impl Rule for NoDupeKeys {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::ObjectExpression(obj) = node.kind() else { return };
+        match node.kind() {
+            AstKind::ObjectExpression(obj) => self.check_component_options(node, obj, ctx),
+            AstKind::CallExpression(call) => check_define_props(node, call, ctx),
+            _ => {}
+        }
+    }
+}
+
+impl NoDupeKeys {
+    fn check_component_options<'a>(
+        &self,
+        node: &AstNode<'a>,
+        obj: &'a ObjectExpression<'a>,
+        ctx: &LintContext<'a>,
+    ) {
         if !is_vue_component_options_object(node, ctx) {
             return;
         }
@@ -109,48 +123,51 @@ impl Rule for NoDupeKeys {
             collect_group_keys(&prop.value, &mut seen, ctx);
         }
     }
+}
 
-    fn run_once(&self, ctx: &LintContext) {
-        if ctx.frameworks_options() != FrameworkOptions::VueSetup {
-            return;
-        }
-        let Some(define_props_call) = find_define_props_call(ctx) else { return };
-        let props = collect_prop_names_from_call(define_props_call, ctx);
-        if props.is_empty() {
-            return;
-        }
-        let (props_symbol_ids, renamed) = collect_props_bindings(define_props_call, ctx);
-        let root_scope_id = ctx.scoping().root_scope_id();
+fn check_define_props<'a>(node: &AstNode<'a>, call: &'a CallExpression<'a>, ctx: &LintContext<'a>) {
+    if ctx.frameworks_options() != FrameworkOptions::VueSetup {
+        return;
+    }
+    if !matches!(call.callee, Expression::Identifier(_))
+        || call.callee_name() != Some("defineProps")
+    {
+        return;
+    }
+    let props = collect_prop_names_from_call(call, ctx);
+    if props.is_empty() {
+        return;
+    }
+    let (props_symbol_ids, renamed) = collect_props_bindings(node, call, ctx);
+    let root_scope_id = ctx.scoping().root_scope_id();
 
-        for prop_name in &props {
-            if renamed.contains(prop_name.as_ref()) {
-                continue;
-            }
-            // Only look in the module (root) scope — nested function/block bindings are invisible
-            let Some(symbol_id) =
-                ctx.scoping().get_binding(root_scope_id, prop_name.as_ref().into())
-            else {
-                continue;
-            };
-            let decl = ctx.semantic().symbol_declaration(symbol_id);
-            let span = match decl.kind() {
-                AstKind::VariableDeclarator(d) => {
-                    if d.init.as_ref().is_some_and(|init| {
-                        // The defineProps call itself counts as a props reference upstream,
-                        // so any initializer containing it (e.g. `reactive(defineProps(...))`)
-                        // is exempt, as is one referencing the props object or any
-                        // destructured binding.
-                        init.span().contains_inclusive(define_props_call.span)
-                            || is_inside_props_reference(init, &props_symbol_ids, ctx)
-                    }) {
-                        continue;
-                    }
-                    d.id.span()
+    for prop_name in &props {
+        if renamed.contains(prop_name.as_ref()) {
+            continue;
+        }
+        // Only look in the module (root) scope — nested function/block bindings are invisible
+        let Some(symbol_id) = ctx.scoping().get_binding(root_scope_id, prop_name.as_ref().into())
+        else {
+            continue;
+        };
+        let decl = ctx.semantic().symbol_declaration(symbol_id);
+        let span = match decl.kind() {
+            AstKind::VariableDeclarator(d) => {
+                if d.init.as_ref().is_some_and(|init| {
+                    // The defineProps call itself counts as a props reference upstream,
+                    // so any initializer containing it (e.g. `reactive(defineProps(...))`)
+                    // is exempt, as is one referencing the props object or any
+                    // destructured binding.
+                    init.span().contains_inclusive(call.span)
+                        || is_inside_props_reference(init, &props_symbol_ids, ctx)
+                }) {
+                    continue;
                 }
-                _ => decl.kind().span(),
-            };
-            ctx.diagnostic(duplicate_key_diagnostic(span, prop_name.as_ref()));
-        }
+                d.id.span()
+            }
+            _ => decl.kind().span(),
+        };
+        ctx.diagnostic(duplicate_key_diagnostic(span, prop_name.as_ref()));
     }
 }
 
@@ -289,41 +306,32 @@ fn static_key_name<'a>(key: &PropertyKey<'a>) -> Option<Cow<'a, str>> {
 
 // ---- script setup helpers ----
 
-fn find_define_props_call<'a>(ctx: &LintContext<'a>) -> Option<&'a CallExpression<'a>> {
-    for node in ctx.nodes() {
-        if let AstKind::CallExpression(call) = node.kind()
-            && matches!(call.callee, Expression::Identifier(_))
-            && call.callee_name() == Some("defineProps")
-        {
-            return Some(call);
-        }
-    }
-    None
-}
-
-/// Collect everything bound by `const ... = defineProps(...)` declarators in one pass:
-/// every bound `SymbolId` (for initializer reference checks) and the prop names renamed
-/// via `const { foo: bar } = defineProps(...)`.
+/// Resolve the declarator binding the defineProps result (directly or via `withDefaults`),
+/// mirroring upstream `getPropsPattern`, and collect every bound `SymbolId` (for
+/// initializer reference checks) plus the prop names renamed via
+/// `const { foo: bar } = defineProps(...)`.
 fn collect_props_bindings<'a>(
+    node: &AstNode<'a>,
     call: &CallExpression<'a>,
     ctx: &LintContext<'a>,
 ) -> (Vec<SymbolId>, FxHashSet<Cow<'a, str>>) {
     let mut ids = Vec::new();
     let mut renamed = FxHashSet::default();
-    for node in ctx.nodes() {
-        let AstKind::VariableDeclarator(decl) = node.kind() else { continue };
-        if !decl.init.as_ref().is_some_and(|init| is_define_props_initializer(init, call)) {
-            continue;
-        }
-        collect_binding_symbol_ids(&decl.id, &mut ids);
-        if let BindingPattern::ObjectPattern(pat) = &decl.id {
-            for prop in &pat.properties {
-                if let Some(key_name) = static_key_name(&prop.key)
-                    && let BindingPattern::BindingIdentifier(val) = &prop.value
-                    && key_name.as_ref() != val.name.as_str()
-                {
-                    renamed.insert(key_name);
-                }
+    let declarator = ctx.nodes().ancestors(node.id()).find_map(|ancestor| {
+        if let AstKind::VariableDeclarator(decl) = ancestor.kind() { Some(decl) } else { None }
+    });
+    let Some(decl) = declarator else { return (ids, renamed) };
+    if !decl.init.as_ref().is_some_and(|init| is_define_props_initializer(init, call)) {
+        return (ids, renamed);
+    }
+    collect_binding_symbol_ids(&decl.id, &mut ids);
+    if let BindingPattern::ObjectPattern(pat) = &decl.id {
+        for prop in &pat.properties {
+            if let Some(key_name) = static_key_name(&prop.key)
+                && let BindingPattern::BindingIdentifier(val) = &prop.value
+                && key_name.as_ref() != val.name.as_str()
+            {
+                renamed.insert(key_name);
             }
         }
     }

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -336,11 +336,11 @@ fn collect_props_bindings<'a>(
     collect_binding_symbol_ids(&decl.id, &mut ids);
     if let BindingPattern::ObjectPattern(pat) = &decl.id {
         for prop in &pat.properties {
-            if let Some(key_name) = static_key_name(&prop.key)
+            if let PropertyKey::StaticIdentifier(key) = &prop.key
                 && let BindingPattern::BindingIdentifier(val) = &prop.value
-                && key_name.as_ref() != val.name.as_str()
+                && key.name != val.name
             {
-                renamed.insert(key_name);
+                renamed.insert(Cow::Borrowed(key.name.as_str()));
             }
         }
     }
@@ -1629,6 +1629,18 @@ const bar = 42
 const { foo: renamedFoo } = defineProps(['foo', 'bar'])
 const foo = 'foo'
 const bar = 'bar'
+</script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ),
+        // Literal destructuring keys are not treated as renamed props upstream.
+        (
+            r"
+<script setup>
+const { 'foo': renamedFoo } = defineProps(['foo'])
+const foo = 'foo'
 </script>
 ",
             None,

--- a/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
+++ b/crates/oxc_linter/src/rules/vue/no_dupe_keys.rs
@@ -6,7 +6,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         ArrayExpressionElement, Expression, ImportDeclarationSpecifier, ObjectExpression,
-        ObjectPropertyKind, PropertyKey, PropertyKind, Statement,
+        ObjectPropertyKind, PropertyKey, PropertyKind, Statement, TSSignature,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -18,7 +18,7 @@ use crate::{
     context::LintContext,
     frameworks::FrameworkOptions,
     rule::Rule,
-    utils::{find_property, is_vue_component_options_object},
+    utils::{find_property, for_each_define_props_type_signature, is_vue_component_options_object},
 };
 
 fn duplicate_key_diagnostic(span: Span, name: &str) -> OxcDiagnostic {
@@ -320,9 +320,9 @@ fn find_define_props_call<'a>(
 
 /// Collects (prop_name, span) pairs from a `defineProps(...)` call.
 /// Returns owned Strings to avoid lifetime issues with `static_name()` → `Cow`.
-fn collect_prop_names_from_call(
-    call: &oxc_ast::ast::CallExpression,
-    ctx: &LintContext,
+fn collect_prop_names_from_call<'a>(
+    call: &'a oxc_ast::ast::CallExpression<'a>,
+    ctx: &LintContext<'a>,
 ) -> Vec<(String, Span)> {
     let mut props: Vec<(String, Span)> = Vec::new();
     if let Some(arg) = call.arguments.first().and_then(|a| a.as_expression()) {
@@ -351,73 +351,23 @@ fn collect_prop_names_from_call(
     props
 }
 
-fn collect_ts_type_prop_names(
-    call: &oxc_ast::ast::CallExpression,
-    ctx: &LintContext,
+fn collect_ts_type_prop_names<'a>(
+    call: &'a oxc_ast::ast::CallExpression<'a>,
+    ctx: &LintContext<'a>,
     out: &mut Vec<(String, Span)>,
 ) {
     let Some(type_params) = &call.type_arguments else { return };
     let Some(first_type) = type_params.params.first() else { return };
-    collect_ts_type_keys(first_type, ctx, out);
-}
-
-fn collect_ts_type_keys(
-    ts_type: &oxc_ast::ast::TSType,
-    ctx: &LintContext,
-    out: &mut Vec<(String, Span)>,
-) {
-    use oxc_ast::ast::{TSSignature, TSType, TSTypeName};
-    match ts_type {
-        TSType::TSTypeLiteral(lit) => {
-            for member in &lit.members {
-                let key = match member {
-                    TSSignature::TSPropertySignature(s) => &s.key,
-                    TSSignature::TSMethodSignature(s) => &s.key,
-                    _ => continue,
-                };
-                if let Some(name) = key.static_name() {
-                    out.push((name.into_owned(), key.span()));
-                }
-            }
+    for_each_define_props_type_signature(first_type, ctx, &mut |sig| {
+        let key = match sig {
+            TSSignature::TSPropertySignature(s) => &s.key,
+            TSSignature::TSMethodSignature(s) => &s.key,
+            _ => return,
+        };
+        if let Some(name) = key.static_name() {
+            out.push((name.into_owned(), key.span()));
         }
-        TSType::TSTypeReference(r) => {
-            let TSTypeName::IdentifierReference(id) = &r.type_name else { return };
-            let Some(reference_id) = id.reference_id.get() else { return };
-            let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id() else {
-                return;
-            };
-            let decl_node = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
-            match decl_node.kind() {
-                AstKind::TSInterfaceDeclaration(iface) => {
-                    for member in &iface.body.body {
-                        let key = match member {
-                            TSSignature::TSPropertySignature(s) => &s.key,
-                            TSSignature::TSMethodSignature(s) => &s.key,
-                            _ => continue,
-                        };
-                        if let Some(name) = key.static_name() {
-                            out.push((name.into_owned(), key.span()));
-                        }
-                    }
-                }
-                AstKind::TSTypeAliasDeclaration(alias) => {
-                    collect_ts_type_keys(&alias.type_annotation, ctx, out);
-                }
-                _ => {}
-            }
-        }
-        TSType::TSIntersectionType(t) => {
-            for ty in &t.types {
-                collect_ts_type_keys(ty, ctx, out);
-            }
-        }
-        TSType::TSUnionType(t) => {
-            for ty in &t.types {
-                collect_ts_type_keys(ty, ctx, out);
-            }
-        }
-        _ => {}
-    }
+    });
 }
 
 /// Prop names that are renamed in `const { foo: bar } = defineProps(...)` — `foo` is renamed.

--- a/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
@@ -195,6 +195,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:7:15]
+ 6 │             return {
+ 7 │               foo: null
+   ·               ───
+ 8 │             }
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
    ╭─[no_dupe_keys.tsx:7:17]
  6 │           return {
  7 │             get foo() {

--- a/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
@@ -338,3 +338,27 @@ source: crates/oxc_linter/src/tester.rs
    ·                      ─
  6 │ }
    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:3:43]
+ 2 │ <script>
+ 3 │ export default { props: ['foo'], data: ({ foo: null }) }
+   ·                                           ───
+ 4 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:3:52]
+ 2 │ <script>
+ 3 │ export default { props: [`foo`], data() { return { foo: 1 } } }
+   ·                                                    ───
+ 4 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:7]
+ 3 │ defineProps([`foo`])
+ 4 │ const foo = 1
+   ·       ───
+ 5 │ </script>
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
@@ -1,0 +1,299 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:6:13]
+ 5 │           computed: {
+ 6 │             foo () {
+   ·             ───
+ 7 │             }
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:11:15]
+ 10 │             return {
+ 11 │               foo: null
+    ·               ───
+ 12 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:15:13]
+ 14 │           methods: {
+ 15 │             foo () {
+    ·             ───
+ 16 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:22:15]
+ 21 │             return {
+ 22 │               foo
+    ·               ───
+ 23 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:6:13]
+ 5 │           computed: {
+ 6 │             foo () {
+   ·             ───
+ 7 │             }
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:11:15]
+ 10 │             return {
+ 11 │               foo: null
+    ·               ───
+ 12 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:15:13]
+ 14 │           methods: {
+ 15 │             foo () {
+    ·             ───
+ 16 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:22:15]
+ 21 │             return {
+ 22 │               foo
+    ·               ───
+ 23 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:6:13]
+ 5 │           computed: {
+ 6 │             foo () {
+   ·             ───
+ 7 │             }
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:10:13]
+  9 │           data: () => ({
+ 10 │             foo: null
+    ·             ───
+ 11 │           }),
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:13:13]
+ 12 │           methods: {
+ 13 │             foo () {
+    ·             ───
+ 14 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:8:13]
+ 7 │           computed: {
+ 8 │             foo: {
+   ·             ───
+ 9 │               get () {
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:14:13]
+ 13 │           data: {
+ 14 │             foo: null
+    ·             ───
+ 15 │           },
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:17:13]
+ 16 │           methods: {
+ 17 │             foo () {
+    ·             ───
+ 18 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:24:15]
+ 23 │             return {
+ 24 │               foo
+    ·               ───
+ 25 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:13]
+ 3 │           foo: {
+ 4 │             bar: String
+   ·             ───
+ 5 │           },
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:13:15]
+ 12 │             return {
+ 13 │               foo
+    ·               ───
+ 14 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:11:15]
+ 10 │             return {
+ 11 │               foo: () => 0
+    ·               ───
+ 12 │             }
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:10:13]
+  9 │           setup: () => ({
+ 10 │             foo: () => 0
+    ·             ───
+ 11 │           })
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:10:13]
+  9 │           setup: () => ({
+ 10 │             foo: computed(() => 0)
+    ·             ───
+ 11 │           })
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:10:13]
+  9 │           setup: () => ({
+ 10 │             foo: ref(0)
+    ·             ───
+ 11 │           })
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:10:13]
+  9 │           setup: () => ({
+ 10 │             foo: 0
+    ·             ───
+ 11 │           })
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:13]
+ 3 │           foo: {
+ 4 │             bar: String
+   ·             ───
+ 5 │           },
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:13]
+ 3 │           foo: {
+ 4 │             bar: String
+   ·             ───
+ 5 │           },
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:7:17]
+ 6 │           return {
+ 7 │             get foo() {
+   ·                 ───
+ 8 │               return foo
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:8:17]
+ 7 │             set foo(v) {},
+ 8 │             get foo() {}
+   ·                 ───
+ 9 │           }
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:7:17]
+ 6 │           return {
+ 7 │             set foo(v) {}
+   ·                 ───
+ 8 │           }
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:8:17]
+ 7 │             set foo(v) {},
+ 8 │             get foo() {},
+   ·                 ───
+ 9 │           }
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:8:17]
+ 7 │             set foo(v) {},
+ 8 │             set foo(v) {},
+   ·                 ───
+ 9 │           }
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:6:9]
+ 5 │   })
+ 6 │   const foo = 0
+   ·         ───
+ 7 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'baz'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:10]
+ 3 │   import { Foo } from './Foo.vue';
+ 4 │   import baz from './baz';
+   ·          ───
+ 5 │ 
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:12:12]
+ 11 │ 
+ 12 │   function foo() {
+    ·            ───
+ 13 │     const baz = 'baz';
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:15:9]
+ 14 │   }
+ 15 │   const bar = () => 'bar';
+    ·         ───
+ 16 │ </script>
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:8:7]
+ 7 │ 
+ 8 │ const foo = 'foo';
+   ·       ───
+ 9 │ const bar = 'bar';
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
+    ╭─[no_dupe_keys.tsx:9:7]
+  8 │ const foo = 'foo';
+  9 │ const bar = 'bar';
+    ·       ───
+ 10 │ </script>
+    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:5:7]
+ 4 │ const { foo } = props
+ 5 │ const bar = 42
+   ·       ───
+ 6 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:5:7]
+ 4 │ const foo = 'foo'
+ 5 │ const bar = 'bar'
+   ·       ───
+ 6 │ </script>
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
@@ -362,3 +362,59 @@ source: crates/oxc_linter/src/tester.rs
    ·       ───
  5 │ </script>
    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:7]
+ 3 │ const [a] = defineProps(['foo', 'bar'])
+ 4 │ const foo = computed(() => a)
+   ·       ───
+ 5 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:7]
+ 3 │ defineProps((['foo']))
+ 4 │ const foo = 1
+   ·       ───
+ 5 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:3:55]
+ 2 │ <script>
+ 3 │ export default { props: [('foo')], data () { return { foo: 1 } } }
+   ·                                                       ───
+ 4 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:7]
+ 3 │ defineProps([('foo')])
+ 4 │ const foo = 1
+   ·       ───
+ 5 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key '1'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:3:55]
+ 2 │ <script>
+ 3 │ export default { props: [1, true], data () { return { 1: 'x', true: 'y' } } }
+   ·                                                       ─
+ 4 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'true'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:3:63]
+ 2 │ <script>
+ 3 │ export default { props: [1, true], data () { return { 1: 'x', true: 'y' } } }
+   ·                                                               ────
+ 4 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key '1e-7'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:3:62]
+ 2 │ <script>
+ 3 │ export default { props: { 1e-7: String }, data () { return { '1e-7': 1 } } }
+   ·                                                              ──────
+ 4 │ </script>
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
@@ -123,11 +123,11 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
-   ╭─[no_dupe_keys.tsx:4:13]
- 3 │           foo: {
- 4 │             bar: String
+   ╭─[no_dupe_keys.tsx:7:13]
+ 6 │           data: {
+ 7 │             bar: null
    ·             ───
- 5 │           },
+ 8 │           },
    ╰────
 
   ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
@@ -179,19 +179,19 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
-   ╭─[no_dupe_keys.tsx:4:13]
- 3 │           foo: {
- 4 │             bar: String
+   ╭─[no_dupe_keys.tsx:7:13]
+ 6 │           data: {
+ 7 │             bar: null
    ·             ───
- 5 │           },
+ 8 │           },
    ╰────
 
   ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
-   ╭─[no_dupe_keys.tsx:4:13]
- 3 │           foo: {
- 4 │             bar: String
+   ╭─[no_dupe_keys.tsx:7:13]
+ 6 │           data: {
+ 7 │             bar: null
    ·             ───
- 5 │           },
+ 8 │           },
    ╰────
 
   ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
@@ -242,20 +242,13 @@ source: crates/oxc_linter/src/tester.rs
  7 │ </script>
    ╰────
 
-  ⚠ vue(no-dupe-keys): Duplicate key 'baz'. May cause name collision in script or template tag.
-   ╭─[no_dupe_keys.tsx:4:10]
- 3 │   import { Foo } from './Foo.vue';
- 4 │   import baz from './baz';
-   ·          ───
- 5 │ 
-   ╰────
-
   ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
-    ╭─[no_dupe_keys.tsx:12:12]
- 11 │ 
- 12 │   function foo() {
-    ·            ───
- 13 │     const baz = 'baz';
+    ╭─[no_dupe_keys.tsx:12:3]
+ 11 │     
+ 12 │ ╭─▶   function foo() {
+ 13 │ │       const baz = 'baz';
+ 14 │ ╰─▶   }
+ 15 │       const bar = () => 'bar';
     ╰────
 
   ⚠ vue(no-dupe-keys): Duplicate key 'bar'. May cause name collision in script or template tag.
@@ -265,6 +258,14 @@ source: crates/oxc_linter/src/tester.rs
     ·         ───
  16 │ </script>
     ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'baz'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:10]
+ 3 │   import { Foo } from './Foo.vue';
+ 4 │   import baz from './baz';
+   ·          ───
+ 5 │ 
+   ╰────
 
   ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
    ╭─[no_dupe_keys.tsx:8:7]
@@ -296,4 +297,44 @@ source: crates/oxc_linter/src/tester.rs
  5 │ const bar = 'bar'
    ·       ───
  6 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'Foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:1]
+ 3 │ defineProps({ Foo: String })
+ 4 │ class Foo {}
+   · ────────────
+ 5 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:7]
+ 3 │ defineProps({ foo: String })
+ 4 │ const { foo } = useSomething()
+   ·       ───────
+ 5 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:6:22]
+ 5 │   data () { return {} },
+ 6 │   data () { return { foo: 1 } }
+   ·                      ───
+ 7 │ }
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:5:23]
+ 4 │   props: ['foo'],
+ 5 │   data () { return ({ foo: null }) }
+   ·                       ───
+ 6 │ }
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key '1'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:5:22]
+ 4 │   props: { 1: String },
+ 5 │   data () { return { 1: 'x' } }
+   ·                      ─
+ 6 │ }
    ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
@@ -418,3 +418,19 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                              ──────
  4 │ </script>
    ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'null'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:3:46]
+ 2 │ <script>
+ 3 │ export default { data () { return { null: 1, null: 2 } } }
+   ·                                              ────
+ 4 │ </script>
+   ╰────
+
+  ⚠ vue(no-dupe-keys): Duplicate key 'true'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:3:64]
+ 2 │ <script>
+ 3 │ export default { props: { [true]: String }, data () { return { 'true': 1 } } }
+   ·                                                                ──────
+ 4 │ </script>
+   ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_dupe_keys.snap
@@ -299,6 +299,14 @@ source: crates/oxc_linter/src/tester.rs
  6 │ </script>
    ╰────
 
+  ⚠ vue(no-dupe-keys): Duplicate key 'foo'. May cause name collision in script or template tag.
+   ╭─[no_dupe_keys.tsx:4:7]
+ 3 │ const { 'foo': renamedFoo } = defineProps(['foo'])
+ 4 │ const foo = 'foo'
+   ·       ───
+ 5 │ </script>
+   ╰────
+
   ⚠ vue(no-dupe-keys): Duplicate key 'Foo'. May cause name collision in script or template tag.
    ╭─[no_dupe_keys.tsx:4:1]
  3 │ defineProps({ Foo: String })

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9741,6 +9741,26 @@
         "vue/no-deprecated-vue-config-keycodes": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "vue/no-dupe-keys": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/NoDupeKeys"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "vue/no-export-in-script-setup": {
           "$ref": "#/definitions/RuleNoConfig"
         },
@@ -12860,6 +12880,24 @@
             "$ref": "#/definitions/DistractingElement"
           },
           "markdownDescription": "List of distracting elements to check for."
+        }
+      },
+      "additionalProperties": false
+    },
+    "NoDupeKeys": {
+      "$ref": "#/definitions/NoDupeKeysConfig"
+    },
+    "NoDupeKeysConfig": {
+      "type": "object",
+      "properties": {
+        "groups": {
+          "description": "Additional group names to search for duplicate keys in, on top of the\nbuilt-in `props`, `computed`, `data`, `methods` and `setup` groups.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "Additional group names to search for duplicate keys in, on top of the\nbuilt-in `props`, `computed`, `data`, `methods` and `setup` groups."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Implements `vue/no-dupe-keys`. Part of #11440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)