### PR TITLE
refactor(minifier): remove dead SymbolValue::scope_id field

### DIFF
--- a/crates/oxc_minifier/src/symbol_value.rs
+++ b/crates/oxc_minifier/src/symbol_value.rs
@@ -1,6 +1,6 @@
 use oxc_ecmascript::constant_evaluation::ConstantValue;
 use oxc_index::IndexVec;
-use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
+use oxc_syntax::symbol::SymbolId;
 
 #[derive(Debug)]
 pub struct SymbolValue<'a> {
@@ -23,8 +23,6 @@ pub struct SymbolValue<'a> {
     /// True for function/class declarations and variable declarations initialized
     /// with object/array/function/class literals.
     pub is_fresh_value: bool,
-
-    pub scope_id: ScopeId,
 }
 
 /// Per-symbol scratch store indexed by `SymbolId`.

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -299,7 +299,6 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
             write_references_count,
             member_write_target_read_count,
             is_fresh_value,
-            scope_id,
         };
         self.state.symbol_values.init_value(symbol_id, symbol_value);
     }


### PR DESCRIPTION
## Summary

- Remove `SymbolValue::scope_id`: it was written in `init_value` but never read. The declaring scope is still looked up locally there to gate `initialized_constant` on the `DirectEval` flag — only the stored-but-unused field (and the now-dead `ScopeId` import) are dropped.
- No behavior change; pure dead-field removal. Verified by `cargo test -p oxc_minifier` (535 + 2 passed).
