### PR TITLE
fix(linter/eslint): validate `complexity` config

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/complexity.rs
+++ b/crates/oxc_linter/src/rules/eslint/complexity.rs
@@ -161,9 +161,8 @@ impl Rule for Complexity {
         {
             Ok(Self(Box::new(ComplexityConfig { max, variant: Variant::Classic })))
         } else {
-            Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-                .unwrap_or_default()
-                .into_inner())
+            serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+                .map(DefaultRuleConfig::into_inner)
         }
     }
 


### PR DESCRIPTION
Returns serde configuration errors for `complexity` options instead of silently falling back to defaults.