### PR TITLE
fix(linter/unicorn/prefer-array-flat): skip non-array `flatMap` receivers

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -2,7 +2,7 @@ use oxc_ast::{
     AstKind,
     ast::{
         Argument, ArrayExpressionElement, BindingPattern, CallExpression, Expression,
-        MemberExpression, Statement,
+        IdentifierReference, MemberExpression, Statement,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -11,7 +11,7 @@ use oxc_span::Span;
 
 use crate::{
     AstNode,
-    ast_util::is_method_call,
+    ast_util::{get_symbol_id_of_variable, is_method_call},
     context::LintContext,
     rule::Rule,
     utils::{
@@ -107,6 +107,17 @@ fn check_array_flat_map_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintConte
         return;
     }
 
+    // Skip receivers that are obviously not arrays, e.g. `Effects.flatMap(x => x)`,
+    // `const text = ""; text.flatMap(x => x)`, `const set = new Set(); set.flatMap(x => x)`.
+    // `flatMap` also exists on non-array types (RxJS observables, custom classes), and `.flat()`
+    // does not, so reporting/auto-fixing those is a false positive and a breaking rewrite. Mirrors
+    // eslint-plugin-unicorn's `isObviouslyNonArrayFlatMapReceiver`.
+    if let Some(member_expr) = call_expr.callee.as_member_expression()
+        && is_obviously_non_array_flat_map_receiver(member_expr.object(), ctx)
+    {
+        return;
+    }
+
     let target_fix_span = call_expr
         .callee
         .as_member_expression()
@@ -119,6 +130,81 @@ fn check_array_flat_map_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintConte
         });
     } else {
         ctx.diagnostic(prefer_array_flat_diagnostic(call_expr.span));
+    }
+}
+
+enum ConstInitKind {
+    Array,
+    NonArray,
+}
+
+/// Whether the `flatMap` receiver is statically known not to be an array, mirroring
+/// eslint-plugin-unicorn's `isObviouslyNonArrayFlatMapReceiver`:
+/// `(isPascalCaseIdentifier && !isConstArrayVariable) || isConstNonArrayVariable`.
+fn is_obviously_non_array_flat_map_receiver(object: &Expression, ctx: &LintContext) -> bool {
+    let Expression::Identifier(ident) = object.without_parentheses() else {
+        return false;
+    };
+    let is_pascal_case = ident.name.chars().next().is_some_and(char::is_uppercase);
+    match const_variable_initializer_kind(ident, ctx) {
+        Some(ConstInitKind::Array) => false,
+        Some(ConstInitKind::NonArray) => true,
+        None => is_pascal_case,
+    }
+}
+
+/// Classify the initializer of a `const` variable as definitely-array or definitely-non-array.
+/// Returns `None` for non-`const` bindings, missing initializers, or initializers whose type
+/// cannot be statically determined (e.g. a call expression).
+fn const_variable_initializer_kind(
+    ident: &IdentifierReference,
+    ctx: &LintContext,
+) -> Option<ConstInitKind> {
+    let symbol_id = get_symbol_id_of_variable(ident, ctx)?;
+    let node = ctx.nodes().get_node(ctx.scoping().symbol_declaration(symbol_id));
+    let AstKind::VariableDeclarator(declarator) = node.kind() else {
+        return None;
+    };
+    if !declarator.kind.is_const() {
+        return None;
+    }
+    let init = declarator.init.as_ref()?.without_parentheses();
+    if is_definitely_array_expression(init) {
+        Some(ConstInitKind::Array)
+    } else if is_definitely_non_array_expression(init) {
+        Some(ConstInitKind::NonArray)
+    } else {
+        None
+    }
+}
+
+fn is_definitely_array_expression(expr: &Expression) -> bool {
+    match expr {
+        Expression::ArrayExpression(_) => true,
+        Expression::NewExpression(new_expr) => {
+            matches!(&new_expr.callee, Expression::Identifier(ident) if ident.name == "Array")
+        }
+        _ => false,
+    }
+}
+
+fn is_definitely_non_array_expression(expr: &Expression) -> bool {
+    match expr {
+        Expression::ObjectExpression(_)
+        | Expression::StringLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::TemplateLiteral(_)
+        | Expression::ArrowFunctionExpression(_)
+        | Expression::FunctionExpression(_)
+        | Expression::ClassExpression(_) => true,
+        Expression::NewExpression(new_expr) => {
+            matches!(&new_expr.callee, Expression::Identifier(ident) if ident.name != "Array")
+        }
+        _ => false,
     }
 }
 
@@ -312,25 +398,25 @@ fn test() {
         "array.flatMap((x, y) => x)",
         // "array.flatMap((x) => { return x; })",
         "array.flatMap(x => y)",
-        // TODO: Get this passing.
-        // "const randomObject = {
-        //         flatMap(function_) {
-        //             function_();
-        //         },
-        //     };
-        //     randomObject.flatMap(x => x);",
-        // "Effects.flatMap(x => x)",
-        // "const effects = {
-        //         flatMap(function_) {
-        //             function_();
-        //         },
-        //     };
-        //     effects.flatMap(x => x);",
-        // "const effects = new Set(); effects.flatMap(x => x);",
-        // "const mapping = new Map(); mapping.flatMap(x => x);",
-        // r#"const text = ""; text.flatMap(x => x);"#,
-        // "const handler = () => {}; handler.flatMap(x => x);",
-        // "const collection = new Foo(); collection.flatMap(x => x);",
+        // Non-array receivers (matches eslint-plugin-unicorn `isObviouslyNonArrayFlatMapReceiver`):
+        "const randomObject = {
+                flatMap(function_) {
+                    function_();
+                },
+            };
+            randomObject.flatMap(x => x);",
+        "Effects.flatMap(x => x)",
+        "const effects = {
+                flatMap(function_) {
+                    function_();
+                },
+            };
+            effects.flatMap(x => x);",
+        "const effects = new Set(); effects.flatMap(x => x);",
+        "const mapping = new Map(); mapping.flatMap(x => x);",
+        r#"const text = ""; text.flatMap(x => x);"#,
+        "const handler = () => {}; handler.flatMap(x => x);",
+        "const collection = new Foo(); collection.flatMap(x => x);",
         "new array.reduce((a, b) => a.concat(b), [])",
         "array.reduce",
         "reduce((a, b) => a.concat(b), [])",

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -157,7 +157,7 @@ fn const_variable_initializer_kind(
     if !declarator.kind.is_const() {
         return None;
     }
-    let init = declarator.init.as_ref()?.without_parentheses();
+    let init = declarator.init.as_ref()?.get_inner_expression();
     if is_definitely_array_expression(init) {
         Some(ConstInitKind::Array)
     } else if is_definitely_non_array_expression(init) {
@@ -509,6 +509,10 @@ fn test() {
         "object._.flatten(array)",
         "array.flat()",
         "array.flat(1)",
+        "const effects = new Set() as Set<unknown>; effects.flatMap(x => x);",
+        r#"const text = "" as string; text.flatMap(x => x);"#,
+        "const handler = (() => {}) as Function; handler.flatMap(x => x);",
+        "const collection = new Foo() satisfies Foo; collection.flatMap(x => x);",
     ];
 
     let fail = vec![
@@ -611,6 +615,7 @@ fn test() {
         "[].concat(some./**/array)",
         "[/**/].concat(some./**/array)",
         "[/**/].concat(some.array)",
+        "const Items = [] as unknown[]; Items.flatMap(x => x);",
     ];
 
     let fix = vec![
@@ -631,6 +636,10 @@ fn test() {
             "for (const value of values) {
                 value.flat();
             }",
+        ),
+        (
+            "const Items = [] as unknown[]; Items.flatMap(x => x);",
+            "const Items = [] as unknown[]; Items.flat();",
         ),
         // TODO: Get these passing.
         // ("/**/[].concat.apply([], array)", "/**/array.flat()"),

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -107,11 +107,6 @@ fn check_array_flat_map_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintConte
         return;
     }
 
-    // Skip receivers that are obviously not arrays, e.g. `Effects.flatMap(x => x)`,
-    // `const text = ""; text.flatMap(x => x)`, `const set = new Set(); set.flatMap(x => x)`.
-    // `flatMap` also exists on non-array types (RxJS observables, custom classes), and `.flat()`
-    // does not, so reporting/auto-fixing those is a false positive and a breaking rewrite. Mirrors
-    // eslint-plugin-unicorn's `isObviouslyNonArrayFlatMapReceiver`.
     if let Some(member_expr) = call_expr.callee.as_member_expression()
         && is_obviously_non_array_flat_map_receiver(member_expr.object(), ctx)
     {
@@ -138,9 +133,6 @@ enum ConstInitKind {
     NonArray,
 }
 
-/// Whether the `flatMap` receiver is statically known not to be an array, mirroring
-/// eslint-plugin-unicorn's `isObviouslyNonArrayFlatMapReceiver`:
-/// `(isPascalCaseIdentifier && !isConstArrayVariable) || isConstNonArrayVariable`.
 fn is_obviously_non_array_flat_map_receiver(object: &Expression, ctx: &LintContext) -> bool {
     let Expression::Identifier(ident) = object.without_parentheses() else {
         return false;
@@ -153,9 +145,6 @@ fn is_obviously_non_array_flat_map_receiver(object: &Expression, ctx: &LintConte
     }
 }
 
-/// Classify the initializer of a `const` variable as definitely-array or definitely-non-array.
-/// Returns `None` for non-`const` bindings, missing initializers, or initializers whose type
-/// cannot be statically determined (e.g. a call expression).
 fn const_variable_initializer_kind(
     ident: &IdentifierReference,
     ctx: &LintContext,
@@ -398,7 +387,6 @@ fn test() {
         "array.flatMap((x, y) => x)",
         // "array.flatMap((x) => { return x; })",
         "array.flatMap(x => y)",
-        // Non-array receivers (matches eslint-plugin-unicorn `isObviouslyNonArrayFlatMapReceiver`):
         "const randomObject = {
                 flatMap(function_) {
                     function_();

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_array_flat.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_array_flat.snap
@@ -574,3 +574,10 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────────────
    ╰────
   help: Call `.flat()` on the array instead.
+
+  ⚠ unicorn(prefer-array-flat): Prefer Array#flat() over legacy techniques to flatten arrays.
+   ╭─[prefer_array_flat.tsx:1:32]
+ 1 │ const Items = [] as unknown[]; Items.flatMap(x => x);
+   ·                                ─────────────────────
+   ╰────
+  help: Call `.flat()` on the array instead.


### PR DESCRIPTION
### Bug
`unicorn/prefer-array-flat` reports `X.flatMap(x => x)` (and, under `--fix-dangerously`, rewrites it to `X.flat()`) for ANY receiver — including ones that are obviously not arrays.

### Repro (all upstream-valid, i.e. should NOT be reported)
```js
Effects.flatMap(x => x)
const text = ""; text.flatMap(x => x)
const set = new Set(); set.flatMap(x => x)
const handler = () => {}; handler.flatMap(x => x)
const collection = new Foo(); collection.flatMap(x => x)
```
`flatMap` also exists on non-array types (RxJS observables, custom classes) where `.flat()` does not, so the diagnostic is a false positive and the `--fix-dangerously` rewrite breaks at runtime.

### Expected
Skip receivers statically known not to be arrays. eslint-plugin-unicorn does this via `isObviouslyNonArrayFlatMapReceiver`.

### Fix
Port that guard: bail when the receiver is a PascalCase identifier (not a `const` bound to an array) or a `const` bound to a non-array (object / literal / template / function / class / `new NonArray()`). Const arrays still report (`const Items = []; Items.flatMap(x => x)`). This enables oxc's own previously-`// TODO: Get this passing` test cases, which are the regression test.

Prepared with AI assistance.