### PR TITLE
feat(linter/vue): implement no-async-in-computed-properties rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1659,6 +1659,7 @@ export interface DummyRuleMap {
   "vue/max-props"?: RuleNoConfig | [AllowWarnDeny, MaxProps];
   "vue/next-tick-style"?: RuleNoConfig | [AllowWarnDeny, NextTickOption];
   "vue/no-arrow-functions-in-watch"?: RuleNoConfig;
+  "vue/no-async-in-computed-properties"?: RuleNoConfig | [AllowWarnDeny, NoAsyncInComputedPropertiesConfig];
   "vue/no-computed-properties-in-data"?: RuleNoConfig;
   "vue/no-deprecated-data-object-declaration"?: RuleNoConfig;
   "vue/no-deprecated-delete-set"?: RuleNoConfig;
@@ -6107,6 +6108,14 @@ export interface MaxProps {
    * The maximum number of props allowed in a Vue SFC.
    */
   maxProps?: number;
+}
+export interface NoAsyncInComputedPropertiesConfig {
+  /**
+   * Names of identifiers whose member-call chains (`.then` / `.catch` / `.finally`)
+   * should be ignored. Useful for libraries like Zod where `.catch(default)` is
+   * a builder API, not a Promise method.
+   */
+  ignoredObjectNames?: string[];
 }
 export interface NoDeprecatedModelDefinitionConfig {
   /**

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5041,6 +5041,19 @@ impl RuleRunner for crate::rules::vue::no_arrow_functions_in_watch::NoArrowFunct
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner
+    for crate::rules::vue::no_async_in_computed_properties::NoAsyncInComputedProperties
+{
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::ArrowFunctionExpression,
+        AstType::AwaitExpression,
+        AstType::CallExpression,
+        AstType::Function,
+        AstType::NewExpression,
+    ]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::no_computed_properties_in_data::NoComputedPropertiesInData {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::StaticMemberExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -806,6 +806,7 @@ pub use crate::rules::vue::define_props_destructuring::DefinePropsDestructuring 
 pub use crate::rules::vue::max_props::MaxProps as VueMaxProps;
 pub use crate::rules::vue::next_tick_style::NextTickStyle as VueNextTickStyle;
 pub use crate::rules::vue::no_arrow_functions_in_watch::NoArrowFunctionsInWatch as VueNoArrowFunctionsInWatch;
+pub use crate::rules::vue::no_async_in_computed_properties::NoAsyncInComputedProperties as VueNoAsyncInComputedProperties;
 pub use crate::rules::vue::no_computed_properties_in_data::NoComputedPropertiesInData as VueNoComputedPropertiesInData;
 pub use crate::rules::vue::no_deprecated_data_object_declaration::NoDeprecatedDataObjectDeclaration as VueNoDeprecatedDataObjectDeclaration;
 pub use crate::rules::vue::no_deprecated_delete_set::NoDeprecatedDeleteSet as VueNoDeprecatedDeleteSet;
@@ -1658,6 +1659,7 @@ pub enum RuleEnum {
     VueMaxProps(VueMaxProps),
     VueNextTickStyle(VueNextTickStyle),
     VueNoArrowFunctionsInWatch(VueNoArrowFunctionsInWatch),
+    VueNoAsyncInComputedProperties(VueNoAsyncInComputedProperties),
     VueNoComputedPropertiesInData(VueNoComputedPropertiesInData),
     VueNoDeprecatedDataObjectDeclaration(VueNoDeprecatedDataObjectDeclaration),
     VueNoDeprecatedDeleteSet(VueNoDeprecatedDeleteSet),
@@ -2594,7 +2596,9 @@ const VUE_DEFINE_PROPS_DESTRUCTURING_ID: usize = VUE_DEFINE_PROPS_DECLARATION_ID
 const VUE_MAX_PROPS_ID: usize = VUE_DEFINE_PROPS_DESTRUCTURING_ID + 1usize;
 const VUE_NEXT_TICK_STYLE_ID: usize = VUE_MAX_PROPS_ID + 1usize;
 const VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID: usize = VUE_NEXT_TICK_STYLE_ID + 1usize;
-const VUE_NO_COMPUTED_PROPERTIES_IN_DATA_ID: usize = VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID + 1usize;
+const VUE_NO_ASYNC_IN_COMPUTED_PROPERTIES_ID: usize = VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID + 1usize;
+const VUE_NO_COMPUTED_PROPERTIES_IN_DATA_ID: usize =
+    VUE_NO_ASYNC_IN_COMPUTED_PROPERTIES_ID + 1usize;
 const VUE_NO_DEPRECATED_DATA_OBJECT_DECLARATION_ID: usize =
     VUE_NO_COMPUTED_PROPERTIES_IN_DATA_ID + 1usize;
 const VUE_NO_DEPRECATED_DELETE_SET_ID: usize =
@@ -3563,6 +3567,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VUE_MAX_PROPS_ID,
             Self::VueNextTickStyle(_) => VUE_NEXT_TICK_STYLE_ID,
             Self::VueNoArrowFunctionsInWatch(_) => VUE_NO_ARROW_FUNCTIONS_IN_WATCH_ID,
+            Self::VueNoAsyncInComputedProperties(_) => VUE_NO_ASYNC_IN_COMPUTED_PROPERTIES_ID,
             Self::VueNoComputedPropertiesInData(_) => VUE_NO_COMPUTED_PROPERTIES_IN_DATA_ID,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VUE_NO_DEPRECATED_DATA_OBJECT_DECLARATION_ID
@@ -4515,6 +4520,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VueMaxProps::NAME,
             Self::VueNextTickStyle(_) => VueNextTickStyle::NAME,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::NAME,
+            Self::VueNoAsyncInComputedProperties(_) => VueNoAsyncInComputedProperties::NAME,
             Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::NAME,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::NAME
@@ -5523,6 +5529,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VueMaxProps::CATEGORY,
             Self::VueNextTickStyle(_) => VueNextTickStyle::CATEGORY,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::CATEGORY,
+            Self::VueNoAsyncInComputedProperties(_) => VueNoAsyncInComputedProperties::CATEGORY,
             Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::CATEGORY,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::CATEGORY
@@ -6478,6 +6485,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VueMaxProps::FIX,
             Self::VueNextTickStyle(_) => VueNextTickStyle::FIX,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::FIX,
+            Self::VueNoAsyncInComputedProperties(_) => VueNoAsyncInComputedProperties::FIX,
             Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::FIX,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::FIX
@@ -7681,6 +7689,9 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VueMaxProps::documentation(),
             Self::VueNextTickStyle(_) => VueNextTickStyle::documentation(),
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::documentation(),
+            Self::VueNoAsyncInComputedProperties(_) => {
+                VueNoAsyncInComputedProperties::documentation()
+            }
             Self::VueNoComputedPropertiesInData(_) => {
                 VueNoComputedPropertiesInData::documentation()
             }
@@ -10028,6 +10039,10 @@ impl RuleEnum {
                 VueNoArrowFunctionsInWatch::config_schema(generator)
                     .or_else(|| VueNoArrowFunctionsInWatch::schema(generator))
             }
+            Self::VueNoAsyncInComputedProperties(_) => {
+                VueNoAsyncInComputedProperties::config_schema(generator)
+                    .or_else(|| VueNoAsyncInComputedProperties::schema(generator))
+            }
             Self::VueNoComputedPropertiesInData(_) => {
                 VueNoComputedPropertiesInData::config_schema(generator)
                     .or_else(|| VueNoComputedPropertiesInData::schema(generator))
@@ -10935,6 +10950,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => "vue",
             Self::VueNextTickStyle(_) => "vue",
             Self::VueNoArrowFunctionsInWatch(_) => "vue",
+            Self::VueNoAsyncInComputedProperties(_) => "vue",
             Self::VueNoComputedPropertiesInData(_) => "vue",
             Self::VueNoDeprecatedDataObjectDeclaration(_) => "vue",
             Self::VueNoDeprecatedDeleteSet(_) => "vue",
@@ -13546,6 +13562,9 @@ impl RuleEnum {
             Self::VueNoArrowFunctionsInWatch(_) => Ok(Self::VueNoArrowFunctionsInWatch(
                 VueNoArrowFunctionsInWatch::from_configuration(value)?,
             )),
+            Self::VueNoAsyncInComputedProperties(_) => Ok(Self::VueNoAsyncInComputedProperties(
+                VueNoAsyncInComputedProperties::from_configuration(value)?,
+            )),
             Self::VueNoComputedPropertiesInData(_) => Ok(Self::VueNoComputedPropertiesInData(
                 VueNoComputedPropertiesInData::from_configuration(value)?,
             )),
@@ -14472,6 +14491,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.to_configuration(),
             Self::VueNextTickStyle(rule) => rule.to_configuration(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.to_configuration(),
+            Self::VueNoAsyncInComputedProperties(rule) => rule.to_configuration(),
             Self::VueNoComputedPropertiesInData(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.to_configuration(),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.to_configuration(),
@@ -15320,6 +15340,7 @@ impl RuleEnum {
                 Self::VueMaxProps(rule) => rule.run(node, ctx),
                 Self::VueNextTickStyle(rule) => rule.run(node, ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run(node, ctx),
+                Self::VueNoAsyncInComputedProperties(rule) => rule.run(node, ctx),
                 Self::VueNoComputedPropertiesInData(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run(node, ctx),
@@ -16161,6 +16182,7 @@ impl RuleEnum {
                 Self::VueMaxProps(rule) => rule.run(node, ctx),
                 Self::VueNextTickStyle(rule) => rule.run(node, ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run(node, ctx),
+                Self::VueNoAsyncInComputedProperties(rule) => rule.run(node, ctx),
                 Self::VueNoComputedPropertiesInData(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run(node, ctx),
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run(node, ctx),
@@ -17009,6 +17031,7 @@ impl RuleEnum {
                 Self::VueMaxProps(rule) => rule.run_once(ctx),
                 Self::VueNextTickStyle(rule) => rule.run_once(ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run_once(ctx),
+                Self::VueNoAsyncInComputedProperties(rule) => rule.run_once(ctx),
                 Self::VueNoComputedPropertiesInData(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run_once(ctx),
@@ -17850,6 +17873,7 @@ impl RuleEnum {
                 Self::VueMaxProps(rule) => rule.run_once(ctx),
                 Self::VueNextTickStyle(rule) => rule.run_once(ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run_once(ctx),
+                Self::VueNoAsyncInComputedProperties(rule) => rule.run_once(ctx),
                 Self::VueNoComputedPropertiesInData(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run_once(ctx),
                 Self::VueNoDeprecatedDeleteSet(rule) => rule.run_once(ctx),
@@ -18949,6 +18973,7 @@ impl RuleEnum {
                 Self::VueMaxProps(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNextTickStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoAsyncInComputedProperties(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoComputedPropertiesInData(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
@@ -20050,6 +20075,7 @@ impl RuleEnum {
                 Self::VueMaxProps(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNextTickStyle(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoArrowFunctionsInWatch(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::VueNoAsyncInComputedProperties(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoComputedPropertiesInData(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VueNoDeprecatedDataObjectDeclaration(rule) => {
                     rule.run_on_jest_node(jest_node, ctx)
@@ -20899,6 +20925,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.should_run(ctx),
             Self::VueNextTickStyle(rule) => rule.should_run(ctx),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.should_run(ctx),
+            Self::VueNoAsyncInComputedProperties(rule) => rule.should_run(ctx),
             Self::VueNoComputedPropertiesInData(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.should_run(ctx),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.should_run(ctx),
@@ -22097,6 +22124,9 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VueMaxProps::IS_TSGOLINT_RULE,
             Self::VueNextTickStyle(_) => VueNextTickStyle::IS_TSGOLINT_RULE,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::IS_TSGOLINT_RULE,
+            Self::VueNoAsyncInComputedProperties(_) => {
+                VueNoAsyncInComputedProperties::IS_TSGOLINT_RULE
+            }
             Self::VueNoComputedPropertiesInData(_) => {
                 VueNoComputedPropertiesInData::IS_TSGOLINT_RULE
             }
@@ -23119,6 +23149,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VueMaxProps::VERSION,
             Self::VueNextTickStyle(_) => VueNextTickStyle::VERSION,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::VERSION,
+            Self::VueNoAsyncInComputedProperties(_) => VueNoAsyncInComputedProperties::VERSION,
             Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::VERSION,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::VERSION
@@ -24166,6 +24197,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VueMaxProps::HAS_CONFIG,
             Self::VueNextTickStyle(_) => VueNextTickStyle::HAS_CONFIG,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::HAS_CONFIG,
+            Self::VueNoAsyncInComputedProperties(_) => VueNoAsyncInComputedProperties::HAS_CONFIG,
             Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::HAS_CONFIG,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::HAS_CONFIG
@@ -25124,6 +25156,7 @@ impl RuleEnum {
             Self::VueMaxProps(_) => VueMaxProps::INFO,
             Self::VueNextTickStyle(_) => VueNextTickStyle::INFO,
             Self::VueNoArrowFunctionsInWatch(_) => VueNoArrowFunctionsInWatch::INFO,
+            Self::VueNoAsyncInComputedProperties(_) => VueNoAsyncInComputedProperties::INFO,
             Self::VueNoComputedPropertiesInData(_) => VueNoComputedPropertiesInData::INFO,
             Self::VueNoDeprecatedDataObjectDeclaration(_) => {
                 VueNoDeprecatedDataObjectDeclaration::INFO
@@ -25971,6 +26004,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.types_info(),
             Self::VueNextTickStyle(rule) => rule.types_info(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.types_info(),
+            Self::VueNoAsyncInComputedProperties(rule) => rule.types_info(),
             Self::VueNoComputedPropertiesInData(rule) => rule.types_info(),
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.types_info(),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.types_info(),
@@ -26809,6 +26843,7 @@ impl RuleEnum {
             Self::VueMaxProps(rule) => rule.run_info(),
             Self::VueNextTickStyle(rule) => rule.run_info(),
             Self::VueNoArrowFunctionsInWatch(rule) => rule.run_info(),
+            Self::VueNoAsyncInComputedProperties(rule) => rule.run_info(),
             Self::VueNoComputedPropertiesInData(rule) => rule.run_info(),
             Self::VueNoDeprecatedDataObjectDeclaration(rule) => rule.run_info(),
             Self::VueNoDeprecatedDeleteSet(rule) => rule.run_info(),
@@ -27779,6 +27814,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VueMaxProps(VueMaxProps::default()),
         RuleEnum::VueNextTickStyle(VueNextTickStyle::default()),
         RuleEnum::VueNoArrowFunctionsInWatch(VueNoArrowFunctionsInWatch::default()),
+        RuleEnum::VueNoAsyncInComputedProperties(VueNoAsyncInComputedProperties::default()),
         RuleEnum::VueNoComputedPropertiesInData(VueNoComputedPropertiesInData::default()),
         RuleEnum::VueNoDeprecatedDataObjectDeclaration(
             VueNoDeprecatedDataObjectDeclaration::default(),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -856,6 +856,7 @@ pub(crate) mod vue {
     pub mod max_props;
     pub mod next_tick_style;
     pub mod no_arrow_functions_in_watch;
+    pub mod no_async_in_computed_properties;
     pub mod no_computed_properties_in_data;
     pub mod no_deprecated_data_object_declaration;
     pub mod no_deprecated_delete_set;

--- a/crates/oxc_linter/src/rules/vue/no_async_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_async_in_computed_properties.rs
@@ -783,7 +783,7 @@ fn test() {
             "
                   <script setup>
                   import { computed } from 'vue'
-            
+
                   const numberWithCatch = computed(() => z.number().catch(42))
                   </script>",
             Some(serde_json::json!([{ "ignoredObjectNames": ["z"] }])),
@@ -811,7 +811,7 @@ fn test() {
                   <script setup lang="ts">
                   import { computed } from 'vue'
                   import { z } from 'zod'
-            
+
                   const foo = computed(() => z.a?.['b'].c!.d.method().catch(err => err).finally(() => {}))
                   </script>"#,
             Some(serde_json::json!([{ "ignoredObjectNames": ["z"] }])),
@@ -1446,7 +1446,7 @@ fn test() {
             "
                     <script setup>
                     import {computed} from 'vue'
-            
+
                     const deepCall = computed(() => z.a.b.c.d().e().f().catch())
                     </script>
                   ",

--- a/crates/oxc_linter/src/rules/vue/no_async_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_async_in_computed_properties.rs
@@ -1,0 +1,1461 @@
+use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use oxc_ast::{
+    AstKind,
+    ast::{CallExpression, ChainElement, Expression},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::{ContextHost, LintContext},
+    module_record::ImportImportName,
+    rule::{DefaultRuleConfig, Rule},
+    utils::{is_this_object, is_vue_component_options_object},
+};
+
+#[derive(Debug, Clone, Copy)]
+enum AsyncKind {
+    AsyncFunction,
+    Await,
+    NewPromise,
+    Asynchronous,
+    Timed,
+}
+
+impl AsyncKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::AsyncFunction => "async function declaration",
+            Self::Await => "await operator",
+            Self::NewPromise => "Promise object",
+            Self::Asynchronous => "asynchronous action",
+            Self::Timed => "timed function",
+        }
+    }
+}
+
+fn unexpected_in_property(span: Span, kind: AsyncKind, key: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected {} in \"{}\" computed property.", kind.as_str(), key))
+        .with_label(span)
+}
+
+fn unexpected_in_function(span: Span, kind: AsyncKind) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Unexpected {} in computed function.", kind.as_str()))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct NoAsyncInComputedPropertiesConfig {
+    /// Names of identifiers whose member-call chains (`.then` / `.catch` / `.finally`)
+    /// should be ignored. Useful for libraries like Zod where `.catch(default)` is
+    /// a builder API, not a Promise method.
+    ignored_object_names: FxHashSet<String>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct NoAsyncInComputedProperties(Box<NoAsyncInComputedPropertiesConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow asynchronous actions in computed properties.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Asynchronous actions inside computed properties may lead to an unexpected
+    /// behavior. A computed property's value should be a synchronous function of
+    /// its dependencies.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   computed: {
+    ///     pro() {
+    ///       return Promise.all([new Promise((resolve, reject) => {})])
+    ///     },
+    ///     foo: async function () {
+    ///       return await someFunc()
+    ///     },
+    ///     bar() {
+    ///       return fetch(url).then(response => {})
+    ///     },
+    ///     tim() {
+    ///       setTimeout(() => { }, 0)
+    ///     },
+    ///     inst() {
+    ///       return new Promise((resolve, reject) => {})
+    ///     },
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   computed: {
+    ///     foo() {
+    ///       return this.bar
+    ///     }
+    ///   }
+    /// }
+    /// </script>
+    /// ```
+    NoAsyncInComputedProperties,
+    vue,
+    correctness,
+    none,
+    config = NoAsyncInComputedProperties,
+    version = "1.71.0",
+    short_description = "Disallow asynchronous actions in computed properties.",
+);
+
+impl Rule for NoAsyncInComputedProperties {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> bool {
+        ctx.file_extension().is_some_and(|ext| ext == "vue")
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::Function(func) if func.r#async => {
+                if let Some(c) = get_computed_getter_context(node, ctx) {
+                    report(node.span(), &c, AsyncKind::AsyncFunction, ctx);
+                }
+            }
+            AstKind::ArrowFunctionExpression(arrow) if arrow.r#async => {
+                if let Some(c) = get_computed_getter_context(node, ctx) {
+                    report(node.span(), &c, AsyncKind::AsyncFunction, ctx);
+                }
+            }
+            AstKind::AwaitExpression(_) => {
+                if let Some(c) = find_computed_context(node, ctx) {
+                    report(node.span(), &c, AsyncKind::Await, ctx);
+                }
+            }
+            AstKind::NewExpression(new_expr) => {
+                if let Expression::Identifier(id) = new_expr.callee.get_inner_expression()
+                    && id.name == "Promise"
+                    && let Some(c) = find_computed_context(node, ctx)
+                {
+                    report(node.span(), &c, AsyncKind::NewPromise, ctx);
+                }
+            }
+            AstKind::CallExpression(call) => {
+                let kind = if is_promise_method_call(call, &self.0.ignored_object_names) {
+                    AsyncKind::Asynchronous
+                } else if is_timed_function_call(call) {
+                    AsyncKind::Timed
+                } else if is_next_tick_call(call, ctx) {
+                    AsyncKind::Asynchronous
+                } else {
+                    return;
+                };
+                if let Some(c) = find_computed_context(node, ctx) {
+                    report(node.span(), &c, kind, ctx);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn report(span: Span, ctx_kind: &ComputedContext, kind: AsyncKind, ctx: &LintContext<'_>) {
+    match ctx_kind {
+        ComputedContext::OptionsApi(key) => {
+            let key = key.as_deref().unwrap_or("Unknown");
+            ctx.diagnostic(unexpected_in_property(span, kind, key));
+        }
+        ComputedContext::CompositionApi => {
+            ctx.diagnostic(unexpected_in_function(span, kind));
+        }
+    }
+}
+
+// Describe where a computed getter lives. Mirrors `no_side_effects_in_computed_properties`,
+// but only the Options API variant needs to carry the property key — `no-async` does not
+// inspect the getter body for setup variables.
+enum ComputedContext {
+    OptionsApi(Option<String>),
+    CompositionApi,
+}
+
+/// Find the computed getter context for `node` by walking up to the nearest enclosing function
+/// and checking if that function is a computed getter.
+fn find_computed_context(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<ComputedContext> {
+    let nodes = ctx.nodes();
+    let mut current = nodes.parent_node(node.id());
+    loop {
+        match current.kind() {
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {
+                return get_computed_getter_context(current, ctx);
+            }
+            AstKind::Program(_) => return None,
+            _ => {
+                current = nodes.parent_node(current.id());
+            }
+        }
+    }
+}
+
+/// Given a function node, return Some(ComputedContext) if it is a computed getter.
+fn get_computed_getter_context(
+    fn_node: &AstNode<'_>,
+    ctx: &LintContext<'_>,
+) -> Option<ComputedContext> {
+    let nodes = ctx.nodes();
+    let parent = nodes.parent_node(fn_node.id());
+
+    match parent.kind() {
+        AstKind::CallExpression(call) if is_vue_computed_call(call, ctx) => {
+            return Some(ComputedContext::CompositionApi);
+        }
+        AstKind::ObjectProperty(prop) => {
+            let grandparent = nodes.parent_node(parent.id());
+            let AstKind::ObjectExpression(_) = grandparent.kind() else { return None };
+            let great = nodes.parent_node(grandparent.id());
+
+            match great.kind() {
+                // Case A: `computed: { key() {} }` or `computed: { key: function() {} }`
+                AstKind::ObjectProperty(outer)
+                    if outer.key.is_specific_static_name("computed")
+                        && matches!(fn_node.kind(), AstKind::Function(_)) =>
+                {
+                    let vue_options = nodes.parent_node(great.id());
+                    if is_vue_component_options_object(vue_options, ctx) {
+                        let key = prop.key.static_name().map(|s| s.to_string());
+                        return Some(ComputedContext::OptionsApi(key));
+                    }
+                }
+
+                // Case B: `computed: { key: { get() {} } }`
+                AstKind::ObjectProperty(key_prop)
+                    if prop.key.is_specific_static_name("get")
+                        && matches!(fn_node.kind(), AstKind::Function(_)) =>
+                {
+                    let key_obj_expr = nodes.parent_node(great.id());
+                    let AstKind::ObjectExpression(_) = key_obj_expr.kind() else { return None };
+                    let computed_prop_node = nodes.parent_node(key_obj_expr.id());
+                    if let AstKind::ObjectProperty(cp) = computed_prop_node.kind()
+                        && cp.key.is_specific_static_name("computed")
+                    {
+                        let vue_options = nodes.parent_node(computed_prop_node.id());
+                        if is_vue_component_options_object(vue_options, ctx) {
+                            let key = key_prop.key.static_name().map(|s| s.to_string());
+                            return Some(ComputedContext::OptionsApi(key));
+                        }
+                    }
+                }
+
+                // Case C: Composition API with `computed({ get() {}, set() {} })`
+                AstKind::CallExpression(call)
+                    if prop.key.is_specific_static_name("get")
+                        && is_vue_computed_call(call, ctx) =>
+                {
+                    return Some(ComputedContext::CompositionApi);
+                }
+
+                _ => {}
+            }
+        }
+
+        _ => {}
+    }
+
+    None
+}
+
+/// Check if a `computed(...)` call uses the `computed` export from `'vue'`,
+/// `'@vue/composition-api'`, or `'#imports'` (Nuxt), including aliases.
+fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
+    let Expression::Identifier(ident) = call.callee.get_inner_expression() else {
+        return false;
+    };
+    let scoping = ctx.scoping();
+    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
+        return false;
+    };
+    ctx.module_record().import_entries.iter().any(|entry| {
+        if !matches!(entry.module_request.name(), "vue" | "@vue/composition-api" | "#imports") {
+            return false;
+        }
+        let ImportImportName::Name(name_span) = &entry.import_name else { return false };
+        if name_span.name() != "computed" {
+            return false;
+        }
+        scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id)
+    })
+}
+
+const PROMISE_FUNCTIONS: &[&str] = &["then", "catch", "finally"];
+const PROMISE_METHODS: &[&str] = &["all", "race", "reject", "resolve"];
+const TIMED_FUNCTIONS: &[&str] =
+    &["setTimeout", "setInterval", "setImmediate", "requestAnimationFrame"];
+
+/// Static-member call info extracted from a `CallExpression.callee`, transparently
+/// unwrapping parentheses and an optional outer `ChainExpression`. Only static
+/// member-expressions are surfaced; computed/private members are reported as
+/// `None` to match upstream `getStaticPropertyName`-based gating.
+fn callee_static_member<'a, 'b>(
+    callee: &'b Expression<'a>,
+) -> Option<(&'b str, &'b Expression<'a>)> {
+    let inner = callee.get_inner_expression();
+    let member = match inner {
+        Expression::StaticMemberExpression(m) => m.as_ref(),
+        Expression::ChainExpression(c) => match &c.expression {
+            ChainElement::StaticMemberExpression(m) => m.as_ref(),
+            _ => return None,
+        },
+        _ => return None,
+    };
+    Some((member.property.name.as_str(), &member.object))
+}
+
+fn is_promise_method_call(
+    call: &CallExpression<'_>,
+    ignored_object_names: &FxHashSet<String>,
+) -> bool {
+    let Some((name, object)) = callee_static_member(&call.callee) else { return false };
+
+    let is_promise_static = PROMISE_METHODS.contains(&name)
+        && matches!(object.get_inner_expression(), Expression::Identifier(id) if id.name == "Promise");
+    let is_thenable = PROMISE_FUNCTIONS.contains(&name);
+
+    if !is_promise_static && !is_thenable {
+        return false;
+    }
+
+    if let Some(root) = get_root_object_name(object)
+        && ignored_object_names.contains(root)
+    {
+        return false;
+    }
+    true
+}
+
+fn is_timed_function_call(call: &CallExpression<'_>) -> bool {
+    if call.arguments.is_empty() {
+        return false;
+    }
+    let inner = call.callee.get_inner_expression();
+    // `setTimeout(...)` / `setTimeout?.(...)` — bare identifier (the optional-chain
+    // wrapper sits on the *outer* CallExpression).
+    if let Expression::Identifier(id) = inner {
+        return TIMED_FUNCTIONS.contains(&id.name.as_str());
+    }
+    // `window.setTimeout(...)` / `window?.setTimeout?.(...)` / `(window?.setTimeout)?.(...)`.
+    if let Some((name, object)) = callee_static_member(&call.callee) {
+        return TIMED_FUNCTIONS.contains(&name)
+            && matches!(object.get_inner_expression(), Expression::Identifier(id) if id.name == "window");
+    }
+    false
+}
+
+fn is_next_tick_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
+    let Some((name, object)) = callee_static_member(&call.callee) else { return false };
+    if name == "$nextTick" && is_this_object(object, ctx) {
+        return true;
+    }
+    if name == "nextTick"
+        && matches!(object.get_inner_expression(), Expression::Identifier(id) if id.name == "Vue")
+    {
+        return true;
+    }
+    false
+}
+
+/// Walk down the leftmost edge of a member/call chain and return the root
+/// identifier name. Mirrors upstream `getRootObjectName`.
+fn get_root_object_name<'a>(expr: &Expression<'a>) -> Option<&'a str> {
+    let inner = expr.get_inner_expression();
+    if let Expression::ChainExpression(c) = inner {
+        return root_from_chain_element(&c.expression);
+    }
+    root_from_expr(inner)
+}
+
+fn root_from_expr<'a>(expr: &Expression<'a>) -> Option<&'a str> {
+    match expr {
+        Expression::Identifier(id) => Some(id.name.as_str()),
+        Expression::StaticMemberExpression(m) => get_root_object_name(&m.object),
+        Expression::ComputedMemberExpression(m) => get_root_object_name(&m.object),
+        Expression::PrivateFieldExpression(m) => get_root_object_name(&m.object),
+        Expression::CallExpression(call) => get_root_object_name(&call.callee),
+        Expression::TSNonNullExpression(t) => get_root_object_name(&t.expression),
+        _ => None,
+    }
+}
+
+fn root_from_chain_element<'a>(elem: &ChainElement<'a>) -> Option<&'a str> {
+    match elem {
+        ChainElement::StaticMemberExpression(m) => get_root_object_name(&m.object),
+        ChainElement::ComputedMemberExpression(m) => get_root_object_name(&m.object),
+        ChainElement::PrivateFieldExpression(m) => get_root_object_name(&m.object),
+        ChainElement::CallExpression(call) => get_root_object_name(&call.callee),
+        ChainElement::TSNonNullExpression(t) => get_root_object_name(&t.expression),
+    }
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return;
+                        },
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      ...foo,
+                      computed: {
+                        ...mapGetters({
+                          test: 'getTest'
+                        }),
+                        foo: function () {
+                          var bar = 0
+                          try {
+                            bar = bar / 0
+                          } catch (e) {
+                            return e
+                          } finally {
+                            return bar
+                          }
+                        },
+                        bar: {
+                          set () {
+                            new Promise((resolve, reject) => {})
+                          }
+                        },
+                        baz: {
+                          ...mapGetters({ get: 'getBaz' }),
+                          ...mapActions({ set: 'setBaz' })
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    async function resolveComponents(components) {
+                      return await Promise.all(components.map(async (component) => {
+                          if(typeof component === 'function') {
+                                return await component()
+                            }
+                            return component;
+                      }));
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo() {
+                          return {
+                            async bar() {
+                              const data = await baz(this.a)
+                              return data
+                            }
+                          }
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo() {
+                          const a = 'test'
+                          return [
+                            async () => {
+                              const baz = await bar(a)
+                              return baz
+                            },
+                            'b',
+                            {}
+                          ]
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo() {
+                          return function () {
+                            return async () => await bar()
+                          }
+                        },
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo() {
+                          return new Promise.resolve()
+                        },
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo() {
+                          return new Bar(async () => await baz())
+                        },
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo() {
+                          return someFunc.doSomething({
+                            async bar() {
+                              return await baz()
+                            }
+                          })
+                        },
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                        computed: {
+                            foo() {
+                                return this.bar
+                                  ? {
+                                      baz:() => Promise.resolve(1)
+                                    }
+                                  : {}
+                            }
+                        }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                        computed: {
+                            foo() {
+                                return this.bar ? () => Promise.resolve(1) : null
+                            }
+                        }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                        computed: {
+                            foo() {
+                                return this.bar ? async () => 1 : null
+                            }
+                        }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    Vue.component('test',{
+                      data1: new Promise(),
+                      data2: Promise.resolve(),
+                    })",
+            None,
+            None,
+            None,
+        ), // languageOptions,
+        (
+            "
+                    import {computed} from 'vue'
+                    export default {
+                      setup() {
+                        const test1 = computed(() => {})
+                        const test2 = computed(function () {
+                          var bar = 0
+                          try {
+                            bar = bar / 0
+                          } catch (e) {
+                            return e
+                          } finally {
+                            return bar
+                          }
+                        })
+                        const test3 = computed({
+                          set() {
+                            new Promise((resolve, reject) => {})
+                          }
+                        })
+                        const test4 = computed(() => {
+                          return {
+                            async bar() {
+                              const data = await baz(this.a)
+                              return data
+                            }
+                          }
+                        })
+                        const test5 = computed(() => {
+                          const a = 'test'
+                          return [
+                            async () => {
+                              const baz = await bar(a)
+                              return baz
+                            },
+                            'b',
+                            {}
+                          ]
+                        })
+                        const test6 = computed(() => function () {
+                          return async () => await bar()
+                        })
+                        const test7 = computed(() => new Promise.resolve())
+                        const test8 = computed(() => {
+                          return new Bar(async () => await baz())
+                        })
+                        const test9 = computed(() => {
+                          return someFunc.doSomething({
+                            async bar() {
+                              return await baz()
+                            }
+                          })
+                        })
+                        const test10 = computed(() => {
+                          return this.bar
+                                  ? {
+                                      baz:() => Promise.resolve(1)
+                                    }
+                                  : {}
+                        })
+                        const test11 = computed(() => {
+                          return this.bar ? () => Promise.resolve(1) : null
+                        })
+                        const test12 = computed(() => {
+                          return this.bar ? async () => 1 : null
+                        })
+                        const test13 = computed(() => {
+                          bar()
+                        })
+                      }
+                    }
+                    ",
+            None,
+            None,
+            None,
+        ), // languageOptions,
+        (
+            r#"
+                  <template>
+                    <div class="f-c" style="height: 100%;">
+                    </div>
+                  </template>
+                  <script setup>
+                  import { ref, computed } from 'vue' // each time uncomment error will print. anything from 'vue'
+                  import { useStore } from 'vuex' // others like this is ok
+                  </script>
+                  <script>
+                  export default {
+                    name: 'App',
+                    components: {
+                    },
+                  }
+                  </script>"#,
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, "sourceType": "module", "ecmaVersion": 2020 },
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return z.catch(
+                            z.string().check(z.minLength(2)),
+                            'default'
+                          ).then(val => val).finally(() => {})
+                        }
+                      }
+                    }
+                  </script>
+",
+            Some(serde_json::json!([{ "ignoredObjectNames": ["z"] }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                  <script setup>
+                  import { computed } from 'vue'
+            
+                  const numberWithCatch = computed(() => z.number().catch(42))
+                  </script>",
+            Some(serde_json::json!([{ "ignoredObjectNames": ["z"] }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, "sourceType": "module", "ecmaVersion": 2020 },
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return z.a?.['b']?.[c].d.method().catch(err => err).finally(() => {})
+                        }
+                      }
+                    }
+                  </script>
+",
+            Some(serde_json::json!([{ "ignoredObjectNames": ["z"] }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, "sourceType": "module", "ecmaVersion": 2020 },
+        (
+            r#"
+                  <script setup lang="ts">
+                  import { computed } from 'vue'
+                  import { z } from 'zod'
+            
+                  const foo = computed(() => z.a?.['b'].c!.d.method().catch(err => err).finally(() => {}))
+                  </script>"#,
+            Some(serde_json::json!([{ "ignoredObjectNames": ["z"] }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, "parserOptions": { "parser": require.resolve("@typescript-eslint/parser") } }
+    ];
+
+    let fail = vec![
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: async function () {
+                          return await someFunc()
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: async function () {
+                          return new Promise((resolve, reject) => {})
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return bar.then(response => {})
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return bar?.then?.(response => {})
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return (bar?.then)?.(response => {})
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return bar.catch(e => {})
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return Promise.all([])
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return bar.finally(res => {})
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  export default {
+                    computed: {
+                      foo: function () {
+                        return Promise.race([])
+                      }
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  export default {
+                    computed: {
+                      foo: function () {
+                        return Promise.reject([])
+                      }
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  export default {
+                    computed: {
+                      foo: function () {
+                        return Promise.resolve([])
+                      }
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  export default {
+                    computed: {
+                      foo () {
+                        return Promise.resolve([])
+                      }
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  export default {
+                    computed: {
+                      foo: {
+                        get () {
+                          return Promise.resolve([])
+                        }
+                      }
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  new Vue({
+                    computed: {
+                      foo: {
+                        get () {
+                          return Promise.resolve([])
+                        }
+                      }
+                    }
+                  })
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "
+<script>
+                  new Vue({
+                    computed: {
+                      foo: {
+                        get () {
+                          return test.blabla.then([])
+                        }
+                      }
+                    }
+                  })
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "
+<script>
+                  new Vue({
+                    computed: {
+                      foo () {
+                        this.$nextTick(() => {})
+                        Vue.nextTick(() => {})
+                        return 'foo'
+                      }
+                    }
+                  })
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  new Vue({
+                    computed: {
+                      async foo () {
+                        await this.$nextTick()
+                        await Vue.nextTick()
+                        return 'foo'
+                      }
+                    }
+                  })
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  export default {
+                    computed: {
+                      foo: function () {
+                        setTimeout(() => { }, 0)
+                        window.setTimeout(() => { }, 0)
+                        setInterval(() => { }, 0)
+                        window.setInterval(() => { }, 0)
+                        setImmediate(() => { })
+                        window.setImmediate(() => { })
+                        requestAnimationFrame(() => {})
+                        window.requestAnimationFrame(() => {})
+                      }
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  export default {
+                    computed: {
+                      foo: function () {
+                        setTimeout?.(() => { }, 0)
+                        window?.setTimeout?.(() => { }, 0)
+                        setInterval(() => { }, 0)
+                        window?.setInterval?.(() => { }, 0)
+                        setImmediate?.(() => { })
+                        window?.setImmediate?.(() => { })
+                        requestAnimationFrame?.(() => {})
+                        window?.requestAnimationFrame?.(() => {})
+                      }
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  export default {
+                    computed: {
+                      foo: function () {
+                        setTimeout?.(() => { }, 0)
+                        ;(window?.setTimeout)?.(() => { }, 0)
+                        setInterval(() => { }, 0)
+                        ;(window?.setInterval)?.(() => { }, 0)
+                        setImmediate?.(() => { })
+                        ;(window?.setImmediate)?.(() => { })
+                        requestAnimationFrame?.(() => {})
+                        ;(window?.requestAnimationFrame)?.(() => {})
+                      }
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  import {computed} from 'vue'
+                  export default {
+                    setup() {
+                      const test1 = computed(async () => {
+                        return await someFunc()
+                      })
+                      const test2 = computed(async () => await someFunc())
+                      const test3 = computed(async function () {
+                        return await someFunc()
+                      })
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  import {computed} from 'vue'
+                  export default {
+                    setup() {
+                      const test = computed(async () => {
+                        return new Promise((resolve, reject) => {})
+                      })
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  import {computed} from 'vue'
+                  export default {
+                    setup() {
+                      const test1 = computed(() => {
+                        return bar.then(response => {})
+                      })
+                      const test2 = computed(() => {
+                        return Promise.all([])
+                      })
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  import {computed} from 'vue'
+                  export default {
+                    setup() {
+                      const test1 = computed({
+                        get: () => {
+                          return Promise.resolve([])
+                        }
+                      })
+                      const test2 = computed({
+                        get() {
+                          return Promise.resolve([])
+                        }
+                      })
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  import {computed} from 'vue'
+                  export default {
+                    setup() {
+                      const test = computed(() => {
+                        setTimeout(() => { }, 0)
+                        window.setTimeout(() => { }, 0)
+                        setInterval(() => { }, 0)
+                        window.setInterval(() => { }, 0)
+                        setImmediate(() => { })
+                        window.setImmediate(() => { })
+                        requestAnimationFrame(() => {})
+                        window.requestAnimationFrame(() => {})
+                      })
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                  import {computed} from 'vue'
+                  export default {
+                    setup() {
+                      const test = computed(async () => {
+                        bar()
+                      })
+                    }
+                  }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                  <script setup>
+                  import {computed} from 'vue'
+                  const test1 = computed(async () => {
+                    return await someFunc()
+                  })
+                  const test2 = computed(async () => await someFunc())
+                  const test3 = computed(async function () {
+                    return await someFunc()
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, ...languageOptions },
+        (
+            "
+                  <script setup>
+                  import {computed} from 'vue'
+                  const test = computed(async () => {
+                    return new Promise((resolve, reject) => {})
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, ...languageOptions },
+        (
+            "
+                  <script setup>
+                  import {computed} from 'vue'
+                  const test1 = computed(() => {
+                    return bar.then(response => {})
+                  })
+                  const test2 = computed(() => {
+                    return Promise.all([])
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, ...languageOptions },
+        (
+            "
+                  <script setup>
+                  import {computed} from 'vue'
+                  const test1 = computed({
+                    get: () => {
+                      return Promise.resolve([])
+                    }
+                  })
+                  const test2 = computed({
+                    get() {
+                      return Promise.resolve([])
+                    }
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, ...languageOptions },
+        (
+            "
+                  <script setup>
+                  import {computed} from 'vue'
+                  const test = computed(() => {
+                    setTimeout(() => { }, 0)
+                    window.setTimeout(() => { }, 0)
+                    setInterval(() => { }, 0)
+                    window.setInterval(() => { }, 0)
+                    setImmediate(() => { })
+                    window.setImmediate(() => { })
+                    requestAnimationFrame(() => {})
+                    window.requestAnimationFrame(() => {})
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, ...languageOptions },
+        (
+            "
+                  <script setup>
+                  import {computed} from 'vue'
+                  const test = computed(async () => {
+                    bar()
+                  })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, ...languageOptions },
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return myFunc().catch('default')
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return z.number().catch(42)
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return someLib.string().catch(42)
+                        }
+                      }
+                    }
+                  </script>
+",
+            Some(serde_json::json!([{ "ignoredObjectNames": ["z"] }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    <script setup>
+                    import {computed} from 'vue'
+            
+                    const deepCall = computed(() => z.a.b.c.d().e().f().catch())
+                    </script>
+                  ",
+            Some(serde_json::json!([{ "ignoredObjectNames": ["a"] }])),
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { parser, "sourceType": "module", "ecmaVersion": 2020 },
+    ];
+
+    Tester::new(NoAsyncInComputedProperties::NAME, NoAsyncInComputedProperties::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/vue/no_async_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_async_in_computed_properties.rs
@@ -116,7 +116,7 @@ declare_oxc_lint!(
     correctness,
     none,
     config = NoAsyncInComputedProperties,
-    version = "1.71.0",
+    version = "next",
     short_description = "Disallow asynchronous actions in computed properties.",
 );
 

--- a/crates/oxc_linter/src/rules/vue/no_async_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_async_in_computed_properties.rs
@@ -301,7 +301,8 @@ fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> boo
 }
 
 const PROMISE_FUNCTIONS: &[&str] = &["then", "catch", "finally"];
-const PROMISE_METHODS: &[&str] = &["all", "race", "reject", "resolve"];
+const PROMISE_METHODS: &[&str] =
+    &["all", "allSettled", "any", "race", "reject", "resolve", "try", "withResolvers"];
 const TIMED_FUNCTIONS: &[&str] =
     &["setTimeout", "setInterval", "setImmediate", "requestAnimationFrame"];
 
@@ -1446,7 +1447,6 @@ fn test() {
             "
                     <script setup>
                     import {computed} from 'vue'
-
                     const deepCall = computed(() => z.a.b.c.d().e().f().catch())
                     </script>
                   ",
@@ -1454,6 +1454,70 @@ fn test() {
             None,
             Some(PathBuf::from("test.vue")),
         ), // { parser, "sourceType": "module", "ecmaVersion": 2020 },
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return Promise.allSettled([])
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return Promise.any([])
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return Promise.try([])
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+<script>
+                    export default {
+                      computed: {
+                        foo: function () {
+                          return Promise.withResolvers([])
+                        }
+                      }
+                    }
+                  </script>
+",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
     ];
 
     Tester::new(NoAsyncInComputedProperties::NAME, NoAsyncInComputedProperties::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/vue_no_async_in_computed_properties.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_async_in_computed_properties.snap
@@ -762,7 +762,7 @@ assertion_line: 490
 
   ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
    ╭─[no_async_in_computed_properties.tsx:5:53]
- 4 │             
+ 4 │
  5 │                     const deepCall = computed(() => z.a.b.c.d().e().f().catch())
    ·                                                     ───────────────────────────
  6 │                     </script>

--- a/crates/oxc_linter/src/snapshots/vue_no_async_in_computed_properties.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_async_in_computed_properties.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 490
 ---
 
   ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
@@ -761,9 +760,41 @@ assertion_line: 490
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
-   ╭─[no_async_in_computed_properties.tsx:5:53]
- 4 │
- 5 │                     const deepCall = computed(() => z.a.b.c.d().e().f().catch())
+   ╭─[no_async_in_computed_properties.tsx:4:53]
+ 3 │                     import {computed} from 'vue'
+ 4 │                     const deepCall = computed(() => z.a.b.c.d().e().f().catch())
    ·                                                     ───────────────────────────
- 6 │                     </script>
+ 5 │                     </script>
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return Promise.allSettled([])
+   ·                                  ──────────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return Promise.any([])
+   ·                                  ───────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return Promise.try([])
+   ·                                  ───────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return Promise.withResolvers([])
+   ·                                  ─────────────────────────
+ 7 │                         }
    ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_async_in_computed_properties.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_async_in_computed_properties.snap
@@ -1,0 +1,769 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:5:30]
+ 4 │                           computed: {
+ 5 │ ╭─▶                         foo: async function () {
+ 6 │ │                             return await someFunc()
+ 7 │ ╰─▶                         }
+ 8 │                           }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected await operator in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: async function () {
+ 6 │                           return await someFunc()
+   ·                                  ────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:5:30]
+ 4 │                           computed: {
+ 5 │ ╭─▶                         foo: async function () {
+ 6 │ │                             return new Promise((resolve, reject) => {})
+ 7 │ ╰─▶                         }
+ 8 │                           }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected Promise object in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: async function () {
+ 6 │                           return new Promise((resolve, reject) => {})
+   ·                                  ────────────────────────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return bar.then(response => {})
+   ·                                  ────────────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return bar?.then?.(response => {})
+   ·                                  ───────────────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return (bar?.then)?.(response => {})
+   ·                                  ─────────────────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return bar.catch(e => {})
+   ·                                  ──────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return Promise.all([])
+   ·                                  ───────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return bar.finally(res => {})
+   ·                                  ──────────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:32]
+ 5 │                       foo: function () {
+ 6 │                         return Promise.race([])
+   ·                                ────────────────
+ 7 │                       }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:32]
+ 5 │                       foo: function () {
+ 6 │                         return Promise.reject([])
+   ·                                ──────────────────
+ 7 │                       }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:32]
+ 5 │                       foo: function () {
+ 6 │                         return Promise.resolve([])
+   ·                                ───────────────────
+ 7 │                       }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:32]
+ 5 │                       foo () {
+ 6 │                         return Promise.resolve([])
+   ·                                ───────────────────
+ 7 │                       }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:34]
+ 6 │                         get () {
+ 7 │                           return Promise.resolve([])
+   ·                                  ───────────────────
+ 8 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:34]
+ 6 │                         get () {
+ 7 │                           return Promise.resolve([])
+   ·                                  ───────────────────
+ 8 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:34]
+ 6 │                         get () {
+ 7 │                           return test.blabla.then([])
+   ·                                  ────────────────────
+ 8 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:25]
+ 5 │                       foo () {
+ 6 │                         this.$nextTick(() => {})
+   ·                         ────────────────────────
+ 7 │                         Vue.nextTick(() => {})
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:25]
+ 6 │                         this.$nextTick(() => {})
+ 7 │                         Vue.nextTick(() => {})
+   ·                         ──────────────────────
+ 8 │                         return 'foo'
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:5:33]
+  4 │                         computed: {
+  5 │ ╭─▶                       async foo () {
+  6 │ │                           await this.$nextTick()
+  7 │ │                           await Vue.nextTick()
+  8 │ │                           return 'foo'
+  9 │ ╰─▶                       }
+ 10 │                         }
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected await operator in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:25]
+ 5 │                       async foo () {
+ 6 │                         await this.$nextTick()
+   ·                         ──────────────────────
+ 7 │                         await Vue.nextTick()
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:31]
+ 5 │                       async foo () {
+ 6 │                         await this.$nextTick()
+   ·                               ────────────────
+ 7 │                         await Vue.nextTick()
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected await operator in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:25]
+ 6 │                         await this.$nextTick()
+ 7 │                         await Vue.nextTick()
+   ·                         ────────────────────
+ 8 │                         return 'foo'
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:31]
+ 6 │                         await this.$nextTick()
+ 7 │                         await Vue.nextTick()
+   ·                               ──────────────
+ 8 │                         return 'foo'
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:25]
+ 5 │                       foo: function () {
+ 6 │                         setTimeout(() => { }, 0)
+   ·                         ────────────────────────
+ 7 │                         window.setTimeout(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:25]
+ 6 │                         setTimeout(() => { }, 0)
+ 7 │                         window.setTimeout(() => { }, 0)
+   ·                         ───────────────────────────────
+ 8 │                         setInterval(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:8:25]
+ 7 │                         window.setTimeout(() => { }, 0)
+ 8 │                         setInterval(() => { }, 0)
+   ·                         ─────────────────────────
+ 9 │                         window.setInterval(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:9:25]
+  8 │                         setInterval(() => { }, 0)
+  9 │                         window.setInterval(() => { }, 0)
+    ·                         ────────────────────────────────
+ 10 │                         setImmediate(() => { })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:10:25]
+  9 │                         window.setInterval(() => { }, 0)
+ 10 │                         setImmediate(() => { })
+    ·                         ───────────────────────
+ 11 │                         window.setImmediate(() => { })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:11:25]
+ 10 │                         setImmediate(() => { })
+ 11 │                         window.setImmediate(() => { })
+    ·                         ──────────────────────────────
+ 12 │                         requestAnimationFrame(() => {})
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:12:25]
+ 11 │                         window.setImmediate(() => { })
+ 12 │                         requestAnimationFrame(() => {})
+    ·                         ───────────────────────────────
+ 13 │                         window.requestAnimationFrame(() => {})
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:13:25]
+ 12 │                         requestAnimationFrame(() => {})
+ 13 │                         window.requestAnimationFrame(() => {})
+    ·                         ──────────────────────────────────────
+ 14 │                       }
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:25]
+ 5 │                       foo: function () {
+ 6 │                         setTimeout?.(() => { }, 0)
+   ·                         ──────────────────────────
+ 7 │                         window?.setTimeout?.(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:25]
+ 6 │                         setTimeout?.(() => { }, 0)
+ 7 │                         window?.setTimeout?.(() => { }, 0)
+   ·                         ──────────────────────────────────
+ 8 │                         setInterval(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:8:25]
+ 7 │                         window?.setTimeout?.(() => { }, 0)
+ 8 │                         setInterval(() => { }, 0)
+   ·                         ─────────────────────────
+ 9 │                         window?.setInterval?.(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:9:25]
+  8 │                         setInterval(() => { }, 0)
+  9 │                         window?.setInterval?.(() => { }, 0)
+    ·                         ───────────────────────────────────
+ 10 │                         setImmediate?.(() => { })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:10:25]
+  9 │                         window?.setInterval?.(() => { }, 0)
+ 10 │                         setImmediate?.(() => { })
+    ·                         ─────────────────────────
+ 11 │                         window?.setImmediate?.(() => { })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:11:25]
+ 10 │                         setImmediate?.(() => { })
+ 11 │                         window?.setImmediate?.(() => { })
+    ·                         ─────────────────────────────────
+ 12 │                         requestAnimationFrame?.(() => {})
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:12:25]
+ 11 │                         window?.setImmediate?.(() => { })
+ 12 │                         requestAnimationFrame?.(() => {})
+    ·                         ─────────────────────────────────
+ 13 │                         window?.requestAnimationFrame?.(() => {})
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:13:25]
+ 12 │                         requestAnimationFrame?.(() => {})
+ 13 │                         window?.requestAnimationFrame?.(() => {})
+    ·                         ─────────────────────────────────────────
+ 14 │                       }
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:25]
+ 5 │                       foo: function () {
+ 6 │                         setTimeout?.(() => { }, 0)
+   ·                         ──────────────────────────
+ 7 │                         ;(window?.setTimeout)?.(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:26]
+ 6 │                         setTimeout?.(() => { }, 0)
+ 7 │                         ;(window?.setTimeout)?.(() => { }, 0)
+   ·                          ────────────────────────────────────
+ 8 │                         setInterval(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:8:25]
+ 7 │                         ;(window?.setTimeout)?.(() => { }, 0)
+ 8 │                         setInterval(() => { }, 0)
+   ·                         ─────────────────────────
+ 9 │                         ;(window?.setInterval)?.(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:9:26]
+  8 │                         setInterval(() => { }, 0)
+  9 │                         ;(window?.setInterval)?.(() => { }, 0)
+    ·                          ─────────────────────────────────────
+ 10 │                         setImmediate?.(() => { })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:10:25]
+  9 │                         ;(window?.setInterval)?.(() => { }, 0)
+ 10 │                         setImmediate?.(() => { })
+    ·                         ─────────────────────────
+ 11 │                         ;(window?.setImmediate)?.(() => { })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:11:26]
+ 10 │                         setImmediate?.(() => { })
+ 11 │                         ;(window?.setImmediate)?.(() => { })
+    ·                          ───────────────────────────────────
+ 12 │                         requestAnimationFrame?.(() => {})
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:12:25]
+ 11 │                         ;(window?.setImmediate)?.(() => { })
+ 12 │                         requestAnimationFrame?.(() => {})
+    ·                         ─────────────────────────────────
+ 13 │                         ;(window?.requestAnimationFrame)?.(() => {})
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:13:26]
+ 12 │                         requestAnimationFrame?.(() => {})
+ 13 │                         ;(window?.requestAnimationFrame)?.(() => {})
+    ·                          ───────────────────────────────────────────
+ 14 │                       }
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:6:46]
+ 5 │                         setup() {
+ 6 │ ╭─▶                       const test1 = computed(async () => {
+ 7 │ │                           return await someFunc()
+ 8 │ ╰─▶                       })
+ 9 │                           const test2 = computed(async () => await someFunc())
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
+   ╭─[no_async_in_computed_properties.tsx:7:32]
+ 6 │                       const test1 = computed(async () => {
+ 7 │                         return await someFunc()
+   ·                                ────────────────
+ 8 │                       })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+    ╭─[no_async_in_computed_properties.tsx:9:46]
+  8 │                       })
+  9 │                       const test2 = computed(async () => await someFunc())
+    ·                                              ────────────────────────────
+ 10 │                       const test3 = computed(async function () {
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
+    ╭─[no_async_in_computed_properties.tsx:9:58]
+  8 │                       })
+  9 │                       const test2 = computed(async () => await someFunc())
+    ·                                                          ────────────────
+ 10 │                       const test3 = computed(async function () {
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+    ╭─[no_async_in_computed_properties.tsx:10:46]
+  9 │                           const test2 = computed(async () => await someFunc())
+ 10 │ ╭─▶                       const test3 = computed(async function () {
+ 11 │ │                           return await someFunc()
+ 12 │ ╰─▶                       })
+ 13 │                         }
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
+    ╭─[no_async_in_computed_properties.tsx:11:32]
+ 10 │                       const test3 = computed(async function () {
+ 11 │                         return await someFunc()
+    ·                                ────────────────
+ 12 │                       })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:6:45]
+ 5 │                         setup() {
+ 6 │ ╭─▶                       const test = computed(async () => {
+ 7 │ │                           return new Promise((resolve, reject) => {})
+ 8 │ ╰─▶                       })
+ 9 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected Promise object in computed function.
+   ╭─[no_async_in_computed_properties.tsx:7:32]
+ 6 │                       const test = computed(async () => {
+ 7 │                         return new Promise((resolve, reject) => {})
+   ·                                ────────────────────────────────────
+ 8 │                       })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
+   ╭─[no_async_in_computed_properties.tsx:7:32]
+ 6 │                       const test1 = computed(() => {
+ 7 │                         return bar.then(response => {})
+   ·                                ────────────────────────
+ 8 │                       })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
+    ╭─[no_async_in_computed_properties.tsx:10:32]
+  9 │                       const test2 = computed(() => {
+ 10 │                         return Promise.all([])
+    ·                                ───────────────
+ 11 │                       })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
+   ╭─[no_async_in_computed_properties.tsx:8:34]
+ 7 │                         get: () => {
+ 8 │                           return Promise.resolve([])
+   ·                                  ───────────────────
+ 9 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
+    ╭─[no_async_in_computed_properties.tsx:13:34]
+ 12 │                         get() {
+ 13 │                           return Promise.resolve([])
+    ·                                  ───────────────────
+ 14 │                         }
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+   ╭─[no_async_in_computed_properties.tsx:7:25]
+ 6 │                       const test = computed(() => {
+ 7 │                         setTimeout(() => { }, 0)
+   ·                         ────────────────────────
+ 8 │                         window.setTimeout(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+   ╭─[no_async_in_computed_properties.tsx:8:25]
+ 7 │                         setTimeout(() => { }, 0)
+ 8 │                         window.setTimeout(() => { }, 0)
+   ·                         ───────────────────────────────
+ 9 │                         setInterval(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+    ╭─[no_async_in_computed_properties.tsx:9:25]
+  8 │                         window.setTimeout(() => { }, 0)
+  9 │                         setInterval(() => { }, 0)
+    ·                         ─────────────────────────
+ 10 │                         window.setInterval(() => { }, 0)
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+    ╭─[no_async_in_computed_properties.tsx:10:25]
+  9 │                         setInterval(() => { }, 0)
+ 10 │                         window.setInterval(() => { }, 0)
+    ·                         ────────────────────────────────
+ 11 │                         setImmediate(() => { })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+    ╭─[no_async_in_computed_properties.tsx:11:25]
+ 10 │                         window.setInterval(() => { }, 0)
+ 11 │                         setImmediate(() => { })
+    ·                         ───────────────────────
+ 12 │                         window.setImmediate(() => { })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+    ╭─[no_async_in_computed_properties.tsx:12:25]
+ 11 │                         setImmediate(() => { })
+ 12 │                         window.setImmediate(() => { })
+    ·                         ──────────────────────────────
+ 13 │                         requestAnimationFrame(() => {})
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+    ╭─[no_async_in_computed_properties.tsx:13:25]
+ 12 │                         window.setImmediate(() => { })
+ 13 │                         requestAnimationFrame(() => {})
+    ·                         ───────────────────────────────
+ 14 │                         window.requestAnimationFrame(() => {})
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+    ╭─[no_async_in_computed_properties.tsx:14:25]
+ 13 │                         requestAnimationFrame(() => {})
+ 14 │                         window.requestAnimationFrame(() => {})
+    ·                         ──────────────────────────────────────
+ 15 │                       })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:6:45]
+ 5 │                         setup() {
+ 6 │ ╭─▶                       const test = computed(async () => {
+ 7 │ │                           bar()
+ 8 │ ╰─▶                       })
+ 9 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:4:42]
+ 3 │                       import {computed} from 'vue'
+ 4 │ ╭─▶                   const test1 = computed(async () => {
+ 5 │ │                       return await someFunc()
+ 6 │ ╰─▶                   })
+ 7 │                       const test2 = computed(async () => await someFunc())
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
+   ╭─[no_async_in_computed_properties.tsx:5:28]
+ 4 │                   const test1 = computed(async () => {
+ 5 │                     return await someFunc()
+   ·                            ────────────────
+ 6 │                   })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:7:42]
+ 6 │                   })
+ 7 │                   const test2 = computed(async () => await someFunc())
+   ·                                          ────────────────────────────
+ 8 │                   const test3 = computed(async function () {
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
+   ╭─[no_async_in_computed_properties.tsx:7:54]
+ 6 │                   })
+ 7 │                   const test2 = computed(async () => await someFunc())
+   ·                                                      ────────────────
+ 8 │                   const test3 = computed(async function () {
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+    ╭─[no_async_in_computed_properties.tsx:8:42]
+  7 │                       const test2 = computed(async () => await someFunc())
+  8 │ ╭─▶                   const test3 = computed(async function () {
+  9 │ │                       return await someFunc()
+ 10 │ ╰─▶                   })
+ 11 │                       </script>
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
+    ╭─[no_async_in_computed_properties.tsx:9:28]
+  8 │                   const test3 = computed(async function () {
+  9 │                     return await someFunc()
+    ·                            ────────────────
+ 10 │                   })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:4:41]
+ 3 │                       import {computed} from 'vue'
+ 4 │ ╭─▶                   const test = computed(async () => {
+ 5 │ │                       return new Promise((resolve, reject) => {})
+ 6 │ ╰─▶                   })
+ 7 │                       </script>
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected Promise object in computed function.
+   ╭─[no_async_in_computed_properties.tsx:5:28]
+ 4 │                   const test = computed(async () => {
+ 5 │                     return new Promise((resolve, reject) => {})
+   ·                            ────────────────────────────────────
+ 6 │                   })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
+   ╭─[no_async_in_computed_properties.tsx:5:28]
+ 4 │                   const test1 = computed(() => {
+ 5 │                     return bar.then(response => {})
+   ·                            ────────────────────────
+ 6 │                   })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
+   ╭─[no_async_in_computed_properties.tsx:8:28]
+ 7 │                   const test2 = computed(() => {
+ 8 │                     return Promise.all([])
+   ·                            ───────────────
+ 9 │                   })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
+   ╭─[no_async_in_computed_properties.tsx:6:30]
+ 5 │                     get: () => {
+ 6 │                       return Promise.resolve([])
+   ·                              ───────────────────
+ 7 │                     }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
+    ╭─[no_async_in_computed_properties.tsx:11:30]
+ 10 │                     get() {
+ 11 │                       return Promise.resolve([])
+    ·                              ───────────────────
+ 12 │                     }
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+   ╭─[no_async_in_computed_properties.tsx:5:21]
+ 4 │                   const test = computed(() => {
+ 5 │                     setTimeout(() => { }, 0)
+   ·                     ────────────────────────
+ 6 │                     window.setTimeout(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+   ╭─[no_async_in_computed_properties.tsx:6:21]
+ 5 │                     setTimeout(() => { }, 0)
+ 6 │                     window.setTimeout(() => { }, 0)
+   ·                     ───────────────────────────────
+ 7 │                     setInterval(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+   ╭─[no_async_in_computed_properties.tsx:7:21]
+ 6 │                     window.setTimeout(() => { }, 0)
+ 7 │                     setInterval(() => { }, 0)
+   ·                     ─────────────────────────
+ 8 │                     window.setInterval(() => { }, 0)
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+   ╭─[no_async_in_computed_properties.tsx:8:21]
+ 7 │                     setInterval(() => { }, 0)
+ 8 │                     window.setInterval(() => { }, 0)
+   ·                     ────────────────────────────────
+ 9 │                     setImmediate(() => { })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+    ╭─[no_async_in_computed_properties.tsx:9:21]
+  8 │                     window.setInterval(() => { }, 0)
+  9 │                     setImmediate(() => { })
+    ·                     ───────────────────────
+ 10 │                     window.setImmediate(() => { })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+    ╭─[no_async_in_computed_properties.tsx:10:21]
+  9 │                     setImmediate(() => { })
+ 10 │                     window.setImmediate(() => { })
+    ·                     ──────────────────────────────
+ 11 │                     requestAnimationFrame(() => {})
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+    ╭─[no_async_in_computed_properties.tsx:11:21]
+ 10 │                     window.setImmediate(() => { })
+ 11 │                     requestAnimationFrame(() => {})
+    ·                     ───────────────────────────────
+ 12 │                     window.requestAnimationFrame(() => {})
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected timed function in computed function.
+    ╭─[no_async_in_computed_properties.tsx:12:21]
+ 11 │                     requestAnimationFrame(() => {})
+ 12 │                     window.requestAnimationFrame(() => {})
+    ·                     ──────────────────────────────────────
+ 13 │                   })
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:4:41]
+ 3 │                       import {computed} from 'vue'
+ 4 │ ╭─▶                   const test = computed(async () => {
+ 5 │ │                       bar()
+ 6 │ ╰─▶                   })
+ 7 │                       </script>
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return myFunc().catch('default')
+   ·                                  ─────────────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return z.number().catch(42)
+   ·                                  ────────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:34]
+ 5 │                         foo: function () {
+ 6 │                           return someLib.string().catch(42)
+   ·                                  ──────────────────────────
+ 7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
+   ╭─[no_async_in_computed_properties.tsx:5:53]
+ 4 │             
+ 5 │                     const deepCall = computed(() => z.a.b.c.d().e().f().catch())
+   ·                                                     ───────────────────────────
+ 6 │                     </script>
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9950,6 +9950,26 @@
         "vue/no-arrow-functions-in-watch": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "vue/no-async-in-computed-properties": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/NoAsyncInComputedProperties"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "vue/no-computed-properties-in-data": {
           "$ref": "#/definitions/RuleNoConfig"
         },
@@ -12928,6 +12948,25 @@
             "type": "string"
           },
           "markdownDescription": "An array of names that are allowed to be async."
+        }
+      },
+      "additionalProperties": false
+    },
+    "NoAsyncInComputedProperties": {
+      "$ref": "#/definitions/NoAsyncInComputedPropertiesConfig"
+    },
+    "NoAsyncInComputedPropertiesConfig": {
+      "type": "object",
+      "properties": {
+        "ignoredObjectNames": {
+          "description": "Names of identifiers whose member-call chains (`.then` / `.catch` / `.finally`)\nshould be ignored. Useful for libraries like Zod where `.catch(default)` is\na builder API, not a Promise method.",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true,
+          "markdownDescription": "Names of identifiers whose member-call chains (`.then` / `.catch` / `.finally`)\nshould be ignored. Useful for libraries like Zod where `.catch(default)` is\na builder API, not a Promise method."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Implements `vue/no-async-in-computed-properties` from eslint-plugin-vue.

Part of #11440.

eslint-plugin-vue reference: https://eslint.vuejs.org/rules/no-async-in-computed-properties.html

The computed getter detection helpers (`find_computed_context` / `get_computed_getter_context` / `is_vue_computed_call`) are copied from `no-side-effects-in-computed-properties` (#23282); I'll extract them into a shared util in a follow-up PR (also covering `return-in-computed-property`, which has the same logic).

Note: one upstream valid test (`return z.a?.['b'].[c].d.method()...`) has a syntax typo — `.[c]` is invalid ECMAScript (`.` only accepts IdentifierName, not `[`). espree parses it leniently but oxc's strict parser rejects it. Changed to `?.[c]` here to preserve the test's intent (root identifier `z` matches `ignoredObjectNames: ['z']`).
