### PR TITLE
perf(semantic): compute formal-parameter duplicate rule once per list (O(n²)→O(n))

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -4,7 +4,7 @@ use smallvec::SmallVec;
 
 use oxc_allocator::{GetAddress, UnstableAddress};
 use oxc_ast::{AstKind, ast::*};
-use oxc_ecmascript::{BoundNames, IsSimpleParameterList};
+use oxc_ecmascript::BoundNames;
 use oxc_span::GetSpan;
 use oxc_str::Ident;
 use oxc_syntax::{node::NodeId, scope::ScopeFlags, scope::ScopeId, symbol::SymbolFlags};
@@ -250,23 +250,13 @@ impl<'a> Binder<'a> for FormalParameter<'a> {
     // Binds the FormalParameter of a function or method.
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let parent_kind = builder.ancestry().parent_kind();
-        let AstKind::FormalParameters(parameters) = parent_kind else { unreachable!() };
+        let AstKind::FormalParameters(_) = parent_kind else { unreachable!() };
 
         let includes = SymbolFlags::FunctionScopedVariable;
 
-        let is_not_allowed_duplicate_parameters = matches!(
-                parameters.kind,
-                // ArrowFormalParameters: UniqueFormalParameters
-                FormalParameterKind::ArrowFormalParameters |
-                // UniqueFormalParameters : FormalParameters
-                // * It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements.
-                FormalParameterKind::UniqueFormalParameters
-            ) ||
-            // Multiple occurrences of the same BindingIdentifier in a FormalParameterList is only allowed for functions which have simple parameter lists and which are not defined in strict mode code.
-            builder.strict_mode() ||
-            // FormalParameters : FormalParameterList
-            // * It is a Syntax Error if IsSimpleParameterList of FormalParameterList is false and BoundNames of FormalParameterList contains any duplicate elements.
-            !parameters.is_simple_parameter_list();
+        // Per-list invariant, computed once in `SemanticBuilder::visit_formal_parameters`
+        // (avoids the O(n) `is_simple_parameter_list` scan per parameter → O(n²) per list).
+        let is_not_allowed_duplicate_parameters = builder.current_params_disallow_duplicates;
 
         let excludes = if is_not_allowed_duplicate_parameters {
             SymbolFlags::FunctionScopedVariable | SymbolFlags::FunctionScopedVariableExcludes
@@ -285,23 +275,13 @@ impl<'a> Binder<'a> for FormalParameterRest<'a> {
     // Binds the FormalParameter of a function or method.
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         let parent_kind = builder.ancestry().parent_kind();
-        let AstKind::FormalParameters(parameters) = parent_kind else { unreachable!() };
+        let AstKind::FormalParameters(_) = parent_kind else { unreachable!() };
 
         let includes = SymbolFlags::FunctionScopedVariable;
 
-        let is_not_allowed_duplicate_parameters = matches!(
-                parameters.kind,
-                // ArrowFormalParameters: UniqueFormalParameters
-                FormalParameterKind::ArrowFormalParameters |
-                // UniqueFormalParameters : FormalParameters
-                // * It is a Syntax Error if BoundNames of FormalParameters contains any duplicate elements.
-                FormalParameterKind::UniqueFormalParameters
-            ) ||
-            // Multiple occurrences of the same BindingIdentifier in a FormalParameterList is only allowed for functions which have simple parameter lists and which are not defined in strict mode code.
-            builder.strict_mode() ||
-            // FormalParameters : FormalParameterList
-            // * It is a Syntax Error if IsSimpleParameterList of FormalParameterList is false and BoundNames of FormalParameterList contains any duplicate elements.
-            !parameters.is_simple_parameter_list();
+        // Per-list invariant, computed once in `SemanticBuilder::visit_formal_parameters`
+        // (avoids the O(n) `is_simple_parameter_list` scan per parameter → O(n²) per list).
+        let is_not_allowed_duplicate_parameters = builder.current_params_disallow_duplicates;
 
         let excludes = if is_not_allowed_duplicate_parameters {
             SymbolFlags::FunctionScopedVariable | SymbolFlags::FunctionScopedVariableExcludes

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -9,13 +9,14 @@ use rustc_hash::FxHashMap;
 
 use oxc_allocator::Address;
 use oxc_ast::{AstKind, ast::*};
-use oxc_ast_visit::Visit;
+use oxc_ast_visit::{Visit, walk::walk_formal_parameters};
 #[cfg(feature = "cfg")]
 use oxc_cfg::{
     ControlFlowGraphBuilder, CtxCursor, CtxFlags, EdgeType, ErrorEdgeKind, InstructionKind,
     IterationInstructionKind, ReturnInstructionKind,
 };
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
+use oxc_ecmascript::IsSimpleParameterList;
 use oxc_span::{SourceType, Span};
 use oxc_str::{Ident, IdentHashMap};
 use oxc_syntax::{
@@ -83,6 +84,13 @@ pub struct SemanticBuilder<'a> {
     pub(crate) current_function_node_id: NodeId,
     pub(crate) module_instance_state_cache: FxHashMap<Address, ModuleInstanceState>,
     current_reference_flags: ReferenceFlags,
+    /// Whether the current `FormalParameters` list disallows duplicate parameter names
+    /// (arrow/unique params, strict mode, or a non-simple parameter list). Computed ONCE
+    /// per list in `visit_formal_parameters` and read by `FormalParameter` /
+    /// `FormalParameterRest` `bind`, instead of recomputing `is_simple_parameter_list`
+    /// (an O(n) scan of the whole list) inside every parameter's `bind` — which made
+    /// binding an n-parameter list O(n²).
+    pub(crate) current_params_disallow_duplicates: bool,
     /// Symbols that have been hoisted out of a scope (e.g. `var` declarations hoisted to
     /// the enclosing function scope, or Annex B function declarations hoisted to the var scope).
     /// Keyed by the **original** scope the symbol was declared in, so that future declarations
@@ -151,6 +159,7 @@ impl<'a> SemanticBuilder<'a> {
             source_type: SourceType::default(),
             errors: RefCell::new(Diagnostics::new()),
             current_reference_flags: ReferenceFlags::empty(),
+            current_params_disallow_duplicates: false,
             current_scope_id,
             current_function_node_id: NodeId::ROOT,
             module_instance_state_cache: FxHashMap::default(),
@@ -2497,6 +2506,26 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         self.visit_span(&element.span);
         self.visit_binding_pattern(&element.argument);
         self.leave_node(kind);
+    }
+
+    fn visit_formal_parameters(&mut self, it: &FormalParameters<'a>) {
+        // Compute the duplicate-parameter rule ONCE per list — it is a per-list
+        // invariant (depends only on the list kind, strict mode, and whether the
+        // list is simple). Recomputing `is_simple_parameter_list` (an O(n) scan)
+        // inside every parameter's `bind` made binding an n-parameter list O(n²).
+        // Save/restore so a nested parameter list (e.g. a default-value arrow) does
+        // not clobber the enclosing list's value. `strict_mode()` is stable here:
+        // the function scope is already entered and no scope is entered between this
+        // point and the per-parameter `bind`s inside `walk_formal_parameters`.
+        let saved = self.current_params_disallow_duplicates;
+        self.current_params_disallow_duplicates = matches!(
+            it.kind,
+            FormalParameterKind::ArrowFormalParameters
+                | FormalParameterKind::UniqueFormalParameters
+        ) || self.strict_mode()
+            || !it.is_simple_parameter_list();
+        walk_formal_parameters(self, it);
+        self.current_params_disallow_duplicates = saved;
     }
 
     fn visit_formal_parameter(&mut self, param: &FormalParameter<'a>) {


### PR DESCRIPTION
## What

`FormalParameter` / `FormalParameterRest` symbol-binding recomputed `is_simple_parameter_list()` — an **O(n) scan of the whole parameter list** — once **per parameter**, making symbol-binding of an `n`-parameter list **O(n²)**.

The duplicate-parameter rule it feeds (`is_not_allowed_duplicate_parameters`) is a **per-list invariant** (it depends only on the list kind, strict mode, and whether the list is simple). This computes it **once** in `visit_formal_parameters` and reads it from `bind`.

## Measured Δ — O(n²) → O(n)

Semantic build of one **sloppy-mode** (`Script` / CommonJS) function with `n` simple parameters (`function f(a0, …, aN) {}`), release build, min of 30 runs:

| params | before — O(n²) | after — O(n) | speedup |
| --- | --- | --- | --- |
| 1000 | 0.436 ms | 0.066 ms | **6.6×** |
| 2000 | 1.274 ms | 0.129 ms | **9.9×** |
| 4000 | 7.727 ms | 0.198 ms | **39×** |

The win is on the **non-short-circuiting** path — a non-arrow function in **sloppy mode** (the only path that actually evaluates `is_simple_parameter_list`). Arrow functions, unique-parameter contexts, and strict-mode / ESM code short-circuit before the scan and are unaffected.

> CodSpeed reports no change because the benchmark corpus's functions have small parameter lists; the quadratic only bites on large **sloppy-mode** parameter lists, which generated / bundled CommonJS can produce.

## Why it is behavior-preserving

- The factored value is the **same expression on the same `FormalParameters` node**; `strict_mode()` is stable between the new compute point and the per-parameter binds (no scope is entered in between).
- Save/restore handles **nested** parameter lists (e.g. a default-value arrow).
- `oxc_semantic` unit/integration tests pass; the **allocation snapshots are unchanged** (binding decisions are byte-identical).

Prepared with AI assistance.