### PR TITLE
perf(codegen)!: borrow sourcemaps from codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3866f9075027840e0711b52e15d2e1ba076fc5f5f01c96eeedd26375410641"
+checksum = "ae44116995c00fe1573068490a91d2a7272b1eb473d740f79188d99e1e1c0660"
 dependencies = [
  "base64-simd",
  "json-escape-simd",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44116995c00fe1573068490a91d2a7272b1eb473d740f79188d99e1e1c0660"
+checksum = "174d2498c2390ccfab0a9caaf47ef5accda1d509aaa34a5be8f45e00e5299f04"
 dependencies = [
  "base64-simd",
  "json-escape-simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ json-strip-comments = "3.1.0" # Strip JSON comments
 oxc-browserslist = "3.0.0" # Browser compatibility queries
 oxc_index = { version = "5.0.0", features = ["nonmax", "serde"] } # Type-safe indices
 oxc_resolver = "11.16.3" # Module resolution
-oxc_sourcemap = "8.0.0" # Source map generation
+oxc_sourcemap = "8.0.1" # Source map generation
 
 #
 allocator-api2 = "=0.2.21" # Allocator trait

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ json-strip-comments = "3.1.0" # Strip JSON comments
 oxc-browserslist = "3.0.0" # Browser compatibility queries
 oxc_index = { version = "5.0.0", features = ["nonmax", "serde"] } # Type-safe indices
 oxc_resolver = "11.16.3" # Module resolution
-oxc_sourcemap = "7.0.0" # Source map generation
+oxc_sourcemap = "8.0.0" # Source map generation
 
 #
 allocator-api2 = "=0.2.21" # Allocator trait

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -27,7 +27,7 @@ impl CompilerInterface for Compiler {
         self.errors.extend(errors);
     }
 
-    fn after_codegen(&mut self, ret: CodegenReturn) {
+    fn after_codegen(&mut self, ret: CodegenReturn<'_>) {
         self.printed = ret.code;
     }
 }
@@ -112,7 +112,7 @@ pub trait CompilerInterface {
         ControlFlow::Continue(())
     }
 
-    fn after_isolated_declarations(&mut self, _ret: CodegenReturn) {}
+    fn after_isolated_declarations(&mut self, _ret: CodegenReturn<'_>) {}
 
     fn after_transform(
         &mut self,
@@ -122,7 +122,7 @@ pub trait CompilerInterface {
         ControlFlow::Continue(())
     }
 
-    fn after_codegen(&mut self, _ret: CodegenReturn) {}
+    fn after_codegen(&mut self, _ret: CodegenReturn<'_>) {}
 
     fn compile(&mut self, source_text: &str, source_type: SourceType, source_path: &Path) {
         let allocator = Allocator::default();
@@ -308,13 +308,13 @@ pub trait CompilerInterface {
         Mangler::new().with_options(options).build(program)
     }
 
-    fn codegen(
+    fn codegen<'a>(
         &self,
-        program: &Program<'_>,
+        program: &Program<'a>,
         source_path: &Path,
         mangler_return: Option<ManglerReturn>,
         options: CodegenOptions,
-    ) -> CodegenReturn {
+    ) -> CodegenReturn<'a> {
         let mut options = options;
         if self.enable_sourcemap() {
             options.source_map_path = Some(source_path.to_path_buf());

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -3,6 +3,8 @@
 //! Code adapted from
 //! * [esbuild](https://github.com/evanw/esbuild/blob/v0.24.0/internal/js_printer/js_printer.go)
 
+#[cfg(not(feature = "sourcemap"))]
+use std::marker::PhantomData;
 use std::{borrow::Cow, cmp, slice};
 
 use cow_utils::CowUtils;
@@ -57,6 +59,9 @@ pub struct CodegenReturn<'a> {
     /// You must set [`CodegenOptions::source_map_path`] for this to be [`Some`].
     #[cfg(feature = "sourcemap")]
     pub map: Option<oxc_sourcemap::SourceMap<'a>>,
+
+    #[cfg(not(feature = "sourcemap"))]
+    _source_map_lifetime: PhantomData<&'a ()>,
 
     /// All the legal comments returned from [LegalComment::Linked] or [LegalComment::External].
     pub legal_comments: Vec<Comment>,
@@ -265,6 +270,8 @@ impl<'a> Codegen<'a> {
             code,
             #[cfg(feature = "sourcemap")]
             map,
+            #[cfg(not(feature = "sourcemap"))]
+            _source_map_lifetime: PhantomData,
             legal_comments,
         }
     }

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -48,7 +48,7 @@ pub use oxc_data_structures::code_buffer::IndentChar;
 
 /// Output from [`Codegen::build`]
 #[non_exhaustive]
-pub struct CodegenReturn {
+pub struct CodegenReturn<'a> {
     /// The generated source code.
     pub code: String,
 
@@ -56,7 +56,7 @@ pub struct CodegenReturn {
     ///
     /// You must set [`CodegenOptions::source_map_path`] for this to be [`Some`].
     #[cfg(feature = "sourcemap")]
-    pub map: Option<oxc_sourcemap::OwnedSourceMap>,
+    pub map: Option<oxc_sourcemap::SourceMap<'a>>,
 
     /// All the legal comments returned from [LegalComment::Linked] or [LegalComment::External].
     pub legal_comments: Vec<Comment>,
@@ -246,7 +246,7 @@ impl<'a> Codegen<'a> {
     ///
     /// A source map will be generated if [`CodegenOptions::source_map_path`] is set.
     #[must_use]
-    pub fn build(mut self, program: &Program<'a>) -> CodegenReturn {
+    pub fn build(mut self, program: &Program<'a>) -> CodegenReturn<'a> {
         self.quote = if self.options.single_quote { Quote::Single } else { Quote::Double };
         self.source_text = Some(program.source_text);
         self.indent = self.options.initial_indent;

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -40,7 +40,10 @@ pub struct Line {
     column_offsets_id: Option<ColumnOffsetsId>,
 }
 
-type ColumnOffsets = Box<[ColumnOffset]>;
+#[derive(Debug)]
+pub struct ColumnOffsets {
+    offsets: Box<[ColumnOffset]>,
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct ColumnOffset {
@@ -154,21 +157,9 @@ impl<'a> SourcemapBuilder<'a> {
         let mut original_column = position - line.byte_offset_to_start_of_line;
         if let Some(column_offsets_id) = line.column_offsets_id {
             let column_offsets = &self.line_offset_tables.column_offsets[column_offsets_id];
-            let offset_index =
-                column_offsets.partition_point(|offset| offset.byte_offset <= original_column);
-            if offset_index != 0 {
-                let offset = column_offsets[offset_index - 1];
-                let char_start = (line.byte_offset_to_start_of_line + offset.byte_offset) as usize;
-                let ch = self.original_source[char_start..].chars().next().unwrap();
-                let byte_len = ch.len_utf8() as u32;
-
-                original_column = if original_column < offset.byte_offset + byte_len {
-                    offset.column
-                } else {
-                    offset.column
-                        + ch.len_utf16() as u32
-                        + (original_column - offset.byte_offset - byte_len)
-                };
+            if original_column >= column_offsets.byte_offset_to_first {
+                original_column = column_offsets.columns
+                    [(original_column - column_offsets.byte_offset_to_first) as usize];
             }
         }
         (original_line as u32, original_column)
@@ -255,6 +246,12 @@ impl<'a> SourcemapBuilder<'a> {
 
         while lines[idx].byte_offset_to_start_of_line > position {
             idx -= 1;
+        }
+
+        if lines[idx].byte_offset_to_start_of_line < position {
+            idx = lines
+                .partition_point(|table| table.byte_offset_to_start_of_line <= position)
+                .saturating_sub(1);
         }
 
         idx
@@ -359,6 +356,7 @@ impl<'a> SourcemapBuilder<'a> {
         // Used as a buffer to reduce memory reallocations.
         // Pre-allocate with reasonable capacity to avoid frequent reallocations.
         // 16 is a guess, probably adequate for most files which don't heavily use unicode chars.
+        // 16 entries is 64 bytes = 1 CPU cache line on most CPUs.
         // If file does heavily use unicode chars, `columns` will grow adaptively as needed.
         let mut columns = Vec::with_capacity(16);
 
@@ -366,8 +364,7 @@ impl<'a> SourcemapBuilder<'a> {
         // For each line, start by assuming line will be entirely ASCII, and read byte-by-byte.
         // If line is all ASCII, UTF-8 columns and UTF-16 columns are the same,
         // so no need to create a `columns` Vec. This is the fast path for common case.
-        // If a Unicode character found, read rest of line char-by-char, recording Unicode char
-        // offsets. ASCII byte columns can then be derived from the closest preceding Unicode char.
+        // If a Unicode character found, read rest of line char-by-char, populating `columns` Vec.
         // At end of line, go back to top of outer loop, and again assume ASCII for next line.
         let mut line_byte_offset = 0;
         'lines: loop {
@@ -410,12 +407,7 @@ impl<'a> SourcemapBuilder<'a> {
                         for (chunk_byte_offset, ch) in remaining.char_indices() {
                             #[expect(clippy::cast_possible_truncation)]
                             let mut chunk_byte_offset = chunk_byte_offset as u32;
-                            if !ch.is_ascii() {
-                                columns.push(ColumnOffset {
-                                    byte_offset: byte_offset_from_line_start + chunk_byte_offset,
-                                    column,
-                                });
-                            }
+                            columns.extend(std::iter::repeat_n(column, ch.len_utf8()));
 
                             match ch {
                                 '\r' => {
@@ -425,6 +417,7 @@ impl<'a> SourcemapBuilder<'a> {
                                         == Some(&b'\n')
                                     {
                                         chunk_byte_offset += 1;
+                                        columns.push(column + 1);
                                     }
                                 }
                                 '\n' => {
@@ -452,15 +445,25 @@ impl<'a> SourcemapBuilder<'a> {
                             // and does not need to reallocate again.
                             // `columns` is reused for next line, and will grow adaptively depending on
                             // how heavily the file uses unicode chars.
-                            column_offsets.push(columns.clone().into_boxed_slice());
+                            column_offsets.push(ColumnOffsets {
+                                byte_offset_to_first: byte_offset_from_line_start,
+                                columns: columns.clone().into_boxed_slice(),
+                            });
                             columns.clear();
 
                             // Revert back to outer loop for next line
                             continue 'lines;
                         }
 
+                        // EOF.
+                        // One last column entry for EOF position.
+                        columns.push(column);
+
                         // Record column offsets
-                        column_offsets.push(columns.into_boxed_slice());
+                        column_offsets.push(ColumnOffsets {
+                            byte_offset_to_first: byte_offset_from_line_start,
+                            columns: columns.into_boxed_slice(),
+                        });
 
                         break 'lines;
                     }
@@ -528,10 +531,6 @@ mod test {
         assert_mapping("\nÖÖ\n", &[(0, 0, 0), (1, 1, 0), (3, 1, 1), (5, 1, 2), (6, 2, 0)]);
         assert_mapping("Ö\ra", &[(0, 0, 0), (2, 0, 1), (3, 1, 0), (4, 1, 1)]);
         assert_mapping("Ö\r\na", &[(0, 0, 0), (2, 0, 1), (3, 0, 2), (4, 1, 0), (5, 1, 1)]);
-        assert_mapping("测a", &[(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 0, 1), (4, 0, 2)]);
-        assert_mapping("😀a", &[(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 0, 0), (4, 0, 2), (5, 0, 3)]);
-        assert_mapping("\u{2028}a", &[(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 1, 0), (4, 1, 1)]);
-        assert_mapping("\u{2029}a", &[(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 1, 0), (4, 1, 1)]);
     }
 
     #[test]

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -40,10 +40,7 @@ pub struct Line {
     column_offsets_id: Option<ColumnOffsetsId>,
 }
 
-#[derive(Debug)]
-pub struct ColumnOffsets {
-    offsets: Box<[ColumnOffset]>,
-}
+type ColumnOffsets = Box<[ColumnOffset]>;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ColumnOffset {
@@ -157,9 +154,21 @@ impl<'a> SourcemapBuilder<'a> {
         let mut original_column = position - line.byte_offset_to_start_of_line;
         if let Some(column_offsets_id) = line.column_offsets_id {
             let column_offsets = &self.line_offset_tables.column_offsets[column_offsets_id];
-            if original_column >= column_offsets.byte_offset_to_first {
-                original_column = column_offsets.columns
-                    [(original_column - column_offsets.byte_offset_to_first) as usize];
+            let offset_index =
+                column_offsets.partition_point(|offset| offset.byte_offset <= original_column);
+            if offset_index != 0 {
+                let offset = column_offsets[offset_index - 1];
+                let char_start = (line.byte_offset_to_start_of_line + offset.byte_offset) as usize;
+                let ch = self.original_source[char_start..].chars().next().unwrap();
+                let byte_len = ch.len_utf8() as u32;
+
+                original_column = if original_column < offset.byte_offset + byte_len {
+                    offset.column
+                } else {
+                    offset.column
+                        + ch.len_utf16() as u32
+                        + (original_column - offset.byte_offset - byte_len)
+                };
             }
         }
         (original_line as u32, original_column)
@@ -246,12 +255,6 @@ impl<'a> SourcemapBuilder<'a> {
 
         while lines[idx].byte_offset_to_start_of_line > position {
             idx -= 1;
-        }
-
-        if lines[idx].byte_offset_to_start_of_line < position {
-            idx = lines
-                .partition_point(|table| table.byte_offset_to_start_of_line <= position)
-                .saturating_sub(1);
         }
 
         idx
@@ -356,7 +359,6 @@ impl<'a> SourcemapBuilder<'a> {
         // Used as a buffer to reduce memory reallocations.
         // Pre-allocate with reasonable capacity to avoid frequent reallocations.
         // 16 is a guess, probably adequate for most files which don't heavily use unicode chars.
-        // 16 entries is 64 bytes = 1 CPU cache line on most CPUs.
         // If file does heavily use unicode chars, `columns` will grow adaptively as needed.
         let mut columns = Vec::with_capacity(16);
 
@@ -364,7 +366,8 @@ impl<'a> SourcemapBuilder<'a> {
         // For each line, start by assuming line will be entirely ASCII, and read byte-by-byte.
         // If line is all ASCII, UTF-8 columns and UTF-16 columns are the same,
         // so no need to create a `columns` Vec. This is the fast path for common case.
-        // If a Unicode character found, read rest of line char-by-char, populating `columns` Vec.
+        // If a Unicode character found, read rest of line char-by-char, recording Unicode char
+        // offsets. ASCII byte columns can then be derived from the closest preceding Unicode char.
         // At end of line, go back to top of outer loop, and again assume ASCII for next line.
         let mut line_byte_offset = 0;
         'lines: loop {
@@ -407,7 +410,12 @@ impl<'a> SourcemapBuilder<'a> {
                         for (chunk_byte_offset, ch) in remaining.char_indices() {
                             #[expect(clippy::cast_possible_truncation)]
                             let mut chunk_byte_offset = chunk_byte_offset as u32;
-                            columns.extend(std::iter::repeat_n(column, ch.len_utf8()));
+                            if !ch.is_ascii() {
+                                columns.push(ColumnOffset {
+                                    byte_offset: byte_offset_from_line_start + chunk_byte_offset,
+                                    column,
+                                });
+                            }
 
                             match ch {
                                 '\r' => {
@@ -417,7 +425,6 @@ impl<'a> SourcemapBuilder<'a> {
                                         == Some(&b'\n')
                                     {
                                         chunk_byte_offset += 1;
-                                        columns.push(column + 1);
                                     }
                                 }
                                 '\n' => {
@@ -445,25 +452,15 @@ impl<'a> SourcemapBuilder<'a> {
                             // and does not need to reallocate again.
                             // `columns` is reused for next line, and will grow adaptively depending on
                             // how heavily the file uses unicode chars.
-                            column_offsets.push(ColumnOffsets {
-                                byte_offset_to_first: byte_offset_from_line_start,
-                                columns: columns.clone().into_boxed_slice(),
-                            });
+                            column_offsets.push(columns.clone().into_boxed_slice());
                             columns.clear();
 
                             // Revert back to outer loop for next line
                             continue 'lines;
                         }
 
-                        // EOF.
-                        // One last column entry for EOF position.
-                        columns.push(column);
-
                         // Record column offsets
-                        column_offsets.push(ColumnOffsets {
-                            byte_offset_to_first: byte_offset_from_line_start,
-                            columns: columns.into_boxed_slice(),
-                        });
+                        column_offsets.push(columns.into_boxed_slice());
 
                         break 'lines;
                     }
@@ -531,6 +528,10 @@ mod test {
         assert_mapping("\nÖÖ\n", &[(0, 0, 0), (1, 1, 0), (3, 1, 1), (5, 1, 2), (6, 2, 0)]);
         assert_mapping("Ö\ra", &[(0, 0, 0), (2, 0, 1), (3, 1, 0), (4, 1, 1)]);
         assert_mapping("Ö\r\na", &[(0, 0, 0), (2, 0, 1), (3, 0, 2), (4, 1, 0), (5, 1, 1)]);
+        assert_mapping("测a", &[(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 0, 1), (4, 0, 2)]);
+        assert_mapping("😀a", &[(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 0, 0), (4, 0, 2), (5, 0, 3)]);
+        assert_mapping("\u{2028}a", &[(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 1, 0), (4, 1, 1)]);
+        assert_mapping("\u{2029}a", &[(0, 0, 0), (1, 0, 0), (2, 0, 0), (3, 1, 0), (4, 1, 1)]);
     }
 
     #[test]

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, path::Path};
 use oxc_index::{IndexVec, define_nonmax_u32_index_type};
 use oxc_span::Span;
 use oxc_syntax::line_terminator::{LS, LS_LAST_2_BYTES, LS_OR_PS_FIRST_BYTE, PS, PS_LAST_2_BYTES};
+use rustc_hash::FxHashMap;
 
 /// Number of lines to check with linear search when translating byte position to line index
 const LINE_SEARCH_LINEAR_ITERATIONS: usize = 16;
@@ -48,11 +49,14 @@ pub struct ColumnOffsets {
 #[expect(clippy::struct_field_names)]
 pub struct SourcemapBuilder<'a> {
     source_id: u32,
+    source_name: String,
     original_source: &'a str,
+    names: Vec<&'a str>,
+    names_map: FxHashMap<&'a str, u32>,
+    tokens: Vec<oxc_sourcemap::Token>,
     last_generated_update: usize,
     last_position: Option<u32>,
     line_offset_tables: LineOffsetTables,
-    sourcemap_builder: oxc_sourcemap::SourceMapBuilder<'a>,
     generated_line: u32,
     generated_column: u32,
     /// Tracks the last accessed line index to optimize sequential lookups in `search_original_line_and_column`.
@@ -63,25 +67,38 @@ pub struct SourcemapBuilder<'a> {
 
 impl<'a> SourcemapBuilder<'a> {
     pub fn new(path: &Path, source_text: &'a str) -> Self {
-        let mut sourcemap_builder = oxc_sourcemap::SourceMapBuilder::default();
         let line_offset_tables = Self::generate_line_offset_tables(source_text);
-        let source_id = sourcemap_builder
-            .set_source_and_content(Cow::Owned(path.to_string_lossy().into_owned()), source_text);
         Self {
-            source_id,
+            source_id: 0,
+            source_name: path.to_string_lossy().into_owned(),
             original_source: source_text,
+            names: Vec::new(),
+            names_map: FxHashMap::default(),
+            tokens: Vec::new(),
             last_generated_update: 0,
             last_position: None,
             line_offset_tables,
-            sourcemap_builder,
             generated_line: 0,
             generated_column: 0,
             last_line_lookup: 0,
         }
     }
 
-    pub fn into_sourcemap(self) -> oxc_sourcemap::SourceMap<'a> {
-        self.sourcemap_builder.into_sourcemap()
+    pub fn into_sourcemap(mut self) -> oxc_sourcemap::SourceMap<'a> {
+        self.names.shrink_to_fit();
+        self.tokens.shrink_to_fit();
+
+        oxc_sourcemap::SourceMap::from_parts(oxc_sourcemap::SourceMapParts {
+            file: None,
+            names: self.names.into_iter().map(Cow::Borrowed).collect(),
+            source_root: None,
+            sources: vec![Cow::Owned(self.source_name)],
+            source_contents: vec![Some(Cow::Borrowed(self.original_source))],
+            tokens: self.tokens.into_boxed_slice(),
+            token_chunks: None,
+            x_google_ignore_list: None,
+            debug_id: None,
+        })
     }
 
     pub fn add_source_mapping_for_name(&mut self, output: &[u8], span: Span, name: &str) {
@@ -105,16 +122,26 @@ impl<'a> SourcemapBuilder<'a> {
         }
         let (original_line, original_column) = self.search_original_line_and_column(position);
         self.update_generated_line_and_column(output);
-        let name_id = name.map(|s| self.sourcemap_builder.add_name(s));
-        self.sourcemap_builder.add_token(
+        let name_id = name.map(|s| self.add_name(s));
+        self.tokens.push(oxc_sourcemap::Token::new(
             self.generated_line,
             self.generated_column,
             original_line,
             original_column,
             Some(self.source_id),
             name_id,
-        );
+        ));
         self.last_position = Some(position);
+    }
+
+    fn add_name(&mut self, name: &'a str) -> u32 {
+        if let Some(&id) = self.names_map.get(name) {
+            return id;
+        }
+        let id = self.names.len() as u32;
+        self.names_map.insert(name, id);
+        self.names.push(name);
+        id
     }
 
     #[expect(clippy::cast_possible_truncation)]

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{borrow::Cow, path::Path};
 
 use oxc_index::{IndexVec, define_nonmax_u32_index_type};
 use oxc_span::Span;
@@ -52,7 +52,7 @@ pub struct SourcemapBuilder<'a> {
     last_generated_update: usize,
     last_position: Option<u32>,
     line_offset_tables: LineOffsetTables,
-    sourcemap_builder: oxc_sourcemap::SourceMapBuilder,
+    sourcemap_builder: oxc_sourcemap::SourceMapBuilder<'a>,
     generated_line: u32,
     generated_column: u32,
     /// Tracks the last accessed line index to optimize sequential lookups in `search_original_line_and_column`.
@@ -65,8 +65,8 @@ impl<'a> SourcemapBuilder<'a> {
     pub fn new(path: &Path, source_text: &'a str) -> Self {
         let mut sourcemap_builder = oxc_sourcemap::SourceMapBuilder::default();
         let line_offset_tables = Self::generate_line_offset_tables(source_text);
-        let source_id =
-            sourcemap_builder.set_source_and_content(path.to_string_lossy().as_ref(), source_text);
+        let source_id = sourcemap_builder
+            .set_source_and_content(Cow::Owned(path.to_string_lossy().into_owned()), source_text);
         Self {
             source_id,
             original_source: source_text,
@@ -80,8 +80,8 @@ impl<'a> SourcemapBuilder<'a> {
         }
     }
 
-    pub fn into_sourcemap(self) -> oxc_sourcemap::OwnedSourceMap {
-        self.sourcemap_builder.into_owned_sourcemap()
+    pub fn into_sourcemap(self) -> oxc_sourcemap::SourceMap<'a> {
+        self.sourcemap_builder.into_sourcemap()
     }
 
     pub fn add_source_mapping_for_name(&mut self, output: &[u8], span: Span, name: &str) {
@@ -99,7 +99,7 @@ impl<'a> SourcemapBuilder<'a> {
         self.add_source_mapping(output, span.start, token_name);
     }
 
-    pub fn add_source_mapping(&mut self, output: &[u8], position: u32, name: Option<&str>) {
+    pub fn add_source_mapping(&mut self, output: &[u8], position: u32, name: Option<&'a str>) {
         if self.last_position == Some(position) {
             return;
         }

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -42,13 +42,16 @@ pub struct Line {
 
 #[derive(Debug)]
 pub struct ColumnOffsets {
-    byte_offset_to_first: u32,
-    columns: Box<[u32]>,
+    offsets: Box<[ColumnOffset]>,
 }
 
-#[expect(clippy::struct_field_names)]
+#[derive(Debug, Clone, Copy)]
+pub struct ColumnOffset {
+    byte_offset: u32,
+    column: u32,
+}
+
 pub struct SourcemapBuilder<'a> {
-    source_id: u32,
     source_name: String,
     original_source: &'a str,
     names: Vec<&'a str>,
@@ -69,7 +72,6 @@ impl<'a> SourcemapBuilder<'a> {
     pub fn new(path: &Path, source_text: &'a str) -> Self {
         let line_offset_tables = Self::generate_line_offset_tables(source_text);
         Self {
-            source_id: 0,
             source_name: path.to_string_lossy().into_owned(),
             original_source: source_text,
             names: Vec::new(),
@@ -128,7 +130,7 @@ impl<'a> SourcemapBuilder<'a> {
             self.generated_column,
             original_line,
             original_column,
-            Some(self.source_id),
+            Some(0),
             name_id,
         ));
         self.last_position = Some(position);
@@ -138,7 +140,7 @@ impl<'a> SourcemapBuilder<'a> {
         if let Some(&id) = self.names_map.get(name) {
             return id;
         }
-        let id = self.names.len() as u32;
+        let id = u32::try_from(self.names.len()).expect("sourcemap names length should fit in u32");
         self.names_map.insert(name, id);
         self.names.push(name);
         id

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -42,13 +42,8 @@ pub struct Line {
 
 #[derive(Debug)]
 pub struct ColumnOffsets {
-    offsets: Box<[ColumnOffset]>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct ColumnOffset {
-    byte_offset: u32,
-    column: u32,
+    byte_offset_to_first: u32,
+    columns: Box<[u32]>,
 }
 
 pub struct SourcemapBuilder<'a> {

--- a/crates/oxc_codegen/tests/integration/tester.rs
+++ b/crates/oxc_codegen/tests/integration/tester.rs
@@ -1,5 +1,6 @@
 use oxc_allocator::Allocator;
-use oxc_codegen::{Codegen, CodegenOptions, CodegenReturn};
+use oxc_ast::ast::Comment;
+use oxc_codegen::{Codegen, CodegenOptions};
 use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
 
@@ -95,14 +96,20 @@ pub fn codegen(source_text: &str) -> String {
 }
 
 #[track_caller]
-pub fn codegen_options(source_text: &str, options: &CodegenOptions) -> CodegenReturn {
+pub fn codegen_options(source_text: &str, options: &CodegenOptions) -> CodegenTestReturn {
     let allocator = Allocator::default();
     let source_type = SourceType::ts();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     assert!(ret.diagnostics.is_empty(), "Parse errors: {:?}", ret.diagnostics);
     let mut options = options.clone();
     options.single_quote = true;
-    Codegen::new().with_options(options).build(&ret.program)
+    let ret = Codegen::new().with_options(options).build(&ret.program);
+    CodegenTestReturn { code: ret.code, legal_comments: ret.legal_comments }
+}
+
+pub struct CodegenTestReturn {
+    pub code: String,
+    pub legal_comments: Vec<Comment>,
 }
 
 #[track_caller]

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -81,15 +81,15 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
-fn minify(
-    allocator: &Allocator,
-    source_text: &str,
+fn minify<'a>(
+    allocator: &'a Allocator,
+    source_text: &'a str,
     source_type: SourceType,
     source_map_path: Option<PathBuf>,
     mangle: bool,
     nospace: bool,
     max_iterations: Option<u8>,
-) -> CodegenReturn {
+) -> CodegenReturn<'a> {
     let ret = Parser::new(allocator, source_text, source_type).parse();
     assert!(ret.diagnostics.is_empty());
     let mut program = ret.program;

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -871,12 +871,12 @@ impl CompilerInterface for Compiler {
         self.inject.clone()
     }
 
-    fn after_codegen(&mut self, ret: CodegenReturn) {
+    fn after_codegen(&mut self, ret: CodegenReturn<'_>) {
         self.printed = ret.code;
         self.printed_sourcemap = ret.map.map(SourceMap::from);
     }
 
-    fn after_isolated_declarations(&mut self, ret: CodegenReturn) {
+    fn after_isolated_declarations(&mut self, ret: CodegenReturn<'_>) {
         self.declaration.replace(ret.code);
         self.declaration_map = ret.map.map(SourceMap::from);
     }

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -119,7 +119,7 @@ impl CompilerInterface for Driver {
         ControlFlow::Continue(())
     }
 
-    fn after_codegen(&mut self, ret: CodegenReturn) {
+    fn after_codegen(&mut self, ret: CodegenReturn<'_>) {
         self.printed = ret.code;
     }
 }

--- a/tasks/transform_conformance/src/driver.rs
+++ b/tasks/transform_conformance/src/driver.rs
@@ -52,7 +52,7 @@ impl CompilerInterface for Driver {
         self.errors.extend(errors);
     }
 
-    fn after_codegen(&mut self, ret: CodegenReturn) {
+    fn after_codegen(&mut self, ret: CodegenReturn<'_>) {
         self.printed = ret.code;
     }
 


### PR DESCRIPTION
Summary:
- Upgrade oxc_sourcemap to 8.0.1.
- Return borrowed SourceMap from CodegenReturn.
- Support no-sourcemap feature builds used by benchmarks.

AI-assisted: yes