### PR TITLE
feat(linter/jsdoc): Added missing options to `require-param-description`

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -963,7 +963,7 @@ export interface DummyRuleMap {
   "jsdoc/implements-on-classes"?: RuleNoConfig;
   "jsdoc/no-defaults"?: RuleNoConfig | [AllowWarnDeny, NoDefaultsConfig];
   "jsdoc/require-param"?: DummyRule;
-  "jsdoc/require-param-description"?: RuleNoConfig;
+  "jsdoc/require-param-description"?: RuleNoConfig | [AllowWarnDeny, RequireParamDescriptionConfig];
   "jsdoc/require-param-name"?: RuleNoConfig;
   "jsdoc/require-param-type"?: RuleNoConfig | [AllowWarnDeny, RequireParamTypeConfig];
   "jsdoc/require-property"?: RuleNoConfig;
@@ -2374,6 +2374,18 @@ export interface NoDefaultsConfig {
    * If true, report the presence of optional param names (square brackets) on `@param` tags.
    */
   noOptionalParamNames?: boolean;
+}
+export interface RequireParamDescriptionConfig {
+  /**
+   * The description string to set by default for destructured roots. Defaults to "The root object".
+   */
+  defaultDestructuredRootDescription?: string;
+  /**
+   * Whether to set a default destructured root description.
+   * For example, you may wish to avoid manually having to set the description for a @param corresponding to a destructured root object as it should always be the same type of object.
+   * Uses `defaultDestructuredRootDescription` for the description string. Defaults to `false`.
+   */
+  setDefaultDestructuredRootDescription?: boolean;
 }
 export interface RequireParamTypeConfig {
   /**

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -2,11 +2,14 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use oxc_str::CompactStr;
+use schemars::JsonSchema;
+use serde::Deserialize;
 
 use crate::{
     AstNode,
     context::LintContext,
-    rule::Rule,
+    rule::{DefaultRuleConfig, Rule},
     utils::{
         ParamKind, collect_params, get_function_nearest_jsdoc_node, should_ignore_as_internal,
         should_ignore_as_private,
@@ -19,8 +22,34 @@ fn missing_type_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
+fn missing_root_description_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Missing root description for @param.")
+        .with_help("Add root description to `@param`.")
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct RequireParamDescriptionConfig {
+    /// The description string to set by default for destructured roots. Defaults to "The root object".
+    default_destructured_root_description: CompactStr,
+    /// Whether to set a default destructured root description.
+    /// For example, you may wish to avoid manually having to set the description for a @param corresponding to a destructured root object as it should always be the same type of object.
+    /// Uses `defaultDestructuredRootDescription` for the description string. Defaults to `false`.
+    set_default_destructured_root_description: bool,
+}
+
+impl Default for RequireParamDescriptionConfig {
+    fn default() -> Self {
+        Self {
+            default_destructured_root_description: CompactStr::from("The root object"),
+            set_default_destructured_root_description: false,
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone)]
-pub struct RequireParamDescription;
+pub struct RequireParamDescription(Box<RequireParamDescriptionConfig>);
 
 declare_oxc_lint!(
     /// ### What it does
@@ -47,12 +76,18 @@ declare_oxc_lint!(
     RequireParamDescription,
     jsdoc,
     pedantic,
-    pending,
+    fix,
+    config = RequireParamDescriptionConfig,
     version = "0.4.4",
     short_description = "Requires that each `@param` tag has a description value.",
 );
 
 impl Rule for RequireParamDescription {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<RequireParamDescriptionConfig>>(value)
+            .map(|config| Self(Box::new(config.into_inner())))
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         // Collected targets from `FormalParameters`
         let params_to_check = match node.kind() {
@@ -100,7 +135,25 @@ impl Rule for RequireParamDescription {
                     continue;
                 }
 
-                ctx.diagnostic(missing_type_diagnostic(tag.kind.span));
+                let is_destructured_root =
+                    matches!(params_to_check.get(root_count - 1), Some(ParamKind::Nested(_)));
+
+                if self.0.set_default_destructured_root_description
+                    && is_destructured_root
+                    && let Some(name_part) = name_part
+                {
+                    ctx.diagnostic_with_fix(
+                        missing_root_description_diagnostic(tag.kind.span),
+                        |fixer| {
+                            fixer.insert_text_after_range(
+                                name_part.span,
+                                format!(" {}", self.0.default_destructured_root_description),
+                            )
+                        },
+                    );
+                } else {
+                    ctx.diagnostic(missing_type_diagnostic(tag.kind.span));
+                }
             }
         }
     }
@@ -117,7 +170,7 @@ fn test() {
 			           *
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -129,7 +182,7 @@ fn test() {
 			           * @param foo Foo.
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -178,7 +231,7 @@ fn test() {
 			           * @param {boolean} baz Baz description
 			           */
 			          function quux (foo, {bar}, baz) {
-			
+
 			          }
 			      ",
             None,
@@ -194,7 +247,7 @@ fn test() {
 			           * @param {object} root.bar
 			           */
 			          function quux (foo, {bar: {baz}}) {
-			
+
 			          }
 			      ",
             None,
@@ -211,7 +264,7 @@ fn test() {
 			           * @param foo
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -223,7 +276,7 @@ fn test() {
 			           * @arg foo
 			           */
 			          function quux (foo) {
-			
+
 			          }
 			      ",
             None,
@@ -239,54 +292,52 @@ fn test() {
 			           * @param {boolean} baz Baz description
 			           */
 			          function quux (foo, {bar}, baz) {
-			
+
 			          }
 			      ",
-            // TODO: support configurations for this rule
-            // Some(
-            //     serde_json::json!([        {          "setDefaultDestructuredRootDescription": true,        },      ]),
-            // ),
-            None,
+            Some(
+                serde_json::json!([        {          "setDefaultDestructuredRootDescription": false,        },      ]),
+            ),
             None,
         ),
         (
             "
-			          /**
-			           * @param {number} foo Foo description
-			           * @param {object} root
-			           * @param {boolean} baz Baz description
-			           */
-			          function quux (foo, {bar}, baz) {
-			
-			          }
-			      ",
-            // TODO: support configurations for this rule
-            // Some(
-            //     serde_json::json!([        {          "defaultDestructuredRootDescription": "Root description",          "setDefaultDestructuredRootDescription": true,        },      ]),
-            // ),
-            None,
-            None,
-        ),
-        (
-            "
-			          /**
-			           * @param {number} foo Foo description
-			           * @param {object} root
-			           * @param {boolean} baz Baz description
-			           */
-			          function quux (foo, {bar}, baz) {
-			
-			          }
-			      ",
-            // TODO: support configurations for this rule
-            // Some(
-            //     serde_json::json!([        {          "setDefaultDestructuredRootDescription": false,        },      ]),
-            // ),
-            None,
+                          /**
+                           * @param {number} foo Foo description
+                           * @param {object} root
+                           * @param {boolean} baz Baz description
+                           */
+                          function quux (foo, {bar}, baz) {
+
+                          }
+                      ",
+            Some(serde_json::json!([{ "setDefaultDestructuredRootDescription": true }])),
             None,
         ),
     ];
 
+    let fix = vec![
+        (
+            "/** @param {object} root */\nfunction quux ({bar}) {}",
+            "/** @param {object} root The root object */\nfunction quux ({bar}) {}",
+            Some(serde_json::json!([{ "setDefaultDestructuredRootDescription": true }])),
+        ),
+        (
+            "/** @param {object} root */\nfunction quux ({bar}) {}",
+            "/** @param {object} root Custom root description */\nfunction quux ({bar}) {}",
+            Some(serde_json::json!([{
+                "defaultDestructuredRootDescription": "Custom root description",
+                "setDefaultDestructuredRootDescription": true
+            }])),
+        ),
+        (
+            "/** @param {number} foo\n * @param {object} root */\nfunction quux (foo, {bar}) {}",
+            "/** @param {number} foo\n * @param {object} root The root object */\nfunction quux (foo, {bar}) {}",
+            Some(serde_json::json!([{ "setDefaultDestructuredRootDescription": true }])),
+        ),
+    ];
+
     Tester::new(RequireParamDescription::NAME, RequireParamDescription::PLUGIN, pass, fail)
+        .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -140,7 +140,7 @@ impl Rule for RequireParamDescription {
 
                 if self.0.set_default_destructured_root_description
                     && is_destructured_root
-                    && let Some(name_part) = name_part
+                    && name_part.is_some()
                 {
                     ctx.diagnostic(missing_root_description_diagnostic(tag.kind.span));
                 } else {

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -76,7 +76,7 @@ declare_oxc_lint!(
     RequireParamDescription,
     jsdoc,
     pedantic,
-    fix,
+    pending,
     config = RequireParamDescriptionConfig,
     version = "0.4.4",
     short_description = "Requires that each `@param` tag has a description value.",
@@ -142,15 +142,7 @@ impl Rule for RequireParamDescription {
                     && is_destructured_root
                     && let Some(name_part) = name_part
                 {
-                    ctx.diagnostic_with_fix(
-                        missing_root_description_diagnostic(tag.kind.span),
-                        |fixer| {
-                            fixer.insert_text_after_range(
-                                name_part.span,
-                                format!(" {}", self.0.default_destructured_root_description),
-                            )
-                        },
-                    );
+                    ctx.diagnostic(missing_root_description_diagnostic(tag.kind.span));
                 } else {
                     ctx.diagnostic(missing_type_diagnostic(tag.kind.span));
                 }
@@ -316,28 +308,6 @@ fn test() {
         ),
     ];
 
-    let fix = vec![
-        (
-            "/** @param {object} root */\nfunction quux ({bar}) {}",
-            "/** @param {object} root The root object */\nfunction quux ({bar}) {}",
-            Some(serde_json::json!([{ "setDefaultDestructuredRootDescription": true }])),
-        ),
-        (
-            "/** @param {object} root */\nfunction quux ({bar}) {}",
-            "/** @param {object} root Custom root description */\nfunction quux ({bar}) {}",
-            Some(serde_json::json!([{
-                "defaultDestructuredRootDescription": "Custom root description",
-                "setDefaultDestructuredRootDescription": true
-            }])),
-        ),
-        (
-            "/** @param {number} foo\n * @param {object} root */\nfunction quux (foo, {bar}) {}",
-            "/** @param {number} foo\n * @param {object} root The root object */\nfunction quux (foo, {bar}) {}",
-            Some(serde_json::json!([{ "setDefaultDestructuredRootDescription": true }])),
-        ),
-    ];
-
     Tester::new(RequireParamDescription::NAME, RequireParamDescription::PLUGIN, pass, fail)
-        .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -1,10 +1,11 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_str::CompactStr;
-use schemars::JsonSchema;
-use serde::Deserialize;
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_param_description.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_param_description.snap
@@ -29,20 +29,11 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add description to `@param` tag.
 
-  ⚠ jsdoc(require-param-description): Missing JSDoc `@param` description.
-   ╭─[require_param_description.tsx:4:17]
- 3 │                        * @param {number} foo Foo description
- 4 │                        * @param {object} root
-   ·                          ──────
- 5 │                        * @param {boolean} baz Baz description
+  ⚠ jsdoc(require-param-description): Missing root description for @param.
+   ╭─[require_param_description.tsx:4:30]
+ 3 │                            * @param {number} foo Foo description
+ 4 │                            * @param {object} root
+   ·                              ──────
+ 5 │                            * @param {boolean} baz Baz description
    ╰────
-  help: Add description to `@param` tag.
-
-  ⚠ jsdoc(require-param-description): Missing JSDoc `@param` description.
-   ╭─[require_param_description.tsx:4:17]
- 3 │                        * @param {number} foo Foo description
- 4 │                        * @param {object} root
-   ·                          ──────
- 5 │                        * @param {boolean} baz Baz description
-   ╰────
-  help: Add description to `@param` tag.
+  help: Add root description to `@param`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -3494,7 +3494,24 @@
           "$ref": "#/definitions/DummyRule"
         },
         "jsdoc/require-param-description": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/RequireParamDescriptionConfig"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
         },
         "jsdoc/require-param-name": {
           "$ref": "#/definitions/RuleNoConfig"
@@ -16932,6 +16949,24 @@
           "default": false,
           "type": "boolean",
           "markdownDescription": "Also require type parameters for `importActual` and `importMock`."
+        }
+      },
+      "additionalProperties": false
+    },
+    "RequireParamDescriptionConfig": {
+      "type": "object",
+      "properties": {
+        "defaultDestructuredRootDescription": {
+          "description": "The description string to set by default for destructured roots. Defaults to \"The root object\".",
+          "default": "The root object",
+          "type": "string",
+          "markdownDescription": "The description string to set by default for destructured roots. Defaults to \"The root object\"."
+        },
+        "setDefaultDestructuredRootDescription": {
+          "description": "Whether to set a default destructured root description.\nFor example, you may wish to avoid manually having to set the description for a @param corresponding to a destructured root object as it should always be the same type of object.\nUses `defaultDestructuredRootDescription` for the description string. Defaults to `false`.",
+          "default": false,
+          "type": "boolean",
+          "markdownDescription": "Whether to set a default destructured root description.\nFor example, you may wish to avoid manually having to set the description for a @param corresponding to a destructured root object as it should always be the same type of object.\nUses `defaultDestructuredRootDescription` for the description string. Defaults to `false`."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Closes #23370

### AI usage disclosure

I used Claude Code to assist me with: port the upstream test cases, wire up the config/fixer, and generate this description.

### Summary

Adds the missing `setDefaultDestructuredRootDescription` and `defaultDestructuredRootDescription` options to the `jsdoc/require-param-description` rule, matching the upstream `eslint-plugin-jsdoc` rule.

When `setDefaultDestructuredRootDescription` is `true`, a destructured root `@param` that is missing a description is reported with a dedicated "Missing root description for @param." message and **auto-fixed** by inserting a default description. The inserted text defaults to `"The root object"` and can be customized via `defaultDestructuredRootDescription`.