### PR TITLE
fix(linter/eslint): use shared id-length regex config

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/id_length.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_length.rs
@@ -18,7 +18,7 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
-    utils::AlwaysNever,
+    utils::{AlwaysNever, deserialize_regex_vec},
 };
 
 fn id_length_is_too_short_diagnostic(span: Span, config_min: u64) -> OxcDiagnostic {
@@ -48,7 +48,7 @@ impl Deref for IdLength {
 pub struct IdLengthConfig {
     /// An array of regex patterns for identifiers to exclude from the rule.
     /// For example, `["^x.*"]` would exclude all identifiers starting with "x".
-    #[serde(deserialize_with = "deserialize_exception_patterns")]
+    #[serde(deserialize_with = "deserialize_regex_vec")]
     exception_patterns: Vec<Regex>,
     /// An array of identifier names that are excluded from the rule.
     /// For example, `["x", "y", "z"]` would allow single-letter identifiers "x", "y", and "z".
@@ -76,18 +76,6 @@ impl Default for IdLengthConfig {
             properties: AlwaysNever::default(),
         }
     }
-}
-
-fn deserialize_exception_patterns<'de, D>(deserializer: D) -> Result<Vec<Regex>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::de::Error;
-
-    Vec::<String>::deserialize(deserializer)?
-        .into_iter()
-        .map(|pattern| Regex::new(&pattern).map_err(D::Error::custom))
-        .collect()
 }
 
 declare_oxc_lint!(


### PR DESCRIPTION
Reuses the shared regex-vector deserializer for `id-length` exception patterns so invalid regex configuration is handled consistently.