### PR TITLE
fix(linter/eslint): validate max-classes-per-file config

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -100,9 +100,8 @@ impl Rule for MaxClassesPerFile {
         {
             Ok(Self(Box::new(MaxClassesPerFileConfig { max, ignore_expressions: false })))
         } else {
-            Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-                .unwrap_or_default()
-                .into_inner())
+            serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+                .map(DefaultRuleConfig::into_inner)
         }
     }
 


### PR DESCRIPTION
Returns serde configuration errors for `max-classes-per-file` options instead of silently falling back to defaults.