### PR TITLE
refactor(react_compiler): drop unneeded enum_eval from Semantic build

### DIFF
--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -87,11 +87,8 @@ pub fn transform<'a>(
         return TransformResult::default();
     }
 
-    let semantic = oxc_semantic::SemanticBuilder::new()
-        .with_build_nodes(true)
-        .with_enum_eval(true)
-        .build(program)
-        .semantic;
+    let semantic =
+        oxc_semantic::SemanticBuilder::new().with_build_nodes(true).build(program).semantic;
 
     let file = convert_program(program, source_text);
     let scope_info = convert_scope_info(&semantic, program);


### PR DESCRIPTION
`transform` built its `Semantic` with `.with_enum_eval(true)`, but the React Compiler never observes the evaluated enum member values — `convert_ast` lowers every `TSEnumMember` to `serde_json::Value::Null`, and `convert_scope_info` reads no enum constants. Evaluating them was pure overhead.

Dropping the flag leaves transform output byte-identical across the full upstream React Compiler fixture suite (1,399 compiled files); the unit and transformer-integration tests pass.
