### PR TITLE
refactor(linter/vue): extract computed getter utils into utils/vue.rs

### DIFF
--- a/crates/oxc_linter/src/rules/vue/no_async_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_async_in_computed_properties.rs
@@ -13,9 +13,8 @@ use oxc_span::{GetSpan, Span};
 use crate::{
     AstNode,
     context::{ContextHost, LintContext},
-    module_record::ImportImportName,
     rule::{DefaultRuleConfig, Rule},
-    utils::{is_this_object, is_vue_component_options_object},
+    utils::{ComputedContext, find_computed_context, get_computed_getter_context, is_this_object},
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -179,125 +178,13 @@ fn report(span: Span, ctx_kind: &ComputedContext, kind: AsyncKind, ctx: &LintCon
             let key = key.as_deref().unwrap_or("Unknown");
             ctx.diagnostic(unexpected_in_property(span, kind, key));
         }
-        ComputedContext::CompositionApi => {
+        // The shared `ComputedContext::CompositionApi` carries a getter span used by
+        // `no-side-effects-in-computed-properties` for setup-variable detection; this rule
+        // doesn't need it.
+        ComputedContext::CompositionApi(_) => {
             ctx.diagnostic(unexpected_in_function(span, kind));
         }
     }
-}
-
-// Describe where a computed getter lives. Mirrors `no_side_effects_in_computed_properties`,
-// but only the Options API variant needs to carry the property key — `no-async` does not
-// inspect the getter body for setup variables.
-enum ComputedContext {
-    OptionsApi(Option<String>),
-    CompositionApi,
-}
-
-/// Find the computed getter context for `node` by walking up to the nearest enclosing function
-/// and checking if that function is a computed getter.
-fn find_computed_context(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<ComputedContext> {
-    let nodes = ctx.nodes();
-    let mut current = nodes.parent_node(node.id());
-    loop {
-        match current.kind() {
-            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {
-                return get_computed_getter_context(current, ctx);
-            }
-            AstKind::Program(_) => return None,
-            _ => {
-                current = nodes.parent_node(current.id());
-            }
-        }
-    }
-}
-
-/// Given a function node, return Some(ComputedContext) if it is a computed getter.
-fn get_computed_getter_context(
-    fn_node: &AstNode<'_>,
-    ctx: &LintContext<'_>,
-) -> Option<ComputedContext> {
-    let nodes = ctx.nodes();
-    let parent = nodes.parent_node(fn_node.id());
-
-    match parent.kind() {
-        AstKind::CallExpression(call) if is_vue_computed_call(call, ctx) => {
-            return Some(ComputedContext::CompositionApi);
-        }
-        AstKind::ObjectProperty(prop) => {
-            let grandparent = nodes.parent_node(parent.id());
-            let AstKind::ObjectExpression(_) = grandparent.kind() else { return None };
-            let great = nodes.parent_node(grandparent.id());
-
-            match great.kind() {
-                // Case A: `computed: { key() {} }` or `computed: { key: function() {} }`
-                AstKind::ObjectProperty(outer)
-                    if outer.key.is_specific_static_name("computed")
-                        && matches!(fn_node.kind(), AstKind::Function(_)) =>
-                {
-                    let vue_options = nodes.parent_node(great.id());
-                    if is_vue_component_options_object(vue_options, ctx) {
-                        let key = prop.key.static_name().map(|s| s.to_string());
-                        return Some(ComputedContext::OptionsApi(key));
-                    }
-                }
-
-                // Case B: `computed: { key: { get() {} } }`
-                AstKind::ObjectProperty(key_prop)
-                    if prop.key.is_specific_static_name("get")
-                        && matches!(fn_node.kind(), AstKind::Function(_)) =>
-                {
-                    let key_obj_expr = nodes.parent_node(great.id());
-                    let AstKind::ObjectExpression(_) = key_obj_expr.kind() else { return None };
-                    let computed_prop_node = nodes.parent_node(key_obj_expr.id());
-                    if let AstKind::ObjectProperty(cp) = computed_prop_node.kind()
-                        && cp.key.is_specific_static_name("computed")
-                    {
-                        let vue_options = nodes.parent_node(computed_prop_node.id());
-                        if is_vue_component_options_object(vue_options, ctx) {
-                            let key = key_prop.key.static_name().map(|s| s.to_string());
-                            return Some(ComputedContext::OptionsApi(key));
-                        }
-                    }
-                }
-
-                // Case C: Composition API with `computed({ get() {}, set() {} })`
-                AstKind::CallExpression(call)
-                    if prop.key.is_specific_static_name("get")
-                        && is_vue_computed_call(call, ctx) =>
-                {
-                    return Some(ComputedContext::CompositionApi);
-                }
-
-                _ => {}
-            }
-        }
-
-        _ => {}
-    }
-
-    None
-}
-
-/// Check if a `computed(...)` call uses the `computed` export from `'vue'`,
-/// `'@vue/composition-api'`, or `'#imports'` (Nuxt), including aliases.
-fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
-    let Expression::Identifier(ident) = call.callee.get_inner_expression() else {
-        return false;
-    };
-    let scoping = ctx.scoping();
-    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
-        return false;
-    };
-    ctx.module_record().import_entries.iter().any(|entry| {
-        if !matches!(entry.module_request.name(), "vue" | "@vue/composition-api" | "#imports") {
-            return false;
-        }
-        let ImportImportName::Name(name_span) = &entry.import_name else { return false };
-        if name_span.name() != "computed" {
-            return false;
-        }
-        scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id)
-    })
 }
 
 const PROMISE_FUNCTIONS: &[&str] = &["then", "catch", "finally"];

--- a/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
+++ b/crates/oxc_linter/src/rules/vue/no_side_effects_in_computed_properties.rs
@@ -10,9 +10,10 @@ use crate::{
     AstNode,
     context::LintContext,
     frameworks::FrameworkOptions,
-    module_record::ImportImportName,
     rule::Rule,
-    utils::{is_this_object, is_vue_component_options_object},
+    utils::{
+        ComputedContext, find_computed_context, is_this_object, is_vue_component_options_object,
+    },
 };
 
 fn unexpected_side_effect_in_property(span: Span, key: &str) -> OxcDiagnostic {
@@ -161,133 +162,6 @@ fn check_mutation<'a>(node: &AstNode<'a>, object: &Expression<'a>, ctx: &LintCon
         }
         None => {}
     }
-}
-
-// Describe where a computed getter lives
-enum ComputedContext {
-    OptionsApi(Option<String>), // key name (None if unnamed/unknown)
-    CompositionApi(Span),       // span of the getter function (to detect locally-declared vars)
-}
-
-/// Find the computed getter context for `node` by walking up to the nearest enclosing function
-/// and checking if that function is a computed getter.
-/// Returns None if the nearest function is NOT a computed getter (nested function case).
-fn find_computed_context(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<ComputedContext> {
-    let nodes = ctx.nodes();
-    let mut current = nodes.parent_node(node.id());
-
-    loop {
-        match current.kind() {
-            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {
-                // Found the nearest enclosing function — check if it's a computed getter
-                return get_computed_getter_context(current, ctx);
-            }
-            AstKind::Program(_) => return None,
-            _ => {
-                current = nodes.parent_node(current.id());
-            }
-        }
-    }
-}
-
-/// Given a function node, return Some(ComputedContext) if it is a computed getter.
-fn get_computed_getter_context(
-    fn_node: &AstNode<'_>,
-    ctx: &LintContext<'_>,
-) -> Option<ComputedContext> {
-    let nodes = ctx.nodes();
-    let fn_span = fn_node.span();
-    let parent = nodes.parent_node(fn_node.id());
-
-    match parent.kind() {
-        // Composition API: `computed(fn)` or `computed(() => ...)`
-        AstKind::CallExpression(call) if is_vue_computed_call(call, ctx) => {
-            return Some(ComputedContext::CompositionApi(fn_span));
-        }
-
-        AstKind::ObjectProperty(prop) => {
-            let grandparent = nodes.parent_node(parent.id());
-            let AstKind::ObjectExpression(_) = grandparent.kind() else { return None };
-            let great = nodes.parent_node(grandparent.id());
-
-            match great.kind() {
-                // Case A: `computed: { key() {} }` or `computed: { key: function() {} }`
-                // Arrow functions are excluded: ESLint's getComputedProperties only matches
-                // FunctionExpression, so `computed: { foo: () => { this.x=1 } }` is not analyzed.
-                // Direct-parent check: `great`'s parent must be the Vue options object itself so
-                // that `computed:` keys nested inside e.g. `data()` return values are not matched.
-                AstKind::ObjectProperty(outer)
-                    if outer.key.is_specific_static_name("computed")
-                        && matches!(fn_node.kind(), AstKind::Function(_)) =>
-                {
-                    let vue_options = nodes.parent_node(great.id());
-                    if is_vue_component_options_object(vue_options, ctx) {
-                        let key = prop.key.static_name().map(|s| s.to_string());
-                        return Some(ComputedContext::OptionsApi(key));
-                    }
-                }
-
-                // Case B: `computed: { key: { get() {} } }`
-                // fn -> ObjectProperty(get) -> ObjectExpression -> ObjectProperty(key)
-                //     -> ObjectExpression(computed body) -> ObjectProperty(computed)
-                // Arrow functions are excluded here as well (same reasoning as Case A).
-                AstKind::ObjectProperty(key_prop)
-                    if prop.key.is_specific_static_name("get")
-                        && matches!(fn_node.kind(), AstKind::Function(_)) =>
-                {
-                    let key_obj_expr = nodes.parent_node(great.id());
-                    let AstKind::ObjectExpression(_) = key_obj_expr.kind() else { return None };
-                    let computed_prop_node = nodes.parent_node(key_obj_expr.id());
-                    if let AstKind::ObjectProperty(cp) = computed_prop_node.kind()
-                        && cp.key.is_specific_static_name("computed")
-                    {
-                        let vue_options = nodes.parent_node(computed_prop_node.id());
-                        if is_vue_component_options_object(vue_options, ctx) {
-                            let key = key_prop.key.static_name().map(|s| s.to_string());
-                            return Some(ComputedContext::OptionsApi(key));
-                        }
-                    }
-                }
-
-                // Case C: Composition API with `computed({ get() {}, set() {} })`
-                AstKind::CallExpression(call)
-                    if prop.key.is_specific_static_name("get")
-                        && is_vue_computed_call(call, ctx) =>
-                {
-                    return Some(ComputedContext::CompositionApi(fn_span));
-                }
-
-                _ => {}
-            }
-        }
-
-        _ => {}
-    }
-
-    None
-}
-
-/// Check if a `computed(...)` call uses the `computed` export from `'vue'`,
-/// `'@vue/composition-api'`, or `'#imports'` (Nuxt), including aliases
-/// (`import { computed as c } from 'vue'`). Matches by symbol ID so the local name is irrelevant.
-fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
-    let Expression::Identifier(ident) = call.callee.get_inner_expression() else {
-        return false;
-    };
-    let scoping = ctx.scoping();
-    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
-        return false;
-    };
-    ctx.module_record().import_entries.iter().any(|entry| {
-        if !matches!(entry.module_request.name(), "vue" | "@vue/composition-api" | "#imports") {
-            return false;
-        }
-        let ImportImportName::Name(name_span) = &entry.import_name else { return false };
-        if name_span.name() != "computed" {
-            return false;
-        }
-        scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id)
-    })
 }
 
 const MUTATING_METHODS: &[&str] =

--- a/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
+++ b/crates/oxc_linter/src/rules/vue/return_in_computed_property.rs
@@ -1,7 +1,4 @@
-use oxc_ast::{
-    AstKind,
-    ast::{CallExpression, Expression},
-};
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -11,9 +8,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     AstNode,
     context::{ContextHost, LintContext},
-    module_record::ImportImportName,
     rule::{DefaultRuleConfig, Rule},
-    utils::{definitely_returns_in_all_codepaths, is_vue_component_options_object},
+    utils::{definitely_returns_in_all_codepaths, get_computed_getter_context},
 };
 
 fn return_in_computed_property_diagnostic(span: Span) -> OxcDiagnostic {
@@ -108,7 +104,7 @@ impl Rule for ReturnInComputedProperty {
             _ => return,
         };
 
-        if !is_vue_computed_getter(node, ctx) {
+        if get_computed_getter_context(node, ctx).is_none() {
             return;
         }
 
@@ -116,105 +112,6 @@ impl Rule for ReturnInComputedProperty {
             ctx.diagnostic(return_in_computed_property_diagnostic(span));
         }
     }
-}
-
-fn is_vue_computed_getter(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    let nodes = ctx.nodes();
-    let parent = nodes.parent_node(node.id());
-
-    let AstKind::ObjectProperty(prop) = parent.kind() else {
-        // `computed(() => {...})` / `computed(function() {...})` —
-        // the function is the direct argument of a `computed(...)` call.
-        return matches!(
-            parent.kind(),
-            AstKind::CallExpression(call) if is_vue_computed_call(call, ctx)
-        );
-    };
-
-    // `set` accessors are setters — they don't need to return.
-    if prop.key.is_specific_static_name("set") {
-        return false;
-    }
-
-    let opts_node = nodes.parent_node(parent.id());
-    if !matches!(opts_node.kind(), AstKind::ObjectExpression(_)) {
-        return false;
-    }
-    let outer = nodes.parent_node(opts_node.id());
-
-    // Case A: `computed: { foo() {...} }` or `computed: { foo: function() {...} }`
-    //   function -> ObjectProperty(foo) -> ObjectExpression(computed body)
-    //            -> ObjectProperty(computed) [outer]
-    if let AstKind::ObjectProperty(outer_prop) = outer.kind()
-        && outer_prop.key.is_specific_static_name("computed")
-    {
-        return is_under_vue_root(outer, ctx);
-    }
-
-    // The remaining cases assume `prop` is the `get` accessor of a get/set object.
-    if !prop.key.is_specific_static_name("get") {
-        return false;
-    }
-
-    // Case B: `computed: { foo: { get() {...} } }`
-    //   get() -> ObjectProperty(get) -> ObjectExpression(get/set obj)
-    //         -> ObjectProperty(foo) [outer]
-    //         -> ObjectExpression(computed body)
-    //         -> ObjectProperty(computed)
-    if let AstKind::ObjectProperty(_) = outer.kind() {
-        let computed_body = nodes.parent_node(outer.id());
-        if !matches!(computed_body.kind(), AstKind::ObjectExpression(_)) {
-            return false;
-        }
-        let computed_prop = nodes.parent_node(computed_body.id());
-        if let AstKind::ObjectProperty(cp) = computed_prop.kind()
-            && cp.key.is_specific_static_name("computed")
-        {
-            return is_under_vue_root(computed_prop, ctx);
-        }
-        return false;
-    }
-
-    // Case C: `computed({ get() {...}, set() {} })`
-    //   get() -> ObjectProperty(get) -> ObjectExpression(get/set obj)
-    //         -> CallExpression(computed) [outer]
-    if let AstKind::CallExpression(call) = outer.kind() {
-        return is_vue_computed_call(call, ctx);
-    }
-
-    false
-}
-
-fn is_under_vue_root(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
-    ctx.nodes().ancestors(node.id()).any(|a| is_vue_component_options_object(a, ctx))
-}
-
-fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
-    let Expression::Identifier(ident) = call.callee.get_inner_expression() else {
-        return false;
-    };
-    if ident.name != "computed" {
-        return false;
-    }
-
-    let scoping = ctx.scoping();
-    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
-        return false;
-    };
-
-    ctx.module_record().import_entries.iter().any(|entry| {
-        if entry.module_request.name() != "vue" {
-            return false;
-        }
-        let imported_name = match &entry.import_name {
-            ImportImportName::Name(name_span) => name_span.name(),
-            _ => return false,
-        };
-        if imported_name != "computed" {
-            return false;
-        }
-        scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id)
-    })
 }
 
 #[test]

--- a/crates/oxc_linter/src/utils/vue.rs
+++ b/crates/oxc_linter/src/utils/vue.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
         ObjectExpression, ObjectProperty, ObjectPropertyKind, TSSignature, TSType, TSTypeName,
     },
 };
-use oxc_span::GetSpan;
+use oxc_span::{GetSpan, Span};
 
 use crate::{
     AstNode, ContextSubHost, LintContext, ast_util::get_declaration_from_reference_id,
@@ -417,4 +417,137 @@ pub fn for_each_define_props_type_signature<'a>(
         }
         _ => {}
     }
+}
+
+/// Describe where a computed getter lives — shared by Vue rules that need to detect
+/// expressions inside `computed` getters (`no-side-effects-in-computed-properties`,
+/// `no-async-in-computed-properties`).
+pub enum ComputedContext {
+    /// Options API: `computed: { foo() {...} }` / `computed: { foo: { get() {...} } }`.
+    /// Carries the property key name (None if it can't be resolved statically).
+    OptionsApi(Option<String>),
+    /// Composition API: `computed(fn)` / `computed({ get: fn })`. Carries the span of
+    /// the getter function so callers can distinguish setup-scope vs getter-local
+    /// variables.
+    CompositionApi(Span),
+}
+
+/// Walk up from `node` to the nearest enclosing function, then return the computed
+/// getter context for that function (None if it isn't a computed getter, or if the
+/// walk reaches `Program` first).
+pub fn find_computed_context(node: &AstNode<'_>, ctx: &LintContext<'_>) -> Option<ComputedContext> {
+    let nodes = ctx.nodes();
+    let mut current = nodes.parent_node(node.id());
+    loop {
+        match current.kind() {
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {
+                return get_computed_getter_context(current, ctx);
+            }
+            AstKind::Program(_) => return None,
+            _ => {
+                current = nodes.parent_node(current.id());
+            }
+        }
+    }
+}
+
+/// Classify a function node: return `Some(ComputedContext)` if it is a Vue computed
+/// getter. Mirrors upstream `getComputedProperties` shape resolution.
+///
+/// Recognized shapes:
+/// - Options API Case A: `computed: { key() {...} }` / `computed: { key: function() {...} }`
+///   (FunctionExpression only — arrow functions are excluded to match upstream)
+/// - Options API Case B: `computed: { key: { get() {...} } }`
+///   (FunctionExpression only — same reasoning as Case A)
+/// - Composition API Case C: `computed(fn)` / `computed({ get: fn })` (both Function and Arrow)
+pub fn get_computed_getter_context(
+    fn_node: &AstNode<'_>,
+    ctx: &LintContext<'_>,
+) -> Option<ComputedContext> {
+    let nodes = ctx.nodes();
+    let fn_span = fn_node.span();
+    let parent = nodes.parent_node(fn_node.id());
+
+    match parent.kind() {
+        // Case C variant: `computed(fn)` / `computed(() => ...)` directly
+        AstKind::CallExpression(call) if is_vue_computed_call(call, ctx) => {
+            return Some(ComputedContext::CompositionApi(fn_span));
+        }
+
+        AstKind::ObjectProperty(prop) => {
+            let grandparent = nodes.parent_node(parent.id());
+            let AstKind::ObjectExpression(_) = grandparent.kind() else { return None };
+            let great = nodes.parent_node(grandparent.id());
+
+            match great.kind() {
+                // Case A: `computed: { key() {} }` or `computed: { key: function() {} }`
+                AstKind::ObjectProperty(outer)
+                    if outer.key.is_specific_static_name("computed")
+                        && matches!(fn_node.kind(), AstKind::Function(_)) =>
+                {
+                    let vue_options = nodes.parent_node(great.id());
+                    if is_vue_component_options_object(vue_options, ctx) {
+                        let key = prop.key.static_name().map(|s| s.to_string());
+                        return Some(ComputedContext::OptionsApi(key));
+                    }
+                }
+
+                // Case B: `computed: { key: { get() {} } }`
+                AstKind::ObjectProperty(key_prop)
+                    if prop.key.is_specific_static_name("get")
+                        && matches!(fn_node.kind(), AstKind::Function(_)) =>
+                {
+                    let key_obj_expr = nodes.parent_node(great.id());
+                    let AstKind::ObjectExpression(_) = key_obj_expr.kind() else { return None };
+                    let computed_prop_node = nodes.parent_node(key_obj_expr.id());
+                    if let AstKind::ObjectProperty(cp) = computed_prop_node.kind()
+                        && cp.key.is_specific_static_name("computed")
+                    {
+                        let vue_options = nodes.parent_node(computed_prop_node.id());
+                        if is_vue_component_options_object(vue_options, ctx) {
+                            let key = key_prop.key.static_name().map(|s| s.to_string());
+                            return Some(ComputedContext::OptionsApi(key));
+                        }
+                    }
+                }
+
+                // Case C variant: `computed({ get() {}, set() {} })`
+                AstKind::CallExpression(call)
+                    if prop.key.is_specific_static_name("get")
+                        && is_vue_computed_call(call, ctx) =>
+                {
+                    return Some(ComputedContext::CompositionApi(fn_span));
+                }
+
+                _ => {}
+            }
+        }
+
+        _ => {}
+    }
+
+    None
+}
+
+/// Whether `call` is a `computed(...)` call that imports from `'vue'`,
+/// `'@vue/composition-api'`, or `'#imports'` (Nuxt). Matches by symbol id so
+/// aliases (`import { computed as c } from 'vue'`) are also recognized.
+pub fn is_vue_computed_call(call: &CallExpression<'_>, ctx: &LintContext<'_>) -> bool {
+    let Expression::Identifier(ident) = call.callee.get_inner_expression() else {
+        return false;
+    };
+    let scoping = ctx.scoping();
+    let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
+        return false;
+    };
+    ctx.module_record().import_entries.iter().any(|entry| {
+        if !matches!(entry.module_request.name(), "vue" | "@vue/composition-api" | "#imports") {
+            return false;
+        }
+        let ImportImportName::Name(name_span) = &entry.import_name else { return false };
+        if name_span.name() != "computed" {
+            return false;
+        }
+        scoping.get_root_binding(entry.local_name.name().into()) == Some(symbol_id)
+    })
 }


### PR DESCRIPTION
Follow-up to #23493.

Shares the computed-getter detection helpers across `no-side-effects-in-computed-properties`, `no-async-in-computed-properties`, and `return-in-computed-property`. The last one previously accepted arrow getters in Options API by accident — now aligned with upstream's `getComputedProperties`.
