### PR TITLE
fix(linter): reject invalid no-unused-vars fix option

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/options.rs
@@ -663,7 +663,13 @@ impl TryFrom<Value> for NoUnusedVarsOptions {
                     .map_or(Some(false), Value::as_bool)
                     .unwrap_or(false);
 
-                let fix = if let Some(fix) = config.get("fix").and_then(Value::as_object) {
+                let fix = if let Some(fix_value) = config.get("fix") {
+                    let Some(fix) = fix_value.as_object() else {
+                        return Err(invalid_option_error(
+                            "fix",
+                            format!("Expected an object, got {fix_value}"),
+                        ));
+                    };
                     NoUnusedVarsFixOptions {
                         imports: parse_fix_mode(fix.get("imports"), "fix.imports")?,
                         variables: parse_fix_mode(fix.get("variables"), "fix.variables")?,
@@ -790,6 +796,11 @@ mod tests {
         // option object provided, no default argsIgnorePattern
         assert!(matches!(rule.vars_ignore_pattern, IgnorePattern::Default));
         assert!(rule.args_ignore_pattern.is_none());
+    }
+
+    #[test]
+    fn invalid_fix_option_error() {
+        assert!(NoUnusedVarsOptions::try_from(json!([{ "fix": true }])).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Reject invalid `no-unused-vars` `fix` option shapes instead of silently treating non-object values as the default fix configuration.

This keeps the change scoped to the `fix` option so stricter parsing for other `no-unused-vars` options can be reviewed separately.

## Testing

- `cargo fmt --check`
- `cargo test -p oxc_linter no_unused_vars --lib`
