### PR TITLE
feat(linter/unicorn): implement prefer-number-coercion rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1546,6 +1546,7 @@ export interface DummyRuleMap {
   "unicorn/prefer-native-coercion-functions"?: RuleNoConfig;
   "unicorn/prefer-negative-index"?: RuleNoConfig;
   "unicorn/prefer-node-protocol"?: RuleNoConfig;
+  "unicorn/prefer-number-coercion"?: RuleNoConfig;
   "unicorn/prefer-number-properties"?: RuleNoConfig | [AllowWarnDeny, PreferNumberPropertiesConfig];
   "unicorn/prefer-object-from-entries"?: RuleNoConfig | [AllowWarnDeny, PreferObjectFromEntriesConfig];
   "unicorn/prefer-optional-catch-binding"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3628,6 +3628,12 @@ impl RuleRunner for crate::rules::unicorn::prefer_node_protocol::PreferNodeProto
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::prefer_number_coercion::PreferNumberCoercion {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::prefer_number_properties::PreferNumberProperties {
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::CallExpression,

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -696,6 +696,7 @@ pub use crate::rules::unicorn::prefer_module::PreferModule as UnicornPreferModul
 pub use crate::rules::unicorn::prefer_native_coercion_functions::PreferNativeCoercionFunctions as UnicornPreferNativeCoercionFunctions;
 pub use crate::rules::unicorn::prefer_negative_index::PreferNegativeIndex as UnicornPreferNegativeIndex;
 pub use crate::rules::unicorn::prefer_node_protocol::PreferNodeProtocol as UnicornPreferNodeProtocol;
+pub use crate::rules::unicorn::prefer_number_coercion::PreferNumberCoercion as UnicornPreferNumberCoercion;
 pub use crate::rules::unicorn::prefer_number_properties::PreferNumberProperties as UnicornPreferNumberProperties;
 pub use crate::rules::unicorn::prefer_object_from_entries::PreferObjectFromEntries as UnicornPreferObjectFromEntries;
 pub use crate::rules::unicorn::prefer_optional_catch_binding::PreferOptionalCatchBinding as UnicornPreferOptionalCatchBinding;
@@ -1414,6 +1415,7 @@ pub enum RuleEnum {
     UnicornPreferNativeCoercionFunctions(UnicornPreferNativeCoercionFunctions),
     UnicornPreferNegativeIndex(UnicornPreferNegativeIndex),
     UnicornPreferNodeProtocol(UnicornPreferNodeProtocol),
+    UnicornPreferNumberCoercion(UnicornPreferNumberCoercion),
     UnicornPreferNumberProperties(UnicornPreferNumberProperties),
     UnicornPreferObjectFromEntries(UnicornPreferObjectFromEntries),
     UnicornPreferOptionalCatchBinding(UnicornPreferOptionalCatchBinding),
@@ -2327,7 +2329,8 @@ const UNICORN_PREFER_NATIVE_COERCION_FUNCTIONS_ID: usize = UNICORN_PREFER_MODULE
 const UNICORN_PREFER_NEGATIVE_INDEX_ID: usize =
     UNICORN_PREFER_NATIVE_COERCION_FUNCTIONS_ID + 1usize;
 const UNICORN_PREFER_NODE_PROTOCOL_ID: usize = UNICORN_PREFER_NEGATIVE_INDEX_ID + 1usize;
-const UNICORN_PREFER_NUMBER_PROPERTIES_ID: usize = UNICORN_PREFER_NODE_PROTOCOL_ID + 1usize;
+const UNICORN_PREFER_NUMBER_COERCION_ID: usize = UNICORN_PREFER_NODE_PROTOCOL_ID + 1usize;
+const UNICORN_PREFER_NUMBER_PROPERTIES_ID: usize = UNICORN_PREFER_NUMBER_COERCION_ID + 1usize;
 const UNICORN_PREFER_OBJECT_FROM_ENTRIES_ID: usize = UNICORN_PREFER_NUMBER_PROPERTIES_ID + 1usize;
 const UNICORN_PREFER_OPTIONAL_CATCH_BINDING_ID: usize =
     UNICORN_PREFER_OBJECT_FROM_ENTRIES_ID + 1usize;
@@ -3301,6 +3304,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferNegativeIndex(_) => UNICORN_PREFER_NEGATIVE_INDEX_ID,
             Self::UnicornPreferNodeProtocol(_) => UNICORN_PREFER_NODE_PROTOCOL_ID,
+            Self::UnicornPreferNumberCoercion(_) => UNICORN_PREFER_NUMBER_COERCION_ID,
             Self::UnicornPreferNumberProperties(_) => UNICORN_PREFER_NUMBER_PROPERTIES_ID,
             Self::UnicornPreferObjectFromEntries(_) => UNICORN_PREFER_OBJECT_FROM_ENTRIES_ID,
             Self::UnicornPreferOptionalCatchBinding(_) => UNICORN_PREFER_OPTIONAL_CATCH_BINDING_ID,
@@ -4259,6 +4263,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferNegativeIndex(_) => UnicornPreferNegativeIndex::NAME,
             Self::UnicornPreferNodeProtocol(_) => UnicornPreferNodeProtocol::NAME,
+            Self::UnicornPreferNumberCoercion(_) => UnicornPreferNumberCoercion::NAME,
             Self::UnicornPreferNumberProperties(_) => UnicornPreferNumberProperties::NAME,
             Self::UnicornPreferObjectFromEntries(_) => UnicornPreferObjectFromEntries::NAME,
             Self::UnicornPreferOptionalCatchBinding(_) => UnicornPreferOptionalCatchBinding::NAME,
@@ -5247,6 +5252,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferNegativeIndex(_) => UnicornPreferNegativeIndex::CATEGORY,
             Self::UnicornPreferNodeProtocol(_) => UnicornPreferNodeProtocol::CATEGORY,
+            Self::UnicornPreferNumberCoercion(_) => UnicornPreferNumberCoercion::CATEGORY,
             Self::UnicornPreferNumberProperties(_) => UnicornPreferNumberProperties::CATEGORY,
             Self::UnicornPreferObjectFromEntries(_) => UnicornPreferObjectFromEntries::CATEGORY,
             Self::UnicornPreferOptionalCatchBinding(_) => {
@@ -6222,6 +6228,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferNegativeIndex(_) => UnicornPreferNegativeIndex::FIX,
             Self::UnicornPreferNodeProtocol(_) => UnicornPreferNodeProtocol::FIX,
+            Self::UnicornPreferNumberCoercion(_) => UnicornPreferNumberCoercion::FIX,
             Self::UnicornPreferNumberProperties(_) => UnicornPreferNumberProperties::FIX,
             Self::UnicornPreferObjectFromEntries(_) => UnicornPreferObjectFromEntries::FIX,
             Self::UnicornPreferOptionalCatchBinding(_) => UnicornPreferOptionalCatchBinding::FIX,
@@ -7335,6 +7342,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferNegativeIndex(_) => UnicornPreferNegativeIndex::documentation(),
             Self::UnicornPreferNodeProtocol(_) => UnicornPreferNodeProtocol::documentation(),
+            Self::UnicornPreferNumberCoercion(_) => UnicornPreferNumberCoercion::documentation(),
             Self::UnicornPreferNumberProperties(_) => {
                 UnicornPreferNumberProperties::documentation()
             }
@@ -9350,6 +9358,10 @@ impl RuleEnum {
                 UnicornPreferNodeProtocol::config_schema(generator)
                     .or_else(|| UnicornPreferNodeProtocol::schema(generator))
             }
+            Self::UnicornPreferNumberCoercion(_) => {
+                UnicornPreferNumberCoercion::config_schema(generator)
+                    .or_else(|| UnicornPreferNumberCoercion::schema(generator))
+            }
             Self::UnicornPreferNumberProperties(_) => {
                 UnicornPreferNumberProperties::config_schema(generator)
                     .or_else(|| UnicornPreferNumberProperties::schema(generator))
@@ -10697,6 +10709,7 @@ impl RuleEnum {
             Self::UnicornPreferNativeCoercionFunctions(_) => "unicorn",
             Self::UnicornPreferNegativeIndex(_) => "unicorn",
             Self::UnicornPreferNodeProtocol(_) => "unicorn",
+            Self::UnicornPreferNumberCoercion(_) => "unicorn",
             Self::UnicornPreferNumberProperties(_) => "unicorn",
             Self::UnicornPreferObjectFromEntries(_) => "unicorn",
             Self::UnicornPreferOptionalCatchBinding(_) => "unicorn",
@@ -12786,6 +12799,9 @@ impl RuleEnum {
             Self::UnicornPreferNodeProtocol(_) => Ok(Self::UnicornPreferNodeProtocol(
                 UnicornPreferNodeProtocol::from_configuration(value)?,
             )),
+            Self::UnicornPreferNumberCoercion(_) => Ok(Self::UnicornPreferNumberCoercion(
+                UnicornPreferNumberCoercion::from_configuration(value)?,
+            )),
             Self::UnicornPreferNumberProperties(_) => Ok(Self::UnicornPreferNumberProperties(
                 UnicornPreferNumberProperties::from_configuration(value)?,
             )),
@@ -14232,6 +14248,7 @@ impl RuleEnum {
             Self::UnicornPreferNativeCoercionFunctions(rule) => rule.to_configuration(),
             Self::UnicornPreferNegativeIndex(rule) => rule.to_configuration(),
             Self::UnicornPreferNodeProtocol(rule) => rule.to_configuration(),
+            Self::UnicornPreferNumberCoercion(rule) => rule.to_configuration(),
             Self::UnicornPreferNumberProperties(rule) => rule.to_configuration(),
             Self::UnicornPreferObjectFromEntries(rule) => rule.to_configuration(),
             Self::UnicornPreferOptionalCatchBinding(rule) => rule.to_configuration(),
@@ -15080,6 +15097,7 @@ impl RuleEnum {
                 Self::UnicornPreferNativeCoercionFunctions(rule) => rule.run(node, ctx),
                 Self::UnicornPreferNegativeIndex(rule) => rule.run(node, ctx),
                 Self::UnicornPreferNodeProtocol(rule) => rule.run(node, ctx),
+                Self::UnicornPreferNumberCoercion(rule) => rule.run(node, ctx),
                 Self::UnicornPreferNumberProperties(rule) => rule.run(node, ctx),
                 Self::UnicornPreferObjectFromEntries(rule) => rule.run(node, ctx),
                 Self::UnicornPreferOptionalCatchBinding(rule) => rule.run(node, ctx),
@@ -15921,6 +15939,7 @@ impl RuleEnum {
                 Self::UnicornPreferNativeCoercionFunctions(rule) => rule.run(node, ctx),
                 Self::UnicornPreferNegativeIndex(rule) => rule.run(node, ctx),
                 Self::UnicornPreferNodeProtocol(rule) => rule.run(node, ctx),
+                Self::UnicornPreferNumberCoercion(rule) => rule.run(node, ctx),
                 Self::UnicornPreferNumberProperties(rule) => rule.run(node, ctx),
                 Self::UnicornPreferObjectFromEntries(rule) => rule.run(node, ctx),
                 Self::UnicornPreferOptionalCatchBinding(rule) => rule.run(node, ctx),
@@ -16769,6 +16788,7 @@ impl RuleEnum {
                 Self::UnicornPreferNativeCoercionFunctions(rule) => rule.run_once(ctx),
                 Self::UnicornPreferNegativeIndex(rule) => rule.run_once(ctx),
                 Self::UnicornPreferNodeProtocol(rule) => rule.run_once(ctx),
+                Self::UnicornPreferNumberCoercion(rule) => rule.run_once(ctx),
                 Self::UnicornPreferNumberProperties(rule) => rule.run_once(ctx),
                 Self::UnicornPreferObjectFromEntries(rule) => rule.run_once(ctx),
                 Self::UnicornPreferOptionalCatchBinding(rule) => rule.run_once(ctx),
@@ -17610,6 +17630,7 @@ impl RuleEnum {
                 Self::UnicornPreferNativeCoercionFunctions(rule) => rule.run_once(ctx),
                 Self::UnicornPreferNegativeIndex(rule) => rule.run_once(ctx),
                 Self::UnicornPreferNodeProtocol(rule) => rule.run_once(ctx),
+                Self::UnicornPreferNumberCoercion(rule) => rule.run_once(ctx),
                 Self::UnicornPreferNumberProperties(rule) => rule.run_once(ctx),
                 Self::UnicornPreferObjectFromEntries(rule) => rule.run_once(ctx),
                 Self::UnicornPreferOptionalCatchBinding(rule) => rule.run_once(ctx),
@@ -18641,6 +18662,7 @@ impl RuleEnum {
                 }
                 Self::UnicornPreferNegativeIndex(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferNodeProtocol(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::UnicornPreferNumberCoercion(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferNumberProperties(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferObjectFromEntries(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferOptionalCatchBinding(rule) => {
@@ -19742,6 +19764,7 @@ impl RuleEnum {
                 }
                 Self::UnicornPreferNegativeIndex(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferNodeProtocol(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::UnicornPreferNumberCoercion(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferNumberProperties(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferObjectFromEntries(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::UnicornPreferOptionalCatchBinding(rule) => {
@@ -20661,6 +20684,7 @@ impl RuleEnum {
             Self::UnicornPreferNativeCoercionFunctions(rule) => rule.should_run(ctx),
             Self::UnicornPreferNegativeIndex(rule) => rule.should_run(ctx),
             Self::UnicornPreferNodeProtocol(rule) => rule.should_run(ctx),
+            Self::UnicornPreferNumberCoercion(rule) => rule.should_run(ctx),
             Self::UnicornPreferNumberProperties(rule) => rule.should_run(ctx),
             Self::UnicornPreferObjectFromEntries(rule) => rule.should_run(ctx),
             Self::UnicornPreferOptionalCatchBinding(rule) => rule.should_run(ctx),
@@ -21751,6 +21775,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferNegativeIndex(_) => UnicornPreferNegativeIndex::IS_TSGOLINT_RULE,
             Self::UnicornPreferNodeProtocol(_) => UnicornPreferNodeProtocol::IS_TSGOLINT_RULE,
+            Self::UnicornPreferNumberCoercion(_) => UnicornPreferNumberCoercion::IS_TSGOLINT_RULE,
             Self::UnicornPreferNumberProperties(_) => {
                 UnicornPreferNumberProperties::IS_TSGOLINT_RULE
             }
@@ -22843,6 +22868,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferNegativeIndex(_) => UnicornPreferNegativeIndex::VERSION,
             Self::UnicornPreferNodeProtocol(_) => UnicornPreferNodeProtocol::VERSION,
+            Self::UnicornPreferNumberCoercion(_) => UnicornPreferNumberCoercion::VERSION,
             Self::UnicornPreferNumberProperties(_) => UnicornPreferNumberProperties::VERSION,
             Self::UnicornPreferObjectFromEntries(_) => UnicornPreferObjectFromEntries::VERSION,
             Self::UnicornPreferOptionalCatchBinding(_) => {
@@ -23878,6 +23904,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferNegativeIndex(_) => UnicornPreferNegativeIndex::HAS_CONFIG,
             Self::UnicornPreferNodeProtocol(_) => UnicornPreferNodeProtocol::HAS_CONFIG,
+            Self::UnicornPreferNumberCoercion(_) => UnicornPreferNumberCoercion::HAS_CONFIG,
             Self::UnicornPreferNumberProperties(_) => UnicornPreferNumberProperties::HAS_CONFIG,
             Self::UnicornPreferObjectFromEntries(_) => UnicornPreferObjectFromEntries::HAS_CONFIG,
             Self::UnicornPreferOptionalCatchBinding(_) => {
@@ -24868,6 +24895,7 @@ impl RuleEnum {
             }
             Self::UnicornPreferNegativeIndex(_) => UnicornPreferNegativeIndex::INFO,
             Self::UnicornPreferNodeProtocol(_) => UnicornPreferNodeProtocol::INFO,
+            Self::UnicornPreferNumberCoercion(_) => UnicornPreferNumberCoercion::INFO,
             Self::UnicornPreferNumberProperties(_) => UnicornPreferNumberProperties::INFO,
             Self::UnicornPreferObjectFromEntries(_) => UnicornPreferObjectFromEntries::INFO,
             Self::UnicornPreferOptionalCatchBinding(_) => UnicornPreferOptionalCatchBinding::INFO,
@@ -25733,6 +25761,7 @@ impl RuleEnum {
             Self::UnicornPreferNativeCoercionFunctions(rule) => rule.types_info(),
             Self::UnicornPreferNegativeIndex(rule) => rule.types_info(),
             Self::UnicornPreferNodeProtocol(rule) => rule.types_info(),
+            Self::UnicornPreferNumberCoercion(rule) => rule.types_info(),
             Self::UnicornPreferNumberProperties(rule) => rule.types_info(),
             Self::UnicornPreferObjectFromEntries(rule) => rule.types_info(),
             Self::UnicornPreferOptionalCatchBinding(rule) => rule.types_info(),
@@ -26571,6 +26600,7 @@ impl RuleEnum {
             Self::UnicornPreferNativeCoercionFunctions(rule) => rule.run_info(),
             Self::UnicornPreferNegativeIndex(rule) => rule.run_info(),
             Self::UnicornPreferNodeProtocol(rule) => rule.run_info(),
+            Self::UnicornPreferNumberCoercion(rule) => rule.run_info(),
             Self::UnicornPreferNumberProperties(rule) => rule.run_info(),
             Self::UnicornPreferObjectFromEntries(rule) => rule.run_info(),
             Self::UnicornPreferOptionalCatchBinding(rule) => rule.run_info(),
@@ -27523,6 +27553,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         ),
         RuleEnum::UnicornPreferNegativeIndex(UnicornPreferNegativeIndex::default()),
         RuleEnum::UnicornPreferNodeProtocol(UnicornPreferNodeProtocol::default()),
+        RuleEnum::UnicornPreferNumberCoercion(UnicornPreferNumberCoercion::default()),
         RuleEnum::UnicornPreferNumberProperties(UnicornPreferNumberProperties::default()),
         RuleEnum::UnicornPreferObjectFromEntries(UnicornPreferObjectFromEntries::default()),
         RuleEnum::UnicornPreferOptionalCatchBinding(UnicornPreferOptionalCatchBinding::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -587,6 +587,7 @@ pub(crate) mod unicorn {
     pub mod prefer_native_coercion_functions;
     pub mod prefer_negative_index;
     pub mod prefer_node_protocol;
+    pub mod prefer_number_coercion;
     pub mod prefer_number_properties;
     pub mod prefer_object_from_entries;
     pub mod prefer_optional_catch_binding;

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_coercion.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_coercion.rs
@@ -1,0 +1,206 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn prefer_number_coercion_diagnostic(span: Span, replacement: &str) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!("Prefer `{replacement}`."))
+        .with_help(format!("Replace this call with `{replacement}`."))
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct PreferNumberCoercion;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prefer `Number()` over `parseFloat()` and base-10 `parseInt()`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `parseFloat()` and `parseInt()` parse numeric prefixes and ignore trailing text.
+    /// `Number()` parses the full input, which better matches intent when coercing values.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// const value = parseFloat(input);
+    /// const integer = parseInt(input, 10);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// const value = Number(input);
+    /// const integer = Math.trunc(Number(input));
+    /// ```
+    PreferNumberCoercion,
+    unicorn,
+    pedantic,
+    suggestion,
+    version = "0.19.0",
+    short_description = "Prefer `Number()` over `parseFloat()` and base-10 `parseInt()`.",
+);
+
+impl Rule for PreferNumberCoercion {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        if call_expr.optional {
+            return;
+        }
+
+        let Some(target) = parse_target(&call_expr.callee, ctx) else {
+            return;
+        };
+
+        let Some(first_argument) = call_expr.arguments.first() else {
+            return;
+        };
+
+        match target {
+            ParseTarget::ParseFloat if call_expr.arguments.len() != 1 => return,
+            ParseTarget::ParseInt => {
+                if call_expr.arguments.len() != 2 {
+                    return;
+                }
+                let Some(second_argument) = call_expr.arguments.get(1) else {
+                    return;
+                };
+                if !is_base_10(second_argument.as_expression()) {
+                    return;
+                }
+            }
+            ParseTarget::ParseFloat => {}
+        }
+
+        if first_argument.as_expression().is_none() {
+            return;
+        }
+
+        let first_argument_text = ctx.source_range(first_argument.span());
+        let replacement_text = match target {
+            ParseTarget::ParseFloat => format!("Number({first_argument_text})"),
+            ParseTarget::ParseInt => format!("Math.trunc(Number({first_argument_text}))"),
+        };
+
+        ctx.diagnostic_with_suggestion(
+            prefer_number_coercion_diagnostic(call_expr.span, &replacement_text),
+            |fixer| fixer.replace(call_expr.span, replacement_text),
+        );
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ParseTarget {
+    ParseFloat,
+    ParseInt,
+}
+
+fn parse_target(callee: &Expression, ctx: &LintContext) -> Option<ParseTarget> {
+    match callee.without_parentheses() {
+        Expression::Identifier(ident) => {
+            if !ctx.is_reference_to_global_variable(ident) {
+                return None;
+            }
+            match ident.name.as_str() {
+                "parseFloat" => Some(ParseTarget::ParseFloat),
+                "parseInt" => Some(ParseTarget::ParseInt),
+                _ => None,
+            }
+        }
+        member_expr if member_expr.is_member_expression() => {
+            let member_expr = member_expr.to_member_expression();
+            let Expression::Identifier(object) = member_expr.object() else {
+                return None;
+            };
+            if object.name != "Number" {
+                return None;
+            }
+            if !ctx.is_reference_to_global_variable(object) {
+                return None;
+            }
+            match member_expr.static_property_name()? {
+                "parseFloat" => Some(ParseTarget::ParseFloat),
+                "parseInt" => Some(ParseTarget::ParseInt),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn is_base_10(expression: Option<&Expression>) -> bool {
+    let Some(expression) = expression else {
+        return false;
+    };
+
+    match expression.without_parentheses() {
+        Expression::NumericLiteral(literal) => literal.value == 10.0,
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "Number(value);",
+        "Number.parseInt(value);",
+        "Number.parseInt(value, 16);",
+        "parseInt(value);",
+        "parseInt(value, 16);",
+        "parseFloat();",
+        "parseInt(value, radix);",
+        "parseFloat(value, sideEffect());",
+        "parseInt(value, 10, sideEffect());",
+        "foo.parseFloat(value);",
+        "foo.parseInt(value, 10);",
+        "const parseFloat = () => {}; parseFloat(value);",
+        "const Number = { parseFloat() {} }; Number.parseFloat(value);",
+    ];
+
+    let fail = vec![
+        "parseFloat(value);",
+        "parseFloat(a + b);",
+        "Number.parseFloat(value);",
+        "Number['parseFloat'](value);",
+        "parseInt(value, 10);",
+        "parseInt(getValue(), 10);",
+        "parseInt(parseInt(value, 10), 10);",
+        "parseInt(value as string, 10);",
+        "Number.parseInt(value, 10);",
+        "parseInt(value, 10.0);",
+        "(parseInt)(value, 10);",
+        "Number.parseInt((value), 10);",
+    ];
+
+    Tester::new(PreferNumberCoercion::NAME, PreferNumberCoercion::PLUGIN, pass, fail)
+        .expect_fix(vec![
+            ("parseFloat(value);", "Number(value);"),
+            ("parseFloat(a + b);", "Number(a + b);"),
+            ("Number.parseFloat(value);", "Number(value);"),
+            ("Number['parseFloat'](value);", "Number(value);"),
+            ("parseInt(value, 10);", "Math.trunc(Number(value));"),
+            ("parseInt(getValue(), 10);", "Math.trunc(Number(getValue()));"),
+            (
+                "parseInt(parseInt(value, 10), 10);",
+                "Math.trunc(Number(parseInt(value, 10)));",
+            ),
+            (
+                "parseInt(value as string, 10);",
+                "Math.trunc(Number(value as string));",
+            ),
+            ("Number.parseInt(value, 10);", "Math.trunc(Number(value));"),
+            ("parseInt(value, 10.0);", "Math.trunc(Number(value));"),
+            ("(parseInt)(value, 10);", "Math.trunc(Number(value));"),
+            ("Number.parseInt((value), 10);", "Math.trunc(Number((value)));"),
+        ])
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_coercion.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_coercion.rs
@@ -72,7 +72,10 @@ impl Rule for PreferNumberCoercion {
                 let Some(second_argument) = call_expr.arguments.get(1) else {
                     return;
                 };
-                if !is_base_10(second_argument.as_expression()) {
+                if !second_argument
+                    .as_expression()
+                    .is_some_and(|expression| expression.is_number_value(10.0))
+                {
                     return;
                 }
             }
@@ -135,15 +138,6 @@ fn parse_target(callee: &Expression, ctx: &LintContext) -> Option<ParseTarget> {
     }
 }
 
-fn is_base_10(expression: Option<&Expression>) -> bool {
-    if let Some(expression) = expression
-        && expression.is_number_value(10.0)
-    {
-        return true;
-    }
-    false
-}
-
 #[test]
 fn test() {
     use crate::tester::Tester;
@@ -187,14 +181,8 @@ fn test() {
             ("Number['parseFloat'](value);", "Number(value);"),
             ("parseInt(value, 10);", "Math.trunc(Number(value));"),
             ("parseInt(getValue(), 10);", "Math.trunc(Number(getValue()));"),
-            (
-                "parseInt(parseInt(value, 10), 10);",
-                "Math.trunc(Number(parseInt(value, 10)));",
-            ),
-            (
-                "parseInt(value as string, 10);",
-                "Math.trunc(Number(value as string));",
-            ),
+            ("parseInt(parseInt(value, 10), 10);", "Math.trunc(Number(parseInt(value, 10)));"),
+            ("parseInt(value as string, 10);", "Math.trunc(Number(value as string));"),
             ("Number.parseInt(value, 10);", "Math.trunc(Number(value));"),
             ("parseInt(value, 10.0);", "Math.trunc(Number(value));"),
             ("(parseInt)(value, 10);", "Math.trunc(Number(value));"),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_coercion.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_coercion.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
     unicorn,
     pedantic,
     suggestion,
-    version = "0.19.0",
+    version = "next",
     short_description = "Prefer `Number()` over `parseFloat()` and base-10 `parseInt()`.",
 );
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_coercion.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_coercion.rs
@@ -173,20 +173,22 @@ fn test() {
         "Number.parseInt((value), 10);",
     ];
 
+    let fix = vec![
+        ("parseFloat(value);", "Number(value);"),
+        ("parseFloat(a + b);", "Number(a + b);"),
+        ("Number.parseFloat(value);", "Number(value);"),
+        ("Number['parseFloat'](value);", "Number(value);"),
+        ("parseInt(value, 10);", "Math.trunc(Number(value));"),
+        ("parseInt(getValue(), 10);", "Math.trunc(Number(getValue()));"),
+        ("parseInt(parseInt(value, 10), 10);", "Math.trunc(Number(parseInt(value, 10)));"),
+        ("parseInt(value as string, 10);", "Math.trunc(Number(value as string));"),
+        ("Number.parseInt(value, 10);", "Math.trunc(Number(value));"),
+        ("parseInt(value, 10.0);", "Math.trunc(Number(value));"),
+        ("(parseInt)(value, 10);", "Math.trunc(Number(value));"),
+        ("Number.parseInt((value), 10);", "Math.trunc(Number((value)));"),
+    ];
+
     Tester::new(PreferNumberCoercion::NAME, PreferNumberCoercion::PLUGIN, pass, fail)
-        .expect_fix(vec![
-            ("parseFloat(value);", "Number(value);"),
-            ("parseFloat(a + b);", "Number(a + b);"),
-            ("Number.parseFloat(value);", "Number(value);"),
-            ("Number['parseFloat'](value);", "Number(value);"),
-            ("parseInt(value, 10);", "Math.trunc(Number(value));"),
-            ("parseInt(getValue(), 10);", "Math.trunc(Number(getValue()));"),
-            ("parseInt(parseInt(value, 10), 10);", "Math.trunc(Number(parseInt(value, 10)));"),
-            ("parseInt(value as string, 10);", "Math.trunc(Number(value as string));"),
-            ("Number.parseInt(value, 10);", "Math.trunc(Number(value));"),
-            ("parseInt(value, 10.0);", "Math.trunc(Number(value));"),
-            ("(parseInt)(value, 10);", "Math.trunc(Number(value));"),
-            ("Number.parseInt((value), 10);", "Math.trunc(Number((value)));"),
-        ])
+        .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_coercion.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_coercion.rs
@@ -136,14 +136,12 @@ fn parse_target(callee: &Expression, ctx: &LintContext) -> Option<ParseTarget> {
 }
 
 fn is_base_10(expression: Option<&Expression>) -> bool {
-    let Some(expression) = expression else {
-        return false;
-    };
-
-    match expression.without_parentheses() {
-        Expression::NumericLiteral(literal) => literal.value == 10.0,
-        _ => false,
+    if let Some(expression) = expression
+        && expression.is_number_value(10.0)
+    {
+        return true;
     }
+    false
 }
 
 #[test]

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_number_coercion.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_number_coercion.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 490
 ---
 
   ⚠ unicorn(prefer-number-coercion): Prefer `Number(value)`.

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_number_coercion.snap.new
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_number_coercion.snap.new
@@ -1,0 +1,95 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Number(value)`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ parseFloat(value);
+   · ─────────────────
+   ╰────
+  help: Replace this call with `Number(value)`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Number(a + b)`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ parseFloat(a + b);
+   · ─────────────────
+   ╰────
+  help: Replace this call with `Number(a + b)`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Number(value)`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ Number.parseFloat(value);
+   · ────────────────────────
+   ╰────
+  help: Replace this call with `Number(value)`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Number(value)`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ Number['parseFloat'](value);
+   · ───────────────────────────
+   ╰────
+  help: Replace this call with `Number(value)`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Math.trunc(Number(value))`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ parseInt(value, 10);
+   · ───────────────────
+   ╰────
+  help: Replace this call with `Math.trunc(Number(value))`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Math.trunc(Number(getValue()))`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ parseInt(getValue(), 10);
+   · ────────────────────────
+   ╰────
+  help: Replace this call with `Math.trunc(Number(getValue()))`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Math.trunc(Number(parseInt(value, 10)))`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ parseInt(parseInt(value, 10), 10);
+   · ─────────────────────────────────
+   ╰────
+  help: Replace this call with `Math.trunc(Number(parseInt(value, 10)))`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Math.trunc(Number(value))`.
+   ╭─[prefer_number_coercion.tsx:1:10]
+ 1 │ parseInt(parseInt(value, 10), 10);
+   ·          ───────────────────
+   ╰────
+  help: Replace this call with `Math.trunc(Number(value))`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Math.trunc(Number(value as string))`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ parseInt(value as string, 10);
+   · ─────────────────────────────
+   ╰────
+  help: Replace this call with `Math.trunc(Number(value as string))`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Math.trunc(Number(value))`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ Number.parseInt(value, 10);
+   · ──────────────────────────
+   ╰────
+  help: Replace this call with `Math.trunc(Number(value))`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Math.trunc(Number(value))`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ parseInt(value, 10.0);
+   · ─────────────────────
+   ╰────
+  help: Replace this call with `Math.trunc(Number(value))`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Math.trunc(Number(value))`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ (parseInt)(value, 10);
+   · ─────────────────────
+   ╰────
+  help: Replace this call with `Math.trunc(Number(value))`.
+
+  ⚠ unicorn(prefer-number-coercion): Prefer `Math.trunc(Number((value)))`.
+   ╭─[prefer_number_coercion.tsx:1:1]
+ 1 │ Number.parseInt((value), 10);
+   · ────────────────────────────
+   ╰────
+  help: Replace this call with `Math.trunc(Number((value)))`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -9016,6 +9016,9 @@
         "unicorn/prefer-node-protocol": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/prefer-number-coercion": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/prefer-number-properties": {
           "anyOf": [
             {


### PR DESCRIPTION
Add unicorn/prefer-number-coercion to prefer Number() over parseFloat() and Math.trunc(Number()) over base-10 parseInt(), with suggestion fixes and tests for radix, arity, shadowing, computed members, and nested calls.

Refs #684