### PR TITLE
refactor(minifier): fold Object method purity checks into one match

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -9,10 +9,9 @@ use crate::{
 
 use super::known_globals::{
     is_error_constructor, is_known_global_constructor, is_known_global_identifier,
-    is_known_global_property, is_known_global_property_deep, is_proxy_sensitive_object_method,
-    is_pure_callable_constructor, is_pure_collection_constructor, is_pure_global_function,
-    is_pure_global_method_call, is_typed_array_constructor, is_unconditionally_pure_constructor,
-    is_valid_regexp,
+    is_known_global_property, is_known_global_property_deep, is_pure_callable_constructor,
+    is_pure_collection_constructor, is_pure_global_function, is_pure_global_method_call,
+    is_typed_array_constructor, is_unconditionally_pure_constructor, is_valid_regexp,
 };
 use super::{MayHaveSideEffects, PropertyReadSideEffects, context::MayHaveSideEffectsContext};
 
@@ -604,49 +603,68 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
             return self.arguments.iter().any(|e| e.may_have_side_effects(ctx));
         }
 
-        // Object introspection methods (`keys`, `getOwnPropertyDescriptor`, ...) are
-        // pure except that a `Proxy` target makes them fire observable traps, and a
-        // `null`/`undefined` target makes them throw. They are side-effect-free only
-        // when the target is provably neither.
-        if is_proxy_sensitive_object_method(object.name.as_str(), name) {
-            // An argument with its own side effects (e.g. inline `new Proxy(...)`) — keep.
-            if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
-                return true;
+        // `Object` static methods that run no user code but whose purity depends on
+        // their arguments.
+        if object.name == "Object" {
+            match name {
+                // Introspection methods (`keys`, `getOwnPropertyDescriptor`, ...) are pure
+                // except that a `Proxy` target makes them fire observable traps, and a
+                // `null`/`undefined` target makes them throw. They introspect their first
+                // argument via internal methods a Proxy can trap (`[[OwnPropertyKeys]]`,
+                // `[[GetOwnProperty]]`, `[[GetPrototypeOf]]`, `[[IsExtensible]]`) but,
+                // unlike `Object.values`/`entries`, never invoke `[[Get]]`, so they run no
+                // getter on a plain object. Side-effect-free only when the target is
+                // provably neither a Proxy nor nullish.
+                "getOwnPropertyDescriptor"
+                | "getOwnPropertyDescriptors"
+                | "getOwnPropertyNames"
+                | "getOwnPropertySymbols"
+                | "getPrototypeOf"
+                | "hasOwn"
+                | "isExtensible"
+                | "isFrozen"
+                | "isSealed"
+                | "keys" => {
+                    // An argument with its own side effects (e.g. inline `new Proxy(...)`) — keep.
+                    if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
+                        return true;
+                    }
+                    // Missing or spread target → `undefined` receiver → `ToObject` throws.
+                    let Some(arg) = self.arguments.first().and_then(Argument::as_expression) else {
+                        return true;
+                    };
+                    let value_type = arg.value_type(ctx);
+                    // `null`/`undefined` → `ToObject` throws a TypeError; keep the call.
+                    if value_type.is_null_or_undefined() {
+                        return true;
+                    }
+                    // With property reads assumed pure, the Proxy-trap concern is waived.
+                    if ctx.property_read_side_effects() == PropertyReadSideEffects::None {
+                        return false;
+                    }
+                    // Otherwise pure only when the target is a determined, non-Proxy value (a
+                    // literal object/array, or a primitive `ToObject` wraps without user code).
+                    // An undetermined value could be a Proxy whose trap is observable.
+                    return value_type.is_undetermined();
+                }
+                // `Object.create(proto)` allocates an object with prototype `proto`; it runs
+                // no user code and is pure when `proto` is provably an object or `null`
+                // (otherwise it throws a TypeError) and there is no `properties` argument
+                // (which would be read via `[[OwnPropertyKeys]]`/`[[Get]]`).
+                "create" => {
+                    if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
+                        return true;
+                    }
+                    if self.arguments.len() == 1
+                        && let Some(arg) = self.arguments[0].as_expression()
+                        && matches!(arg.value_type(ctx), ValueType::Object | ValueType::Null)
+                    {
+                        return false;
+                    }
+                    return true;
+                }
+                _ => {}
             }
-            // Missing or spread target → `undefined` receiver → `ToObject` throws.
-            let Some(arg) = self.arguments.first().and_then(Argument::as_expression) else {
-                return true;
-            };
-            let value_type = arg.value_type(ctx);
-            // `null`/`undefined` → `ToObject` throws a TypeError; keep the call.
-            if value_type.is_null_or_undefined() {
-                return true;
-            }
-            // With property reads assumed pure, the Proxy-trap concern is waived.
-            if ctx.property_read_side_effects() == PropertyReadSideEffects::None {
-                return false;
-            }
-            // Otherwise pure only when the target is a determined, non-Proxy value (a
-            // literal object/array, or a primitive `ToObject` wraps without user code).
-            // An undetermined value could be a Proxy whose trap is observable.
-            return value_type.is_undetermined();
-        }
-
-        // `Object.create(proto)` allocates an object with prototype `proto`; it runs no
-        // user code and is pure when `proto` is provably an object or `null` (otherwise
-        // it throws a TypeError) and there is no `properties` argument (which would be
-        // read via `[[OwnPropertyKeys]]`/`[[Get]]`).
-        if object.name == "Object" && name == "create" {
-            if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
-                return true;
-            }
-            if self.arguments.len() == 1
-                && let Some(arg) = self.arguments[0].as_expression()
-                && matches!(arg.value_type(ctx), ValueType::Object | ValueType::Null)
-            {
-                return false;
-            }
-            return true;
         }
 
         true

--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -603,71 +603,71 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
             return self.arguments.iter().any(|e| e.may_have_side_effects(ctx));
         }
 
-        // `Object` static methods that run no user code but whose purity depends on
-        // their arguments.
-        if object.name == "Object" {
-            match name {
-                // Introspection methods (`keys`, `getOwnPropertyDescriptor`, ...) are pure
-                // except that a `Proxy` target makes them fire observable traps, and a
-                // `null`/`undefined` target makes them throw. They introspect their first
-                // argument via internal methods a Proxy can trap (`[[OwnPropertyKeys]]`,
-                // `[[GetOwnProperty]]`, `[[GetPrototypeOf]]`, `[[IsExtensible]]`) but,
-                // unlike `Object.values`/`entries`, never invoke `[[Get]]`, so they run no
-                // getter on a plain object. Side-effect-free only when the target is
-                // provably neither a Proxy nor nullish.
-                "getOwnPropertyDescriptor"
-                | "getOwnPropertyDescriptors"
-                | "getOwnPropertyNames"
-                | "getOwnPropertySymbols"
-                | "getPrototypeOf"
-                | "hasOwn"
-                | "isExtensible"
-                | "isFrozen"
-                | "isSealed"
-                | "keys" => {
-                    // An argument with its own side effects (e.g. inline `new Proxy(...)`) — keep.
-                    if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
-                        return true;
-                    }
-                    // Missing or spread target → `undefined` receiver → `ToObject` throws.
-                    let Some(arg) = self.arguments.first().and_then(Argument::as_expression) else {
-                        return true;
-                    };
-                    let value_type = arg.value_type(ctx);
-                    // `null`/`undefined` → `ToObject` throws a TypeError; keep the call.
-                    if value_type.is_null_or_undefined() {
-                        return true;
-                    }
-                    // With property reads assumed pure, the Proxy-trap concern is waived.
-                    if ctx.property_read_side_effects() == PropertyReadSideEffects::None {
-                        return false;
-                    }
-                    // Otherwise pure only when the target is a determined, non-Proxy value (a
-                    // literal object/array, or a primitive `ToObject` wraps without user code).
-                    // An undetermined value could be a Proxy whose trap is observable.
-                    return value_type.is_undetermined();
-                }
-                // `Object.create(proto)` allocates an object with prototype `proto`; it runs
-                // no user code and is pure when `proto` is provably an object or `null`
-                // (otherwise it throws a TypeError) and there is no `properties` argument
-                // (which would be read via `[[OwnPropertyKeys]]`/`[[Get]]`).
-                "create" => {
-                    if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
-                        return true;
-                    }
-                    if self.arguments.len() == 1
-                        && let Some(arg) = self.arguments[0].as_expression()
-                        && matches!(arg.value_type(ctx), ValueType::Object | ValueType::Null)
-                    {
-                        return false;
-                    }
-                    return true;
-                }
-                _ => {}
-            }
+        if object.name != "Object" {
+            return true;
         }
 
-        true
+        // `Object` static methods that run no user code but whose purity depends on
+        // their arguments.
+        match name {
+            // Introspection methods (`keys`, `getOwnPropertyDescriptor`, ...) are pure
+            // except that a `Proxy` target makes them fire observable traps, and a
+            // `null`/`undefined` target makes them throw. They introspect their first
+            // argument via internal methods a Proxy can trap (`[[OwnPropertyKeys]]`,
+            // `[[GetOwnProperty]]`, `[[GetPrototypeOf]]`, `[[IsExtensible]]`) but,
+            // unlike `Object.values`/`entries`, never invoke `[[Get]]`, so they run no
+            // getter on a plain object. Side-effect-free only when the target is
+            // provably neither a Proxy nor nullish.
+            "getOwnPropertyDescriptor"
+            | "getOwnPropertyDescriptors"
+            | "getOwnPropertyNames"
+            | "getOwnPropertySymbols"
+            | "getPrototypeOf"
+            | "hasOwn"
+            | "isExtensible"
+            | "isFrozen"
+            | "isSealed"
+            | "keys" => {
+                // An argument with its own side effects (e.g. inline `new Proxy(...)`) — keep.
+                if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
+                    return true;
+                }
+                // Missing or spread target → `undefined` receiver → `ToObject` throws.
+                let Some(arg) = self.arguments.first().and_then(Argument::as_expression) else {
+                    return true;
+                };
+                let value_type = arg.value_type(ctx);
+                // `null`/`undefined` → `ToObject` throws a TypeError; keep the call.
+                if value_type.is_null_or_undefined() {
+                    return true;
+                }
+                // With property reads assumed pure, the Proxy-trap concern is waived.
+                if ctx.property_read_side_effects() == PropertyReadSideEffects::None {
+                    return false;
+                }
+                // Otherwise pure only when the target is a determined, non-Proxy value (a
+                // literal object/array, or a primitive `ToObject` wraps without user code).
+                // An undetermined value could be a Proxy whose trap is observable.
+                value_type.is_undetermined()
+            }
+            // `Object.create(proto)` allocates an object with prototype `proto`; it runs
+            // no user code and is pure when `proto` is provably an object or `null`
+            // (otherwise it throws a TypeError) and there is no `properties` argument
+            // (which would be read via `[[OwnPropertyKeys]]`/`[[Get]]`).
+            "create" => {
+                if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
+                    return true;
+                }
+                if self.arguments.len() == 1
+                    && let Some(arg) = self.arguments[0].as_expression()
+                    && matches!(arg.value_type(ctx), ValueType::Object | ValueType::Null)
+                {
+                    return false;
+                }
+                true
+            }
+            _ => true,
+        }
     }
 }
 

--- a/crates/oxc_ecmascript/src/side_effects/known_globals.rs
+++ b/crates/oxc_ecmascript/src/side_effects/known_globals.rs
@@ -402,9 +402,8 @@ pub(super) fn is_pure_global_method_call(object: &str, method: &str) -> bool {
         "Number" => matches!(method, "isFinite" | "isInteger" | "isNaN" | "isSafeInteger" | "parseFloat" | "parseInt"),
         // Only `Object.is` is unconditionally pure. The introspection methods
         // (`keys`, `getOwnPropertyDescriptor`, ...) can trigger Proxy traps on their
-        // target (see `proxy_sensitive_arg_index`), and `Object.create` reads its
-        // `properties` argument; both are handled in
-        // `CallExpression::may_have_side_effects`.
+        // target, and `Object.create` reads its `properties` argument; both are
+        // handled in `CallExpression::may_have_side_effects`.
         "Object" => method == "is",
         "String" => matches!(method, "fromCharCode" | "fromCodePoint" | "raw"),
         "Symbol" => matches!(method, "for" | "keyFor"),
@@ -412,25 +411,6 @@ pub(super) fn is_pure_global_method_call(object: &str, method: &str) -> bool {
         _ if is_typed_array_constructor(object) => method == "of",
         _ => false,
     }
-}
-
-/// Whether a global method call is pure *except* for Proxy traps fired on its
-/// first argument.
-///
-/// These `Object` methods introspect their first argument via internal methods a
-/// Proxy can trap (`[[OwnPropertyKeys]]`, `[[GetOwnProperty]]`, `[[GetPrototypeOf]]`,
-/// `[[IsExtensible]]`), but — unlike `Object.values`/`entries` — they never invoke
-/// `[[Get]]`, so they run no getter on a plain object. They also throw on a
-/// `null`/`undefined` target; the caller handles both the Proxy and throw checks.
-///
-/// `Object.is` is unconditionally pure; `Object.create` and `Object.values`/
-/// `entries` are handled separately, not here.
-#[rustfmt::skip]
-pub(super) fn is_proxy_sensitive_object_method(object: &str, method: &str) -> bool {
-    matches!((object, method), ("Object",
-        "getOwnPropertyDescriptor" | "getOwnPropertyDescriptors"
-        | "getOwnPropertyNames" | "getOwnPropertySymbols" | "getPrototypeOf"
-        | "hasOwn" | "isExtensible" | "isFrozen" | "isSealed" | "keys"))
 }
 
 /// Whether the property read on a known global is side-effect-free.


### PR DESCRIPTION
Collapse the separate `is_proxy_sensitive_object_method` guard and the `Object.create` branch in `CallExpression::may_have_side_effects` into a single `if object.name == "Object"` early-return and a single `match name { ... }` block, so the `"Object"` receiver is tested once.

- Inline `is_proxy_sensitive_object_method` (it only ever matched `"Object"`); its doc moves onto the introspection-method match arm.
- Drop the stale `proxy_sensitive_arg_index` reference in the comment on `is_pure_global_method_call`.