### PR TITLE
perf(linter/no-useless-spread): avoid collecting `Vec` before iterating

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -283,10 +283,8 @@ fn diagnose_array_in_array_spread<'a>(
             ctx.diagnostic_with_fix(diagnostic, |fixer| {
                 let mut codegen = fixer.codegen();
                 codegen.print_ascii_byte(b'[');
-                let elements =
-                    spreads.iter().flat_map(|arr| arr.elements.iter()).collect::<Vec<_>>();
-                let n = elements.len();
-                for (i, el) in elements.into_iter().enumerate() {
+                let n = spreads.iter().map(|arr| arr.elements.len()).sum::<usize>();
+                for (i, el) in spreads.iter().flat_map(|arr| arr.elements.iter()).enumerate() {
                     match el {
                         ArrayExpressionElement::Elision(_) => {
                             if i == n - 1 {


### PR DESCRIPTION
- Avoid collecting flattened inner array elements into a temporary `Vec` in the `no-useless-spread` array fixer.
- Precompute the flattened element count and stream the iterator so comma and elision output stays unchanged.