### PR TITLE
fix(linter/jsx-a11y/control-has-associated-label): reject excessive label depth

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/control_has_associated_label.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/control_has_associated_label.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, de};
 
 use oxc_ast::{
     AstKind,
@@ -59,7 +59,8 @@ const DEFAULT_IGNORE_ROLES: [&str; 10] = [
 pub struct ControlHasAssociatedLabelConfig {
     /// Maximum depth to search for an accessible label within the element.
     /// Defaults to `2`.
-    #[serde(deserialize_with = "cap_to_25")]
+    #[serde(deserialize_with = "validate_depth")]
+    #[schemars(range(max = 25))]
     depth: u8,
     /// Additional attributes to check for accessible label text.
     label_attributes: Vec<CompactStr>,
@@ -73,12 +74,15 @@ pub struct ControlHasAssociatedLabelConfig {
     ignore_roles: Vec<CompactStr>,
 }
 
-fn cap_to_25<'de, D>(deserializer: D) -> Result<u8, D::Error>
+fn validate_depth<'de, D>(deserializer: D) -> Result<u8, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let val = u8::deserialize(deserializer)?;
-    Ok(val.min(25)) // Clamps the value to a maximum of 25
+    let depth = u8::deserialize(deserializer)?;
+    if depth > 25 {
+        return Err(de::Error::custom("depth must be less than or equal to 25"));
+    }
+    Ok(depth)
 }
 
 impl Deref for ControlHasAssociatedLabel {

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1709,6 +1709,7 @@
           "default": 2,
           "type": "integer",
           "format": "uint8",
+          "maximum": 25.0,
           "minimum": 0.0,
           "markdownDescription": "Maximum depth to search for an accessible label within the element.\nDefaults to `2`."
         },


### PR DESCRIPTION
Reject `jsx-a11y/control-has-associated-label` configs with `depth` greater than 25 instead of silently clamping them, and update the generated oxlint config schema to expose the same maximum.

Fixes #23375