### PR TITLE
fix(linter/unicorn): validate prefer-object-from-entries config

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_object_from_entries.rs
@@ -88,10 +88,6 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferObjectFromEntries {
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
-    }
-
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else { return };
 
@@ -237,6 +233,12 @@ impl Rule for PreferObjectFromEntries {
                 call_expr_member_expr_property_span(call_expr),
             ));
         }
+    }
+
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<PreferObjectFromEntriesConfig>>(value)
+            .map(DefaultRuleConfig::into_inner)
+            .map(|config| Self(Box::new(config)))
     }
 }
 


### PR DESCRIPTION
Deserializes `prefer-object-from-entries` options through its config struct so invalid configuration returns serde errors.