### PR TITLE
fix(linter/jsx-a11y/no-noninteractive-element-to-interactive-role): allow custom roles config

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_to_interactive_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_to_interactive_role.rs
@@ -75,7 +75,6 @@ pub struct NoNoninteractiveElementToInteractiveRole(
 );
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
 struct NoNoninteractiveElementToInteractiveRoleConfig {
     /// A mapping of HTML element names to arrays of ARIA role strings that are
     /// allowed overrides for that element. For example, `{ "ul": ["menu", "tablist"] }`
@@ -215,6 +214,12 @@ fn test() {
         })
     }
 
+    fn custom_allowed_roles_config() -> serde_json::Value {
+        serde_json::json!([{
+            "table": ["grid"],
+        }])
+    }
+
     // Default config uses recommended allowed roles.
     let pass = vec![
         // Custom components (not in HTML_TAG — skipped)
@@ -334,6 +339,7 @@ fn test() {
         (r#"<li role="treeitem" />"#, None, None),
         (r#"<fieldset role="radiogroup" />"#, None, None),
         (r#"<fieldset role="presentation" />"#, None, None),
+        (r#"<table role="grid" />"#, Some(custom_allowed_roles_config()), None),
     ];
 
     let fail = vec![
@@ -420,6 +426,7 @@ fn test() {
         (r#"<thead role="menuitem" />"#, None, None),
         // Custom component mapped via settings to non-interactive element
         (r#"<Article role="button" />"#, None, Some(components_settings())),
+        (r#"<table role="button" />"#, Some(custom_allowed_roles_config()), None),
     ];
 
     // Strict mode tests: recommended allowed overrides become invalid.

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_element_to_interactive_role.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_no_noninteractive_element_to_interactive_role.snap
@@ -563,6 +563,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the interactive role or use an appropriate interactive element instead.
 
   ⚠ jsx-a11y(no-noninteractive-element-to-interactive-role): Non-interactive elements should not be assigned interactive roles.
+   ╭─[no_noninteractive_element_to_interactive_role.tsx:1:8]
+ 1 │ <table role="button" />
+   ·        ─────────────
+   ╰────
+  help: Remove the interactive role or use an appropriate interactive element instead.
+
+  ⚠ jsx-a11y(no-noninteractive-element-to-interactive-role): Non-interactive elements should not be assigned interactive roles.
    ╭─[no_noninteractive_element_to_interactive_role.tsx:1:5]
  1 │ <ul role="menu" />
    ·     ───────────


### PR DESCRIPTION
Allow `jsx-a11y/no-noninteractive-element-to-interactive-role` to deserialize custom element-to-role option maps instead of rejecting arbitrary element keys like `ul`, `table`, or `td`. The config still applies narrowly: allowed custom roles pass, while unlisted interactive roles continue to report.

Fixes #23476