### PR TITLE
perf(semantic,mangler,minifier): fix `Semantic::stats` node count and reuse stats in mangler builds

### DIFF
--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -232,7 +232,8 @@ pub trait CompilerInterface {
 
         /* Mangler */
 
-        let mangler = self.mangle_options().map(|options| self.mangle(&mut program, options));
+        let mangler =
+            self.mangle_options().map(|options| self.mangle(&mut program, options, stats));
 
         /* Codegen */
 
@@ -304,8 +305,15 @@ pub trait CompilerInterface {
         Compressor::new(allocator).build_with_scoping(program, scoping, options);
     }
 
-    fn mangle(&self, program: &mut Program<'_>, options: MangleOptions) -> ManglerReturn {
-        Mangler::new().with_options(options).build(program)
+    /// `stats` from a prior semantic build size the mangler's internal semantic
+    /// rebuild, avoiding a full-AST counting pass.
+    fn mangle(
+        &self,
+        program: &mut Program<'_>,
+        options: MangleOptions,
+        stats: Stats,
+    ) -> ManglerReturn {
+        Mangler::new().with_options(options).with_stats(stats).build(program)
     }
 
     fn codegen<'a>(

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -10,7 +10,7 @@ use base54::base54;
 use oxc_allocator::{Allocator, BitSet, HashSet, Vec};
 use oxc_ast::ast::{Declaration, Program, Statement};
 use oxc_data_structures::inline_string::InlineString;
-use oxc_semantic::{AstNodes, Reference, Scoping, Semantic, SemanticBuilder, SymbolId};
+use oxc_semantic::{AstNodes, Reference, Scoping, Semantic, SemanticBuilder, Stats, SymbolId};
 use oxc_span::SourceType;
 use oxc_str::{CompactStr, Ident, Str};
 
@@ -199,6 +199,9 @@ pub struct ManglerReturn {
 /// - slot 3: `bar`
 pub struct Mangler<'t> {
     options: MangleOptions,
+    /// Statistics from a prior semantic build of the same program, used to
+    /// pre-allocate the semantic data [`Mangler::build`] constructs.
+    stats: Option<Stats>,
     /// An allocator meant to be used for temporary allocations during mangling.
     /// It can be cleared after mangling is done, to free up memory for subsequent
     /// files or other operations.
@@ -209,6 +212,7 @@ impl Default for Mangler<'_> {
     fn default() -> Self {
         Self {
             options: MangleOptions::default(),
+            stats: None,
             temp_allocator: TempAllocator::Owned(Allocator::default()),
         }
     }
@@ -267,6 +271,7 @@ impl<'t> Mangler<'t> {
     pub fn new_with_temp_allocator(temp_allocator: &'t Allocator) -> Self {
         Self {
             options: MangleOptions::default(),
+            stats: None,
             temp_allocator: TempAllocator::Borrowed(temp_allocator),
         }
     }
@@ -277,15 +282,25 @@ impl<'t> Mangler<'t> {
         self
     }
 
+    /// Provide statistics from a prior semantic analysis of the same program
+    /// (see [`Semantic::stats`]) to pre-allocate the semantic data [`Mangler::build`]
+    /// constructs, avoiding the full-AST counting pass `SemanticBuilder` otherwise
+    /// performs.
+    #[must_use]
+    pub fn with_stats(mut self, stats: Stats) -> Self {
+        self.stats = Some(stats);
+        self
+    }
+
     /// Mangles the program. The resulting SymbolTable contains the mangled symbols - `program` is not modified.
     /// Pass the symbol table to oxc_codegen to generate the mangled code.
     #[must_use]
     pub fn build(self, program: &Program<'_>) -> ManglerReturn {
-        let mut semantic = SemanticBuilder::new()
-            .with_build_nodes(true)
-            .with_class_table(true)
-            .build(program)
-            .semantic;
+        let mut builder = SemanticBuilder::new().with_build_nodes(true).with_class_table(true);
+        if let Some(stats) = self.stats {
+            builder = builder.with_stats(stats);
+        }
+        let mut semantic = builder.build(program).semantic;
         let class_private_mappings = self.build_with_semantic(&mut semantic, program);
         ManglerReturn { scoping: semantic.into_scoping(), class_private_mappings }
     }

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -135,19 +135,19 @@ impl<'a> Minifier {
                 } else {
                     compressor.build_with_scoping(program, scoping, options)
                 };
-                (stats, iterations)
+                (Some(stats), iterations)
             })
             .unwrap_or_default();
         let (scoping, class_private_mappings) = self
             .options
             .mangle
             .map(|options| {
-                let mut semantic = SemanticBuilder::new()
-                    .with_build_nodes(true)
-                    .with_stats(stats)
-                    .with_class_table(true)
-                    .build(program)
-                    .semantic;
+                let mut builder =
+                    SemanticBuilder::new().with_build_nodes(true).with_class_table(true);
+                if let Some(stats) = stats {
+                    builder = builder.with_stats(stats);
+                }
+                let mut semantic = builder.build(program).semantic;
                 let class_private_mappings = Mangler::default()
                     .with_options(options)
                     .build_with_semantic(&mut semantic, program);

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -374,12 +374,14 @@ impl<'a> SemanticBuilder<'a> {
         #[cfg(debug_assertions)]
         self.unused_labels.assert_empty();
 
+        let node_count = self.node_store.node_count();
         let semantic = Semantic {
             source_text: self.source_text,
             source_type: self.source_type,
             comments: &program.comments,
             irregular_whitespaces: [].into(),
             nodes: self.node_store.into_nodes(),
+            node_count,
             scoping: self.scoping,
             classes: self.class_table_builder.build(),
             #[cfg(feature = "jsdoc")]

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -78,6 +78,12 @@ pub struct Semantic<'a> {
     /// The Abstract Syntax Tree (AST) nodes.
     nodes: AstNodes<'a>,
 
+    /// Number of AST nodes in the program.
+    ///
+    /// Tracked separately from `nodes`, which is empty unless the builder ran
+    /// with [`SemanticBuilder::with_build_nodes`] enabled.
+    node_count: u32,
+
     scoping: Scoping,
 
     classes: ClassTable<'a>,
@@ -220,7 +226,7 @@ impl<'a> Semantic<'a> {
     pub fn stats(&self) -> Stats {
         #[expect(clippy::cast_possible_truncation)]
         Stats::new(
-            self.nodes.len() as u32,
+            self.node_count,
             self.scoping.scopes_len() as u32,
             self.scoping.symbols_len() as u32,
             self.scoping.references.len() as u32,

--- a/crates/oxc_semantic/src/node/store.rs
+++ b/crates/oxc_semantic/src/node/store.rs
@@ -61,8 +61,6 @@ impl<'a> AstNodeStore<'a> {
     }
 
     /// Number of nodes allocated so far. Source of truth, valid in both modes.
-    /// Only used by the debug-only stats accuracy check.
-    #[cfg(debug_assertions)]
     #[inline]
     pub fn node_count(&self) -> u32 {
         self.node_count

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||            162 |             52 ||         152742 |          28244
+checker.ts                 | 2.92 MB        ||            162 |              5 ||         152742 |          28244
 
-App.tsx                    | 415.34 kB      ||            115 |             49 ||          17012 |           2702
+App.tsx                    | 415.34 kB      ||            115 |              8 ||          17012 |           2702
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             24 |             20 ||             32 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             24 |              0 ||             32 |              6
 
-pdf.mjs                    | 567.30 kB      ||           2613 |            249 ||          47485 |           7740
+pdf.mjs                    | 567.30 kB      ||           2613 |            205 ||          47485 |           7740
 
-antd.js                    | 6.69 MB        ||           3084 |            106 ||         337233 |          69333
+antd.js                    | 6.69 MB        ||           3084 |             56 ||         337233 |          69333
 
-binder.ts                  | 193.08 kB      ||             41 |             36 ||           7083 |            824
+binder.ts                  | 193.08 kB      ||             41 |              1 ||           7083 |            824
 
-kitchen-sink.tsx           | 732.90 kB      ||           2640 |            218 ||          90554 |          15823
+kitchen-sink.tsx           | 732.90 kB      ||           2640 |            174 ||          90554 |          15823
 


### PR DESCRIPTION
## What

Fix three allocation problems in the semantic rebuilds performed by the minify/mangle paths, found while auditing the compiler pipeline's scoping rebuilds.

## Details

- **`Semantic::stats` reported `nodes: 0` after node-less builds.** It read `self.nodes.len()`, which is empty when the builder runs in ancestry mode (`with_build_nodes(false)` — the compiler pipeline default). `Semantic` now tracks `node_count` (from `AstNodeStore::node_count`, the source of truth in both modes) and `stats()` returns it. The mangler build inside `Minifier::build` previously received `nodes: 0` and grew the `AstNodes` store from zero capacity by repeated doubling; it now pre-allocates correctly.
- **`Minifier::build` with `compress: None` fed the mangler `Stats::default()`.** All-zero stats are worse than no stats: they skip the `Stats::count` fallback *and* reserve zero capacity for every table. Stats are now threaded as `Option<Stats>` and only passed when the compress phase produced them; the mangle-only path falls back to the counting pass and sizes correctly.
- **`Mangler::build` always re-counted the AST.** Added `Mangler::with_stats`, and `CompilerInterface::mangle` now receives the stats from the initial semantic build, so the mangler's internal semantic rebuild skips its full-AST counting traversal.

Output is unchanged — stats only affect pre-allocation.

## Note

`CompilerInterface::mangle` gains a `stats: Stats` parameter — a breaking change for external implementors that override it (same shape as the `compress` change in #23153).

🤖 Generated with [Claude Code](https://claude.com/claude-code)