### PR TITLE
feat(linter): add pass-on-unpruned-suppressions

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -82,6 +82,10 @@ pub struct SuppressionOptions {
     /// Remove entries for violations that no longer exist
     #[bpaf(switch, hide)]
     pub prune_suppressions: bool,
+
+    /// Ignore unused suppressions when calculating the exit code
+    #[bpaf(switch, hide)]
+    pub pass_on_unpruned_suppressions: bool,
 }
 
 impl LintCommand {
@@ -802,6 +806,7 @@ mod lint_options {
         let options = get_lint_options("--suppress-all");
         assert!(options.suppression_options.suppress_all);
         assert!(!options.suppression_options.prune_suppressions);
+        assert!(!options.suppression_options.pass_on_unpruned_suppressions);
     }
 
     #[test]
@@ -809,6 +814,15 @@ mod lint_options {
         let options = get_lint_options("--prune-suppressions");
         assert!(options.suppression_options.prune_suppressions);
         assert!(!options.suppression_options.suppress_all);
+        assert!(!options.suppression_options.pass_on_unpruned_suppressions);
+    }
+
+    #[test]
+    fn pass_on_unpruned_suppressions() {
+        let options = get_lint_options("--pass-on-unpruned-suppressions");
+        assert!(options.suppression_options.pass_on_unpruned_suppressions);
+        assert!(!options.suppression_options.suppress_all);
+        assert!(!options.suppression_options.prune_suppressions);
     }
 
     #[test]

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -512,7 +512,12 @@ impl CliRunner {
             }
         }
 
-        let result = suppression_manager.finalize(diff_manager, &tx_error, &cwd);
+        let result = suppression_manager.finalize(
+            diff_manager,
+            &tx_error,
+            &cwd,
+            suppression_options.pass_on_unpruned_suppressions,
+        );
         let suppress_all_succeeded = suppression_options.suppress_all && result.is_ok();
 
         drop(tx_error);
@@ -547,7 +552,7 @@ impl CliRunner {
             return CliRunResult::LintSucceeded;
         }
 
-        if has_unpruned_suppressions {
+        if has_unpruned_suppressions && !suppression_options.pass_on_unpruned_suppressions {
             return CliRunResult::LintUnprunedSuppressions;
         }
 
@@ -2007,6 +2012,44 @@ mod suppression {
         assert!(
             matches!(result, CliRunResult::LintUnprunedSuppressions),
             "Expected LintUnprunedSuppressions (exit code 2), got {result:?}"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(target_endian = "big", ignore = "disabled on big-endian")]
+    fn test_pass_on_unpruned_suppressions_exit_code() {
+        let args = &["--pass-on-unpruned-suppressions"];
+        let (stdout, result) = Tester::new()
+            .with_cwd("fixtures/suppression/decreased_violations_are_reported".into())
+            .test_output(args);
+        assert!(
+            matches!(result, CliRunResult::LintSucceeded),
+            "Expected LintSucceeded with --pass-on-unpruned-suppressions, got {result:?}"
+        );
+        assert!(
+            !stdout.contains("There are suppressions that do not occur anymore."),
+            "Unused suppression diagnostic should be hidden with --pass-on-unpruned-suppressions.\nOutput: {stdout}"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(target_endian = "big", ignore = "disabled on big-endian")]
+    fn test_pass_on_unpruned_suppressions_keeps_new_violations_failing() {
+        let args = &["--pass-on-unpruned-suppressions", "--type-aware", "--type-check"];
+        let (stdout, result) = Tester::new()
+            .with_cwd("fixtures/suppression/fixed_violations_are_reported".into())
+            .test_output(args);
+        assert!(
+            matches!(result, CliRunResult::LintFoundErrors),
+            "Expected LintFoundErrors when new violations remain, got {result:?}"
+        );
+        assert!(
+            !stdout.contains("There are suppressions that do not occur anymore."),
+            "Unused suppression diagnostic should be hidden with --pass-on-unpruned-suppressions.\nOutput: {stdout}"
+        );
+        assert!(
+            stdout.contains("Found 3 warnings and 2 errors."),
+            "Expected remaining new violations to affect the output summary.\nOutput: {stdout}"
         );
     }
 

--- a/crates/oxc_linter/src/suppression/mod.rs
+++ b/crates/oxc_linter/src/suppression/mod.rs
@@ -144,6 +144,7 @@ impl SuppressionManager {
         diff_manager: Arc<DiffManager>,
         tx_error: &DiagnosticSender,
         cwd: &Path,
+        ignore_unused_suppressions: bool,
     ) -> Result<(), OxcDiagnostic> {
         // Nothing to do if there's no suppression file and we're not creating one
         if self.suppressions_by_file.is_none() && !self.suppress_all {
@@ -167,7 +168,8 @@ impl SuppressionManager {
             self.write()
         } else {
             // Read-only mode: report diagnostics for any differences
-            let (errors, has_unused) = Self::compute_diagnostics(&static_map, &runtime_map);
+            let (errors, has_unused) =
+                Self::compute_diagnostics(&static_map, &runtime_map, ignore_unused_suppressions);
             if !errors.is_empty() {
                 let diagnostics =
                     DiagnosticService::wrap_diagnostics(cwd, Path::new(""), "", errors);
@@ -246,6 +248,7 @@ impl SuppressionManager {
     fn compute_diagnostics(
         static_map: &StaticSuppressionMap,
         runtime_map: &FxHashMap<Filename, FileSuppressionsMap>,
+        ignore_unused_suppressions: bool,
     ) -> (Vec<OxcDiagnostic>, bool) {
         let mut has_unused = false;
         let mut has_new = false;
@@ -296,7 +299,7 @@ impl SuppressionManager {
 
         let mut errors = vec![];
 
-        if has_unused {
+        if has_unused && !ignore_unused_suppressions {
             errors.push(
                 OxcDiagnostic::error("There are suppressions that do not occur anymore.")
                     .with_help("Run `oxlint --prune-suppressions` to remove unused suppressions."),


### PR DESCRIPTION
## Summary

- add the hidden `--pass-on-unpruned-suppressions` CLI option for bulk suppressions
- skip the unused-suppression diagnostic and `LintUnprunedSuppressions` result when the flag is set
- keep new violations and normal lint errors failing as before

Closes #20991
Part of #21102

## Verification

- `cargo test -p oxlint suppression --lib`
- `cargo test -p oxlint pass_on_unpruned_suppressions --lib`
- `cargo test -p oxlint unpruned_suppressions --lib`
- `cargo fmt --check`
- `git diff --check`

AI assistance was used; I reviewed and tested the changes.
