### PR TITLE
perf(linter): type-major rule dispatch

### DIFF
--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -853,7 +853,7 @@ use crate::{
     timing::RuleTimingStat,
     utils::PossibleJestNode,
 };
-use oxc_semantic::AstTypesBitset;
+use oxc_semantic::{AstNodes, AstTypesBitset, NodeId};
 #[derive(Debug, Clone)]
 pub enum RuleEnum {
     ImportConsistentTypeSpecifierStyle(ImportConsistentTypeSpecifierStyle),
@@ -16240,6 +16240,8384 @@ impl RuleEnum {
                 Self::VueValidDefineOptions(rule) => rule.run(node, ctx),
                 Self::VueValidDefineProps(rule) => rule.run(node, ctx),
                 Self::VueValidNextTick(rule) => rule.run(node, ctx),
+            }
+        }
+    }
+    #[doc = r" Run this rule over every node in `node_ids` (all of the same AST type), resolving"]
+    #[doc = r" each id against `nodes`. The enum match happens once per call rather than once per"]
+    #[doc = r" node, so the per-node dispatch is a direct, inlinable call into the concrete rule."]
+    pub(crate) fn run_batch<'a, const TIMINGS: bool>(
+        &self,
+        node_ids: &[NodeId],
+        nodes: &AstNodes<'a>,
+        ctx: &LintContext<'a>,
+        timing_stat: Option<&mut RuleTimingStat>,
+    ) {
+        if TIMINGS {
+            timing_stat.expect("missing rule timing stat").time(|| match self {
+                Self::ImportConsistentTypeSpecifierStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportDefault(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportExportsLast(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportExtensions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportFirst(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportGroupExports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportMaxDependencies(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNamed(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNamespace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNewlineAfterImport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoAbsolutePath(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoAmd(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoAnonymousDefaultExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoCommonjs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoCycle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoDefaultExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoDuplicates(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoDynamicRequire(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoEmptyNamedBlocks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoMutableExports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNamedAsDefault(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNamedAsDefaultMember(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNamedDefault(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNamedExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNamespace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNodejsModules(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoRelativeParentImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoSelfImport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoUnassignedImport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoWebpackLoaderSyntax(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportPreferDefaultExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportUnambiguous(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintAccessorPairs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintArrayCallbackReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintArrowBodyStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintBlockScopedVar(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintCapitalizedComments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintClassMethodsUseThis(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintComplexity(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintConstructorSuper(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintCurly(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintDefaultCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintDefaultCaseLast(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintDefaultParamLast(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintEqeqeq(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintForDirection(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintFuncNameMatching(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintFuncNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintFuncStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintGetterReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintGroupedAccessorPairs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintGuardForIn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintIdLength(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintIdMatch(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintInitDeclarations(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintLogicalAssignmentOperators(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxClassesPerFile(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxDepth(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxLines(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxLinesPerFunction(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxNestedCallbacks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxParams(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxStatements(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNewCap(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoAlert(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoArrayConstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoAsyncPromiseExecutor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoAwaitInLoop(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoBitwise(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoCaller(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoCaseDeclarations(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoClassAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoCompareNegZero(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoCondAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoConsole(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoConstAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoConstantBinaryExpression(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoConstantCondition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoConstructorReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoContinue(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoControlRegex(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDebugger(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDeleteVar(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDivRegex(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDupeClassMembers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDupeElseIf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDupeKeys(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDuplicateCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDuplicateImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoElseReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEmpty(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEmptyCharacterClass(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEmptyFunction(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEmptyPattern(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEmptyStaticBlock(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEqNull(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEval(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoExAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoExtendNative(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoExtraBind(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoExtraBooleanCast(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoExtraLabel(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoFallthrough(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoFuncAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoGlobalAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoImplicitCoercion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoImplicitGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoImpliedEval(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoImportAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoInlineComments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoInnerDeclarations(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoInvalidRegexp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoIrregularWhitespace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoIterator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLabelVar(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLabels(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLoneBlocks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLonelyIf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLoopFunc(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLossOfPrecision(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoMagicNumbers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoMisleadingCharacterClass(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoMultiAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoMultiStr(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNegatedCondition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNestedTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNew(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNewFunc(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNewNativeNonconstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNewWrappers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNonoctalDecimalEscape(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoObjCalls(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoObjectConstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoParamReassign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoPlusplus(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoPromiseExecutorReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoProto(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoPrototypeBuiltins(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRedeclare(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRegexSpaces(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRestrictedExports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRestrictedGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRestrictedImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRestrictedProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoReturnAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoScriptUrl(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoSelfAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoSelfCompare(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoSequences(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoSetterReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoShadow(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoShadowRestrictedNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoSparseArrays(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoTemplateCurlyInString(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoThisBeforeSuper(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoThrowLiteral(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnassignedVars(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUndef(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUndefined(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnderscoreDangle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnexpectedMultiline(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnmodifiedLoopCondition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnneededTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnreachable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnsafeFinally(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnsafeNegation(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnsafeOptionalChaining(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnusedExpressions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnusedLabels(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnusedPrivateClassMembers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnusedVars(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUseBeforeDefine(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessBackreference(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessCall(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessCatch(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessComputedKey(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessConcat(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessConstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessEscape(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessRename(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoVar(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoVoid(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoWarningComments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintObjectShorthand(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintOperatorAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferArrowCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferConst(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferDestructuring(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferExponentiationOperator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferNamedCaptureGroup(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferNumericLiterals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferObjectHasOwn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferObjectSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferPromiseRejectErrors(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferRegexLiterals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferRestParams(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferTemplate(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreserveCaughtError(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintRadix(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintRequireAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintRequireUnicodeRegexp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintRequireYield(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintSortImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintSortKeys(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintSortVars(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintSymbolDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintUnicodeBom(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintUseIsnan(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintValidTypeof(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintVarsOnTop(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintYoda(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptAdjacentOverloadSignatures(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptArrayType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptAwaitThenable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptBanTsComment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptBanTslintComment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptBanTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptClassLiteralPropertyStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentGenericConstructors(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentIndexedObjectStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentTypeAssertions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentTypeDefinitions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentTypeExports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentTypeImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptDotNotation(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptExplicitFunctionReturnType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptExplicitMemberAccessibility(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptExplicitModuleBoundaryTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptMethodSignatureStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoArrayDelete(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoBaseToString(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoConfusingNonNullAssertion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoConfusingVoidExpression(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoDeprecated(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoDuplicateEnumValues(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoDuplicateTypeConstituents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoDynamicDelete(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoEmptyInterface(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoEmptyObjectType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoExplicitAny(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoExtraNonNullAssertion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoExtraneousClass(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoFloatingPromises(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoForInArray(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoImpliedEval(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoImportTypeSideEffects(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoInferrableTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoInvalidVoidType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoMeaninglessVoidOperator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoMisusedNew(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoMisusedPromises(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoMisusedSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoMixedEnums(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoNamespace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoNonNullAssertedNullishCoalescing(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoNonNullAssertedOptionalChain(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoNonNullAssertion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoRedundantTypeConstituents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoRequireImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoRestrictedTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoThisAlias(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryBooleanLiteralCompare(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryCondition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryParameterPropertyAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryQualifier(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTemplateExpression(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTypeArguments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTypeAssertion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTypeConstraint(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTypeConversion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTypeParameters(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeArgument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeCall(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeDeclarationMerging(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeEnumComparison(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeFunctionType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeMemberAccess(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeTypeAssertion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeUnaryMinus(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUselessDefaultAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUselessEmptyExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoVarRequires(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoWrapperObjectTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNonNullableTypeAssertionStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptOnlyThrowError(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptParameterProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferAsConst(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferEnumInitializers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferFind(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferForOf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferFunctionType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferIncludes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferLiteralEnumMember(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferNamespaceKeyword(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferNullishCoalescing(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferOptionalChain(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferPromiseRejectErrors(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferReadonly(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferReadonlyParameterTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferReduceTypeParameter(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferRegexpExec(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferReturnThisType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferStringStartsEndsWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferTsExpectError(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPromiseFunctionAsync(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptRelatedGetterSetterPairs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptRequireArraySortCompare(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptRequireAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptRestrictPlusOperands(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptRestrictTemplateExpressions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptReturnAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptStrictBooleanExpressions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptStrictVoidReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptSwitchExhaustivenessCheck(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptTripleSlashReference(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptUnboundMethod(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptUnifiedSignatures(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptUseUnknownInCatchCallbackVariable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestConsistentTestIt(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestExpectExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestMaxExpects(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestMaxNestedDescribe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoAliasMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoCommentedOutTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoConditionalExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoConditionalInTest(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoConfusingSetTimeout(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoDeprecatedFunctions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoDisabledTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoDoneCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoDuplicateHooks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoFocusedTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoHooks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoIdenticalTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoInterpolationInSnapshots(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoJasmineGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoLargeSnapshots(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoMocksImport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoRestrictedJestMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoRestrictedMatchers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoStandaloneExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoTestPrefixes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoTestReturnStatement(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoUnneededAsyncExpectFunction(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoUntypedMockFactory(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPaddingAroundAfterAllBlocks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPaddingAroundTestBlocks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferCalledWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferComparisonMatcher(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferEach(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferEndingWithAnExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferEqualityMatcher(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferExpectAssertions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferExpectResolves(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferHooksInOrder(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferHooksOnTop(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferImportingJestGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferJestMocked(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferLowercaseTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferMockPromiseShorthand(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferMockReturnShorthand(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferSnapshotHint(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferSpyOn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferStrictEqual(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferToBe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferToContain(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferToHaveBeenCalled(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferToHaveBeenCalledTimes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferToHaveLength(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferTodo(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestRequireHook(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestRequireToThrowMessage(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestRequireTopLevelDescribe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestValidDescribeCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestValidExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestValidExpectInPromise(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestValidTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactButtonHasType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactDisplayName(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactExhaustiveDeps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactForbidComponentProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactForbidDomProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactForbidElements(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactForwardRefUsesRef(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactHookUseState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactIframeMissingSandbox(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxBooleanValue(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxCurlyBracePresence(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxFilenameExtension(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxFragments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxHandlerNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxKey(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxMaxDepth(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoCommentTextnodes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoConstructedContextValues(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoDuplicateProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoLiterals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoScriptUrl(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoTargetBlank(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoUndef(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoUselessFragment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxPascalCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxPropsNoSpreadMulti(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxPropsNoSpreading(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoArrayIndexKey(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoChildrenProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoCloneElement(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoDanger(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoDangerWithChildren(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoDidMountSetState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoDidUpdateSetState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoDirectMutationState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoFindDomNode(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoIsMounted(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoMultiComp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoNamespace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoObjectTypeAsDefaultProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoReactChildren(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoRedundantShouldComponentUpdate(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoRenderReturnValue(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoSetState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoStringRefs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoThisInSfc(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoUnescapedEntities(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoUnknownProperty(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoUnsafe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoUnstableNestedComponents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoWillUpdateSetState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactOnlyExportComponents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPreferEs6Class(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPreferFunctionComponent(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactReactCompiler(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactReactInJsxScope(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactRequireRenderReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactRulesOfHooks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactSelfClosingComp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactStateInConstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactStylePropObject(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactVoidDomElementsNoChildren(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPerfJsxNoJsxAsProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPerfJsxNoNewArrayAsProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPerfJsxNoNewFunctionAsProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPerfJsxNoNewObjectAsProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornCatchErrorName(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentAssert(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentDateClone(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentEmptyArraySpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentExistenceIndexCheck(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentFunctionScoping(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentTemplateLiteralEscape(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornCustomErrorDefinition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornEmptyBraceSpaces(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornErrorMessage(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornEscapeCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornExplicitLengthCheck(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornFilenameCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornImportStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornMaxNestedCalls(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNewForBuiltins(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoAbusiveEslintDisable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoAccessorRecursion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoAnonymousDefaultExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayCallbackReference(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayFillWithReferenceType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayForEach(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayMethodThisArgument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayReduce(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayReverse(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArraySort(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoAwaitExpressionMember(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoAwaitInPromiseMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoConsoleSpaces(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoDocumentCookie(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoEmptyFile(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoHexEscape(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoImmediateMutation(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoInstanceofArray(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoInstanceofBuiltins(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoInvalidFetchOptions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoInvalidRemoveEventListener(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoLengthAsSliceEnd(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoLonelyIf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoMagicArrayFlatDepth(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNegatedCondition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNegationInEqualityCheck(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNestedTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNewArray(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNewBuffer(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNull(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoObjectAsDefaultParameter(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoProcessExit(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoSinglePromiseInPromiseMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoStaticOnlyClass(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoThenable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoThisAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoTypeofUndefined(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnnecessaryArrayFlatDepth(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnnecessaryArraySpliceCount(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnnecessaryAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnnecessarySliceEnd(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnreadableArrayDestructuring(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnreadableIife(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessCollectionArgument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessErrorCaptureStackTrace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessFallbackInSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessIteratorToArray(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessLengthCheck(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessPromiseResolveReject(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessSwitchCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessUndefined(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoZeroFractions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNumberLiteralCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNumericSeparatorsStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferAddEventListener(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferArrayFind(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferArrayFlat(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferArrayFlatMap(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferArrayIndexOf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferArraySome(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferAt(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferBigintLiterals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferBlobReadingMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferClassFields(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferClasslistToggle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferCodePoint(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDateNow(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDefaultParameters(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDomNodeAppend(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDomNodeDataset(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDomNodeRemove(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDomNodeTextContent(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferEventTarget(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferExportFrom(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferGlobalThis(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferImportMetaProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferIncludes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferKeyboardEventKey(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferLogicalOperatorOverTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferMathMinMax(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferMathTrunc(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferModernDomApis(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferModernMathApis(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferModule(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferNativeCoercionFunctions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferNegativeIndex(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferNodeProtocol(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferNumberCoercion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferNumberProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferObjectFromEntries(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferOptionalCatchBinding(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferPrototypeMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferQuerySelector(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferReflectApply(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferRegexpTest(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferResponseStaticJson(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferSetHas(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferSetSize(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferSingleCall(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStringRaw(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStringReplaceAll(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStringSlice(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStringStartsEndsWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStringTrimStartEnd(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStructuredClone(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferTopLevelAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferTypeError(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRelativeUrlStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRequireArrayJoinSeparator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRequireModuleAttributes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRequireModuleSpecifiers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRequireNumberToFixedDigitsArgument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRequirePostMessageTargetOrigin(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornSwitchCaseBraces(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornSwitchCaseBreakPosition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornTextEncodingIdentifierCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornThrowNewError(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAltText(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAnchorAmbiguousText(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAnchorHasContent(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAnchorIsValid(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAriaActivedescendantHasTabindex(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAriaProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAriaProptypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAriaRole(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAriaUnsupportedElements(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAutocompleteValid(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YClickEventsHaveKeyEvents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YControlHasAssociatedLabel(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YHeadingHasContent(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YHtmlHasLang(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YIframeHasTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YImgRedundantAlt(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YInteractiveSupportsFocus(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YLabelHasAssociatedControl(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YLang(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YMediaHasCaption(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YMouseEventsHaveKeyEvents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoAccessKey(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoAriaHiddenOnFocusable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoAutofocus(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoDistractingElements(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoInteractiveElementToNoninteractiveRole(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoNoninteractiveElementInteractions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoNoninteractiveElementToInteractiveRole(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoNoninteractiveTabindex(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoRedundantRoles(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoStaticElementInteractions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YPreferTagOverRole(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YRoleHasRequiredAriaProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YRoleSupportsAriaProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YScope(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YTabindexNoPositive(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcApproxConstant(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadArrayMethodOnArguments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadBitwiseOperator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadCharAtComparison(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadComparisonSequence(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadMinMaxFunc(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadObjectLiteralComparison(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadReplaceAllArg(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBranchesSharingCode(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcConstComparisons(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcDoubleComparisons(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcErasingOp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcMisrefactoredAssignOp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcMissingThrow(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoAccumulatingSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoAsyncAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoAsyncEndpointHandlers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoBarrelFile(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoConstEnum(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoMapSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoOptionalChaining(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoRestSpreadProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoThisInExportedFunction(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNumberArgOutOfRange(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcOnlyUsedInRecursion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcUninvokedArrayCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsGoogleFontDisplay(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsGoogleFontPreconnect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsInlineScriptId(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNextScriptForGa(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoAssignModuleVariable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoAsyncClientComponent(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoBeforeInteractiveScriptOutsideDocument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoCssTags(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoDocumentImportInPage(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoDuplicateHead(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoHeadElement(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoHeadImportInDocument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoHtmlLinkForPages(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoImgElement(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoPageCustomFont(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoScriptComponentInHead(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoStyledJsxInDocument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoSyncScripts(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoTitleInDocumentHead(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoTypos(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoUnwantedPolyfillio(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocCheckAccess(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocCheckPropertyNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocCheckTagNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocEmptyTags(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocImplementsOnClasses(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocNoDefaults(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireParam(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireParamDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireParamName(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireParamType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireProperty(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequirePropertyDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequirePropertyName(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequirePropertyType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireReturns(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireReturnsDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireReturnsType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireThrowsDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireThrowsType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireYields(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireYieldsDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireYieldsType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseAlwaysReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseAvoidNew(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseCatchOrReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoCallbackInPromise(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoMultipleResolved(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoNesting(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoNewStatics(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoPromiseInCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoReturnInFinally(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoReturnWrap(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseParamNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromisePreferAwaitToCallbacks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromisePreferAwaitToThen(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromisePreferCatch(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseSpecOnly(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseValidParams(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestConsistentEachFor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestConsistentTestFilename(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestConsistentTestIt(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestConsistentVitestVi(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestExpectExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestHoistedApisOnTop(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestMaxExpects(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestMaxNestedDescribe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoAliasMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoCommentedOutTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoConditionalExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoConditionalInTest(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoConditionalTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoDisabledTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoDuplicateHooks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoFocusedTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoHooks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoIdenticalTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoImportNodeTest(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoImportingVitestGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoInterpolationInSnapshots(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoLargeSnapshots(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoMocksImport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoRestrictedMatchers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoRestrictedViMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoStandaloneExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoTestPrefixes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoTestReturnStatement(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoUnneededAsyncExpectFunction(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPaddingAroundAfterAllBlocks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferCalledExactlyOnceWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferCalledOnce(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferCalledTimes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferCalledWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferComparisonMatcher(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferDescribeFunctionTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferEach(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferEqualityMatcher(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferExpectAssertions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferExpectResolves(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferExpectTypeOf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferHooksInOrder(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferHooksOnTop(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferImportInMock(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferImportingVitestGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferLowercaseTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferMockPromiseShorthand(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferMockReturnShorthand(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferSnapshotHint(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferSpyOn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferStrictBooleanMatchers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferStrictEqual(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToBe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToBeFalsy(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToBeObject(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToBeTruthy(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToContain(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToHaveBeenCalledTimes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToHaveLength(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferTodo(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireAwaitedExpectPoll(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireHook(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireMockTypeParameters(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireTestTimeout(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireToThrowMessage(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireTopLevelDescribe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestValidDescribeCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestValidExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestValidExpectInPromise(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestValidTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestWarnTodo(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeCallbackReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeGlobalRequire(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeHandleCallbackErr(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeNoExportsAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeNoNewRequire(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeNoPathConcat(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeNoProcessEnv(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueComponentDefinitionNameCasing(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueDefineEmitsDeclaration(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueDefinePropsDeclaration(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueDefinePropsDestructuring(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueMaxProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNextTickStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoArrowFunctionsInWatch(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoAsyncInComputedProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoComputedPropertiesInData(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedDataObjectDeclaration(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedDeleteSet(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedDestroyedLifecycle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedEventsApi(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedModelDefinition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedPropsDefaultThis(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedVueConfigKeycodes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDupeKeys(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoExportInScriptSetup(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoExposeAfterAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoImportCompilerMacros(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoLifecycleAfterAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoMultipleSlotArgs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoRequiredPropWithDefault(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoReservedComponentNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoReservedKeys(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoReservedProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoSharedComponentData(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoSideEffectsInComputedProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoThisInBeforeRouteEnter(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoWatchAfterAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VuePreferImportFromVue(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VuePropNameCasing(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireDefaultExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireDefaultProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireDirectExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequirePropTypeConstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequirePropTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireRenderReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireSlotsAsFunctions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireTypedRef(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueReturnInComputedProperty(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueReturnInEmitsValidator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueValidDefineEmits(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueValidDefineOptions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueValidDefineProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueValidNextTick(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+            });
+        } else {
+            match self {
+                Self::ImportConsistentTypeSpecifierStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportDefault(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportExportsLast(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportExtensions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportFirst(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportGroupExports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportMaxDependencies(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNamed(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNamespace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNewlineAfterImport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoAbsolutePath(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoAmd(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoAnonymousDefaultExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoCommonjs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoCycle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoDefaultExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoDuplicates(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoDynamicRequire(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoEmptyNamedBlocks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoMutableExports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNamedAsDefault(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNamedAsDefaultMember(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNamedDefault(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNamedExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNamespace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoNodejsModules(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoRelativeParentImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoSelfImport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoUnassignedImport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportNoWebpackLoaderSyntax(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportPreferDefaultExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ImportUnambiguous(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintAccessorPairs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintArrayCallbackReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintArrowBodyStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintBlockScopedVar(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintCapitalizedComments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintClassMethodsUseThis(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintComplexity(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintConstructorSuper(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintCurly(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintDefaultCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintDefaultCaseLast(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintDefaultParamLast(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintEqeqeq(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintForDirection(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintFuncNameMatching(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintFuncNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintFuncStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintGetterReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintGroupedAccessorPairs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintGuardForIn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintIdLength(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintIdMatch(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintInitDeclarations(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintLogicalAssignmentOperators(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxClassesPerFile(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxDepth(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxLines(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxLinesPerFunction(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxNestedCallbacks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxParams(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintMaxStatements(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNewCap(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoAlert(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoArrayConstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoAsyncPromiseExecutor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoAwaitInLoop(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoBitwise(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoCaller(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoCaseDeclarations(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoClassAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoCompareNegZero(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoCondAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoConsole(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoConstAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoConstantBinaryExpression(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoConstantCondition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoConstructorReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoContinue(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoControlRegex(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDebugger(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDeleteVar(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDivRegex(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDupeClassMembers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDupeElseIf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDupeKeys(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDuplicateCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoDuplicateImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoElseReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEmpty(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEmptyCharacterClass(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEmptyFunction(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEmptyPattern(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEmptyStaticBlock(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEqNull(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoEval(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoExAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoExtendNative(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoExtraBind(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoExtraBooleanCast(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoExtraLabel(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoFallthrough(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoFuncAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoGlobalAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoImplicitCoercion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoImplicitGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoImpliedEval(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoImportAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoInlineComments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoInnerDeclarations(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoInvalidRegexp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoIrregularWhitespace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoIterator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLabelVar(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLabels(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLoneBlocks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLonelyIf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLoopFunc(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoLossOfPrecision(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoMagicNumbers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoMisleadingCharacterClass(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoMultiAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoMultiStr(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNegatedCondition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNestedTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNew(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNewFunc(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNewNativeNonconstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNewWrappers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoNonoctalDecimalEscape(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoObjCalls(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoObjectConstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoParamReassign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoPlusplus(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoPromiseExecutorReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoProto(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoPrototypeBuiltins(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRedeclare(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRegexSpaces(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRestrictedExports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRestrictedGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRestrictedImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoRestrictedProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoReturnAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoScriptUrl(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoSelfAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoSelfCompare(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoSequences(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoSetterReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoShadow(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoShadowRestrictedNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoSparseArrays(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoTemplateCurlyInString(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoThisBeforeSuper(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoThrowLiteral(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnassignedVars(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUndef(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUndefined(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnderscoreDangle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnexpectedMultiline(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnmodifiedLoopCondition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnneededTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnreachable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnsafeFinally(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnsafeNegation(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnsafeOptionalChaining(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnusedExpressions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnusedLabels(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnusedPrivateClassMembers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUnusedVars(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUseBeforeDefine(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessBackreference(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessCall(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessCatch(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessComputedKey(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessConcat(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessConstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessEscape(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessRename(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoUselessReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoVar(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoVoid(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoWarningComments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintNoWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintObjectShorthand(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintOperatorAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferArrowCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferConst(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferDestructuring(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferExponentiationOperator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferNamedCaptureGroup(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferNumericLiterals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferObjectHasOwn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferObjectSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferPromiseRejectErrors(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferRegexLiterals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferRestParams(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreferTemplate(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintPreserveCaughtError(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintRadix(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintRequireAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintRequireUnicodeRegexp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintRequireYield(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintSortImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintSortKeys(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintSortVars(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintSymbolDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintUnicodeBom(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintUseIsnan(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintValidTypeof(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintVarsOnTop(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::EslintYoda(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptAdjacentOverloadSignatures(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptArrayType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptAwaitThenable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptBanTsComment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptBanTslintComment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptBanTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptClassLiteralPropertyStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentGenericConstructors(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentIndexedObjectStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentTypeAssertions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentTypeDefinitions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentTypeExports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptConsistentTypeImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptDotNotation(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptExplicitFunctionReturnType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptExplicitMemberAccessibility(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptExplicitModuleBoundaryTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptMethodSignatureStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoArrayDelete(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoBaseToString(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoConfusingNonNullAssertion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoConfusingVoidExpression(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoDeprecated(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoDuplicateEnumValues(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoDuplicateTypeConstituents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoDynamicDelete(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoEmptyInterface(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoEmptyObjectType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoExplicitAny(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoExtraNonNullAssertion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoExtraneousClass(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoFloatingPromises(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoForInArray(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoImpliedEval(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoImportTypeSideEffects(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoInferrableTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoInvalidVoidType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoMeaninglessVoidOperator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoMisusedNew(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoMisusedPromises(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoMisusedSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoMixedEnums(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoNamespace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoNonNullAssertedNullishCoalescing(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoNonNullAssertedOptionalChain(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoNonNullAssertion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoRedundantTypeConstituents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoRequireImports(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoRestrictedTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoThisAlias(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryBooleanLiteralCompare(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryCondition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryParameterPropertyAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryQualifier(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTemplateExpression(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTypeArguments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTypeAssertion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTypeConstraint(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTypeConversion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnnecessaryTypeParameters(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeArgument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeCall(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeDeclarationMerging(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeEnumComparison(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeFunctionType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeMemberAccess(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeTypeAssertion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUnsafeUnaryMinus(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUselessDefaultAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoUselessEmptyExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoVarRequires(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNoWrapperObjectTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptNonNullableTypeAssertionStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptOnlyThrowError(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptParameterProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferAsConst(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferEnumInitializers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferFind(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferForOf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferFunctionType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferIncludes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferLiteralEnumMember(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferNamespaceKeyword(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferNullishCoalescing(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferOptionalChain(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferPromiseRejectErrors(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferReadonly(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferReadonlyParameterTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferReduceTypeParameter(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferRegexpExec(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferReturnThisType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferStringStartsEndsWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPreferTsExpectError(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptPromiseFunctionAsync(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptRelatedGetterSetterPairs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptRequireArraySortCompare(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptRequireAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptRestrictPlusOperands(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptRestrictTemplateExpressions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptReturnAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptStrictBooleanExpressions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptStrictVoidReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptSwitchExhaustivenessCheck(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptTripleSlashReference(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptUnboundMethod(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptUnifiedSignatures(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::TypescriptUseUnknownInCatchCallbackVariable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestConsistentTestIt(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestExpectExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestMaxExpects(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestMaxNestedDescribe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoAliasMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoCommentedOutTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoConditionalExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoConditionalInTest(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoConfusingSetTimeout(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoDeprecatedFunctions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoDisabledTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoDoneCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoDuplicateHooks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoFocusedTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoHooks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoIdenticalTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoInterpolationInSnapshots(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoJasmineGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoLargeSnapshots(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoMocksImport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoRestrictedJestMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoRestrictedMatchers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoStandaloneExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoTestPrefixes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoTestReturnStatement(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoUnneededAsyncExpectFunction(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestNoUntypedMockFactory(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPaddingAroundAfterAllBlocks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPaddingAroundTestBlocks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferCalledWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferComparisonMatcher(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferEach(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferEndingWithAnExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferEqualityMatcher(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferExpectAssertions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferExpectResolves(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferHooksInOrder(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferHooksOnTop(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferImportingJestGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferJestMocked(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferLowercaseTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferMockPromiseShorthand(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferMockReturnShorthand(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferSnapshotHint(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferSpyOn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferStrictEqual(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferToBe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferToContain(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferToHaveBeenCalled(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferToHaveBeenCalledTimes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferToHaveLength(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestPreferTodo(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestRequireHook(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestRequireToThrowMessage(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestRequireTopLevelDescribe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestValidDescribeCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestValidExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestValidExpectInPromise(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JestValidTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactButtonHasType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactCheckedRequiresOnchangeOrReadonly(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactDisplayName(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactExhaustiveDeps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactForbidComponentProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactForbidDomProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactForbidElements(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactForwardRefUsesRef(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactHookUseState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactIframeMissingSandbox(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxBooleanValue(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxCurlyBracePresence(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxFilenameExtension(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxFragments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxHandlerNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxKey(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxMaxDepth(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoCommentTextnodes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoConstructedContextValues(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoDuplicateProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoLiterals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoScriptUrl(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoTargetBlank(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoUndef(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxNoUselessFragment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxPascalCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxPropsNoSpreadMulti(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactJsxPropsNoSpreading(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoArrayIndexKey(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoChildrenProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoCloneElement(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoDanger(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoDangerWithChildren(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoDidMountSetState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoDidUpdateSetState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoDirectMutationState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoFindDomNode(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoIsMounted(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoMultiComp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoNamespace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoObjectTypeAsDefaultProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoReactChildren(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoRedundantShouldComponentUpdate(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoRenderReturnValue(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoSetState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoStringRefs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoThisInSfc(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoUnescapedEntities(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoUnknownProperty(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoUnsafe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoUnstableNestedComponents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactNoWillUpdateSetState(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactOnlyExportComponents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPreferEs6Class(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPreferFunctionComponent(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactReactCompiler(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactReactInJsxScope(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactRequireRenderReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactRulesOfHooks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactSelfClosingComp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactStateInConstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactStylePropObject(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactVoidDomElementsNoChildren(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPerfJsxNoJsxAsProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPerfJsxNoNewArrayAsProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPerfJsxNoNewFunctionAsProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::ReactPerfJsxNoNewObjectAsProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornCatchErrorName(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentAssert(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentDateClone(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentEmptyArraySpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentExistenceIndexCheck(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentFunctionScoping(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornConsistentTemplateLiteralEscape(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornCustomErrorDefinition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornEmptyBraceSpaces(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornErrorMessage(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornEscapeCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornExplicitLengthCheck(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornFilenameCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornImportStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornMaxNestedCalls(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNewForBuiltins(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoAbusiveEslintDisable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoAccessorRecursion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoAnonymousDefaultExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayCallbackReference(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayFillWithReferenceType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayForEach(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayMethodThisArgument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayReduce(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArrayReverse(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoArraySort(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoAwaitExpressionMember(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoAwaitInPromiseMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoConsoleSpaces(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoDocumentCookie(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoEmptyFile(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoHexEscape(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoImmediateMutation(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoInstanceofArray(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoInstanceofBuiltins(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoInvalidFetchOptions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoInvalidRemoveEventListener(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoLengthAsSliceEnd(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoLonelyIf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoMagicArrayFlatDepth(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNegatedCondition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNegationInEqualityCheck(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNestedTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNewArray(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNewBuffer(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoNull(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoObjectAsDefaultParameter(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoProcessExit(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoSinglePromiseInPromiseMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoStaticOnlyClass(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoThenable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoThisAssignment(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoTypeofUndefined(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnnecessaryArrayFlatDepth(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnnecessaryArraySpliceCount(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnnecessaryAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnnecessarySliceEnd(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnreadableArrayDestructuring(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUnreadableIife(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessCollectionArgument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessErrorCaptureStackTrace(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessFallbackInSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessIteratorToArray(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessLengthCheck(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessPromiseResolveReject(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessSwitchCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoUselessUndefined(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNoZeroFractions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNumberLiteralCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornNumericSeparatorsStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferAddEventListener(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferArrayFind(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferArrayFlat(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferArrayFlatMap(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferArrayIndexOf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferArraySome(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferAt(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferBigintLiterals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferBlobReadingMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferClassFields(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferClasslistToggle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferCodePoint(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDateNow(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDefaultParameters(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDomNodeAppend(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDomNodeDataset(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDomNodeRemove(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferDomNodeTextContent(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferEventTarget(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferExportFrom(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferGlobalThis(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferImportMetaProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferIncludes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferKeyboardEventKey(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferLogicalOperatorOverTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferMathMinMax(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferMathTrunc(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferModernDomApis(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferModernMathApis(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferModule(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferNativeCoercionFunctions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferNegativeIndex(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferNodeProtocol(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferNumberCoercion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferNumberProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferObjectFromEntries(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferOptionalCatchBinding(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferPrototypeMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferQuerySelector(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferReflectApply(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferRegexpTest(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferResponseStaticJson(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferSetHas(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferSetSize(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferSingleCall(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStringRaw(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStringReplaceAll(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStringSlice(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStringStartsEndsWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStringTrimStartEnd(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferStructuredClone(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferTernary(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferTopLevelAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornPreferTypeError(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRelativeUrlStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRequireArrayJoinSeparator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRequireModuleAttributes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRequireModuleSpecifiers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRequireNumberToFixedDigitsArgument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornRequirePostMessageTargetOrigin(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornSwitchCaseBraces(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornSwitchCaseBreakPosition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornTextEncodingIdentifierCase(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::UnicornThrowNewError(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAltText(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAnchorAmbiguousText(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAnchorHasContent(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAnchorIsValid(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAriaActivedescendantHasTabindex(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAriaProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAriaProptypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAriaRole(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAriaUnsupportedElements(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YAutocompleteValid(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YClickEventsHaveKeyEvents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YControlHasAssociatedLabel(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YHeadingHasContent(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YHtmlHasLang(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YIframeHasTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YImgRedundantAlt(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YInteractiveSupportsFocus(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YLabelHasAssociatedControl(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YLang(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YMediaHasCaption(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YMouseEventsHaveKeyEvents(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoAccessKey(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoAriaHiddenOnFocusable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoAutofocus(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoDistractingElements(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoInteractiveElementToNoninteractiveRole(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoNoninteractiveElementInteractions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoNoninteractiveElementToInteractiveRole(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoNoninteractiveTabindex(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoRedundantRoles(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YNoStaticElementInteractions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YPreferTagOverRole(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YRoleHasRequiredAriaProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YRoleSupportsAriaProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YScope(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsxA11YTabindexNoPositive(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcApproxConstant(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadArrayMethodOnArguments(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadBitwiseOperator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadCharAtComparison(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadComparisonSequence(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadMinMaxFunc(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadObjectLiteralComparison(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBadReplaceAllArg(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcBranchesSharingCode(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcConstComparisons(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcDoubleComparisons(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcErasingOp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcMisrefactoredAssignOp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcMissingThrow(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoAccumulatingSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoAsyncAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoAsyncEndpointHandlers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoBarrelFile(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoConstEnum(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoMapSpread(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoOptionalChaining(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoRestSpreadProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNoThisInExportedFunction(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcNumberArgOutOfRange(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcOnlyUsedInRecursion(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::OxcUninvokedArrayCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsGoogleFontDisplay(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsGoogleFontPreconnect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsInlineScriptId(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNextScriptForGa(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoAssignModuleVariable(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoAsyncClientComponent(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoBeforeInteractiveScriptOutsideDocument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoCssTags(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoDocumentImportInPage(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoDuplicateHead(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoHeadElement(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoHeadImportInDocument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoHtmlLinkForPages(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoImgElement(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoPageCustomFont(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoScriptComponentInHead(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoStyledJsxInDocument(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoSyncScripts(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoTitleInDocumentHead(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoTypos(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NextjsNoUnwantedPolyfillio(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocCheckAccess(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocCheckPropertyNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocCheckTagNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocEmptyTags(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocImplementsOnClasses(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocNoDefaults(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireParam(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireParamDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireParamName(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireParamType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireProperty(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequirePropertyDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequirePropertyName(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequirePropertyType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireReturns(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireReturnsDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireReturnsType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireThrowsDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireThrowsType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireYields(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireYieldsDescription(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::JsdocRequireYieldsType(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseAlwaysReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseAvoidNew(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseCatchOrReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoCallbackInPromise(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoMultipleResolved(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoNesting(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoNewStatics(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoPromiseInCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoReturnInFinally(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseNoReturnWrap(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseParamNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromisePreferAwaitToCallbacks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromisePreferAwaitToThen(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromisePreferCatch(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseSpecOnly(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::PromiseValidParams(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestConsistentEachFor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestConsistentTestFilename(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestConsistentTestIt(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestConsistentVitestVi(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestExpectExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestHoistedApisOnTop(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestMaxExpects(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestMaxNestedDescribe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoAliasMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoCommentedOutTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoConditionalExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoConditionalInTest(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoConditionalTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoDisabledTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoDuplicateHooks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoFocusedTests(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoHooks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoIdenticalTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoImportNodeTest(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoImportingVitestGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoInterpolationInSnapshots(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoLargeSnapshots(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoMocksImport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoRestrictedMatchers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoRestrictedViMethods(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoStandaloneExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoTestPrefixes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoTestReturnStatement(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestNoUnneededAsyncExpectFunction(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPaddingAroundAfterAllBlocks(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferCalledExactlyOnceWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferCalledOnce(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferCalledTimes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferCalledWith(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferComparisonMatcher(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferDescribeFunctionTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferEach(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferEqualityMatcher(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferExpectAssertions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferExpectResolves(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferExpectTypeOf(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferHooksInOrder(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferHooksOnTop(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferImportInMock(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferImportingVitestGlobals(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferLowercaseTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferMockPromiseShorthand(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferMockReturnShorthand(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferSnapshotHint(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferSpyOn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferStrictBooleanMatchers(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferStrictEqual(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToBe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToBeFalsy(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToBeObject(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToBeTruthy(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToContain(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToHaveBeenCalledTimes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferToHaveLength(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestPreferTodo(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireAwaitedExpectPoll(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireHook(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireLocalTestContextForConcurrentSnapshots(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireMockTypeParameters(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireTestTimeout(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireToThrowMessage(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestRequireTopLevelDescribe(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestValidDescribeCallback(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestValidExpect(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestValidExpectInPromise(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestValidTitle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VitestWarnTodo(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeCallbackReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeGlobalRequire(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeHandleCallbackErr(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeNoExportsAssign(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeNoNewRequire(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeNoPathConcat(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::NodeNoProcessEnv(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueComponentDefinitionNameCasing(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueDefineEmitsDeclaration(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueDefinePropsDeclaration(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueDefinePropsDestructuring(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueMaxProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNextTickStyle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoArrowFunctionsInWatch(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoAsyncInComputedProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoComputedPropertiesInData(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedDataObjectDeclaration(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedDeleteSet(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedDestroyedLifecycle(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedEventsApi(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedModelDefinition(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedPropsDefaultThis(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDeprecatedVueConfigKeycodes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoDupeKeys(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoExportInScriptSetup(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoExposeAfterAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoImportCompilerMacros(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoLifecycleAfterAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoMultipleSlotArgs(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoRequiredPropWithDefault(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoReservedComponentNames(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoReservedKeys(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoReservedProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoSharedComponentData(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoSideEffectsInComputedProperties(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoThisInBeforeRouteEnter(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueNoWatchAfterAwait(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VuePreferImportFromVue(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VuePropNameCasing(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireDefaultExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireDefaultProp(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireDirectExport(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequirePropTypeConstructor(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequirePropTypes(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireRenderReturn(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireSlotsAsFunctions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueRequireTypedRef(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueReturnInComputedProperty(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueReturnInEmitsValidator(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueValidDefineEmits(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueValidDefineOptions(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueValidDefineProps(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
+                Self::VueValidNextTick(rule) => {
+                    for &node_id in node_ids {
+                        rule.run(nodes.get_node(node_id), ctx);
+                    }
+                }
             }
         }
     }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -26,7 +26,7 @@ use oxc_data_structures::box_macros::boxed_array;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_estree_tokens::{ESTreeTokenOptionsJS, update_tokens};
 use oxc_parser::Token;
-use oxc_semantic::{AstNode, Semantic};
+use oxc_semantic::{AstNode, NodeId, Semantic};
 use oxc_span::Span;
 
 mod ast_util;
@@ -167,6 +167,12 @@ struct RuleBuckets {
     by_type: Box<[Vec<usize>; AST_TYPE_MAX as usize + 1]>,
     /// Indices of rules that run on every node (rules without `types_info`).
     any_type: Vec<usize>,
+    /// `node_ids_by_type[ast_type]` = ids of all AST nodes of that type, in source order. Built once
+    /// per file so the dispatch can be type-major: for each type, run each bucketed rule over the
+    /// whole node slice in a single monomorphic loop (one enum match per rule, not per node).
+    node_ids_by_type: Box<[Vec<NodeId>; AST_TYPE_MAX as usize + 1]>,
+    /// Ids of all AST nodes, in source order. Used to dispatch `any_type` rules over every node.
+    all_node_ids: Vec<NodeId>,
 }
 
 impl RuleBuckets {
@@ -175,6 +181,10 @@ impl RuleBuckets {
             bucket.clear();
         }
         self.any_type.clear();
+        for bucket in self.node_ids_by_type.iter_mut() {
+            bucket.clear();
+        }
+        self.all_node_ids.clear();
     }
 }
 
@@ -182,6 +192,8 @@ thread_local! {
     static RULE_BUCKETS: std::cell::RefCell<RuleBuckets> = std::cell::RefCell::new(RuleBuckets {
         by_type: boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1],
         any_type: Vec::new(),
+        node_ids_by_type: boxed_array![Vec::new(); AST_TYPE_MAX as usize + 1],
+        all_node_ids: Vec::new(),
     });
 }
 
@@ -195,11 +207,10 @@ fn execute_rules<'a, const TIMINGS: bool>(
     let mut timing_stats = TIMINGS.then(|| vec![RuleTimingStat::default(); rules.len()]);
 
     if with_runtime_optimization {
-        // Bucket rules by the AST node types they care about into a reused per-thread buffer, then
-        // make a single pass over the AST, dispatching each node only to the rules registered for
-        // its type. This replaces "every rule tests every node" (which dominated dispatch cost in
-        // profiles), and because the buffer is reused there is no per-file allocation — so this is
-        // a win for files of all sizes, not just large ones.
+        // Bucket rules by the AST node types they care about, and node ids by their type, into
+        // reused per-thread buffers, then dispatch type-major via `RuleEnum::run_batch`. This keeps
+        // the per-node dispatch a direct call (the enum match is hoisted to once per rule-per-type)
+        // and, because the buffers are reused, incurs no per-file allocation.
         RULE_BUCKETS.with_borrow_mut(|buckets| {
             buckets.clear();
 
@@ -221,17 +232,34 @@ fn execute_rules<'a, const TIMINGS: bool>(
                 }
             }
 
-            for node in semantic.nodes() {
-                for &rule_index in &buckets.by_type[node.kind().ty() as usize] {
+            // Group node ids by AST type in a single pass, then dispatch type-major: for each type,
+            // run every bucketed rule over the whole node slice. This way the `RuleEnum` match runs
+            // once per (rule, type) instead of once per (node, rule) — the per-node call inside
+            // `run_batch` is a direct, inlinable call into the concrete rule.
+            let nodes = semantic.nodes();
+            for node in nodes {
+                let id = node.id();
+                buckets.node_ids_by_type[node.kind().ty() as usize].push(id);
+                buckets.all_node_ids.push(id);
+            }
+
+            for ty in 0..buckets.node_ids_by_type.len() {
+                let node_ids = &buckets.node_ids_by_type[ty];
+                if node_ids.is_empty() {
+                    continue;
+                }
+                for &rule_index in &buckets.by_type[ty] {
                     let (rule, ctx) = &rules[rule_index];
                     let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                    rule.run::<TIMINGS>(node, ctx, timing_stat);
+                    rule.run_batch::<TIMINGS>(node_ids, nodes, ctx, timing_stat);
                 }
-                for &rule_index in &buckets.any_type {
-                    let (rule, ctx) = &rules[rule_index];
-                    let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                    rule.run::<TIMINGS>(node, ctx, timing_stat);
-                }
+            }
+
+            // `any_type` rules (no `types_info`) run on every node.
+            for &rule_index in &buckets.any_type {
+                let (rule, ctx) = &rules[rule_index];
+                let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                rule.run_batch::<TIMINGS>(&buckets.all_node_ids, nodes, ctx, timing_stat);
             }
 
             if should_run_on_jest_node {

--- a/crates/oxc_linter/src/snapshots/eslint_accessor_pairs.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_accessor_pairs.snap
@@ -1367,19 +1367,19 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Define a setter for this property
 
-  ⚠ eslint(accessor-pairs): Getter is defined without a setter
-   ╭─[accessor_pairs.tsx:1:17]
- 1 │ A = class { get a() {} }, { set a(foo) {} }
-   ·                 ─
-   ╰────
-  help: Define a setter for this property
-
   ⚠ eslint(accessor-pairs): Setter is defined without a getter
    ╭─[accessor_pairs.tsx:1:33]
  1 │ A = class { get a() {} }, { set a(foo) {} }
    ·                                 ─
    ╰────
   help: Define a getter for this property
+
+  ⚠ eslint(accessor-pairs): Getter is defined without a setter
+   ╭─[accessor_pairs.tsx:1:17]
+ 1 │ A = class { get a() {} }, { set a(foo) {} }
+   ·                 ─
+   ╰────
+  help: Define a setter for this property
 
   ⚠ eslint(accessor-pairs): Getter is defined without a setter
    ╭─[accessor_pairs.tsx:1:11]

--- a/crates/oxc_linter/src/snapshots/eslint_complexity.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_complexity.snap
@@ -530,16 +530,16 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────────────────────────
    ╰────
 
-  ⚠ eslint(complexity): function `b` has a complexity of 3. Maximum allowed is 2.
-   ╭─[complexity.tsx:1:18]
- 1 │ const obj = { b: (a) => a?.b?.c, c: function (a) { return a?.b?.c; } };
-   ·                  ──────────────
-   ╰────
-
   ⚠ eslint(complexity): function `c` has a complexity of 3. Maximum allowed is 2.
    ╭─[complexity.tsx:1:37]
  1 │ const obj = { b: (a) => a?.b?.c, c: function (a) { return a?.b?.c; } };
    ·                                     ────────────────────────────────
+   ╰────
+
+  ⚠ eslint(complexity): function `b` has a complexity of 3. Maximum allowed is 2.
+   ╭─[complexity.tsx:1:18]
+ 1 │ const obj = { b: (a) => a?.b?.c, c: function (a) { return a?.b?.c; } };
+   ·                  ──────────────
    ╰────
 
   ⚠ eslint(complexity): function `a` has a complexity of 2. Maximum allowed is 1.

--- a/crates/oxc_linter/src/snapshots/eslint_curly.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_curly.snap
@@ -433,13 +433,6 @@ source: crates/oxc_linter/src/tester.rs
         			 doSomething();
         			 `.
 
-  ⚠ eslint(curly): Expected { after 'for-in'.
-   ╭─[curly.tsx:1:22]
- 1 │ for (var foo in bar) if (foo) console.log(1); else console.log(2);
-   ·                      ─────────────────────────────────────────────
-   ╰────
-  help: Replace `if (foo) console.log(1); else console.log(2);` with `{if (foo) console.log(1); else console.log(2);}`.
-
   ⚠ eslint(curly): Expected { after 'if' condition.
    ╭─[curly.tsx:1:31]
  1 │ for (var foo in bar) if (foo) console.log(1); else console.log(2);
@@ -453,6 +446,13 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                    ───────────────
    ╰────
   help: Replace `console.log(2);` with `{console.log(2);}`.
+
+  ⚠ eslint(curly): Expected { after 'for-in'.
+   ╭─[curly.tsx:1:22]
+ 1 │ for (var foo in bar) if (foo) console.log(1); else console.log(2);
+   ·                      ─────────────────────────────────────────────
+   ╰────
+  help: Replace `if (foo) console.log(1); else console.log(2);` with `{if (foo) console.log(1); else console.log(2);}`.
 
   ⚠ eslint(curly): Expected { after 'for-in'.
    ╭─[curly.tsx:2:5]

--- a/crates/oxc_linter/src/snapshots/eslint_id_match.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_id_match.snap
@@ -194,16 +194,16 @@ source: crates/oxc_linter/src/tester.rs
    ·                ─────────────
    ╰────
 
-  ⚠ eslint(id-match): Identifier 'no_camelcased' does not match the pattern '^[^_]+$'.
-   ╭─[id_match.tsx:1:7]
- 1 │ const no_camelcased = 0; function foo({ camelcased_value = no_camelcased }) {}
-   ·       ─────────────
-   ╰────
-
   ⚠ eslint(id-match): Identifier 'camelcased_value' does not match the pattern '^[^_]+$'.
    ╭─[id_match.tsx:1:41]
  1 │ const no_camelcased = 0; function foo({ camelcased_value = no_camelcased }) {}
    ·                                         ────────────────
+   ╰────
+
+  ⚠ eslint(id-match): Identifier 'no_camelcased' does not match the pattern '^[^_]+$'.
+   ╭─[id_match.tsx:1:7]
+ 1 │ const no_camelcased = 0; function foo({ camelcased_value = no_camelcased }) {}
+   ·       ─────────────
    ╰────
 
   ⚠ eslint(id-match): Identifier 'no_camelcased' does not match the pattern '^[^_]+$'.
@@ -236,6 +236,24 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
    ╰────
 
+  ⚠ eslint(id-match): Identifier 'Array' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
+   ╭─[id_match.tsx:1:221]
+ 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
+   ·                                                                                                                                                                                                                             ─────
+   ╰────
+
+  ⚠ eslint(id-match): Identifier 'Object' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
+   ╭─[id_match.tsx:1:151]
+ 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
+   ·                                                                                                                                                       ──────
+   ╰────
+
+  ⚠ eslint(id-match): Identifier 'Array' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
+   ╭─[id_match.tsx:1:194]
+ 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
+   ·                                                                                                                                                                                                  ─────
+   ╰────
+
   ⚠ eslint(id-match): Identifier 'foo_variable' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
    ╭─[id_match.tsx:1:7]
  1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
@@ -254,28 +272,10 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                                                                                                            ──────
    ╰────
 
-  ⚠ eslint(id-match): Identifier 'Object' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
-   ╭─[id_match.tsx:1:151]
- 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
-   ·                                                                                                                                                       ──────
-   ╰────
-
   ⚠ eslint(id-match): Identifier 'Array' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
    ╭─[id_match.tsx:1:184]
  1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
    ·                                                                                                                                                                                        ─────
-   ╰────
-
-  ⚠ eslint(id-match): Identifier 'Array' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
-   ╭─[id_match.tsx:1:194]
- 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
-   ·                                                                                                                                                                                                  ─────
-   ╰────
-
-  ⚠ eslint(id-match): Identifier 'Array' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
-   ╭─[id_match.tsx:1:221]
- 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
-   ·                                                                                                                                                                                                                             ─────
    ╰────
 
   ⚠ eslint(id-match): Identifier '_foo' does not match the pattern '^[^_]+$'.
@@ -459,12 +459,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
-   ╭─[id_match.tsx:1:7]
- 1 │ const bad_name = 1; export { bad_name };
-   ·       ────────
-   ╰────
-
-  ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
    ╭─[id_match.tsx:1:30]
  1 │ const bad_name = 1; export { bad_name };
    ·                              ────────
@@ -472,14 +466,8 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
    ╭─[id_match.tsx:1:7]
- 1 │ const bad_name = 1; export { bad_name as bad_name };
+ 1 │ const bad_name = 1; export { bad_name };
    ·       ────────
-   ╰────
-
-  ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
-   ╭─[id_match.tsx:1:30]
- 1 │ const bad_name = 1; export { bad_name as bad_name };
-   ·                              ────────
    ╰────
 
   ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
@@ -489,8 +477,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
+   ╭─[id_match.tsx:1:30]
+ 1 │ const bad_name = 1; export { bad_name as bad_name };
+   ·                              ────────
+   ╰────
+
+  ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
    ╭─[id_match.tsx:1:7]
- 1 │ const bad_name = 1; export { bad_name as goodName };
+ 1 │ const bad_name = 1; export { bad_name as bad_name };
    ·       ────────
    ╰────
 
@@ -498,6 +492,12 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[id_match.tsx:1:30]
  1 │ const bad_name = 1; export { bad_name as goodName };
    ·                              ────────
+   ╰────
+
+  ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
+   ╭─[id_match.tsx:1:7]
+ 1 │ const bad_name = 1; export { bad_name as goodName };
+   ·       ────────
    ╰────
 
   ⚠ eslint(id-match): Identifier 'bad_label' does not match the pattern '^[^_]+$'.

--- a/crates/oxc_linter/src/snapshots/eslint_no_constant_condition.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_constant_condition.snap
@@ -1099,14 +1099,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Update the condition to not be constant, or remove the condition entirely
 
   ⚠ eslint(no-constant-condition): Unexpected constant condition
-   ╭─[no_constant_condition.tsx:1:23]
- 1 │ function* foo(){while(true){if (true) {yield 'foo';}}}
-   ·                       ──┬─
-   ·                         ╰── this expression will always evaluate to the same value
-   ╰────
-  help: Update the condition to not be constant, or remove the condition entirely
-
-  ⚠ eslint(no-constant-condition): Unexpected constant condition
    ╭─[no_constant_condition.tsx:1:33]
  1 │ function* foo(){while(true){if (true) {yield 'foo';}}}
    ·                                 ──┬─
@@ -1127,6 +1119,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function* foo(){while(true){if (true) {yield 'foo';}}}
    ·                                 ──┬─
    ·                                   ╰── this expression will always evaluate to the same value
+   ╰────
+  help: Update the condition to not be constant, or remove the condition entirely
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:23]
+ 1 │ function* foo(){while(true){if (true) {yield 'foo';}}}
+   ·                       ──┬─
+   ·                         ╰── this expression will always evaluate to the same value
    ╰────
   help: Update the condition to not be constant, or remove the condition entirely
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_extra_boolean_cast.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_extra_boolean_cast.snap
@@ -2935,13 +2935,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the double negation as it will already be coerced to a boolean
 
-  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
-   ╭─[no_extra_boolean_cast.tsx:1:5]
- 1 │ if (!!a && Boolean(b)) {}
-   ·     ───
-   ╰────
-  help: Remove the double negation as it will already be coerced to a boolean
-
   ⚠ eslint(no-extra-boolean-cast): Redundant Boolean call
    ╭─[no_extra_boolean_cast.tsx:1:12]
  1 │ if (!!a && Boolean(b)) {}
@@ -2950,9 +2943,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the Boolean call as it will already be coerced to a boolean
 
   ⚠ eslint(no-extra-boolean-cast): Redundant double negation
-   ╭─[no_extra_boolean_cast.tsx:1:6]
- 1 │ if ((!!a) || (Boolean(b))) {}
-   ·      ───
+   ╭─[no_extra_boolean_cast.tsx:1:5]
+ 1 │ if (!!a && Boolean(b)) {}
+   ·     ───
    ╰────
   help: Remove the double negation as it will already be coerced to a boolean
 
@@ -2962,6 +2955,13 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────
    ╰────
   help: Remove the Boolean call as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:6]
+ 1 │ if ((!!a) || (Boolean(b))) {}
+   ·      ───
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
 
   ⚠ eslint(no-extra-boolean-cast): Redundant Boolean call
    ╭─[no_extra_boolean_cast.tsx:1:5]
@@ -3425,13 +3425,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the double negation as it will already be coerced to a boolean
 
-  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
-   ╭─[no_extra_boolean_cast.tsx:1:5]
- 1 │ if (!!a && Boolean(b)) {}
-   ·     ───
-   ╰────
-  help: Remove the double negation as it will already be coerced to a boolean
-
   ⚠ eslint(no-extra-boolean-cast): Redundant Boolean call
    ╭─[no_extra_boolean_cast.tsx:1:12]
  1 │ if (!!a && Boolean(b)) {}
@@ -3440,9 +3433,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the Boolean call as it will already be coerced to a boolean
 
   ⚠ eslint(no-extra-boolean-cast): Redundant double negation
-   ╭─[no_extra_boolean_cast.tsx:1:6]
- 1 │ if ((!!a) || (Boolean(b))) {}
-   ·      ───
+   ╭─[no_extra_boolean_cast.tsx:1:5]
+ 1 │ if (!!a && Boolean(b)) {}
+   ·     ───
    ╰────
   help: Remove the double negation as it will already be coerced to a boolean
 
@@ -3452,6 +3445,13 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────
    ╰────
   help: Remove the Boolean call as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:6]
+ 1 │ if ((!!a) || (Boolean(b))) {}
+   ·      ───
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
 
   ⚠ eslint(no-extra-boolean-cast): Redundant Boolean call
    ╭─[no_extra_boolean_cast.tsx:1:5]

--- a/crates/oxc_linter/src/snapshots/eslint_no_inner_declarations.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_inner_declarations.snap
@@ -24,13 +24,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Move variable declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:11]
- 1 │ if (foo){ function f(){ if(bar){ var a; } } }
-   ·           ────────
-   ╰────
-  help: Move function declaration to program root
-
-  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
    ╭─[no_inner_declarations.mjs:1:34]
  1 │ if (foo){ function f(){ if(bar){ var a; } } }
    ·                                  ───
@@ -38,9 +31,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Move variable declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:10]
- 1 │ if (foo) function f(){ if(bar) var a; }
-   ·          ────────
+   ╭─[no_inner_declarations.mjs:1:11]
+ 1 │ if (foo){ function f(){ if(bar){ var a; } } }
+   ·           ────────
    ╰────
   help: Move function declaration to program root
 
@@ -50,6 +43,13 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ───
    ╰────
   help: Move variable declaration to function body root
+
+  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
+   ╭─[no_inner_declarations.mjs:1:10]
+ 1 │ if (foo) function f(){ if(bar) var a; }
+   ·          ────────
+   ╰────
+  help: Move function declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
    ╭─[no_inner_declarations.mjs:1:12]

--- a/crates/oxc_linter/src/snapshots/eslint_no_labels.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_labels.snap
@@ -9,13 +9,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
 
-  ⚠ eslint(no-labels): Labeled statement is not allowed
-   ╭─[no_labels.tsx:1:1]
- 1 │ label: while (true) { break label; }
-   · ─────
-   ╰────
-  help: Consider refactoring the code to eliminate the need for labels.
-
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:29]
  1 │ label: while (true) { break label; }
@@ -25,7 +18,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ label: while (true) { continue label; }
+ 1 │ label: while (true) { break label; }
    · ─────
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -39,14 +32,14 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: var foo = 0;
-   · ─
+ 1 │ label: while (true) { continue label; }
+   · ─────
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: break A;
+ 1 │ A: var foo = 0;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -60,7 +53,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: { if (foo()) { break A; } bar(); };
+ 1 │ A: break A;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -74,7 +67,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: if (a) { if (foo()) { break A; } bar(); };
+ 1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -88,7 +81,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: switch (a) { case 0: break A; default: break; };
+ 1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -102,15 +95,8 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: switch (a) { case 0: B: { break A; } default: break; };
+ 1 │ A: switch (a) { case 0: break A; default: break; };
    · ─
-   ╰────
-  help: Consider refactoring the code to eliminate the need for labels.
-
-  ⚠ eslint(no-labels): Labeled statement is not allowed
-   ╭─[no_labels.tsx:1:25]
- 1 │ A: switch (a) { case 0: B: { break A; } default: break; };
-   ·                         ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
 
@@ -123,14 +109,21 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: var foo = 0;
+ 1 │ A: switch (a) { case 0: B: { break A; } default: break; };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
+   ╭─[no_labels.tsx:1:25]
+ 1 │ A: switch (a) { case 0: B: { break A; } default: break; };
+   ·                         ─
+   ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
+
+  ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: break A;
+ 1 │ A: var foo = 0;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -144,7 +137,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: { if (foo()) { break A; } bar(); };
+ 1 │ A: break A;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -158,7 +151,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: if (a) { if (foo()) { break A; } bar(); };
+ 1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -172,7 +165,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: switch (a) { case 0: break A; default: break; };
+ 1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -186,14 +179,14 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: var foo = 0;
+ 1 │ A: switch (a) { case 0: break A; default: break; };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: break A;
+ 1 │ A: var foo = 0;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -207,7 +200,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: { if (foo()) { break A; } bar(); };
+ 1 │ A: break A;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -221,7 +214,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: if (a) { if (foo()) { break A; } bar(); };
+ 1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -235,7 +228,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: while (a) { break A; }
+ 1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -249,7 +242,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: do { if (b) { break A; } } while (a);
+ 1 │ A: while (a) { break A; }
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -263,7 +256,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }
+ 1 │ A: do { if (b) { break A; } } while (a);
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -272,5 +265,12 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_labels.tsx:1:63]
  1 │ A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }
    ·                                                               ─
+   ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
+
+  ⚠ eslint(no-labels): Labeled statement is not allowed
+   ╭─[no_labels.tsx:1:1]
+ 1 │ A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }
+   · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.

--- a/crates/oxc_linter/src/snapshots/eslint_no_multi_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_multi_assign.snap
@@ -10,13 +10,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Separate each assignment into its own statement
 
   ⚠ eslint(no-multi-assign): Do not use chained assignment
-   ╭─[no_multi_assign.tsx:1:9]
- 1 │ var a = b = c = d;
-   ·         ─────────
-   ╰────
-  help: Separate each assignment into its own statement
-
-  ⚠ eslint(no-multi-assign): Do not use chained assignment
    ╭─[no_multi_assign.tsx:1:13]
  1 │ var a = b = c = d;
    ·             ─────
@@ -24,9 +17,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Separate each assignment into its own statement
 
   ⚠ eslint(no-multi-assign): Do not use chained assignment
-   ╭─[no_multi_assign.tsx:1:11]
- 1 │ let foo = bar = cee = 100;
-   ·           ───────────────
+   ╭─[no_multi_assign.tsx:1:9]
+ 1 │ var a = b = c = d;
+   ·         ─────────
    ╰────
   help: Separate each assignment into its own statement
 
@@ -34,6 +27,13 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_multi_assign.tsx:1:17]
  1 │ let foo = bar = cee = 100;
    ·                 ─────────
+   ╰────
+  help: Separate each assignment into its own statement
+
+  ⚠ eslint(no-multi-assign): Do not use chained assignment
+   ╭─[no_multi_assign.tsx:1:11]
+ 1 │ let foo = bar = cee = 100;
+   ·           ───────────────
    ╰────
   help: Separate each assignment into its own statement
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_undefined.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_undefined.snap
@@ -159,15 +159,15 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
-   ╭─[no_undefined.tsx:1:5]
- 1 │ var undefined = true; undefined = false;
-   ·     ─────────
-   ╰────
-
-  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:23]
  1 │ var undefined = true; undefined = false;
    ·                       ─────────
+   ╰────
+
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
+   ╭─[no_undefined.tsx:1:5]
+ 1 │ var undefined = true; undefined = false;
+   ·     ─────────
    ╰────
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`

--- a/crates/oxc_linter/src/snapshots/eslint_no_useless_backreference.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_useless_backreference.snap
@@ -555,17 +555,17 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider revising the pattern to remove or relocate the backreference so it points to a group that can be matched at the time of evaluation.
 
-  ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(b)' which appears before in the same lookbehind.
-   ╭─[no_useless_backreference.tsx:1:5]
- 1 │ /(a)\2(b)/; RegExp('(\\1)');
-   ·     ──
-   ╰────
-  help: Consider revising the pattern to remove or relocate the backreference so it points to a group that can be matched at the time of evaluation.
-
   ⚠ eslint(no-useless-backreference): Backreference '\\1' will be ignored. It references group '(\\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:22]
  1 │ /(a)\2(b)/; RegExp('(\\1)');
    ·                      ───
+   ╰────
+  help: Consider revising the pattern to remove or relocate the backreference so it points to a group that can be matched at the time of evaluation.
+
+  ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(b)' which appears before in the same lookbehind.
+   ╭─[no_useless_backreference.tsx:1:5]
+ 1 │ /(a)\2(b)/; RegExp('(\\1)');
+   ·     ──
    ╰────
   help: Consider revising the pattern to remove or relocate the backreference so it points to a group that can be matched at the time of evaluation.
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_regex_literals.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_regex_literals.snap
@@ -687,12 +687,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(prefer-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
-   ╭─[prefer_regex_literals.tsx:1:1]
- 1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")**RegExp('a')
-   · ─────────────────────────────────
-   ╰────
-
-  ⚠ eslint(prefer-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
    ╭─[prefer_regex_literals.tsx:1:36]
  1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")**RegExp('a')
    ·                                    ───────────
@@ -700,7 +694,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(prefer-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
    ╭─[prefer_regex_literals.tsx:1:1]
- 1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")%RegExp('a')
+ 1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")**RegExp('a')
    · ─────────────────────────────────
    ╰────
 
@@ -708,6 +702,12 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_regex_literals.tsx:1:35]
  1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")%RegExp('a')
    ·                                   ───────────
+   ╰────
+
+  ⚠ eslint(prefer-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
+   ╭─[prefer_regex_literals.tsx:1:1]
+ 1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")%RegExp('a')
+   · ─────────────────────────────────
    ╰────
 
   ⚠ eslint(prefer-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
@@ -57,20 +57,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:11:15]
- 10 │               }
- 11 │               arrow = () => 'arrow';
-    ·               ────────
- 12 │               private method() {
-    ╰────
-  help: Require explicit return types on functions and class methods.
-
-  ⚠ typescript(explicit-function-return-type): Missing return type on function.
     ╭─[explicit_function_return_type.tsx:12:15]
  11 │               arrow = () => 'arrow';
  12 │               private method() {
     ·               ──────────────
  13 │                 return;
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:11:15]
+ 10 │               }
+ 11 │               arrow = () => 'arrow';
+    ·               ────────
+ 12 │               private method() {
     ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -112,15 +112,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:15]
- 2 │             class Foo {
- 3 │               public a = () => {};
-   ·               ───────────
- 4 │               public b = function () {};
-   ╰────
-  help: Require explicit return types on functions and class methods.
-
-  ⚠ typescript(explicit-function-return-type): Missing return type on function.
    ╭─[explicit_function_return_type.tsx:4:15]
  3 │               public a = () => {};
  4 │               public b = function () {};
@@ -139,20 +130,29 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:7:15]
- 6 │ 
- 7 │               static d = () => {};
-   ·               ───────────
- 8 │               static e = function () {};
-   ╰────
-  help: Require explicit return types on functions and class methods.
-
-  ⚠ typescript(explicit-function-return-type): Missing return type on function.
    ╭─[explicit_function_return_type.tsx:8:15]
  7 │               static d = () => {};
  8 │               static e = function () {};
    ·               ────────────────────
  9 │             }
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:15]
+ 2 │             class Foo {
+ 3 │               public a = () => {};
+   ·               ───────────
+ 4 │               public b = function () {};
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:7:15]
+ 6 │ 
+ 7 │               static d = () => {};
+   ·               ───────────
+ 8 │               static e = function () {};
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -554,15 +554,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:5:28]
- 4 │             }
- 5 │             const foo = () => {
-   ·                            ──
- 6 │               return;
-   ╰────
-  help: Require explicit return types on functions and class methods.
-
-  ⚠ typescript(explicit-function-return-type): Missing return type on function.
    ╭─[explicit_function_return_type.tsx:8:25]
  7 │             };
  8 │             const baz = function () {
@@ -596,6 +587,15 @@ source: crates/oxc_linter/src/tester.rs
     ·               ────────────
  21 │                 return;
     ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:5:28]
+ 4 │             }
+ 5 │             const foo = () => {
+   ·                            ──
+ 6 │               return;
+   ╰────
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_member_accessibility.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_member_accessibility.snap
@@ -56,21 +56,21 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
-  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:15]
- 2 │             class Test {
- 3 │               x?: number;
-   ·               ─
- 4 │               getX?() {
-   ╰────
-  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
-
   ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on method definition getX.
    ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               x?: number;
  4 │               getX?() {
    ·               ────
  5 │                 return this.x;
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             class Test {
+ 3 │               x?: number;
+   ·               ─
+ 4 │               getX?() {
    ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
@@ -92,21 +92,21 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
-  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:15]
- 2 │             class Test {
- 3 │               public x: number;
-   ·               ──────
- 4 │               public getX() {
-   ╰────
-  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
-
   ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on method definition getX.
    ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               public x: number;
  4 │               public getX() {
    ·               ──────
  5 │                 return this.x;
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             class Test {
+ 3 │               public x: number;
+   ·               ──────
+ 4 │               public getX() {
    ╰────
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
@@ -281,24 +281,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
-  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property foo.
-   ╭─[explicit_member_accessibility.tsx:3:15]
- 2 │             class Test {
- 3 │               public 'foo' = 1;
-   ·               ──────
- 4 │               public 'foo foo' = 2;
-   ╰────
-  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
-
-  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property foo foo.
-   ╭─[explicit_member_accessibility.tsx:4:15]
- 3 │               public 'foo' = 1;
- 4 │               public 'foo foo' = 2;
-   ·               ──────
- 5 │               public 'bar'() {}
-   ╰────
-  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
-
   ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on method definition bar.
    ╭─[explicit_member_accessibility.tsx:5:15]
  4 │               public 'foo foo' = 2;
@@ -314,6 +296,24 @@ source: crates/oxc_linter/src/tester.rs
  6 │               public 'bar bar'() {}
    ·               ──────
  7 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property foo.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             class Test {
+ 3 │               public 'foo' = 1;
+   ·               ──────
+ 4 │               public 'foo foo' = 2;
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property foo foo.
+   ╭─[explicit_member_accessibility.tsx:4:15]
+ 3 │               public 'foo' = 1;
+ 4 │               public 'foo foo' = 2;
+   ·               ──────
+ 5 │               public 'bar'() {}
    ╰────
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
@@ -371,15 +371,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
-  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
-   ╭─[explicit_member_accessibility.tsx:3:15]
- 2 │             class DecoratedClass {
- 3 │               constructor(@foo @bar() readonly arg: string) {}
-   ·               ───────────
- 4 │               @foo @bar() x: string;
-   ╰────
-  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
-
   ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on parameter property arg.
    ╭─[explicit_member_accessibility.tsx:3:48]
  2 │             class DecoratedClass {
@@ -389,12 +380,12 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
-  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:4:27]
+  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             class DecoratedClass {
  3 │               constructor(@foo @bar() readonly arg: string) {}
+   ·               ───────────
  4 │               @foo @bar() x: string;
-   ·                           ─
- 5 │               @foo @bar() getX() {
    ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
@@ -423,6 +414,15 @@ source: crates/oxc_linter/src/tester.rs
     ·                               ─
  14 │                 this.x = x;
     ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:4:27]
+ 3 │               constructor(@foo @bar() readonly arg: string) {}
+ 4 │               @foo @bar() x: string;
+   ·                           ─
+ 5 │               @foo @bar() getX() {
+   ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on method definition computed-method-name.

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_array_find.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_array_find.snap
@@ -454,32 +454,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:1:19]
- 1 │ const quz = array.filter(fn);
-   ·                   ──────
- 2 │             const [foo] = array.filter(quz[0]);
-   ╰────
-  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
-
-  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:2:33]
- 1 │ const quz = array.filter(fn);
- 2 │             const [foo] = array.filter(quz[0]);
-   ·                                 ──────
- 3 │             [{bar: baz}] = foo[
-   ╰────
-  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
-
-  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:5:15]
- 4 │                 array.filter(fn)[0]
- 5 │             ].filter(
-   ·               ──────
- 6 │                 array.filter(fn).shift()
-   ╰────
-  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
-
-  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
    ╭─[prefer_array_find.tsx:4:23]
  3 │             [{bar: baz}] = foo[
  4 │                 array.filter(fn)[0]
@@ -498,11 +472,28 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
+   ╭─[prefer_array_find.tsx:5:15]
+ 4 │                 array.filter(fn)[0]
+ 5 │             ].filter(
+   ·               ──────
+ 6 │                 array.filter(fn).shift()
+   ╰────
+  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
+
+  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
+   ╭─[prefer_array_find.tsx:1:19]
+ 1 │ const quz = array.filter(fn);
+   ·                   ──────
+ 2 │             const [foo] = array.filter(quz[0]);
+   ╰────
+  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
+
+  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
    ╭─[prefer_array_find.tsx:2:33]
- 1 │ const quz = array.find(fn);
- 2 │             const [foo] = array.filter(quz);
+ 1 │ const quz = array.filter(fn);
+ 2 │             const [foo] = array.filter(quz[0]);
    ·                                 ──────
- 3 │             ({bar: baz} = foo[
+ 3 │             [{bar: baz}] = foo[
    ╰────
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
@@ -521,6 +512,15 @@ source: crates/oxc_linter/src/tester.rs
  6 │                 array.filter(fn).shift()
    ·                       ──────
  7 │             ));
+   ╰────
+  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
+
+  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
+   ╭─[prefer_array_find.tsx:2:33]
+ 1 │ const quz = array.find(fn);
+ 2 │             const [foo] = array.filter(quz);
+   ·                                 ──────
+ 3 │             ({bar: baz} = foo[
    ╰────
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_keyboard_event_key.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_keyboard_event_key.snap
@@ -349,16 +349,6 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
   note: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
 
-  ⚠ unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:7:41]
- 6 │                             {
- 7 │                                 const { charCode } = e;
-   ·                                         ────────
- 8 │                                 console.log(e.keyCode, charCode);
-   ╰────
-  help: The `charCode` property is deprecated.
-  note: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
-
   ⚠ unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
    ╭─[prefer_keyboard_event_key.tsx:8:47]
  7 │                                 const { charCode } = e;
@@ -367,6 +357,16 @@ source: crates/oxc_linter/src/tester.rs
  9 │                             }
    ╰────
   help: The `keyCode` property is deprecated.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+
+  ⚠ unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
+   ╭─[prefer_keyboard_event_key.tsx:7:41]
+ 6 │                             {
+ 7 │                                 const { charCode } = e;
+   ·                                         ────────
+ 8 │                                 console.log(e.keyCode, charCode);
+   ╰────
+  help: The `charCode` property is deprecated.
   note: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
 
   ⚠ unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_math_trunc.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_math_trunc.snap
@@ -233,19 +233,19 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `~ /* will remove 1 */ ~ /* will remove 2 */ 3.4` with `Math.trunc(3.4)`.
 
-  ⚠ unicorn(prefer-math-trunc): Prefer `Math.trunc()` over instead of `| 0`.
-   ╭─[prefer_math_trunc.tsx:1:13]
- 1 │ const foo = ~~bar | 0;
-   ·             ─────────
-   ╰────
-  help: Replace `~~bar | 0` with `Math.trunc(~~bar)`.
-
   ⚠ unicorn(prefer-math-trunc): Prefer `Math.trunc()` over instead of `~ 0`.
    ╭─[prefer_math_trunc.tsx:1:13]
  1 │ const foo = ~~bar | 0;
    ·             ─────
    ╰────
   help: Replace `~~bar` with `Math.trunc(bar)`.
+
+  ⚠ unicorn(prefer-math-trunc): Prefer `Math.trunc()` over instead of `| 0`.
+   ╭─[prefer_math_trunc.tsx:1:13]
+ 1 │ const foo = ~~bar | 0;
+   ·             ─────────
+   ╰────
+  help: Replace `~~bar | 0` with `Math.trunc(~~bar)`.
 
   ⚠ unicorn(prefer-math-trunc): Prefer `Math.trunc()` over instead of `~ 0`.
    ╭─[prefer_math_trunc.tsx:1:13]

--- a/crates/oxc_linter/src/snapshots/vitest_consistent_vitest_vi.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_consistent_vitest_vi.snap
@@ -17,18 +17,18 @@ source: crates/oxc_linter/src/tester.rs
   help: Prefer using `vi` instead of `vitest`.
 
   ⚠ vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
-   ╭─[consistent_vitest_vi.tsx:1:10]
- 1 │ import { vitest } from "vitest";
-   ·          ──────
- 2 │             vitest.stubEnv("NODE_ENV", "production");
-   ╰────
-  help: Prefer using `vi` instead of `vitest`.
-
-  ⚠ vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
    ╭─[consistent_vitest_vi.tsx:2:4]
  1 │ import { vitest } from "vitest";
  2 │             vitest.stubEnv("NODE_ENV", "production");
    ·             ──────
+   ╰────
+  help: Prefer using `vi` instead of `vitest`.
+
+  ⚠ vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
+   ╭─[consistent_vitest_vi.tsx:1:10]
+ 1 │ import { vitest } from "vitest";
+   ·          ──────
+ 2 │             vitest.stubEnv("NODE_ENV", "production");
    ╰────
   help: Prefer using `vi` instead of `vitest`.
 

--- a/crates/oxc_linter/src/snapshots/vue_next_tick_style.snap
+++ b/crates/oxc_linter/src/snapshots/vue_next_tick_style.snap
@@ -3,48 +3,12 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
-   ╭─[next_tick_style.tsx:5:26]
- 4 │                 mounted() {
- 5 │                     this.$nextTick(() => callback());
-   ·                          ─────────
- 6 │                     Vue.nextTick(() => callback());
-   ╰────
-  help: Insert `().then`
-
-  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
-   ╭─[next_tick_style.tsx:6:25]
- 5 │                     this.$nextTick(() => callback());
- 6 │                     Vue.nextTick(() => callback());
-   ·                         ────────
- 7 │                     nt(() => callback());
-   ╰────
-  help: Insert `().then`
-
-  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
    ╭─[next_tick_style.tsx:7:21]
  6 │                     Vue.nextTick(() => callback());
  7 │                     nt(() => callback());
    ·                     ──
  8 │                     this.$nextTick(callback);
    ╰────
-  help: Insert `().then`
-
-  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
-   ╭─[next_tick_style.tsx:8:26]
- 7 │                     nt(() => callback());
- 8 │                     this.$nextTick(callback);
-   ·                          ─────────
- 9 │                     Vue.nextTick(callback);
-   ╰────
-  help: Insert `().then`
-
-  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
-    ╭─[next_tick_style.tsx:9:25]
-  8 │                     this.$nextTick(callback);
-  9 │                     Vue.nextTick(callback);
-    ·                         ────────
- 10 │                     nt(callback);
-    ╰────
   help: Insert `().then`
 
   ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
@@ -75,11 +39,56 @@ source: crates/oxc_linter/src/tester.rs
   help: Insert `().then`
 
   ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
+   ╭─[next_tick_style.tsx:8:26]
+ 7 │                     nt(() => callback());
+ 8 │                     this.$nextTick(callback);
+   ·                          ─────────
+ 9 │                     Vue.nextTick(callback);
+   ╰────
+  help: Insert `().then`
+
+  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
+    ╭─[next_tick_style.tsx:9:25]
+  8 │                     this.$nextTick(callback);
+  9 │                     Vue.nextTick(callback);
+    ·                         ────────
+ 10 │                     nt(callback);
+    ╰────
+  help: Insert `().then`
+
+  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
    ╭─[next_tick_style.tsx:7:21]
  6 │                     Vue.nextTick(() => callback());
  7 │                     nt(() => callback());
    ·                     ──
  8 │                     this.$nextTick(callback);
+   ╰────
+  help: Insert `().then`
+
+  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
+    ╭─[next_tick_style.tsx:10:21]
+  9 │                     Vue.nextTick(callback);
+ 10 │                     nt(callback);
+    ·                     ──
+ 11 │                 }
+    ╰────
+  help: Insert `().then`
+
+  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
+   ╭─[next_tick_style.tsx:5:26]
+ 4 │                 mounted() {
+ 5 │                     this.$nextTick(() => callback());
+   ·                          ─────────
+ 6 │                     Vue.nextTick(() => callback());
+   ╰────
+  help: Insert `().then`
+
+  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
+   ╭─[next_tick_style.tsx:6:25]
+ 5 │                     this.$nextTick(() => callback());
+ 6 │                     Vue.nextTick(() => callback());
+   ·                         ────────
+ 7 │                     nt(() => callback());
    ╰────
   help: Insert `().then`
 
@@ -101,14 +110,21 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Insert `().then`
 
-  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
-    ╭─[next_tick_style.tsx:10:21]
-  9 │                     Vue.nextTick(callback);
- 10 │                     nt(callback);
-    ·                     ──
+  ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
+   ╭─[next_tick_style.tsx:7:21]
+ 6 │                     Vue.nextTick().then(() => callback());
+ 7 │                     nt().then(() => callback());
+   ·                     ──
+ 8 │                     await this.$nextTick(); callback();
+   ╰────
+
+  ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
+    ╭─[next_tick_style.tsx:10:27]
+  9 │                     await Vue.nextTick(); callback();
+ 10 │                     await nt(); callback();
+    ·                           ──
  11 │                 }
     ╰────
-  help: Insert `().then`
 
   ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
    ╭─[next_tick_style.tsx:5:26]
@@ -127,14 +143,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
-   ╭─[next_tick_style.tsx:7:21]
- 6 │                     Vue.nextTick().then(() => callback());
- 7 │                     nt().then(() => callback());
-   ·                     ──
- 8 │                     await this.$nextTick(); callback();
-   ╰────
-
-  ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
    ╭─[next_tick_style.tsx:8:32]
  7 │                     nt().then(() => callback());
  8 │                     await this.$nextTick(); callback();
@@ -148,12 +156,4 @@ source: crates/oxc_linter/src/tester.rs
   9 │                     await Vue.nextTick(); callback();
     ·                               ────────
  10 │                     await nt(); callback();
-    ╰────
-
-  ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
-    ╭─[next_tick_style.tsx:10:27]
-  9 │                     await Vue.nextTick(); callback();
- 10 │                     await nt(); callback();
-    ·                           ──
- 11 │                 }
     ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_async_in_computed_properties.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_async_in_computed_properties.snap
@@ -2,15 +2,6 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
-   ╭─[no_async_in_computed_properties.tsx:5:30]
- 4 │                           computed: {
- 5 │ ╭─▶                         foo: async function () {
- 6 │ │                             return await someFunc()
- 7 │ ╰─▶                         }
- 8 │                           }
-   ╰────
-
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in "foo" computed property.
    ╭─[no_async_in_computed_properties.tsx:6:34]
  5 │                         foo: async function () {
@@ -23,7 +14,7 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_async_in_computed_properties.tsx:5:30]
  4 │                           computed: {
  5 │ ╭─▶                         foo: async function () {
- 6 │ │                             return new Promise((resolve, reject) => {})
+ 6 │ │                             return await someFunc()
  7 │ ╰─▶                         }
  8 │                           }
    ╰────
@@ -34,6 +25,15 @@ source: crates/oxc_linter/src/tester.rs
  6 │                           return new Promise((resolve, reject) => {})
    ·                                  ────────────────────────────────────
  7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:5:30]
+ 4 │                           computed: {
+ 5 │ ╭─▶                         foo: async function () {
+ 6 │ │                             return new Promise((resolve, reject) => {})
+ 7 │ ╰─▶                         }
+ 8 │                           }
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
@@ -156,30 +156,27 @@ source: crates/oxc_linter/src/tester.rs
  8 │                         return 'foo'
    ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
-    ╭─[no_async_in_computed_properties.tsx:5:33]
-  4 │                         computed: {
-  5 │ ╭─▶                       async foo () {
-  6 │ │                           await this.$nextTick()
-  7 │ │                           await Vue.nextTick()
-  8 │ │                           return 'foo'
-  9 │ ╰─▶                       }
- 10 │                         }
-    ╰────
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:31]
+ 5 │                       async foo () {
+ 6 │                         await this.$nextTick()
+   ·                               ────────────────
+ 7 │                         await Vue.nextTick()
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:31]
+ 6 │                         await this.$nextTick()
+ 7 │                         await Vue.nextTick()
+   ·                               ──────────────
+ 8 │                         return 'foo'
+   ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in "foo" computed property.
    ╭─[no_async_in_computed_properties.tsx:6:25]
  5 │                       async foo () {
  6 │                         await this.$nextTick()
    ·                         ──────────────────────
- 7 │                         await Vue.nextTick()
-   ╰────
-
-  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
-   ╭─[no_async_in_computed_properties.tsx:6:31]
- 5 │                       async foo () {
- 6 │                         await this.$nextTick()
-   ·                               ────────────────
  7 │                         await Vue.nextTick()
    ╰────
 
@@ -191,13 +188,16 @@ source: crates/oxc_linter/src/tester.rs
  8 │                         return 'foo'
    ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
-   ╭─[no_async_in_computed_properties.tsx:7:31]
- 6 │                         await this.$nextTick()
- 7 │                         await Vue.nextTick()
-   ·                               ──────────────
- 8 │                         return 'foo'
-   ╰────
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:5:33]
+  4 │                         computed: {
+  5 │ ╭─▶                       async foo () {
+  6 │ │                           await this.$nextTick()
+  7 │ │                           await Vue.nextTick()
+  8 │ │                           return 'foo'
+  9 │ ╰─▶                       }
+ 10 │                         }
+    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
    ╭─[no_async_in_computed_properties.tsx:6:25]
@@ -391,15 +391,6 @@ source: crates/oxc_linter/src/tester.rs
  14 │                       }
     ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-   ╭─[no_async_in_computed_properties.tsx:6:46]
- 5 │                         setup() {
- 6 │ ╭─▶                       const test1 = computed(async () => {
- 7 │ │                           return await someFunc()
- 8 │ ╰─▶                       })
- 9 │                           const test2 = computed(async () => await someFunc())
-   ╰────
-
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
    ╭─[no_async_in_computed_properties.tsx:7:32]
  6 │                       const test1 = computed(async () => {
@@ -408,29 +399,12 @@ source: crates/oxc_linter/src/tester.rs
  8 │                       })
    ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-    ╭─[no_async_in_computed_properties.tsx:9:46]
-  8 │                       })
-  9 │                       const test2 = computed(async () => await someFunc())
-    ·                                              ────────────────────────────
- 10 │                       const test3 = computed(async function () {
-    ╰────
-
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
     ╭─[no_async_in_computed_properties.tsx:9:58]
   8 │                       })
   9 │                       const test2 = computed(async () => await someFunc())
     ·                                                          ────────────────
  10 │                       const test3 = computed(async function () {
-    ╰────
-
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-    ╭─[no_async_in_computed_properties.tsx:10:46]
-  9 │                           const test2 = computed(async () => await someFunc())
- 10 │ ╭─▶                       const test3 = computed(async function () {
- 11 │ │                           return await someFunc()
- 12 │ ╰─▶                       })
- 13 │                         }
     ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
@@ -442,13 +416,30 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-   ╭─[no_async_in_computed_properties.tsx:6:45]
+    ╭─[no_async_in_computed_properties.tsx:10:46]
+  9 │                           const test2 = computed(async () => await someFunc())
+ 10 │ ╭─▶                       const test3 = computed(async function () {
+ 11 │ │                           return await someFunc()
+ 12 │ ╰─▶                       })
+ 13 │                         }
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:6:46]
  5 │                         setup() {
- 6 │ ╭─▶                       const test = computed(async () => {
- 7 │ │                           return new Promise((resolve, reject) => {})
+ 6 │ ╭─▶                       const test1 = computed(async () => {
+ 7 │ │                           return await someFunc()
  8 │ ╰─▶                       })
- 9 │                         }
+ 9 │                           const test2 = computed(async () => await someFunc())
    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+    ╭─[no_async_in_computed_properties.tsx:9:46]
+  8 │                       })
+  9 │                       const test2 = computed(async () => await someFunc())
+    ·                                              ────────────────────────────
+ 10 │                       const test3 = computed(async function () {
+    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected Promise object in computed function.
    ╭─[no_async_in_computed_properties.tsx:7:32]
@@ -456,6 +447,15 @@ source: crates/oxc_linter/src/tester.rs
  7 │                         return new Promise((resolve, reject) => {})
    ·                                ────────────────────────────────────
  8 │                       })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:6:45]
+ 5 │                         setup() {
+ 6 │ ╭─▶                       const test = computed(async () => {
+ 7 │ │                           return new Promise((resolve, reject) => {})
+ 8 │ ╰─▶                       })
+ 9 │                         }
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
@@ -563,29 +563,12 @@ source: crates/oxc_linter/src/tester.rs
  9 │                         }
    ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-   ╭─[no_async_in_computed_properties.tsx:4:42]
- 3 │                       import {computed} from 'vue'
- 4 │ ╭─▶                   const test1 = computed(async () => {
- 5 │ │                       return await someFunc()
- 6 │ ╰─▶                   })
- 7 │                       const test2 = computed(async () => await someFunc())
-   ╰────
-
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
    ╭─[no_async_in_computed_properties.tsx:5:28]
  4 │                   const test1 = computed(async () => {
  5 │                     return await someFunc()
    ·                            ────────────────
  6 │                   })
-   ╰────
-
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-   ╭─[no_async_in_computed_properties.tsx:7:42]
- 6 │                   })
- 7 │                   const test2 = computed(async () => await someFunc())
-   ·                                          ────────────────────────────
- 8 │                   const test3 = computed(async function () {
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
@@ -596,15 +579,6 @@ source: crates/oxc_linter/src/tester.rs
  8 │                   const test3 = computed(async function () {
    ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-    ╭─[no_async_in_computed_properties.tsx:8:42]
-  7 │                       const test2 = computed(async () => await someFunc())
-  8 │ ╭─▶                   const test3 = computed(async function () {
-  9 │ │                       return await someFunc()
- 10 │ ╰─▶                   })
- 11 │                       </script>
-    ╰────
-
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
     ╭─[no_async_in_computed_properties.tsx:9:28]
   8 │                   const test3 = computed(async function () {
@@ -614,12 +588,29 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-   ╭─[no_async_in_computed_properties.tsx:4:41]
+    ╭─[no_async_in_computed_properties.tsx:8:42]
+  7 │                       const test2 = computed(async () => await someFunc())
+  8 │ ╭─▶                   const test3 = computed(async function () {
+  9 │ │                       return await someFunc()
+ 10 │ ╰─▶                   })
+ 11 │                       </script>
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:4:42]
  3 │                       import {computed} from 'vue'
- 4 │ ╭─▶                   const test = computed(async () => {
- 5 │ │                       return new Promise((resolve, reject) => {})
+ 4 │ ╭─▶                   const test1 = computed(async () => {
+ 5 │ │                       return await someFunc()
  6 │ ╰─▶                   })
- 7 │                       </script>
+ 7 │                       const test2 = computed(async () => await someFunc())
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:7:42]
+ 6 │                   })
+ 7 │                   const test2 = computed(async () => await someFunc())
+   ·                                          ────────────────────────────
+ 8 │                   const test3 = computed(async function () {
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected Promise object in computed function.
@@ -628,6 +619,15 @@ source: crates/oxc_linter/src/tester.rs
  5 │                     return new Promise((resolve, reject) => {})
    ·                            ────────────────────────────────────
  6 │                   })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:4:41]
+ 3 │                       import {computed} from 'vue'
+ 4 │ ╭─▶                   const test = computed(async () => {
+ 5 │ │                       return new Promise((resolve, reject) => {})
+ 6 │ ╰─▶                   })
+ 7 │                       </script>
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.

--- a/crates/oxc_linter/src/snapshots/vue_return_in_computed_property.snap
+++ b/crates/oxc_linter/src/snapshots/vue_return_in_computed_property.snap
@@ -85,20 +85,20 @@ source: crates/oxc_linter/src/tester.rs
   help: All code paths inside a computed getter must return a value.
 
   ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
-   ╭─[return_in_computed_property.tsx:6:42]
- 5 │                   setup() {
- 6 │                     const foo = computed(() => {})
-   ·                                          ────────
- 7 │                     const foo2 = computed(function() {})
-   ╰────
-  help: All code paths inside a computed getter must return a value.
-
-  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
    ╭─[return_in_computed_property.tsx:7:43]
  6 │                     const foo = computed(() => {})
  7 │                     const foo2 = computed(function() {})
    ·                                           ─────────────
  8 │                     const foo3 = computed(() => {
+   ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:6:42]
+ 5 │                   setup() {
+ 6 │                     const foo = computed(() => {})
+   ·                                          ────────
+ 7 │                     const foo2 = computed(function() {})
    ╰────
   help: All code paths inside a computed getter must return a value.
 

--- a/crates/oxc_linter/src/snapshots/vue_valid_next_tick.snap
+++ b/crates/oxc_linter/src/snapshots/vue_valid_next_tick.snap
@@ -36,6 +36,15 @@ source: crates/oxc_linter/src/tester.rs
   help: Insert `()`
 
   ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:8:23]
+ 7 │ 
+ 8 │                       nt.then(callback);
+   ·                       ──
+ 9 │                       Vue.nextTick.then(callback);
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
    ╭─[valid_next_tick.tsx:5:27]
  4 │                       nt;
  5 │                       Vue.nextTick;
@@ -50,15 +59,6 @@ source: crates/oxc_linter/src/tester.rs
  6 │                       this.$nextTick;
    ·                            ─────────
  7 │ 
-   ╰────
-  help: Insert `()`
-
-  ⚠ vue(valid-next-tick): `nextTick` is a function.
-   ╭─[valid_next_tick.tsx:8:23]
- 7 │ 
- 8 │                       nt.then(callback);
-   ·                       ──
- 9 │                       Vue.nextTick.then(callback);
    ╰────
   help: Insert `()`
 
@@ -167,6 +167,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
+   ╭─[valid_next_tick.tsx:8:29]
+ 7 │ 
+ 8 │                       await nt(callback);
+   ·                             ──
+ 9 │                       await Vue.nextTick(callback);
+   ╰────
+
+  ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
    ╭─[valid_next_tick.tsx:5:27]
  4 │                       nt(callback).then(anotherCallback);
  5 │                       Vue.nextTick(callback).then(anotherCallback);
@@ -180,14 +188,6 @@ source: crates/oxc_linter/src/tester.rs
  6 │                       this.$nextTick(callback).then(anotherCallback);
    ·                            ─────────
  7 │ 
-   ╰────
-
-  ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
-   ╭─[valid_next_tick.tsx:8:29]
- 7 │ 
- 8 │                       await nt(callback);
-   ·                             ──
- 9 │                       await Vue.nextTick(callback);
    ╰────
 
   ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.

--- a/tasks/linter_codegen/src/rules_enum.rs
+++ b/tasks/linter_codegen/src/rules_enum.rs
@@ -118,7 +118,7 @@ fn generate_imports() -> TokenStream {
         };
         #[cfg(feature = "ruledocs")]
         use crate::rule::RuleInfo;
-        use oxc_semantic::AstTypesBitset;
+        use oxc_semantic::{AstNodes, AstTypesBitset, NodeId};
     }
 }
 
@@ -219,6 +219,20 @@ fn generate_rule_enum_impl(rule_entries: &[RuleEntry<'_>]) -> TokenStream {
         .map(|rule| {
             let enum_name = make_enum_ident(rule);
             quote! { Self::#enum_name(rule) => rule.run(node, ctx) }
+        })
+        .collect();
+
+    let run_batch_arms: Vec<TokenStream> = rule_entries
+        .iter()
+        .map(|rule| {
+            let enum_name = make_enum_ident(rule);
+            // Match on `self` once per call, then dispatch the whole node slice with a monomorphic,
+            // directly-inlinable loop. This hoists the enum match out of the per-node dispatch loop.
+            quote! { Self::#enum_name(rule) => {
+                for &node_id in node_ids {
+                    rule.run(nodes.get_node(node_id), ctx);
+                }
+            } }
         })
         .collect();
 
@@ -368,6 +382,27 @@ fn generate_rule_enum_impl(rule_entries: &[RuleEntry<'_>]) -> TokenStream {
                 } else {
                     match self {
                         #(#run_arms),*
+                    }
+                }
+            }
+
+            /// Run this rule over every node in `node_ids` (all of the same AST type), resolving
+            /// each id against `nodes`. The enum match happens once per call rather than once per
+            /// node, so the per-node dispatch is a direct, inlinable call into the concrete rule.
+            pub(crate) fn run_batch<'a, const TIMINGS: bool>(
+                &self,
+                node_ids: &[NodeId],
+                nodes: &AstNodes<'a>,
+                ctx: &LintContext<'a>,
+                timing_stat: Option<&mut RuleTimingStat>,
+            ) {
+                if TIMINGS {
+                    timing_stat.expect("missing rule timing stat").time(|| match self {
+                        #(#run_batch_arms),*
+                    });
+                } else {
+                    match self {
+                        #(#run_batch_arms),*
                     }
                 }
             }


### PR DESCRIPTION
## What

Hoist the `RuleEnum::run` match out of the per-node dispatch loop.

`execute_rules` iterated AST nodes and, for each node, ran each bucketed rule through `RuleEnum::run` — an 834-arm match that lowers to a mispredicted indirect jump, taken once per `(node, rule)` pair. A samply profile of the all-rules linter bench showed `RuleEnum::run` is the single hottest function at ~8% of samples (plus ~2% in the bucket loop).

Dispatch is now **type-major**: node ids are grouped by AST type into reused thread-local buffers, then for each type every bucketed rule runs over the whole slice via a generated `RuleEnum::run_batch`, which matches `self` **once** and loops with a direct, inlinable call into the concrete rule. The enum match moves from once-per-`(node, rule)` (millions) to once-per-`(rule, type)` (thousands). Rule source is unchanged — only the codegen and `execute_rules` change.

## Benchmarks

Criterion with `ConfigStoreBuilder::all()`, same machine:

| file | before | after | |
| --- | --- | --- | --- |
| react.development.js | 2.361 ms | 2.048 ms | **−13%** |
| App.tsx | 19.97 ms | 19.82 ms | −0.8% |
| RadixUIAdoptionSection.jsx | 1.241 ms | 1.231 ms | −0.8% |

Dispatch-heavy JS benefits most; rule-body-heavy TS files less; nothing regressed (the type-major locality trade-off did not show a net loss on these inputs).

## Correctness

The debug reference-path assertion (optimized vs. unoptimized dispatch) still passes — identical diagnostic **set**. 22 multi-type-rule snapshots change because diagnostics are now emitted grouped by type rather than in source order. oxlint sorts diagnostics by span before output (`apps/oxlint/src/output_formatter/default.rs`), so user-visible output is unchanged — this is the same kind of snapshot churn as #23452.

Draft: pending a full `just ready` + conformance run (the conformance suites also exercise the reference-path assertion in debug).

_Implemented with AI assistance (Claude), per the AGENTS.md disclosure policy._
