### PR TITLE
feat(parser): add friendly error for adjacent JSX elements

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -859,6 +859,13 @@ pub fn jsx_fragment_no_match(opening_span: Span, closing_span: Span) -> OxcDiagn
 }
 
 #[cold]
+pub fn adjacent_jsx_elements(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("Adjacent JSX elements must be wrapped in an enclosing tag.")
+        .with_help("Did you want a JSX fragment `<>...</>`?")
+        .with_label(span)
+}
+
+#[cold]
 pub fn cover_initialized_name(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Invalid assignment in object literal")
 .with_help("Did you mean to use a ':'? An '=' can only follow a property name when the containing object literal is part of a destructuring pattern.")

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -26,13 +26,22 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         self.bump_any(); // bump `<`
         let kind = self.cur_kind();
-        if kind == Kind::RAngle {
+        let expr = if kind == Kind::RAngle {
             Expression::JSXFragment(self.parse_jsx_fragment(span, false))
         } else if kind.is_identifier_or_keyword() {
             Expression::JSXElement(self.parse_jsx_element(span, false))
         } else {
-            self.unexpected()
+            return self.unexpected();
+        };
+
+        // A top-level JSX element/fragment immediately followed by `<` is a second,
+        // adjacent JSX element that isn't wrapped in an enclosing tag, e.g.
+        // `<div></div><span></span>`.
+        if self.at(Kind::LAngle) && self.fatal_error.is_none() {
+            self.set_fatal_error(diagnostics::adjacent_jsx_elements(self.cur_token().span()));
         }
+
+        expr
     }
 
     /// `JSXFragment` :

--- a/tasks/coverage/misc/fail/jsx-adjacent-elements.jsx
+++ b/tasks/coverage/misc/fail/jsx-adjacent-elements.jsx
@@ -1,0 +1,4 @@
+const element = (
+  <div />
+  <span />
+);

--- a/tasks/coverage/misc/fail/jsx-element-followed-by-less-than.jsx
+++ b/tasks/coverage/misc/fail/jsx-element-followed-by-less-than.jsx
@@ -1,0 +1,6 @@
+// `<div />` is a complete JSX element, so the `<` that follows begins a second,
+// adjacent JSX element. The JSX grammar technically allows a `JSXElement` as the
+// left-hand side of a relational expression, so `<div /> < 5` could be read as
+// `(<div />) < 5`. But Babel and TypeScript both reject any `<` directly after a
+// JSX element as unwrapped adjacent JSX, and oxc follows them for consistency.
+const a = <div /> < 5;

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 69/69 (100.00%)
 Positive Passed: 69/69 (100.00%)
-Negative Passed: 147/147 (100.00%)
+Negative Passed: 149/149 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -360,6 +360,23 @@ Negative Passed: 147/147 (100.00%)
  1 │ type T<X> = X extends infer string ? string : never;
    ·                             ──────
    ╰────
+
+  × Adjacent JSX elements must be wrapped in an enclosing tag.
+   ╭─[misc/fail/jsx-adjacent-elements.jsx:3:3]
+ 2 │   <div />
+ 3 │   <span />
+   ·   ─
+ 4 │ );
+   ╰────
+  help: Did you want a JSX fragment `<>...</>`?
+
+  × Adjacent JSX elements must be wrapped in an enclosing tag.
+   ╭─[misc/fail/jsx-element-followed-by-less-than.jsx:6:19]
+ 5 │ // JSX element as unwrapped adjacent JSX, and oxc follows them for consistency.
+ 6 │ const a = <div /> < 5;
+   ·                   ─
+   ╰────
+  help: Did you want a JSX fragment `<>...</>`?
 
   × Unexpected JSX expression
    ╭─[misc/fail/jsx-in-js.js:1:20]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -24024,19 +24024,21 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  5 │ }
    ╰────
 
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/jsx/tsxErrorRecovery2.tsx:4:7]
+  × Adjacent JSX elements must be wrapped in an enclosing tag.
+   ╭─[typescript/tests/cases/conformance/jsx/tsxErrorRecovery2.tsx:4:1]
  3 │ <div></div>
  4 │ <div></div>
-   ·       ─
+   · ─
    ╰────
+  help: Did you want a JSX fragment `<>...</>`?
 
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/jsx/tsxErrorRecovery3.tsx:4:7]
+  × Adjacent JSX elements must be wrapped in an enclosing tag.
+   ╭─[typescript/tests/cases/conformance/jsx/tsxErrorRecovery3.tsx:4:1]
  3 │ <div></div>
  4 │ <div></div>
-   ·       ─
+   · ─
    ╰────
+  help: Did you want a JSX fragment `<>...</>`?
 
   × Expected corresponding closing tag for JSX fragment.
     ╭─[typescript/tests/cases/conformance/jsx/tsxFragmentErrors.tsx:9:7]
@@ -24048,12 +24050,13 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/types/wit
  10 │ 
     ╰────
 
-  × Unexpected token
-    ╭─[typescript/tests/cases/conformance/jsx/tsxFragmentErrors.tsx:11:2]
+  × Adjacent JSX elements must be wrapped in an enclosing tag.
+    ╭─[typescript/tests/cases/conformance/jsx/tsxFragmentErrors.tsx:11:1]
  10 │ 
  11 │ <>eof   // Error
-    ·  ─
+    · ─
     ╰────
+  help: Did you want a JSX fragment `<>...</>`?
 
   × Unexpected token. Did you mean `{'>'}` or `&gt;`?
    ╭─[typescript/tests/cases/conformance/jsx/tsxGenericArrowFunctionParsing.tsx:8:17]


### PR DESCRIPTION
Add a friendly error for adjancent JSX element case:

```
  × Adjacent JSX elements must be wrapped in an enclosing tag.
   ╭─[misc/fail/jsx-adjacent-elements.jsx:3:3]
 2 │   <div />
 3 │   <span />
   ·   ─
 4 │ );
   ╰────
  help: Did you want a JSX fragment `<>...</>`?
```

This error message exists in babel.