### PR TITLE
fix(ci/parser): use `minimal` for vitest reporter

### DIFF
--- a/napi/parser/vitest.config.ts
+++ b/napi/parser/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
       expand: false,
     },
     exclude,
-    reporters: process.env.CI ? ["dot"] : ["default"],
+    reporters: process.env.CI ? ["minimal"] : ["default"],
   },
   plugins: [
     // Enable Codspeed plugin in CI only


### PR DESCRIPTION
The large output from the dot reporter (caused by `RUN_LAZY_TESTS`, `RUN_RAW_TESTS`, `RUN_RAW_RANGE_TESTS` and `RUN_RAW_TOKENS_TESTS`) sometimes causes CI to fail.

This PR switches to the [`minimal` reporter ](https://vitest.dev/guide/reporters.html#minimal-reporter) which should only log on failed test cases.