### PR TITLE
refactor(allocator,formatter): consolidate borrow-passthrough into reusable alloc_cow_str

### DIFF
--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -1,5 +1,6 @@
 use std::{
     alloc::Layout,
+    borrow::Cow,
     ptr::{self, NonNull},
     slice, str,
 };
@@ -300,6 +301,35 @@ impl Allocator {
     #[inline(always)]
     pub fn alloc_str<'alloc>(&'alloc self, src: &str) -> &'alloc str {
         self.arena.alloc_str(src)
+    }
+
+    /// Get a `&str` out of a [`Cow`], **without copying** when it is [`Cow::Borrowed`].
+    ///
+    /// The borrow-passthrough optimization: a [`Cow::Borrowed`] already references data that
+    /// lives at least as long as this allocator (`'alloc`), so it is returned as-is; only a
+    /// [`Cow::Owned`] is copied into the arena via [`alloc_str`].
+    ///
+    /// Takes the `Cow` by shared reference so it also works when the `Cow` lives behind a `&self`
+    /// borrow and cannot be moved out. Prefer this over `allocator.alloc_str(&cow)`, which always
+    /// copies even when `cow` is borrowed. It is most useful when normalizing source text (string
+    /// / number / bigint literals, etc.): the common case needs no normalization and stays
+    /// borrowed, so the arena copy is avoided entirely.
+    ///
+    /// # Panics
+    /// In the [`Cow::Owned`] case only, panics if reserving space in the arena fails. A
+    /// [`Cow::Borrowed`] never allocates.
+    ///
+    /// [`alloc_str`]: Allocator::alloc_str
+    //
+    // `#[inline(always)]` to match `alloc_str`: this is a hot path and the borrowed arm is a
+    // no-op, so we always want it inlined.
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    pub fn alloc_cow_str<'alloc>(&'alloc self, cow: &Cow<'alloc, str>) -> &'alloc str {
+        match *cow {
+            Cow::Borrowed(s) => s,
+            Cow::Owned(ref s) => self.alloc_str(s),
+        }
     }
 
     /// `Copy` a slice into this [`Allocator`] and return an exclusive reference to the copy.

--- a/crates/oxc_formatter/src/formatter/token/number.rs
+++ b/crates/oxc_formatter/src/formatter/token/number.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 pub use oxc_formatter_core::spec::{format_trimmed_number, is_simple_number};
 
 use crate::formatter::{Format, JsFormatter, prelude::*};
@@ -18,15 +16,10 @@ pub struct CleanedNumberLiteralText<'a> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for CleanedNumberLiteralText<'a> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
+        // In the common case the number needs no reformatting, so `format_trimmed_number` returns
+        // a `Cow::Borrowed` slice of the source; `alloc_cow_str` passes it straight through,
+        // copying into the arena only for the owned (reformatted) case.
         let text = format_trimmed_number(self.text, self.keep_one_trailing_decimal_zero);
-        // In the common case the number needs no reformatting, so `format_trimmed_number`
-        // returns a `Cow::Borrowed` slice of the source (lifetime `'a`); pass it straight
-        // through and only copy into the arena for the owned (reformatted) case. Mirrors the
-        // borrowed-passthrough for string literals in `utils/string.rs`.
-        let text_str: &'a str = match &text {
-            Cow::Borrowed(borrowed) => borrowed,
-            Cow::Owned(owned) => f.allocator().alloc_str(owned),
-        };
-        text_without_whitespace(text_str).fmt(f);
+        text_without_whitespace(f.allocator().alloc_cow_str(&text)).fmt(f);
     }
 }

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -41,8 +41,6 @@ pub use binary_like_expression::{BinaryLikeExpression, should_flatten};
 pub use fragment::{FormatFunctionParams, FormatTypeParameters};
 pub use function::FormatFunctionOptions;
 
-use std::borrow::Cow;
-
 use cow_utils::CowUtils;
 
 use oxc_allocator::Vec;
@@ -1076,14 +1074,14 @@ impl<'a> FormatWrite<'a> for AstNode<'a, StringLiteral<'a>> {
 
 impl<'a> FormatWrite<'a> for AstNode<'a, BigIntLiteral<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        // Already-lowercase bigints (the common case, e.g. `123n`) stay `Cow::Borrowed`, so the
-        // arena copy is avoided; only an uppercase literal (e.g. `0xFFn`) is copied.
-        let lowered = self.raw().unwrap().as_str().cow_to_ascii_lowercase();
-        let text_str: &'a str = match lowered {
-            Cow::Borrowed(borrowed) => borrowed,
-            Cow::Owned(owned) => f.allocator().alloc_str(&owned),
-        };
-        write!(f, text(text_str));
+        // Already-lowercase bigints (the common case, e.g. `123n`) stay `Cow::Borrowed`, so
+        // `alloc_cow_str` avoids the arena copy; only an uppercase literal (e.g. `0xFFn`) is copied.
+        write!(
+            f,
+            text(
+                f.allocator().alloc_cow_str(&self.raw().unwrap().as_str().cow_to_ascii_lowercase())
+            )
+        );
     }
 }
 

--- a/crates/oxc_formatter/src/utils/string.rs
+++ b/crates/oxc_formatter/src/utils/string.rs
@@ -82,14 +82,10 @@ impl CleanedStringLiteralText<'_> {
 
 impl<'a> Format<'a, JsFormatContext<'a>> for CleanedStringLiteralText<'a> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
-        // In the common case the literal needs no normalization, so `text` borrows a slice of the
-        // source (`Cow::Borrowed`) which already outlives the buffer; pass it straight through and
-        // only copy into the arena for the owned (normalized) case.
-        let text_str: &'a str = match &self.text {
-            Cow::Borrowed(borrowed) => borrowed,
-            Cow::Owned(owned) => f.allocator().alloc_str(owned),
-        };
-        text(text_str).fmt(f);
+        // In the common case the literal needs no normalization, so `self.text` borrows a slice of
+        // the source (`Cow::Borrowed`) which already outlives the buffer; `alloc_cow_str` passes it
+        // straight through, copying into the arena only for the owned (normalized) case.
+        text(f.allocator().alloc_cow_str(&self.text)).fmt(f);
     }
 }
 

--- a/crates/oxc_formatter_json/src/print/literal.rs
+++ b/crates/oxc_formatter_json/src/print/literal.rs
@@ -10,7 +10,7 @@ use oxc_formatter_core::{
 
 use crate::context::JsonFormatContext;
 
-use super::{JsonFormatter, arena_cow_str, write_quoted_str};
+use super::{JsonFormatter, write_quoted_str};
 
 pub struct FmtJsonString<'a, 'b> {
     pub lit: &'b StringLiteral<'a>,
@@ -44,7 +44,7 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FmtJsonString<'a, '_> {
             return;
         }
 
-        write_quoted_str(f, chosen_quote, arena_cow_str(normalized, f));
+        write_quoted_str(f, chosen_quote, f.allocator().alloc_cow_str(&normalized));
     }
 }
 
@@ -71,6 +71,6 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FmtJsonNumber<'a, '_> {
         // `keep_one_trailing_decimal_zero` matches Prettier's JS/JSON behavior (`1.00000` → `1.0`, not `1`).
         let normalized =
             format_trimmed_number(raw.as_str(), /* keep_one_trailing_decimal_zero */ true);
-        write!(f, text(arena_cow_str(normalized, f)));
+        write!(f, text(f.allocator().alloc_cow_str(&normalized)));
     }
 }

--- a/crates/oxc_formatter_json/src/print/mod.rs
+++ b/crates/oxc_formatter_json/src/print/mod.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use oxc_ast::ast::Expression;
 use oxc_formatter_core::{Buffer, Format, Formatter, builders::FormatWith, builders::text, write};
 use oxc_span::{GetSpan, Span};
@@ -26,15 +24,6 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for &'static str {
     #[inline]
     fn fmt(&self, f: &mut JsonFormatter<'_, 'a>) {
         write!(f, oxc_formatter_core::builders::token(self));
-    }
-}
-
-/// Lifts a `Cow<'a, str>` to `&'a str`, allocating in the arena only for the owned case.
-/// Borrowed Cows already point into arena-resident source, so they pass through unchanged.
-pub fn arena_cow_str<'a>(cow: Cow<'a, str>, f: &JsonFormatter<'_, 'a>) -> &'a str {
-    match cow {
-        Cow::Borrowed(s) => s,
-        Cow::Owned(s) => f.allocator().alloc_str(&s),
     }
 }
 

--- a/crates/oxc_formatter_json/src/print/object.rs
+++ b/crates/oxc_formatter_json/src/print/object.rs
@@ -21,8 +21,8 @@ use crate::{
 };
 
 use super::{
-    FmtJsonValue, FormatInvalidJson, JsonFormatter, arena_cow_str, format_with,
-    literal::FmtJsonString, number_string_round_trips, write_quoted_str,
+    FmtJsonValue, FormatInvalidJson, JsonFormatter, format_with, literal::FmtJsonString,
+    number_string_round_trips, write_quoted_str,
 };
 
 pub struct FmtJsonObject<'a, 'b> {
@@ -237,7 +237,7 @@ fn json5_unquoted_key<'a>(lit: &StringLiteral<'a>) -> Option<&'a str> {
 fn json5_write_quoted_key<'a>(content: &'a str, f: &mut JsonFormatter<'_, 'a>) {
     let quote_byte = f.context().options().preferred_quote(content);
     let normalized = normalize_string(content, quote_byte, /* quotes_will_change */ false);
-    write_quoted_str(f, quote_byte, arena_cow_str(normalized, f));
+    write_quoted_str(f, quote_byte, f.allocator().alloc_cow_str(&normalized));
 }
 
 /// Resolves Prettier's `quoteProps: "consistent"` for `object`:
@@ -264,7 +264,7 @@ fn normalized_numeric_key<'a>(lit: &NumericLiteral<'a>, f: &JsonFormatter<'_, 'a
     let raw = lit.raw.as_ref().map_or("", oxc_ast::ast::Str::as_str);
     // JSON keeps one trailing decimal zero (`x.00000` -> `x.0`); see `format_trimmed_number`.
     let printed = format_trimmed_number(raw, /* keep_one_trailing_decimal_zero */ true);
-    arena_cow_str(printed, f)
+    f.allocator().alloc_cow_str(&printed)
 }
 
 /// Returns `true` if a normalized numeric key should be wrapped in double quotes.

--- a/crates/oxc_formatter_json/src/print/stringify.rs
+++ b/crates/oxc_formatter_json/src/print/stringify.rs
@@ -21,7 +21,7 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::context::JsonFormatContext;
 
 use super::{
-    FormatInvalidJson, JsonFormatter, arena_cow_str, format_with, literal::FmtJsonString,
+    FormatInvalidJson, JsonFormatter, format_with, literal::FmtJsonString,
     number_string_round_trips, write_quoted_str,
 };
 
@@ -90,7 +90,7 @@ fn write_number_value<'a>(lit: &NumericLiteral<'a>, f: &mut JsonFormatter<'_, 'a
 fn write_string<'a>(lit: &StringLiteral<'a>, f: &mut JsonFormatter<'_, 'a>) {
     if COMPAT_PRE_18405 {
         let body = json_stringify_escape(lit.value.as_str(), lit.lone_surrogates);
-        write_quoted_str(f, b'"', arena_cow_str(body, f));
+        write_quoted_str(f, b'"', f.allocator().alloc_cow_str(&body));
     } else {
         // `preferred_quote` already pins `json-stringify` to `"`.
         FmtJsonString { lit }.fmt(f);
@@ -212,7 +212,7 @@ fn write_template<'a>(template: &TemplateLiteral<'a>, f: &mut JsonFormatter<'_, 
         return;
     };
     let body = json_stringify_escape(cooked.as_str(), quasi.lone_surrogates);
-    write_quoted_str(f, b'"', arena_cow_str(body, f));
+    write_quoted_str(f, b'"', f.allocator().alloc_cow_str(&body));
 }
 
 /// Escapes `content` the way `JSON.stringify` does for a string body


### PR DESCRIPTION
## What

Introduces `Allocator::alloc_cow_str(&cow)` — returns a `Cow`'s `&str` **without copying** when it is `Cow::Borrowed`, copying into the arena only for `Cow::Owned`. Crystallizes the borrow-passthrough pattern (string #23465, number #23512, bigint #23534) into one documented, reusable helper instead of an inline `match` repeated at each site.

It takes the `Cow` **by shared reference** so it also works where the `Cow` lives behind a `&self` borrow (string literals) and can't be moved out — letting **every** in-tree site use it.

Pure consolidation: **behavior- and allocation-neutral** (the bigint alloc win landed separately in #23534; allocation snapshots are unchanged here).

## Migrated sites (all of them)

- `oxc_formatter` **string** literals (`CleanedStringLiteralText::fmt`)
- `oxc_formatter` **numeric** literals (`CleanedNumberLiteralText::fmt`)
- `oxc_formatter` **bigint** literals
- `oxc_formatter_json`: **removed** the crate-local `arena_cow_str` wrapper; its call sites now use the shared helper directly (`f.allocator().alloc_cow_str(&cow)`) — matching how both formatters already call `f.allocator().alloc_str(...)` directly, with no per-crate wrapper.

## Addresses review (@leaysgur)

- Added `# Panics` doc.
- `#[inline(always)]` (+ `#[expect(clippy::inline_always)]`) to match the sibling `alloc_str`.
- Migrated the other in-tree site that had a local copy (`oxc_formatter_json`) — and every remaining inline occurrence of the pattern.

Prepared with AI assistance.