### PR TITLE
feat(linter/node): implement `no-mixed-requires` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1193,7 +1193,14 @@ export interface DummyRuleMap {
   "node/global-require"?: RuleNoConfig;
   "node/handle-callback-err"?: RuleNoConfig | [AllowWarnDeny, HandleCallbackErrConfig];
   "node/no-exports-assign"?: RuleNoConfig;
-  "node/no-mixed-requires"?: RuleNoConfig;
+  "node/no-mixed-requires"?:
+    | RuleNoConfig
+    | (
+        | [AllowWarnDeny, boolean]
+        | [AllowWarnDeny, boolean, NoMixedRequiresOptions]
+        | [AllowWarnDeny, boolean]
+        | [AllowWarnDeny, NoMixedRequiresOptions]
+      );
   "node/no-new-require"?: RuleNoConfig;
   "node/no-path-concat"?: RuleNoConfig;
   "node/no-process-env"?: RuleNoConfig | [AllowWarnDeny, NoProcessEnvConfig];
@@ -3849,6 +3856,10 @@ export interface NoWarningCommentsConfigJson {
   decoration?: string[];
   location?: Location;
   terms?: string[];
+}
+export interface NoMixedRequiresOptions {
+  allowCall?: boolean;
+  grouping?: boolean;
 }
 export interface NoProcessEnvConfig {
   /**

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -151,6 +151,7 @@ export type Location = "start" | "anywhere";
  * Default: `"err"`.
  */
 export type HandleCallbackErrConfig = string;
+export type NoMixedRequiresConfig = boolean | NoMixedRequiresOptions;
 export type ShorthandType = "always" | "methods" | "properties" | "consistent" | "consistent-as-needed" | "never";
 export type Destructuring = "any" | "all";
 export type PreferDestructuringOption = PreferDestructuringTargetOption | PreferDestructuringAssignmentConfig;
@@ -1193,14 +1194,7 @@ export interface DummyRuleMap {
   "node/global-require"?: RuleNoConfig;
   "node/handle-callback-err"?: RuleNoConfig | [AllowWarnDeny, HandleCallbackErrConfig];
   "node/no-exports-assign"?: RuleNoConfig;
-  "node/no-mixed-requires"?:
-    | RuleNoConfig
-    | (
-        | [AllowWarnDeny, boolean]
-        | [AllowWarnDeny, boolean, NoMixedRequiresOptions]
-        | [AllowWarnDeny, boolean]
-        | [AllowWarnDeny, NoMixedRequiresOptions]
-      );
+  "node/no-mixed-requires"?: RuleNoConfig | [AllowWarnDeny, NoMixedRequiresConfig];
   "node/no-new-require"?: RuleNoConfig;
   "node/no-path-concat"?: RuleNoConfig;
   "node/no-process-env"?: RuleNoConfig | [AllowWarnDeny, NoProcessEnvConfig];

--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1193,6 +1193,7 @@ export interface DummyRuleMap {
   "node/global-require"?: RuleNoConfig;
   "node/handle-callback-err"?: RuleNoConfig | [AllowWarnDeny, HandleCallbackErrConfig];
   "node/no-exports-assign"?: RuleNoConfig;
+  "node/no-mixed-requires"?: RuleNoConfig;
   "node/no-new-require"?: RuleNoConfig;
   "node/no-path-concat"?: RuleNoConfig;
   "node/no-process-env"?: RuleNoConfig | [AllowWarnDeny, NoProcessEnvConfig];

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4956,11 +4956,6 @@ impl RuleRunner for crate::rules::vitest::warn_todo::WarnTodo {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
-impl RuleRunner for crate::rules::node::no_mixed_requires::NoMixedRequires {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
-}
-
 impl RuleRunner for crate::rules::node::callback_return::CallbackReturn {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
@@ -4982,6 +4977,12 @@ impl RuleRunner for crate::rules::node::handle_callback_err::HandleCallbackErr {
 impl RuleRunner for crate::rules::node::no_exports_assign::NoExportsAssign {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::AssignmentExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
+impl RuleRunner for crate::rules::node::no_mixed_requires::NoMixedRequires {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::VariableDeclaration]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4956,6 +4956,11 @@ impl RuleRunner for crate::rules::vitest::warn_todo::WarnTodo {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnJestNode;
 }
 
+impl RuleRunner for crate::rules::node::no_mixed_requires::NoMixedRequires {
+    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::node::callback_return::CallbackReturn {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -1648,11 +1648,11 @@ pub enum RuleEnum {
     VitestValidExpectInPromise(VitestValidExpectInPromise),
     VitestValidTitle(VitestValidTitle),
     VitestWarnTodo(VitestWarnTodo),
-    NodeNoMixedRequires(NodeNoMixedRequires),
     NodeCallbackReturn(NodeCallbackReturn),
     NodeGlobalRequire(NodeGlobalRequire),
     NodeHandleCallbackErr(NodeHandleCallbackErr),
     NodeNoExportsAssign(NodeNoExportsAssign),
+    NodeNoMixedRequires(NodeNoMixedRequires),
     NodeNoNewRequire(NodeNoNewRequire),
     NodeNoPathConcat(NodeNoPathConcat),
     NodeNoProcessEnv(NodeNoProcessEnv),
@@ -2587,12 +2587,12 @@ const VITEST_VALID_EXPECT_ID: usize = VITEST_VALID_DESCRIBE_CALLBACK_ID + 1usize
 const VITEST_VALID_EXPECT_IN_PROMISE_ID: usize = VITEST_VALID_EXPECT_ID + 1usize;
 const VITEST_VALID_TITLE_ID: usize = VITEST_VALID_EXPECT_IN_PROMISE_ID + 1usize;
 const VITEST_WARN_TODO_ID: usize = VITEST_VALID_TITLE_ID + 1usize;
-const NODE_NO_MIXED_REQUIRES_ID: usize = VITEST_WARN_TODO_ID + 1usize;
-const NODE_CALLBACK_RETURN_ID: usize = NODE_NO_MIXED_REQUIRES_ID + 1usize;
+const NODE_CALLBACK_RETURN_ID: usize = VITEST_WARN_TODO_ID + 1usize;
 const NODE_GLOBAL_REQUIRE_ID: usize = NODE_CALLBACK_RETURN_ID + 1usize;
 const NODE_HANDLE_CALLBACK_ERR_ID: usize = NODE_GLOBAL_REQUIRE_ID + 1usize;
 const NODE_NO_EXPORTS_ASSIGN_ID: usize = NODE_HANDLE_CALLBACK_ERR_ID + 1usize;
-const NODE_NO_NEW_REQUIRE_ID: usize = NODE_NO_EXPORTS_ASSIGN_ID + 1usize;
+const NODE_NO_MIXED_REQUIRES_ID: usize = NODE_NO_EXPORTS_ASSIGN_ID + 1usize;
+const NODE_NO_NEW_REQUIRE_ID: usize = NODE_NO_MIXED_REQUIRES_ID + 1usize;
 const NODE_NO_PATH_CONCAT_ID: usize = NODE_NO_NEW_REQUIRE_ID + 1usize;
 const NODE_NO_PROCESS_ENV_ID: usize = NODE_NO_PATH_CONCAT_ID + 1usize;
 const VUE_COMPONENT_DEFINITION_NAME_CASING_ID: usize = NODE_NO_PROCESS_ENV_ID + 1usize;
@@ -3560,11 +3560,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VITEST_VALID_EXPECT_IN_PROMISE_ID,
             Self::VitestValidTitle(_) => VITEST_VALID_TITLE_ID,
             Self::VitestWarnTodo(_) => VITEST_WARN_TODO_ID,
-            Self::NodeNoMixedRequires(_) => NODE_NO_MIXED_REQUIRES_ID,
             Self::NodeCallbackReturn(_) => NODE_CALLBACK_RETURN_ID,
             Self::NodeGlobalRequire(_) => NODE_GLOBAL_REQUIRE_ID,
             Self::NodeHandleCallbackErr(_) => NODE_HANDLE_CALLBACK_ERR_ID,
             Self::NodeNoExportsAssign(_) => NODE_NO_EXPORTS_ASSIGN_ID,
+            Self::NodeNoMixedRequires(_) => NODE_NO_MIXED_REQUIRES_ID,
             Self::NodeNoNewRequire(_) => NODE_NO_NEW_REQUIRE_ID,
             Self::NodeNoPathConcat(_) => NODE_NO_PATH_CONCAT_ID,
             Self::NodeNoProcessEnv(_) => NODE_NO_PROCESS_ENV_ID,
@@ -4515,11 +4515,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::NAME,
             Self::VitestValidTitle(_) => VitestValidTitle::NAME,
             Self::VitestWarnTodo(_) => VitestWarnTodo::NAME,
-            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::NAME,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::NAME,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::NAME,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::NAME,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::NAME,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::NAME,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::NAME,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::NAME,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::NAME,
@@ -5526,11 +5526,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::CATEGORY,
             Self::VitestValidTitle(_) => VitestValidTitle::CATEGORY,
             Self::VitestWarnTodo(_) => VitestWarnTodo::CATEGORY,
-            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::CATEGORY,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::CATEGORY,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::CATEGORY,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::CATEGORY,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::CATEGORY,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::CATEGORY,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::CATEGORY,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::CATEGORY,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::CATEGORY,
@@ -6484,11 +6484,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::FIX,
             Self::VitestValidTitle(_) => VitestValidTitle::FIX,
             Self::VitestWarnTodo(_) => VitestWarnTodo::FIX,
-            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::FIX,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::FIX,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::FIX,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::FIX,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::FIX,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::FIX,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::FIX,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::FIX,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::FIX,
@@ -7688,11 +7688,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::documentation(),
             Self::VitestValidTitle(_) => VitestValidTitle::documentation(),
             Self::VitestWarnTodo(_) => VitestWarnTodo::documentation(),
-            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::documentation(),
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::documentation(),
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::documentation(),
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::documentation(),
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::documentation(),
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::documentation(),
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::documentation(),
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::documentation(),
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::documentation(),
@@ -10020,8 +10020,6 @@ impl RuleEnum {
                 .or_else(|| VitestValidTitle::schema(generator)),
             Self::VitestWarnTodo(_) => VitestWarnTodo::config_schema(generator)
                 .or_else(|| VitestWarnTodo::schema(generator)),
-            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::config_schema(generator)
-                .or_else(|| NodeNoMixedRequires::schema(generator)),
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::config_schema(generator)
                 .or_else(|| NodeCallbackReturn::schema(generator)),
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::config_schema(generator)
@@ -10030,6 +10028,8 @@ impl RuleEnum {
                 .or_else(|| NodeHandleCallbackErr::schema(generator)),
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::config_schema(generator)
                 .or_else(|| NodeNoExportsAssign::schema(generator)),
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::config_schema(generator)
+                .or_else(|| NodeNoMixedRequires::schema(generator)),
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::config_schema(generator)
                 .or_else(|| NodeNoNewRequire::schema(generator)),
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::config_schema(generator)
@@ -10959,11 +10959,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => "vitest",
             Self::VitestValidTitle(_) => "vitest",
             Self::VitestWarnTodo(_) => "vitest",
-            Self::NodeNoMixedRequires(_) => "node",
             Self::NodeCallbackReturn(_) => "node",
             Self::NodeGlobalRequire(_) => "node",
             Self::NodeHandleCallbackErr(_) => "node",
             Self::NodeNoExportsAssign(_) => "node",
+            Self::NodeNoMixedRequires(_) => "node",
             Self::NodeNoNewRequire(_) => "node",
             Self::NodeNoPathConcat(_) => "node",
             Self::NodeNoProcessEnv(_) => "node",
@@ -13547,9 +13547,6 @@ impl RuleEnum {
             Self::VitestWarnTodo(_) => {
                 Ok(Self::VitestWarnTodo(VitestWarnTodo::from_configuration(value)?))
             }
-            Self::NodeNoMixedRequires(_) => {
-                Ok(Self::NodeNoMixedRequires(NodeNoMixedRequires::from_configuration(value)?))
-            }
             Self::NodeCallbackReturn(_) => {
                 Ok(Self::NodeCallbackReturn(NodeCallbackReturn::from_configuration(value)?))
             }
@@ -13561,6 +13558,9 @@ impl RuleEnum {
             }
             Self::NodeNoExportsAssign(_) => {
                 Ok(Self::NodeNoExportsAssign(NodeNoExportsAssign::from_configuration(value)?))
+            }
+            Self::NodeNoMixedRequires(_) => {
+                Ok(Self::NodeNoMixedRequires(NodeNoMixedRequires::from_configuration(value)?))
             }
             Self::NodeNoNewRequire(_) => {
                 Ok(Self::NodeNoNewRequire(NodeNoNewRequire::from_configuration(value)?))
@@ -14508,11 +14508,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(rule) => rule.to_configuration(),
             Self::VitestValidTitle(rule) => rule.to_configuration(),
             Self::VitestWarnTodo(rule) => rule.to_configuration(),
-            Self::NodeNoMixedRequires(rule) => rule.to_configuration(),
             Self::NodeCallbackReturn(rule) => rule.to_configuration(),
             Self::NodeGlobalRequire(rule) => rule.to_configuration(),
             Self::NodeHandleCallbackErr(rule) => rule.to_configuration(),
             Self::NodeNoExportsAssign(rule) => rule.to_configuration(),
+            Self::NodeNoMixedRequires(rule) => rule.to_configuration(),
             Self::NodeNoNewRequire(rule) => rule.to_configuration(),
             Self::NodeNoPathConcat(rule) => rule.to_configuration(),
             Self::NodeNoProcessEnv(rule) => rule.to_configuration(),
@@ -15359,11 +15359,11 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run(node, ctx),
                 Self::VitestValidTitle(rule) => rule.run(node, ctx),
                 Self::VitestWarnTodo(rule) => rule.run(node, ctx),
-                Self::NodeNoMixedRequires(rule) => rule.run(node, ctx),
                 Self::NodeCallbackReturn(rule) => rule.run(node, ctx),
                 Self::NodeGlobalRequire(rule) => rule.run(node, ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run(node, ctx),
                 Self::NodeNoExportsAssign(rule) => rule.run(node, ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run(node, ctx),
                 Self::NodeNoNewRequire(rule) => rule.run(node, ctx),
                 Self::NodeNoPathConcat(rule) => rule.run(node, ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run(node, ctx),
@@ -16203,11 +16203,11 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run(node, ctx),
                 Self::VitestValidTitle(rule) => rule.run(node, ctx),
                 Self::VitestWarnTodo(rule) => rule.run(node, ctx),
-                Self::NodeNoMixedRequires(rule) => rule.run(node, ctx),
                 Self::NodeCallbackReturn(rule) => rule.run(node, ctx),
                 Self::NodeGlobalRequire(rule) => rule.run(node, ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run(node, ctx),
                 Self::NodeNoExportsAssign(rule) => rule.run(node, ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run(node, ctx),
                 Self::NodeNoNewRequire(rule) => rule.run(node, ctx),
                 Self::NodeNoPathConcat(rule) => rule.run(node, ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run(node, ctx),
@@ -17054,11 +17054,11 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run_once(ctx),
                 Self::VitestValidTitle(rule) => rule.run_once(ctx),
                 Self::VitestWarnTodo(rule) => rule.run_once(ctx),
-                Self::NodeNoMixedRequires(rule) => rule.run_once(ctx),
                 Self::NodeCallbackReturn(rule) => rule.run_once(ctx),
                 Self::NodeGlobalRequire(rule) => rule.run_once(ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run_once(ctx),
                 Self::NodeNoExportsAssign(rule) => rule.run_once(ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run_once(ctx),
                 Self::NodeNoNewRequire(rule) => rule.run_once(ctx),
                 Self::NodeNoPathConcat(rule) => rule.run_once(ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run_once(ctx),
@@ -17898,11 +17898,11 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run_once(ctx),
                 Self::VitestValidTitle(rule) => rule.run_once(ctx),
                 Self::VitestWarnTodo(rule) => rule.run_once(ctx),
-                Self::NodeNoMixedRequires(rule) => rule.run_once(ctx),
                 Self::NodeCallbackReturn(rule) => rule.run_once(ctx),
                 Self::NodeGlobalRequire(rule) => rule.run_once(ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run_once(ctx),
                 Self::NodeNoExportsAssign(rule) => rule.run_once(ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run_once(ctx),
                 Self::NodeNoNewRequire(rule) => rule.run_once(ctx),
                 Self::NodeNoPathConcat(rule) => rule.run_once(ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run_once(ctx),
@@ -18998,11 +18998,11 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestValidTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestWarnTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
-                Self::NodeNoMixedRequires(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeCallbackReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeGlobalRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoExportsAssign(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoNewRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoPathConcat(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20102,11 +20102,11 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestValidTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestWarnTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
-                Self::NodeNoMixedRequires(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeCallbackReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeGlobalRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoExportsAssign(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoNewRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoPathConcat(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeNoProcessEnv(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20956,11 +20956,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(rule) => rule.should_run(ctx),
             Self::VitestValidTitle(rule) => rule.should_run(ctx),
             Self::VitestWarnTodo(rule) => rule.should_run(ctx),
-            Self::NodeNoMixedRequires(rule) => rule.should_run(ctx),
             Self::NodeCallbackReturn(rule) => rule.should_run(ctx),
             Self::NodeGlobalRequire(rule) => rule.should_run(ctx),
             Self::NodeHandleCallbackErr(rule) => rule.should_run(ctx),
             Self::NodeNoExportsAssign(rule) => rule.should_run(ctx),
+            Self::NodeNoMixedRequires(rule) => rule.should_run(ctx),
             Self::NodeNoNewRequire(rule) => rule.should_run(ctx),
             Self::NodeNoPathConcat(rule) => rule.should_run(ctx),
             Self::NodeNoProcessEnv(rule) => rule.should_run(ctx),
@@ -22155,11 +22155,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::IS_TSGOLINT_RULE,
             Self::VitestValidTitle(_) => VitestValidTitle::IS_TSGOLINT_RULE,
             Self::VitestWarnTodo(_) => VitestWarnTodo::IS_TSGOLINT_RULE,
-            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::IS_TSGOLINT_RULE,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::IS_TSGOLINT_RULE,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::IS_TSGOLINT_RULE,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::IS_TSGOLINT_RULE,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::IS_TSGOLINT_RULE,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::IS_TSGOLINT_RULE,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::IS_TSGOLINT_RULE,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::IS_TSGOLINT_RULE,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::IS_TSGOLINT_RULE,
@@ -23184,11 +23184,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::VERSION,
             Self::VitestValidTitle(_) => VitestValidTitle::VERSION,
             Self::VitestWarnTodo(_) => VitestWarnTodo::VERSION,
-            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::VERSION,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::VERSION,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::VERSION,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::VERSION,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::VERSION,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::VERSION,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::VERSION,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::VERSION,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::VERSION,
@@ -24232,11 +24232,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::HAS_CONFIG,
             Self::VitestValidTitle(_) => VitestValidTitle::HAS_CONFIG,
             Self::VitestWarnTodo(_) => VitestWarnTodo::HAS_CONFIG,
-            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::HAS_CONFIG,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::HAS_CONFIG,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::HAS_CONFIG,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::HAS_CONFIG,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::HAS_CONFIG,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::HAS_CONFIG,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::HAS_CONFIG,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::HAS_CONFIG,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::HAS_CONFIG,
@@ -25195,11 +25195,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::INFO,
             Self::VitestValidTitle(_) => VitestValidTitle::INFO,
             Self::VitestWarnTodo(_) => VitestWarnTodo::INFO,
-            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::INFO,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::INFO,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::INFO,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::INFO,
             Self::NodeNoExportsAssign(_) => NodeNoExportsAssign::INFO,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::INFO,
             Self::NodeNoNewRequire(_) => NodeNoNewRequire::INFO,
             Self::NodeNoPathConcat(_) => NodeNoPathConcat::INFO,
             Self::NodeNoProcessEnv(_) => NodeNoProcessEnv::INFO,
@@ -26045,11 +26045,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(rule) => rule.types_info(),
             Self::VitestValidTitle(rule) => rule.types_info(),
             Self::VitestWarnTodo(rule) => rule.types_info(),
-            Self::NodeNoMixedRequires(rule) => rule.types_info(),
             Self::NodeCallbackReturn(rule) => rule.types_info(),
             Self::NodeGlobalRequire(rule) => rule.types_info(),
             Self::NodeHandleCallbackErr(rule) => rule.types_info(),
             Self::NodeNoExportsAssign(rule) => rule.types_info(),
+            Self::NodeNoMixedRequires(rule) => rule.types_info(),
             Self::NodeNoNewRequire(rule) => rule.types_info(),
             Self::NodeNoPathConcat(rule) => rule.types_info(),
             Self::NodeNoProcessEnv(rule) => rule.types_info(),
@@ -26886,11 +26886,11 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(rule) => rule.run_info(),
             Self::VitestValidTitle(rule) => rule.run_info(),
             Self::VitestWarnTodo(rule) => rule.run_info(),
-            Self::NodeNoMixedRequires(rule) => rule.run_info(),
             Self::NodeCallbackReturn(rule) => rule.run_info(),
             Self::NodeGlobalRequire(rule) => rule.run_info(),
             Self::NodeHandleCallbackErr(rule) => rule.run_info(),
             Self::NodeNoExportsAssign(rule) => rule.run_info(),
+            Self::NodeNoMixedRequires(rule) => rule.run_info(),
             Self::NodeNoNewRequire(rule) => rule.run_info(),
             Self::NodeNoPathConcat(rule) => rule.run_info(),
             Self::NodeNoProcessEnv(rule) => rule.run_info(),
@@ -27859,11 +27859,11 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestValidExpectInPromise(VitestValidExpectInPromise::default()),
         RuleEnum::VitestValidTitle(VitestValidTitle::default()),
         RuleEnum::VitestWarnTodo(VitestWarnTodo::default()),
-        RuleEnum::NodeNoMixedRequires(NodeNoMixedRequires::default()),
         RuleEnum::NodeCallbackReturn(NodeCallbackReturn::default()),
         RuleEnum::NodeGlobalRequire(NodeGlobalRequire::default()),
         RuleEnum::NodeHandleCallbackErr(NodeHandleCallbackErr::default()),
         RuleEnum::NodeNoExportsAssign(NodeNoExportsAssign::default()),
+        RuleEnum::NodeNoMixedRequires(NodeNoMixedRequires::default()),
         RuleEnum::NodeNoNewRequire(NodeNoNewRequire::default()),
         RuleEnum::NodeNoPathConcat(NodeNoPathConcat::default()),
         RuleEnum::NodeNoProcessEnv(NodeNoProcessEnv::default()),

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -370,6 +370,7 @@ pub use crate::rules::node::callback_return::CallbackReturn as NodeCallbackRetur
 pub use crate::rules::node::global_require::GlobalRequire as NodeGlobalRequire;
 pub use crate::rules::node::handle_callback_err::HandleCallbackErr as NodeHandleCallbackErr;
 pub use crate::rules::node::no_exports_assign::NoExportsAssign as NodeNoExportsAssign;
+pub use crate::rules::node::no_mixed_requires::NoMixedRequires as NodeNoMixedRequires;
 pub use crate::rules::node::no_new_require::NoNewRequire as NodeNoNewRequire;
 pub use crate::rules::node::no_path_concat::NoPathConcat as NodeNoPathConcat;
 pub use crate::rules::node::no_process_env::NoProcessEnv as NodeNoProcessEnv;
@@ -1647,6 +1648,7 @@ pub enum RuleEnum {
     VitestValidExpectInPromise(VitestValidExpectInPromise),
     VitestValidTitle(VitestValidTitle),
     VitestWarnTodo(VitestWarnTodo),
+    NodeNoMixedRequires(NodeNoMixedRequires),
     NodeCallbackReturn(NodeCallbackReturn),
     NodeGlobalRequire(NodeGlobalRequire),
     NodeHandleCallbackErr(NodeHandleCallbackErr),
@@ -2585,7 +2587,8 @@ const VITEST_VALID_EXPECT_ID: usize = VITEST_VALID_DESCRIBE_CALLBACK_ID + 1usize
 const VITEST_VALID_EXPECT_IN_PROMISE_ID: usize = VITEST_VALID_EXPECT_ID + 1usize;
 const VITEST_VALID_TITLE_ID: usize = VITEST_VALID_EXPECT_IN_PROMISE_ID + 1usize;
 const VITEST_WARN_TODO_ID: usize = VITEST_VALID_TITLE_ID + 1usize;
-const NODE_CALLBACK_RETURN_ID: usize = VITEST_WARN_TODO_ID + 1usize;
+const NODE_NO_MIXED_REQUIRES_ID: usize = VITEST_WARN_TODO_ID + 1usize;
+const NODE_CALLBACK_RETURN_ID: usize = NODE_NO_MIXED_REQUIRES_ID + 1usize;
 const NODE_GLOBAL_REQUIRE_ID: usize = NODE_CALLBACK_RETURN_ID + 1usize;
 const NODE_HANDLE_CALLBACK_ERR_ID: usize = NODE_GLOBAL_REQUIRE_ID + 1usize;
 const NODE_NO_EXPORTS_ASSIGN_ID: usize = NODE_HANDLE_CALLBACK_ERR_ID + 1usize;
@@ -3557,6 +3560,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VITEST_VALID_EXPECT_IN_PROMISE_ID,
             Self::VitestValidTitle(_) => VITEST_VALID_TITLE_ID,
             Self::VitestWarnTodo(_) => VITEST_WARN_TODO_ID,
+            Self::NodeNoMixedRequires(_) => NODE_NO_MIXED_REQUIRES_ID,
             Self::NodeCallbackReturn(_) => NODE_CALLBACK_RETURN_ID,
             Self::NodeGlobalRequire(_) => NODE_GLOBAL_REQUIRE_ID,
             Self::NodeHandleCallbackErr(_) => NODE_HANDLE_CALLBACK_ERR_ID,
@@ -4511,6 +4515,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::NAME,
             Self::VitestValidTitle(_) => VitestValidTitle::NAME,
             Self::VitestWarnTodo(_) => VitestWarnTodo::NAME,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::NAME,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::NAME,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::NAME,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::NAME,
@@ -5521,6 +5526,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::CATEGORY,
             Self::VitestValidTitle(_) => VitestValidTitle::CATEGORY,
             Self::VitestWarnTodo(_) => VitestWarnTodo::CATEGORY,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::CATEGORY,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::CATEGORY,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::CATEGORY,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::CATEGORY,
@@ -6478,6 +6484,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::FIX,
             Self::VitestValidTitle(_) => VitestValidTitle::FIX,
             Self::VitestWarnTodo(_) => VitestWarnTodo::FIX,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::FIX,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::FIX,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::FIX,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::FIX,
@@ -7681,6 +7688,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::documentation(),
             Self::VitestValidTitle(_) => VitestValidTitle::documentation(),
             Self::VitestWarnTodo(_) => VitestWarnTodo::documentation(),
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::documentation(),
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::documentation(),
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::documentation(),
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::documentation(),
@@ -10012,6 +10020,8 @@ impl RuleEnum {
                 .or_else(|| VitestValidTitle::schema(generator)),
             Self::VitestWarnTodo(_) => VitestWarnTodo::config_schema(generator)
                 .or_else(|| VitestWarnTodo::schema(generator)),
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::config_schema(generator)
+                .or_else(|| NodeNoMixedRequires::schema(generator)),
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::config_schema(generator)
                 .or_else(|| NodeCallbackReturn::schema(generator)),
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::config_schema(generator)
@@ -10949,6 +10959,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => "vitest",
             Self::VitestValidTitle(_) => "vitest",
             Self::VitestWarnTodo(_) => "vitest",
+            Self::NodeNoMixedRequires(_) => "node",
             Self::NodeCallbackReturn(_) => "node",
             Self::NodeGlobalRequire(_) => "node",
             Self::NodeHandleCallbackErr(_) => "node",
@@ -13536,6 +13547,9 @@ impl RuleEnum {
             Self::VitestWarnTodo(_) => {
                 Ok(Self::VitestWarnTodo(VitestWarnTodo::from_configuration(value)?))
             }
+            Self::NodeNoMixedRequires(_) => {
+                Ok(Self::NodeNoMixedRequires(NodeNoMixedRequires::from_configuration(value)?))
+            }
             Self::NodeCallbackReturn(_) => {
                 Ok(Self::NodeCallbackReturn(NodeCallbackReturn::from_configuration(value)?))
             }
@@ -14494,6 +14508,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(rule) => rule.to_configuration(),
             Self::VitestValidTitle(rule) => rule.to_configuration(),
             Self::VitestWarnTodo(rule) => rule.to_configuration(),
+            Self::NodeNoMixedRequires(rule) => rule.to_configuration(),
             Self::NodeCallbackReturn(rule) => rule.to_configuration(),
             Self::NodeGlobalRequire(rule) => rule.to_configuration(),
             Self::NodeHandleCallbackErr(rule) => rule.to_configuration(),
@@ -15344,6 +15359,7 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run(node, ctx),
                 Self::VitestValidTitle(rule) => rule.run(node, ctx),
                 Self::VitestWarnTodo(rule) => rule.run(node, ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run(node, ctx),
                 Self::NodeCallbackReturn(rule) => rule.run(node, ctx),
                 Self::NodeGlobalRequire(rule) => rule.run(node, ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run(node, ctx),
@@ -16187,6 +16203,7 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run(node, ctx),
                 Self::VitestValidTitle(rule) => rule.run(node, ctx),
                 Self::VitestWarnTodo(rule) => rule.run(node, ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run(node, ctx),
                 Self::NodeCallbackReturn(rule) => rule.run(node, ctx),
                 Self::NodeGlobalRequire(rule) => rule.run(node, ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run(node, ctx),
@@ -17037,6 +17054,7 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run_once(ctx),
                 Self::VitestValidTitle(rule) => rule.run_once(ctx),
                 Self::VitestWarnTodo(rule) => rule.run_once(ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run_once(ctx),
                 Self::NodeCallbackReturn(rule) => rule.run_once(ctx),
                 Self::NodeGlobalRequire(rule) => rule.run_once(ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run_once(ctx),
@@ -17880,6 +17898,7 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run_once(ctx),
                 Self::VitestValidTitle(rule) => rule.run_once(ctx),
                 Self::VitestWarnTodo(rule) => rule.run_once(ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run_once(ctx),
                 Self::NodeCallbackReturn(rule) => rule.run_once(ctx),
                 Self::NodeGlobalRequire(rule) => rule.run_once(ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run_once(ctx),
@@ -18979,6 +18998,7 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestValidTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestWarnTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeCallbackReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeGlobalRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20082,6 +20102,7 @@ impl RuleEnum {
                 Self::VitestValidExpectInPromise(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestValidTitle(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::VitestWarnTodo(rule) => rule.run_on_jest_node(jest_node, ctx),
+                Self::NodeNoMixedRequires(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeCallbackReturn(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeGlobalRequire(rule) => rule.run_on_jest_node(jest_node, ctx),
                 Self::NodeHandleCallbackErr(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -20935,6 +20956,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(rule) => rule.should_run(ctx),
             Self::VitestValidTitle(rule) => rule.should_run(ctx),
             Self::VitestWarnTodo(rule) => rule.should_run(ctx),
+            Self::NodeNoMixedRequires(rule) => rule.should_run(ctx),
             Self::NodeCallbackReturn(rule) => rule.should_run(ctx),
             Self::NodeGlobalRequire(rule) => rule.should_run(ctx),
             Self::NodeHandleCallbackErr(rule) => rule.should_run(ctx),
@@ -22133,6 +22155,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::IS_TSGOLINT_RULE,
             Self::VitestValidTitle(_) => VitestValidTitle::IS_TSGOLINT_RULE,
             Self::VitestWarnTodo(_) => VitestWarnTodo::IS_TSGOLINT_RULE,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::IS_TSGOLINT_RULE,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::IS_TSGOLINT_RULE,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::IS_TSGOLINT_RULE,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::IS_TSGOLINT_RULE,
@@ -23161,6 +23184,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::VERSION,
             Self::VitestValidTitle(_) => VitestValidTitle::VERSION,
             Self::VitestWarnTodo(_) => VitestWarnTodo::VERSION,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::VERSION,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::VERSION,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::VERSION,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::VERSION,
@@ -24208,6 +24232,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::HAS_CONFIG,
             Self::VitestValidTitle(_) => VitestValidTitle::HAS_CONFIG,
             Self::VitestWarnTodo(_) => VitestWarnTodo::HAS_CONFIG,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::HAS_CONFIG,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::HAS_CONFIG,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::HAS_CONFIG,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::HAS_CONFIG,
@@ -25170,6 +25195,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(_) => VitestValidExpectInPromise::INFO,
             Self::VitestValidTitle(_) => VitestValidTitle::INFO,
             Self::VitestWarnTodo(_) => VitestWarnTodo::INFO,
+            Self::NodeNoMixedRequires(_) => NodeNoMixedRequires::INFO,
             Self::NodeCallbackReturn(_) => NodeCallbackReturn::INFO,
             Self::NodeGlobalRequire(_) => NodeGlobalRequire::INFO,
             Self::NodeHandleCallbackErr(_) => NodeHandleCallbackErr::INFO,
@@ -26019,6 +26045,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(rule) => rule.types_info(),
             Self::VitestValidTitle(rule) => rule.types_info(),
             Self::VitestWarnTodo(rule) => rule.types_info(),
+            Self::NodeNoMixedRequires(rule) => rule.types_info(),
             Self::NodeCallbackReturn(rule) => rule.types_info(),
             Self::NodeGlobalRequire(rule) => rule.types_info(),
             Self::NodeHandleCallbackErr(rule) => rule.types_info(),
@@ -26859,6 +26886,7 @@ impl RuleEnum {
             Self::VitestValidExpectInPromise(rule) => rule.run_info(),
             Self::VitestValidTitle(rule) => rule.run_info(),
             Self::VitestWarnTodo(rule) => rule.run_info(),
+            Self::NodeNoMixedRequires(rule) => rule.run_info(),
             Self::NodeCallbackReturn(rule) => rule.run_info(),
             Self::NodeGlobalRequire(rule) => rule.run_info(),
             Self::NodeHandleCallbackErr(rule) => rule.run_info(),
@@ -27831,6 +27859,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::VitestValidExpectInPromise(VitestValidExpectInPromise::default()),
         RuleEnum::VitestValidTitle(VitestValidTitle::default()),
         RuleEnum::VitestWarnTodo(VitestWarnTodo::default()),
+        RuleEnum::NodeNoMixedRequires(NodeNoMixedRequires::default()),
         RuleEnum::NodeCallbackReturn(NodeCallbackReturn::default()),
         RuleEnum::NodeGlobalRequire(NodeGlobalRequire::default()),
         RuleEnum::NodeHandleCallbackErr(NodeHandleCallbackErr::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -843,6 +843,7 @@ pub(crate) mod node {
     pub mod global_require;
     pub mod handle_callback_err;
     pub mod no_exports_assign;
+    pub mod no_mixed_requires;
     pub mod no_new_require;
     pub mod no_path_concat;
     pub mod no_process_env;

--- a/crates/oxc_linter/src/rules/node/no_mixed_requires.rs
+++ b/crates/oxc_linter/src/rules/node/no_mixed_requires.rs
@@ -12,7 +12,7 @@ use oxc_span::Span;
 use crate::{
     AstNode,
     context::LintContext,
-    rule::{MixedTupleRuleConfig, Rule},
+    rule::{DefaultRuleConfig, Rule},
 };
 
 fn no_mix_require_diagnostic(span: Span) -> OxcDiagnostic {
@@ -21,6 +21,104 @@ fn no_mix_require_diagnostic(span: Span) -> OxcDiagnostic {
 
 fn no_mix_core_module_file_computed_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not mix core, module, file and computed requires.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+struct NoMixedRequiresOptions {
+    grouping: bool,
+    allow_call: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum NoMixedRequiresConfig {
+    Grouping(bool),
+    Options(NoMixedRequiresOptions),
+}
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+pub struct NoMixedRequires(NoMixedRequiresOptions);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows `require` calls to be mixed with regular variable declarations.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// In the Node.js community it is often customary to separate initializations with calls to
+    /// `require` modules from other variable declarations, sometimes also grouping them by the type
+    /// of module.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// var fs = require('fs'),
+    ///     i = 0;
+    ///
+    /// var async = require('async'),
+    ///     debug = require('diagnostics').someFunction('my-module'),
+    ///     eslint = require('eslint');
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// var eventEmitter = require('events').EventEmitter,
+    ///     myUtils = require('./utils'),
+    ///     util = require('util'),
+    ///     bar = require(getBarModuleName());
+    ///
+    /// var foo = 42,
+    ///     bar = 'baz';
+    /// ```
+    NoMixedRequires,
+    node,
+    style,
+    config = NoMixedRequiresConfig,
+    version = "next",
+    short_description = "Disallow `require` calls to be mixed with regular variable declarations.",
+);
+
+impl Rule for NoMixedRequires {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        let config = serde_json::from_value::<DefaultRuleConfig<NoMixedRequiresConfig>>(value)?;
+        Ok(Self(config.into_inner().into()))
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::VariableDeclaration(var_decl) = node.kind() else {
+            return;
+        };
+
+        let grouping = self.0.grouping;
+        let allow_call = self.0.allow_call;
+
+        if is_mixed(&var_decl.declarations, allow_call) {
+            ctx.diagnostic(no_mix_require_diagnostic(var_decl.span));
+            return;
+        }
+
+        if grouping && !is_grouped(&var_decl.declarations, allow_call) {
+            ctx.diagnostic(no_mix_core_module_file_computed_diagnostic(var_decl.span));
+        }
+    }
+}
+
+impl Default for NoMixedRequiresConfig {
+    fn default() -> Self {
+        Self::Options(NoMixedRequiresOptions::default())
+    }
+}
+
+impl From<NoMixedRequiresConfig> for NoMixedRequiresOptions {
+    fn from(config: NoMixedRequiresConfig) -> Self {
+        match config {
+            NoMixedRequiresConfig::Grouping(grouping) => Self { grouping, allow_call: false },
+            NoMixedRequiresConfig::Options(options) => options,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,16 +135,6 @@ enum ModuleType {
     Module,
     Computed,
 }
-
-#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
-struct NoMixedRequiresOptions {
-    grouping: bool,
-    allow_call: bool,
-}
-
-#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
-pub struct NoMixedRequires(MixedTupleRuleConfig<bool, NoMixedRequiresOptions>);
 
 // This list is generated using `require("module").builtinModules` and was last updated using Node v13.8.0.
 // See <https://github.com/eslint-community/eslint-plugin-n/blob/master/lib/rules/no-mixed-requires.js>.
@@ -106,72 +194,6 @@ const BUILTIN_MODULES: &[&str] = &[
     "worker_threads",
     "zlib",
 ];
-
-declare_oxc_lint!(
-    /// ### What it does
-    ///
-    /// Disallows `require` calls to be mixed with regular variable declarations.
-    ///
-    /// ### Why is this bad?
-    ///
-    /// In the Node.js community it is often customary to separate initializations with calls to
-    /// `require` modules from other variable declarations, sometimes also grouping them by the type
-    /// of module.
-    ///
-    /// ### Examples
-    ///
-    /// Examples of **incorrect** code for this rule:
-    /// ```js
-    /// var fs = require('fs'),
-    ///     i = 0;
-    ///
-    /// var async = require('async'),
-    ///     debug = require('diagnostics').someFunction('my-module'),
-    ///     eslint = require('eslint');
-    /// ```
-    ///
-    /// Examples of **correct** code for this rule:
-    /// ```js
-    /// var eventEmitter = require('events').EventEmitter,
-    ///     myUtils = require('./utils'),
-    ///     util = require('util'),
-    ///     bar = require(getBarModuleName());
-    ///
-    /// var foo = 42,
-    ///     bar = 'baz';
-    /// ```
-    NoMixedRequires,
-    node,
-    style,
-    config = MixedTupleRuleConfig<bool, NoMixedRequiresOptions>,
-    version = "next",
-    short_description = "Disallow `require` calls to be mixed with regular variable declarations.",
-);
-
-impl Rule for NoMixedRequires {
-    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<MixedTupleRuleConfig<bool, NoMixedRequiresOptions>>(value)
-            .map(NoMixedRequires)
-    }
-
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        let AstKind::VariableDeclaration(var_decl) = node.kind() else {
-            return;
-        };
-
-        let grouping = if self.0.0 { true } else { self.0.1.grouping };
-        let allow_call = self.0.1.allow_call;
-
-        if is_mixed(&var_decl.declarations, allow_call) {
-            ctx.diagnostic(no_mix_require_diagnostic(var_decl.span));
-            return;
-        }
-
-        if grouping && !is_grouped(&var_decl.declarations, allow_call) {
-            ctx.diagnostic(no_mix_core_module_file_computed_diagnostic(var_decl.span));
-        }
-    }
-}
 
 fn get_declaration_type(init: Option<&Expression>, allow_call: bool) -> DeclarationType {
     let Some(init) = init else {

--- a/crates/oxc_linter/src/rules/node/no_mixed_requires.rs
+++ b/crates/oxc_linter/src/rules/node/no_mixed_requires.rs
@@ -1,0 +1,344 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, VariableDeclarator},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    rule::{MixedTupleRuleConfig, Rule},
+};
+
+fn no_mix_require_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not mix 'require' and other declarations.").with_label(span)
+}
+
+fn no_mix_core_module_file_computed_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Do not mix core, module, file and computed requires.").with_label(span)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DeclarationType {
+    Require,
+    Uninitialized,
+    Other,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ModuleType {
+    Core,
+    File,
+    Module,
+    Computed,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields, default)]
+struct NoMixedRequiresOptions {
+    grouping: bool,
+    allow_call: bool,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, JsonSchema)]
+pub struct NoMixedRequires(MixedTupleRuleConfig<bool, NoMixedRequiresOptions>);
+
+// This list is generated using `require("module").builtinModules` and was last updated using Node v13.8.0.
+// See <https://github.com/eslint-community/eslint-plugin-n/blob/master/lib/rules/no-mixed-requires.js>.
+const BUILTIN_MODULES: &[&str] = &[
+    "_http_agent",
+    "_http_client",
+    "_http_common",
+    "_http_incoming",
+    "_http_outgoing",
+    "_http_server",
+    "_stream_duplex",
+    "_stream_passthrough",
+    "_stream_readable",
+    "_stream_transform",
+    "_stream_wrap",
+    "_stream_writable",
+    "_tls_common",
+    "_tls_wrap",
+    "assert",
+    "async_hooks",
+    "buffer",
+    "child_process",
+    "cluster",
+    "console",
+    "constants",
+    "crypto",
+    "dgram",
+    "dns",
+    "domain",
+    "events",
+    "fs",
+    "http",
+    "http2",
+    "https",
+    "inspector",
+    "module",
+    "net",
+    "os",
+    "path",
+    "perf_hooks",
+    "process",
+    "punycode",
+    "querystring",
+    "readline",
+    "repl",
+    "stream",
+    "string_decoder",
+    "sys",
+    "timers",
+    "tls",
+    "trace_events",
+    "tty",
+    "url",
+    "util",
+    "v8",
+    "vm",
+    "worker_threads",
+    "zlib",
+];
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows `require` calls to be mixed with regular variable declarations.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// In the Node.js community it is often customary to separate initializations with calls to
+    /// `require` modules from other variable declarations, sometimes also grouping them by the type
+    /// of module.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// var fs = require('fs'),
+    ///     i = 0;
+    ///
+    /// var async = require('async'),
+    ///     debug = require('diagnostics').someFunction('my-module'),
+    ///     eslint = require('eslint');
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// var eventEmitter = require('events').EventEmitter,
+    ///     myUtils = require('./utils'),
+    ///     util = require('util'),
+    ///     bar = require(getBarModuleName());
+    ///
+    /// var foo = 42,
+    ///     bar = 'baz';
+    /// ```
+    NoMixedRequires,
+    node,
+    style,
+    config = NoMixedRequires,
+    version = "next",
+    short_description = "Disallow `require` calls to be mixed with regular variable declarations.",
+);
+
+impl Rule for NoMixedRequires {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<NoMixedRequires>(value)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::VariableDeclaration(var_decl) = node.kind() else {
+            return;
+        };
+
+        let grouping = if self.0.0 { true } else { self.0.1.grouping };
+        let allow_call = self.0.1.allow_call;
+
+        if is_mixed(&var_decl.declarations, allow_call) {
+            ctx.diagnostic(no_mix_require_diagnostic(var_decl.span));
+            return;
+        }
+
+        if grouping && !is_grouped(&var_decl.declarations, allow_call) {
+            ctx.diagnostic(no_mix_core_module_file_computed_diagnostic(var_decl.span));
+        }
+    }
+}
+
+fn get_declaration_type(init: Option<&Expression>, allow_call: bool) -> DeclarationType {
+    let Some(init) = init else {
+        return DeclarationType::Uninitialized;
+    };
+
+    if is_require_call(init, allow_call) {
+        return DeclarationType::Require;
+    }
+
+    if allow_call
+        && let Expression::CallExpression(call) = init
+        && call.callee.is_call_expression()
+    {
+        return get_declaration_type(Some(&call.callee), allow_call);
+    }
+
+    if let Some(member) = init.as_member_expression() {
+        return get_declaration_type(Some(&member.object()), allow_call);
+    }
+
+    DeclarationType::Other
+}
+
+fn infer_module_type(init: &Expression) -> ModuleType {
+    if let Some(member) = init.as_member_expression() {
+        return infer_module_type(&member.object());
+    }
+
+    let Expression::CallExpression(call) = init else {
+        return ModuleType::Module;
+    };
+
+    if call.arguments.is_empty() {
+        return ModuleType::Computed;
+    }
+
+    let Some(arg) = call.arguments.first() else {
+        return ModuleType::Computed;
+    };
+
+    let Some(value) = arg.as_expression().and_then(|expr| match expr {
+        Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+        _ => None,
+    }) else {
+        return ModuleType::Computed;
+    };
+
+    if BUILTIN_MODULES.contains(&value) {
+        return ModuleType::Core;
+    }
+
+    if value.starts_with("./") || value.starts_with("../") || value.starts_with("/") {
+        return ModuleType::File;
+    }
+
+    ModuleType::Module
+}
+
+fn is_mixed(declarations: &[VariableDeclarator], allow_call: bool) -> bool {
+    let mut has_require = false;
+    let mut has_uninitialized = false;
+    let mut has_other = false;
+
+    for declaration in declarations {
+        match get_declaration_type(declaration.init.as_ref(), allow_call) {
+            DeclarationType::Require => has_require = true,
+            DeclarationType::Uninitialized => has_uninitialized = true,
+            DeclarationType::Other => has_other = true,
+        }
+    }
+
+    has_require && (has_uninitialized || has_other)
+}
+
+fn is_grouped(declarations: &[VariableDeclarator], allow_call: bool) -> bool {
+    let mut found = [false, false, false, false];
+
+    for declaration in declarations {
+        if let Some(init) = declaration.init.as_ref()
+            && get_declaration_type(Some(init), allow_call) == DeclarationType::Require
+        {
+            match infer_module_type(init) {
+                ModuleType::Core => found[0] = true,
+                ModuleType::File => found[1] = true,
+                ModuleType::Module => found[2] = true,
+                ModuleType::Computed => found[3] = true,
+            }
+        }
+    }
+
+    found.iter().filter(|&&found| found).count() <= 1
+}
+
+fn is_require_call(expr: &Expression, allow_call: bool) -> bool {
+    let Expression::CallExpression(call) = expr else {
+        return false;
+    };
+
+    if call.callee.is_specific_id("require") {
+        return true;
+    }
+
+    if allow_call && call.callee.is_call_expression() {
+        return is_require_call(&call.callee, allow_call);
+    }
+
+    false
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        ("var a, b = 42, c = doStuff()", Some(serde_json::json!([false]))),
+        (
+            "var a = require(42), b = require(), c = require('y'), d = require(doStuff())",
+            Some(serde_json::json!([false])),
+        ),
+        ("var fs = require('fs'), foo = require('foo')", Some(serde_json::json!([false]))),
+        (
+            "var exec = require('child_process').exec, foo = require('foo')",
+            Some(serde_json::json!([false])),
+        ),
+        ("var fs = require('fs'), foo = require('./foo')", Some(serde_json::json!([false]))),
+        ("var foo = require('foo'), foo2 = require('./foo')", Some(serde_json::json!([false]))),
+        (
+            "var emitter = require('events').EventEmitter, fs = require('fs')",
+            Some(serde_json::json!([false])),
+        ),
+        ("var foo = require(42), bar = require(getName())", Some(serde_json::json!([false]))),
+        ("var foo = require(42), bar = require(getName())", Some(serde_json::json!([true]))),
+        (
+            "var fs = require('fs'), foo = require('./foo')",
+            Some(serde_json::json!([{ "grouping": false }])),
+        ),
+        ("var foo = require('foo'), bar = require(getName())", Some(serde_json::json!([false]))),
+        ("var a;", Some(serde_json::json!([true]))),
+        (
+            "var async = require('async'), debug = require('diagnostics')('my-module')",
+            Some(serde_json::json!([{ "allowCall": true }])),
+        ),
+    ];
+
+    let fail = vec![
+        ("var fs = require('fs'), foo = 42", Some(serde_json::json!([false]))),
+        ("var fs = require('fs'), foo", Some(serde_json::json!([false]))),
+        (
+            "var a = require(42), b = require(), c = require('y'), d = require(doStuff())",
+            Some(serde_json::json!([true])),
+        ),
+        ("var fs = require('fs'), foo = require('foo')", Some(serde_json::json!([true]))),
+        (
+            "var fs = require('fs'), foo = require('foo')",
+            Some(serde_json::json!([{ "grouping": true }])),
+        ),
+        (
+            "var exec = require('child_process').exec, foo = require('foo')",
+            Some(serde_json::json!([true])),
+        ),
+        ("var fs = require('fs'), foo = require('./foo')", Some(serde_json::json!([true]))),
+        ("var foo = require('foo'), foo2 = require('./foo')", Some(serde_json::json!([true]))),
+        ("var foo = require('foo'), bar = require(getName())", Some(serde_json::json!([true]))),
+        (
+            "var async = require('async'), debug = require('diagnostics').someFun('my-module')",
+            Some(serde_json::json!([{ "allowCall": true }])),
+        ),
+    ];
+
+    Tester::new(NoMixedRequires::NAME, NoMixedRequires::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/node/no_mixed_requires.rs
+++ b/crates/oxc_linter/src/rules/node/no_mixed_requires.rs
@@ -142,14 +142,15 @@ declare_oxc_lint!(
     NoMixedRequires,
     node,
     style,
-    config = NoMixedRequires,
+    config = MixedTupleRuleConfig<bool, NoMixedRequiresOptions>,
     version = "next",
     short_description = "Disallow `require` calls to be mixed with regular variable declarations.",
 );
 
 impl Rule for NoMixedRequires {
     fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
-        serde_json::from_value::<NoMixedRequires>(value)
+        serde_json::from_value::<MixedTupleRuleConfig<bool, NoMixedRequiresOptions>>(value)
+            .map(NoMixedRequires)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -188,7 +189,7 @@ fn get_declaration_type(init: Option<&Expression>, allow_call: bool) -> Declarat
     }
 
     if let Some(member) = init.as_member_expression() {
-        return get_declaration_type(Some(&member.object()), allow_call);
+        return get_declaration_type(Some(member.object()), allow_call);
     }
 
     DeclarationType::Other
@@ -196,7 +197,7 @@ fn get_declaration_type(init: Option<&Expression>, allow_call: bool) -> Declarat
 
 fn infer_module_type(init: &Expression) -> ModuleType {
     if let Some(member) = init.as_member_expression() {
-        return infer_module_type(&member.object());
+        return infer_module_type(member.object());
     }
 
     let Expression::CallExpression(call) = init else {
@@ -222,7 +223,7 @@ fn infer_module_type(init: &Expression) -> ModuleType {
         return ModuleType::Core;
     }
 
-    if value.starts_with("./") || value.starts_with("../") || value.starts_with("/") {
+    if value.starts_with("./") || value.starts_with("../") || value.starts_with('/') {
         return ModuleType::File;
     }
 

--- a/crates/oxc_linter/src/rules/node/no_mixed_requires.rs
+++ b/crates/oxc_linter/src/rules/node/no_mixed_requires.rs
@@ -1,3 +1,6 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::{
     AstKind,
     ast::{Expression, VariableDeclarator},
@@ -5,8 +8,6 @@ use oxc_ast::{
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use schemars::JsonSchema;
-use serde::Deserialize;
 
 use crate::{
     AstNode,

--- a/crates/oxc_linter/src/snapshots/node_no_mixed_requires.snap
+++ b/crates/oxc_linter/src/snapshots/node_no_mixed_requires.snap
@@ -1,0 +1,64 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
+---
+
+  ⚠ node(no-mixed-requires): Do not mix 'require' and other declarations.
+   ╭─[no_mixed_requires.tsx:1:1]
+ 1 │ var fs = require('fs'), foo = 42
+   · ────────────────────────────────
+   ╰────
+
+  ⚠ node(no-mixed-requires): Do not mix 'require' and other declarations.
+   ╭─[no_mixed_requires.tsx:1:1]
+ 1 │ var fs = require('fs'), foo
+   · ───────────────────────────
+   ╰────
+
+  ⚠ node(no-mixed-requires): Do not mix core, module, file and computed requires.
+   ╭─[no_mixed_requires.tsx:1:1]
+ 1 │ var a = require(42), b = require(), c = require('y'), d = require(doStuff())
+   · ────────────────────────────────────────────────────────────────────────────
+   ╰────
+
+  ⚠ node(no-mixed-requires): Do not mix core, module, file and computed requires.
+   ╭─[no_mixed_requires.tsx:1:1]
+ 1 │ var fs = require('fs'), foo = require('foo')
+   · ────────────────────────────────────────────
+   ╰────
+
+  ⚠ node(no-mixed-requires): Do not mix core, module, file and computed requires.
+   ╭─[no_mixed_requires.tsx:1:1]
+ 1 │ var fs = require('fs'), foo = require('foo')
+   · ────────────────────────────────────────────
+   ╰────
+
+  ⚠ node(no-mixed-requires): Do not mix core, module, file and computed requires.
+   ╭─[no_mixed_requires.tsx:1:1]
+ 1 │ var exec = require('child_process').exec, foo = require('foo')
+   · ──────────────────────────────────────────────────────────────
+   ╰────
+
+  ⚠ node(no-mixed-requires): Do not mix core, module, file and computed requires.
+   ╭─[no_mixed_requires.tsx:1:1]
+ 1 │ var fs = require('fs'), foo = require('./foo')
+   · ──────────────────────────────────────────────
+   ╰────
+
+  ⚠ node(no-mixed-requires): Do not mix core, module, file and computed requires.
+   ╭─[no_mixed_requires.tsx:1:1]
+ 1 │ var foo = require('foo'), foo2 = require('./foo')
+   · ─────────────────────────────────────────────────
+   ╰────
+
+  ⚠ node(no-mixed-requires): Do not mix core, module, file and computed requires.
+   ╭─[no_mixed_requires.tsx:1:1]
+ 1 │ var foo = require('foo'), bar = require(getName())
+   · ──────────────────────────────────────────────────
+   ╰────
+
+  ⚠ node(no-mixed-requires): Do not mix 'require' and other declarations.
+   ╭─[no_mixed_requires.tsx:1:1]
+ 1 │ var async = require('async'), debug = require('diagnostics').someFun('my-module')
+   · ─────────────────────────────────────────────────────────────────────────────────
+   ╰────

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5619,6 +5619,9 @@
         "node/no-exports-assign": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "node/no-mixed-requires": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "node/no-new-require": {
           "$ref": "#/definitions/RuleNoConfig"
         },

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5620,7 +5620,57 @@
           "$ref": "#/definitions/RuleNoConfig"
         },
         "node/no-mixed-requires": {
-          "$ref": "#/definitions/RuleNoConfig"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "$ref": "#/definitions/AllowWarnDeny"
+                    },
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "$ref": "#/definitions/NoMixedRequiresOptions"
+                    }
+                  ],
+                  "maxItems": 3,
+                  "minItems": 2
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "$ref": "#/definitions/AllowWarnDeny"
+                    },
+                    {
+                      "type": "boolean"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                },
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "$ref": "#/definitions/AllowWarnDeny"
+                    },
+                    {
+                      "$ref": "#/definitions/NoMixedRequiresOptions"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                }
+              ]
+            }
+          ]
         },
         "node/no-new-require": {
           "$ref": "#/definitions/RuleNoConfig"
@@ -14191,6 +14241,20 @@
             "$ref": "#/definitions/TypeOrValueSpecifier"
           },
           "markdownDescription": "An array of type or value specifiers that are allowed to be spread\neven if they would normally be flagged as misused."
+        }
+      },
+      "additionalProperties": false
+    },
+    "NoMixedRequiresOptions": {
+      "type": "object",
+      "properties": {
+        "allowCall": {
+          "default": false,
+          "type": "boolean"
+        },
+        "grouping": {
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -5625,50 +5625,17 @@
               "$ref": "#/definitions/RuleNoConfig"
             },
             {
-              "anyOf": [
+              "type": "array",
+              "items": [
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "type": "boolean"
-                    },
-                    {
-                      "$ref": "#/definitions/NoMixedRequiresOptions"
-                    }
-                  ],
-                  "maxItems": 3,
-                  "minItems": 2
+                  "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "type": "boolean"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
-                },
-                {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "$ref": "#/definitions/NoMixedRequiresOptions"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/NoMixedRequiresConfig"
                 }
-              ]
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           ]
         },
@@ -14244,6 +14211,16 @@
         }
       },
       "additionalProperties": false
+    },
+    "NoMixedRequiresConfig": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/NoMixedRequiresOptions"
+        }
+      ]
     },
     "NoMixedRequiresOptions": {
       "type": "object",


### PR DESCRIPTION
## Summary

- Implement `n/no-mixed-requires` from eslint-plugin-n (#493)
- Disallows mixing `require()` declarations with other variable declarations in the same `var` statement
- Supports `grouping` and `allowCall` options (including legacy boolean config for grouping)

## Test plan

- [x] `cargo test -p oxc_linter no_mixed_requires`
- [x] Snapshot tests from upstream eslint-plugin-n test cases