### PR TITLE
feat(linter): `unicorn/numeric-separators-style` support missing options

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -1,7 +1,7 @@
 use cow_utils::CowUtils;
 use oxc_ast::{
     AstKind,
-    ast::{BigIntLiteral, NumericLiteral},
+    ast::{BigIntLiteral, BigintBase, NumberBase, NumericLiteral},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -17,7 +17,7 @@ fn numeric_separators_style_diagnostic(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 pub struct NumericSeparatorsStyle(Box<NumericSeparatorsStyleConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Deserialize)]
@@ -39,7 +39,7 @@ pub struct NumericSeparatorsStyleConfig {
     octal: NumericBaseConfig,
     /// Configuration for decimal numbers (integers, fraction parts, and exponents).
     /// Controls how digits are grouped and when separators are applied.
-    number: NumericBaseConfig,
+    number: NumericNumberConfig,
 }
 
 impl std::ops::Deref for NumericSeparatorsStyle {
@@ -54,17 +54,34 @@ impl Default for NumericSeparatorsStyleConfig {
     fn default() -> Self {
         Self {
             only_if_contains_separator: false,
-            binary: NumericBaseConfig { group_length: 4, minimum_digits: 0 },
-            hexadecimal: NumericBaseConfig { group_length: 2, minimum_digits: 0 },
-            number: NumericBaseConfig { group_length: 3, minimum_digits: 5 },
-            octal: NumericBaseConfig { group_length: 4, minimum_digits: 0 },
+            binary: NumericBaseConfig {
+                group_length: 4,
+                minimum_digits: 0,
+                only_if_contains_separator: None,
+            },
+            hexadecimal: NumericBaseConfig {
+                group_length: 2,
+                minimum_digits: 0,
+                only_if_contains_separator: None,
+            },
+            number: NumericNumberConfig::default(),
+            octal: NumericBaseConfig {
+                group_length: 4,
+                minimum_digits: 0,
+                only_if_contains_separator: None,
+            },
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Default, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
 struct NumericBaseConfig {
+    /// Only enforce the rule when the numeric literal already contains a separator (`_`).
+    ///
+    /// When `true`, numbers without separators are left as-is; when `false` (default),
+    /// grouping will be enforced for eligible numbers even if they don't include separators yet.
+    only_if_contains_separator: Option<bool>,
     /// The number of digits per group when inserting numeric separators.
     /// For example, a `groupLength` of 3 formats `1234567` as `1_234_567`.
     group_length: usize,
@@ -81,9 +98,45 @@ impl NumericBaseConfig {
         if let Some(minimum_digits) = val.get("minimumDigits").and_then(serde_json::Value::as_u64) {
             self.minimum_digits = usize::try_from(minimum_digits).unwrap();
         }
+
+        if let Some(val) = val.get("onlyIfContainsSeparator").map(serde_json::Value::as_bool) {
+            self.only_if_contains_separator = val;
+        }
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct NumericNumberConfig {
+    #[serde(flatten)]
+    base: NumericBaseConfig,
+    /// The size a group of digits in the fractional part (after the decimal point) should be.
+    fraction_group_length: usize,
+}
+
+impl NumericNumberConfig {
+    pub(self) fn set_numeric_number_from_config(&mut self, val: &serde_json::Value) {
+        self.base.set_numeric_base_from_config(val);
+        if let Some(fraction_group_length) =
+            val.get("fractionGroupLength").and_then(serde_json::Value::as_u64)
+        {
+            self.fraction_group_length = usize::try_from(fraction_group_length).unwrap();
+        }
+    }
+}
+
+impl Default for NumericNumberConfig {
+    fn default() -> Self {
+        Self {
+            base: NumericBaseConfig {
+                group_length: 3,
+                minimum_digits: 5,
+                only_if_contains_separator: None,
+            },
+            fraction_group_length: usize::MAX,
+        }
+    }
+}
 declare_oxc_lint!(
     /// ### What it does
     ///
@@ -152,7 +205,7 @@ impl Rule for NumericSeparatorsStyle {
                 cfg.hexadecimal.set_numeric_base_from_config(config);
             }
             if let Some(config) = config.get("number") {
-                cfg.number.set_numeric_base_from_config(config);
+                cfg.number.set_numeric_number_from_config(config);
             }
             if let Some(config) = config.get("octal") {
                 cfg.octal.set_numeric_base_from_config(config);
@@ -172,7 +225,7 @@ impl Rule for NumericSeparatorsStyle {
         match node.kind() {
             AstKind::NumericLiteral(number) => {
                 let raw = number.raw.as_ref().unwrap().as_str();
-                if self.only_if_contains_separator && !raw.contains('_') {
+                if !raw.contains('_') && self.skip_number_separator(number.base) {
                     return;
                 }
 
@@ -187,7 +240,7 @@ impl Rule for NumericSeparatorsStyle {
             }
             AstKind::BigIntLiteral(number) => {
                 let raw = number.raw.unwrap().as_str();
-                if self.only_if_contains_separator && !raw.contains('_') {
+                if !raw.contains('_') && self.skip_bigint_separator(number.base) {
                     return;
                 }
 
@@ -206,6 +259,26 @@ impl Rule for NumericSeparatorsStyle {
 }
 
 impl NumericSeparatorsStyle {
+    fn skip_number_separator(&self, base: NumberBase) -> bool {
+        let base_config = match base {
+            NumberBase::Binary => self.binary.only_if_contains_separator,
+            NumberBase::Decimal | NumberBase::Float => self.number.base.only_if_contains_separator,
+            NumberBase::Hex => self.hexadecimal.only_if_contains_separator,
+            NumberBase::Octal => self.octal.only_if_contains_separator,
+        };
+        base_config.unwrap_or(self.only_if_contains_separator)
+    }
+
+    fn skip_bigint_separator(&self, base: BigintBase) -> bool {
+        let base_config = match base {
+            BigintBase::Binary => self.binary.only_if_contains_separator,
+            BigintBase::Decimal => self.number.base.only_if_contains_separator,
+            BigintBase::Hex => self.hexadecimal.only_if_contains_separator,
+            BigintBase::Octal => self.octal.only_if_contains_separator,
+        };
+        base_config.unwrap_or(self.only_if_contains_separator)
+    }
+
     fn format_number(&self, number: &NumericLiteral) -> String {
         use oxc_syntax::number::NumberBase;
 
@@ -237,7 +310,7 @@ impl NumericSeparatorsStyle {
 
         let mut to_format = raw_number[2..].cow_replace('_', "").into_owned();
 
-        add_separators(&mut to_format, &SeparatorDir::Right, &self.binary);
+        add_separators(&mut to_format, &SeparatorDir::Right, &self.binary, None);
         to_format.insert_str(0, prefix);
         to_format
     }
@@ -247,7 +320,7 @@ impl NumericSeparatorsStyle {
 
         let mut to_format = number_raw[2..].cow_replace('_', "").into_owned();
 
-        add_separators(&mut to_format, &SeparatorDir::Right, &self.hexadecimal);
+        add_separators(&mut to_format, &SeparatorDir::Right, &self.hexadecimal, None);
         to_format.insert_str(0, prefix);
         to_format
     }
@@ -264,7 +337,7 @@ impl NumericSeparatorsStyle {
 
         let mut to_format = number_raw[2..].cow_replace('_', "").into_owned();
 
-        add_separators(&mut to_format, &SeparatorDir::Right, &self.octal);
+        add_separators(&mut to_format, &SeparatorDir::Right, &self.octal, None);
         to_format.insert_str(0, prefix);
         to_format
     }
@@ -279,7 +352,12 @@ impl NumericSeparatorsStyle {
 
         let mut push_formatted_part = |part: &str, dir: &SeparatorDir, out: &mut String| {
             tmp.push_str(part);
-            add_separators(&mut tmp, dir, &self.number);
+            add_separators(
+                &mut tmp,
+                dir,
+                &self.number.base,
+                Some(self.number.fraction_group_length),
+            );
             out.push_str(&tmp);
             tmp.clear();
         };
@@ -321,29 +399,41 @@ impl NumericSeparatorsStyle {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 enum SeparatorDir {
     Left,
     Right,
 }
 
-fn add_separators(s: &mut String, dir: &SeparatorDir, config: &NumericBaseConfig) {
-    if s.len() < config.minimum_digits || s.len() < config.group_length + 1 {
+fn add_separators(
+    s: &mut String,
+    dir: &SeparatorDir,
+    config: &NumericBaseConfig,
+    fraction_group_length: Option<usize>,
+) {
+    let length = if *dir == SeparatorDir::Left && fraction_group_length.is_some() {
+        fraction_group_length.unwrap_or(usize::MAX)
+    } else {
+        config.group_length
+    };
+
+    if s.len() < config.minimum_digits || s.len() < length.saturating_add(1) {
         return;
     }
 
     match dir {
         SeparatorDir::Right => {
             let mut pos = s.len();
-            while pos > config.group_length {
-                pos -= config.group_length;
+            while pos > length {
+                pos -= length;
                 s.insert(pos, '_');
             }
         }
         SeparatorDir::Left => {
-            let mut pos = config.group_length;
+            let mut pos = length;
             while pos < s.len() {
                 s.insert(pos, '_');
-                pos += config.group_length + 1;
+                pos += length + 1;
             }
         }
     }
@@ -419,235 +509,323 @@ fn parse_number_literal(num: &str) -> ParsedNumberLiteral<'_> {
 }
 
 #[test]
-fn test_with_snapshot() {
-    use crate::tester::Tester;
-
-    let fail = vec![
-        "const foo = 0b10_10_0001",
-        "const foo = 0b0_00_0",
-        "const foo = 0b10101010101010",
-        "const foo = 0B10101010101010",
-        "const foo = 0xA_B_CDE_F0",
-        "const foo = 0xABCDEF",
-        "const foo = 0xA_B",
-        "const foo = 0XAB_C_D",
-        "const foo = 0o12_34_5670",
-        "const foo = 0o7_7_77",
-        "const foo = 0o010101010101",
-        "const foo = 0O010101010101",
-        "const foo = 0b10_10_0001n",
-        "const foo = 0b0_00_0n",
-        "const foo = 0b10101010101010n",
-        "const foo = 0B10101010101010n",
-        "const foo = 1_9_223n",
-        "const foo = 80_7n",
-        "const foo = 123456789_100n",
-        "const foo = 1e10000",
-        "const foo = 39804e10000",
-        "const foo = -123456e100",
-        "const foo = -100000e-10000",
-        "const foo = -1000e+10000",
-        "const foo = -1000e+00010000",
-        "const foo = 3.6e12000",
-        "const foo = -1200000e5",
-        "const foo = 3.65432E12000",
-        "const foo = 9807.1234567",
-        "const foo = 3819.123_4325",
-        "const foo = 138789.12343_2_42",
-        "const foo = .000000_1",
-        "const foo = 12345678..toString()",
-        "const foo = 12345678 .toString()",
-        "const foo = .00000",
-        "const foo = 0.00000",
-        // Numbers
-        "const foo = 1_2_345_678",
-        "const foo = 12_3",
-        "const foo = 1234567890",
-        // Negative numbers
-        "const foo = -100000_1",
-    ];
-
-    let fix = vec![("const foo = 0b10_10_0001", "const foo = 0b1010_0001")];
-
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, vec![], fail)
-        .expect_fix(fix)
-        .test_and_snapshot();
-}
-
-#[test]
-fn test_number_binary() {
+fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        "const foo = 0b1010_0001_1000_0101",
-        "const foo = 0b0000",
-        "const foo = 0b10",
-        "const foo = 0b1_0111_0101_0101",
-        "const foo = 0B1010",
+        ("const foo = 0xAB_CD", None),
+        ("const foo = 0xAB", None),
+        ("const foo = 0xA", None),
+        ("const foo = 0xA_BC_DE_F0", None),
+        ("const foo = 0xab_e8_12", None),
+        ("const foo = 0xe", None),
+        ("const foo = 0Xab_e3_cd", None),
+        ("const foo = 0o1234_5670", None),
+        ("const foo = 0o7777", None),
+        ("const foo = 0o01", None),
+        ("const foo = 0o12_7000_0000", None),
+        ("const foo = 0O1111_1111", None),
+        ("const foo = 0b1010_0001_1000_0101", None),
+        ("const foo = 0b0000", None),
+        ("const foo = 0b10", None),
+        ("const foo = 0b1_0111_0101_0101", None),
+        ("const foo = 0B1010", None),
+        ("const foo = 0b1010n", None),
+        ("const foo = 0b1010_1010n", None),
+        ("const foo = 9_223_372_036_854_775_807n", None),
+        ("const foo = 807n", None),
+        ("const foo = 1n", None),
+        ("const foo = 9_372_854_807n", None),
+        ("const foo = 9807n", None),
+        ("const foo = 0n", None),
+        ("const foo = 12_345_678", None),
+        ("const foo = 123", None),
+        ("const foo = 1", None),
+        ("const foo = 1234", None),
+        (
+            "const foo = 1_234",
+            Some(serde_json::json!([{"number": {"minimumDigits": 0, "groupLength": 3}}])),
+        ),
+        ("const foo = 9807.123", None),
+        ("const foo = 3819.123432", None),
+        ("const foo = 138_789.12343242", None),
+        ("const foo = .0000001", None),
+        ("const foo = .00000", None),
+        ("const foo = 0.00000", None),
+        ("const foo = 0.55228474983", None),
+        (
+            "const foo = 1.234_567",
+            Some(serde_json::json!([{"number": {"fractionGroupLength": 3}}])),
+        ),
+        (
+            "const foo = 149_597_870_700.31415_92653_58979",
+            Some(
+                serde_json::json!([{"number": {"minimumDigits": 0, "groupLength": 3, "fractionGroupLength": 5}}]),
+            ),
+        ),
+        ("const foo = 1.2345", Some(serde_json::json!([{"number": {"fractionGroupLength": 2}}]))),
+        ("const foo = -3000", None),
+        ("const foo = -10_000_000", None),
+        ("const foo = 1e10_000", None),
+        ("const foo = 39_804e1000", None),
+        ("const foo = -123_456e-100", None),
+        ("const foo = -100_000e-100_000", None),
+        ("const foo = -100_000e+100_000", None),
+        ("const foo = 3.6e12_000", None),
+        ("const foo = 3.6E12_000", None),
+        ("const foo = -1_200_000e5", None),
+        ("const foo = -282_932 - (1938 / 10_000) * .1 + 18.1000002", None),
+        ("const foo = NaN", None),
+        ("const foo = Infinity", None),
+        (r#"const foo = "1234567n""#, None),
+        ("const foo = 10000", Some(serde_json::json!([{"number": {"minimumDigits": 6}}]))),
+        ("const foo = 100_0000_0000", Some(serde_json::json!([{"number": {"groupLength": 4}}]))),
+        (
+            "const foo = 0xA_B_C_D_E_1_2_3_4",
+            Some(serde_json::json!([{"hexadecimal": {"groupLength": 1}}])),
+        ),
+        (
+            "const foo = 0b111",
+            Some(serde_json::json!([{"number": {"minimumDigits": 3, "groupLength": 1}}])),
+        ),
+        (
+            "const binary = 0b10101010;
+            const octal = 0o76543210;
+            const hexadecimal = 0xfedcba97;
+            const number = 12345678.12345678e12345678;",
+            Some(serde_json::json!([{ "onlyIfContainsSeparator": true, }])),
+        ),
+        (
+            "const binary = 0b1010_1010;
+            const octal = 0o76543210;
+            const hexadecimal = 0xfedcba97;
+            const number = 12345678.12345678e12345678;",
+            Some(
+                serde_json::json!([{ "onlyIfContainsSeparator": true, "binary": { "onlyIfContainsSeparator": false, }, }]),
+            ),
+        ),
+        (
+            "const binary = 0b10_10_10_10;
+            const octal = 0o76543210;
+            const hexadecimal = 0xfedcba97;
+            const number = 12345678.12345678e12345678;",
+            Some(
+                serde_json::json!([{ "onlyIfContainsSeparator": true, "binary": { "onlyIfContainsSeparator": false, "groupLength": 2, }, }]),
+            ),
+        ),
+        (
+            "const binary = 0b10101010;
+            const octal = 0o7654_3210;
+            const hexadecimal = 0xfe_dc_ba_97;
+            const number = 12_345_678.12345678e12_345_678;",
+            Some(serde_json::json!([{ "binary": { "onlyIfContainsSeparator": true, }, }])),
+        ),
+        (
+            "const foo = 12345",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": true}}])),
+        ),
+        (
+            "const foo = 12345678",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": true}}])),
+        ),
+        (
+            "const foo = 12_345",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": true}}])),
+        ),
+        (
+            "const foo = -100_000e+100_000",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": true}}])),
+        ),
+        (
+            "const foo = -100000e+100000",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": true}}])),
+        ),
+        (
+            "const foo = 0xA_B_C_D_E",
+            Some(
+                serde_json::json!([{"hexadecimal": {"onlyIfContainsSeparator": true, "groupLength": 1}}]),
+            ),
+        ),
+        (
+            "const foo = 0o7777",
+            Some(
+                serde_json::json!([{"octal": {"onlyIfContainsSeparator": true, "minimumDigits": 4}}]),
+            ),
+        ),
+        (
+            "const foo = 0xABCDEF012",
+            Some(serde_json::json!([{"hexadecimal": {"onlyIfContainsSeparator": true}}])),
+        ),
+        (
+            "const foo = 0o777777",
+            Some(
+                serde_json::json!([{"octal": {"onlyIfContainsSeparator": true, "minimumDigits": 3}}]),
+            ),
+        ),
+        (
+            "const foo = 0o777777",
+            Some(
+                serde_json::json!([{"octal": {"onlyIfContainsSeparator": true, "minimumDigits": 3, "groupLength": 2}}]),
+            ),
+        ),
+        (
+            "const foo = 0o777_777",
+            Some(
+                serde_json::json!([{"octal": {"onlyIfContainsSeparator": true, "minimumDigits": 2, "groupLength": 3}}]),
+            ),
+        ),
+        (
+            "const foo = 0b01010101",
+            Some(
+                serde_json::json!([{"onlyIfContainsSeparator": true, "binary": {"onlyIfContainsSeparator": true}}]),
+            ),
+        ),
+        (
+            "const foo = 0b0101_0101",
+            Some(
+                serde_json::json!([{"onlyIfContainsSeparator": false, "binary": {"onlyIfContainsSeparator": true}}]),
+            ),
+        ),
+        (
+            "const foo = 0b0101_0101",
+            Some(
+                serde_json::json!([{"onlyIfContainsSeparator": false, "binary": {"onlyIfContainsSeparator": false}}]),
+            ),
+        ),
     ];
 
     let fail = vec![
-        "const foo = 0b10_10_0001",
-        "const foo = 0b0_00_0",
-        "const foo = 0b10101010101010",
-        "const foo = 0B10101010101010",
+        ("const foo = 0xA_B_CDE_F0", None),
+        ("const foo = 0xABCDEF", None),
+        ("const foo = 0xA_B", None),
+        ("const foo = 0XAB_C_D", None),
+        ("const foo = 0o12_34_5670", None),
+        ("const foo = 0o7_7_77", None),
+        ("const foo = 0o010101010101", None),
+        ("const foo = 0O010101010101", None),
+        ("const foo = 0b10_10_0001", None),
+        ("const foo = 0b0_00_0", None),
+        ("const foo = 0b10101010101010", None),
+        ("const foo = 0B10101010101010", None),
+        ("const foo = 1_9_223n", None),
+        ("const foo = 80_7n", None),
+        ("const foo = 123456789_100n", None),
+        ("const foo = 1_2_345_678", None),
+        ("const foo = 12_3", None),
+        ("const foo = 1234567890", None),
+        ("const foo = 0.552_284_749_83", None),
+        ("const foo = 3819.123_4325", None),
+        ("const foo = 138789.12343_2_42", None),
+        ("const foo = .000000_1", None),
+        ("const foo = 12345678..toString()", None),
+        ("const foo = 12345678 .toString()", None),
+        ("const foo = 1.234567", Some(serde_json::json!([{"number": {"fractionGroupLength": 3}}]))),
+        (
+            "const foo = 1789.123_432_42",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": true}}])),
+        ),
+        (
+            "const foo = -282_932 - (1938 / 10_000) * .1 + 18.100_000_2",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": true}}])),
+        ),
+        ("const foo = -100000_1", None),
+        ("const foo = 1e10000", None),
+        ("const foo = 39804e10000", None),
+        ("const foo = -123456e100", None),
+        ("const foo = -100000e-10000", None),
+        ("const foo = -1000e+10000", None),
+        ("const foo = -1000e+00010000", None),
+        ("const foo = 3.6e12000", None),
+        ("const foo = -1200000e5", None),
+        ("const foo = 3.65432E12000", None),
+        ("const foo = 1000000", Some(serde_json::json!([{"number": {"minimumDigits": 6}}]))),
+        ("const foo = 10_000_000_000", Some(serde_json::json!([{"number": {"groupLength": 4}}]))),
+        ("const foo = 0xA_B_CD", Some(serde_json::json!([{"hexadecimal": {"groupLength": 1}}]))),
+        (
+            "const foo = 0b1_11",
+            Some(serde_json::json!([{"number": {"minimumDigits": 3, "groupLength": 2}}])),
+        ),
+        (
+            "const foo = -100000e+100000",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": false}}])),
+        ),
+        (
+            "const binary = 0b10_101010;
+            const octal = 0o76_543210;
+            const hexadecimal = 0xfe_dcba97;
+            const number = 12_345678.12345678e12345678;",
+            Some(serde_json::json!([{ "onlyIfContainsSeparator": true, }])),
+        ),
+        (
+            "const binary = 0b10101010;
+            const octal = 0o76_543210;
+            const hexadecimal = 0xfe_dcba97;
+            const number = 12_345678.12345678e12345678;",
+            Some(
+                serde_json::json!([{ "onlyIfContainsSeparator": true, "binary": { "onlyIfContainsSeparator": false, }, }]),
+            ),
+        ),
+        (
+            "const binary = 0b10101010;
+            const octal = 0o76_543210;
+            const hexadecimal = 0xfe_dcba97;
+            const number = 12_345678.12345678e12345678;",
+            Some(
+                serde_json::json!([{ "onlyIfContainsSeparator": true, "binary": { "onlyIfContainsSeparator": false, "groupLength": 2, }, }]),
+            ),
+        ),
+        (
+            "const binary = 0b10_101010;
+            const octal = 0o76543210;
+            const hexadecimal = 0xfedcba97;
+            const number = 12345678.12345678e12345678;",
+            Some(serde_json::json!([{ "binary": { "onlyIfContainsSeparator": true, }, }])),
+        ),
+        ("console.log(0XdeEdBeeFn)", None),
+        ("const foo = 12345678..toString()", None),
     ];
 
     let fix = vec![
+        ("const foo = 0xA_B_CDE_F0", "const foo = 0xA_BC_DE_F0", None),
+        ("const foo = 0xABCDEF", "const foo = 0xAB_CD_EF", None),
+        ("const foo = 0xA_B", "const foo = 0xAB", None),
+        ("const foo = 0XAB_C_D", "const foo = 0XAB_CD", None),
+        ("const foo = 0o12_34_5670", "const foo = 0o1234_5670", None),
+        ("const foo = 0o7_7_77", "const foo = 0o7777", None),
+        ("const foo = 0o010101010101", "const foo = 0o0101_0101_0101", None),
+        ("const foo = 0O010101010101", "const foo = 0O0101_0101_0101", None),
         ("const foo = 0b10_10_0001", "const foo = 0b1010_0001", None),
         ("const foo = 0b0_00_0", "const foo = 0b0000", None),
         ("const foo = 0b10101010101010", "const foo = 0b10_1010_1010_1010", None),
         ("const foo = 0B10101010101010", "const foo = 0B10_1010_1010_1010", None),
-    ];
-
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
-        .expect_fix(fix)
-        .test();
-}
-
-#[test]
-fn test_number_hexadecimal() {
-    use crate::tester::Tester;
-
-    let pass = vec![
-        "const foo = 0xAB_CD",
-        "const foo = 0xAB",
-        "const foo = 0xA",
-        "const foo = 0xA_BC_DE_F0",
-        "const foo = 0xab_e8_12",
-        "const foo = 0xe",
-        "const foo = 0Xab_e3_cd",
-    ];
-
-    let fail = vec![
-        "const foo = 0xA_B_CDE_F0",
-        "const foo = 0xABCDEF",
-        "const foo = 0xA_B",
-        "const foo = 0XAB_C_D",
-    ];
-
-    let fix = vec![("const foo = 0xA_B_CDE_F0", "const foo = 0xA_BC_DE_F0", None)];
-
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
-        .expect_fix(fix)
-        .test();
-}
-
-#[test]
-fn test_number_octal() {
-    use crate::tester::Tester;
-
-    let pass = vec![
-        "const foo = 0o1234_5670",
-        "const foo = 0o7777",
-        "const foo = 0o01",
-        "const foo = 0o12_7000_0000",
-        "const foo = 0O1111_1111",
-        // Legacy
-        "const foo = 0777777",
-        "let foo = 0111222",
-    ];
-
-    let fail = vec![
-        "const foo = 0o12_34_5670",
-        "const foo = 0o7_7_77",
-        "const foo = 0o010101010101",
-        "const foo = 0O010101010101",
-    ];
-
-    let fix = vec![("const foo = 0o12_34_5670", "const foo = 0o1234_5670", None)];
-
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
-        .expect_fix(fix)
-        .test();
-}
-
-#[test]
-fn test_bigint_binary() {
-    use crate::tester::Tester;
-
-    let pass = vec![
-        "const foo = 0b1010_0001_1000_0101n",
-        "const foo = 0b0000n",
-        "const foo = 0b10n",
-        "const foo = 0b1_0111_0101_0101n",
-        "const foo = 0B1010n",
-    ];
-
-    let fail = vec![
-        "const foo = 0b10_10_0001n",
-        "const foo = 0b0_00_0n",
-        "const foo = 0b10101010101010n",
-        "const foo = 0B10101010101010n",
-    ];
-
-    let fix = vec![
-        ("const foo = 0b10_10_0001n", "const foo = 0b1010_0001n", None),
-        ("const foo = 0b0_00_0n", "const foo = 0b0000n", None),
-        ("const foo = 0b10101010101010n", "const foo = 0b10_1010_1010_1010n", None),
-        ("const foo = 0B10101010101010n", "const foo = 0B10_1010_1010_1010n", None),
-    ];
-
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
-        .expect_fix(fix)
-        .test();
-}
-
-#[test]
-fn test_bigint() {
-    use crate::tester::Tester;
-
-    let pass = vec![
-        "const foo = 9_223_372_036_854_775_807n",
-        "const foo = 807n",
-        "const foo = 1n",
-        "const foo = 9_372_854_807n",
-        "const foo = 9807n",
-        "const foo = 0n",
-    ];
-
-    let fail = vec![
-        // BigInt
-        "const foo = 1_9_223n",
-        "const foo = 80_7n",
-        "const foo = 123456789_100n",
-    ];
-
-    let fix = vec![("const foo = 1_9_223n", "const foo = 19_223n", None)];
-
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
-        .expect_fix(fix)
-        .test();
-}
-
-#[test]
-fn test_number_decimal_exponential() {
-    use crate::tester::Tester;
-
-    let pass = vec![
-        "const foo = 1e10_000",
-        "const foo = 39_804e1000",
-        "const foo = -123_456e-100",
-        "const foo = -100_000e-100_000",
-        "const foo = -100_000e+100_000",
-        "const foo = 3.6e12_000",
-        "const foo = 3.6E12_000",
-        "const foo = -1_200_000e5",
-    ];
-
-    let fail = vec![
-        "const foo = 1e10000",
-        "const foo = 39804e10000",
-        "const foo = -123456e100",
-        "const foo = -100000e-10000",
-        "const foo = -1000e+10000",
-        "const foo = -1000e+00010000",
-        "const foo = 3.6e12000",
-        "const foo = -1200000e5",
-        "const foo = 3.65432E12000",
-    ];
-
-    let fix = vec![
+        ("const foo = 1_9_223n", "const foo = 19_223n", None),
+        ("const foo = 80_7n", "const foo = 807n", None),
+        ("const foo = 123456789_100n", "const foo = 123_456_789_100n", None),
+        ("const foo = 1_2_345_678", "const foo = 12_345_678", None),
+        ("const foo = 12_3", "const foo = 123", None),
+        ("const foo = 1234567890", "const foo = 1_234_567_890", None),
+        ("const foo = 0.552_284_749_83", "const foo = 0.55228474983", None),
+        ("const foo = 3819.123_4325", "const foo = 3819.1234325", None),
+        ("const foo = 138789.12343_2_42", "const foo = 138_789.12343242", None),
+        ("const foo = .000000_1", "const foo = .0000001", None),
+        // ("const foo = 12345678..toString()", "const foo = 12_345_678..toString()", None), // TODO: the second dot is needed
+        ("const foo = 12345678 .toString()", "const foo = 12_345_678 .toString()", None),
+        (
+            "const foo = 1.234567",
+            "const foo = 1.234_567",
+            Some(serde_json::json!([{"number": {"fractionGroupLength": 3}}])),
+        ),
+        (
+            "const foo = 1789.123_432_42",
+            "const foo = 1789.12343242",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": true}}])),
+        ),
+        (
+            "const foo = -282_932 - (1938 / 10_000) * .1 + 18.100_000_2",
+            "const foo = -282_932 - (1938 / 10_000) * .1 + 18.1000002",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": true}}])),
+        ),
+        ("const foo = -100000_1", "const foo = -1_000_001", None),
         ("const foo = 1e10000", "const foo = 1e10_000", None),
         ("const foo = 39804e10000", "const foo = 39_804e10_000", None),
         ("const foo = -123456e100", "const foo = -123_456e100", None),
@@ -656,133 +834,85 @@ fn test_number_decimal_exponential() {
         ("const foo = -1000e+00010000", "const foo = -1000e+00_010_000", None),
         ("const foo = 3.6e12000", "const foo = 3.6e12_000", None),
         ("const foo = -1200000e5", "const foo = -1_200_000e5", None),
-        ("const foo = 3.65432E12000", "const foo = 3.654_32E12_000", None),
+        ("const foo = 3.65432E12000", "const foo = 3.65432E12_000", None),
+        (
+            "const foo = 1000000",
+            "const foo = 1_000_000",
+            Some(serde_json::json!([{"number": {"minimumDigits": 6}}])),
+        ),
+        (
+            "const foo = 10_000_000_000",
+            "const foo = 100_0000_0000",
+            Some(serde_json::json!([{"number": {"groupLength": 4}}])),
+        ),
+        (
+            "const foo = 0xA_B_CD",
+            "const foo = 0xA_B_C_D",
+            Some(serde_json::json!([{"hexadecimal": {"groupLength": 1}}])),
+        ),
+        (
+            "const foo = 0b1_11",
+            "const foo = 0b111",
+            Some(serde_json::json!([{"number": {"minimumDigits": 3, "groupLength": 2}}])),
+        ),
+        (
+            "const foo = -100000e+100000",
+            "const foo = -100_000e+100_000",
+            Some(serde_json::json!([{"number": {"onlyIfContainsSeparator": false}}])),
+        ),
+        (
+            "const binary = 0b10_101010;
+            const octal = 0o76_543210;
+            const hexadecimal = 0xfe_dcba97;
+            const number = 12_345678.12345678e12345678;",
+            "const binary = 0b1010_1010;
+            const octal = 0o7654_3210;
+            const hexadecimal = 0xfe_dc_ba_97;
+            const number = 12_345_678.12345678e12_345_678;",
+            Some(serde_json::json!([{ "onlyIfContainsSeparator": true, }])),
+        ),
+        (
+            "const binary = 0b10101010;
+            const octal = 0o76_543210;
+            const hexadecimal = 0xfe_dcba97;
+            const number = 12_345678.12345678e12345678;",
+            "const binary = 0b1010_1010;
+            const octal = 0o7654_3210;
+            const hexadecimal = 0xfe_dc_ba_97;
+            const number = 12_345_678.12345678e12_345_678;",
+            Some(
+                serde_json::json!([{ "onlyIfContainsSeparator": true, "binary": { "onlyIfContainsSeparator": false, }, }]),
+            ),
+        ),
+        (
+            "const binary = 0b10101010;
+            const octal = 0o76_543210;
+            const hexadecimal = 0xfe_dcba97;
+            const number = 12_345678.12345678e12345678;",
+            "const binary = 0b10_10_10_10;
+            const octal = 0o7654_3210;
+            const hexadecimal = 0xfe_dc_ba_97;
+            const number = 12_345_678.12345678e12_345_678;",
+            Some(
+                serde_json::json!([{ "onlyIfContainsSeparator": true, "binary": { "onlyIfContainsSeparator": false, "groupLength": 2, }, }]),
+            ),
+        ),
+        (
+            "const binary = 0b10_101010;
+            const octal = 0o76543210;
+            const hexadecimal = 0xfedcba97;
+            const number = 12345678.12345678e12345678;",
+            "const binary = 0b1010_1010;
+            const octal = 0o7654_3210;
+            const hexadecimal = 0xfe_dc_ba_97;
+            const number = 12_345_678.12345678e12_345_678;",
+            Some(serde_json::json!([{ "binary": { "onlyIfContainsSeparator": true, }, }])),
+        ),
     ];
 
     Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
         .expect_fix(fix)
-        .test();
-}
-
-#[test]
-fn test_number_decimal_float() {
-    use crate::tester::Tester;
-
-    let pass = vec![
-        "const foo = 9807.123",
-        "const foo = 3819.123_432",
-        "const foo = 138_789.123_432_42",
-        "const foo = .000_000_1",
-    ];
-
-    let fail = vec![
-        "const foo = 9807.1234567",
-        "const foo = 3819.123_4325",
-        "const foo = 138789.12343_2_42",
-        "const foo = .000000_1",
-        "const foo = 12345678..toString()",
-        "const foo = 12345678 .toString()",
-        "const foo = .00000",
-        "const foo = 0.00000",
-    ];
-
-    let fix = vec![("const foo = 9807.1234567", "const foo = 9807.123_456_7", None)];
-
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
-        .expect_fix(fix)
-        .test();
-}
-
-#[test]
-fn test_number_decimal_integer() {
-    use crate::tester::Tester;
-
-    let pass = vec![
-        // Numbers
-        "const foo = 123_456",
-        "const foo = 12_345_678",
-        "const foo = 123",
-        "const foo = 1",
-        "const foo = 1234",
-        // Negative numbers
-        "const foo = -4000",
-        "const foo = -50_000",
-        "const foo = -600_000",
-        "const foo = -7_000_000",
-        "const foo = -80_000_000",
-    ];
-
-    let fail = vec![
-        // Numbers
-        "const foo = 1_2_345_678",
-        "const foo = 12_3",
-        "const foo = 1234567890",
-        // Negative numbers
-        "const foo = -100000_1",
-    ];
-
-    let fix = vec![
-        ("const foo = 1234567890", "const foo = 1_234_567_890", None),
-        ("const foo = -100000_1", "const foo = -1_000_001", None),
-    ];
-
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
-        .expect_fix(fix)
-        .test();
-}
-
-#[test]
-fn test_with_config() {
-    use serde_json::json;
-
-    use crate::tester::Tester;
-
-    let pass = vec![
-        ("1234567890", Some(json!([{ "onlyIfContainsSeparator": true }]))),
-        ("0b11111111", Some(json!([{ "onlyIfContainsSeparator": true }]))),
-        ("0o77777777", Some(json!([{ "onlyIfContainsSeparator": true }]))),
-        ("0xffffffff", Some(json!([{ "onlyIfContainsSeparator": true }]))),
-        ("1234567890n", Some(json!([{ "onlyIfContainsSeparator": true }]))),
-        ("0b11111111n", Some(json!([{ "onlyIfContainsSeparator": true }]))),
-        ("0o77777777n", Some(json!([{ "onlyIfContainsSeparator": true }]))),
-        ("0xffffffffn", Some(json!([{ "onlyIfContainsSeparator": true }]))),
-        ("12_34_56", Some(json!([{ "number": { "groupLength": 2 } }]))),
-        ("12345", Some(json!([{ "number": { "minimumDigits": 10 } }]))),
-        ("0b1_1_1_1_1", Some(json!([{ "binary": { "groupLength": 1 } }]))),
-        ("0o7_7_7_7_7", Some(json!([{ "octal": { "groupLength": 1 } }]))),
-        ("0xf_f_f_f_f", Some(json!([{ "hexadecimal": { "groupLength": 1 } }]))),
-        ("12_34_56n", Some(json!([{ "number": { "groupLength": 2 } }]))),
-        ("12345n", Some(json!([{ "number": { "minimumDigits": 10 } }]))),
-        ("0b1_1_1_1_1n", Some(json!([{ "binary": { "groupLength": 1 } }]))),
-        ("0o7_7_7_7_7n", Some(json!([{ "octal": { "groupLength": 1 } }]))),
-        ("0xf_f_f_f_fn", Some(json!([{ "hexadecimal": { "groupLength": 1 } }]))),
-    ];
-
-    let fail = vec![];
-
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
-        .intentionally_allow_no_fix_tests()
-        .test();
-}
-
-#[test]
-fn test_misc() {
-    use crate::tester::Tester;
-
-    let pass = vec![
-        "const foo = -282_932 - (1938 / 10_000) * .1 + 18.100_000_2",
-        "const foo = NaN",
-        "const foo = Infinity",
-        "const foo = -Infinity",
-        "const foo = '1234567n'",
-    ];
-
-    let fail = vec!["1_23_4444"];
-    let fix = vec![("1_23_4444", "1_234_444")];
-
-    Tester::new(NumericSeparatorsStyle::NAME, NumericSeparatorsStyle::PLUGIN, pass, fail)
-        .expect_fix(fix)
-        .test();
+        .test_and_snapshot();
 }
 
 #[cfg(test)]
@@ -796,7 +926,7 @@ mod internal_tests {
         let config = json!([{
                 "binary": {"groupLength": 2, "minimumDigits": 4},
                 "hexadecimal": {"groupLength": 8, "minimumDigits": 16},
-                "number": {"groupLength": 32, "minimumDigits": 64},
+                "number": {"groupLength": 32, "minimumDigits": 64, "fractionGroupLength": 128},
                 "octal": {"groupLength": 128, "minimumDigits": 256},
                 "onlyIfContainsSeparator": true
         }]);
@@ -806,8 +936,9 @@ mod internal_tests {
         assert_eq!(rule.binary.minimum_digits, 4);
         assert_eq!(rule.hexadecimal.group_length, 8);
         assert_eq!(rule.hexadecimal.minimum_digits, 16);
-        assert_eq!(rule.number.group_length, 32);
-        assert_eq!(rule.number.minimum_digits, 64);
+        assert_eq!(rule.number.base.group_length, 32);
+        assert_eq!(rule.number.base.minimum_digits, 64);
+        assert_eq!(rule.number.fraction_group_length, 128);
         assert_eq!(rule.octal.group_length, 128);
         assert_eq!(rule.octal.minimum_digits, 256);
         assert!(rule.only_if_contains_separator);

--- a/crates/oxc_linter/src/snapshots/unicorn_numeric_separators_style.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_numeric_separators_style.snap
@@ -4,34 +4,6 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
    ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 0b10_10_0001
-   ·             ────────────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 0b0_00_0
-   ·             ────────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 0b10101010101010
-   ·             ────────────────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 0B10101010101010
-   ·             ────────────────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:13]
  1 │ const foo = 0xA_B_CDE_F0
    ·             ────────────
    ╰────
@@ -88,29 +60,29 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
    ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 0b10_10_0001n
-   ·             ─────────────
+ 1 │ const foo = 0b10_10_0001
+   ·             ────────────
    ╰────
   help: Group digits with numeric separators (_) so longer numbers are easier to read.
 
   ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
    ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 0b0_00_0n
-   ·             ─────────
+ 1 │ const foo = 0b0_00_0
+   ·             ────────
    ╰────
   help: Group digits with numeric separators (_) so longer numbers are easier to read.
 
   ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
    ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 0b10101010101010n
-   ·             ─────────────────
+ 1 │ const foo = 0b10101010101010
+   ·             ────────────────
    ╰────
   help: Group digits with numeric separators (_) so longer numbers are easier to read.
 
   ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
    ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 0B10101010101010n
-   ·             ─────────────────
+ 1 │ const foo = 0B10101010101010
+   ·             ────────────────
    ╰────
   help: Group digits with numeric separators (_) so longer numbers are easier to read.
 
@@ -132,6 +104,97 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[numeric_separators_style.tsx:1:13]
  1 │ const foo = 123456789_100n
    ·             ──────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = 1_2_345_678
+   ·             ───────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = 12_3
+   ·             ────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = 1234567890
+   ·             ──────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = 0.552_284_749_83
+   ·             ────────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = 3819.123_4325
+   ·             ─────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = 138789.12343_2_42
+   ·             ─────────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = .000000_1
+   ·             ─────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = 12345678..toString()
+   ·             ─────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = 12345678 .toString()
+   ·             ────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = 1.234567
+   ·             ────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ const foo = 1789.123_432_42
+   ·             ───────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:47]
+ 1 │ const foo = -282_932 - (1938 / 10_000) * .1 + 18.100_000_2
+   ·                                               ────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:14]
+ 1 │ const foo = -100000_1
+   ·              ────────
    ╰────
   help: Group digits with numeric separators (_) so longer numbers are easier to read.
 
@@ -200,29 +263,179 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
    ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 9807.1234567
-   ·             ────────────
+ 1 │ const foo = 1000000
+   ·             ───────
    ╰────
   help: Group digits with numeric separators (_) so longer numbers are easier to read.
 
   ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
    ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 3819.123_4325
-   ·             ─────────────
+ 1 │ const foo = 10_000_000_000
+   ·             ──────────────
    ╰────
   help: Group digits with numeric separators (_) so longer numbers are easier to read.
 
   ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
    ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 138789.12343_2_42
-   ·             ─────────────────
+ 1 │ const foo = 0xA_B_CD
+   ·             ────────
    ╰────
   help: Group digits with numeric separators (_) so longer numbers are easier to read.
 
   ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
    ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = .000000_1
-   ·             ─────────
+ 1 │ const foo = 0b1_11
+   ·             ──────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:14]
+ 1 │ const foo = -100000e+100000
+   ·              ──────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:16]
+ 1 │ const binary = 0b10_101010;
+   ·                ───────────
+ 2 │             const octal = 0o76_543210;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:2:27]
+ 1 │ const binary = 0b10_101010;
+ 2 │             const octal = 0o76_543210;
+   ·                           ───────────
+ 3 │             const hexadecimal = 0xfe_dcba97;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:3:33]
+ 2 │             const octal = 0o76_543210;
+ 3 │             const hexadecimal = 0xfe_dcba97;
+   ·                                 ───────────
+ 4 │             const number = 12_345678.12345678e12345678;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:4:28]
+ 3 │             const hexadecimal = 0xfe_dcba97;
+ 4 │             const number = 12_345678.12345678e12345678;
+   ·                            ───────────────────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:16]
+ 1 │ const binary = 0b10101010;
+   ·                ──────────
+ 2 │             const octal = 0o76_543210;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:2:27]
+ 1 │ const binary = 0b10101010;
+ 2 │             const octal = 0o76_543210;
+   ·                           ───────────
+ 3 │             const hexadecimal = 0xfe_dcba97;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:3:33]
+ 2 │             const octal = 0o76_543210;
+ 3 │             const hexadecimal = 0xfe_dcba97;
+   ·                                 ───────────
+ 4 │             const number = 12_345678.12345678e12345678;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:4:28]
+ 3 │             const hexadecimal = 0xfe_dcba97;
+ 4 │             const number = 12_345678.12345678e12345678;
+   ·                            ───────────────────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:16]
+ 1 │ const binary = 0b10101010;
+   ·                ──────────
+ 2 │             const octal = 0o76_543210;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:2:27]
+ 1 │ const binary = 0b10101010;
+ 2 │             const octal = 0o76_543210;
+   ·                           ───────────
+ 3 │             const hexadecimal = 0xfe_dcba97;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:3:33]
+ 2 │             const octal = 0o76_543210;
+ 3 │             const hexadecimal = 0xfe_dcba97;
+   ·                                 ───────────
+ 4 │             const number = 12_345678.12345678e12345678;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:4:28]
+ 3 │             const hexadecimal = 0xfe_dcba97;
+ 4 │             const number = 12_345678.12345678e12345678;
+   ·                            ───────────────────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:16]
+ 1 │ const binary = 0b10_101010;
+   ·                ───────────
+ 2 │             const octal = 0o76543210;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:2:27]
+ 1 │ const binary = 0b10_101010;
+ 2 │             const octal = 0o76543210;
+   ·                           ──────────
+ 3 │             const hexadecimal = 0xfedcba97;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:3:33]
+ 2 │             const octal = 0o76543210;
+ 3 │             const hexadecimal = 0xfedcba97;
+   ·                                 ──────────
+ 4 │             const number = 12345678.12345678e12345678;
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:4:28]
+ 3 │             const hexadecimal = 0xfedcba97;
+ 4 │             const number = 12345678.12345678e12345678;
+   ·                            ──────────────────────────
+   ╰────
+  help: Group digits with numeric separators (_) so longer numbers are easier to read.
+
+  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
+   ╭─[numeric_separators_style.tsx:1:13]
+ 1 │ console.log(0XdeEdBeeFn)
+   ·             ───────────
    ╰────
   help: Group digits with numeric separators (_) so longer numbers are easier to read.
 
@@ -230,54 +443,5 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[numeric_separators_style.tsx:1:13]
  1 │ const foo = 12345678..toString()
    ·             ─────────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 12345678 .toString()
-   ·             ────────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = .00000
-   ·             ──────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 0.00000
-   ·             ───────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 1_2_345_678
-   ·             ───────────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 12_3
-   ·             ────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:13]
- 1 │ const foo = 1234567890
-   ·             ──────────
-   ╰────
-  help: Group digits with numeric separators (_) so longer numbers are easier to read.
-
-  ⚠ unicorn(numeric-separators-style): Invalid group length in numeric value.
-   ╭─[numeric_separators_style.tsx:1:14]
- 1 │ const foo = -100000_1
-   ·              ────────
    ╰────
   help: Group digits with numeric separators (_) so longer numbers are easier to read.


### PR DESCRIPTION
Closes https://github.com/oxc-project/oxc/issues/23383
Tests generated by upstream rule and our `just` script.

