### PR TITLE
fix(formatter_json): handle wrapped error span

### DIFF
--- a/crates/oxc_formatter_json/src/parse.rs
+++ b/crates/oxc_formatter_json/src/parse.rs
@@ -3,7 +3,7 @@ use oxc_ast::{
     Comment,
     ast::{Expression, Statement},
 };
-use oxc_diagnostics::OxcDiagnostic;
+use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
 use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
 
@@ -68,7 +68,13 @@ pub fn parse_json<'a>(
         }
 
         if let Some(err) = ret.diagnostics.into_iter().next() {
-            return Err(err);
+            // The parser ran on `wrapped_source`, so its label spans are in wrapped coordinates.
+            // And can even point at the synthetic trailing `)` / `\n` (e.g. for an unterminated `{`).
+            // Remap them back to user-source coordinates so the diagnostic renders against the original `source`
+            // without going out of bounds.
+            // Out-of-bounds spans would otherwise make the graphical reporter fail to render.
+            let source_len = u32::try_from(source.len()).unwrap_or(u32::MAX);
+            return Err(remap_error_to_user_source(err, source_len));
         }
         return Err(OxcDiagnostic::error("Failed to parse JSON source"));
     }
@@ -98,6 +104,28 @@ pub fn parse_json<'a>(
         wrapped_source,
         source_offset: 1,
     })
+}
+
+/// Remap a parser diagnostic from `wrapped_source` coordinates back to user-`source` coordinates.
+///
+/// `source_len` is the byte length of the original user source.
+/// Each label is shifted left by the leading-`(` of `wrapped_source` and clamped to `[0, source_len]`,
+/// so a span pointing at the synthetic trailing `)` / `\n` collapses to an end-of-input marker
+/// instead of an out-of-bounds span the reporter cannot render.
+fn remap_error_to_user_source(mut err: OxcDiagnostic, source_len: u32) -> OxcDiagnostic {
+    // The wrapper prepends a single `(`, so user-source byte N sits at wrapped byte `N + 1`.
+    const SOURCE_OFFSET: u32 = 1;
+    for label in err.labels.as_mut_slice() {
+        let start = label.offset().saturating_sub(SOURCE_OFFSET).min(source_len);
+        let end = (label.offset() + label.len()).saturating_sub(SOURCE_OFFSET).min(source_len);
+        let text = label.label().map(ToString::to_string);
+        *label = if label.primary() {
+            LabeledSpan::new_primary_with_span(text, start..end)
+        } else {
+            LabeledSpan::new_with_span(text, start..end)
+        };
+    }
+    err
 }
 
 /// Fallback path for the wrapped-parse failure:
@@ -194,6 +222,28 @@ mod tests {
             let allocator = Allocator::default();
             let result = parse_json(&allocator, src, variant);
             assert_eq!(result.is_ok(), should_succeed, "src={src:?} variant={variant:?}");
+        }
+    }
+
+    #[test]
+    fn parse_error_spans_stay_within_source() {
+        // Unterminated / truncated inputs whose error naturally lands at end-of-input.
+        let cases = ["{", "{\n", "[1,", "{\n  \"test\":\n}\n"];
+
+        for src in cases {
+            let allocator = Allocator::default();
+            let Err(err) = parse_json(&allocator, src, Json) else {
+                panic!("src={src:?} expected a parse error");
+            };
+            let len = src.len();
+            for label in err.labels.as_slice() {
+                let start = label.offset() as usize;
+                let end = start + label.len() as usize;
+                assert!(
+                    start <= len && end <= len,
+                    "src={src:?} label span {start}..{end} exceeds source len {len}",
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
- The `formatter_json` uses the `oxc_parser` to parse content
- Because a valid JSON `{}` is considered invalid JS, it is wrapped in `({})` before parsing
- As a result, the spans reported in parsing errors are offset by the width of that opening parenthesis 1