### PR TITLE
perf(linter): stream React lifecycle ancestors

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_did_mount_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_did_mount_set_state.rs
@@ -9,7 +9,7 @@ use crate::{
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
     rules::ContextHost,
-    utils::{AllowedOrDisallowInFunc, is_es5_component, is_es6_component},
+    utils::{AllowedOrDisallowInFunc, function_count_before_lifecycle_component},
 };
 
 fn no_did_mount_set_state_diagnostic(span: Span) -> OxcDiagnostic {
@@ -89,49 +89,11 @@ impl Rule for NoDidMountSetState {
             return;
         }
 
-        let ancestors: Vec<_> = ctx.nodes().ancestors(node.id()).skip(1).collect();
-
-        let component_did_mount_index =
-            ancestors.iter().position(|ancestor| match ancestor.kind() {
-                AstKind::ObjectProperty(prop)
-                    if prop.key.static_name().is_some_and(|key| key == "componentDidMount") =>
-                {
-                    true
-                }
-                AstKind::MethodDefinition(method)
-                    if method.key.static_name().is_some_and(|name| name == "componentDidMount") =>
-                {
-                    true
-                }
-                AstKind::PropertyDefinition(prop)
-                    if prop.key.static_name().is_some_and(|name| name == "componentDidMount") =>
-                {
-                    true
-                }
-                _ => false,
-            });
-
-        let Some(component_did_mount_idx) = component_did_mount_index else {
+        let Some(function_count_before_component_did_mount) =
+            function_count_before_lifecycle_component(node, ctx, "componentDidMount")
+        else {
             return;
         };
-
-        let in_component_did_mount = ancestors[component_did_mount_idx..]
-            .iter()
-            .any(|ancestor| is_es5_component(ancestor) || is_es6_component(ancestor));
-
-        if !in_component_did_mount {
-            return;
-        }
-
-        let function_count_before_component_did_mount = ancestors[..component_did_mount_idx]
-            .iter()
-            .filter(|ancestor| {
-                matches!(
-                    ancestor.kind(),
-                    AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
-                )
-            })
-            .count();
 
         let in_nested_function = function_count_before_component_did_mount > 1;
 

--- a/crates/oxc_linter/src/rules/react/no_did_update_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_did_update_set_state.rs
@@ -8,7 +8,7 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::{DefaultRuleConfig, Rule},
-    utils::{AllowedOrDisallowInFunc, is_es5_component, is_es6_component},
+    utils::{AllowedOrDisallowInFunc, function_count_before_lifecycle_component},
 };
 
 fn no_did_update_set_state_diagnostic(span: Span) -> OxcDiagnostic {
@@ -95,52 +95,11 @@ impl Rule for NoDidUpdateSetState {
             return;
         }
 
-        let ancestors: Vec<_> = ctx.nodes().ancestors(node.id()).skip(1).collect();
-
-        let component_did_update_index =
-            ancestors.iter().position(|ancestor| match ancestor.kind() {
-                AstKind::ObjectProperty(prop)
-                    if prop.key.static_name().is_some_and(|key| key == "componentDidUpdate") =>
-                {
-                    true
-                }
-                AstKind::MethodDefinition(method)
-                    if method
-                        .key
-                        .static_name()
-                        .is_some_and(|name| name == "componentDidUpdate") =>
-                {
-                    true
-                }
-                AstKind::PropertyDefinition(prop)
-                    if prop.key.static_name().is_some_and(|name| name == "componentDidUpdate") =>
-                {
-                    true
-                }
-                _ => false,
-            });
-
-        let Some(component_did_update_idx) = component_did_update_index else {
+        let Some(function_count_before_component_did_update) =
+            function_count_before_lifecycle_component(node, ctx, "componentDidUpdate")
+        else {
             return;
         };
-
-        let in_component_did_update = ancestors[component_did_update_idx..]
-            .iter()
-            .any(|ancestor| is_es5_component(ancestor) || is_es6_component(ancestor));
-
-        if !in_component_did_update {
-            return;
-        }
-
-        let function_count_before_component_did_update = ancestors[..component_did_update_idx]
-            .iter()
-            .filter(|ancestor| {
-                matches!(
-                    ancestor.kind(),
-                    AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
-                )
-            })
-            .count();
 
         let in_nested_function = function_count_before_component_did_update > 1;
 

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -595,6 +595,49 @@ pub fn get_parent_component<'a, 'b>(
     ctx.nodes().ancestors(node.id()).find(|node| is_es5_component(node) || is_es6_component(node))
 }
 
+pub fn function_count_before_lifecycle_component(
+    node: &AstNode,
+    ctx: &LintContext,
+    lifecycle_method_name: &str,
+) -> Option<usize> {
+    let mut function_count = 0;
+    let mut in_lifecycle = false;
+
+    for ancestor in ctx.nodes().ancestors(node.id()).skip(1) {
+        if !in_lifecycle {
+            if is_lifecycle_component_method(ancestor, lifecycle_method_name) {
+                in_lifecycle = true;
+            } else if matches!(
+                ancestor.kind(),
+                AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
+            ) {
+                function_count += 1;
+            }
+        }
+
+        if in_lifecycle && (is_es5_component(ancestor) || is_es6_component(ancestor)) {
+            return Some(function_count);
+        }
+    }
+
+    None
+}
+
+fn is_lifecycle_component_method(node: &AstNode, lifecycle_method_name: &str) -> bool {
+    match node.kind() {
+        AstKind::ObjectProperty(prop) => {
+            prop.key.static_name().is_some_and(|key| key == lifecycle_method_name)
+        }
+        AstKind::MethodDefinition(method) => {
+            method.key.static_name().is_some_and(|name| name == lifecycle_method_name)
+        }
+        AstKind::PropertyDefinition(prop) => {
+            prop.key.static_name().is_some_and(|name| name == lifecycle_method_name)
+        }
+        _ => false,
+    }
+}
+
 fn get_jsx_mem_expr_name<'a>(jsx_mem_expr: &JSXMemberExpression) -> Cow<'a, str> {
     let prefix = match &jsx_mem_expr.object {
         JSXMemberExpressionObject::IdentifierReference(id) => Cow::Borrowed(id.name.as_str()),


### PR DESCRIPTION
- Stream React lifecycle ancestors for `no-did-mount-set-state` and `no-did-update-set-state` instead of collecting them into a `Vec`.
- Share the lifecycle component ancestor helper in React linter utilities so both rules use the same single-pass logic.