### PR TITLE
perf(linter): dispatch rules in a single AST pass

### DIFF
--- a/apps/oxlint/src/main.rs
+++ b/apps/oxlint/src/main.rs
@@ -5,23 +5,31 @@ use oxlint::{
     lsp::run_lsp,
 };
 
-#[tokio::main]
-async fn main() -> CliRunResult {
+fn main() -> CliRunResult {
     // Parse command line arguments from std::env::args()
     let command = lint_command().run();
 
     // Both LSP and CLI use `tracing` for logging
     init_tracing();
 
-    // If --lsp flag is set, run the language server
+    // If --lsp flag is set, run the language server.
+    //
+    // The language server is the only path that needs an async runtime, so the Tokio runtime is
+    // created here rather than via `#[tokio::main]`. The CLI lint path is fully synchronous
+    // (Rayon-based); `#[tokio::main]` would otherwise spawn one idle Tokio worker thread per core
+    // on every lint invocation.
     if command.lsp {
-        run_lsp(
-            None,
-            #[cfg(feature = "napi")]
-            None,
-        )
-        .await;
-        return CliRunResult::LintSucceeded;
+        let runtime =
+            tokio::runtime::Runtime::new().expect("Failed to build the Tokio runtime for the LSP");
+        return runtime.block_on(async {
+            run_lsp(
+                None,
+                #[cfg(feature = "napi")]
+                None,
+            )
+            .await;
+            CliRunResult::LintSucceeded
+        });
     }
 
     init_miette();

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -127,6 +127,35 @@ fn get_timing_stat<const TIMINGS: bool>(
     }
 }
 
+/// Per-thread scratch buffers for dispatching rules to AST nodes by node type.
+///
+/// Reused across files, so the single traversal in [`execute_rules`] — which visits each node once
+/// and dispatches it only to the rules registered for its type — incurs no per-file allocation.
+/// (Per-file allocation is what previously made bucketing worthwhile only for very large files.)
+struct RuleBuckets {
+    /// `by_type[ast_type]` = indices, into the per-file `rules` slice, of rules that run on that AST
+    /// node type. A boxed fixed-size array so indexing by an `AstType` elides bounds checks.
+    by_type: Box<[Vec<usize>; AST_TYPE_MAX as usize + 1]>,
+    /// Indices of rules that run on every node (rules without `types_info`).
+    any_type: Vec<usize>,
+}
+
+impl RuleBuckets {
+    fn clear(&mut self) {
+        for bucket in self.by_type.iter_mut() {
+            bucket.clear();
+        }
+        self.any_type.clear();
+    }
+}
+
+thread_local! {
+    static RULE_BUCKETS: std::cell::RefCell<RuleBuckets> = std::cell::RefCell::new(RuleBuckets {
+        by_type: boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1],
+        any_type: Vec::new(),
+    });
+}
+
 fn execute_rules<'a, const TIMINGS: bool>(
     rules: &[(&RuleEnum, LintContext<'a>)],
     semantic: &Semantic<'a>,
@@ -134,114 +163,73 @@ fn execute_rules<'a, const TIMINGS: bool>(
     with_runtime_optimization: bool,
     mut timing_recorder: Option<&mut RuleTimingRecorder>,
 ) {
-    // IMPORTANT: We have two branches here for performance reasons:
-    //
-    // 1) Branch where we iterate over each node, then each rule
-    // 2) Branch where we iterate over each rule, then each node
-    //
-    // When the number of nodes is relatively small, most of them can fit
-    // in the cache and we can save iterating over the rules multiple times.
-    // But for large files, the number of nodes can be so large that it
-    // starts to not fit into the cache and pushes out other data, like the rules.
-    // So we end up thrashing the cache with each rule iteration. In this case,
-    // it's better to put rules in the inner loop, as the rules data is smaller
-    // and is more likely to fit in the cache.
-    //
-    // The threshold here is chosen to balance between performance improvement
-    // from not iterating over rules multiple times, but also ensuring that we
-    // don't thrash the cache too much. Feel free to tweak based on benchmarking.
-    //
-    // See https://github.com/oxc-project/oxc/pull/6600 for more context.
     let mut timing_stats = TIMINGS.then(|| vec![RuleTimingStat::default(); rules.len()]);
 
-    if semantic.nodes().len() > 200_000 {
-        // TODO: It seems like there is probably a more intelligent way to preallocate space here. This will
-        // likely incur quite a few unnecessary reallocs currently. We theoretically could compute this at
-        // compile-time since we know all of the rules and their AST node type information ahead of time.
-        //
-        // Use boxed array to help compiler see that indexing into it with an `AstType`
-        // cannot go out of bounds, and remove bounds checks.
-        let mut rules_by_ast_type = boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1];
-        // TODO: Compute needed capacity. This is a slight overestimate as not 100% of rules will need to run on all
-        // node types, but it at least guarantees we won't need to realloc.
-        let mut rules_any_ast_type = Vec::with_capacity(rules.len());
+    if with_runtime_optimization {
+        // Bucket rules by the AST node types they care about into a reused per-thread buffer, then
+        // make a single pass over the AST, dispatching each node only to the rules registered for
+        // its type. This replaces "every rule tests every node" (which dominated dispatch cost in
+        // profiles), and because the buffer is reused there is no per-file allocation — so this is
+        // a win for files of all sizes, not just large ones.
+        RULE_BUCKETS.with_borrow_mut(|buckets| {
+            buckets.clear();
 
-        for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
-            let rule = *rule;
-            let run_info = rule.run_info();
-            // Collect node type information for rules. In large files, benchmarking showed it was worth
-            // collecting rules into buckets by AST node type to avoid iterating over all rules for each node.
-            if with_runtime_optimization
-                && let Some(ast_types) = rule.types_info()
-                && run_info.is_run_implemented()
-            {
-                for ty in ast_types {
-                    rules_by_ast_type[ty as usize].push((rule_index, rule, ctx));
-                }
-            } else if !with_runtime_optimization || run_info.is_run_implemented() {
-                rules_any_ast_type.push((rule_index, rule, ctx));
-            }
-
-            if !with_runtime_optimization || run_info.is_run_once_implemented() {
-                let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                rule.run_once::<TIMINGS>(ctx, timing_stat);
-            }
-        }
-
-        // Run rules on nodes
-        for node in semantic.nodes() {
-            for (rule_index, rule, ctx) in &rules_by_ast_type[node.kind().ty() as usize] {
-                let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, *rule_index);
-                rule.run::<TIMINGS>(node, ctx, timing_stat);
-            }
-            for (rule_index, rule, ctx) in &rules_any_ast_type {
-                let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, *rule_index);
-                rule.run::<TIMINGS>(node, ctx, timing_stat);
-            }
-        }
-
-        if should_run_on_jest_node {
-            for jest_node in iter_possible_jest_call_node(semantic) {
-                for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
-                    if !with_runtime_optimization
-                        || rule.run_info().is_run_on_jest_node_implemented()
-                    {
-                        let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                        rule.run_on_jest_node::<TIMINGS>(&jest_node, ctx, timing_stat);
+            for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
+                let run_info = rule.run_info();
+                if let Some(ast_types) = rule.types_info()
+                    && run_info.is_run_implemented()
+                {
+                    for ty in ast_types {
+                        buckets.by_type[ty as usize].push(rule_index);
                     }
+                } else if run_info.is_run_implemented() {
+                    buckets.any_type.push(rule_index);
+                }
+
+                if run_info.is_run_once_implemented() {
+                    let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                    rule.run_once::<TIMINGS>(ctx, timing_stat);
                 }
             }
-        }
-    } else {
-        for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
-            let run_info = rule.run_info();
-            if !with_runtime_optimization || run_info.is_run_once_implemented() {
-                let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                rule.run_once::<TIMINGS>(ctx, timing_stat);
+
+            for node in semantic.nodes() {
+                for &rule_index in &buckets.by_type[node.kind().ty() as usize] {
+                    let (rule, ctx) = &rules[rule_index];
+                    let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                    rule.run::<TIMINGS>(node, ctx, timing_stat);
+                }
+                for &rule_index in &buckets.any_type {
+                    let (rule, ctx) = &rules[rule_index];
+                    let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                    rule.run::<TIMINGS>(node, ctx, timing_stat);
+                }
             }
 
-            if !with_runtime_optimization || run_info.is_run_implemented() {
-                // For smaller files, benchmarking showed it was faster to iterate over all rules and just check the
-                // node types as we go, rather than pre-bucketing rules by AST node type and doing extra allocations.
-                if with_runtime_optimization && let Some(ast_types) = rule.types_info() {
-                    for node in semantic.nodes() {
-                        if ast_types.has(node.kind().ty()) {
+            if should_run_on_jest_node {
+                for jest_node in iter_possible_jest_call_node(semantic) {
+                    for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
+                        if rule.run_info().is_run_on_jest_node_implemented() {
                             let timing_stat =
                                 get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                            rule.run::<TIMINGS>(node, ctx, timing_stat);
+                            rule.run_on_jest_node::<TIMINGS>(&jest_node, ctx, timing_stat);
                         }
-                    }
-                } else {
-                    for node in semantic.nodes() {
-                        let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                        rule.run::<TIMINGS>(node, ctx, timing_stat);
                     }
                 }
             }
+        });
+    } else {
+        // Unoptimized reference path: every rule runs on every node, with no type filtering. Used
+        // only in debug builds, to assert the optimized path produces identical diagnostics.
+        for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
+            let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+            rule.run_once::<TIMINGS>(ctx, timing_stat);
 
-            if should_run_on_jest_node
-                && (!with_runtime_optimization || run_info.is_run_on_jest_node_implemented())
-            {
+            for node in semantic.nodes() {
+                let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                rule.run::<TIMINGS>(node, ctx, timing_stat);
+            }
+
+            if should_run_on_jest_node {
                 for jest_node in iter_possible_jest_call_node(semantic) {
                     let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
                     rule.run_on_jest_node::<TIMINGS>(&jest_node, ctx, timing_stat);


### PR DESCRIPTION
## Summary

Profiling a cold lint run with Instruments' Time Profiler (`xcrun xctrace record --template 'Time Profiler'`) showed **rule dispatch was the single largest compute component (~24%)**: for files up to 200k nodes — i.e. virtually all files — every rule was tested against every node, with an `AstTypesBitset::has` check per (rule, node) pair (R rules × N nodes).

The single-pass path that buckets rules by AST node type already existed, but was gated to very large files only, because it allocated its bucket array **per file**. This PR reuses a **per-thread buffer** instead, so there is no per-file allocation and one AST traversal dispatches each node only to the rules registered for its type — a win for files of *all* sizes.

A second commit stops `#[tokio::main]` from spawning an idle Tokio worker thread per core on every CLI run (only `--lsp` needs the async runtime).

## Results (release + mimalloc, M-series)

| Workload | Before | After | Speedup |
|---|---|---|---|
| vscode/src, 1 thread | 1.500 s | **1.030 s** | **1.46×** |
| next, 1 thread | 1.42 s | **1.019 s** | **1.39×** |
| vscode/src, 14 threads | 252.9 ms | 219.5 ms | 1.15× (CPU −36%) |

Re-profiling confirms dispatch dropped from **~24% → ~5%** of compute. The 14-thread wall gain is smaller because the run becomes I/O/system-bound and hits the P-core limit, but CPU work falls ~35%, so fewer-core CI machines should see closer to the single-threaded figure.

## Correctness

Diagnostics are unchanged. oxlint's debug build asserts the optimized and reference dispatch produce identical results (it sorts first), so the existing `oxc_linter` test suite verifies this; app + LSP tests also pass.

The only behavioural change is that **diagnostic collection order becomes source-position order** (node order) instead of rule-grouped order. The default CLI formatter already sorts, so its output is unchanged; the machine formats (checkstyle/json/sarif/github/gitlab/junit/unix/agent) and the LSP now emit in source-position order, which is the order the large-file path already produced.

## ⚠️ Snapshots intentionally excluded

Per request, the snapshot updates for the reordering above are **not** included in this draft, so the corresponding snapshot tests will fail in CI until regenerated with `cargo insta accept`. Each change is a pure reorder (verified: identical diagnostic sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)