### PR TITLE
perf(react_compiler): clone only needed scope fields before compile

### DIFF
--- a/crates/oxc_react_compiler/src/apply_renames.rs
+++ b/crates/oxc_react_compiler/src/apply_renames.rs
@@ -6,17 +6,19 @@
 //! Apply the React Compiler's binding renames to identifiers in uncompiled
 //! sibling code (compiled functions already carry the renamed identifiers).
 
+use indexmap::IndexMap;
 use oxc_ast::ast::*;
 use oxc_ast_visit::VisitMut;
 use oxc_ast_visit::walk_mut;
 use react_compiler::entrypoint::compile_result::BindingRenameInfo;
+use react_compiler_ast::scope::BindingData;
 use react_compiler_ast::scope::BindingId;
-use react_compiler_ast::scope::ScopeInfo;
 use rustc_hash::FxHashMap;
 
 /// Map each `span.start` of a renamed-binding reference to its new name.
 pub fn build_rename_plan(
-    scope_info: &ScopeInfo,
+    bindings: &[BindingData],
+    ref_node_id_to_binding: &IndexMap<u32, BindingId>,
     renames: &[BindingRenameInfo],
 ) -> FxHashMap<u32, String> {
     if renames.is_empty() {
@@ -27,7 +29,7 @@ pub fn build_rename_plan(
         renames.iter().map(|rename| (rename.declaration_start, rename)).collect();
 
     let mut renamed_bindings: FxHashMap<BindingId, String> = FxHashMap::default();
-    for binding in &scope_info.bindings {
+    for binding in bindings {
         let Some(rename) =
             binding.declaration_start.and_then(|start| renames_by_declaration.get(&start))
         else {
@@ -43,11 +45,10 @@ pub fn build_rename_plan(
     }
 
     // `ref_node_id_to_binding` is node-id keyed; in OXC node_id == span.start.
-    scope_info
-        .ref_node_id_to_binding
+    ref_node_id_to_binding
         .iter()
         .filter_map(|(&position, binding_id)| {
-            if scope_info.bindings[binding_id.0 as usize].declaration_start == Some(position) {
+            if bindings[binding_id.0 as usize].declaration_start == Some(position) {
                 return None;
             }
             renamed_bindings.get(binding_id).map(|renamed| (position, renamed.clone()))

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -97,8 +97,12 @@ pub fn transform<'a>(
 
     let file = convert_program(program, source_text);
     let scope_info = convert_scope_info(&semantic, program);
-    let result =
-        react_compiler::entrypoint::program::compile_program(file, scope_info.clone(), options);
+    // `compile_program` consumes `scope_info`, but `build_rename_plan` (below) only needs these two
+    // fields afterwards. Clone just those instead of the whole `ScopeInfo` (which would also deep-clone
+    // `scopes` and its per-scope `HashMap<String, _>` binding-name keys, plus several other maps).
+    let rename_bindings = scope_info.bindings.clone();
+    let rename_refs = scope_info.ref_node_id_to_binding.clone();
+    let result = react_compiler::entrypoint::program::compile_program(file, scope_info, options);
 
     let diagnostics = compile_result_to_diagnostics(&result);
     let (program_ast, events, renames) = match result {
@@ -114,7 +118,7 @@ pub fn transform<'a>(
     };
 
     // Rename plan maps source positions of uncompiled references to new names.
-    let rename_plan = build_rename_plan(&scope_info, &renames);
+    let rename_plan = build_rename_plan(&rename_bindings, &rename_refs, &renames);
 
     let compiled_program = program_ast.map(|file: react_compiler_ast::File| {
         let mut compiled =


### PR DESCRIPTION
## What & why

`compile_program` consumes its `ScopeInfo` by value, so the code cloned the **entire** `ScopeInfo` just
to keep the original alive for `build_rename_plan` afterwards:

```rust
let result = compile_program(file, scope_info.clone(), options);   // full deep clone
...
let rename_plan = build_rename_plan(&scope_info, &renames);
```

But `build_rename_plan` reads only two of `ScopeInfo`'s fields — `bindings` and
`ref_node_id_to_binding`. The full clone also deep-copies `scopes: Vec<ScopeData>` — and **each
`ScopeData` owns a `HashMap<String, BindingId>` whose String keys (binding names) all get
re-allocated** — plus several other maps, none of which `build_rename_plan` touches. This clones just
the two needed fields and **moves** the rest into `compile_program`:

```rust
let rename_bindings = scope_info.bindings.clone();
let rename_refs = scope_info.ref_node_id_to_binding.clone();
let result = compile_program(file, scope_info, options);   // moved, no clone
...
let rename_plan = build_rename_plan(&rename_bindings, &rename_refs, &renames);
```

**The win:** per compiled file, this drops the deep clone of the per-scope `HashMap<String, _>`
binding-name keys (system-heap String + bucket reallocations) and 4–5 other maps — keeping only
`bindings` (needed) and the cheap `ref_node_id_to_binding` (u32→BindingId, no Strings). `ref_node_id_to_binding`
preserves insertion order (`IndexMap`), so iteration is unchanged. This is the same class of system-heap
removal as #23471, which CodSpeed confirmed at +6.43% on `react_compiler[binder.ts]`.

(`oxc_react_compiler` has no `allocs_*.snap`, so the `react_compiler` CodSpeed bench is the arbiter.
`build_rename_plan` is oxc-added orchestration, not upstream-synced code.)

## Behavior-preserving

`build_rename_plan` reads exactly and only `bindings` + `ref_node_id_to_binding` (the two cloned
fields), so its result is identical; `compile_program` takes `ScopeInfo` by value and can't mutate the
caller's data, so the pre-compile snapshots match the old behavior. `cargo test -p oxc_react_compiler`
(17 tests, incl. the rename-path cases) passes; no snapshot drift.

---
Prepared with AI assistance.
