### PR TITLE
fix(linter): false positives with non `*.setTimeout` call in `no-confusing-set-timeout`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -2,8 +2,8 @@ use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::{AstNode, NodeId, ReferenceId};
-use oxc_span::{GetSpan, Span};
-use rustc_hash::FxHashMap;
+use oxc_span::Span;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
     context::LintContext,
@@ -89,6 +89,7 @@ impl Rule for NoConfusingSetTimeout {
             });
 
         let mut jest_reference_id_list: Vec<(ReferenceId, Span)> = vec![];
+        let mut reported_unordered_set_timeouts = FxHashSet::default();
         let mut seen_jest_set_timeout = false;
 
         for reference_ids in scopes.root_unresolved_references_ids() {
@@ -109,6 +110,7 @@ impl Rule for NoConfusingSetTimeout {
                 reference_id_list,
                 &jest_reference_id_list,
                 &mut seen_jest_set_timeout,
+                &mut reported_unordered_set_timeouts,
                 &id_to_jest_node_map,
             );
         }
@@ -119,6 +121,7 @@ impl Rule for NoConfusingSetTimeout {
                 reference_id_list.iter().copied(),
                 &jest_reference_id_list,
                 &mut seen_jest_set_timeout,
+                &mut reported_unordered_set_timeouts,
                 &id_to_jest_node_map,
             );
         }
@@ -139,19 +142,22 @@ fn collect_jest_reference_id(
         if !is_jest_call(ctx.semantic().reference_name(reference)) {
             continue;
         }
-        let parent_node = nodes.parent_node(reference.node_id());
-        if !parent_node.kind().is_member_expression_kind() {
+        let AstKind::StaticMemberExpression(expr) = nodes.parent_node(reference.node_id()).kind()
+        else {
             continue;
+        };
+        if expr.property.name == "setTimeout" {
+            jest_reference_list.push((reference_id, expr.span));
         }
-        jest_reference_list.push((reference_id, parent_node.kind().span()));
     }
 }
 
 fn handle_jest_set_time_out<'a>(
     ctx: &LintContext<'a>,
     reference_id_list: impl Iterator<Item = ReferenceId>,
-    jest_reference_id_list: &Vec<(ReferenceId, Span)>,
+    jest_reference_id_list: &[(ReferenceId, Span)],
     seen_jest_set_timeout: &mut bool,
+    reported_unordered_set_timeouts: &mut FxHashSet<ReferenceId>,
     id_to_jest_node_map: &FxHashMap<NodeId, &PossibleJestNode<'a, '_>>,
 ) {
     let nodes = ctx.nodes();
@@ -165,7 +171,9 @@ fn handle_jest_set_time_out<'a>(
         if !is_jest_call(ctx.semantic().reference_name(reference)) {
             if is_jest_fn_call(parent_node, id_to_jest_node_map, ctx) {
                 for (jest_reference_id, span) in jest_reference_id_list {
-                    if jest_reference_id > &reference_id {
+                    if jest_reference_id > &reference_id
+                        && reported_unordered_set_timeouts.insert(*jest_reference_id)
+                    {
                         ctx.diagnostic(no_unorder_set_timeout_diagnostic(*span));
                     }
                 }
@@ -345,6 +353,22 @@ fn test() {
                     setTimeout(() => {
                         Promise.resolv();
                     }, 5000);
+                });
+            ",
+            None,
+        ),
+        (
+            "
+                describe('example', () => {
+                    beforeEach(() => {
+                        jest.clearAllMocks();
+                    });
+
+                    it('works', () => {
+                        const fn = jest.fn();
+                        fn();
+                        expect(fn).toHaveBeenCalled();
+                    });
                 });
             ",
             None,

--- a/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_confusing_set_timeout.snap
@@ -10,14 +10,6 @@ source: crates/oxc_linter/src/tester.rs
  11 │             
     ╰────
 
-  ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-    ╭─[no_confusing_set_timeout.tsx:10:17]
-  9 │                 });
- 10 │                 jest.setTimeout(800);
-    ·                 ───────────────
- 11 │             
-    ╰────
-
   ⚠ jest(no-confusing-set-timeout): Do not call `jest.setTimeout` multiple times
     ╭─[no_confusing_set_timeout.tsx:10:17]
   9 │                 });
@@ -28,22 +20,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Only the last call to `jest.setTimeout` will have an effect.
 
   ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-    ╭─[no_confusing_set_timeout.tsx:10:17]
-  9 │                 });
- 10 │                 jest.setTimeout(800);
-    ·                 ───────────────
- 11 │             
-    ╰────
-
-  ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-    ╭─[no_confusing_set_timeout.tsx:10:17]
-  9 │                 });
- 10 │                 jest.setTimeout(800);
-    ·                 ───────────────
- 11 │             
-    ╰────
-
-  ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
    ╭─[no_confusing_set_timeout.tsx:3:21]
  2 │                 describe('A', () => {
  3 │                     jest.setTimeout(800);
@@ -57,14 +33,6 @@ source: crates/oxc_linter/src/tester.rs
  3 │                     jest.setTimeout(800);
    ·                     ───────────────
  4 │                     beforeEach(async () => { await new Promise(resolve => { setTimeout(resolve, 10000).unref(); });});
-   ╰────
-
-  ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-   ╭─[no_confusing_set_timeout.tsx:5:25]
- 4 │                         await new Promise((resolve) => {
- 5 │                         jest.setTimeout(1000);
-   ·                         ───────────────
- 6 │                         setTimeout(resolve, 10000).unref();
    ╰────
 
   ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
@@ -97,30 +65,6 @@ source: crates/oxc_linter/src/tester.rs
  3 │                     jest.setTimeout(1000);
    ·                     ───────────────
  4 │                 });
-   ╰────
-
-  ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-   ╭─[no_confusing_set_timeout.tsx:7:17]
- 6 │                 });
- 7 │                 jest.setTimeout(1000);
-   ·                 ───────────────
- 8 │             
-   ╰────
-
-  ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-   ╭─[no_confusing_set_timeout.tsx:7:17]
- 6 │                 });
- 7 │                 jest.setTimeout(1000);
-   ·                 ───────────────
- 8 │             
-   ╰────
-
-  ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-   ╭─[no_confusing_set_timeout.tsx:7:17]
- 6 │                 });
- 7 │                 jest.setTimeout(1000);
-   ·                 ───────────────
- 8 │             
    ╰────
 
   ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
@@ -170,22 +114,6 @@ source: crates/oxc_linter/src/tester.rs
  8 │                 Jest.setTimeout(800);
    ·                 ───────────────
  9 │                 setTimeout(800);
-   ╰────
-
-  ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-   ╭─[no_confusing_set_timeout.tsx:8:17]
- 7 │                 });
- 8 │                 Jest.setTimeout(800);
-   ·                 ───────────────
- 9 │                 setTimeout(800);
-   ╰────
-
-  ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.
-   ╭─[no_confusing_set_timeout.tsx:5:21]
- 4 │                     });
- 5 │                     jest.setTimeout(1000);
-   ·                     ───────────────
- 6 │                 
    ╰────
 
   ⚠ jest(no-confusing-set-timeout): `jest.setTimeout` should be placed before any other jest methods.


### PR DESCRIPTION
Prevent `jest/no-confusing-set-timeout` from treating arbitrary `jest.*` calls as late `jest.setTimeout` calls by collecting only static `jest.setTimeout` member references, and de-dupe unordered reports for the same offending call.

Fixes #23360