### PR TITLE
refactor(linter): share non-generic config-error formatting (-0.56% binary size)

### DIFF
--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -75,6 +75,19 @@ pub trait Rule: Sized + Default + fmt::Debug {
     }
 }
 
+/// Pretty-print a JSON value and collapse all whitespace runs to single spaces,
+/// for embedding a "received config" snippet in a rule-config deserialization error.
+///
+/// Kept non-generic (and out of the generic `Deserialize` impls below) so the heavy
+/// `serde_json::to_string_pretty` machinery is compiled once instead of being
+/// monomorphized into every rule-config `deserialize` instantiation. Returns `None`
+/// when serialization fails, so callers fall back to the bare error.
+fn compact_json_for_error(value: &serde_json::Value) -> Option<String> {
+    serde_json::to_string_pretty(value)
+        .ok()
+        .map(|value_str| value_str.split_whitespace().collect::<Vec<_>>().join(" "))
+}
+
 /// A wrapper type for deserializing ESLint-style rule configurations.
 ///
 /// ESLint configurations are typically arrays where the first element contains
@@ -127,15 +140,12 @@ where
 
         if let serde_json::Value::Array(arr) = value {
             let config = match arr.into_iter().next() {
-                Some(v) => T::deserialize(&v).map_err(|e| {
-                    // Try to include the config object in the error message if we can.
-                    // Collapse any whitespace so we emit a single-line message.
-                    if let Ok(value_str) = serde_json::to_string_pretty(&v) {
-                        let compact = value_str.split_whitespace().collect::<Vec<_>>().join(" ");
+                // Try to include the config object in the error message if we can.
+                Some(v) => T::deserialize(&v).map_err(|e| match compact_json_for_error(&v) {
+                    Some(compact) => {
                         D::Error::custom(format!("{e}\n  received config: `{compact}`"))
-                    } else {
-                        D::Error::custom(e)
                     }
+                    None => D::Error::custom(e),
                 })?,
                 None => T::default(),
             };
@@ -207,14 +217,11 @@ where
             } else {
                 // Parse the entire array as the tuple configuration.
                 let arr_value = serde_json::Value::Array(arr);
+                // Try to include the config array in the error message if we can.
                 T::deserialize(&arr_value).map_err(|e| {
-                    // Try to include the config array in the error message if we can.
-                    // Collapse any whitespace so we emit a single-line message.
-                    if let Ok(value_str) = serde_json::to_string_pretty(&arr_value) {
-                        let compact = value_str.split_whitespace().collect::<Vec<_>>().join(" ");
-                        D::Error::custom(format!("{e}, received `{compact}`"))
-                    } else {
-                        D::Error::custom(e)
+                    match compact_json_for_error(&arr_value) {
+                        Some(compact) => D::Error::custom(format!("{e}, received `{compact}`")),
+                        None => D::Error::custom(e),
                     }
                 })?
             };

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -140,7 +140,6 @@ where
 
         if let serde_json::Value::Array(arr) = value {
             let config = match arr.into_iter().next() {
-                // Try to include the config object in the error message if we can.
                 Some(v) => T::deserialize(&v).map_err(|e| match compact_json_for_error(&v) {
                     Some(compact) => {
                         D::Error::custom(format!("{e}\n  received config: `{compact}`"))
@@ -217,7 +216,6 @@ where
             } else {
                 // Parse the entire array as the tuple configuration.
                 let arr_value = serde_json::Value::Array(arr);
-                // Try to include the config array in the error message if we can.
                 T::deserialize(&arr_value).map_err(|e| {
                     match compact_json_for_error(&arr_value) {
                         Some(compact) => D::Error::custom(format!("{e}, received `{compact}`")),


### PR DESCRIPTION
Extracts the duplicated invalid-config **error-formatting** path out of two generic `Deserialize` impls into a single non-generic helper, so it is compiled once instead of monomorphized into every rule's config type.

### Size win (stripped `oxlint`)

| surface | before | after | saved |
| --- | ---: | ---: | ---: |
| `oxlint` (release, stripped) | 17,567,376 | 17,468,304 | **−99,072 B (~97 KB, −0.56%)** |

### What & why

`DefaultRuleConfig<T>` and `TupleRuleConfig<T>` implement `serde::Deserialize` and are instantiated for **every** rule that uses serde-based config (260+ and growing). Each instantiation duplicated the invalid-config error path, which calls `serde_json::to_string_pretty` (the JSON pretty-printer) plus a whitespace-collapse + `format!`. That whole path is concrete (`serde_json::Value` / `serde_json::Error`), so it was the same machine code copied per rule.

This PR hoists it into one private non-generic fn:

```rust
fn compact_json_for_error(value: &serde_json::Value) -> Option<String> {
    serde_json::to_string_pretty(value)
        .ok()
        .map(|value_str| value_str.split_whitespace().collect::<Vec<_>>().join(" "))
}
```

Both `deserialize` impls now call it; the per-rule generic code stays tiny.

### Behavior

Pure refactor — error messages are byte-identical (format strings unchanged), control flow unchanged. `just ready` is green and the 1170 linter unit tests + rule-configuration tests pass with **no snapshot changes**.

### Perf

Perf-neutral. The changed code runs only at **config load** (once per configured rule, from `from_configuration`) and only the helper is on the **error** path; the success path is unchanged. It is never per-file or per-AST-node. CodSpeed runs on this PR (touches `crates/**`), though the linter benchmark builds config via `ConfigStoreBuilder::all()` which doesn't exercise `from_configuration`, so no benchmarked hot loop is affected.

### Measurement

`cargo build --release -p oxlint --features allocator && stat -f%z target/release/oxlint`, rustc 1.96.0, same base commit, single-file diff. Reproduced deterministically.

Prepared with AI assistance.