### PR TITLE
perf(linter/eslint/max-classes): gate rule by rule config threshold

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -133,7 +133,13 @@ impl Rule for MaxClassesPerFile {
     }
 
     fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.semantic().classes().len() > 0
+        let classes = ctx.semantic().classes();
+        let max = usize::try_from(self.max).unwrap_or(usize::MAX);
+        if self.ignore_expressions {
+            return classes.declarations.len() > max;
+        }
+
+        classes.len() > max
     }
 }
 


### PR DESCRIPTION
- Gate `max-classes-per-file` execution on whether the configured class limit can be exceeded.
- Use total class count normally, and declaration count when `ignoreExpressions` excludes class expressions from the rule.