### PR TITLE
perf(linter/oxc/branches-sharing-code): borrow shared branch suggestion text

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/branches_sharing_code.rs
+++ b/crates/oxc_linter/src/rules/oxc/branches_sharing_code.rs
@@ -127,7 +127,7 @@ impl Rule for BranchesSharingCode {
                     .iter()
                     .map(|body| get_duplicated_delete_span(start, body, false))
                     .collect::<Vec<_>>();
-                let moved_code = ctx.source_range(spans[0]).to_string();
+                let moved_code = ctx.source_range(spans[0]);
                 ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
                     let fixer = fixer.for_multifix();
                     let mut fix = fixer.new_fix_with_capacity(spans.len() + 1);
@@ -156,7 +156,7 @@ impl Rule for BranchesSharingCode {
                     .iter()
                     .map(|body| get_duplicated_delete_span(end, body, true))
                     .collect::<Vec<_>>();
-                let moved_code = ctx.source_range(spans[0]).to_string();
+                let moved_code = ctx.source_range(spans[0]);
                 ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
                     let fixer = fixer.for_multifix();
                     let mut fix = fixer.new_fix_with_capacity(spans.len() + 1);


### PR DESCRIPTION
- Borrow the duplicated statement source while building `branches-sharing-code` suggestions instead of allocating a `String` before formatting.
- Preserve the generated suggestion text while avoiding an eager moved-code allocation.