### PR TITLE
fix(linter/jest): validate no-restricted-matchers config

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_restricted_matchers.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 
 use crate::{
     context::LintContext,
+    rule::DefaultRuleConfig,
     utils::{
         JestFnKind, KnownMemberExpressionProperty, PossibleJestNode, is_type_of_jest_fn_call,
         object_with_nullable_string_schema, parse_expect_jest_fn_call,
@@ -87,7 +88,7 @@ describe('when an error happens', () => {
 "#;
 
 #[derive(Debug, Default, Clone, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+#[serde(rename_all = "camelCase", default)]
 pub struct NoRestrictedMatchersConfig {
     /// A map of restricted matchers/modifiers to custom messages.
     /// The key is the matcher/modifier name (e.g., "toBeFalsy", "resolves", "not.toHaveBeenCalledWith").
@@ -100,15 +101,9 @@ pub struct NoRestrictedMatchersConfig {
 const MODIFIER_NAME: [&str; 3] = ["not", "rejects", "resolves"];
 
 impl NoRestrictedMatchersConfig {
-    #[expect(clippy::unnecessary_wraps)]
     pub fn from_configuration(value: &serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        let restricted_matchers = value
-            .get(0)
-            .and_then(serde_json::Value::as_object)
-            .map(Self::compile_restricted_matchers)
-            .unwrap_or_default();
-
-        Ok(NoRestrictedMatchersConfig { restricted_matchers })
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value.clone())
+            .map(DefaultRuleConfig::into_inner)
     }
 
     pub fn run<'a>(&self, possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
@@ -159,14 +154,5 @@ impl NoRestrictedMatchersConfig {
         } else {
             chain_call == restriction
         }
-    }
-
-    pub fn compile_restricted_matchers(
-        matchers: &serde_json::Map<String, serde_json::Value>,
-    ) -> FxHashMap<String, Option<CompactStr>> {
-        matchers
-            .iter()
-            .map(|(key, value)| (String::from(key), value.as_str().map(CompactStr::from)))
-            .collect()
     }
 }


### PR DESCRIPTION
Deserializes `no-restricted-matchers` options through serde so invalid configuration is reported instead of silently defaulting.