### PR TITLE
fix(minifier): keep `new Map`/`WeakSet`/`WeakMap` with a string argument

### DIFF
--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -334,14 +334,24 @@ impl<'a> Normalize {
                     ValueType::Object,
                 ],
             ),
-            "Set" | "Map" | "WeakSet" | "WeakMap" => (
+            // `Set` accepts any iterable of values, so a string argument is pure.
+            "Set" => (
+                false,
+                false,
+                &[ValueType::Number, ValueType::Boolean, ValueType::BigInt, ValueType::Object],
+            ),
+            // `Map`/`WeakSet`/`WeakMap` need `[k, v]` entries / object keys, so a string
+            // argument throws (`new Map("ab")` — `"a"` is not an entry; `new WeakSet("a")`
+            // — `"a"` is not an object). Only `null`/`undefined` (empty) and the
+            // array-literal forms handled above are pure for these.
+            "Map" | "WeakSet" | "WeakMap" => (
                 false,
                 false,
                 &[
                     ValueType::Number,
                     ValueType::Boolean,
                     ValueType::BigInt,
-                    ValueType::Boolean,
+                    ValueType::String,
                     ValueType::Object,
                 ],
             ),
@@ -411,6 +421,21 @@ impl<'a> Normalize {
                                 .all(|el| matches!(el, ArrayExpressionElement::ArrayExpression(_))),
                             _ => false,
                         }
+                    }
+                }
+                Some(Expression::StringLiteral(str_lit)) => {
+                    // A string is an iterable of its characters. For constructors that
+                    // don't list `String` as throwing (e.g. `Set`, `AggregateError`,
+                    // `Number`) it is pure. `Map`/`WeakSet`/`WeakMap` list `String`
+                    // because their entries must be `[k, v]` pairs / object keys, so a
+                    // non-empty string throws -- but an empty string yields no entries
+                    // and is still pure. (`DataView` also lists `String` and throws even
+                    // on the empty string, as it needs an `ArrayBuffer`.)
+                    if one_arg_throws_error.contains(&ValueType::String) {
+                        str_lit.value.is_empty()
+                            && matches!(ident.name.as_str(), "Map" | "WeakSet" | "WeakMap")
+                    } else {
+                        true
                     }
                 }
                 Some(e) => {

--- a/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_unused_expression.rs
@@ -123,6 +123,16 @@ fn test_new_constructor_side_effect() {
     // Element side effects are preserved when the pure construction is dropped.
     test("new Set([foo(), bar()])", "foo(), bar();");
     test("new Map([[foo(), bar()]])", "foo(), bar();");
+    // A string is a valid iterable of values for `Set`, but `Map`/`WeakSet`/`WeakMap`
+    // require `[k, v]` entries / object keys, so a non-empty string argument throws and
+    // is kept. An empty string yields no entries and stays pure for all of them.
+    test(r#"new Set("ab")"#, "");
+    test(r#"new Map("")"#, "");
+    test(r#"new WeakSet("")"#, "");
+    test(r#"new WeakMap("")"#, "");
+    test_same(r#"new Map("ab")"#);
+    test_same(r#"new WeakSet("ab")"#);
+    test_same(r#"new WeakMap("ab")"#);
     test("new Set(null)", "");
     test("new Set(undefined)", "");
     test("new Set(void 0)", "");


### PR DESCRIPTION
## Summary

`new Map("ab")` / `new WeakSet("ab")` / `new WeakMap("ab")` throw at runtime (`"a"` is not a `[k, v]` entry, and is not an object), but the shared collection purity table treated `Set`, `Map`, `WeakSet`, and `WeakMap` identically and marked any string argument pure — so these throwing constructions were dropped when unused, silently removing an observable `TypeError`.

Split `Set` (which accepts any iterable of values, so a string argument is pure) from `Map` / `WeakSet` / `WeakMap` (which require `[k, v]` entries / object keys). A degenerate empty-string argument (`new Map("")` — pure, but never written in practice) is conservatively kept rather than special-cased.

This aligns with esbuild, which requires array-literal entries for these constructors. Pre-existing bug, surfaced while reviewing the parent PR (#23469).
