### PR TITLE
refactor(parser): emit all TS1274 checks from parser

### DIFF
--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -34,7 +34,8 @@ fn cases() {
     test_same("type T = (A | B) & C;\n");
     test_same("declare interface A {}\n");
     test_same("interface I<in out T,> {}\n");
-    test_same("function F<const in out T,>() {}\n");
+    test_same("function F<const T,>() {}\n");
+    test_same("class C<const in out T,> {}\n");
     test_same("class C {\n\tp = await(0);\n}\n");
     test_same(
         "class Foo {\n\t#name: string;\n\tf() {\n\t\t#name in other && this.#name === other.#name;\n\t}\n}\n",

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -89,7 +89,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.check_reserved_type_name(id, "Class");
         }
 
-        let type_parameters = if self.is_ts { self.parse_ts_type_parameters() } else { None };
+        let type_parameters =
+            if self.is_ts { self.parse_ts_type_parameters_with_variance() } else { None };
         let (extends, implements) = self.parse_heritage_clause();
         let mut super_class = None;
         let mut super_type_parameters = None;

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -131,7 +131,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let id = self.parse_binding_identifier();
         self.check_reserved_type_name(&id, "Type alias");
-        let params = self.parse_ts_type_parameters();
+        let params = self.parse_ts_type_parameters_with_variance();
         // A `const` modifier is only valid on a type parameter of a function, method, or class
         // (TS1277), so reject it on a type alias, e.g. `type T<const U> = ...`.
         if let Some(type_params) = &params {
@@ -216,7 +216,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> Declaration<'a> {
         let id = self.parse_binding_identifier();
         self.check_reserved_type_name(&id, "Interface");
-        let type_parameters = self.parse_ts_type_parameters();
+        let type_parameters = self.parse_ts_type_parameters_with_variance();
         if let Some(type_parameters) = &type_parameters {
             for param in &type_parameters.params {
                 if param.r#const {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -151,7 +151,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_ts_type_parameters(
         &mut self,
     ) -> Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        self.parse_ts_type_parameters_impl().0
+        self.parse_ts_type_parameters_impl(false).0
+    }
+
+    pub(crate) fn parse_ts_type_parameters_with_variance(
+        &mut self,
+    ) -> Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        self.parse_ts_type_parameters_impl(true).0
     }
 
     /// Parse TypeScript type parameters and return whether there was a trailing comma.
@@ -159,11 +165,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_ts_type_parameters_with_trailing_comma(
         &mut self,
     ) -> (Option<Box<'a, TSTypeParameterDeclaration<'a>>>, bool) {
-        self.parse_ts_type_parameters_impl()
+        self.parse_ts_type_parameters_impl(false)
     }
 
     fn parse_ts_type_parameters_impl(
         &mut self,
+        allow_variance: bool,
     ) -> (Option<Box<'a, TSTypeParameterDeclaration<'a>>>, bool) {
         if !self.is_ts {
             return (None, false);
@@ -174,12 +181,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LAngle);
-        let (params, trailing_comma) = self.parse_delimited_list(
-            Kind::RAngle,
-            Kind::Comma,
-            opening_span,
-            Self::parse_ts_type_parameter,
-        );
+        let (params, trailing_comma) =
+            self.parse_delimited_list(Kind::RAngle, Kind::Comma, opening_span, |p| {
+                p.parse_ts_type_parameter(allow_variance)
+            });
         self.expect(Kind::RAngle);
         let span = self.end_span(span);
         if params.is_empty() {
@@ -198,15 +203,28 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         implements
     }
 
-    pub(crate) fn parse_ts_type_parameter(&mut self) -> TSTypeParameter<'a> {
+    fn parse_ts_type_parameter(&mut self, allow_variance: bool) -> TSTypeParameter<'a> {
         let span = self.start_span();
 
         let modifiers = self.parse_modifiers(true, false);
+        let allowed_modifiers = if allow_variance {
+            ModifierKinds::new([ModifierKind::In, ModifierKind::Out, ModifierKind::Const])
+        } else {
+            ModifierKinds::new([ModifierKind::Const])
+        };
         self.verify_modifiers(
             &modifiers,
-            ModifierKinds::new([ModifierKind::In, ModifierKind::Out, ModifierKind::Const]),
-            false, // `in` and `out` are only allowed on a type parameter of a class, interface or type alias
-            diagnostics::cannot_appear_on_a_type_parameter,
+            allowed_modifiers,
+            false,
+            |modifier, allowed| match modifier.kind {
+                ModifierKind::In | ModifierKind::Out => {
+                    diagnostics::can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
+                        modifier.kind,
+                        modifier.span(),
+                    )
+                }
+                _ => diagnostics::cannot_appear_on_a_type_parameter(modifier, allowed),
+            },
         );
 
         let name = self.parse_binding_identifier();

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -105,7 +105,6 @@ pub fn check<'a>(kind: AstKind<'a>, ctx: &SemanticBuilder<'a>) {
         }
         AstKind::TSTypeAnnotation(annot) => ts::check_ts_type_annotation(annot, ctx),
         AstKind::TSTypePredicate(predicate) => ts::check_ts_type_predicate(predicate, ctx),
-        AstKind::TSTypeParameter(param) => ts::check_ts_type_parameter(param, ctx),
         AstKind::TSModuleDeclaration(decl) => ts::check_ts_module_declaration(decl, ctx),
         AstKind::TSGlobalDeclaration(decl) => ts::check_ts_global_declaration(decl, ctx),
         AstKind::TSEnumDeclaration(decl) => ts::check_ts_enum_declaration(decl, ctx),

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -10,30 +10,6 @@ use oxc_str::Str;
 
 use crate::{builder::SemanticBuilder, diagnostics};
 
-pub fn check_ts_type_parameter<'a>(param: &TSTypeParameter<'a>, ctx: &SemanticBuilder<'a>) {
-    if param.r#in || param.out {
-        let is_allowed_node = matches!(
-            // skip parent TSTypeParameterDeclaration (grandparent is index 1)
-            ctx.ancestry().ancestor_kinds().nth(1).unwrap(),
-            AstKind::TSInterfaceDeclaration(_)
-                | AstKind::Class(_)
-                | AstKind::TSTypeAliasDeclaration(_)
-        );
-        if !is_allowed_node {
-            if param.r#in {
-                ctx.error(diagnostics::can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
-                    "in", param.span,
-                ));
-            }
-            if param.out {
-                ctx.error(diagnostics::can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
-                    "out", param.span,
-                ));
-            }
-        }
-    }
-}
-
 pub fn check_ts_type_annotation(annotation: &TSTypeAnnotation<'_>, ctx: &SemanticBuilder<'_>) {
     let (modifier, is_start, span_with_illegal_modifier) = match &annotation.type_annotation {
         TSType::JSDocNonNullableType(ty) => ('!', !ty.postfix, ty.span()),

--- a/crates/oxc_semantic/src/diagnostics.rs
+++ b/crates/oxc_semantic/src/diagnostics.rs
@@ -288,15 +288,6 @@ pub fn await_or_yield_in_parameter(x0: &str, span1: Span) -> OxcDiagnostic {
 
 // TypeScript diagnostics
 
-#[cold]
-pub fn can_only_appear_on_a_type_parameter_of_a_class_interface_or_type_alias(
-    modifier: &str,
-    span: Span,
-) -> OxcDiagnostic {
-    ts_error("1274", format!("'{modifier}' modifier can only appear on a type parameter of a class, interface or type alias."))
-        .with_label(span)
-}
-
 /// '?' at the end of a type is not valid TypeScript syntax. Did you mean to write 'number | null | undefined'?(17019)
 #[cold]
 pub fn jsdoc_type_in_annotation(

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -15127,6 +15127,22 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
   help: Remove the duplicate modifier.
 
   × TS(1274): 'in' modifier can only appear on a type parameter of a class, interface or type alias.
+     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations/input.ts:100:21]
+  99 │ 
+ 100 │ declare function f1<in T>(x: T): void;  // Error
+     ·                     ──
+ 101 │ declare function f2<out T>(): T;  // Error
+     ╰────
+
+  × TS(1274): 'out' modifier can only appear on a type parameter of a class, interface or type alias.
+     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations/input.ts:101:21]
+ 100 │ declare function f1<in T>(x: T): void;  // Error
+ 101 │ declare function f2<out T>(): T;  // Error
+     ·                     ───
+ 102 │ 
+     ╰────
+
+  × TS(1274): 'in' modifier can only appear on a type parameter of a class, interface or type alias.
      ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations/input.ts:104:5]
  103 │ class C {
  104 │     in a = 0;  // Error
@@ -15140,22 +15156,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  105 │     out b = 0;  // Error
      ·     ───
  106 │ }
-     ╰────
-
-  × TS(1274): 'in' modifier can only appear on a type parameter of a class, interface or type alias.
-     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations/input.ts:100:21]
-  99 │ 
- 100 │ declare function f1<in T>(x: T): void;  // Error
-     ·                     ────
- 101 │ declare function f2<out T>(): T;  // Error
-     ╰────
-
-  × TS(1274): 'out' modifier can only appear on a type parameter of a class, interface or type alias.
-     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations/input.ts:101:21]
- 100 │ declare function f1<in T>(x: T): void;  // Error
- 101 │ declare function f2<out T>(): T;  // Error
-     ·                     ─────
- 102 │ 
      ╰────
 
   × Unexpected token. Did you mean `{'>'}` or `&gt;`?

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -30731,6 +30731,22 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
   help: Remove the duplicate modifier.
 
   × TS(1274): 'in' modifier can only appear on a type parameter of a class, interface or type alias.
+     ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts:100:21]
+  99 │ 
+ 100 │ declare function f1<in T>(x: T): void;  // Error
+     ·                     ──
+ 101 │ declare function f2<out T>(): T;  // Error
+     ╰────
+
+  × TS(1274): 'out' modifier can only appear on a type parameter of a class, interface or type alias.
+     ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts:101:21]
+ 100 │ declare function f1<in T>(x: T): void;  // Error
+ 101 │ declare function f2<out T>(): T;  // Error
+     ·                     ───
+ 102 │ 
+     ╰────
+
+  × TS(1274): 'in' modifier can only appear on a type parameter of a class, interface or type alias.
      ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts:104:5]
  103 │ class C {
  104 │     in a = 0;  // Error
@@ -30744,22 +30760,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  105 │     out b = 0;  // Error
      ·     ───
  106 │ }
-     ╰────
-
-  × TS(1274): 'in' modifier can only appear on a type parameter of a class, interface or type alias.
-     ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts:100:21]
-  99 │ 
- 100 │ declare function f1<in T>(x: T): void;  // Error
-     ·                     ────
- 101 │ declare function f2<out T>(): T;  // Error
-     ╰────
-
-  × TS(1274): 'out' modifier can only appear on a type parameter of a class, interface or type alias.
-     ╭─[typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/varianceAnnotations.ts:101:21]
- 100 │ declare function f1<in T>(x: T): void;  // Error
- 101 │ declare function f2<out T>(): T;  // Error
-     ·                     ─────
- 102 │ 
      ╰────
 
   × Identifier expected. 'in' is a reserved word that cannot be used here.


### PR DESCRIPTION
Move TS1274 variance modifier validation into the parser and remove the duplicate semantic diagnostic path.