### PR TITLE
perf(react_compiler): borrow binding names in prefilter instead of allocating

### DIFF
--- a/crates/oxc_react_compiler/src/prefilter.rs
+++ b/crates/oxc_react_compiler/src/prefilter.rs
@@ -34,9 +34,9 @@ fn is_component_wrapper(callee: &Expression) -> bool {
     }
 }
 
-struct ReactLikeVisitor {
+struct ReactLikeVisitor<'a> {
     found: bool,
-    current_name: Option<String>,
+    current_name: Option<&'a str>,
 }
 
 struct ResourceManagementVisitor {
@@ -56,14 +56,14 @@ impl<'a> Visit<'a> for ResourceManagementVisitor {
     }
 }
 
-impl<'a> Visit<'a> for ReactLikeVisitor {
+impl<'a> Visit<'a> for ReactLikeVisitor<'a> {
     fn visit_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
         if self.found {
             return;
         }
 
         let name = match &decl.id {
-            oxc_ast::ast::BindingPattern::BindingIdentifier(ident) => Some(ident.name.to_string()),
+            oxc_ast::ast::BindingPattern::BindingIdentifier(ident) => Some(ident.name.as_str()),
             _ => None,
         };
 
@@ -83,7 +83,7 @@ impl<'a> Visit<'a> for ReactLikeVisitor {
         }
 
         let name = match &expr.left {
-            AssignmentTarget::AssignmentTargetIdentifier(ident) => Some(ident.name.to_string()),
+            AssignmentTarget::AssignmentTargetIdentifier(ident) => Some(ident.name.as_str()),
             _ => None,
         };
 


### PR DESCRIPTION
## What & why

The React-compiler prefilter (`has_react_like_functions`) runs on **every file** in `transform()`
before deciding whether to compile it, and walks the whole program (for non-React files it never
short-circuits). For **every variable declarator and every assignment-target identifier** it did:

```rust
current_name: Option<String>,
// ...
Some(ident.name.to_string())   // heap String, used only to call is_react_like_name(&str)
```

`ident.name` is already an arena `Ident<'a>` (`as_str()` returns `&'a str`), and `current_name` is
only ever read by `is_react_like_name(name: &str)`. So the owned `String` — a heap alloc + memcpy of
the name bytes, per binding, thrown away immediately — is pure waste. This borrows it instead:

```rust
struct ReactLikeVisitor<'a> { found: bool, current_name: Option<&'a str> }
// ...
Some(ident.name.as_str())      // zero-cost arena borrow
```

**The positive signal:** one heap `String` allocation (malloc/free + name-byte memcpy) is removed per
declarator and per assignment-target identifier, across the whole program, on a path that runs for
every file. On non-React files (e.g. a large `binder.ts`) the prefilter never short-circuits, so this
is thousands of throwaway allocations eliminated. `&str`/`Ident` is `Copy` and the struct shrinks
(`Option<&str>` 16B vs `Option<String>` 24B), so it is strictly less work — never more.

`oxc_react_compiler` is **not** covered by `allocs_*.snap`, so there's no local snapshot to quantify
this; the `react_compiler` CodSpeed benchmark is the arbiter (removing system `malloc`/`free` is real
retired instructions, so it should register).

## Behavior-preserving

The borrowed `&'a str` holds the identical bytes the `String` did; `is_react_like_name` is a pure
read. Prefilter include/exclude decisions are byte-for-byte identical. The lifetime is sound:
`Ident::as_str() -> &'a str` points into the arena (the program's `'a`), which outlives the visitor.
`cargo test -p oxc_react_compiler` (17 tests) passes; no snapshot drift.

> Note: `prefilter.rs` is vendored from the upstream React Compiler (`react_compiler_oxc`), but is
> already substantially oxc-diverged (it adds `ResourceManagementVisitor`, `memo`/`forwardRef`
> handling, etc.). This is an intentional oxc-side idiom tightening — flagging it for anyone re-syncing.

---

Prepared with AI assistance.
