### PR TITLE
feat(linter/unicorn): implement `max-nested-calls` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1442,6 +1442,7 @@ export interface DummyRuleMap {
   "unicorn/explicit-length-check"?: RuleNoConfig | [AllowWarnDeny, ExplicitLengthCheck];
   "unicorn/filename-case"?: DummyRule;
   "unicorn/import-style"?: RuleNoConfig | [AllowWarnDeny, ImportStyleConfig];
+  "unicorn/max-nested-calls"?: RuleNoConfig | [AllowWarnDeny, number | MaxNestedCalls];
   "unicorn/new-for-builtins"?: RuleNoConfig;
   "unicorn/no-abusive-eslint-disable"?: RuleNoConfig;
   "unicorn/no-accessor-recursion"?: RuleNoConfig;
@@ -5824,6 +5825,12 @@ export interface ImportStyleConfig {
   styles?: {
     [k: string]: ModuleStylesOverride;
   };
+}
+export interface MaxNestedCalls {
+  /**
+   * The maximum allowed nested call depth.
+   */
+  max?: number;
 }
 export interface NoArrayReduce {
   /**

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1442,7 +1442,7 @@ export interface DummyRuleMap {
   "unicorn/explicit-length-check"?: RuleNoConfig | [AllowWarnDeny, ExplicitLengthCheck];
   "unicorn/filename-case"?: DummyRule;
   "unicorn/import-style"?: RuleNoConfig | [AllowWarnDeny, ImportStyleConfig];
-  "unicorn/max-nested-calls"?: RuleNoConfig | [AllowWarnDeny, number | MaxNestedCalls];
+  "unicorn/max-nested-calls"?: RuleNoConfig | [AllowWarnDeny, MaxNestedCalls];
   "unicorn/new-for-builtins"?: RuleNoConfig;
   "unicorn/no-abusive-eslint-disable"?: RuleNoConfig;
   "unicorn/no-accessor-recursion"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2909,6 +2909,11 @@ impl RuleRunner for crate::rules::react_perf::jsx_no_new_object_as_prop::JsxNoNe
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
 }
 
+impl RuleRunner for crate::rules::unicorn::max_nested_calls::MaxNestedCalls {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::catch_error_name::CatchErrorName {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::CatchParameter]));

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2909,11 +2909,6 @@ impl RuleRunner for crate::rules::react_perf::jsx_no_new_object_as_prop::JsxNoNe
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
 }
 
-impl RuleRunner for crate::rules::unicorn::max_nested_calls::MaxNestedCalls {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
-}
-
 impl RuleRunner for crate::rules::unicorn::catch_error_name::CatchErrorName {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::CatchParameter]));
@@ -3014,6 +3009,11 @@ impl RuleRunner for crate::rules::unicorn::import_style::ImportStyle {
         AstType::ImportExpression,
         AstType::VariableDeclarator,
     ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::unicorn::max_nested_calls::MaxNestedCalls {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3013,7 +3013,8 @@ impl RuleRunner for crate::rules::unicorn::import_style::ImportStyle {
 }
 
 impl RuleRunner for crate::rules::unicorn::max_nested_calls::MaxNestedCalls {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::NewExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -1310,7 +1310,6 @@ pub enum RuleEnum {
     ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp),
     ReactPerfJsxNoNewFunctionAsProp(ReactPerfJsxNoNewFunctionAsProp),
     ReactPerfJsxNoNewObjectAsProp(ReactPerfJsxNoNewObjectAsProp),
-    UnicornMaxNestedCalls(UnicornMaxNestedCalls),
     UnicornCatchErrorName(UnicornCatchErrorName),
     UnicornConsistentAssert(UnicornConsistentAssert),
     UnicornConsistentDateClone(UnicornConsistentDateClone),
@@ -1325,6 +1324,7 @@ pub enum RuleEnum {
     UnicornExplicitLengthCheck(UnicornExplicitLengthCheck),
     UnicornFilenameCase(UnicornFilenameCase),
     UnicornImportStyle(UnicornImportStyle),
+    UnicornMaxNestedCalls(UnicornMaxNestedCalls),
     UnicornNewForBuiltins(UnicornNewForBuiltins),
     UnicornNoAbusiveEslintDisable(UnicornNoAbusiveEslintDisable),
     UnicornNoAccessorRecursion(UnicornNoAccessorRecursion),
@@ -2203,8 +2203,7 @@ const REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID: usize =
     REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID + 1usize;
 const REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID: usize =
     REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID + 1usize;
-const UNICORN_MAX_NESTED_CALLS_ID: usize = REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID + 1usize;
-const UNICORN_CATCH_ERROR_NAME_ID: usize = UNICORN_MAX_NESTED_CALLS_ID + 1usize;
+const UNICORN_CATCH_ERROR_NAME_ID: usize = REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID + 1usize;
 const UNICORN_CONSISTENT_ASSERT_ID: usize = UNICORN_CATCH_ERROR_NAME_ID + 1usize;
 const UNICORN_CONSISTENT_DATE_CLONE_ID: usize = UNICORN_CONSISTENT_ASSERT_ID + 1usize;
 const UNICORN_CONSISTENT_EMPTY_ARRAY_SPREAD_ID: usize = UNICORN_CONSISTENT_DATE_CLONE_ID + 1usize;
@@ -2222,7 +2221,8 @@ const UNICORN_ESCAPE_CASE_ID: usize = UNICORN_ERROR_MESSAGE_ID + 1usize;
 const UNICORN_EXPLICIT_LENGTH_CHECK_ID: usize = UNICORN_ESCAPE_CASE_ID + 1usize;
 const UNICORN_FILENAME_CASE_ID: usize = UNICORN_EXPLICIT_LENGTH_CHECK_ID + 1usize;
 const UNICORN_IMPORT_STYLE_ID: usize = UNICORN_FILENAME_CASE_ID + 1usize;
-const UNICORN_NEW_FOR_BUILTINS_ID: usize = UNICORN_IMPORT_STYLE_ID + 1usize;
+const UNICORN_MAX_NESTED_CALLS_ID: usize = UNICORN_IMPORT_STYLE_ID + 1usize;
+const UNICORN_NEW_FOR_BUILTINS_ID: usize = UNICORN_MAX_NESTED_CALLS_ID + 1usize;
 const UNICORN_NO_ABUSIVE_ESLINT_DISABLE_ID: usize = UNICORN_NEW_FOR_BUILTINS_ID + 1usize;
 const UNICORN_NO_ACCESSOR_RECURSION_ID: usize = UNICORN_NO_ABUSIVE_ESLINT_DISABLE_ID + 1usize;
 const UNICORN_NO_ANONYMOUS_DEFAULT_EXPORT_ID: usize = UNICORN_NO_ACCESSOR_RECURSION_ID + 1usize;
@@ -3171,7 +3171,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID,
-            Self::UnicornMaxNestedCalls(_) => UNICORN_MAX_NESTED_CALLS_ID,
             Self::UnicornCatchErrorName(_) => UNICORN_CATCH_ERROR_NAME_ID,
             Self::UnicornConsistentAssert(_) => UNICORN_CONSISTENT_ASSERT_ID,
             Self::UnicornConsistentDateClone(_) => UNICORN_CONSISTENT_DATE_CLONE_ID,
@@ -3190,6 +3189,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(_) => UNICORN_EXPLICIT_LENGTH_CHECK_ID,
             Self::UnicornFilenameCase(_) => UNICORN_FILENAME_CASE_ID,
             Self::UnicornImportStyle(_) => UNICORN_IMPORT_STYLE_ID,
+            Self::UnicornMaxNestedCalls(_) => UNICORN_MAX_NESTED_CALLS_ID,
             Self::UnicornNewForBuiltins(_) => UNICORN_NEW_FOR_BUILTINS_ID,
             Self::UnicornNoAbusiveEslintDisable(_) => UNICORN_NO_ABUSIVE_ESLINT_DISABLE_ID,
             Self::UnicornNoAccessorRecursion(_) => UNICORN_NO_ACCESSOR_RECURSION_ID,
@@ -4133,7 +4133,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::NAME,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::NAME,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::NAME,
-            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::NAME,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::NAME,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::NAME,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::NAME,
@@ -4152,6 +4151,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(_) => UnicornExplicitLengthCheck::NAME,
             Self::UnicornFilenameCase(_) => UnicornFilenameCase::NAME,
             Self::UnicornImportStyle(_) => UnicornImportStyle::NAME,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::NAME,
             Self::UnicornNewForBuiltins(_) => UnicornNewForBuiltins::NAME,
             Self::UnicornNoAbusiveEslintDisable(_) => UnicornNoAbusiveEslintDisable::NAME,
             Self::UnicornNoAccessorRecursion(_) => UnicornNoAccessorRecursion::NAME,
@@ -5111,7 +5111,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::CATEGORY,
-            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::CATEGORY,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::CATEGORY,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::CATEGORY,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::CATEGORY,
@@ -5132,6 +5131,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(_) => UnicornExplicitLengthCheck::CATEGORY,
             Self::UnicornFilenameCase(_) => UnicornFilenameCase::CATEGORY,
             Self::UnicornImportStyle(_) => UnicornImportStyle::CATEGORY,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::CATEGORY,
             Self::UnicornNewForBuiltins(_) => UnicornNewForBuiltins::CATEGORY,
             Self::UnicornNoAbusiveEslintDisable(_) => UnicornNoAbusiveEslintDisable::CATEGORY,
             Self::UnicornNoAccessorRecursion(_) => UnicornNoAccessorRecursion::CATEGORY,
@@ -6096,7 +6096,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::FIX,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::FIX,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::FIX,
-            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::FIX,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::FIX,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::FIX,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::FIX,
@@ -6115,6 +6114,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(_) => UnicornExplicitLengthCheck::FIX,
             Self::UnicornFilenameCase(_) => UnicornFilenameCase::FIX,
             Self::UnicornImportStyle(_) => UnicornImportStyle::FIX,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::FIX,
             Self::UnicornNewForBuiltins(_) => UnicornNewForBuiltins::FIX,
             Self::UnicornNoAbusiveEslintDisable(_) => UnicornNoAbusiveEslintDisable::FIX,
             Self::UnicornNoAccessorRecursion(_) => UnicornNoAccessorRecursion::FIX,
@@ -7167,7 +7167,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewObjectAsProp(_) => {
                 ReactPerfJsxNoNewObjectAsProp::documentation()
             }
-            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::documentation(),
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::documentation(),
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::documentation(),
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::documentation(),
@@ -7190,6 +7189,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(_) => UnicornExplicitLengthCheck::documentation(),
             Self::UnicornFilenameCase(_) => UnicornFilenameCase::documentation(),
             Self::UnicornImportStyle(_) => UnicornImportStyle::documentation(),
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::documentation(),
             Self::UnicornNewForBuiltins(_) => UnicornNewForBuiltins::documentation(),
             Self::UnicornNoAbusiveEslintDisable(_) => {
                 UnicornNoAbusiveEslintDisable::documentation()
@@ -9025,8 +9025,6 @@ impl RuleEnum {
                 ReactPerfJsxNoNewObjectAsProp::config_schema(generator)
                     .or_else(|| ReactPerfJsxNoNewObjectAsProp::schema(generator))
             }
-            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::config_schema(generator)
-                .or_else(|| UnicornMaxNestedCalls::schema(generator)),
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::config_schema(generator)
                 .or_else(|| UnicornCatchErrorName::schema(generator)),
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::config_schema(generator)
@@ -9069,6 +9067,8 @@ impl RuleEnum {
                 .or_else(|| UnicornFilenameCase::schema(generator)),
             Self::UnicornImportStyle(_) => UnicornImportStyle::config_schema(generator)
                 .or_else(|| UnicornImportStyle::schema(generator)),
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::config_schema(generator)
+                .or_else(|| UnicornMaxNestedCalls::schema(generator)),
             Self::UnicornNewForBuiltins(_) => UnicornNewForBuiltins::config_schema(generator)
                 .or_else(|| UnicornNewForBuiltins::schema(generator)),
             Self::UnicornNoAbusiveEslintDisable(_) => {
@@ -10593,7 +10593,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewObjectAsProp(_) => "react_perf",
-            Self::UnicornMaxNestedCalls(_) => "unicorn",
             Self::UnicornCatchErrorName(_) => "unicorn",
             Self::UnicornConsistentAssert(_) => "unicorn",
             Self::UnicornConsistentDateClone(_) => "unicorn",
@@ -10608,6 +10607,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(_) => "unicorn",
             Self::UnicornFilenameCase(_) => "unicorn",
             Self::UnicornImportStyle(_) => "unicorn",
+            Self::UnicornMaxNestedCalls(_) => "unicorn",
             Self::UnicornNewForBuiltins(_) => "unicorn",
             Self::UnicornNoAbusiveEslintDisable(_) => "unicorn",
             Self::UnicornNoAccessorRecursion(_) => "unicorn",
@@ -12434,9 +12434,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewObjectAsProp(_) => Ok(Self::ReactPerfJsxNoNewObjectAsProp(
                 ReactPerfJsxNoNewObjectAsProp::from_configuration(value)?,
             )),
-            Self::UnicornMaxNestedCalls(_) => {
-                Ok(Self::UnicornMaxNestedCalls(UnicornMaxNestedCalls::from_configuration(value)?))
-            }
             Self::UnicornCatchErrorName(_) => {
                 Ok(Self::UnicornCatchErrorName(UnicornCatchErrorName::from_configuration(value)?))
             }
@@ -12486,6 +12483,9 @@ impl RuleEnum {
             }
             Self::UnicornImportStyle(_) => {
                 Ok(Self::UnicornImportStyle(UnicornImportStyle::from_configuration(value)?))
+            }
+            Self::UnicornMaxNestedCalls(_) => {
+                Ok(Self::UnicornMaxNestedCalls(UnicornMaxNestedCalls::from_configuration(value)?))
             }
             Self::UnicornNewForBuiltins(_) => {
                 Ok(Self::UnicornNewForBuiltins(UnicornNewForBuiltins::from_configuration(value)?))
@@ -14128,7 +14128,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.to_configuration(),
-            Self::UnicornMaxNestedCalls(rule) => rule.to_configuration(),
             Self::UnicornCatchErrorName(rule) => rule.to_configuration(),
             Self::UnicornConsistentAssert(rule) => rule.to_configuration(),
             Self::UnicornConsistentDateClone(rule) => rule.to_configuration(),
@@ -14143,6 +14142,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(rule) => rule.to_configuration(),
             Self::UnicornFilenameCase(rule) => rule.to_configuration(),
             Self::UnicornImportStyle(rule) => rule.to_configuration(),
+            Self::UnicornMaxNestedCalls(rule) => rule.to_configuration(),
             Self::UnicornNewForBuiltins(rule) => rule.to_configuration(),
             Self::UnicornNoAbusiveEslintDisable(rule) => rule.to_configuration(),
             Self::UnicornNoAccessorRecursion(rule) => rule.to_configuration(),
@@ -14976,7 +14976,6 @@ impl RuleEnum {
                 Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run(node, ctx),
                 Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run(node, ctx),
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run(node, ctx),
-                Self::UnicornMaxNestedCalls(rule) => rule.run(node, ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run(node, ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run(node, ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run(node, ctx),
@@ -14991,6 +14990,7 @@ impl RuleEnum {
                 Self::UnicornExplicitLengthCheck(rule) => rule.run(node, ctx),
                 Self::UnicornFilenameCase(rule) => rule.run(node, ctx),
                 Self::UnicornImportStyle(rule) => rule.run(node, ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run(node, ctx),
                 Self::UnicornNewForBuiltins(rule) => rule.run(node, ctx),
                 Self::UnicornNoAbusiveEslintDisable(rule) => rule.run(node, ctx),
                 Self::UnicornNoAccessorRecursion(rule) => rule.run(node, ctx),
@@ -15817,7 +15817,6 @@ impl RuleEnum {
                 Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run(node, ctx),
                 Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run(node, ctx),
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run(node, ctx),
-                Self::UnicornMaxNestedCalls(rule) => rule.run(node, ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run(node, ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run(node, ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run(node, ctx),
@@ -15832,6 +15831,7 @@ impl RuleEnum {
                 Self::UnicornExplicitLengthCheck(rule) => rule.run(node, ctx),
                 Self::UnicornFilenameCase(rule) => rule.run(node, ctx),
                 Self::UnicornImportStyle(rule) => rule.run(node, ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run(node, ctx),
                 Self::UnicornNewForBuiltins(rule) => rule.run(node, ctx),
                 Self::UnicornNoAbusiveEslintDisable(rule) => rule.run(node, ctx),
                 Self::UnicornNoAccessorRecursion(rule) => rule.run(node, ctx),
@@ -16665,7 +16665,6 @@ impl RuleEnum {
                 Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_once(ctx),
                 Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_once(ctx),
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_once(ctx),
-                Self::UnicornMaxNestedCalls(rule) => rule.run_once(ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run_once(ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run_once(ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run_once(ctx),
@@ -16680,6 +16679,7 @@ impl RuleEnum {
                 Self::UnicornExplicitLengthCheck(rule) => rule.run_once(ctx),
                 Self::UnicornFilenameCase(rule) => rule.run_once(ctx),
                 Self::UnicornImportStyle(rule) => rule.run_once(ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run_once(ctx),
                 Self::UnicornNewForBuiltins(rule) => rule.run_once(ctx),
                 Self::UnicornNoAbusiveEslintDisable(rule) => rule.run_once(ctx),
                 Self::UnicornNoAccessorRecursion(rule) => rule.run_once(ctx),
@@ -17506,7 +17506,6 @@ impl RuleEnum {
                 Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_once(ctx),
                 Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_once(ctx),
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_once(ctx),
-                Self::UnicornMaxNestedCalls(rule) => rule.run_once(ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run_once(ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run_once(ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run_once(ctx),
@@ -17521,6 +17520,7 @@ impl RuleEnum {
                 Self::UnicornExplicitLengthCheck(rule) => rule.run_once(ctx),
                 Self::UnicornFilenameCase(rule) => rule.run_once(ctx),
                 Self::UnicornImportStyle(rule) => rule.run_once(ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run_once(ctx),
                 Self::UnicornNewForBuiltins(rule) => rule.run_once(ctx),
                 Self::UnicornNoAbusiveEslintDisable(rule) => rule.run_once(ctx),
                 Self::UnicornNoAccessorRecursion(rule) => rule.run_once(ctx),
@@ -18487,7 +18487,6 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
-                Self::UnicornMaxNestedCalls(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18510,6 +18509,7 @@ impl RuleEnum {
                 Self::UnicornExplicitLengthCheck(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornFilenameCase(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornImportStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornNewForBuiltins(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornNoAbusiveEslintDisable(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornNoAccessorRecursion(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19588,7 +19588,6 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
-                Self::UnicornMaxNestedCalls(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19611,6 +19610,7 @@ impl RuleEnum {
                 Self::UnicornExplicitLengthCheck(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornFilenameCase(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornImportStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornNewForBuiltins(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornNoAbusiveEslintDisable(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornNoAccessorRecursion(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20557,7 +20557,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.should_run(ctx),
-            Self::UnicornMaxNestedCalls(rule) => rule.should_run(ctx),
             Self::UnicornCatchErrorName(rule) => rule.should_run(ctx),
             Self::UnicornConsistentAssert(rule) => rule.should_run(ctx),
             Self::UnicornConsistentDateClone(rule) => rule.should_run(ctx),
@@ -20572,6 +20571,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(rule) => rule.should_run(ctx),
             Self::UnicornFilenameCase(rule) => rule.should_run(ctx),
             Self::UnicornImportStyle(rule) => rule.should_run(ctx),
+            Self::UnicornMaxNestedCalls(rule) => rule.should_run(ctx),
             Self::UnicornNewForBuiltins(rule) => rule.should_run(ctx),
             Self::UnicornNoAbusiveEslintDisable(rule) => rule.should_run(ctx),
             Self::UnicornNoAccessorRecursion(rule) => rule.should_run(ctx),
@@ -21583,7 +21583,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewObjectAsProp(_) => {
                 ReactPerfJsxNoNewObjectAsProp::IS_TSGOLINT_RULE
             }
-            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::IS_TSGOLINT_RULE,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::IS_TSGOLINT_RULE,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::IS_TSGOLINT_RULE,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::IS_TSGOLINT_RULE,
@@ -21606,6 +21605,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(_) => UnicornExplicitLengthCheck::IS_TSGOLINT_RULE,
             Self::UnicornFilenameCase(_) => UnicornFilenameCase::IS_TSGOLINT_RULE,
             Self::UnicornImportStyle(_) => UnicornImportStyle::IS_TSGOLINT_RULE,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::IS_TSGOLINT_RULE,
             Self::UnicornNewForBuiltins(_) => UnicornNewForBuiltins::IS_TSGOLINT_RULE,
             Self::UnicornNoAbusiveEslintDisable(_) => {
                 UnicornNoAbusiveEslintDisable::IS_TSGOLINT_RULE
@@ -22707,7 +22707,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::VERSION,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::VERSION,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::VERSION,
-            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::VERSION,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::VERSION,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::VERSION,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::VERSION,
@@ -22728,6 +22727,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(_) => UnicornExplicitLengthCheck::VERSION,
             Self::UnicornFilenameCase(_) => UnicornFilenameCase::VERSION,
             Self::UnicornImportStyle(_) => UnicornImportStyle::VERSION,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::VERSION,
             Self::UnicornNewForBuiltins(_) => UnicornNewForBuiltins::VERSION,
             Self::UnicornNoAbusiveEslintDisable(_) => UnicornNoAbusiveEslintDisable::VERSION,
             Self::UnicornNoAccessorRecursion(_) => UnicornNoAccessorRecursion::VERSION,
@@ -23734,7 +23734,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::HAS_CONFIG,
-            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::HAS_CONFIG,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::HAS_CONFIG,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::HAS_CONFIG,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::HAS_CONFIG,
@@ -23757,6 +23756,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(_) => UnicornExplicitLengthCheck::HAS_CONFIG,
             Self::UnicornFilenameCase(_) => UnicornFilenameCase::HAS_CONFIG,
             Self::UnicornImportStyle(_) => UnicornImportStyle::HAS_CONFIG,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::HAS_CONFIG,
             Self::UnicornNewForBuiltins(_) => UnicornNewForBuiltins::HAS_CONFIG,
             Self::UnicornNoAbusiveEslintDisable(_) => UnicornNoAbusiveEslintDisable::HAS_CONFIG,
             Self::UnicornNoAccessorRecursion(_) => UnicornNoAccessorRecursion::HAS_CONFIG,
@@ -24742,7 +24742,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::INFO,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::INFO,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::INFO,
-            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::INFO,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::INFO,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::INFO,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::INFO,
@@ -24761,6 +24760,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(_) => UnicornExplicitLengthCheck::INFO,
             Self::UnicornFilenameCase(_) => UnicornFilenameCase::INFO,
             Self::UnicornImportStyle(_) => UnicornImportStyle::INFO,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::INFO,
             Self::UnicornNewForBuiltins(_) => UnicornNewForBuiltins::INFO,
             Self::UnicornNoAbusiveEslintDisable(_) => UnicornNoAbusiveEslintDisable::INFO,
             Self::UnicornNoAccessorRecursion(_) => UnicornNoAccessorRecursion::INFO,
@@ -25629,7 +25629,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.types_info(),
-            Self::UnicornMaxNestedCalls(rule) => rule.types_info(),
             Self::UnicornCatchErrorName(rule) => rule.types_info(),
             Self::UnicornConsistentAssert(rule) => rule.types_info(),
             Self::UnicornConsistentDateClone(rule) => rule.types_info(),
@@ -25644,6 +25643,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(rule) => rule.types_info(),
             Self::UnicornFilenameCase(rule) => rule.types_info(),
             Self::UnicornImportStyle(rule) => rule.types_info(),
+            Self::UnicornMaxNestedCalls(rule) => rule.types_info(),
             Self::UnicornNewForBuiltins(rule) => rule.types_info(),
             Self::UnicornNoAbusiveEslintDisable(rule) => rule.types_info(),
             Self::UnicornNoAccessorRecursion(rule) => rule.types_info(),
@@ -26467,7 +26467,6 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_info(),
-            Self::UnicornMaxNestedCalls(rule) => rule.run_info(),
             Self::UnicornCatchErrorName(rule) => rule.run_info(),
             Self::UnicornConsistentAssert(rule) => rule.run_info(),
             Self::UnicornConsistentDateClone(rule) => rule.run_info(),
@@ -26482,6 +26481,7 @@ impl RuleEnum {
             Self::UnicornExplicitLengthCheck(rule) => rule.run_info(),
             Self::UnicornFilenameCase(rule) => rule.run_info(),
             Self::UnicornImportStyle(rule) => rule.run_info(),
+            Self::UnicornMaxNestedCalls(rule) => rule.run_info(),
             Self::UnicornNewForBuiltins(rule) => rule.run_info(),
             Self::UnicornNoAbusiveEslintDisable(rule) => rule.run_info(),
             Self::UnicornNoAccessorRecursion(rule) => rule.run_info(),
@@ -27397,7 +27397,6 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewFunctionAsProp(ReactPerfJsxNoNewFunctionAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewObjectAsProp(ReactPerfJsxNoNewObjectAsProp::default()),
-        RuleEnum::UnicornMaxNestedCalls(UnicornMaxNestedCalls::default()),
         RuleEnum::UnicornCatchErrorName(UnicornCatchErrorName::default()),
         RuleEnum::UnicornConsistentAssert(UnicornConsistentAssert::default()),
         RuleEnum::UnicornConsistentDateClone(UnicornConsistentDateClone::default()),
@@ -27416,6 +27415,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornExplicitLengthCheck(UnicornExplicitLengthCheck::default()),
         RuleEnum::UnicornFilenameCase(UnicornFilenameCase::default()),
         RuleEnum::UnicornImportStyle(UnicornImportStyle::default()),
+        RuleEnum::UnicornMaxNestedCalls(UnicornMaxNestedCalls::default()),
         RuleEnum::UnicornNewForBuiltins(UnicornNewForBuiltins::default()),
         RuleEnum::UnicornNoAbusiveEslintDisable(UnicornNoAbusiveEslintDisable::default()),
         RuleEnum::UnicornNoAccessorRecursion(UnicornNoAccessorRecursion::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -606,6 +606,7 @@ pub use crate::rules::unicorn::escape_case::EscapeCase as UnicornEscapeCase;
 pub use crate::rules::unicorn::explicit_length_check::ExplicitLengthCheck as UnicornExplicitLengthCheck;
 pub use crate::rules::unicorn::filename_case::FilenameCase as UnicornFilenameCase;
 pub use crate::rules::unicorn::import_style::ImportStyle as UnicornImportStyle;
+pub use crate::rules::unicorn::max_nested_calls::MaxNestedCalls as UnicornMaxNestedCalls;
 pub use crate::rules::unicorn::new_for_builtins::NewForBuiltins as UnicornNewForBuiltins;
 pub use crate::rules::unicorn::no_abusive_eslint_disable::NoAbusiveEslintDisable as UnicornNoAbusiveEslintDisable;
 pub use crate::rules::unicorn::no_accessor_recursion::NoAccessorRecursion as UnicornNoAccessorRecursion;
@@ -1309,6 +1310,7 @@ pub enum RuleEnum {
     ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp),
     ReactPerfJsxNoNewFunctionAsProp(ReactPerfJsxNoNewFunctionAsProp),
     ReactPerfJsxNoNewObjectAsProp(ReactPerfJsxNoNewObjectAsProp),
+    UnicornMaxNestedCalls(UnicornMaxNestedCalls),
     UnicornCatchErrorName(UnicornCatchErrorName),
     UnicornConsistentAssert(UnicornConsistentAssert),
     UnicornConsistentDateClone(UnicornConsistentDateClone),
@@ -2201,7 +2203,8 @@ const REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID: usize =
     REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID + 1usize;
 const REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID: usize =
     REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID + 1usize;
-const UNICORN_CATCH_ERROR_NAME_ID: usize = REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID + 1usize;
+const UNICORN_MAX_NESTED_CALLS_ID: usize = REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID + 1usize;
+const UNICORN_CATCH_ERROR_NAME_ID: usize = UNICORN_MAX_NESTED_CALLS_ID + 1usize;
 const UNICORN_CONSISTENT_ASSERT_ID: usize = UNICORN_CATCH_ERROR_NAME_ID + 1usize;
 const UNICORN_CONSISTENT_DATE_CLONE_ID: usize = UNICORN_CONSISTENT_ASSERT_ID + 1usize;
 const UNICORN_CONSISTENT_EMPTY_ARRAY_SPREAD_ID: usize = UNICORN_CONSISTENT_DATE_CLONE_ID + 1usize;
@@ -3168,6 +3171,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID,
+            Self::UnicornMaxNestedCalls(_) => UNICORN_MAX_NESTED_CALLS_ID,
             Self::UnicornCatchErrorName(_) => UNICORN_CATCH_ERROR_NAME_ID,
             Self::UnicornConsistentAssert(_) => UNICORN_CONSISTENT_ASSERT_ID,
             Self::UnicornConsistentDateClone(_) => UNICORN_CONSISTENT_DATE_CLONE_ID,
@@ -4129,6 +4133,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::NAME,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::NAME,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::NAME,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::NAME,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::NAME,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::NAME,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::NAME,
@@ -5106,6 +5111,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::CATEGORY,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::CATEGORY,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::CATEGORY,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::CATEGORY,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::CATEGORY,
@@ -6090,6 +6096,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::FIX,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::FIX,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::FIX,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::FIX,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::FIX,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::FIX,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::FIX,
@@ -7160,6 +7167,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewObjectAsProp(_) => {
                 ReactPerfJsxNoNewObjectAsProp::documentation()
             }
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::documentation(),
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::documentation(),
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::documentation(),
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::documentation(),
@@ -9017,6 +9025,8 @@ impl RuleEnum {
                 ReactPerfJsxNoNewObjectAsProp::config_schema(generator)
                     .or_else(|| ReactPerfJsxNoNewObjectAsProp::schema(generator))
             }
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::config_schema(generator)
+                .or_else(|| UnicornMaxNestedCalls::schema(generator)),
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::config_schema(generator)
                 .or_else(|| UnicornCatchErrorName::schema(generator)),
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::config_schema(generator)
@@ -10583,6 +10593,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewObjectAsProp(_) => "react_perf",
+            Self::UnicornMaxNestedCalls(_) => "unicorn",
             Self::UnicornCatchErrorName(_) => "unicorn",
             Self::UnicornConsistentAssert(_) => "unicorn",
             Self::UnicornConsistentDateClone(_) => "unicorn",
@@ -12423,6 +12434,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewObjectAsProp(_) => Ok(Self::ReactPerfJsxNoNewObjectAsProp(
                 ReactPerfJsxNoNewObjectAsProp::from_configuration(value)?,
             )),
+            Self::UnicornMaxNestedCalls(_) => {
+                Ok(Self::UnicornMaxNestedCalls(UnicornMaxNestedCalls::from_configuration(value)?))
+            }
             Self::UnicornCatchErrorName(_) => {
                 Ok(Self::UnicornCatchErrorName(UnicornCatchErrorName::from_configuration(value)?))
             }
@@ -14114,6 +14128,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.to_configuration(),
+            Self::UnicornMaxNestedCalls(rule) => rule.to_configuration(),
             Self::UnicornCatchErrorName(rule) => rule.to_configuration(),
             Self::UnicornConsistentAssert(rule) => rule.to_configuration(),
             Self::UnicornConsistentDateClone(rule) => rule.to_configuration(),
@@ -14961,6 +14976,7 @@ impl RuleEnum {
                 Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run(node, ctx),
                 Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run(node, ctx),
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run(node, ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run(node, ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run(node, ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run(node, ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run(node, ctx),
@@ -15801,6 +15817,7 @@ impl RuleEnum {
                 Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run(node, ctx),
                 Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run(node, ctx),
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run(node, ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run(node, ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run(node, ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run(node, ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run(node, ctx),
@@ -16648,6 +16665,7 @@ impl RuleEnum {
                 Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_once(ctx),
                 Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_once(ctx),
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_once(ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run_once(ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run_once(ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run_once(ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run_once(ctx),
@@ -17488,6 +17506,7 @@ impl RuleEnum {
                 Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_once(ctx),
                 Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_once(ctx),
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_once(ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run_once(ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run_once(ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run_once(ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run_once(ctx),
@@ -18468,6 +18487,7 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -19568,6 +19588,7 @@ impl RuleEnum {
                     rule.run_on_jest_node(jest_node, ctx)
                 }
                 Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::UnicornMaxNestedCalls(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornCatchErrorName(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornConsistentAssert(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornConsistentDateClone(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20536,6 +20557,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.should_run(ctx),
+            Self::UnicornMaxNestedCalls(rule) => rule.should_run(ctx),
             Self::UnicornCatchErrorName(rule) => rule.should_run(ctx),
             Self::UnicornConsistentAssert(rule) => rule.should_run(ctx),
             Self::UnicornConsistentDateClone(rule) => rule.should_run(ctx),
@@ -21561,6 +21583,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewObjectAsProp(_) => {
                 ReactPerfJsxNoNewObjectAsProp::IS_TSGOLINT_RULE
             }
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::IS_TSGOLINT_RULE,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::IS_TSGOLINT_RULE,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::IS_TSGOLINT_RULE,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::IS_TSGOLINT_RULE,
@@ -22684,6 +22707,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::VERSION,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::VERSION,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::VERSION,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::VERSION,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::VERSION,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::VERSION,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::VERSION,
@@ -23710,6 +23734,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::HAS_CONFIG,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::HAS_CONFIG,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::HAS_CONFIG,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::HAS_CONFIG,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::HAS_CONFIG,
@@ -24717,6 +24742,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::INFO,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::INFO,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::INFO,
+            Self::UnicornMaxNestedCalls(_) => UnicornMaxNestedCalls::INFO,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::INFO,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::INFO,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::INFO,
@@ -25603,6 +25629,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.types_info(),
+            Self::UnicornMaxNestedCalls(rule) => rule.types_info(),
             Self::UnicornCatchErrorName(rule) => rule.types_info(),
             Self::UnicornConsistentAssert(rule) => rule.types_info(),
             Self::UnicornConsistentDateClone(rule) => rule.types_info(),
@@ -26440,6 +26467,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_info(),
+            Self::UnicornMaxNestedCalls(rule) => rule.run_info(),
             Self::UnicornCatchErrorName(rule) => rule.run_info(),
             Self::UnicornConsistentAssert(rule) => rule.run_info(),
             Self::UnicornConsistentDateClone(rule) => rule.run_info(),
@@ -27369,6 +27397,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewFunctionAsProp(ReactPerfJsxNoNewFunctionAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewObjectAsProp(ReactPerfJsxNoNewObjectAsProp::default()),
+        RuleEnum::UnicornMaxNestedCalls(UnicornMaxNestedCalls::default()),
         RuleEnum::UnicornCatchErrorName(UnicornCatchErrorName::default()),
         RuleEnum::UnicornConsistentAssert(UnicornConsistentAssert::default()),
         RuleEnum::UnicornConsistentDateClone(UnicornConsistentDateClone::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -497,6 +497,7 @@ pub(crate) mod unicorn {
     pub mod explicit_length_check;
     pub mod filename_case;
     pub mod import_style;
+    pub mod max_nested_calls;
     pub mod new_for_builtins;
     pub mod no_abusive_eslint_disable;
     pub mod no_accessor_recursion;

--- a/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
+++ b/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
@@ -76,7 +76,7 @@ declare_oxc_lint!(
     /// ```
     MaxNestedCalls,
     unicorn,
-    pedantic,
+    style,
     config = MaxNestedCalls,
     version = "next",
     short_description = "Limit the depth of nested calls.",

--- a/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
+++ b/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
@@ -1,6 +1,5 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
-use serde_json::Value;
 
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
@@ -31,18 +30,6 @@ const DEFAULT_MAX_NESTED_CALLS: u32 = 3;
 impl Default for MaxNestedCalls {
     fn default() -> Self {
         Self { max: DEFAULT_MAX_NESTED_CALLS }
-    }
-}
-
-#[cfg(feature = "ruledocs")]
-impl MaxNestedCalls {
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn config_schema(
-        r#gen: &mut schemars::r#gen::SchemaGenerator,
-    ) -> Option<schemars::schema::Schema> {
-        let mut schema = r#gen.subschema_for::<Self>();
-        crate::utils::number_as_object_schema(r#gen, &mut schema, None);
-        Some(schema)
     }
 }
 
@@ -97,17 +84,7 @@ declare_oxc_lint!(
 
 impl Rule for MaxNestedCalls {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        if let Some(max) = value
-            .get(0)
-            .and_then(Value::as_number)
-            .and_then(serde_json::Number::as_u64)
-            .and_then(|v| u32::try_from(v).ok())
-        {
-            Ok(Self { max })
-        } else {
-            serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-                .map(DefaultRuleConfig::into_inner)
-        }
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -212,4 +189,9 @@ fn test() {
     ];
 
     Tester::new(MaxNestedCalls::NAME, MaxNestedCalls::PLUGIN, pass, fail).test_and_snapshot();
+}
+
+#[test]
+fn reject_number_configuration() {
+    assert!(MaxNestedCalls::from_configuration(serde_json::json!([4])).is_err());
 }

--- a/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
+++ b/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
@@ -1,0 +1,212 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{DefaultRuleConfig, Rule},
+};
+
+fn max_nested_calls_diagnostic(max: u32, span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Call is nested too deeply. Maximum allowed is {max}."))
+        .with_help("Extract intermediate results into named variables to reduce nesting.")
+        .with_label(span)
+}
+
+#[derive(Debug, Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+pub struct MaxNestedCalls {
+    /// The maximum allowed nested call depth.
+    max: u32,
+}
+
+const DEFAULT_MAX_NESTED_CALLS: u32 = 3;
+
+impl Default for MaxNestedCalls {
+    fn default() -> Self {
+        Self { max: DEFAULT_MAX_NESTED_CALLS }
+    }
+}
+
+#[cfg(feature = "ruledocs")]
+impl MaxNestedCalls {
+    #[expect(clippy::unnecessary_wraps)]
+    pub fn config_schema(
+        r#gen: &mut schemars::r#gen::SchemaGenerator,
+    ) -> Option<schemars::schema::Schema> {
+        let mut schema = r#gen.subschema_for::<Self>();
+        crate::utils::number_as_object_schema(r#gen, &mut schema, None);
+        Some(schema)
+    }
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Limit the depth of nested calls.
+    ///
+    /// This rule counts calls and constructor calls passed into other calls or
+    /// constructors. Fluent receiver chains and JSX wrappers are ignored.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Deeply nested calls make code hard to read. Extracting intermediate
+    /// results into named variables improves readability.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// foo(bar(baz(qux())));
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// const value = baz(qux());
+    /// foo(bar(value));
+    ///
+    /// // Fluent chains are ignored.
+    /// query().filter().map().toArray();
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// #### max
+    ///
+    /// `{ type: integer, default: 3 }`
+    ///
+    /// The maximum allowed nested call depth.
+    ///
+    /// Example:
+    /// ```json
+    /// "unicorn/max-nested-calls": ["error", { "max": 4 }]
+    /// ```
+    MaxNestedCalls,
+    unicorn,
+    pedantic,
+    config = MaxNestedCalls,
+    version = "next",
+    short_description = "Limit the depth of nested calls.",
+);
+
+impl Rule for MaxNestedCalls {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        if !matches!(node.kind(), AstKind::CallExpression(_) | AstKind::NewExpression(_)) {
+            return;
+        }
+
+        let mut depth = 1u32;
+        let mut child_span = node.span();
+
+        for ancestor in ctx.nodes().ancestors(node.id()) {
+            match ancestor.kind() {
+                // Calls inside a new scope are counted independently.
+                AstKind::Function(_)
+                | AstKind::ArrowFunctionExpression(_)
+                | AstKind::Class(_)
+                | AstKind::StaticBlock(_)
+                | AstKind::JSXElement(_)
+                | AstKind::JSXFragment(_) => break,
+                AstKind::CallExpression(call)
+                    if call.arguments.iter().any(|argument| argument.span() == child_span) =>
+                {
+                    depth += 1;
+                }
+                AstKind::NewExpression(new_expression)
+                    if new_expression
+                        .arguments
+                        .iter()
+                        .any(|argument| argument.span() == child_span) =>
+                {
+                    depth += 1;
+                }
+                _ => {}
+            }
+            child_span = ancestor.span();
+        }
+
+        if depth > self.max {
+            ctx.diagnostic(max_nested_calls_diagnostic(self.max, node.span()));
+        }
+    }
+
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        if let Some(max) = value
+            .get(0)
+            .and_then(Value::as_number)
+            .and_then(serde_json::Number::as_u64)
+            .and_then(|v| u32::try_from(v).ok())
+        {
+            Ok(Self { max })
+        } else {
+            serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+                .map(DefaultRuleConfig::into_inner)
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("foo();", None),
+        ("foo(bar(baz()));", None),
+        ("foo(bar(), baz(), qux());", None),
+        ("query().filter().map().toArray();", None),
+        ("foo()[bar()]().baz();", None),
+        ("foo(() => bar(baz(qux())));", None),
+        ("foo(bar(class {field = baz(qux());}));", None),
+        ("foo(bar(class {static {baz(qux());}}));", None),
+        ("new Foo(new Bar(new Baz()));", None),
+        ("await foo(await bar(await baz()));", None),
+        ("foo?.(bar?.(baz?.()));", None),
+        ("foo(...bar(baz()));", None),
+        ("foo(condition ? bar(baz()) : qux());", None),
+        (
+            "nativeDiffButtons.parentElement.after(
+                tooltipped(
+                    {},
+                    <a className={cx('btn', isHidingWhitespace() && 'color-fg-subtle')} />,
+                ),
+            );",
+            None,
+        ),
+        (
+            "nativeDiffButtons.parentElement.after(
+                tooltipped(
+                    {},
+                    <>{cx('btn', isHidingWhitespace() && 'color-fg-subtle')}</>,
+                ),
+            );",
+            None,
+        ),
+        ("foo(bar(baz(qux())));", Some(serde_json::json!([{"max": 4}]))),
+    ];
+
+    let fail = vec![
+        ("foo(bar(baz(qux())));", None),
+        ("foo(bar(baz()));", Some(serde_json::json!([{"max": 2}]))),
+        ("new Foo(new Bar(new Baz(new Qux())));", None),
+        ("await foo(await bar(await baz(await qux())));", None),
+        ("foo?.(bar?.(baz?.(qux?.())));", None),
+        ("foo(...bar(baz(qux())));", None),
+        ("foo(condition ? bar(baz(qux())) : zed());", None),
+        ("foo(class {field = bar(baz(qux(zed())));});", None),
+        ("<Component value={foo(bar(baz(qux())))} />;", None),
+        (
+            "mergeReports(await pMap(
+                await mergeWithFileConfigs(uniq(paths), inputOptions, configFiles),
+                async ({files, options, prettierOptions}) => runEslint(files, buildConfig(options, prettierOptions), {isQuiet: options.quiet}),
+            ));",
+            None,
+        ),
+    ];
+
+    Tester::new(MaxNestedCalls::NAME, MaxNestedCalls::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
+++ b/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
@@ -1,10 +1,11 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
-use schemars::JsonSchema;
-use serde::Deserialize;
-use serde_json::Value;
 
 use crate::{
     AstNode,
@@ -95,6 +96,20 @@ declare_oxc_lint!(
 );
 
 impl Rule for MaxNestedCalls {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        if let Some(max) = value
+            .get(0)
+            .and_then(Value::as_number)
+            .and_then(serde_json::Number::as_u64)
+            .and_then(|v| u32::try_from(v).ok())
+        {
+            Ok(Self { max })
+        } else {
+            serde_json::from_value::<DefaultRuleConfig<Self>>(value)
+                .map(DefaultRuleConfig::into_inner)
+        }
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if !matches!(node.kind(), AstKind::CallExpression(_) | AstKind::NewExpression(_)) {
             return;
@@ -132,20 +147,6 @@ impl Rule for MaxNestedCalls {
 
         if depth > self.max {
             ctx.diagnostic(max_nested_calls_diagnostic(self.max, node.span()));
-        }
-    }
-
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        if let Some(max) = value
-            .get(0)
-            .and_then(Value::as_number)
-            .and_then(serde_json::Number::as_u64)
-            .and_then(|v| u32::try_from(v).ok())
-        {
-            Ok(Self { max })
-        } else {
-            serde_json::from_value::<DefaultRuleConfig<Self>>(value)
-                .map(DefaultRuleConfig::into_inner)
         }
     }
 }

--- a/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
+++ b/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
@@ -61,19 +61,6 @@ declare_oxc_lint!(
     /// // Fluent chains are ignored.
     /// query().filter().map().toArray();
     /// ```
-    ///
-    /// ### Options
-    ///
-    /// #### max
-    ///
-    /// `{ type: integer, default: 3 }`
-    ///
-    /// The maximum allowed nested call depth.
-    ///
-    /// Example:
-    /// ```json
-    /// "unicorn/max-nested-calls": ["error", { "max": 4 }]
-    /// ```
     MaxNestedCalls,
     unicorn,
     style,

--- a/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
+++ b/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
@@ -190,8 +190,3 @@ fn test() {
 
     Tester::new(MaxNestedCalls::NAME, MaxNestedCalls::PLUGIN, pass, fail).test_and_snapshot();
 }
-
-#[test]
-fn reject_number_configuration() {
-    assert!(MaxNestedCalls::from_configuration(serde_json::json!([4])).is_err());
-}

--- a/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
+++ b/crates/oxc_linter/src/rules/unicorn/max_nested_calls.rs
@@ -111,12 +111,14 @@ impl Rule for MaxNestedCalls {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        if !matches!(node.kind(), AstKind::CallExpression(_) | AstKind::NewExpression(_)) {
-            return;
-        }
+        let node_span = match node.kind() {
+            AstKind::CallExpression(call) => call.span,
+            AstKind::NewExpression(new_expression) => new_expression.span,
+            _ => return,
+        };
 
         let mut depth = 1u32;
-        let mut child_span = node.span();
+        let mut child_span = node_span;
 
         for ancestor in ctx.nodes().ancestors(node.id()) {
             match ancestor.kind() {
@@ -146,7 +148,7 @@ impl Rule for MaxNestedCalls {
         }
 
         if depth > self.max {
-            ctx.diagnostic(max_nested_calls_diagnostic(self.max, node.span()));
+            ctx.diagnostic(max_nested_calls_diagnostic(self.max, node_span));
         }
     }
 }

--- a/crates/oxc_linter/src/snapshots/unicorn_max_nested_calls.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_max_nested_calls.snap
@@ -1,0 +1,75 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(max-nested-calls): Call is nested too deeply. Maximum allowed is 3.
+   ╭─[max_nested_calls.tsx:1:13]
+ 1 │ foo(bar(baz(qux())));
+   ·             ─────
+   ╰────
+  help: Extract intermediate results into named variables to reduce nesting.
+
+  ⚠ unicorn(max-nested-calls): Call is nested too deeply. Maximum allowed is 2.
+   ╭─[max_nested_calls.tsx:1:9]
+ 1 │ foo(bar(baz()));
+   ·         ─────
+   ╰────
+  help: Extract intermediate results into named variables to reduce nesting.
+
+  ⚠ unicorn(max-nested-calls): Call is nested too deeply. Maximum allowed is 3.
+   ╭─[max_nested_calls.tsx:1:25]
+ 1 │ new Foo(new Bar(new Baz(new Qux())));
+   ·                         ─────────
+   ╰────
+  help: Extract intermediate results into named variables to reduce nesting.
+
+  ⚠ unicorn(max-nested-calls): Call is nested too deeply. Maximum allowed is 3.
+   ╭─[max_nested_calls.tsx:1:37]
+ 1 │ await foo(await bar(await baz(await qux())));
+   ·                                     ─────
+   ╰────
+  help: Extract intermediate results into named variables to reduce nesting.
+
+  ⚠ unicorn(max-nested-calls): Call is nested too deeply. Maximum allowed is 3.
+   ╭─[max_nested_calls.tsx:1:19]
+ 1 │ foo?.(bar?.(baz?.(qux?.())));
+   ·                   ───────
+   ╰────
+  help: Extract intermediate results into named variables to reduce nesting.
+
+  ⚠ unicorn(max-nested-calls): Call is nested too deeply. Maximum allowed is 3.
+   ╭─[max_nested_calls.tsx:1:16]
+ 1 │ foo(...bar(baz(qux())));
+   ·                ─────
+   ╰────
+  help: Extract intermediate results into named variables to reduce nesting.
+
+  ⚠ unicorn(max-nested-calls): Call is nested too deeply. Maximum allowed is 3.
+   ╭─[max_nested_calls.tsx:1:25]
+ 1 │ foo(condition ? bar(baz(qux())) : zed());
+   ·                         ─────
+   ╰────
+  help: Extract intermediate results into named variables to reduce nesting.
+
+  ⚠ unicorn(max-nested-calls): Call is nested too deeply. Maximum allowed is 3.
+   ╭─[max_nested_calls.tsx:1:32]
+ 1 │ foo(class {field = bar(baz(qux(zed())));});
+   ·                                ─────
+   ╰────
+  help: Extract intermediate results into named variables to reduce nesting.
+
+  ⚠ unicorn(max-nested-calls): Call is nested too deeply. Maximum allowed is 3.
+   ╭─[max_nested_calls.tsx:1:31]
+ 1 │ <Component value={foo(bar(baz(qux())))} />;
+   ·                               ─────
+   ╰────
+  help: Extract intermediate results into named variables to reduce nesting.
+
+  ⚠ unicorn(max-nested-calls): Call is nested too deeply. Maximum allowed is 3.
+   ╭─[max_nested_calls.tsx:2:44]
+ 1 │ mergeReports(await pMap(
+ 2 │                 await mergeWithFileConfigs(uniq(paths), inputOptions, configFiles),
+   ·                                            ───────────
+ 3 │                 async ({files, options, prettierOptions}) => runEslint(files, buildConfig(options, prettierOptions), {isQuiet: options.quiet}),
+   ╰────
+  help: Extract intermediate results into named variables to reduce nesting.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -8387,6 +8387,33 @@
             }
           ]
         },
+        "unicorn/max-nested-calls": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "$ref": "#/definitions/MaxNestedCalls"
+                    }
+                  ]
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "unicorn/new-for-builtins": {
           "$ref": "#/definitions/RuleNoConfig"
         },
@@ -12076,6 +12103,20 @@
           "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The `max` enforces a maximum depth that callbacks can be nested."
+        }
+      },
+      "additionalProperties": false
+    },
+    "MaxNestedCalls": {
+      "type": "object",
+      "properties": {
+        "max": {
+          "description": "The maximum allowed nested call depth.",
+          "default": 3,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "markdownDescription": "The maximum allowed nested call depth."
         }
       },
       "additionalProperties": false

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -8399,14 +8399,7 @@
                   "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "anyOf": [
-                    {
-                      "type": "number"
-                    },
-                    {
-                      "$ref": "#/definitions/MaxNestedCalls"
-                    }
-                  ]
+                  "$ref": "#/definitions/MaxNestedCalls"
                 }
               ],
               "maxItems": 2,


### PR DESCRIPTION
Implements the `unicorn/max-nested-calls` rule. Part of #684.

Limits the depth of nested calls, following the [eslint-plugin-unicorn rule](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/max-nested-calls.md).

## What it does

Counts calls and constructor calls passed as arguments into other calls/constructors. Reports when the depth exceeds `max` (default `3`). Fluent receiver chains and JSX wrappers are ignored, and a new scope (function, class, static block, JSX element/fragment) resets the count.

```js
// ❌
foo(bar(baz(qux())));

// ✅
const value = baz(qux());
foo(bar(value));

// ✅ fluent chains are ignored
query().filter().map().toArray();
```

## Options

`max` (integer, default `3`) — the maximum allowed nested call depth.

## Notes

- All 16 pass / 10 fail fixtures from the upstream rule are ported, including `new`, `await`, optional calls (`?.`), spread arguments, ternaries, and the JSX/class/static-block boundary cases.
- The depth walk tracks the child node through each ancestor and only counts an ancestor call/`new` when the child is one of its arguments (not its callee), which is what makes fluent chains and JSX wrappers transparent.