### PR TITLE
fix(linter/eslint): validate max-depth config

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -119,9 +119,8 @@ impl Rule for MaxDepth {
         {
             Ok(MaxDepth { max })
         } else {
-            Ok(serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-                .unwrap_or_default()
-                .into_inner())
+            serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+                .map(DefaultRuleConfig::into_inner)
         }
     }
 


### PR DESCRIPTION
Returns serde configuration errors for `max-depth` options instead of silently falling back to defaults.