### PR TITLE
docs(linter/plugins): update usage instruction

### DIFF
--- a/npm/oxlint-plugin-eslint/README.md
+++ b/npm/oxlint-plugin-eslint/README.md
@@ -20,7 +20,7 @@ Add to your Oxlint config:
 
 ```json
 {
-  "jsPlugins": ["oxlint-plugin-eslint"],
+  "jsPlugins": [{ "name": "eslint-js", "specifier": "oxlint-plugin-eslint" }],
   "rules": {
     "eslint-js/no-restricted-syntax": [
       "error",


### PR DESCRIPTION
## Why

With the introduction of #23335, the official `oxlint-plugin-eslint` got normalize to `eslint`, which will result oxlint v1.70.0 (works fine on <= v1.69.0)
```sh
Failed to parse oxlint configuration file.

  × Plugin name 'eslint' is reserved, and cannot be used for JS plugins.
  │ 
  │ The 'eslint' plugin is already implemented natively in Rust within oxlint.
  │ Using both the native and JS versions would create ambiguity about which rules to use.
  │ 
  │ To use an external 'eslint' plugin instead, provide a custom alias:
  │ 
  │ "jsPlugins": [{ "name": "eslint-js", "specifier": "eslint-plugin-eslint" }]
  │ 
  │ Then reference rules using your alias:
  │ 
  │ "rules": {
  │   "eslint-js/rule-name": "error"
  │ }
  │ 
  │ See: https://oxc.rs/docs/guide/usage/linter/js-plugins.html
```