### PR TITLE
test(oxfmt): add gitlab as graphql conformance

### DIFF
--- a/apps/oxfmt/conformance/download-fixtures.js
+++ b/apps/oxfmt/conformance/download-fixtures.js
@@ -32,6 +32,11 @@ const sources = [
     repo: "sveltejs/prettier-plugin-svelte/test/formatting/samples",
     version: `prettier-plugin-svelte@${pkg.dependencies["prettier-plugin-svelte"]}`,
   },
+  {
+    name: "gitlab",
+    repo: "gitlabhq/gitlabhq/app/assets",
+    version: "v16.9.0",
+  },
 ];
 
 await Promise.all(

--- a/apps/oxfmt/conformance/run.ts
+++ b/apps/oxfmt/conformance/run.ts
@@ -177,6 +177,18 @@ const categories: Category[] = [
     ],
     notes: {},
   },
+  {
+    name: "graphql",
+    sources: [
+      {
+        dir: join(EXTERNALS_DIR, "gitlab"),
+        ext: ".graphql",
+        excludes: [],
+      },
+    ],
+    optionSets: [{ printWidth: 80 }, { printWidth: 100 }],
+    notes: {},
+  },
 ];
 
 // ---

--- a/apps/oxfmt/conformance/snapshots/conformance.snap.md
+++ b/apps/oxfmt/conformance/snapshots/conformance.snap.md
@@ -137,3 +137,17 @@
 ```json
 {"printWidth":120,"singleQuote":true,"htmlWhitespaceSensitivity":"ignore","bracketSameLine":true,"svelteIndentScriptAndStyle":true,"svelteSortOrder":"options-scripts-styles-markup","svelte":{"indentScriptAndStyle":true,"sortOrder":"options-scripts-styles-markup"}}
 ```
+
+## graphql
+
+### Option 1: 712/712 (100.00%)
+
+```json
+{"printWidth":80}
+```
+
+### Option 2: 712/712 (100.00%)
+
+```json
+{"printWidth":100}
+```


### PR DESCRIPTION
- Add `gitlabhq/gitlab` repo to oxfmt conformance
  - There are 700~ graphql files
- Once `gitlab` repo is migrated Oxfmt, we can add it to ecosystem-ci