### PR TITLE
docs(linter): remove manually written options doc for `eslint/no-sequences`

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -3282,7 +3282,6 @@ export interface NoSequences {
   /**
    * If this option is set to `false`, this rule disallows the comma operator
    * even when the expression sequence is explicitly wrapped in parentheses.
-   * Default is `true`.
    */
   allowInParentheses?: boolean;
 }

--- a/crates/oxc_linter/src/rules/eslint/no_sequences.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_sequences.rs
@@ -21,7 +21,6 @@ fn no_sequences_diagnostic(span: Span) -> OxcDiagnostic {
 pub struct NoSequences {
     /// If this option is set to `false`, this rule disallows the comma operator
     /// even when the expression sequence is explicitly wrapped in parentheses.
-    /// Default is `true`.
     allow_in_parentheses: bool,
 }
 
@@ -41,11 +40,6 @@ declare_oxc_lint!(
     /// The comma operator evaluates each of its operands (from left to right)
     /// and returns the value of the last operand. However, this frequently
     /// obscures side effects, and its use is often an accident.
-    ///
-    /// ### Options
-    ///
-    /// - `allowInParentheses` (default: `true`): If set to `false`, disallows
-    ///   the comma operator even when wrapped in parentheses.
     ///
     /// ### Examples
     ///

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -14158,10 +14158,10 @@
       "type": "object",
       "properties": {
         "allowInParentheses": {
-          "description": "If this option is set to `false`, this rule disallows the comma operator\neven when the expression sequence is explicitly wrapped in parentheses.\nDefault is `true`.",
+          "description": "If this option is set to `false`, this rule disallows the comma operator\neven when the expression sequence is explicitly wrapped in parentheses.",
           "default": true,
           "type": "boolean",
-          "markdownDescription": "If this option is set to `false`, this rule disallows the comma operator\neven when the expression sequence is explicitly wrapped in parentheses.\nDefault is `true`."
+          "markdownDescription": "If this option is set to `false`, this rule disallows the comma operator\neven when the expression sequence is explicitly wrapped in parentheses."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
this PR removes manually written options doc for `eslint/no-sequences` to avoid duplication

before:

<img width="2658" height="2524" alt="image" src="https://github.com/user-attachments/assets/0c47043b-c05a-430b-968d-d0297f9a1bf8" />

after: 

<img width="2604" height="2366" alt="image" src="https://github.com/user-attachments/assets/93b3dcfa-5d56-4814-b531-27aa547f913e" />
