### PR TITLE
refactor(linter): reuse `RuleNoConfig` reference for rule schema

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -58,8 +58,8 @@ export type LintPluginOptionsSchema =
   | "node"
   | "vue";
 export type LintPlugins = LintPluginOptionsSchema[];
-export type Mode2 = "as-needed" | "always" | "never";
 export type RuleNoConfig = AllowWarnDeny | [AllowWarnDeny];
+export type Mode2 = "as-needed" | "always" | "never";
 export type AlwaysNever = "always" | "never";
 export type OptionsJsonEnum =
   | CommentConfigJson
@@ -822,106 +822,95 @@ export interface OxlintOverride {
  * See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)
  */
 export interface DummyRuleMap {
-  "accessor-pairs"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AccessorPairsConfig];
-  "array-callback-return"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ArrayCallbackReturn];
-  "arrow-body-style"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, Mode2]
-    | [AllowWarnDeny, Mode2, ArrowBodyStyleConfig];
+  "accessor-pairs"?: RuleNoConfig | [AllowWarnDeny, AccessorPairsConfig];
+  "array-callback-return"?: RuleNoConfig | [AllowWarnDeny, ArrayCallbackReturn];
+  "arrow-body-style"?: RuleNoConfig | [AllowWarnDeny, Mode2] | [AllowWarnDeny, Mode2, ArrowBodyStyleConfig];
   "block-scoped-var"?: RuleNoConfig;
-  "capitalized-comments"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, AlwaysNever]
-    | [AllowWarnDeny, AlwaysNever, OptionsJsonEnum];
-  "class-methods-use-this"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ClassMethodsUseThisConfig];
-  complexity?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | ComplexityConfig];
+  "capitalized-comments"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever] | [AllowWarnDeny, AlwaysNever, OptionsJsonEnum];
+  "class-methods-use-this"?: RuleNoConfig | [AllowWarnDeny, ClassMethodsUseThisConfig];
+  complexity?: RuleNoConfig | [AllowWarnDeny, number | ComplexityConfig];
   "constructor-super"?: RuleNoConfig;
-  curly?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, CurlyType] | [AllowWarnDeny, CurlyType, CurlyConsistent];
-  "default-case"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, DefaultCaseConfig];
+  curly?: RuleNoConfig | [AllowWarnDeny, CurlyType] | [AllowWarnDeny, CurlyType, CurlyConsistent];
+  "default-case"?: RuleNoConfig | [AllowWarnDeny, DefaultCaseConfig];
   "default-case-last"?: RuleNoConfig;
   "default-param-last"?: RuleNoConfig;
-  eqeqeq?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, CompareType] | [AllowWarnDeny, CompareType, EqeqeqOptions];
+  eqeqeq?: RuleNoConfig | [AllowWarnDeny, CompareType] | [AllowWarnDeny, CompareType, EqeqeqOptions];
   "for-direction"?: RuleNoConfig;
   "func-name-matching"?: DummyRule;
   "func-names"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
+    | RuleNoConfig
     | [AllowWarnDeny, FuncNamesConfigType]
     | [AllowWarnDeny, FuncNamesConfigType, FuncNamesGeneratorsConfig];
-  "func-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, Style] | [AllowWarnDeny, Style, FuncStyleConfig];
-  "getter-return"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, GetterReturn];
+  "func-style"?: RuleNoConfig | [AllowWarnDeny, Style] | [AllowWarnDeny, Style, FuncStyleConfig];
+  "getter-return"?: RuleNoConfig | [AllowWarnDeny, GetterReturn];
   "grouped-accessor-pairs"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
+    | RuleNoConfig
     | [AllowWarnDeny, PairOrder]
     | [AllowWarnDeny, PairOrder, GroupedAccessorPairsConfig];
   "guard-for-in"?: RuleNoConfig;
-  "id-length"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, IdLengthConfig];
-  "id-match"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, string] | [AllowWarnDeny, string, IdMatchOptions];
-  "import/consistent-type-specifier-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, Mode];
+  "id-length"?: RuleNoConfig | [AllowWarnDeny, IdLengthConfig];
+  "id-match"?: RuleNoConfig | [AllowWarnDeny, string] | [AllowWarnDeny, string, IdMatchOptions];
+  "import/consistent-type-specifier-style"?: RuleNoConfig | [AllowWarnDeny, Mode];
   "import/default"?: RuleNoConfig;
   "import/export"?: RuleNoConfig;
   "import/exports-last"?: RuleNoConfig;
   "import/extensions"?: DummyRule;
-  "import/first"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AbsoluteFirst];
+  "import/first"?: RuleNoConfig | [AllowWarnDeny, AbsoluteFirst];
   "import/group-exports"?: RuleNoConfig;
-  "import/max-dependencies"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MaxDependenciesConfigJson];
+  "import/max-dependencies"?: RuleNoConfig | [AllowWarnDeny, MaxDependenciesConfigJson];
   "import/named"?: RuleNoConfig;
-  "import/namespace"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, Namespace];
-  "import/newline-after-import"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NewlineAfterImport];
-  "import/no-absolute-path"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoAbsolutePath];
+  "import/namespace"?: RuleNoConfig | [AllowWarnDeny, Namespace];
+  "import/newline-after-import"?: RuleNoConfig | [AllowWarnDeny, NewlineAfterImport];
+  "import/no-absolute-path"?: RuleNoConfig | [AllowWarnDeny, NoAbsolutePath];
   "import/no-amd"?: RuleNoConfig;
-  "import/no-anonymous-default-export"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoAnonymousDefaultExport];
-  "import/no-commonjs"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoCommonjs];
-  "import/no-cycle"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoCycle];
+  "import/no-anonymous-default-export"?: RuleNoConfig | [AllowWarnDeny, NoAnonymousDefaultExport];
+  "import/no-commonjs"?: RuleNoConfig | [AllowWarnDeny, NoCommonjs];
+  "import/no-cycle"?: RuleNoConfig | [AllowWarnDeny, NoCycle];
   "import/no-default-export"?: RuleNoConfig;
-  "import/no-duplicates"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoDuplicates];
-  "import/no-dynamic-require"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoDynamicRequire];
+  "import/no-duplicates"?: RuleNoConfig | [AllowWarnDeny, NoDuplicates];
+  "import/no-dynamic-require"?: RuleNoConfig | [AllowWarnDeny, NoDynamicRequire];
   "import/no-empty-named-blocks"?: RuleNoConfig;
   "import/no-mutable-exports"?: RuleNoConfig;
   "import/no-named-as-default"?: RuleNoConfig;
   "import/no-named-as-default-member"?: RuleNoConfig;
   "import/no-named-default"?: RuleNoConfig;
   "import/no-named-export"?: RuleNoConfig;
-  "import/no-namespace"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoNamespaceConfig];
-  "import/no-nodejs-modules"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoNodejsModulesConfig];
+  "import/no-namespace"?: RuleNoConfig | [AllowWarnDeny, NoNamespaceConfig];
+  "import/no-nodejs-modules"?: RuleNoConfig | [AllowWarnDeny, NoNodejsModulesConfig];
   "import/no-relative-parent-imports"?: RuleNoConfig;
   "import/no-self-import"?: RuleNoConfig;
-  "import/no-unassigned-import"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnassignedImportConfig];
+  "import/no-unassigned-import"?: RuleNoConfig | [AllowWarnDeny, NoUnassignedImportConfig];
   "import/no-webpack-loader-syntax"?: RuleNoConfig;
-  "import/prefer-default-export"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferDefaultExport];
+  "import/prefer-default-export"?: RuleNoConfig | [AllowWarnDeny, PreferDefaultExport];
   "import/unambiguous"?: RuleNoConfig;
   "init-declarations"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
+    | RuleNoConfig
     | [AllowWarnDeny, AlwaysNever]
     | [AllowWarnDeny, AlwaysNever, InitDeclarationsConfig];
-  "jest/consistent-test-it"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentTestItConfig];
-  "jest/expect-expect"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ExpectExpectConfig];
-  "jest/max-expects"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MaxExpectsConfig];
-  "jest/max-nested-describe"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MaxNestedDescribeConfig];
+  "jest/consistent-test-it"?: RuleNoConfig | [AllowWarnDeny, ConsistentTestItConfig];
+  "jest/expect-expect"?: RuleNoConfig | [AllowWarnDeny, ExpectExpectConfig];
+  "jest/max-expects"?: RuleNoConfig | [AllowWarnDeny, MaxExpectsConfig];
+  "jest/max-nested-describe"?: RuleNoConfig | [AllowWarnDeny, MaxNestedDescribeConfig];
   "jest/no-alias-methods"?: RuleNoConfig;
   "jest/no-commented-out-tests"?: RuleNoConfig;
   "jest/no-conditional-expect"?: RuleNoConfig;
   "jest/no-conditional-in-test"?: RuleNoConfig;
   "jest/no-confusing-set-timeout"?: RuleNoConfig;
-  "jest/no-deprecated-functions"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoDeprecatedFunctionsConfig];
+  "jest/no-deprecated-functions"?: RuleNoConfig | [AllowWarnDeny, NoDeprecatedFunctionsConfig];
   "jest/no-disabled-tests"?: RuleNoConfig;
   "jest/no-done-callback"?: RuleNoConfig;
   "jest/no-duplicate-hooks"?: RuleNoConfig;
   "jest/no-export"?: RuleNoConfig;
   "jest/no-focused-tests"?: RuleNoConfig;
-  "jest/no-hooks"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoHooksConfig];
+  "jest/no-hooks"?: RuleNoConfig | [AllowWarnDeny, NoHooksConfig];
   "jest/no-identical-title"?: RuleNoConfig;
   "jest/no-interpolation-in-snapshots"?: RuleNoConfig;
   "jest/no-jasmine-globals"?: RuleNoConfig;
-  "jest/no-large-snapshots"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoLargeSnapshotsConfig];
+  "jest/no-large-snapshots"?: RuleNoConfig | [AllowWarnDeny, NoLargeSnapshotsConfig];
   "jest/no-mocks-import"?: RuleNoConfig;
-  "jest/no-restricted-jest-methods"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRestrictedTestMethodsConfig];
-  "jest/no-restricted-matchers"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRestrictedMatchersConfig];
-  "jest/no-standalone-expect"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoStandaloneExpectConfig];
+  "jest/no-restricted-jest-methods"?: RuleNoConfig | [AllowWarnDeny, NoRestrictedTestMethodsConfig];
+  "jest/no-restricted-matchers"?: RuleNoConfig | [AllowWarnDeny, NoRestrictedMatchersConfig];
+  "jest/no-standalone-expect"?: RuleNoConfig | [AllowWarnDeny, NoStandaloneExpectConfig];
   "jest/no-test-prefixes"?: RuleNoConfig;
   "jest/no-test-return-statement"?: RuleNoConfig;
   "jest/no-unneeded-async-expect-function"?: RuleNoConfig;
@@ -931,24 +920,18 @@ export interface DummyRuleMap {
   "jest/prefer-called-with"?: RuleNoConfig;
   "jest/prefer-comparison-matcher"?: RuleNoConfig;
   "jest/prefer-each"?: RuleNoConfig;
-  "jest/prefer-ending-with-an-expect"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, PreferEndingWithAnExpectConfig];
+  "jest/prefer-ending-with-an-expect"?: RuleNoConfig | [AllowWarnDeny, PreferEndingWithAnExpectConfig];
   "jest/prefer-equality-matcher"?: RuleNoConfig;
-  "jest/prefer-expect-assertions"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferExpectAssertionsConfig];
+  "jest/prefer-expect-assertions"?: RuleNoConfig | [AllowWarnDeny, PreferExpectAssertionsConfig];
   "jest/prefer-expect-resolves"?: RuleNoConfig;
   "jest/prefer-hooks-in-order"?: RuleNoConfig;
   "jest/prefer-hooks-on-top"?: RuleNoConfig;
-  "jest/prefer-importing-jest-globals"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, PreferImportingJestGlobalsConfig];
+  "jest/prefer-importing-jest-globals"?: RuleNoConfig | [AllowWarnDeny, PreferImportingJestGlobalsConfig];
   "jest/prefer-jest-mocked"?: RuleNoConfig;
   "jest/prefer-lowercase-title"?: DummyRule;
   "jest/prefer-mock-promise-shorthand"?: RuleNoConfig;
   "jest/prefer-mock-return-shorthand"?: RuleNoConfig;
-  "jest/prefer-snapshot-hint"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SnapshotHintMode];
+  "jest/prefer-snapshot-hint"?: RuleNoConfig | [AllowWarnDeny, SnapshotHintMode];
   "jest/prefer-spy-on"?: RuleNoConfig;
   "jest/prefer-strict-equal"?: RuleNoConfig;
   "jest/prefer-to-be"?: RuleNoConfig;
@@ -957,19 +940,19 @@ export interface DummyRuleMap {
   "jest/prefer-to-have-been-called-times"?: RuleNoConfig;
   "jest/prefer-to-have-length"?: RuleNoConfig;
   "jest/prefer-todo"?: RuleNoConfig;
-  "jest/require-hook"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RequireHookConfig];
+  "jest/require-hook"?: RuleNoConfig | [AllowWarnDeny, RequireHookConfig];
   "jest/require-to-throw-message"?: RuleNoConfig;
-  "jest/require-top-level-describe"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RequireTopLevelDescribeConfig];
+  "jest/require-top-level-describe"?: RuleNoConfig | [AllowWarnDeny, RequireTopLevelDescribeConfig];
   "jest/valid-describe-callback"?: RuleNoConfig;
-  "jest/valid-expect"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ValidExpectConfig];
+  "jest/valid-expect"?: RuleNoConfig | [AllowWarnDeny, ValidExpectConfig];
   "jest/valid-expect-in-promise"?: RuleNoConfig;
   "jest/valid-title"?: DummyRule;
   "jsdoc/check-access"?: RuleNoConfig;
   "jsdoc/check-property-names"?: RuleNoConfig;
-  "jsdoc/check-tag-names"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, CheckTagNamesConfig];
-  "jsdoc/empty-tags"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, EmptyTagsConfig];
+  "jsdoc/check-tag-names"?: RuleNoConfig | [AllowWarnDeny, CheckTagNamesConfig];
+  "jsdoc/empty-tags"?: RuleNoConfig | [AllowWarnDeny, EmptyTagsConfig];
   "jsdoc/implements-on-classes"?: RuleNoConfig;
-  "jsdoc/no-defaults"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoDefaultsConfig];
+  "jsdoc/no-defaults"?: RuleNoConfig | [AllowWarnDeny, NoDefaultsConfig];
   "jsdoc/require-param"?: DummyRule;
   "jsdoc/require-param-description"?: RuleNoConfig;
   "jsdoc/require-param-name"?: RuleNoConfig;
@@ -978,87 +961,66 @@ export interface DummyRuleMap {
   "jsdoc/require-property-description"?: RuleNoConfig;
   "jsdoc/require-property-name"?: RuleNoConfig;
   "jsdoc/require-property-type"?: RuleNoConfig;
-  "jsdoc/require-returns"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RequireReturnsConfig];
+  "jsdoc/require-returns"?: RuleNoConfig | [AllowWarnDeny, RequireReturnsConfig];
   "jsdoc/require-returns-description"?: RuleNoConfig;
   "jsdoc/require-returns-type"?: RuleNoConfig;
   "jsdoc/require-throws-description"?: RuleNoConfig;
   "jsdoc/require-throws-type"?: RuleNoConfig;
-  "jsdoc/require-yields"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RequireYieldsConfig];
+  "jsdoc/require-yields"?: RuleNoConfig | [AllowWarnDeny, RequireYieldsConfig];
   "jsdoc/require-yields-description"?: RuleNoConfig;
   "jsdoc/require-yields-type"?: RuleNoConfig;
-  "jsx-a11y/alt-text"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AltTextConfigSchema];
-  "jsx-a11y/anchor-ambiguous-text"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AnchorAmbiguousTextConfig];
+  "jsx-a11y/alt-text"?: RuleNoConfig | [AllowWarnDeny, AltTextConfigSchema];
+  "jsx-a11y/anchor-ambiguous-text"?: RuleNoConfig | [AllowWarnDeny, AnchorAmbiguousTextConfig];
   "jsx-a11y/anchor-has-content"?: RuleNoConfig;
   "jsx-a11y/anchor-is-valid"?: DummyRule;
   "jsx-a11y/aria-activedescendant-has-tabindex"?: RuleNoConfig;
   "jsx-a11y/aria-props"?: RuleNoConfig;
   "jsx-a11y/aria-proptypes"?: RuleNoConfig;
-  "jsx-a11y/aria-role"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AriaRoleConfig];
+  "jsx-a11y/aria-role"?: RuleNoConfig | [AllowWarnDeny, AriaRoleConfig];
   "jsx-a11y/aria-unsupported-elements"?: RuleNoConfig;
-  "jsx-a11y/autocomplete-valid"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AutocompleteValidConfig];
+  "jsx-a11y/autocomplete-valid"?: RuleNoConfig | [AllowWarnDeny, AutocompleteValidConfig];
   "jsx-a11y/click-events-have-key-events"?: RuleNoConfig;
-  "jsx-a11y/control-has-associated-label"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, ControlHasAssociatedLabelConfig];
-  "jsx-a11y/heading-has-content"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, HeadingHasContentConfig];
+  "jsx-a11y/control-has-associated-label"?: RuleNoConfig | [AllowWarnDeny, ControlHasAssociatedLabelConfig];
+  "jsx-a11y/heading-has-content"?: RuleNoConfig | [AllowWarnDeny, HeadingHasContentConfig];
   "jsx-a11y/html-has-lang"?: RuleNoConfig;
   "jsx-a11y/iframe-has-title"?: RuleNoConfig;
-  "jsx-a11y/img-redundant-alt"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ImgRedundantAltConfig];
-  "jsx-a11y/interactive-supports-focus"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, InteractiveSupportsFocusConfig];
-  "jsx-a11y/label-has-associated-control"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, LabelHasAssociatedControlConfig];
+  "jsx-a11y/img-redundant-alt"?: RuleNoConfig | [AllowWarnDeny, ImgRedundantAltConfig];
+  "jsx-a11y/interactive-supports-focus"?: RuleNoConfig | [AllowWarnDeny, InteractiveSupportsFocusConfig];
+  "jsx-a11y/label-has-associated-control"?: RuleNoConfig | [AllowWarnDeny, LabelHasAssociatedControlConfig];
   "jsx-a11y/lang"?: RuleNoConfig;
-  "jsx-a11y/media-has-caption"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MediaHasCaptionConfig];
-  "jsx-a11y/mouse-events-have-key-events"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, MouseEventsHaveKeyEventsConfig];
+  "jsx-a11y/media-has-caption"?: RuleNoConfig | [AllowWarnDeny, MediaHasCaptionConfig];
+  "jsx-a11y/mouse-events-have-key-events"?: RuleNoConfig | [AllowWarnDeny, MouseEventsHaveKeyEventsConfig];
   "jsx-a11y/no-access-key"?: RuleNoConfig;
   "jsx-a11y/no-aria-hidden-on-focusable"?: RuleNoConfig;
-  "jsx-a11y/no-autofocus"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoAutofocus];
-  "jsx-a11y/no-distracting-elements"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoDistractingElementsConfig];
+  "jsx-a11y/no-autofocus"?: RuleNoConfig | [AllowWarnDeny, NoAutofocus];
+  "jsx-a11y/no-distracting-elements"?: RuleNoConfig | [AllowWarnDeny, NoDistractingElementsConfig];
   "jsx-a11y/no-interactive-element-to-noninteractive-role"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
+    | RuleNoConfig
     | [AllowWarnDeny, NoInteractiveElementToNoninteractiveRoleConfig];
   "jsx-a11y/no-noninteractive-element-interactions"?: DummyRule;
   "jsx-a11y/no-noninteractive-element-to-interactive-role"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
+    | RuleNoConfig
     | [AllowWarnDeny, NoNoninteractiveElementToInteractiveRoleConfig];
-  "jsx-a11y/no-noninteractive-tabindex"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, NoNoninteractiveTabindexConfig];
-  "jsx-a11y/no-redundant-roles"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRedundantRolesConfig];
-  "jsx-a11y/no-static-element-interactions"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, NoStaticElementInteractionsConfig];
+  "jsx-a11y/no-noninteractive-tabindex"?: RuleNoConfig | [AllowWarnDeny, NoNoninteractiveTabindexConfig];
+  "jsx-a11y/no-redundant-roles"?: RuleNoConfig | [AllowWarnDeny, NoRedundantRolesConfig];
+  "jsx-a11y/no-static-element-interactions"?: RuleNoConfig | [AllowWarnDeny, NoStaticElementInteractionsConfig];
   "jsx-a11y/prefer-tag-over-role"?: RuleNoConfig;
   "jsx-a11y/role-has-required-aria-props"?: RuleNoConfig;
   "jsx-a11y/role-supports-aria-props"?: RuleNoConfig;
   "jsx-a11y/scope"?: RuleNoConfig;
   "jsx-a11y/tabindex-no-positive"?: RuleNoConfig;
   "logical-assignment-operators"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
+    | RuleNoConfig
     | [AllowWarnDeny, AlwaysNever]
     | [AllowWarnDeny, AlwaysNever, LogicalAssignmentOperatorsConfig];
-  "max-classes-per-file"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxClassesPerFileConfig];
-  "max-depth"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxDepth];
-  "max-lines"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxLinesConfig];
-  "max-lines-per-function"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxLinesPerFunctionConfig];
-  "max-nested-callbacks"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxNestedCallbacks];
-  "max-params"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxParamsConfig];
-  "max-statements"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, number | MaxStatementsConfig];
-  "new-cap"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NewCapConfig];
+  "max-classes-per-file"?: RuleNoConfig | [AllowWarnDeny, number | MaxClassesPerFileConfig];
+  "max-depth"?: RuleNoConfig | [AllowWarnDeny, number | MaxDepth];
+  "max-lines"?: RuleNoConfig | [AllowWarnDeny, number | MaxLinesConfig];
+  "max-lines-per-function"?: RuleNoConfig | [AllowWarnDeny, number | MaxLinesPerFunctionConfig];
+  "max-nested-callbacks"?: RuleNoConfig | [AllowWarnDeny, number | MaxNestedCallbacks];
+  "max-params"?: RuleNoConfig | [AllowWarnDeny, number | MaxParamsConfig];
+  "max-statements"?: RuleNoConfig | [AllowWarnDeny, number | MaxStatementsConfig];
+  "new-cap"?: RuleNoConfig | [AllowWarnDeny, NewCapConfig];
   "nextjs/google-font-display"?: RuleNoConfig;
   "nextjs/google-font-preconnect"?: RuleNoConfig;
   "nextjs/inline-script-id"?: RuleNoConfig;
@@ -1084,16 +1046,16 @@ export interface DummyRuleMap {
   "no-array-constructor"?: RuleNoConfig;
   "no-async-promise-executor"?: RuleNoConfig;
   "no-await-in-loop"?: RuleNoConfig;
-  "no-bitwise"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoBitwiseConfig];
+  "no-bitwise"?: RuleNoConfig | [AllowWarnDeny, NoBitwiseConfig];
   "no-caller"?: RuleNoConfig;
   "no-case-declarations"?: RuleNoConfig;
   "no-class-assign"?: RuleNoConfig;
   "no-compare-neg-zero"?: RuleNoConfig;
-  "no-cond-assign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoCondAssignConfig];
-  "no-console"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoConsoleConfig];
+  "no-cond-assign"?: RuleNoConfig | [AllowWarnDeny, NoCondAssignConfig];
+  "no-console"?: RuleNoConfig | [AllowWarnDeny, NoConsoleConfig];
   "no-const-assign"?: RuleNoConfig;
   "no-constant-binary-expression"?: RuleNoConfig;
-  "no-constant-condition"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoConstantCondition];
+  "no-constant-condition"?: RuleNoConfig | [AllowWarnDeny, NoConstantCondition];
   "no-constructor-return"?: RuleNoConfig;
   "no-continue"?: RuleNoConfig;
   "no-control-regex"?: RuleNoConfig;
@@ -1104,45 +1066,44 @@ export interface DummyRuleMap {
   "no-dupe-else-if"?: RuleNoConfig;
   "no-dupe-keys"?: RuleNoConfig;
   "no-duplicate-case"?: RuleNoConfig;
-  "no-duplicate-imports"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoDuplicateImports];
-  "no-else-return"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoElseReturn];
-  "no-empty"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoEmpty];
+  "no-duplicate-imports"?: RuleNoConfig | [AllowWarnDeny, NoDuplicateImports];
+  "no-else-return"?: RuleNoConfig | [AllowWarnDeny, NoElseReturn];
+  "no-empty"?: RuleNoConfig | [AllowWarnDeny, NoEmpty];
   "no-empty-character-class"?: RuleNoConfig;
-  "no-empty-function"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoEmptyFunctionConfig];
-  "no-empty-pattern"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoEmptyPattern];
+  "no-empty-function"?: RuleNoConfig | [AllowWarnDeny, NoEmptyFunctionConfig];
+  "no-empty-pattern"?: RuleNoConfig | [AllowWarnDeny, NoEmptyPattern];
   "no-empty-static-block"?: RuleNoConfig;
   "no-eq-null"?: RuleNoConfig;
-  "no-eval"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoEval];
+  "no-eval"?: RuleNoConfig | [AllowWarnDeny, NoEval];
   "no-ex-assign"?: RuleNoConfig;
-  "no-extend-native"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoExtendNativeConfig];
+  "no-extend-native"?: RuleNoConfig | [AllowWarnDeny, NoExtendNativeConfig];
   "no-extra-bind"?: RuleNoConfig;
-  "no-extra-boolean-cast"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoExtraBooleanCast];
+  "no-extra-boolean-cast"?: RuleNoConfig | [AllowWarnDeny, NoExtraBooleanCast];
   "no-extra-label"?: RuleNoConfig;
-  "no-fallthrough"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoFallthroughConfig];
+  "no-fallthrough"?: RuleNoConfig | [AllowWarnDeny, NoFallthroughConfig];
   "no-func-assign"?: RuleNoConfig;
-  "no-global-assign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoGlobalAssignConfig];
-  "no-implicit-coercion"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoImplicitCoercionConfig];
-  "no-implicit-globals"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoImplicitGlobalsConfig];
+  "no-global-assign"?: RuleNoConfig | [AllowWarnDeny, NoGlobalAssignConfig];
+  "no-implicit-coercion"?: RuleNoConfig | [AllowWarnDeny, NoImplicitCoercionConfig];
+  "no-implicit-globals"?: RuleNoConfig | [AllowWarnDeny, NoImplicitGlobalsConfig];
   "no-implied-eval"?: RuleNoConfig;
   "no-import-assign"?: RuleNoConfig;
-  "no-inline-comments"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoInlineCommentsConfig];
+  "no-inline-comments"?: RuleNoConfig | [AllowWarnDeny, NoInlineCommentsConfig];
   "no-inner-declarations"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
+    | RuleNoConfig
     | [AllowWarnDeny, NoInnerDeclarationsConfig]
     | [AllowWarnDeny, NoInnerDeclarationsConfig, NoInnerDeclarationsOptions];
-  "no-invalid-regexp"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoInvalidRegexpConfig];
-  "no-irregular-whitespace"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoIrregularWhitespaceConfig];
+  "no-invalid-regexp"?: RuleNoConfig | [AllowWarnDeny, NoInvalidRegexpConfig];
+  "no-irregular-whitespace"?: RuleNoConfig | [AllowWarnDeny, NoIrregularWhitespaceConfig];
   "no-iterator"?: RuleNoConfig;
   "no-label-var"?: RuleNoConfig;
-  "no-labels"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoLabels];
+  "no-labels"?: RuleNoConfig | [AllowWarnDeny, NoLabels];
   "no-lone-blocks"?: RuleNoConfig;
   "no-lonely-if"?: RuleNoConfig;
   "no-loop-func"?: RuleNoConfig;
   "no-loss-of-precision"?: RuleNoConfig;
-  "no-magic-numbers"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoMagicNumbersConfig];
-  "no-misleading-character-class"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoMisleadingCharacterClass];
-  "no-multi-assign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoMultiAssign];
+  "no-magic-numbers"?: RuleNoConfig | [AllowWarnDeny, NoMagicNumbersConfig];
+  "no-misleading-character-class"?: RuleNoConfig | [AllowWarnDeny, NoMisleadingCharacterClass];
+  "no-multi-assign"?: RuleNoConfig | [AllowWarnDeny, NoMultiAssign];
   "no-multi-str"?: RuleNoConfig;
   "no-negated-condition"?: RuleNoConfig;
   "no-nested-ternary"?: RuleNoConfig;
@@ -1153,73 +1114,72 @@ export interface DummyRuleMap {
   "no-nonoctal-decimal-escape"?: RuleNoConfig;
   "no-obj-calls"?: RuleNoConfig;
   "no-object-constructor"?: RuleNoConfig;
-  "no-param-reassign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoParamReassignConfig];
-  "no-plusplus"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoPlusplus];
-  "no-promise-executor-return"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoPromiseExecutorReturnConfig];
+  "no-param-reassign"?: RuleNoConfig | [AllowWarnDeny, NoParamReassignConfig];
+  "no-plusplus"?: RuleNoConfig | [AllowWarnDeny, NoPlusplus];
+  "no-promise-executor-return"?: RuleNoConfig | [AllowWarnDeny, NoPromiseExecutorReturnConfig];
   "no-proto"?: RuleNoConfig;
   "no-prototype-builtins"?: RuleNoConfig;
-  "no-redeclare"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRedeclare];
+  "no-redeclare"?: RuleNoConfig | [AllowWarnDeny, NoRedeclare];
   "no-regex-spaces"?: RuleNoConfig;
-  "no-restricted-exports"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRestrictedExportsConfig];
+  "no-restricted-exports"?: RuleNoConfig | [AllowWarnDeny, NoRestrictedExportsConfig];
   "no-restricted-globals"?: DummyRule;
   "no-restricted-imports"?: DummyRule;
   "no-restricted-properties"?: DummyRule;
-  "no-return-assign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoReturnAssignMode];
+  "no-return-assign"?: RuleNoConfig | [AllowWarnDeny, NoReturnAssignMode];
   "no-script-url"?: RuleNoConfig;
-  "no-self-assign"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoSelfAssign];
+  "no-self-assign"?: RuleNoConfig | [AllowWarnDeny, NoSelfAssign];
   "no-self-compare"?: RuleNoConfig;
-  "no-sequences"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoSequences];
+  "no-sequences"?: RuleNoConfig | [AllowWarnDeny, NoSequences];
   "no-setter-return"?: RuleNoConfig;
-  "no-shadow"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoShadowConfig];
-  "no-shadow-restricted-names"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoShadowRestrictedNamesConfig];
+  "no-shadow"?: RuleNoConfig | [AllowWarnDeny, NoShadowConfig];
+  "no-shadow-restricted-names"?: RuleNoConfig | [AllowWarnDeny, NoShadowRestrictedNamesConfig];
   "no-sparse-arrays"?: RuleNoConfig;
   "no-template-curly-in-string"?: RuleNoConfig;
   "no-ternary"?: RuleNoConfig;
   "no-this-before-super"?: RuleNoConfig;
   "no-throw-literal"?: RuleNoConfig;
   "no-unassigned-vars"?: RuleNoConfig;
-  "no-undef"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUndef];
+  "no-undef"?: RuleNoConfig | [AllowWarnDeny, NoUndef];
   "no-undefined"?: RuleNoConfig;
-  "no-underscore-dangle"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnderscoreDangleConfig];
+  "no-underscore-dangle"?: RuleNoConfig | [AllowWarnDeny, NoUnderscoreDangleConfig];
   "no-unexpected-multiline"?: RuleNoConfig;
   "no-unmodified-loop-condition"?: RuleNoConfig;
-  "no-unneeded-ternary"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnneededTernary];
+  "no-unneeded-ternary"?: RuleNoConfig | [AllowWarnDeny, NoUnneededTernary];
   "no-unreachable"?: RuleNoConfig;
   "no-unsafe-finally"?: RuleNoConfig;
-  "no-unsafe-negation"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnsafeNegation];
-  "no-unsafe-optional-chaining"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnsafeOptionalChaining];
-  "no-unused-expressions"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnusedExpressionsConfig];
+  "no-unsafe-negation"?: RuleNoConfig | [AllowWarnDeny, NoUnsafeNegation];
+  "no-unsafe-optional-chaining"?: RuleNoConfig | [AllowWarnDeny, NoUnsafeOptionalChaining];
+  "no-unused-expressions"?: RuleNoConfig | [AllowWarnDeny, NoUnusedExpressionsConfig];
   "no-unused-labels"?: RuleNoConfig;
   "no-unused-private-class-members"?: RuleNoConfig;
-  "no-unused-vars"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnusedVarsConfig];
-  "no-use-before-define"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUseBeforeDefineConfigJson];
+  "no-unused-vars"?: RuleNoConfig | [AllowWarnDeny, NoUnusedVarsConfig];
+  "no-use-before-define"?: RuleNoConfig | [AllowWarnDeny, NoUseBeforeDefineConfigJson];
   "no-useless-assignment"?: RuleNoConfig;
   "no-useless-backreference"?: RuleNoConfig;
   "no-useless-call"?: RuleNoConfig;
   "no-useless-catch"?: RuleNoConfig;
-  "no-useless-computed-key"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUselessComputedKey];
+  "no-useless-computed-key"?: RuleNoConfig | [AllowWarnDeny, NoUselessComputedKey];
   "no-useless-concat"?: RuleNoConfig;
   "no-useless-constructor"?: RuleNoConfig;
-  "no-useless-escape"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUselessEscapeConfig];
-  "no-useless-rename"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUselessRenameConfig];
+  "no-useless-escape"?: RuleNoConfig | [AllowWarnDeny, NoUselessEscapeConfig];
+  "no-useless-rename"?: RuleNoConfig | [AllowWarnDeny, NoUselessRenameConfig];
   "no-useless-return"?: RuleNoConfig;
   "no-var"?: RuleNoConfig;
-  "no-void"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoVoid];
-  "no-warning-comments"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoWarningCommentsConfigJson];
+  "no-void"?: RuleNoConfig | [AllowWarnDeny, NoVoid];
+  "no-warning-comments"?: RuleNoConfig | [AllowWarnDeny, NoWarningCommentsConfigJson];
   "no-with"?: RuleNoConfig;
   "node/callback-return"?: DummyRule;
   "node/global-require"?: RuleNoConfig;
-  "node/handle-callback-err"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, HandleCallbackErrConfig];
+  "node/handle-callback-err"?: RuleNoConfig | [AllowWarnDeny, HandleCallbackErrConfig];
   "node/no-exports-assign"?: RuleNoConfig;
   "node/no-new-require"?: RuleNoConfig;
   "node/no-path-concat"?: RuleNoConfig;
-  "node/no-process-env"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoProcessEnvConfig];
+  "node/no-process-env"?: RuleNoConfig | [AllowWarnDeny, NoProcessEnvConfig];
   "object-shorthand"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
+    | RuleNoConfig
     | [AllowWarnDeny, ShorthandType]
     | [AllowWarnDeny, ShorthandType, ObjectShorthandOptions];
-  "operator-assignment"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AlwaysNever];
+  "operator-assignment"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever];
   "oxc/approx-constant"?: RuleNoConfig;
   "oxc/bad-array-method-on-arguments"?: RuleNoConfig;
   "oxc/bad-bitwise-operator"?: RuleNoConfig;
@@ -1236,231 +1196,183 @@ export interface DummyRuleMap {
   "oxc/missing-throw"?: RuleNoConfig;
   "oxc/no-accumulating-spread"?: RuleNoConfig;
   "oxc/no-async-await"?: RuleNoConfig;
-  "oxc/no-async-endpoint-handlers"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoAsyncEndpointHandlersConfig];
-  "oxc/no-barrel-file"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoBarrelFile];
+  "oxc/no-async-endpoint-handlers"?: RuleNoConfig | [AllowWarnDeny, NoAsyncEndpointHandlersConfig];
+  "oxc/no-barrel-file"?: RuleNoConfig | [AllowWarnDeny, NoBarrelFile];
   "oxc/no-const-enum"?: RuleNoConfig;
-  "oxc/no-map-spread"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoMapSpreadConfig];
-  "oxc/no-optional-chaining"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoOptionalChainingConfig];
-  "oxc/no-rest-spread-properties"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRestSpreadPropertiesOptions];
+  "oxc/no-map-spread"?: RuleNoConfig | [AllowWarnDeny, NoMapSpreadConfig];
+  "oxc/no-optional-chaining"?: RuleNoConfig | [AllowWarnDeny, NoOptionalChainingConfig];
+  "oxc/no-rest-spread-properties"?: RuleNoConfig | [AllowWarnDeny, NoRestSpreadPropertiesOptions];
   "oxc/no-this-in-exported-function"?: RuleNoConfig;
   "oxc/number-arg-out-of-range"?: RuleNoConfig;
   "oxc/only-used-in-recursion"?: RuleNoConfig;
   "oxc/uninvoked-array-callback"?: RuleNoConfig;
-  "prefer-arrow-callback"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferArrowCallbackConfig];
-  "prefer-const"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferConstConfig];
+  "prefer-arrow-callback"?: RuleNoConfig | [AllowWarnDeny, PreferArrowCallbackConfig];
+  "prefer-const"?: RuleNoConfig | [AllowWarnDeny, PreferConstConfig];
   "prefer-destructuring"?: DummyRule;
   "prefer-exponentiation-operator"?: RuleNoConfig;
   "prefer-named-capture-group"?: RuleNoConfig;
   "prefer-numeric-literals"?: RuleNoConfig;
   "prefer-object-has-own"?: RuleNoConfig;
   "prefer-object-spread"?: RuleNoConfig;
-  "prefer-promise-reject-errors"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferPromiseRejectErrors];
-  "prefer-regex-literals"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferRegexLiteralsConfig];
+  "prefer-promise-reject-errors"?: RuleNoConfig | [AllowWarnDeny, PreferPromiseRejectErrors];
+  "prefer-regex-literals"?: RuleNoConfig | [AllowWarnDeny, PreferRegexLiteralsConfig];
   "prefer-rest-params"?: RuleNoConfig;
   "prefer-spread"?: RuleNoConfig;
   "prefer-template"?: RuleNoConfig;
-  "preserve-caught-error"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreserveCaughtErrorOptions];
-  "promise/always-return"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AlwaysReturnConfig];
+  "preserve-caught-error"?: RuleNoConfig | [AllowWarnDeny, PreserveCaughtErrorOptions];
+  "promise/always-return"?: RuleNoConfig | [AllowWarnDeny, AlwaysReturnConfig];
   "promise/avoid-new"?: RuleNoConfig;
-  "promise/catch-or-return"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, CatchOrReturnConfig];
-  "promise/no-callback-in-promise"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoCallbackInPromiseConfig];
+  "promise/catch-or-return"?: RuleNoConfig | [AllowWarnDeny, CatchOrReturnConfig];
+  "promise/no-callback-in-promise"?: RuleNoConfig | [AllowWarnDeny, NoCallbackInPromiseConfig];
   "promise/no-multiple-resolved"?: RuleNoConfig;
   "promise/no-nesting"?: RuleNoConfig;
   "promise/no-new-statics"?: RuleNoConfig;
-  "promise/no-promise-in-callback"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoPromiseInCallbackConfig];
+  "promise/no-promise-in-callback"?: RuleNoConfig | [AllowWarnDeny, NoPromiseInCallbackConfig];
   "promise/no-return-in-finally"?: RuleNoConfig;
-  "promise/no-return-wrap"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoReturnWrap];
-  "promise/param-names"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ParamNamesConfig];
+  "promise/no-return-wrap"?: RuleNoConfig | [AllowWarnDeny, NoReturnWrap];
+  "promise/param-names"?: RuleNoConfig | [AllowWarnDeny, ParamNamesConfig];
   "promise/prefer-await-to-callbacks"?: RuleNoConfig;
-  "promise/prefer-await-to-then"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferAwaitToThenConfig];
+  "promise/prefer-await-to-then"?: RuleNoConfig | [AllowWarnDeny, PreferAwaitToThenConfig];
   "promise/prefer-catch"?: RuleNoConfig;
-  "promise/spec-only"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SpecOnlyConfig];
+  "promise/spec-only"?: RuleNoConfig | [AllowWarnDeny, SpecOnlyConfig];
   "promise/valid-params"?: RuleNoConfig;
-  radix?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RadixType];
-  "react-perf/jsx-no-jsx-as-prop"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ReactPerfConfig];
-  "react-perf/jsx-no-new-array-as-prop"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ReactPerfConfig];
-  "react-perf/jsx-no-new-function-as-prop"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ReactPerfConfig];
-  "react-perf/jsx-no-new-object-as-prop"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ReactPerfConfig];
-  "react/button-has-type"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ButtonHasType];
-  "react/checked-requires-onchange-or-readonly"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, CheckedRequiresOnchangeOrReadonly];
-  "react/display-name"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, DisplayNameConfig];
-  "react/exhaustive-deps"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ExhaustiveDepsConfig];
-  "react/forbid-component-props"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ForbidComponentPropsConfig];
-  "react/forbid-dom-props"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ForbidDomPropsConfig];
-  "react/forbid-elements"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ForbidElementsConfig];
+  radix?: RuleNoConfig | [AllowWarnDeny, RadixType];
+  "react-perf/jsx-no-jsx-as-prop"?: RuleNoConfig | [AllowWarnDeny, ReactPerfConfig];
+  "react-perf/jsx-no-new-array-as-prop"?: RuleNoConfig | [AllowWarnDeny, ReactPerfConfig];
+  "react-perf/jsx-no-new-function-as-prop"?: RuleNoConfig | [AllowWarnDeny, ReactPerfConfig];
+  "react-perf/jsx-no-new-object-as-prop"?: RuleNoConfig | [AllowWarnDeny, ReactPerfConfig];
+  "react/button-has-type"?: RuleNoConfig | [AllowWarnDeny, ButtonHasType];
+  "react/checked-requires-onchange-or-readonly"?: RuleNoConfig | [AllowWarnDeny, CheckedRequiresOnchangeOrReadonly];
+  "react/display-name"?: RuleNoConfig | [AllowWarnDeny, DisplayNameConfig];
+  "react/exhaustive-deps"?: RuleNoConfig | [AllowWarnDeny, ExhaustiveDepsConfig];
+  "react/forbid-component-props"?: RuleNoConfig | [AllowWarnDeny, ForbidComponentPropsConfig];
+  "react/forbid-dom-props"?: RuleNoConfig | [AllowWarnDeny, ForbidDomPropsConfig];
+  "react/forbid-elements"?: RuleNoConfig | [AllowWarnDeny, ForbidElementsConfig];
   "react/forward-ref-uses-ref"?: RuleNoConfig;
-  "react/hook-use-state"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, HookUseStateConfig];
+  "react/hook-use-state"?: RuleNoConfig | [AllowWarnDeny, HookUseStateConfig];
   "react/iframe-missing-sandbox"?: RuleNoConfig;
   "react/jsx-boolean-value"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
+    | RuleNoConfig
     | [AllowWarnDeny, EnforceBooleanAttribute]
     | [AllowWarnDeny, EnforceBooleanAttribute, JsxBooleanValueOptions];
-  "react/jsx-curly-brace-presence"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxCurlyBracePresenceConfig];
-  "react/jsx-filename-extension"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxFilenameExtensionConfig];
-  "react/jsx-fragments"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, FragmentMode];
-  "react/jsx-handler-names"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxHandlerNamesConfig];
-  "react/jsx-key"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxKeyConfig];
-  "react/jsx-max-depth"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxMaxDepthConfig];
+  "react/jsx-curly-brace-presence"?: RuleNoConfig | [AllowWarnDeny, JsxCurlyBracePresenceConfig];
+  "react/jsx-filename-extension"?: RuleNoConfig | [AllowWarnDeny, JsxFilenameExtensionConfig];
+  "react/jsx-fragments"?: RuleNoConfig | [AllowWarnDeny, FragmentMode];
+  "react/jsx-handler-names"?: RuleNoConfig | [AllowWarnDeny, JsxHandlerNamesConfig];
+  "react/jsx-key"?: RuleNoConfig | [AllowWarnDeny, JsxKeyConfig];
+  "react/jsx-max-depth"?: RuleNoConfig | [AllowWarnDeny, JsxMaxDepthConfig];
   "react/jsx-no-comment-textnodes"?: RuleNoConfig;
   "react/jsx-no-constructed-context-values"?: RuleNoConfig;
   "react/jsx-no-duplicate-props"?: RuleNoConfig;
-  "react/jsx-no-literals"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxNoLiteralsConfig];
+  "react/jsx-no-literals"?: RuleNoConfig | [AllowWarnDeny, JsxNoLiteralsConfig];
   "react/jsx-no-script-url"?: DummyRule;
-  "react/jsx-no-target-blank"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxNoTargetBlank];
+  "react/jsx-no-target-blank"?: RuleNoConfig | [AllowWarnDeny, JsxNoTargetBlank];
   "react/jsx-no-undef"?: RuleNoConfig;
-  "react/jsx-no-useless-fragment"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxNoUselessFragment];
-  "react/jsx-pascal-case"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxPascalCaseConfig];
+  "react/jsx-no-useless-fragment"?: RuleNoConfig | [AllowWarnDeny, JsxNoUselessFragment];
+  "react/jsx-pascal-case"?: RuleNoConfig | [AllowWarnDeny, JsxPascalCaseConfig];
   "react/jsx-props-no-spread-multi"?: RuleNoConfig;
-  "react/jsx-props-no-spreading"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, JsxPropsNoSpreadingConfig];
+  "react/jsx-props-no-spreading"?: RuleNoConfig | [AllowWarnDeny, JsxPropsNoSpreadingConfig];
   "react/no-array-index-key"?: RuleNoConfig;
   "react/no-children-prop"?: RuleNoConfig;
   "react/no-clone-element"?: RuleNoConfig;
   "react/no-danger"?: RuleNoConfig;
   "react/no-danger-with-children"?: RuleNoConfig;
-  "react/no-did-mount-set-state"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AllowedOrDisallowInFunc];
-  "react/no-did-update-set-state"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AllowedOrDisallowInFunc];
+  "react/no-did-mount-set-state"?: RuleNoConfig | [AllowWarnDeny, AllowedOrDisallowInFunc];
+  "react/no-did-update-set-state"?: RuleNoConfig | [AllowWarnDeny, AllowedOrDisallowInFunc];
   "react/no-direct-mutation-state"?: RuleNoConfig;
   "react/no-find-dom-node"?: RuleNoConfig;
   "react/no-is-mounted"?: RuleNoConfig;
-  "react/no-multi-comp"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoMultiCompConfig];
+  "react/no-multi-comp"?: RuleNoConfig | [AllowWarnDeny, NoMultiCompConfig];
   "react/no-namespace"?: RuleNoConfig;
   "react/no-object-type-as-default-prop"?: RuleNoConfig;
   "react/no-react-children"?: RuleNoConfig;
   "react/no-redundant-should-component-update"?: RuleNoConfig;
   "react/no-render-return-value"?: RuleNoConfig;
   "react/no-set-state"?: RuleNoConfig;
-  "react/no-string-refs"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoStringRefs];
+  "react/no-string-refs"?: RuleNoConfig | [AllowWarnDeny, NoStringRefs];
   "react/no-this-in-sfc"?: RuleNoConfig;
   "react/no-unescaped-entities"?: RuleNoConfig;
-  "react/no-unknown-property"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnknownPropertyConfig];
-  "react/no-unsafe"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnsafeConfig];
-  "react/no-unstable-nested-components"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, NoUnstableNestedComponentsConfig];
-  "react/no-will-update-set-state"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AllowedOrDisallowInFunc];
-  "react/only-export-components"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, OnlyExportComponentsConfig];
-  "react/prefer-es6-class"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AlwaysNever];
-  "react/prefer-function-component"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferFunctionComponent];
+  "react/no-unknown-property"?: RuleNoConfig | [AllowWarnDeny, NoUnknownPropertyConfig];
+  "react/no-unsafe"?: RuleNoConfig | [AllowWarnDeny, NoUnsafeConfig];
+  "react/no-unstable-nested-components"?: RuleNoConfig | [AllowWarnDeny, NoUnstableNestedComponentsConfig];
+  "react/no-will-update-set-state"?: RuleNoConfig | [AllowWarnDeny, AllowedOrDisallowInFunc];
+  "react/only-export-components"?: RuleNoConfig | [AllowWarnDeny, OnlyExportComponentsConfig];
+  "react/prefer-es6-class"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever];
+  "react/prefer-function-component"?: RuleNoConfig | [AllowWarnDeny, PreferFunctionComponent];
   "react/react-in-jsx-scope"?: RuleNoConfig;
   "react/require-render-return"?: RuleNoConfig;
   "react/rules-of-hooks"?: RuleNoConfig;
-  "react/self-closing-comp"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SelfClosingComp];
-  "react/state-in-constructor"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AlwaysNever];
-  "react/style-prop-object"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, StylePropObjectConfig];
+  "react/self-closing-comp"?: RuleNoConfig | [AllowWarnDeny, SelfClosingComp];
+  "react/state-in-constructor"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever];
+  "react/style-prop-object"?: RuleNoConfig | [AllowWarnDeny, StylePropObjectConfig];
   "react/void-dom-elements-no-children"?: RuleNoConfig;
   "require-await"?: RuleNoConfig;
-  "require-unicode-regexp"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RequireUnicodeRegexpConfig];
+  "require-unicode-regexp"?: RuleNoConfig | [AllowWarnDeny, RequireUnicodeRegexpConfig];
   "require-yield"?: RuleNoConfig;
-  "sort-imports"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SortImportsOptions];
-  "sort-keys"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, SortOrder]
-    | [AllowWarnDeny, SortOrder, SortKeysOptions];
-  "sort-vars"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SortVars];
+  "sort-imports"?: RuleNoConfig | [AllowWarnDeny, SortImportsOptions];
+  "sort-keys"?: RuleNoConfig | [AllowWarnDeny, SortOrder] | [AllowWarnDeny, SortOrder, SortKeysOptions];
+  "sort-vars"?: RuleNoConfig | [AllowWarnDeny, SortVars];
   "symbol-description"?: RuleNoConfig;
   "typescript/adjacent-overload-signatures"?: RuleNoConfig;
-  "typescript/array-type"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ArrayTypeConfig];
+  "typescript/array-type"?: RuleNoConfig | [AllowWarnDeny, ArrayTypeConfig];
   "typescript/await-thenable"?: RuleNoConfig;
-  "typescript/ban-ts-comment"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, BanTsCommentConfig];
+  "typescript/ban-ts-comment"?: RuleNoConfig | [AllowWarnDeny, BanTsCommentConfig];
   "typescript/ban-tslint-comment"?: RuleNoConfig;
   "typescript/ban-types"?: RuleNoConfig;
-  "typescript/class-literal-property-style"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, ClassLiteralPropertyStyleOption];
-  "typescript/consistent-generic-constructors"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferGenericType];
-  "typescript/consistent-indexed-object-style"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, ConsistentIndexedObjectStyleConfig];
-  "typescript/consistent-return"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentReturnConfig];
-  "typescript/consistent-type-assertions"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, ConsistentTypeAssertionsConfig];
-  "typescript/consistent-type-definitions"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, ConsistentTypeDefinitionsConfig];
-  "typescript/consistent-type-exports"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentTypeExportsConfig];
-  "typescript/consistent-type-imports"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentTypeImportsConfig];
-  "typescript/dot-notation"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, DotNotationConfig];
-  "typescript/explicit-function-return-type"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, ExplicitFunctionReturnTypeConfig];
-  "typescript/explicit-member-accessibility"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, ExplicitMemberAccessibilityConfig];
-  "typescript/explicit-module-boundary-types"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, ExplicitModuleBoundaryTypesConfig];
-  "typescript/method-signature-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MethodSignatureStyleConfig];
+  "typescript/class-literal-property-style"?: RuleNoConfig | [AllowWarnDeny, ClassLiteralPropertyStyleOption];
+  "typescript/consistent-generic-constructors"?: RuleNoConfig | [AllowWarnDeny, PreferGenericType];
+  "typescript/consistent-indexed-object-style"?: RuleNoConfig | [AllowWarnDeny, ConsistentIndexedObjectStyleConfig];
+  "typescript/consistent-return"?: RuleNoConfig | [AllowWarnDeny, ConsistentReturnConfig];
+  "typescript/consistent-type-assertions"?: RuleNoConfig | [AllowWarnDeny, ConsistentTypeAssertionsConfig];
+  "typescript/consistent-type-definitions"?: RuleNoConfig | [AllowWarnDeny, ConsistentTypeDefinitionsConfig];
+  "typescript/consistent-type-exports"?: RuleNoConfig | [AllowWarnDeny, ConsistentTypeExportsConfig];
+  "typescript/consistent-type-imports"?: RuleNoConfig | [AllowWarnDeny, ConsistentTypeImportsConfig];
+  "typescript/dot-notation"?: RuleNoConfig | [AllowWarnDeny, DotNotationConfig];
+  "typescript/explicit-function-return-type"?: RuleNoConfig | [AllowWarnDeny, ExplicitFunctionReturnTypeConfig];
+  "typescript/explicit-member-accessibility"?: RuleNoConfig | [AllowWarnDeny, ExplicitMemberAccessibilityConfig];
+  "typescript/explicit-module-boundary-types"?: RuleNoConfig | [AllowWarnDeny, ExplicitModuleBoundaryTypesConfig];
+  "typescript/method-signature-style"?: RuleNoConfig | [AllowWarnDeny, MethodSignatureStyleConfig];
   "typescript/no-array-delete"?: RuleNoConfig;
-  "typescript/no-base-to-string"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoBaseToStringConfig];
+  "typescript/no-base-to-string"?: RuleNoConfig | [AllowWarnDeny, NoBaseToStringConfig];
   "typescript/no-confusing-non-null-assertion"?: RuleNoConfig;
-  "typescript/no-confusing-void-expression"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, NoConfusingVoidExpressionConfig];
-  "typescript/no-deprecated"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoDeprecatedConfig];
+  "typescript/no-confusing-void-expression"?: RuleNoConfig | [AllowWarnDeny, NoConfusingVoidExpressionConfig];
+  "typescript/no-deprecated"?: RuleNoConfig | [AllowWarnDeny, NoDeprecatedConfig];
   "typescript/no-duplicate-enum-values"?: RuleNoConfig;
-  "typescript/no-duplicate-type-constituents"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, NoDuplicateTypeConstituentsConfig];
+  "typescript/no-duplicate-type-constituents"?: RuleNoConfig | [AllowWarnDeny, NoDuplicateTypeConstituentsConfig];
   "typescript/no-dynamic-delete"?: RuleNoConfig;
-  "typescript/no-empty-interface"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoEmptyInterface];
-  "typescript/no-empty-object-type"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoEmptyObjectTypeConfig];
-  "typescript/no-explicit-any"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoExplicitAny];
+  "typescript/no-empty-interface"?: RuleNoConfig | [AllowWarnDeny, NoEmptyInterface];
+  "typescript/no-empty-object-type"?: RuleNoConfig | [AllowWarnDeny, NoEmptyObjectTypeConfig];
+  "typescript/no-explicit-any"?: RuleNoConfig | [AllowWarnDeny, NoExplicitAny];
   "typescript/no-extra-non-null-assertion"?: RuleNoConfig;
-  "typescript/no-extraneous-class"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoExtraneousClass];
-  "typescript/no-floating-promises"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoFloatingPromisesConfig];
+  "typescript/no-extraneous-class"?: RuleNoConfig | [AllowWarnDeny, NoExtraneousClass];
+  "typescript/no-floating-promises"?: RuleNoConfig | [AllowWarnDeny, NoFloatingPromisesConfig];
   "typescript/no-for-in-array"?: RuleNoConfig;
   "typescript/no-implied-eval"?: RuleNoConfig;
   "typescript/no-import-type-side-effects"?: RuleNoConfig;
-  "typescript/no-inferrable-types"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoInferrableTypes];
-  "typescript/no-invalid-void-type"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoInvalidVoidTypeConfig];
-  "typescript/no-meaningless-void-operator"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, NoMeaninglessVoidOperatorConfig];
+  "typescript/no-inferrable-types"?: RuleNoConfig | [AllowWarnDeny, NoInferrableTypes];
+  "typescript/no-invalid-void-type"?: RuleNoConfig | [AllowWarnDeny, NoInvalidVoidTypeConfig];
+  "typescript/no-meaningless-void-operator"?: RuleNoConfig | [AllowWarnDeny, NoMeaninglessVoidOperatorConfig];
   "typescript/no-misused-new"?: RuleNoConfig;
-  "typescript/no-misused-promises"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoMisusedPromisesConfig];
-  "typescript/no-misused-spread"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoMisusedSpreadConfig];
+  "typescript/no-misused-promises"?: RuleNoConfig | [AllowWarnDeny, NoMisusedPromisesConfig];
+  "typescript/no-misused-spread"?: RuleNoConfig | [AllowWarnDeny, NoMisusedSpreadConfig];
   "typescript/no-mixed-enums"?: RuleNoConfig;
-  "typescript/no-namespace"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoNamespace];
+  "typescript/no-namespace"?: RuleNoConfig | [AllowWarnDeny, NoNamespace];
   "typescript/no-non-null-asserted-nullish-coalescing"?: RuleNoConfig;
   "typescript/no-non-null-asserted-optional-chain"?: RuleNoConfig;
   "typescript/no-non-null-assertion"?: RuleNoConfig;
   "typescript/no-redundant-type-constituents"?: RuleNoConfig;
-  "typescript/no-require-imports"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRequireImportsConfig];
-  "typescript/no-restricted-types"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRestrictedTypesConfig];
-  "typescript/no-this-alias"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoThisAliasConfig];
+  "typescript/no-require-imports"?: RuleNoConfig | [AllowWarnDeny, NoRequireImportsConfig];
+  "typescript/no-restricted-types"?: RuleNoConfig | [AllowWarnDeny, NoRestrictedTypesConfig];
+  "typescript/no-this-alias"?: RuleNoConfig | [AllowWarnDeny, NoThisAliasConfig];
   "typescript/no-unnecessary-boolean-literal-compare"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
+    | RuleNoConfig
     | [AllowWarnDeny, NoUnnecessaryBooleanLiteralCompareConfig];
-  "typescript/no-unnecessary-condition"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, NoUnnecessaryConditionConfig];
+  "typescript/no-unnecessary-condition"?: RuleNoConfig | [AllowWarnDeny, NoUnnecessaryConditionConfig];
   "typescript/no-unnecessary-parameter-property-assignment"?: RuleNoConfig;
   "typescript/no-unnecessary-qualifier"?: RuleNoConfig;
   "typescript/no-unnecessary-template-expression"?: RuleNoConfig;
   "typescript/no-unnecessary-type-arguments"?: RuleNoConfig;
-  "typescript/no-unnecessary-type-assertion"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, NoUnnecessaryTypeAssertionConfig];
+  "typescript/no-unnecessary-type-assertion"?: RuleNoConfig | [AllowWarnDeny, NoUnnecessaryTypeAssertionConfig];
   "typescript/no-unnecessary-type-constraint"?: RuleNoConfig;
   "typescript/no-unnecessary-type-conversion"?: RuleNoConfig;
   "typescript/no-unnecessary-type-parameters"?: RuleNoConfig;
@@ -1470,7 +1382,7 @@ export interface DummyRuleMap {
   "typescript/no-unsafe-declaration-merging"?: RuleNoConfig;
   "typescript/no-unsafe-enum-comparison"?: RuleNoConfig;
   "typescript/no-unsafe-function-type"?: RuleNoConfig;
-  "typescript/no-unsafe-member-access"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUnsafeMemberAccessConfig];
+  "typescript/no-unsafe-member-access"?: RuleNoConfig | [AllowWarnDeny, NoUnsafeMemberAccessConfig];
   "typescript/no-unsafe-return"?: RuleNoConfig;
   "typescript/no-unsafe-type-assertion"?: RuleNoConfig;
   "typescript/no-unsafe-unary-minus"?: RuleNoConfig;
@@ -1479,79 +1391,55 @@ export interface DummyRuleMap {
   "typescript/no-var-requires"?: RuleNoConfig;
   "typescript/no-wrapper-object-types"?: RuleNoConfig;
   "typescript/non-nullable-type-assertion-style"?: RuleNoConfig;
-  "typescript/only-throw-error"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, OnlyThrowErrorConfig];
-  "typescript/parameter-properties"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ParameterPropertiesConfig];
+  "typescript/only-throw-error"?: RuleNoConfig | [AllowWarnDeny, OnlyThrowErrorConfig];
+  "typescript/parameter-properties"?: RuleNoConfig | [AllowWarnDeny, ParameterPropertiesConfig];
   "typescript/prefer-as-const"?: RuleNoConfig;
   "typescript/prefer-enum-initializers"?: RuleNoConfig;
   "typescript/prefer-find"?: RuleNoConfig;
   "typescript/prefer-for-of"?: RuleNoConfig;
   "typescript/prefer-function-type"?: RuleNoConfig;
   "typescript/prefer-includes"?: RuleNoConfig;
-  "typescript/prefer-literal-enum-member"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferLiteralEnumMember];
+  "typescript/prefer-literal-enum-member"?: RuleNoConfig | [AllowWarnDeny, PreferLiteralEnumMember];
   "typescript/prefer-namespace-keyword"?: RuleNoConfig;
-  "typescript/prefer-nullish-coalescing"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, PreferNullishCoalescingConfig];
-  "typescript/prefer-optional-chain"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferOptionalChainConfig];
-  "typescript/prefer-promise-reject-errors"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, PreferPromiseRejectErrorsConfig];
-  "typescript/prefer-readonly"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferReadonlyConfig];
-  "typescript/prefer-readonly-parameter-types"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, PreferReadonlyParameterTypesConfig];
+  "typescript/prefer-nullish-coalescing"?: RuleNoConfig | [AllowWarnDeny, PreferNullishCoalescingConfig];
+  "typescript/prefer-optional-chain"?: RuleNoConfig | [AllowWarnDeny, PreferOptionalChainConfig];
+  "typescript/prefer-promise-reject-errors"?: RuleNoConfig | [AllowWarnDeny, PreferPromiseRejectErrorsConfig];
+  "typescript/prefer-readonly"?: RuleNoConfig | [AllowWarnDeny, PreferReadonlyConfig];
+  "typescript/prefer-readonly-parameter-types"?: RuleNoConfig | [AllowWarnDeny, PreferReadonlyParameterTypesConfig];
   "typescript/prefer-reduce-type-parameter"?: RuleNoConfig;
   "typescript/prefer-regexp-exec"?: RuleNoConfig;
   "typescript/prefer-return-this-type"?: RuleNoConfig;
-  "typescript/prefer-string-starts-ends-with"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, PreferStringStartsEndsWithConfig];
+  "typescript/prefer-string-starts-ends-with"?: RuleNoConfig | [AllowWarnDeny, PreferStringStartsEndsWithConfig];
   "typescript/prefer-ts-expect-error"?: RuleNoConfig;
-  "typescript/promise-function-async"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PromiseFunctionAsyncConfig];
+  "typescript/promise-function-async"?: RuleNoConfig | [AllowWarnDeny, PromiseFunctionAsyncConfig];
   "typescript/related-getter-setter-pairs"?: RuleNoConfig;
-  "typescript/require-array-sort-compare"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, RequireArraySortCompareConfig];
+  "typescript/require-array-sort-compare"?: RuleNoConfig | [AllowWarnDeny, RequireArraySortCompareConfig];
   "typescript/require-await"?: RuleNoConfig;
-  "typescript/restrict-plus-operands"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RestrictPlusOperandsConfig];
-  "typescript/restrict-template-expressions"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, RestrictTemplateExpressionsConfig];
-  "typescript/return-await"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ReturnAwaitOption];
-  "typescript/strict-boolean-expressions"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, StrictBooleanExpressionsConfig];
-  "typescript/strict-void-return"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, StrictVoidReturnConfig];
-  "typescript/switch-exhaustiveness-check"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, SwitchExhaustivenessCheckConfig];
-  "typescript/triple-slash-reference"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, TripleSlashReferenceConfig];
-  "typescript/unbound-method"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, UnboundMethodConfig];
-  "typescript/unified-signatures"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, UnifiedSignaturesOptions];
+  "typescript/restrict-plus-operands"?: RuleNoConfig | [AllowWarnDeny, RestrictPlusOperandsConfig];
+  "typescript/restrict-template-expressions"?: RuleNoConfig | [AllowWarnDeny, RestrictTemplateExpressionsConfig];
+  "typescript/return-await"?: RuleNoConfig | [AllowWarnDeny, ReturnAwaitOption];
+  "typescript/strict-boolean-expressions"?: RuleNoConfig | [AllowWarnDeny, StrictBooleanExpressionsConfig];
+  "typescript/strict-void-return"?: RuleNoConfig | [AllowWarnDeny, StrictVoidReturnConfig];
+  "typescript/switch-exhaustiveness-check"?: RuleNoConfig | [AllowWarnDeny, SwitchExhaustivenessCheckConfig];
+  "typescript/triple-slash-reference"?: RuleNoConfig | [AllowWarnDeny, TripleSlashReferenceConfig];
+  "typescript/unbound-method"?: RuleNoConfig | [AllowWarnDeny, UnboundMethodConfig];
+  "typescript/unified-signatures"?: RuleNoConfig | [AllowWarnDeny, UnifiedSignaturesOptions];
   "typescript/use-unknown-in-catch-callback-variable"?: RuleNoConfig;
-  "unicode-bom"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, BomOptionType];
-  "unicorn/catch-error-name"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, CatchErrorNameConfig];
+  "unicode-bom"?: RuleNoConfig | [AllowWarnDeny, BomOptionType];
+  "unicorn/catch-error-name"?: RuleNoConfig | [AllowWarnDeny, CatchErrorNameConfig];
   "unicorn/consistent-assert"?: RuleNoConfig;
   "unicorn/consistent-date-clone"?: RuleNoConfig;
   "unicorn/consistent-empty-array-spread"?: RuleNoConfig;
   "unicorn/consistent-existence-index-check"?: RuleNoConfig;
-  "unicorn/consistent-function-scoping"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentFunctionScoping];
+  "unicorn/consistent-function-scoping"?: RuleNoConfig | [AllowWarnDeny, ConsistentFunctionScoping];
   "unicorn/consistent-template-literal-escape"?: RuleNoConfig;
   "unicorn/custom-error-definition"?: RuleNoConfig;
   "unicorn/empty-brace-spaces"?: RuleNoConfig;
   "unicorn/error-message"?: RuleNoConfig;
   "unicorn/escape-case"?: RuleNoConfig;
-  "unicorn/explicit-length-check"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ExplicitLengthCheck];
+  "unicorn/explicit-length-check"?: RuleNoConfig | [AllowWarnDeny, ExplicitLengthCheck];
   "unicorn/filename-case"?: DummyRule;
-  "unicorn/import-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ImportStyleConfig];
+  "unicorn/import-style"?: RuleNoConfig | [AllowWarnDeny, ImportStyleConfig];
   "unicorn/new-for-builtins"?: RuleNoConfig;
   "unicorn/no-abusive-eslint-disable"?: RuleNoConfig;
   "unicorn/no-accessor-recursion"?: RuleNoConfig;
@@ -1560,9 +1448,9 @@ export interface DummyRuleMap {
   "unicorn/no-array-fill-with-reference-type"?: RuleNoConfig;
   "unicorn/no-array-for-each"?: RuleNoConfig;
   "unicorn/no-array-method-this-argument"?: RuleNoConfig;
-  "unicorn/no-array-reduce"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoArrayReduce];
-  "unicorn/no-array-reverse"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoArrayReverse];
-  "unicorn/no-array-sort"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoArraySort];
+  "unicorn/no-array-reduce"?: RuleNoConfig | [AllowWarnDeny, NoArrayReduce];
+  "unicorn/no-array-reverse"?: RuleNoConfig | [AllowWarnDeny, NoArrayReverse];
+  "unicorn/no-array-sort"?: RuleNoConfig | [AllowWarnDeny, NoArraySort];
   "unicorn/no-await-expression-member"?: RuleNoConfig;
   "unicorn/no-await-in-promise-methods"?: RuleNoConfig;
   "unicorn/no-console-spaces"?: RuleNoConfig;
@@ -1571,7 +1459,7 @@ export interface DummyRuleMap {
   "unicorn/no-hex-escape"?: RuleNoConfig;
   "unicorn/no-immediate-mutation"?: RuleNoConfig;
   "unicorn/no-instanceof-array"?: RuleNoConfig;
-  "unicorn/no-instanceof-builtins"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoInstanceofBuiltinsConfig];
+  "unicorn/no-instanceof-builtins"?: RuleNoConfig | [AllowWarnDeny, NoInstanceofBuiltinsConfig];
   "unicorn/no-invalid-fetch-options"?: RuleNoConfig;
   "unicorn/no-invalid-remove-event-listener"?: RuleNoConfig;
   "unicorn/no-length-as-slice-end"?: RuleNoConfig;
@@ -1582,14 +1470,14 @@ export interface DummyRuleMap {
   "unicorn/no-nested-ternary"?: RuleNoConfig;
   "unicorn/no-new-array"?: RuleNoConfig;
   "unicorn/no-new-buffer"?: RuleNoConfig;
-  "unicorn/no-null"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoNull];
+  "unicorn/no-null"?: RuleNoConfig | [AllowWarnDeny, NoNull];
   "unicorn/no-object-as-default-parameter"?: RuleNoConfig;
   "unicorn/no-process-exit"?: RuleNoConfig;
   "unicorn/no-single-promise-in-promise-methods"?: RuleNoConfig;
   "unicorn/no-static-only-class"?: RuleNoConfig;
   "unicorn/no-thenable"?: RuleNoConfig;
   "unicorn/no-this-assignment"?: RuleNoConfig;
-  "unicorn/no-typeof-undefined"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoTypeofUndefined];
+  "unicorn/no-typeof-undefined"?: RuleNoConfig | [AllowWarnDeny, NoTypeofUndefined];
   "unicorn/no-unnecessary-array-flat-depth"?: RuleNoConfig;
   "unicorn/no-unnecessary-array-splice-count"?: RuleNoConfig;
   "unicorn/no-unnecessary-await"?: RuleNoConfig;
@@ -1601,13 +1489,10 @@ export interface DummyRuleMap {
   "unicorn/no-useless-fallback-in-spread"?: RuleNoConfig;
   "unicorn/no-useless-iterator-to-array"?: RuleNoConfig;
   "unicorn/no-useless-length-check"?: RuleNoConfig;
-  "unicorn/no-useless-promise-resolve-reject"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, NoUselessPromiseResolveRejectOptions];
+  "unicorn/no-useless-promise-resolve-reject"?: RuleNoConfig | [AllowWarnDeny, NoUselessPromiseResolveRejectOptions];
   "unicorn/no-useless-spread"?: RuleNoConfig;
   "unicorn/no-useless-switch-case"?: RuleNoConfig;
-  "unicorn/no-useless-undefined"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoUselessUndefined];
+  "unicorn/no-useless-undefined"?: RuleNoConfig | [AllowWarnDeny, NoUselessUndefined];
   "unicorn/no-zero-fractions"?: RuleNoConfig;
   "unicorn/number-literal-case"?: RuleNoConfig;
   "unicorn/numeric-separators-style"?: DummyRule;
@@ -1617,7 +1502,7 @@ export interface DummyRuleMap {
   "unicorn/prefer-array-flat-map"?: RuleNoConfig;
   "unicorn/prefer-array-index-of"?: RuleNoConfig;
   "unicorn/prefer-array-some"?: RuleNoConfig;
-  "unicorn/prefer-at"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferAtConfig];
+  "unicorn/prefer-at"?: RuleNoConfig | [AllowWarnDeny, PreferAtConfig];
   "unicorn/prefer-bigint-literals"?: RuleNoConfig;
   "unicorn/prefer-blob-reading-methods"?: RuleNoConfig;
   "unicorn/prefer-class-fields"?: RuleNoConfig;
@@ -1630,7 +1515,7 @@ export interface DummyRuleMap {
   "unicorn/prefer-dom-node-remove"?: RuleNoConfig;
   "unicorn/prefer-dom-node-text-content"?: RuleNoConfig;
   "unicorn/prefer-event-target"?: RuleNoConfig;
-  "unicorn/prefer-export-from"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferExportFrom];
+  "unicorn/prefer-export-from"?: RuleNoConfig | [AllowWarnDeny, PreferExportFrom];
   "unicorn/prefer-global-this"?: RuleNoConfig;
   "unicorn/prefer-import-meta-properties"?: RuleNoConfig;
   "unicorn/prefer-includes"?: RuleNoConfig;
@@ -1644,11 +1529,8 @@ export interface DummyRuleMap {
   "unicorn/prefer-native-coercion-functions"?: RuleNoConfig;
   "unicorn/prefer-negative-index"?: RuleNoConfig;
   "unicorn/prefer-node-protocol"?: RuleNoConfig;
-  "unicorn/prefer-number-properties"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferNumberPropertiesConfig];
-  "unicorn/prefer-object-from-entries"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, PreferObjectFromEntriesConfig];
+  "unicorn/prefer-number-properties"?: RuleNoConfig | [AllowWarnDeny, PreferNumberPropertiesConfig];
+  "unicorn/prefer-object-from-entries"?: RuleNoConfig | [AllowWarnDeny, PreferObjectFromEntriesConfig];
   "unicorn/prefer-optional-catch-binding"?: RuleNoConfig;
   "unicorn/prefer-prototype-methods"?: RuleNoConfig;
   "unicorn/prefer-query-selector"?: RuleNoConfig;
@@ -1657,41 +1539,38 @@ export interface DummyRuleMap {
   "unicorn/prefer-response-static-json"?: RuleNoConfig;
   "unicorn/prefer-set-has"?: RuleNoConfig;
   "unicorn/prefer-set-size"?: RuleNoConfig;
-  "unicorn/prefer-single-call"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferSingleCallConfig];
+  "unicorn/prefer-single-call"?: RuleNoConfig | [AllowWarnDeny, PreferSingleCallConfig];
   "unicorn/prefer-spread"?: RuleNoConfig;
   "unicorn/prefer-string-raw"?: RuleNoConfig;
   "unicorn/prefer-string-replace-all"?: RuleNoConfig;
   "unicorn/prefer-string-slice"?: RuleNoConfig;
   "unicorn/prefer-string-starts-ends-with"?: RuleNoConfig;
   "unicorn/prefer-string-trim-start-end"?: RuleNoConfig;
-  "unicorn/prefer-structured-clone"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferStructuredCloneConfig];
-  "unicorn/prefer-ternary"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferTernaryOption];
+  "unicorn/prefer-structured-clone"?: RuleNoConfig | [AllowWarnDeny, PreferStructuredCloneConfig];
+  "unicorn/prefer-ternary"?: RuleNoConfig | [AllowWarnDeny, PreferTernaryOption];
   "unicorn/prefer-top-level-await"?: RuleNoConfig;
   "unicorn/prefer-type-error"?: RuleNoConfig;
-  "unicorn/relative-url-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RelativeUrlStyleConfig];
+  "unicorn/relative-url-style"?: RuleNoConfig | [AllowWarnDeny, RelativeUrlStyleConfig];
   "unicorn/require-array-join-separator"?: RuleNoConfig;
   "unicorn/require-module-attributes"?: RuleNoConfig;
   "unicorn/require-module-specifiers"?: RuleNoConfig;
   "unicorn/require-number-to-fixed-digits-argument"?: RuleNoConfig;
   "unicorn/require-post-message-target-origin"?: RuleNoConfig;
-  "unicorn/switch-case-braces"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SwitchCaseBracesConfig];
+  "unicorn/switch-case-braces"?: RuleNoConfig | [AllowWarnDeny, SwitchCaseBracesConfig];
   "unicorn/switch-case-break-position"?: RuleNoConfig;
-  "unicorn/text-encoding-identifier-case"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, TextEncodingIdentifierCase];
+  "unicorn/text-encoding-identifier-case"?: RuleNoConfig | [AllowWarnDeny, TextEncodingIdentifierCase];
   "unicorn/throw-new-error"?: RuleNoConfig;
-  "use-isnan"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, UseIsnan];
-  "valid-typeof"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ValidTypeof];
+  "use-isnan"?: RuleNoConfig | [AllowWarnDeny, UseIsnan];
+  "valid-typeof"?: RuleNoConfig | [AllowWarnDeny, ValidTypeof];
   "vars-on-top"?: RuleNoConfig;
-  "vitest/consistent-each-for"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentEachForJson];
-  "vitest/consistent-test-filename"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentTestFilenameConfig];
-  "vitest/consistent-test-it"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentTestItConfig];
-  "vitest/consistent-vitest-vi"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ConsistentVitestConfig];
-  "vitest/expect-expect"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ExpectExpectConfig];
+  "vitest/consistent-each-for"?: RuleNoConfig | [AllowWarnDeny, ConsistentEachForJson];
+  "vitest/consistent-test-filename"?: RuleNoConfig | [AllowWarnDeny, ConsistentTestFilenameConfig];
+  "vitest/consistent-test-it"?: RuleNoConfig | [AllowWarnDeny, ConsistentTestItConfig];
+  "vitest/consistent-vitest-vi"?: RuleNoConfig | [AllowWarnDeny, ConsistentVitestConfig];
+  "vitest/expect-expect"?: RuleNoConfig | [AllowWarnDeny, ExpectExpectConfig];
   "vitest/hoisted-apis-on-top"?: RuleNoConfig;
-  "vitest/max-expects"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MaxExpectsConfig];
-  "vitest/max-nested-describe"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MaxNestedDescribeConfig];
+  "vitest/max-expects"?: RuleNoConfig | [AllowWarnDeny, MaxExpectsConfig];
+  "vitest/max-nested-describe"?: RuleNoConfig | [AllowWarnDeny, MaxNestedDescribeConfig];
   "vitest/no-alias-methods"?: RuleNoConfig;
   "vitest/no-commented-out-tests"?: RuleNoConfig;
   "vitest/no-conditional-expect"?: RuleNoConfig;
@@ -1700,16 +1579,16 @@ export interface DummyRuleMap {
   "vitest/no-disabled-tests"?: RuleNoConfig;
   "vitest/no-duplicate-hooks"?: RuleNoConfig;
   "vitest/no-focused-tests"?: RuleNoConfig;
-  "vitest/no-hooks"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoHooksConfig];
+  "vitest/no-hooks"?: RuleNoConfig | [AllowWarnDeny, NoHooksConfig];
   "vitest/no-identical-title"?: RuleNoConfig;
   "vitest/no-import-node-test"?: RuleNoConfig;
   "vitest/no-importing-vitest-globals"?: RuleNoConfig;
   "vitest/no-interpolation-in-snapshots"?: RuleNoConfig;
-  "vitest/no-large-snapshots"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoLargeSnapshotsConfig];
+  "vitest/no-large-snapshots"?: RuleNoConfig | [AllowWarnDeny, NoLargeSnapshotsConfig];
   "vitest/no-mocks-import"?: RuleNoConfig;
-  "vitest/no-restricted-matchers"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRestrictedMatchersConfig];
-  "vitest/no-restricted-vi-methods"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoRestrictedTestMethodsConfig];
-  "vitest/no-standalone-expect"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoStandaloneExpectConfig];
+  "vitest/no-restricted-matchers"?: RuleNoConfig | [AllowWarnDeny, NoRestrictedMatchersConfig];
+  "vitest/no-restricted-vi-methods"?: RuleNoConfig | [AllowWarnDeny, NoRestrictedTestMethodsConfig];
+  "vitest/no-standalone-expect"?: RuleNoConfig | [AllowWarnDeny, NoStandaloneExpectConfig];
   "vitest/no-test-prefixes"?: RuleNoConfig;
   "vitest/no-test-return-statement"?: RuleNoConfig;
   "vitest/no-unneeded-async-expect-function"?: RuleNoConfig;
@@ -1722,17 +1601,17 @@ export interface DummyRuleMap {
   "vitest/prefer-describe-function-title"?: RuleNoConfig;
   "vitest/prefer-each"?: RuleNoConfig;
   "vitest/prefer-equality-matcher"?: RuleNoConfig;
-  "vitest/prefer-expect-assertions"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferExpectAssertionsConfig];
+  "vitest/prefer-expect-assertions"?: RuleNoConfig | [AllowWarnDeny, PreferExpectAssertionsConfig];
   "vitest/prefer-expect-resolves"?: RuleNoConfig;
   "vitest/prefer-expect-type-of"?: RuleNoConfig;
   "vitest/prefer-hooks-in-order"?: RuleNoConfig;
   "vitest/prefer-hooks-on-top"?: RuleNoConfig;
-  "vitest/prefer-import-in-mock"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, PreferImportInMockConfig];
+  "vitest/prefer-import-in-mock"?: RuleNoConfig | [AllowWarnDeny, PreferImportInMockConfig];
   "vitest/prefer-importing-vitest-globals"?: RuleNoConfig;
   "vitest/prefer-lowercase-title"?: DummyRule;
   "vitest/prefer-mock-promise-shorthand"?: RuleNoConfig;
   "vitest/prefer-mock-return-shorthand"?: RuleNoConfig;
-  "vitest/prefer-snapshot-hint"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, SnapshotHintMode];
+  "vitest/prefer-snapshot-hint"?: RuleNoConfig | [AllowWarnDeny, SnapshotHintMode];
   "vitest/prefer-spy-on"?: RuleNoConfig;
   "vitest/prefer-strict-boolean-matchers"?: RuleNoConfig;
   "vitest/prefer-strict-equal"?: RuleNoConfig;
@@ -1745,39 +1624,30 @@ export interface DummyRuleMap {
   "vitest/prefer-to-have-length"?: RuleNoConfig;
   "vitest/prefer-todo"?: RuleNoConfig;
   "vitest/require-awaited-expect-poll"?: RuleNoConfig;
-  "vitest/require-hook"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RequireHookConfig];
+  "vitest/require-hook"?: RuleNoConfig | [AllowWarnDeny, RequireHookConfig];
   "vitest/require-local-test-context-for-concurrent-snapshots"?: RuleNoConfig;
-  "vitest/require-mock-type-parameters"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, RequireMockTypeParametersConfig];
+  "vitest/require-mock-type-parameters"?: RuleNoConfig | [AllowWarnDeny, RequireMockTypeParametersConfig];
   "vitest/require-test-timeout"?: RuleNoConfig;
   "vitest/require-to-throw-message"?: RuleNoConfig;
-  "vitest/require-top-level-describe"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, RequireTopLevelDescribeConfig];
+  "vitest/require-top-level-describe"?: RuleNoConfig | [AllowWarnDeny, RequireTopLevelDescribeConfig];
   "vitest/valid-describe-callback"?: RuleNoConfig;
-  "vitest/valid-expect"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ValidExpectConfig];
+  "vitest/valid-expect"?: RuleNoConfig | [AllowWarnDeny, ValidExpectConfig];
   "vitest/valid-expect-in-promise"?: RuleNoConfig;
   "vitest/valid-title"?: DummyRule;
   "vitest/warn-todo"?: RuleNoConfig;
-  "vue/component-definition-name-casing"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, CaseType];
-  "vue/define-emits-declaration"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, DeclarationStyle];
-  "vue/define-props-declaration"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, DeclarationStyle2];
-  "vue/define-props-destructuring"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, DefinePropsDestructuring];
-  "vue/max-props"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, MaxProps];
-  "vue/next-tick-style"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NextTickOption];
+  "vue/component-definition-name-casing"?: RuleNoConfig | [AllowWarnDeny, CaseType];
+  "vue/define-emits-declaration"?: RuleNoConfig | [AllowWarnDeny, DeclarationStyle];
+  "vue/define-props-declaration"?: RuleNoConfig | [AllowWarnDeny, DeclarationStyle2];
+  "vue/define-props-destructuring"?: RuleNoConfig | [AllowWarnDeny, DefinePropsDestructuring];
+  "vue/max-props"?: RuleNoConfig | [AllowWarnDeny, MaxProps];
+  "vue/next-tick-style"?: RuleNoConfig | [AllowWarnDeny, NextTickOption];
   "vue/no-arrow-functions-in-watch"?: RuleNoConfig;
   "vue/no-computed-properties-in-data"?: RuleNoConfig;
   "vue/no-deprecated-data-object-declaration"?: RuleNoConfig;
   "vue/no-deprecated-delete-set"?: RuleNoConfig;
   "vue/no-deprecated-destroyed-lifecycle"?: RuleNoConfig;
   "vue/no-deprecated-events-api"?: RuleNoConfig;
-  "vue/no-deprecated-model-definition"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, NoDeprecatedModelDefinitionConfig];
+  "vue/no-deprecated-model-definition"?: RuleNoConfig | [AllowWarnDeny, NoDeprecatedModelDefinitionConfig];
   "vue/no-deprecated-props-default-this"?: RuleNoConfig;
   "vue/no-deprecated-vue-config-keycodes"?: RuleNoConfig;
   "vue/no-export-in-script-setup"?: RuleNoConfig;
@@ -1786,34 +1656,30 @@ export interface DummyRuleMap {
   "vue/no-lifecycle-after-await"?: RuleNoConfig;
   "vue/no-multiple-slot-args"?: RuleNoConfig;
   "vue/no-required-prop-with-default"?: RuleNoConfig;
-  "vue/no-reserved-component-names"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoReservedComponentNames];
-  "vue/no-reserved-keys"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoReservedKeysConfig];
-  "vue/no-reserved-props"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, NoReservedPropsConfig];
+  "vue/no-reserved-component-names"?: RuleNoConfig | [AllowWarnDeny, NoReservedComponentNames];
+  "vue/no-reserved-keys"?: RuleNoConfig | [AllowWarnDeny, NoReservedKeysConfig];
+  "vue/no-reserved-props"?: RuleNoConfig | [AllowWarnDeny, NoReservedPropsConfig];
   "vue/no-shared-component-data"?: RuleNoConfig;
   "vue/no-side-effects-in-computed-properties"?: RuleNoConfig;
   "vue/no-this-in-before-route-enter"?: RuleNoConfig;
   "vue/no-watch-after-await"?: RuleNoConfig;
   "vue/prefer-import-from-vue"?: RuleNoConfig;
-  "vue/prop-name-casing"?:
-    | AllowWarnDeny
-    | [AllowWarnDeny]
-    | [AllowWarnDeny, CaseType2]
-    | [AllowWarnDeny, CaseType2, Options];
+  "vue/prop-name-casing"?: RuleNoConfig | [AllowWarnDeny, CaseType2] | [AllowWarnDeny, CaseType2, Options];
   "vue/require-default-export"?: RuleNoConfig;
   "vue/require-default-prop"?: RuleNoConfig;
-  "vue/require-direct-export"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, RequireDirectExport];
+  "vue/require-direct-export"?: RuleNoConfig | [AllowWarnDeny, RequireDirectExport];
   "vue/require-prop-type-constructor"?: RuleNoConfig;
   "vue/require-prop-types"?: RuleNoConfig;
   "vue/require-render-return"?: RuleNoConfig;
   "vue/require-slots-as-functions"?: RuleNoConfig;
   "vue/require-typed-ref"?: RuleNoConfig;
-  "vue/return-in-computed-property"?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, ReturnInComputedPropertyConfig];
+  "vue/return-in-computed-property"?: RuleNoConfig | [AllowWarnDeny, ReturnInComputedPropertyConfig];
   "vue/return-in-emits-validator"?: RuleNoConfig;
   "vue/valid-define-emits"?: RuleNoConfig;
   "vue/valid-define-options"?: RuleNoConfig;
   "vue/valid-define-props"?: RuleNoConfig;
   "vue/valid-next-tick"?: RuleNoConfig;
-  yoda?: AllowWarnDeny | [AllowWarnDeny] | [AllowWarnDeny, AllowYoda] | [AllowWarnDeny, AllowYoda, YodaOptions];
+  yoda?: RuleNoConfig | [AllowWarnDeny, AllowYoda] | [AllowWarnDeny, AllowYoda, YodaOptions];
   [k: string]: DummyRule | undefined;
 }
 export interface AccessorPairsConfig {

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -380,14 +380,14 @@ impl JsonSchema for OxlintRules {
                 #[expect(clippy::cast_possible_truncation)]
                 #[cfg(feature = "ruledocs")]
                 fn rule_config_schema(r: &RuleEnum, r#gen: &mut SchemaGenerator) -> Schema {
-                    fn with_toggle_schema(
+                    fn with_default_rule_schema(
                         config_schema: Schema,
                         r#gen: &mut SchemaGenerator,
                     ) -> Schema {
                         SchemaObject {
                             subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
                                 any_of: Some(vec![
-                                    r#gen.subschema_for::<AllowWarnDeny>(),
+                                    r#gen.subschema_for::<RuleNoConfig>(),
                                     config_schema,
                                 ]),
                                 ..Default::default()
@@ -411,14 +411,14 @@ impl JsonSchema for OxlintRules {
                                     r#gen.subschema_for::<AllowWarnDeny>(),
                                     Schema::Bool(true),
                                 ])),
-                                min_items: Some(1),
+                                min_items: Some(2),
                                 max_items: Some(2),
                                 ..Default::default()
                             })),
                             ..Default::default()
                         }
                         .into();
-                        return with_toggle_schema(array_schema, r#gen);
+                        return with_default_rule_schema(array_schema, r#gen);
                     };
 
                     debug_assert!(
@@ -440,14 +440,14 @@ impl JsonSchema for OxlintRules {
                                         ..Default::default()
                                     }),
                                 ])),
-                                min_items: Some(1),
+                                min_items: Some(2),
                                 max_items: Some(2),
                                 ..Default::default()
                             })),
                             ..Default::default()
                         }
                         .into();
-                        return with_toggle_schema(array_schema, r#gen);
+                        return with_default_rule_schema(array_schema, r#gen);
                     }
 
                     if let Some(array) = obj.array {
@@ -470,14 +470,14 @@ impl JsonSchema for OxlintRules {
                             instance_type: Some(InstanceType::Array.into()),
                             array: Some(Box::new(ArrayValidation {
                                 items: Some(SingleOrVec::Vec(items)),
-                                min_items: Some(1),
+                                min_items: Some(2),
                                 max_items: Some(config_length),
                                 ..Default::default()
                             })),
                             ..Default::default()
                         }
                         .into();
-                        return with_toggle_schema(array_schema, r#gen);
+                        return with_default_rule_schema(array_schema, r#gen);
                     }
 
                     let array_schema = Schema::Object(SchemaObject {
@@ -487,14 +487,14 @@ impl JsonSchema for OxlintRules {
                                 r#gen.subschema_for::<AllowWarnDeny>(),
                                 Schema::Object(obj),
                             ])),
-                            min_items: Some(1),
+                            min_items: Some(2),
                             max_items: Some(2),
                             ..Default::default()
                         })),
                         ..Default::default()
                     });
 
-                    with_toggle_schema(array_schema, r#gen)
+                    with_default_rule_schema(array_schema, r#gen)
                 }
 
                 let dummy_schema = r#gen.subschema_for::<DummyRule>();

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -2123,7 +2123,7 @@
         "accessor-pairs": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2136,14 +2136,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "array-callback-return": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2156,14 +2156,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "arrow-body-style": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2179,7 +2179,7 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2189,7 +2189,7 @@
         "capitalized-comments": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2205,14 +2205,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "class-methods-use-this": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2225,14 +2225,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "complexity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2252,7 +2252,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2262,7 +2262,7 @@
         "curly": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2278,14 +2278,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "default-case": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2298,7 +2298,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2311,7 +2311,7 @@
         "eqeqeq": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2327,7 +2327,7 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2340,7 +2340,7 @@
         "func-names": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2356,14 +2356,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "func-style": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2379,14 +2379,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "getter-return": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2399,14 +2399,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "grouped-accessor-pairs": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2422,7 +2422,7 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2432,7 +2432,7 @@
         "id-length": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2445,14 +2445,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "id-match": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2468,14 +2468,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "import/consistent-type-specifier-style": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2488,7 +2488,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2507,7 +2507,7 @@
         "import/first": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2520,7 +2520,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2530,7 +2530,7 @@
         "import/max-dependencies": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2543,7 +2543,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2553,7 +2553,7 @@
         "import/namespace": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2566,14 +2566,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "import/newline-after-import": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2586,14 +2586,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "import/no-absolute-path": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2606,7 +2606,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2616,7 +2616,7 @@
         "import/no-anonymous-default-export": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2629,14 +2629,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "import/no-commonjs": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2649,14 +2649,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "import/no-cycle": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2669,7 +2669,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2679,7 +2679,7 @@
         "import/no-duplicates": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2692,14 +2692,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "import/no-dynamic-require": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2712,7 +2712,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2737,7 +2737,7 @@
         "import/no-namespace": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2750,14 +2750,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "import/no-nodejs-modules": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2770,7 +2770,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2783,7 +2783,7 @@
         "import/no-unassigned-import": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2796,7 +2796,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2806,7 +2806,7 @@
         "import/prefer-default-export": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2819,7 +2819,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2829,7 +2829,7 @@
         "init-declarations": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2845,14 +2845,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jest/consistent-test-it": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2865,14 +2865,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jest/expect-expect": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2885,14 +2885,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jest/max-expects": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2905,14 +2905,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jest/max-nested-describe": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2925,7 +2925,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2947,7 +2947,7 @@
         "jest/no-deprecated-functions": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2960,7 +2960,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -2982,7 +2982,7 @@
         "jest/no-hooks": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -2995,7 +2995,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3011,7 +3011,7 @@
         "jest/no-large-snapshots": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3024,7 +3024,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3034,7 +3034,7 @@
         "jest/no-restricted-jest-methods": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3047,14 +3047,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jest/no-restricted-matchers": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3067,14 +3067,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jest/no-standalone-expect": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3087,7 +3087,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3121,7 +3121,7 @@
         "jest/prefer-ending-with-an-expect": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3134,7 +3134,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3144,7 +3144,7 @@
         "jest/prefer-expect-assertions": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3157,7 +3157,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3173,7 +3173,7 @@
         "jest/prefer-importing-jest-globals": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3186,7 +3186,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3205,7 +3205,7 @@
         "jest/prefer-snapshot-hint": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3218,7 +3218,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3249,7 +3249,7 @@
         "jest/require-hook": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3262,7 +3262,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3272,7 +3272,7 @@
         "jest/require-top-level-describe": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3285,7 +3285,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3295,7 +3295,7 @@
         "jest/valid-expect": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3308,7 +3308,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3327,7 +3327,7 @@
         "jsdoc/check-tag-names": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3340,14 +3340,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsdoc/empty-tags": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3360,7 +3360,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3370,7 +3370,7 @@
         "jsdoc/no-defaults": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3383,7 +3383,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3414,7 +3414,7 @@
         "jsdoc/require-returns": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3427,7 +3427,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3446,7 +3446,7 @@
         "jsdoc/require-yields": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3459,7 +3459,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3472,7 +3472,7 @@
         "jsx-a11y/alt-text": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3485,14 +3485,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsx-a11y/anchor-ambiguous-text": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3505,7 +3505,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3527,7 +3527,7 @@
         "jsx-a11y/aria-role": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3540,7 +3540,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3550,7 +3550,7 @@
         "jsx-a11y/autocomplete-valid": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3563,7 +3563,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3573,7 +3573,7 @@
         "jsx-a11y/control-has-associated-label": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3586,14 +3586,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsx-a11y/heading-has-content": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3606,7 +3606,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3619,7 +3619,7 @@
         "jsx-a11y/img-redundant-alt": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3632,14 +3632,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsx-a11y/interactive-supports-focus": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3652,14 +3652,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsx-a11y/label-has-associated-control": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3672,7 +3672,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3682,7 +3682,7 @@
         "jsx-a11y/media-has-caption": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3695,14 +3695,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsx-a11y/mouse-events-have-key-events": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3715,7 +3715,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3728,7 +3728,7 @@
         "jsx-a11y/no-autofocus": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3741,14 +3741,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsx-a11y/no-distracting-elements": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3761,14 +3761,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsx-a11y/no-interactive-element-to-noninteractive-role": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3781,7 +3781,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3791,7 +3791,7 @@
         "jsx-a11y/no-noninteractive-element-to-interactive-role": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3804,14 +3804,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsx-a11y/no-noninteractive-tabindex": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3824,14 +3824,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsx-a11y/no-redundant-roles": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3844,14 +3844,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "jsx-a11y/no-static-element-interactions": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3864,7 +3864,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -3886,7 +3886,7 @@
         "logical-assignment-operators": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3902,14 +3902,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "max-classes-per-file": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3929,14 +3929,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "max-depth": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3956,14 +3956,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "max-lines": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -3983,14 +3983,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "max-lines-per-function": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4010,14 +4010,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "max-nested-callbacks": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4037,14 +4037,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "max-params": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4064,14 +4064,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "max-statements": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4091,14 +4091,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "new-cap": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4111,7 +4111,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4193,7 +4193,7 @@
         "no-bitwise": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4206,7 +4206,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4225,7 +4225,7 @@
         "no-cond-assign": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4238,14 +4238,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-console": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4258,7 +4258,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4271,7 +4271,7 @@
         "no-constant-condition": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4284,7 +4284,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4321,7 +4321,7 @@
         "no-duplicate-imports": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4334,14 +4334,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-else-return": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4354,14 +4354,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-empty": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4374,7 +4374,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4384,7 +4384,7 @@
         "no-empty-function": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4397,14 +4397,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-empty-pattern": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4417,7 +4417,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4430,7 +4430,7 @@
         "no-eval": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4443,7 +4443,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4453,7 +4453,7 @@
         "no-extend-native": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4466,7 +4466,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4476,7 +4476,7 @@
         "no-extra-boolean-cast": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4489,7 +4489,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4499,7 +4499,7 @@
         "no-fallthrough": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4512,7 +4512,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4522,7 +4522,7 @@
         "no-global-assign": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4535,14 +4535,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-implicit-coercion": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4555,14 +4555,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-implicit-globals": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4575,7 +4575,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4588,7 +4588,7 @@
         "no-inline-comments": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4601,14 +4601,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-inner-declarations": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4624,14 +4624,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-invalid-regexp": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4644,14 +4644,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-irregular-whitespace": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4664,7 +4664,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4677,7 +4677,7 @@
         "no-labels": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4690,7 +4690,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4709,7 +4709,7 @@
         "no-magic-numbers": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4722,14 +4722,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-misleading-character-class": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4742,14 +4742,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-multi-assign": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4762,7 +4762,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4799,7 +4799,7 @@
         "no-param-reassign": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4812,14 +4812,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-plusplus": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4832,14 +4832,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-promise-executor-return": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4852,7 +4852,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4865,7 +4865,7 @@
         "no-redeclare": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4878,7 +4878,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4888,7 +4888,7 @@
         "no-restricted-exports": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4901,7 +4901,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4917,7 +4917,7 @@
         "no-return-assign": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4930,7 +4930,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4940,7 +4940,7 @@
         "no-self-assign": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4953,7 +4953,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4963,7 +4963,7 @@
         "no-sequences": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4976,7 +4976,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -4986,7 +4986,7 @@
         "no-shadow": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -4999,14 +4999,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-shadow-restricted-names": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5019,7 +5019,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5044,7 +5044,7 @@
         "no-undef": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5057,7 +5057,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5067,7 +5067,7 @@
         "no-underscore-dangle": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5080,7 +5080,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5093,7 +5093,7 @@
         "no-unneeded-ternary": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5106,7 +5106,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5119,7 +5119,7 @@
         "no-unsafe-negation": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5132,14 +5132,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-unsafe-optional-chaining": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5152,14 +5152,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-unused-expressions": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5172,7 +5172,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5185,7 +5185,7 @@
         "no-unused-vars": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5198,14 +5198,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-use-before-define": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5218,7 +5218,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5237,7 +5237,7 @@
         "no-useless-computed-key": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5250,7 +5250,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5263,7 +5263,7 @@
         "no-useless-escape": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5276,14 +5276,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-useless-rename": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5296,7 +5296,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5309,7 +5309,7 @@
         "no-void": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5322,14 +5322,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "no-warning-comments": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5342,7 +5342,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5358,7 +5358,7 @@
         "node/handle-callback-err": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5371,7 +5371,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5387,7 +5387,7 @@
         "node/no-process-env": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5400,14 +5400,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "object-shorthand": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5423,14 +5423,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "operator-assignment": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5443,7 +5443,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5498,7 +5498,7 @@
         "oxc/no-async-endpoint-handlers": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5511,14 +5511,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "oxc/no-barrel-file": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5531,7 +5531,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5541,7 +5541,7 @@
         "oxc/no-map-spread": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5554,14 +5554,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "oxc/no-optional-chaining": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5574,14 +5574,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "oxc/no-rest-spread-properties": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5594,7 +5594,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5613,7 +5613,7 @@
         "prefer-arrow-callback": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5626,14 +5626,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "prefer-const": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5646,7 +5646,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5671,7 +5671,7 @@
         "prefer-promise-reject-errors": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5684,14 +5684,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "prefer-regex-literals": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5704,7 +5704,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5720,7 +5720,7 @@
         "preserve-caught-error": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5733,14 +5733,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "promise/always-return": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5753,7 +5753,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5763,7 +5763,7 @@
         "promise/catch-or-return": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5776,14 +5776,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "promise/no-callback-in-promise": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5796,7 +5796,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5812,7 +5812,7 @@
         "promise/no-promise-in-callback": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5825,7 +5825,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5835,7 +5835,7 @@
         "promise/no-return-wrap": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5848,14 +5848,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "promise/param-names": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5868,7 +5868,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5878,7 +5878,7 @@
         "promise/prefer-await-to-then": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5891,7 +5891,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5901,7 +5901,7 @@
         "promise/spec-only": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5914,7 +5914,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -5924,7 +5924,7 @@
         "radix": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5937,14 +5937,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react-perf/jsx-no-jsx-as-prop": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5957,14 +5957,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react-perf/jsx-no-new-array-as-prop": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5977,14 +5977,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react-perf/jsx-no-new-function-as-prop": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -5997,14 +5997,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react-perf/jsx-no-new-object-as-prop": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6017,14 +6017,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/button-has-type": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6037,14 +6037,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/checked-requires-onchange-or-readonly": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6057,14 +6057,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/display-name": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6077,14 +6077,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/exhaustive-deps": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6097,14 +6097,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/forbid-component-props": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6117,14 +6117,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/forbid-dom-props": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6137,14 +6137,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/forbid-elements": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6157,7 +6157,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6167,7 +6167,7 @@
         "react/hook-use-state": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6180,7 +6180,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6190,7 +6190,7 @@
         "react/jsx-boolean-value": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6206,14 +6206,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/jsx-curly-brace-presence": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6226,14 +6226,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/jsx-filename-extension": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6246,14 +6246,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/jsx-fragments": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6266,14 +6266,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/jsx-handler-names": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6286,14 +6286,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/jsx-key": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6306,14 +6306,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/jsx-max-depth": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6326,7 +6326,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6342,7 +6342,7 @@
         "react/jsx-no-literals": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6355,7 +6355,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6365,7 +6365,7 @@
         "react/jsx-no-target-blank": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6378,7 +6378,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6388,7 +6388,7 @@
         "react/jsx-no-useless-fragment": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6401,14 +6401,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/jsx-pascal-case": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6421,7 +6421,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6431,7 +6431,7 @@
         "react/jsx-props-no-spreading": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6444,7 +6444,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6466,7 +6466,7 @@
         "react/no-did-mount-set-state": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6479,14 +6479,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/no-did-update-set-state": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6499,7 +6499,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6515,7 +6515,7 @@
         "react/no-multi-comp": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6528,7 +6528,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6553,7 +6553,7 @@
         "react/no-string-refs": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6566,7 +6566,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6579,7 +6579,7 @@
         "react/no-unknown-property": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6592,14 +6592,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/no-unsafe": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6612,14 +6612,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/no-unstable-nested-components": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6632,14 +6632,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/no-will-update-set-state": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6652,14 +6652,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/only-export-components": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6672,14 +6672,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/prefer-es6-class": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6692,14 +6692,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/prefer-function-component": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6712,7 +6712,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6728,7 +6728,7 @@
         "react/self-closing-comp": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6741,14 +6741,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/state-in-constructor": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6761,14 +6761,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "react/style-prop-object": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6781,7 +6781,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6794,7 +6794,7 @@
         "require-unicode-regexp": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6807,7 +6807,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6817,7 +6817,7 @@
         "sort-imports": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6830,14 +6830,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "sort-keys": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6853,14 +6853,14 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "sort-vars": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6873,7 +6873,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6886,7 +6886,7 @@
         "typescript/array-type": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6899,7 +6899,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6909,7 +6909,7 @@
         "typescript/ban-ts-comment": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6922,7 +6922,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -6935,7 +6935,7 @@
         "typescript/class-literal-property-style": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6948,14 +6948,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/consistent-generic-constructors": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6968,14 +6968,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/consistent-indexed-object-style": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -6988,14 +6988,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/consistent-return": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7008,14 +7008,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/consistent-type-assertions": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7028,14 +7028,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/consistent-type-definitions": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7048,14 +7048,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/consistent-type-exports": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7068,14 +7068,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/consistent-type-imports": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7088,14 +7088,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/dot-notation": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7108,14 +7108,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/explicit-function-return-type": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7128,14 +7128,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/explicit-member-accessibility": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7148,14 +7148,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/explicit-module-boundary-types": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7168,14 +7168,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/method-signature-style": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7188,7 +7188,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7198,7 +7198,7 @@
         "typescript/no-base-to-string": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7211,7 +7211,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7221,7 +7221,7 @@
         "typescript/no-confusing-void-expression": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7234,14 +7234,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-deprecated": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7254,7 +7254,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7264,7 +7264,7 @@
         "typescript/no-duplicate-type-constituents": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7277,7 +7277,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7287,7 +7287,7 @@
         "typescript/no-empty-interface": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7300,14 +7300,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-empty-object-type": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7320,14 +7320,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-explicit-any": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7340,7 +7340,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7350,7 +7350,7 @@
         "typescript/no-extraneous-class": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7363,14 +7363,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-floating-promises": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7383,7 +7383,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7399,7 +7399,7 @@
         "typescript/no-inferrable-types": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7412,14 +7412,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-invalid-void-type": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7432,14 +7432,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-meaningless-void-operator": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7452,7 +7452,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7462,7 +7462,7 @@
         "typescript/no-misused-promises": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7475,14 +7475,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-misused-spread": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7495,7 +7495,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7505,7 +7505,7 @@
         "typescript/no-namespace": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7518,7 +7518,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7537,7 +7537,7 @@
         "typescript/no-require-imports": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7550,14 +7550,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-restricted-types": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7570,14 +7570,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-this-alias": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7590,14 +7590,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-unnecessary-boolean-literal-compare": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7610,14 +7610,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/no-unnecessary-condition": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7630,7 +7630,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7649,7 +7649,7 @@
         "typescript/no-unnecessary-type-assertion": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7662,7 +7662,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7696,7 +7696,7 @@
         "typescript/no-unsafe-member-access": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7709,7 +7709,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7740,7 +7740,7 @@
         "typescript/only-throw-error": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7753,14 +7753,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/parameter-properties": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7773,7 +7773,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7798,7 +7798,7 @@
         "typescript/prefer-literal-enum-member": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7811,7 +7811,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7821,7 +7821,7 @@
         "typescript/prefer-nullish-coalescing": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7834,14 +7834,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/prefer-optional-chain": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7854,14 +7854,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/prefer-promise-reject-errors": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7874,14 +7874,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/prefer-readonly": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7894,14 +7894,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/prefer-readonly-parameter-types": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7914,7 +7914,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7930,7 +7930,7 @@
         "typescript/prefer-string-starts-ends-with": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7943,7 +7943,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7953,7 +7953,7 @@
         "typescript/promise-function-async": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7966,7 +7966,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7976,7 +7976,7 @@
         "typescript/require-array-sort-compare": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -7989,7 +7989,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -7999,7 +7999,7 @@
         "typescript/restrict-plus-operands": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8012,14 +8012,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/restrict-template-expressions": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8032,14 +8032,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/return-await": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8052,14 +8052,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/strict-boolean-expressions": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8072,14 +8072,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/strict-void-return": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8092,14 +8092,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/switch-exhaustiveness-check": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8112,14 +8112,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/triple-slash-reference": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8132,14 +8132,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/unbound-method": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8152,14 +8152,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "typescript/unified-signatures": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8172,7 +8172,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8182,7 +8182,7 @@
         "unicode-bom": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8195,14 +8195,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "unicorn/catch-error-name": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8215,7 +8215,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8234,7 +8234,7 @@
         "unicorn/consistent-function-scoping": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8247,7 +8247,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8269,7 +8269,7 @@
         "unicorn/explicit-length-check": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8282,7 +8282,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8292,7 +8292,7 @@
         "unicorn/import-style": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8305,7 +8305,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8336,7 +8336,7 @@
         "unicorn/no-array-reduce": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8349,14 +8349,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "unicorn/no-array-reverse": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8369,14 +8369,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "unicorn/no-array-sort": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8389,7 +8389,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8420,7 +8420,7 @@
         "unicorn/no-instanceof-builtins": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8433,7 +8433,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8470,7 +8470,7 @@
         "unicorn/no-null": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8483,7 +8483,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8508,7 +8508,7 @@
         "unicorn/no-typeof-undefined": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8521,7 +8521,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8561,7 +8561,7 @@
         "unicorn/no-useless-promise-resolve-reject": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8574,7 +8574,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8587,7 +8587,7 @@
         "unicorn/no-useless-undefined": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8600,7 +8600,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8634,7 +8634,7 @@
         "unicorn/prefer-at": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8647,7 +8647,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8690,7 +8690,7 @@
         "unicorn/prefer-export-from": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8703,7 +8703,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8749,7 +8749,7 @@
         "unicorn/prefer-number-properties": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8762,14 +8762,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "unicorn/prefer-object-from-entries": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8782,7 +8782,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8813,7 +8813,7 @@
         "unicorn/prefer-single-call": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8826,7 +8826,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8851,7 +8851,7 @@
         "unicorn/prefer-structured-clone": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8864,14 +8864,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "unicorn/prefer-ternary": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8884,7 +8884,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8897,7 +8897,7 @@
         "unicorn/relative-url-style": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8910,7 +8910,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8932,7 +8932,7 @@
         "unicorn/switch-case-braces": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8945,7 +8945,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8955,7 +8955,7 @@
         "unicorn/text-encoding-identifier-case": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8968,7 +8968,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -8978,7 +8978,7 @@
         "use-isnan": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -8991,14 +8991,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "valid-typeof": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9011,7 +9011,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9021,7 +9021,7 @@
         "vitest/consistent-each-for": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9034,14 +9034,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vitest/consistent-test-filename": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9054,14 +9054,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vitest/consistent-test-it": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9074,14 +9074,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vitest/consistent-vitest-vi": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9094,14 +9094,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vitest/expect-expect": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9114,7 +9114,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9124,7 +9124,7 @@
         "vitest/max-expects": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9137,14 +9137,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vitest/max-nested-describe": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9157,7 +9157,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9188,7 +9188,7 @@
         "vitest/no-hooks": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9201,7 +9201,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9220,7 +9220,7 @@
         "vitest/no-large-snapshots": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9233,7 +9233,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9243,7 +9243,7 @@
         "vitest/no-restricted-matchers": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9256,14 +9256,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vitest/no-restricted-vi-methods": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9276,14 +9276,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vitest/no-standalone-expect": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9296,7 +9296,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9339,7 +9339,7 @@
         "vitest/prefer-expect-assertions": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9352,7 +9352,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9371,7 +9371,7 @@
         "vitest/prefer-import-in-mock": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9384,7 +9384,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9403,7 +9403,7 @@
         "vitest/prefer-snapshot-hint": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9416,7 +9416,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9459,7 +9459,7 @@
         "vitest/require-hook": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9472,7 +9472,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9482,7 +9482,7 @@
         "vitest/require-mock-type-parameters": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9495,7 +9495,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9508,7 +9508,7 @@
         "vitest/require-top-level-describe": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9521,7 +9521,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9531,7 +9531,7 @@
         "vitest/valid-expect": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9544,7 +9544,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9560,7 +9560,7 @@
         "vue/component-definition-name-casing": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9573,14 +9573,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vue/define-emits-declaration": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9593,14 +9593,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vue/define-props-declaration": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9613,14 +9613,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vue/define-props-destructuring": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9633,14 +9633,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vue/max-props": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9653,14 +9653,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vue/next-tick-style": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9673,7 +9673,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9698,7 +9698,7 @@
         "vue/no-deprecated-model-definition": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9711,7 +9711,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9742,7 +9742,7 @@
         "vue/no-reserved-component-names": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9755,14 +9755,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vue/no-reserved-keys": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9775,14 +9775,14 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
         "vue/no-reserved-props": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9795,7 +9795,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9817,7 +9817,7 @@
         "vue/prop-name-casing": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9833,7 +9833,7 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9846,7 +9846,7 @@
         "vue/require-direct-export": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9859,7 +9859,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9881,7 +9881,7 @@
         "vue/return-in-computed-property": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9894,7 +9894,7 @@
                 }
               ],
               "maxItems": 2,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         },
@@ -9916,7 +9916,7 @@
         "yoda": {
           "anyOf": [
             {
-              "$ref": "#/definitions/AllowWarnDeny"
+              "$ref": "#/definitions/RuleNoConfig"
             },
             {
               "type": "array",
@@ -9932,7 +9932,7 @@
                 }
               ],
               "maxItems": 3,
-              "minItems": 1
+              "minItems": 2
             }
           ]
         }


### PR DESCRIPTION
Because `RuleNoConfig` is already `AllowWarnDeny | [AllowWarnDeny]` we can reuse the reference for all other rules config and saving us some bytes on the TS config types generation.