### PR TITLE
feat(minifier): fold write-once falsy var to false in boolean context

### DIFF
--- a/crates/oxc_minifier/src/peephole/inline.rs
+++ b/crates/oxc_minifier/src/peephole/inline.rs
@@ -12,6 +12,15 @@ impl<'a> PeepholeOptimizations {
     pub fn init_symbol_value(decl: &VariableDeclarator<'a>, ctx: &mut TraverseCtx<'a>) {
         let BindingPattern::BindingIdentifier(ident) = &decl.id else { return };
         let Some(symbol_id) = ident.symbol_id.get() else { return };
+        // Evaluate the initializer's constant once; reuse it for the value-context
+        // constant and the boolean-falsy fact below. `None` for a non-constant or
+        // absent initializer.
+        let init_constant = decl.init.as_ref().and_then(|e| e.evaluate_value(ctx));
+        // Whether the initializer is an explicit falsy constant (not the implicit
+        // `undefined` of `var x;`, which `init_constant` leaves `None`). Fed to
+        // `init_value`, which turns it into the `boolean_falsy` fact (see
+        // `SymbolValue::boolean_falsy`).
+        let falsy_init = init_constant.as_ref().is_some_and(Self::is_falsy_constant);
         let value = if Self::is_for_statement_init(ctx) {
             // for-statement initializers have their value set by the for statement itself.
             None
@@ -20,10 +29,23 @@ impl<'a> PeepholeOptimizations {
             // Skip unless the safety predicate proves no such read exists.
             None
         } else {
-            decl.init.as_ref().map_or(Some(ConstantValue::Undefined), |e| e.evaluate_value(ctx))
+            // No initializer hoists to `undefined`; otherwise reuse the constant.
+            decl.init.as_ref().map_or(Some(ConstantValue::Undefined), |_| init_constant)
         };
         let is_fresh_value = decl.init.as_ref().is_some_and(Self::is_fresh_value_expression);
-        ctx.init_value(symbol_id, value, is_fresh_value);
+        ctx.init_value(symbol_id, value, is_fresh_value, falsy_init);
+    }
+
+    /// A `ConstantValue` that coerces to `false` (`false`, `0`/`-0`/`NaN`, `""`,
+    /// `null`, `undefined`). BigInt is skipped conservatively.
+    fn is_falsy_constant(cv: &ConstantValue<'a>) -> bool {
+        match cv {
+            ConstantValue::Boolean(b) => !b,
+            ConstantValue::Number(n) => n.is_nan() || *n == 0.0,
+            ConstantValue::String(s) => s.as_ref().is_empty(),
+            ConstantValue::Null | ConstantValue::Undefined => true,
+            ConstantValue::BigInt(_) => false,
+        }
     }
 
     /// Predicate for inlining a hoisted `var x = <literal>;`. True when no read
@@ -37,10 +59,13 @@ impl<'a> PeepholeOptimizations {
     ///   `export … from`, `export * from`), skip: a cyclic importer can call
     ///   into our exports and observe any var our exported functions/classes
     ///   close over, regardless of export status;
-    /// - exactly one read, and it sits inside a nested function/arrow body
-    ///   (multi-use and same-call-frame reads are handled by
-    ///   `inline_identifier_reference`'s small-value rule or by
-    ///   `substitute_single_use_symbol`).
+    /// - every read sits inside a nested function/arrow body (the gap
+    ///   `substitute_single_use_symbol` can't reach). Multiple such reads are
+    ///   fine: the prelude check proves none observes the hoisted `undefined`,
+    ///   so the value is constant at every read, and the small-value rule /
+    ///   write-count guard in `inline_identifier_reference` decide whether each
+    ///   read actually folds (e.g. a write-once falsy flag read by `if (flag)`
+    ///   throughout — the Svelte/Vue `hydrating` shape, #14001).
     ///
     /// Limitation: the constant is recorded here at the declarator's exit, so a
     /// reader in a function declared *before* the var in source order has
@@ -61,11 +86,13 @@ impl<'a> PeepholeOptimizations {
         if body_unsafe || ctx.current_scope_id() != body_scope {
             return false;
         }
-        // Exactly one read, and it crosses a function boundary.
+        // At least one read, and every read crosses a function boundary.
         let mut reads = ctx.scoping().get_resolved_references(symbol_id).filter(|r| r.is_read());
-        let Some(read) = reads.next() else { return false };
-        reads.next().is_none()
-            && Self::read_crosses_function_boundary(read.scope_id(), body_scope, ctx)
+        let Some(first) = reads.next() else { return false };
+        if !Self::read_crosses_function_boundary(first.scope_id(), body_scope, ctx) {
+            return false;
+        }
+        reads.all(|read| Self::read_crosses_function_boundary(read.scope_id(), body_scope, ctx))
     }
 
     /// True if the scope chain from `read_scope` to `body_scope` (exclusive of
@@ -168,7 +195,7 @@ impl<'a> PeepholeOptimizations {
     ) {
         let Some(id) = id else { return };
         let Some(symbol_id) = id.symbol_id.get() else { return };
-        ctx.init_value(symbol_id, None, true);
+        ctx.init_value(symbol_id, None, true, false);
     }
 
     /// Initialize symbol value for class declarations.
@@ -178,7 +205,7 @@ impl<'a> PeepholeOptimizations {
         let Some(id) = &class.id else { return };
         let Some(symbol_id) = id.symbol_id.get() else { return };
         let is_fresh = !Self::class_may_have_property_side_effects(class);
-        ctx.init_value(symbol_id, None, is_fresh);
+        ctx.init_value(symbol_id, None, is_fresh, false);
     }
 
     fn is_for_statement_init(ctx: &TraverseCtx<'a>) -> bool {

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -103,6 +103,25 @@ impl<'a> PeepholeOptimizations {
                     Self::minimize_expression_in_boolean_context(last, ctx);
                 }
             }
+            // A binding that is provably falsy in boolean context (a write-once
+            // falsy `var` whose constant was withheld from value-context folding,
+            // e.g. a bundled `var hydrating = false` flag) folds to `false` here,
+            // where `undefined`-before-init is indistinguishable from the falsy
+            // init. The existing `if (false)` dead-code pass removes the branch.
+            Expression::Identifier(ident) => {
+                let reference_id = ident.reference_id();
+                let span = ident.span;
+                if let Some(symbol_id) = ctx.scoping().get_reference(reference_id).symbol_id()
+                    && ctx
+                        .state
+                        .symbol_values
+                        .get_symbol_value(symbol_id)
+                        .is_some_and(|sv| sv.boolean_falsy)
+                {
+                    let new_expr = ctx.ast.expression_boolean_literal(span, false);
+                    ctx.replace_expression(expr, new_expr);
+                }
+            }
             _ => {}
         }
     }

--- a/crates/oxc_minifier/src/symbol_value.rs
+++ b/crates/oxc_minifier/src/symbol_value.rs
@@ -23,6 +23,15 @@ pub struct SymbolValue<'a> {
     /// True for function/class declarations and variable declarations initialized
     /// with object/array/function/class literals.
     pub is_fresh_value: bool,
+
+    /// The symbol is provably falsy in **boolean context** but not necessarily
+    /// foldable in value context. Set for a write-once binding with a falsy
+    /// constant initializer whose `initialized_constant` was withheld (a hoisted
+    /// `var` whose declarative prelude isn't clean): a read before the
+    /// initializer sees `undefined`, but `undefined` and the falsy init are
+    /// indistinguishable inside `if (x)` / `x ? …` / `!x`, so such reads fold to
+    /// `false` there. See `minimize_expression_in_boolean_context` / #14001.
+    pub boolean_falsy: bool,
 }
 
 /// Per-symbol scratch store indexed by `SymbolId`.

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -258,6 +258,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         symbol_id: SymbolId,
         constant: Option<ConstantValue<'a>>,
         is_fresh_value: bool,
+        falsy_init: bool,
     ) {
         let mut exported = false;
         if self.scoping.current_scope_id() == self.scoping().root_scope_id() {
@@ -289,8 +290,21 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
         let scope_id = self.scoping().symbol_scope_id(symbol_id);
         let scope_flags = self.scoping().scope_flags(scope_id);
 
+        // `constant` is the value-context value, `None` when withheld (e.g. a hoisted
+        // `var` past a dirty prelude). Capture before it's moved just below.
+        let value_withheld = constant.is_none();
         let initialized_constant =
             if scope_flags.contains(ScopeFlags::DirectEval) { None } else { constant };
+
+        // `boolean_falsy` (see `SymbolValue::boolean_falsy`) gated to a sound subset:
+        // write-once, outside a direct-`eval` scope, and not a script's top-level
+        // global (another script could reassign it, so a 0 in-module write count
+        // doesn't prove write-once).
+        let boolean_falsy = falsy_init
+            && value_withheld
+            && write_references_count == 0
+            && !scope_flags.contains(ScopeFlags::DirectEval)
+            && !(self.source_type().is_script() && scope_id == self.scoping().root_scope_id());
 
         let symbol_value = SymbolValue {
             initialized_constant,
@@ -299,6 +313,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
             write_references_count,
             member_write_target_read_count,
             is_fresh_value,
+            boolean_falsy,
         };
         self.state.symbol_values.init_value(symbol_id, symbol_value);
     }

--- a/crates/oxc_minifier/tests/peephole/inline.rs
+++ b/crates/oxc_minifier/tests/peephole/inline.rs
@@ -93,11 +93,15 @@ fn readonly_var_with_imports_present() {
         "import './b.js'; var flag = true; export function check() { return flag; }",
         "import './b.js'; var flag = !0; export function check() { return flag; }",
     );
-    // Even with no export, an import anywhere disqualifies — we can't tell
-    // statically whether a cycle exists.
+    // A write-once falsy `var` read only in boolean context (`if (DEBUG)`) folds
+    // even with imports present: the cyclic-import hazard is that an observer sees
+    // the hoisted `undefined` instead of the init value, but in boolean context
+    // `undefined` and the falsy init are indistinguishable (`if (undefined)` ===
+    // `if (false)`), and an importer cannot write the binding to make it truthy.
+    // So `DEBUG` collapses and `log` becomes a no-op. (boolean_falsy, #14001)
     test_smallest(
         "import './side-effect.js'; var DEBUG = false; function log(x) { if (DEBUG) console.log(x); } log('hi');",
-        "import './side-effect.js'; var DEBUG = !1; function log(x) { DEBUG && console.log(x); } log('hi');",
+        "import './side-effect.js';",
     );
     // Imports are hoisted, so an import appearing *after* the var in source
     // still triggers the gate — the pre-scan checks the whole body.
@@ -202,6 +206,37 @@ fn readonly_var_after_type_declaration() {
         "type T = number; interface I {} var b = 2; function f() { return b; } log(f());",
         "type T = number; interface I {} function f() { return 2; } log(f());",
         SourceType::ts().with_module(true),
+        &CompressOptions::smallest(),
+    );
+}
+
+// A write-once falsy `var` flag read only in boolean context folds even past a
+// dirty declarative prelude — the bundled `var hydrating = false` shape read by
+// `if (hydrating)` throughout a framework runtime (Svelte/Vue, #14001). The
+// value-context constant is withheld for hoisting safety, but `undefined`
+// (pre-init) and the falsy init are indistinguishable in boolean context.
+#[test]
+fn fold_writeonce_falsy_var_in_boolean_context() {
+    // Multiple same-frame boolean reads.
+    test_smallest("var h = false; if (h) a(); if (h) b()", "");
+    // Read inside a function, past a side-effectful prelude (`g()` runs first):
+    // the hoisting gate withholds value-context folding; boolean context is sound.
+    test_smallest("g(); var h = false; function f() { if (h) a() } f()", "g();");
+
+    // Value context must NOT fold (a pre-init read would observe `undefined`).
+    test_smallest(
+        "g(); var h = false; function f() { sink(h) } f()",
+        "g(); var h = !1; function f() { sink(h); } f();",
+    );
+    // Reassigned => not write-once => not folded.
+    test_smallest("var h = false; h = 1; if (h) a()", "var h = !1; h = 1, h && a();");
+
+    // Script mode: a top-level `var` is a global another script can reassign, so
+    // an in-module write count of 0 doesn't prove write-once — not folded.
+    test_options_source_type(
+        "var h = false; function f() { if (h) a() } f()",
+        "var h = !1; function f() { h && a(); } f();",
+        SourceType::cjs().with_script(true),
         &CompressOptions::smallest(),
     );
 }

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,7 +1,7 @@
            | Oxc        | ESBuild    | Oxc        | ESBuild    |
 Original   | minified   | minified   | gzip       | gzip       | Iterations | File      
 -------------------------------------------------------------------------------------
-72.14 kB   | 23.14 kB   | 23.70 kB   | 8.36 kB    | 8.54 kB    |          2 | react.development.js 
+72.14 kB   | 23.12 kB   | 23.70 kB   | 8.35 kB    | 8.54 kB    |          2 | react.development.js 
 
 173.90 kB  | 59.40 kB   | 59.82 kB   | 19.15 kB   | 19.33 kB   |          2 | moment.js  
 
@@ -9,7 +9,7 @@ Original   | minified   | minified   | gzip       | gzip       | Iterations | Fi
 
 342.15 kB  | 116.97 kB  | 118.14 kB  | 43.18 kB   | 44.37 kB   |          2 | vue.js     
 
-544.10 kB  | 70.96 kB   | 72.48 kB   | 25.77 kB   | 26.20 kB   |          2 | lodash.js  
+544.10 kB  | 70.92 kB   | 72.48 kB   | 25.74 kB   | 26.20 kB   |          2 | lodash.js  
 
 555.77 kB  | 267.40 kB  | 270.13 kB  | 88.01 kB   | 90.80 kB   |          2 | d3.js      
 

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -8,7 +8,7 @@ RadixUIAdoptionSection.jsx | 2.52 kB        ||             24 |              0 |
 
 pdf.mjs                    | 567.30 kB      ||           2612 |            205 ||          47485 |           7740
 
-antd.js                    | 6.69 MB        ||           3084 |             56 ||         337232 |          69333
+antd.js                    | 6.69 MB        ||           3104 |             56 ||         337232 |          69333
 
 binder.ts                  | 193.08 kB      ||             41 |              1 ||           7083 |            824
 


### PR DESCRIPTION
## What

A `var` initialized to a falsy constant and never reassigned is always falsy. oxc already folds such a `let`/`const` everywhere, but a `var` is held back by a hoisting check (a read before the declarator runs sees the hoisted `undefined`), so a multi-read `var` flag past a non-trivial declarative prelude was never folded.

In **boolean context** that check is unnecessary: a pre-init `var` read yields `undefined`, which is indistinguishable from the falsy init inside `if (x)` / `x ? … : …` / `!x`. So fold such reads to `false` there; the existing `if (false)` dead-code pass removes the branch.

This is the bundled-flag shape behind this issue. Svelte's `var hydrating = false` is read by `if (hydrating)` throughout the runtime; once a client-only bundle tree-shakes the `set_hydrating` setter, `hydrating` is a write-once falsy `var` and the whole hydration path becomes dead and is eliminated.

## Why it is sound

- `SymbolValue::boolean_falsy` is set only for a write-once binding with a falsy constant initializer.
- It folds to `false` **only** in boolean context; value-context reads keep their hoisting-correct behavior (never folded here).
- Gated off for a script's top-level `var` (a global another script can reassign, so an in-module write count of 0 doesn't prove write-once) and for `eval` scopes.

## Verification

- `oxc_minifier` tests pass; idempotent.
- On a real client-only Svelte (Vite/Rollup) bundle, every `if (hydrating)` check is eliminated.
- `minsize`: react 23.14 → 23.12 kB, lodash 70.96 → 70.92 kB (gzip down too). `allocs_minifier.snap`: +20 sys allocs on antd (from evaluating `var` initializers; arena allocs unchanged).
- Cross-validated for soundness: on the Svelte bundle, terser `--module` and esbuild `--format=esm` independently fold the same write-once flag (16 → 0), agreeing with oxc. On a Vue 3 client bundle the runtime's flags are multi-write (e.g. `isInSSRComponentSetup` has two assignments, so it can be truthy) and oxc correctly leaves them untouched — the write-once gate is the right line.

## Scope (partial fix)

This handles the real-world **bundled** shape — a write-once falsy `var` flag read in boolean context (the Svelte/Vue hydration case, where the bundler has already tree-shaken the setter). It does **not** fold the issue's literal source snippet:

```js
let foo = false;
function bar(val) { foo = val; }
if (foo) { bar(true) }
console.log(foo);
```

There `foo` is still reassigned via `bar` (so it isn't write-once), and proving the write dead requires self-referential / flow-sensitive analysis — out of scope here (see #22753 for that direction). So this is a partial step.

Refs #14001.

Prepared with AI assistance.
