### PR TITLE
fix(linter/react/display-name): ignore lowercase jsx helpers

### DIFF
--- a/crates/oxc_linter/src/rules/react/display_name.rs
+++ b/crates/oxc_linter/src/rules/react/display_name.rs
@@ -490,7 +490,10 @@ fn is_react_component_node<'a>(
             // Check for function/arrow function components with JSX
             if let Some(expr) = &decl.init {
                 // Check if it's a direct component (has JSX directly)
-                if expression_contains_jsx(expr) {
+                let contains_jsx = expression_contains_jsx(expr);
+                if contains_jsx
+                    && name.as_ref().is_some_and(|name| is_react_component_name(name.as_str()))
+                {
                     return Some(ReactComponentInfo {
                         span: decl.id.span(),
                         is_context: false,
@@ -499,7 +502,9 @@ fn is_react_component_node<'a>(
                 }
 
                 // Check if it's a HOF pattern
-                if let Some(innermost) = find_innermost_function_with_jsx(expr, ctx) {
+                if !contains_jsx
+                    && let Some(innermost) = find_innermost_function_with_jsx(expr, ctx)
+                {
                     let inner_has_name = match innermost {
                         InnermostFunction::Function(func) => func.id.is_some(),
                         InnermostFunction::ArrowFunction => false,
@@ -1760,6 +1765,17 @@ fn test() {
                       return <div>Hello {this.props.name}</div>;
                     }
                     Hello.displayName = 'Hello';
+                  ",
+            Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
+            None,
+        ),
+        (
+            "
+                    export default function Testing() {
+                      const renderThing = () => <div>Thing</div>;
+                      return <div>{renderThing()}</div>;
+                    }
+                    Testing.displayName = 'Testing';
                   ",
             Some(serde_json::json!([{ "ignoreTranspilerName": true }])),
             None,


### PR DESCRIPTION
`react/display-name` was treating any variable initialized with JSX as a component, so lowercase render helpers used inside components required `displayName`. Match `eslint-plugin-react`'s component-name boundary by only treating direct variable JSX initializers as components when the binding is component-shaped, while keeping the existing HOF detection for nested component factories.

Fixes #23478