### PR TITLE
docs(linter): remove manually written options doc for `eslint/prefer-arrow-callback`

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -3839,7 +3839,13 @@ export interface NoRestSpreadPropertiesOptions {
   objectSpreadMessage?: string;
 }
 export interface PreferArrowCallbackConfig {
+  /**
+   * If this option is set to `true`, named function expressions are allowed.
+   */
   allowNamedFunctions?: boolean;
+  /**
+   * If this option is set to `false`, function expressions that reference `this` are reported even when they are not bound to a `this` value.
+   */
   allowUnboundThis?: boolean;
 }
 export interface PreferConstConfig {

--- a/crates/oxc_linter/src/rules/eslint/prefer_arrow_callback.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_arrow_callback.rs
@@ -31,7 +31,9 @@ fn prefer_arrow_callback_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 struct PreferArrowCallbackConfig {
+    /// If this option is set to `true`, named function expressions are allowed.
     allow_named_functions: bool,
+    /// If this option is set to `false`, function expressions that reference `this` are reported even when they are not bound to a `this` value.
     allow_unbound_this: bool,
 }
 
@@ -56,23 +58,6 @@ declare_oxc_lint!(
     /// - inherit `this` from the surrounding scope, avoiding a common source of bugs;
     /// - are shorter and easier to read;
     /// - cannot be used as constructors, which is desirable for callbacks.
-    ///
-    /// ### Options
-    ///
-    /// ```json
-    /// {
-    ///   "prefer-arrow-callback": ["error", {
-    ///     "allowNamedFunctions": false,
-    ///     "allowUnboundThis": true
-    ///   }]
-    /// }
-    /// ```
-    ///
-    /// - `allowNamedFunctions` (default `false`) — when `true`, named function
-    ///   expressions are allowed.
-    /// - `allowUnboundThis` (default `true`) — when `false`, function
-    ///   expressions that reference `this` are reported even when they are not
-    ///   bound to a `this` value.
     ///
     /// ### Examples
     ///

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -15707,12 +15707,16 @@
       "type": "object",
       "properties": {
         "allowNamedFunctions": {
+          "description": "If this option is set to `true`, named function expressions are allowed.",
           "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "markdownDescription": "If this option is set to `true`, named function expressions are allowed."
         },
         "allowUnboundThis": {
+          "description": "If this option is set to `false`, function expressions that reference `this` are reported even when they are not bound to a `this` value.",
           "default": true,
-          "type": "boolean"
+          "type": "boolean",
+          "markdownDescription": "If this option is set to `false`, function expressions that reference `this` are reported even when they are not bound to a `this` value."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
this PR removes manually written options doc for `eslint/prefer-arrow-callback` to avoid duplication

before:

<img width="1116" height="1218" alt="Снимок экрана 2026-06-15 в 14 42 27" src="https://github.com/user-attachments/assets/3e485bdd-ca0e-4c5a-b9e2-38601df45852" />

after:

<img width="928" height="1037" alt="Снимок экрана 2026-06-15 в 14 47 48" src="https://github.com/user-attachments/assets/8abb72cb-162e-4dd9-aa98-9409fff6ccd4" />
