### PR TITLE
refactor(linter): separate optimized rule dispatch path

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -134,78 +134,113 @@ fn execute_rules<'a, const TIMINGS: bool>(
     with_runtime_optimization: bool,
     mut timing_recorder: Option<&mut RuleTimingRecorder>,
 ) {
-    // IMPORTANT: We have two branches here for performance reasons:
-    //
-    // 1) Branch where we iterate over each node, then each rule
-    // 2) Branch where we iterate over each rule, then each node
-    //
-    // When the number of nodes is relatively small, most of them can fit
-    // in the cache and we can save iterating over the rules multiple times.
-    // But for large files, the number of nodes can be so large that it
-    // starts to not fit into the cache and pushes out other data, like the rules.
-    // So we end up thrashing the cache with each rule iteration. In this case,
-    // it's better to put rules in the inner loop, as the rules data is smaller
-    // and is more likely to fit in the cache.
-    //
-    // The threshold here is chosen to balance between performance improvement
-    // from not iterating over rules multiple times, but also ensuring that we
-    // don't thrash the cache too much. Feel free to tweak based on benchmarking.
-    //
-    // See https://github.com/oxc-project/oxc/pull/6600 for more context.
     let mut timing_stats = TIMINGS.then(|| vec![RuleTimingStat::default(); rules.len()]);
 
-    if semantic.nodes().len() > 200_000 {
-        // TODO: It seems like there is probably a more intelligent way to preallocate space here. This will
-        // likely incur quite a few unnecessary reallocs currently. We theoretically could compute this at
-        // compile-time since we know all of the rules and their AST node type information ahead of time.
+    if with_runtime_optimization {
+        // IMPORTANT: We have two branches here for performance reasons:
         //
-        // Use boxed array to help compiler see that indexing into it with an `AstType`
-        // cannot go out of bounds, and remove bounds checks.
-        let mut rules_by_ast_type = boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1];
-        // TODO: Compute needed capacity. This is a slight overestimate as not 100% of rules will need to run on all
-        // node types, but it at least guarantees we won't need to realloc.
-        let mut rules_any_ast_type = Vec::with_capacity(rules.len());
+        // 1) Branch where we iterate over each node, then each rule
+        // 2) Branch where we iterate over each rule, then each node
+        //
+        // When the number of nodes is relatively small, most of them can fit
+        // in the cache and we can save iterating over the rules multiple times.
+        // But for large files, the number of nodes can be so large that it
+        // starts to not fit into the cache and pushes out other data, like the rules.
+        // So we end up thrashing the cache with each rule iteration. In this case,
+        // it's better to put rules in the inner loop, as the rules data is smaller
+        // and is more likely to fit in the cache.
+        //
+        // The threshold here is chosen to balance between performance improvement
+        // from not iterating over rules multiple times, but also ensuring that we
+        // don't thrash the cache too much. Feel free to tweak based on benchmarking.
+        //
+        // See https://github.com/oxc-project/oxc/pull/6600 for more context.
+        if semantic.nodes().len() > 200_000 {
+            // TODO: It seems like there is probably a more intelligent way to preallocate space here. This will
+            // likely incur quite a few unnecessary reallocs currently. We theoretically could compute this at
+            // compile-time since we know all of the rules and their AST node type information ahead of time.
+            //
+            // Use boxed array to help compiler see that indexing into it with an `AstType`
+            // cannot go out of bounds, and remove bounds checks.
+            let mut rules_by_ast_type = boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1];
+            // TODO: Compute needed capacity. This is a slight overestimate as not 100% of rules will need to run on all
+            // node types, but it at least guarantees we won't need to realloc.
+            let mut rules_any_ast_type = Vec::with_capacity(rules.len());
 
-        for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
-            let rule = *rule;
-            let run_info = rule.run_info();
-            // Collect node type information for rules. In large files, benchmarking showed it was worth
-            // collecting rules into buckets by AST node type to avoid iterating over all rules for each node.
-            if with_runtime_optimization
-                && let Some(ast_types) = rule.types_info()
-                && run_info.is_run_implemented()
-            {
-                for ty in ast_types {
-                    rules_by_ast_type[ty as usize].push((rule_index, rule, ctx));
+            for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
+                let rule = *rule;
+                let run_info = rule.run_info();
+                // Collect node type information for rules. In large files, benchmarking showed it was worth
+                // collecting rules into buckets by AST node type to avoid iterating over all rules for each node.
+                if let Some(ast_types) = rule.types_info()
+                    && run_info.is_run_implemented()
+                {
+                    for ty in ast_types {
+                        rules_by_ast_type[ty as usize].push((rule_index, rule, ctx));
+                    }
+                } else if run_info.is_run_implemented() {
+                    rules_any_ast_type.push((rule_index, rule, ctx));
                 }
-            } else if !with_runtime_optimization || run_info.is_run_implemented() {
-                rules_any_ast_type.push((rule_index, rule, ctx));
+
+                if run_info.is_run_once_implemented() {
+                    let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                    rule.run_once::<TIMINGS>(ctx, timing_stat);
+                }
             }
 
-            if !with_runtime_optimization || run_info.is_run_once_implemented() {
-                let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                rule.run_once::<TIMINGS>(ctx, timing_stat);
+            // Run rules on nodes
+            for node in semantic.nodes() {
+                for (rule_index, rule, ctx) in &rules_by_ast_type[node.kind().ty() as usize] {
+                    let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, *rule_index);
+                    rule.run::<TIMINGS>(node, ctx, timing_stat);
+                }
+                for (rule_index, rule, ctx) in &rules_any_ast_type {
+                    let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, *rule_index);
+                    rule.run::<TIMINGS>(node, ctx, timing_stat);
+                }
             }
-        }
 
-        // Run rules on nodes
-        for node in semantic.nodes() {
-            for (rule_index, rule, ctx) in &rules_by_ast_type[node.kind().ty() as usize] {
-                let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, *rule_index);
-                rule.run::<TIMINGS>(node, ctx, timing_stat);
+            if should_run_on_jest_node {
+                for jest_node in iter_possible_jest_call_node(semantic) {
+                    for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
+                        if rule.run_info().is_run_on_jest_node_implemented() {
+                            let timing_stat =
+                                get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                            rule.run_on_jest_node::<TIMINGS>(&jest_node, ctx, timing_stat);
+                        }
+                    }
+                }
             }
-            for (rule_index, rule, ctx) in &rules_any_ast_type {
-                let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, *rule_index);
-                rule.run::<TIMINGS>(node, ctx, timing_stat);
-            }
-        }
+        } else {
+            for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
+                let run_info = rule.run_info();
+                if run_info.is_run_once_implemented() {
+                    let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                    rule.run_once::<TIMINGS>(ctx, timing_stat);
+                }
 
-        if should_run_on_jest_node {
-            for jest_node in iter_possible_jest_call_node(semantic) {
-                for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
-                    if !with_runtime_optimization
-                        || rule.run_info().is_run_on_jest_node_implemented()
-                    {
+                if run_info.is_run_implemented() {
+                    // For smaller files, benchmarking showed it was faster to iterate over all rules and just check the
+                    // node types as we go, rather than pre-bucketing rules by AST node type and doing extra allocations.
+                    if let Some(ast_types) = rule.types_info() {
+                        for node in semantic.nodes() {
+                            if ast_types.has(node.kind().ty()) {
+                                let timing_stat =
+                                    get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                                rule.run::<TIMINGS>(node, ctx, timing_stat);
+                            }
+                        }
+                    } else {
+                        for node in semantic.nodes() {
+                            let timing_stat =
+                                get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                            rule.run::<TIMINGS>(node, ctx, timing_stat);
+                        }
+                    }
+                }
+
+                if should_run_on_jest_node && run_info.is_run_on_jest_node_implemented() {
+                    for jest_node in iter_possible_jest_call_node(semantic) {
                         let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
                         rule.run_on_jest_node::<TIMINGS>(&jest_node, ctx, timing_stat);
                     }
@@ -213,35 +248,18 @@ fn execute_rules<'a, const TIMINGS: bool>(
             }
         }
     } else {
+        // Unoptimized reference path: every rule runs on every node, with no type filtering. Used
+        // only in debug builds, to assert the optimized path produces identical diagnostics.
         for (rule_index, (rule, ctx)) in rules.iter().enumerate() {
-            let run_info = rule.run_info();
-            if !with_runtime_optimization || run_info.is_run_once_implemented() {
+            let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+            rule.run_once::<TIMINGS>(ctx, timing_stat);
+
+            for node in semantic.nodes() {
                 let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                rule.run_once::<TIMINGS>(ctx, timing_stat);
+                rule.run::<TIMINGS>(node, ctx, timing_stat);
             }
 
-            if !with_runtime_optimization || run_info.is_run_implemented() {
-                // For smaller files, benchmarking showed it was faster to iterate over all rules and just check the
-                // node types as we go, rather than pre-bucketing rules by AST node type and doing extra allocations.
-                if with_runtime_optimization && let Some(ast_types) = rule.types_info() {
-                    for node in semantic.nodes() {
-                        if ast_types.has(node.kind().ty()) {
-                            let timing_stat =
-                                get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                            rule.run::<TIMINGS>(node, ctx, timing_stat);
-                        }
-                    }
-                } else {
-                    for node in semantic.nodes() {
-                        let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                        rule.run::<TIMINGS>(node, ctx, timing_stat);
-                    }
-                }
-            }
-
-            if should_run_on_jest_node
-                && (!with_runtime_optimization || run_info.is_run_on_jest_node_implemented())
-            {
+            if should_run_on_jest_node {
                 for jest_node in iter_possible_jest_call_node(semantic) {
                     let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
                     rule.run_on_jest_node::<TIMINGS>(&jest_node, ctx, timing_stat);


### PR DESCRIPTION
- Split from #23409.
- Separates the optimized linter rule dispatch path from the unoptimized debug reference path.
- Keeps runtime type filtering contained inside the optimized branch so the debug comparison path always runs every rule on every node.

Co-authored-by: Boshen <boshenc@gmail.com>