### PR TITLE
docs(linter): add `short_descriptions` to more rules

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/block_scoped_var.rs
@@ -124,6 +124,7 @@ declare_oxc_lint!(
     eslint,
     suspicious,
     version = "0.16.9",
+    short_description = "Enforce the use of variables within the scope they are defined.",
 );
 
 impl Rule for BlockScopedVar {

--- a/crates/oxc_linter/src/rules/eslint/curly.rs
+++ b/crates/oxc_linter/src/rules/eslint/curly.rs
@@ -268,6 +268,7 @@ declare_oxc_lint!(
     fix,
     config = Curly,
     version = "0.15.13",
+    short_description = "Enforce consistent brace style for all control statements.",
 );
 
 impl Rule for Curly {

--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -106,6 +106,7 @@ declare_oxc_lint!(
     pedantic,
     config = MaxDepth,
     version = "0.15.12",
+    short_description = "Enforce a maximum depth that blocks can be nested.",
 );
 
 impl Rule for MaxDepth {

--- a/crates/oxc_linter/src/rules/eslint/max_nested_callbacks.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_nested_callbacks.rs
@@ -101,6 +101,7 @@ declare_oxc_lint!(
     pedantic,
     config = MaxNestedCallbacks,
     version = "0.15.12",
+    short_description = "Enforce a maximum depth that callbacks can be nested.",
 );
 
 impl Rule for MaxNestedCallbacks {

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -86,6 +86,7 @@ declare_oxc_lint!(
     eslint,
     correctness,
     version = "0.0.3",
+    short_description = "Disallow reassigning class members.",
 );
 
 impl Rule for NoClassAssign {

--- a/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_fallthrough.rs
@@ -250,6 +250,7 @@ declare_oxc_lint!(
     pending, // TODO: add a dangerous suggestion for this rule.
     config = NoFallthroughConfig,
     version = "0.0.14",
+    short_description = "Disallow fallthrough of `case` statements.",
 );
 
 impl Rule for NoFallthrough {

--- a/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
@@ -246,6 +246,7 @@ declare_oxc_lint!(
     pending, // TODO: enforceConst, probably copy from https://github.com/oxc-project/oxc/pull/5144
     config = NoMagicNumbersConfig,
     version = "0.9.3",
+    short_description = "Disallow magic numbers.",
 );
 
 #[derive(Debug)]

--- a/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
@@ -20,6 +20,7 @@ declare_oxc_lint!(
     pending,
     docs = DOCUMENTATION,
     version = "0.0.18",
+    short_description = "Disallow negated conditions.",
 );
 
 impl Rule for NoNegatedCondition {

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     eslint,
     correctness,
     version = "0.3.3",
+    short_description = "Disallow `new` operators with global non-constructor functions.",
 );
 
 impl Rule for NoNewNativeNonconstructor {

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -68,6 +68,7 @@ declare_oxc_lint!(
     pedantic,
     config = NoRedeclare,
     version = "0.0.13",
+    short_description = "Disallow variable redeclaration.",
 );
 
 impl Rule for NoRedeclare {

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_exports.rs
@@ -184,6 +184,7 @@ declare_oxc_lint!(
     nursery, // TODO: change category to `restriction`
     config = NoRestrictedExportsConfig,
     version = "1.59.0",
+    short_description = "Disallow specified names in exports.",
 );
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -554,6 +554,7 @@ declare_oxc_lint!(
     // indicate that this rule has configuration and avoid errors.
     config = Value,
     version = "0.15.0",
+    short_description = "Disallow specified modules when loaded by `import`.",
 );
 
 fn add_configuration_path_from_object(

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     eslint,
     correctness,
     version = "0.0.3",
+    short_description = "Disallow returning values from setters.",
 );
 
 impl Rule for NoSetterReturn {

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -54,6 +54,7 @@ declare_oxc_lint!(
     nursery,
     config = NoUndef,
     version = "0.0.8",
+    short_description = "Disallow the use of undeclared variables.",
 );
 
 impl Rule for NoUndef {

--- a/crates/oxc_linter/src/rules/eslint/no_unexpected_multiline.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unexpected_multiline.rs
@@ -105,6 +105,7 @@ declare_oxc_lint!(
     suspicious,
     fix_dangerous,
     version = "0.9.7",
+    short_description = "Disallow confusing multiline expressions.",
 );
 
 impl Rule for NoUnexpectedMultiline {

--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_negation.rs
@@ -72,6 +72,7 @@ declare_oxc_lint!(
     fix,
     config = NoUnsafeNegation,
     version = "0.0.3",
+    short_description = "Disallow negating the left side of relational operators.",
 );
 
 impl Rule for NoUnsafeNegation {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_assignment.rs
@@ -44,8 +44,6 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js
-    /// /* eslint no-useless-assignment: "error" */
-    ///
     /// function fn1() {
     ///   let v = 'used';
     ///   doSomething(v);
@@ -73,7 +71,6 @@ declare_oxc_lint!(
     ///
     /// Examples of **correct** code for this rule:
     /// ```js
-    ///
     /// function fn1() {
     ///   let v = 'used';
     ///   doSomething(v);
@@ -103,6 +100,7 @@ declare_oxc_lint!(
     eslint,
     nursery,
     version = "1.59.0",
+    short_description = "Disallow variable assignments when the value is not used.",
 );
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/oxc_linter/src/rules/eslint/no_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_var.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     restriction,
     conditional_fix,
     version = "0.1.1",
+    short_description = "Enforce using `let` or `const` over `var`.",
 );
 
 impl Rule for NoVar {

--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -97,6 +97,7 @@ declare_oxc_lint!(
     fix_dangerous,
     config = AlwaysNever,
     version = "0.15.13",
+    short_description = "Enforce whether to use assignment operator shorthand.",
 );
 
 impl Rule for OperatorAssignment {

--- a/crates/oxc_linter/src/rules/import/extensions.rs
+++ b/crates/oxc_linter/src/rules/import/extensions.rs
@@ -474,6 +474,7 @@ declare_oxc_lint!(
     restriction,
     config = ExtensionsConfig,
     version = "1.2.0",
+    short_description = "Enforce consistent use of file extensions in import paths.",
 );
 
 impl Rule for Extensions {

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -112,6 +112,7 @@ declare_oxc_lint!(
     correctness,
     config = Namespace,
     version = "0.2.11",
+    short_description = "Ensure imported namespaces contain dereferenced properties as they are dereferenced.",
 );
 
 impl Rule for Namespace {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -72,6 +72,7 @@ declare_oxc_lint!(
     import,
     suspicious,
     version = "0.2.3",
+    short_description = "Forbid using an exported name as the identifier of a default export.",
 );
 
 impl Rule for NoNamedAsDefault {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -64,6 +64,7 @@ declare_oxc_lint!(
     import,
     suspicious,
     version = "0.2.1",
+    short_description = "Forbid using an exported name as a property on a default export.",
 );
 
 fn get_symbol_id_from_ident(

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -78,9 +78,10 @@ declare_oxc_lint!(
     NoNamespace,
     import,
     style,
-    pending,  // TODO: fixer
+    pending, // TODO: fixer
     config = NoNamespaceConfig,
     version = "0.12.0",
+    short_description = "Forbid namespace (also known as wildcard `*`) imports.",
 );
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/no-namespace.md>

--- a/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
+++ b/crates/oxc_linter/src/rules/react/checked_requires_onchange_or_readonly.rs
@@ -79,6 +79,7 @@ declare_oxc_lint!(
     pedantic,
     config = CheckedRequiresOnchangeOrReadonly,
     version = "0.2.15",
+    short_description = "Enforce using `onChange` or `readOnly` attributes when `checked` is used on an `<input>` field.",
 );
 
 impl Rule for CheckedRequiresOnchangeOrReadonly {

--- a/crates/oxc_linter/src/rules/react/forbid_component_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_component_props.rs
@@ -275,7 +275,8 @@ declare_oxc_lint!(
     react,
     restriction,
     config = ForbidComponentPropsConfig,
-    version = "1.62.0"
+    version = "1.62.0",
+    short_description = "Disallow specific props on components.",
 );
 
 impl Rule for ForbidComponentProps {

--- a/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
@@ -143,6 +143,7 @@ declare_oxc_lint!(
     restriction,
     config = ForbidDomPropsConfig,
     version = "1.24.0",
+    short_description = "Disallow certain props on DOM Nodes.",
 );
 
 impl Rule for ForbidDomProps {

--- a/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs
+++ b/crates/oxc_linter/src/rules/react/forward_ref_uses_ref.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     correctness,
     suggestion,
     version = "0.16.9",
+    short_description = "Require all `forwardRef` components include a `ref` parameter.",
 );
 
 impl Rule for ForwardRefUsesRef {

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -335,6 +335,7 @@ declare_oxc_lint!(
     fix,
     config = JsxCurlyBracePresenceConfig,
     version = "0.7.0",
+    short_description = "Disallow unnecessary JSX expressions when literals alone are sufficient.",
 );
 
 impl Rule for JsxCurlyBracePresence {

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -42,6 +42,7 @@ declare_oxc_lint!(
     react,
     correctness,
     version = "0.1.1",
+    short_description = "Disallow undeclared variables in JSX.",
 );
 
 fn get_resolvable_ident<'a>(node: &'a JSXElementName<'a>) -> Option<&'a IdentifierReference<'a>> {

--- a/crates/oxc_linter/src/rules/react/no_did_mount_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_did_mount_set_state.rs
@@ -70,6 +70,7 @@ declare_oxc_lint!(
     correctness,
     config = AllowedOrDisallowInFunc,
     version = "1.36.0",
+    short_description = "Disallow usage of `setState` in `componentDidMount`.",
 );
 
 impl Rule for NoDidMountSetState {

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -92,6 +92,7 @@ declare_oxc_lint!(
     react,
     correctness,
     version = "0.2.0",
+    short_description = "Disallow direct mutation of `this.state`.",
 );
 
 impl Rule for NoDirectMutationState {

--- a/crates/oxc_linter/src/rules/react/no_redundant_should_component_update.rs
+++ b/crates/oxc_linter/src/rules/react/no_redundant_should_component_update.rs
@@ -96,6 +96,7 @@ declare_oxc_lint!(
     react,
     style,
     version = "1.33.0",
+    short_description = "Disallow usage of `shouldComponentUpdate` when extending `React.PureComponent`.",
 );
 
 impl Rule for NoRedundantShouldComponentUpdate {

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     react,
     suspicious,
     version = "0.0.20",
+    short_description = "Enforce that React is in scope when using JSX.",
 );
 
 impl Rule for ReactInJsxScope {

--- a/crates/oxc_linter/src/rules/react/state_in_constructor.rs
+++ b/crates/oxc_linter/src/rules/react/state_in_constructor.rs
@@ -105,6 +105,7 @@ declare_oxc_lint!(
     style,
     config = AlwaysNever,
     version = "1.26.0",
+    short_description = "Enforce a consistent style for initializing class component state.",
 );
 
 impl Rule for StateInConstructor {

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -80,6 +80,7 @@ declare_oxc_lint!(
     pedantic,
     none,
     version = "0.0.14",
+    short_description = "Disallow certain types.",
 );
 
 impl Rule for BanTypes {

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -78,6 +78,7 @@ declare_oxc_lint!(
     fix,
     config = PreferGenericType,
     version = "0.14.0",
+    short_description = "Enforce specifying generic type arguments on type annotation or constructor name of a constructor call.",
 );
 
 impl Rule for ConsistentGenericConstructors {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -182,6 +182,7 @@ declare_oxc_lint!(
     conditional_fix,
     config = ConsistentTypeImportsConfig,
     version = "0.5.2",
+    short_description = "Enforce consistent usage of type imports.",
 );
 
 impl Rule for ConsistentTypeImports {

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -158,6 +158,7 @@ declare_oxc_lint!(
     pending,
     config = NoEmptyObjectTypeConfig,
     version = "0.12.0",
+    short_description = "Disallow accidentally using the \"empty object\" type.",
 );
 
 impl Rule for NoEmptyObjectType {

--- a/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extraneous_class.rs
@@ -90,6 +90,7 @@ declare_oxc_lint!(
     dangerous_suggestion,
     config = NoExtraneousClass,
     version = "0.7.0",
+    short_description = "Disallow classes used as namespaces.",
 );
 
 fn empty_class_diagnostic(span: Span, has_decorators: bool) -> OxcDiagnostic {

--- a/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_floating_promises.rs
@@ -109,6 +109,7 @@ declare_oxc_lint!(
     suggestion,
     config = NoFloatingPromisesConfig,
     version = "1.11.0",
+    short_description = "Require Promise-like statements to be handled appropriately.",
 );
 
 impl Rule for NoFloatingPromises {

--- a/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_promises.rs
@@ -127,6 +127,7 @@ declare_oxc_lint!(
     pedantic,
     config = NoMisusedPromisesConfig,
     version = "1.11.0",
+    short_description = "Disallow Promises in places not designed to handle them.",
 );
 
 impl Rule for NoMisusedPromises {

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     correctness,
     fix,
     version = "0.7.0",
+    short_description = "Require using `namespace` keyword over `module` keyword to declare custom TypeScript modules.",
 );
 
 fn is_valid_module(module: &TSModuleDeclaration) -> bool {

--- a/crates/oxc_linter/src/rules/unicorn/consistent_existence_index_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_existence_index_check.rs
@@ -69,6 +69,7 @@ declare_oxc_lint!(
     style,
     fix,
     version = "0.12.0",
+    short_description = "Enforce consistent style for element existence checks with `indexOf()`, `lastIndexOf()`, `findIndex()`, and `findLastIndex()`.",
 );
 
 const METHOD_NAMES: [&str; 4] = ["indexOf", "lastIndexOf", "findIndex", "findLastIndex"];

--- a/crates/oxc_linter/src/rules/unicorn/custom_error_definition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/custom_error_definition.rs
@@ -126,6 +126,7 @@ declare_oxc_lint!(
     style,
     pending,
     version = "1.57.0",
+    short_description = "Enforce correct `Error` subclassing.",
 );
 
 impl Rule for CustomErrorDefinition {

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -49,6 +49,7 @@ declare_oxc_lint!(
     style,
     fix,
     version = "0.0.18",
+    short_description = "Enforce no spaces between braces.",
 );
 
 impl Rule for EmptyBraceSpaces {

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -51,6 +51,7 @@ declare_oxc_lint!(
     pedantic,
     pending,
     version = "0.0.16",
+    short_description = "Enforce the use of `new` for most builtins.",
 );
 
 impl Rule for NewForBuiltins {

--- a/crates/oxc_linter/src/rules/unicorn/no_instanceof_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_instanceof_builtins.rs
@@ -127,6 +127,7 @@ declare_oxc_lint!(
     conditional_suggestion,
     config = NoInstanceofBuiltinsConfig,
     version = "0.16.12",
+    short_description = "Disallow `instanceof` with built-in objects.",
 );
 
 impl Rule for NoInstanceofBuiltins {

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -56,6 +56,7 @@ declare_oxc_lint!(
     unicorn,
     correctness,
     version = "0.15.12",
+    short_description = "Disallow invalid options in `fetch()` and `new Request()`.",
 );
 
 impl Rule for NoInvalidFetchOptions {

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -20,6 +20,7 @@ declare_oxc_lint!(
     pending,
     docs = DOCUMENTATION,
     version = "0.0.18",
+    short_description = "Disallow negated conditions.",
 );
 
 impl Rule for NoNegatedCondition {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_length_check.rs
@@ -63,6 +63,7 @@ declare_oxc_lint!(
     correctness,
     pending,
     version = "0.0.19",
+    short_description = "Disallow useless array length check.",
 );
 
 struct ConditionDTO<T: ToString> {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -144,6 +144,7 @@ declare_oxc_lint!(
     correctness,
     fix_dangerous,
     version = "0.0.19",
+    short_description = "Disallow unnecessary spread.",
 );
 
 impl Rule for NoUselessSpread {

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_undefined.rs
@@ -79,6 +79,7 @@ declare_oxc_lint!(
     fix,
     config = NoUselessUndefined,
     version = "0.6.1",
+    short_description = "Disallow useless `undefined`.",
 );
 
 // Create a static set for all function names

--- a/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_add_event_listener.rs
@@ -43,6 +43,7 @@ declare_oxc_lint!(
     suspicious,
     pending,
     version = "0.0.16",
+    short_description = "Prefer `.addEventListener()` and `.removeEventListener()` over `on`-functions.",
 );
 
 impl Rule for PreferAddEventListener {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_event_target.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     unicorn,
     pedantic,
     version = "0.0.18",
+    short_description = "Prefer `EventTarget` over `EventEmitter`.",
 );
 
 impl Rule for PreferEventTarget {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
@@ -71,6 +71,7 @@ declare_oxc_lint!(
     style,
     fix,
     version = "1.33.0",
+    short_description = "Prefer `KeyboardEvent#key` over `KeyboardEvent#keyCode`.",
 );
 
 impl Rule for PreferKeyboardEventKey {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_math_trunc.rs
@@ -48,6 +48,7 @@ declare_oxc_lint!(
     pedantic,
     suggestion,
     version = "0.0.18",
+    short_description = "Enforce the use of `Math.trunc` instead of bitwise operators.",
 );
 
 impl Rule for PreferMathTrunc {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -64,6 +64,7 @@ declare_oxc_lint!(
     pedantic,
     conditional_fix,
     version = "0.0.15",
+    short_description = "Prefer `.querySelector()` over `.getElementById()`, and `.querySelectorAll()` over `.getElementsByClassName()` and `.getElementsByTagName()`.",
 );
 
 impl Rule for PreferQuerySelector {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_single_call.rs
@@ -80,7 +80,8 @@ declare_oxc_lint!(
     pending,
     fix,
     config = PreferSingleCallConfig,
-    version = "next"
+    version = "next",
+    short_description = "Enforce combining multiple `Array#push()`, `Element#classList.{add,remove}()`, and `importScripts()` into one call.",
 );
 
 impl Rule for PreferSingleCall {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -57,6 +57,7 @@ declare_oxc_lint!(
     correctness,
     fix,
     version = "0.0.18",
+    short_description = "Prefer `String#startsWith()` and `String#endsWith()` over `RegExp#test()`.",
 );
 
 impl Rule for PreferStringStartsEndsWith {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_trim_start_end.rs
@@ -45,6 +45,7 @@ declare_oxc_lint!(
     style,
     fix,
     version = "0.0.16",
+    short_description = "Prefer `trimStart` / `trimEnd` over `trimLeft` / `trimRight` on String.",
 );
 
 impl Rule for PreferStringTrimStartEnd {

--- a/crates/oxc_linter/src/rules/unicorn/require_post_message_target_origin.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_post_message_target_origin.rs
@@ -52,6 +52,7 @@ declare_oxc_lint!(
     suspicious,
     suggestion,
     version = "0.15.15",
+    short_description = "Enforce using the `targetOrigin` argument with `window.postMessage()`.",
 );
 
 impl Rule for RequirePostMessageTargetOrigin {

--- a/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/text_encoding_identifier_case.rs
@@ -79,6 +79,7 @@ declare_oxc_lint!(
     fix,
     config = TextEncodingIdentifierCase,
     version = "0.0.15",
+    short_description = "Enforce consistent case for text encoding identifiers.",
 );
 
 impl Rule for TextEncodingIdentifierCase {


### PR DESCRIPTION
Another set of `short_description` additions, completes all rules in the `eslint`, `typescript`, `react`, `import`, and `unicorn` plugins.

With this, the only remaining rules to update are the shared rules in jest/vitest.