### PR TITLE
fix(linter/eslint/no-useless-assignment): handle exceptional control-flow paths

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_assignment.rs
@@ -310,10 +310,7 @@ impl Rule for NoUselessAssignment {
 
                         match edge.weight() {
                             // Normal Flow: We will process these through the block's Ops
-                            EdgeType::Normal
-                            | EdgeType::NewFunction
-                            | EdgeType::Finalize
-                            | EdgeType::Join => {
+                            EdgeType::Normal | EdgeType::NewFunction | EdgeType::Join => {
                                 scratch_live.union(&cfg_traverse_state[succ_id]);
                             }
                             EdgeType::Jump => {
@@ -340,8 +337,8 @@ impl Rule for NoUselessAssignment {
                                     );
                                 }
                             }
-                            // Error Flow: This is the "Branch" that bypasses this block's Ops
-                            EdgeType::Error(_) => {
+                            // Error/finalizer flow can bypass this block's remaining Ops.
+                            EdgeType::Error(_) | EdgeType::Finalize => {
                                 scratch_catch.union(&cfg_traverse_state[succ_id]);
                             }
                             EdgeType::Backedge => {
@@ -613,7 +610,11 @@ impl NoUselessAssignment {
 
         for edge in graph.edges_directed(node, Direction::Outgoing) {
             match edge.weight() {
-                EdgeType::Normal | EdgeType::Jump | EdgeType::NewFunction | EdgeType::Backedge => {
+                EdgeType::Normal
+                | EdgeType::Jump
+                | EdgeType::NewFunction
+                | EdgeType::Backedge
+                | EdgeType::Error(_) => {
                     let target = edge.target();
                     if target == loop_header_id {
                         continue;
@@ -629,7 +630,7 @@ impl NoUselessAssignment {
                         visited,
                     );
                 }
-                _ => {}
+                EdgeType::Finalize | EdgeType::Join | EdgeType::Unreachable => {}
             }
         }
 
@@ -1179,6 +1180,60 @@ fn test() {
 
     return [(1 * y) - 16, 1 * (x - y), 1 * (y - z)];
 };",
+        "const maxRetries = 3;
+
+async function retryUntilSuccess(run: () => Promise<void>): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await run();
+    } catch (error) {
+      if (attempt >= maxRetries) {
+        throw error;
+      }
+    }
+  }
+}",
+        r#"async function waitWithBackoff(run: () => Promise<void>): Promise<void> {
+  let backoffMillis = 20;
+  let releaseRequested = false;
+
+  while (Date.now() < Date.now() + 2000) {
+    try {
+      return await run();
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.startsWith("LeaseHeldError")) {
+        throw error;
+      }
+    }
+
+    if (!releaseRequested) {
+      releaseRequested = true;
+    }
+
+    const waitUntil = Math.min(Date.now() + backoffMillis, Date.now() + 2000);
+    backoffMillis *= 2;
+    await new Promise((resolve) => setTimeout(resolve, waitUntil - Date.now()));
+  }
+}"#,
+        "function makeResource(): { readonly release: () => void } {
+  return { release() {} };
+}
+
+function useResource(unsafe: (resource: { readonly release: () => void }) => void): { readonly release: () => void } {
+  const resource = makeResource();
+  let owned = true;
+
+  try {
+    unsafe(resource);
+    owned = false;
+  } finally {
+    if (owned) {
+      resource.release();
+    }
+  }
+
+  return resource;
+}",
     ];
 
     let fail = vec![


### PR DESCRIPTION
## Summary
- Model exceptional control-flow paths in `no-useless-assignment` liveness analysis so values read by `catch`/`finally` are not treated as dead stores.
- Add regression coverage for the loop-update retry case, loop-body backoff case, and try/finally ownership-flag case from #23519.

## Why
`no-useless-assignment` walks the CFG backwards and reports a write when no later read can observe it. The false positives in #23519 came from paths where a later read is only reachable through exceptional control flow.

For loop retries, the update expression is used by the next iteration's catch path:

```ts
for (let attempt = 0; ; attempt++) {
  try {
    return await run();
  } catch (error) {
    if (attempt >= maxRetries) throw error;
  }
}
```

Before this PR, loop liveness only followed normal loop paths, so `attempt++` looked unused. After this PR, loop liveness also follows `Error(_)` edges inside the loop body.

```mermaid
flowchart LR
  U["for update: attempt++"] --> T["next iteration try"]
  T -->|"throws"| C["catch reads attempt"]
```

For try/finally ownership flags, the initial value can be observed if a try statement throws before ownership is transferred:

```ts
let owned = true;

try {
  unsafe(resource);
  owned = false;
} finally {
  if (owned) resource.release();
}
```

Before this PR, `Finalize` was merged as normal successor liveness. That let the later `owned = false` write kill the `finally` read for the whole block, even though `unsafe(resource)` can jump to `finally` before that write runs. After this PR, `Finalize` is treated as a bypass path alongside `Error(_)`, so writes later in the same block do not erase values that finalizers may read on an earlier throw path.

```mermaid
flowchart LR
  I["let owned = true"] --> A["unsafe(resource)"]
  A -->|"normal"| W["owned = false"]
  A -->|"throws"| F["finally reads owned"]
  W --> F
```

## Details
- Main block liveness now puts `Finalize` successors in the bypass set with `Error(_)`.
- Loop liveness now follows `Error(_)` edges while computing reads that can occur on later iterations.
- `Finalize`, `Join`, and `Unreachable` remain excluded from the recursive loop-liveness walk.

Fixes #23519
