### PR TITLE
fix(linter/unicorn/explicit-length-check): ignore optional chains

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -123,6 +123,24 @@ fn is_compare_right(expr: &BinaryExpression, op: BinaryOperator, value: f64) -> 
     )
 }
 
+fn expression_uses_optional_chain(expr: &Expression) -> bool {
+    let expr = expr.get_inner_expression();
+
+    if matches!(expr, Expression::ChainExpression(_)) {
+        return true;
+    }
+
+    if let Some(member_expr) = expr.as_member_expression() {
+        return member_expr.optional() || expression_uses_optional_chain(member_expr.object());
+    }
+
+    if let Expression::CallExpression(call_expr) = expr {
+        return call_expr.optional || expression_uses_optional_chain(&call_expr.callee);
+    }
+
+    false
+}
+
 fn get_length_check_node<'a, 'b>(
     node: &AstNode<'a>,
     ctx: &'b LintContext<'a>,
@@ -269,6 +287,9 @@ impl Rule for ExplicitLengthCheck {
             if property.name != "length" && property.name != "size" {
                 return;
             }
+            if static_member_expr.optional || expression_uses_optional_chain(object) {
+                return;
+            }
             if let Expression::ThisExpression(_) = object {
                 return;
             }
@@ -355,6 +376,9 @@ fn test() {
             "const totalCount = tests.reduce((count, test) => count + (test.enabled ? test.maxSize : test.size), 0)",
             None,
         ),
+        ("const hasList = Boolean(foo.list?.length)", None),
+        ("const hasList = Boolean(foo?.list.length)", None),
+        ("const hasList = Boolean(foo?.list?.length)", None),
     ];
 
     let fail = vec![


### PR DESCRIPTION
Skip `unicorn/explicit-length-check` for `.length` and `.size` member chains that use optional chaining. Upstream Unicorn allows these cases because replacing `foo.list?.length` with `foo.list?.length > 0` produces an unsafe comparison when the optional chain can evaluate to `undefined`.

Fixes #23480