### PR TITLE
fix(linter/unicorn/prefer-spread): don't report `.slice()` on non-array receivers

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -370,9 +370,6 @@ fn test() {
         "array.slice(0, array.length)",
         "array.slice(0, 0)",
         "array.notSlice()",
-        // Non-array receivers must not be reported/auto-fixed: `"foo".slice()` returns a string,
-        // so `[..."foo"]` would be `["f","o","o"]` (different value and type). Matches
-        // eslint-plugin-unicorn, which bails on non-array receivers via `isNotArray`.
         r#""".slice()"#,
         r#""foo".slice()"#,
         "[...foo].slice()",

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -111,18 +111,17 @@ fn check_unicorn_prefer_spread<'a>(
 
             let member_expr_obj = member_expr.object().without_parentheses();
 
-            // Skip receivers that are statically known not to be arrays (e.g. string/number
-            // literals, template literals, `x.join()`). `"foo".slice()` returns a string, so the
-            // `[...x]` rewrite would change both value and type. Mirrors the `concat` arm and
-            // eslint-plugin-unicorn (which bails via `isNotArray`).
-            if is_not_array(member_expr_obj, ctx) {
-                return;
-            }
-
             if matches!(
                 member_expr_obj,
                 Expression::ArrayExpression(_) | Expression::ThisExpression(_)
             ) {
+                return;
+            }
+
+            // Skip receivers that are statically known not to be arrays (e.g. string/number
+            // literals, template literals, `x.join()`). `"foo".slice()` returns a string, so the
+            // `[...x]` rewrite would change both value and type.
+            if is_not_array(member_expr_obj, ctx) {
                 return;
             }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -111,6 +111,14 @@ fn check_unicorn_prefer_spread<'a>(
 
             let member_expr_obj = member_expr.object().without_parentheses();
 
+            // Skip receivers that are statically known not to be arrays (e.g. string/number
+            // literals, template literals, `x.join()`). `"foo".slice()` returns a string, so the
+            // `[...x]` rewrite would change both value and type. Mirrors the `concat` arm and
+            // eslint-plugin-unicorn (which bails via `isNotArray`).
+            if is_not_array(member_expr_obj, ctx) {
+                return;
+            }
+
             if matches!(
                 member_expr_obj,
                 Expression::ArrayExpression(_) | Expression::ThisExpression(_)
@@ -362,6 +370,11 @@ fn test() {
         "array.slice(0, array.length)",
         "array.slice(0, 0)",
         "array.notSlice()",
+        // Non-array receivers must not be reported/auto-fixed: `"foo".slice()` returns a string,
+        // so `[..."foo"]` would be `["f","o","o"]` (different value and type). Matches
+        // eslint-plugin-unicorn, which bails on non-array receivers via `isNotArray`.
+        r#""".slice()"#,
+        r#""foo".slice()"#,
         "[...foo].slice()",
         "[foo].slice()",
         "arrayBuffer.slice()",
@@ -577,7 +590,6 @@ fn test() {
         "(scopeManager?.scopes).slice()",
         "bar()
             foo.slice()",
-        r#""".slice()"#,
         "array.slice(0)",
         "array.slice(0b0)",
         "array.slice(0.00)",

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_spread.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_spread.snap
@@ -833,13 +833,6 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ unicorn(prefer-spread): Prefer the spread operator (`...`) over array.slice()
    ╭─[prefer_spread.tsx:1:1]
- 1 │ "".slice()
-   · ──────────
-   ╰────
-  help: The spread operator (`...`) is more concise and readable.
-
-  ⚠ unicorn(prefer-spread): Prefer the spread operator (`...`) over array.slice()
-   ╭─[prefer_spread.tsx:1:1]
  1 │ array.slice(0)
    · ──────────────
    ╰────


### PR DESCRIPTION
### Bug
`unicorn/prefer-spread`'s `slice` handler reports and auto-fixes `x.slice()`/`x.slice(0)` → `[...x]` without checking that `x` is an array (unlike the `concat` handler). For a non-array receiver this changes both value and type.

### Repro
`"foo".slice()` is flagged and auto-fixed to `[..."foo"]` — but `"foo".slice()` returns the string `"foo"`, while `[..."foo"]` is `["f","o","o"]`. (`"".slice()` likewise turns `""` into `[]`.)

### Expected
Don't report non-array receivers. eslint-plugin-unicorn bails here via `isNotArray` (true for string/number literals, template literals, binary expressions, `.join()` calls, and class names).

### Fix
Add the same `is_not_array` guard the `concat` arm already uses to the `slice` arm. Regression test: `"".slice()` moves to the pass tests and `"foo".slice()` is added (snapshot regenerated — only the `"".slice()` diagnostic is removed; all array receivers still report).

Prepared with AI assistance.