### PR TITLE
fix(formatter): use `Ordering::reverse()` with `order: desc` for idempotency

### DIFF
--- a/crates/oxc_formatter/src/ir_transform/sort_imports/sortable_imports.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/sortable_imports.rs
@@ -151,13 +151,17 @@ fn sort_indices_by_source(
     imports: &[SortableImport],
     options: &SortImportsOptions,
 ) {
+    // NOTE: Apply `desc` by reversing the per-comparison `Ordering`,
+    // NOT by reversing the sorted slice afterwards.
+    // `reverse()` on the slice would also flip imports that compare `Equal` (e.g. same source),
+    // breaking stability and making sorting non-idempotent.
+    // `Ordering::reverse()` keeps `Equal` as `Equal`,
+    // so the stable `sort_by` preserves the original order of equal imports.
     indices.sort_by(|&a, &b| {
-        natord::compare(&imports[a].normalized_source, &imports[b].normalized_source)
+        let ordering =
+            natord::compare(&imports[a].normalized_source, &imports[b].normalized_source);
+        if options.order.is_desc() { ordering.reverse() } else { ordering }
     });
-
-    if options.order.is_desc() {
-        indices.reverse();
-    }
 }
 
 // ---

--- a/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
+++ b/crates/oxc_formatter/tests/ir_transform/sort_imports/basic.rs
@@ -853,6 +853,19 @@ import { log2 } from "./log2";
 import { log10 } from "./log10";
 "#,
     );
+
+    // Already-sorted input must stay unchanged
+    assert_format(
+        r#"
+import * as Sentry from "@sentry/browser";
+import type { BrowserOptions } from "@sentry/browser";
+"#,
+        r#"{ "sortImports": { "order": "desc" } }"#,
+        r#"
+import * as Sentry from "@sentry/browser";
+import type { BrowserOptions } from "@sentry/browser";
+"#,
+    );
 }
 
 // ---


### PR DESCRIPTION
Fixes #23541