### PR TITLE
fix(linter/unicorn/no-unnecessary-await): don't paste operators into invalid syntax

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -1,6 +1,10 @@
-use oxc_ast::{AstKind, ast::Expression};
+use oxc_ast::{
+    AstKind,
+    ast::{AwaitExpression, Expression},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_semantic::AstNodes;
 use oxc_span::Span;
 use oxc_syntax::operator::{UnaryOperator, UpdateOperator};
 
@@ -53,41 +57,13 @@ impl Rule for NoUnnecessaryAwait {
             if !not_promise(&expr.argument) {
                 return;
             }
-            if {
-                // Removing `await` may change them to a declaration, if there is no `id` will cause SyntaxError
-                matches!(expr.argument, Expression::FunctionExpression(_))
-                    || matches!(expr.argument, Expression::ClassExpression(_))
-            } || {
-                // Removing `await` would paste the parent unary operator onto the argument's
-                // leading operator and change tokenization into a syntax error:
-                // `+await +1` -> `++1`, `+await ++a` -> `+++a`, `-await --a` -> `---a`.
-                // Skip the fix in those cases (the diagnostic is still reported).
-                let parent = ctx.nodes().parent_node(node.id());
-                match (parent.kind(), &expr.argument) {
-                    (
-                        AstKind::UnaryExpression(parent_unary),
-                        Expression::UnaryExpression(inner_unary),
-                    ) => parent_unary.operator == inner_unary.operator,
-                    (
-                        AstKind::UnaryExpression(parent_unary),
-                        Expression::UpdateExpression(inner_update),
-                    ) => {
-                        inner_update.prefix
-                            && matches!(
-                                (parent_unary.operator, inner_update.operator),
-                                (UnaryOperator::UnaryPlus, UpdateOperator::Increment)
-                                    | (UnaryOperator::UnaryNegation, UpdateOperator::Decrement)
-                            )
-                    }
-                    _ => false,
-                }
-            } {
-                ctx.diagnostic(no_unnecessary_await_diagnostic(Span::sized(expr.span.start, 5)));
-            } else {
+            if is_fixable(expr, ctx.nodes()) {
                 ctx.diagnostic_with_fix(
                     no_unnecessary_await_diagnostic(Span::sized(expr.span.start, 5)),
                     |fixer| fixer.replace_with(expr, &expr.argument),
                 );
+            } else {
+                ctx.diagnostic(no_unnecessary_await_diagnostic(Span::sized(expr.span.start, 5)));
             }
         }
     }
@@ -115,6 +91,33 @@ fn not_promise(expr: &Expression) -> bool {
         Expression::SequenceExpression(expr) => not_promise(expr.expressions.last().unwrap()),
         Expression::ParenthesizedExpression(expr) => not_promise(&expr.expression),
         _ => false,
+    }
+}
+
+fn is_fixable(expr: &AwaitExpression, nodes: &AstNodes<'_>) -> bool {
+    // Removing `await` may change them to a declaration, if there is no `id` will cause SyntaxError
+    if matches!(expr.argument, Expression::FunctionExpression(_) | Expression::ClassExpression(_)) {
+        return false;
+    }
+
+    // Removing `await` would paste the parent unary operator onto the argument's
+    // leading operator and change tokenization into a syntax error:
+    // `+await +1` -> `++1`, `+await ++a` -> `+++a`, `-await --a` -> `---a`.
+    // Skip the fix in those cases (the diagnostic is still reported).
+    let parent = nodes.parent_node(expr.node_id());
+    match (parent.kind(), &expr.argument) {
+        (AstKind::UnaryExpression(parent_unary), Expression::UnaryExpression(inner_unary)) => {
+            parent_unary.operator != inner_unary.operator
+        }
+        (AstKind::UnaryExpression(parent_unary), Expression::UpdateExpression(inner_update)) => {
+            !(inner_update.prefix
+                && matches!(
+                    (parent_unary.operator, inner_update.operator),
+                    (UnaryOperator::UnaryPlus, UpdateOperator::Increment)
+                        | (UnaryOperator::UnaryNegation, UpdateOperator::Decrement)
+                ))
+        }
+        _ => true,
     }
 }
 
@@ -170,11 +173,10 @@ fn test() {
         "async function foo() {+await +1}",
         "async function foo() {-await-1}",
         "async function foo() {+await -1}",
-        // `+await ++a` / `-await --a`: removing `await` would paste `+`+`++` into `+++` / `-`+`--` into `---`
-        "async function foo() {+await ++a}",
-        "async function foo() {-await --a}",
         // https://github.com/oxc-project/oxc/issues/1718
         "await await this.assertTotalDocumentCount(expectedFormattedTotalDocCount);",
+        "async function foo() {+await ++a}",
+        "async function foo() {-await --a}",
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unnecessary_await.rs
@@ -2,6 +2,7 @@ use oxc_ast::{AstKind, ast::Expression};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
+use oxc_syntax::operator::{UnaryOperator, UpdateOperator};
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -57,16 +58,28 @@ impl Rule for NoUnnecessaryAwait {
                 matches!(expr.argument, Expression::FunctionExpression(_))
                     || matches!(expr.argument, Expression::ClassExpression(_))
             } || {
-                // `+await +1` -> `++1`
+                // Removing `await` would paste the parent unary operator onto the argument's
+                // leading operator and change tokenization into a syntax error:
+                // `+await +1` -> `++1`, `+await ++a` -> `+++a`, `-await --a` -> `---a`.
+                // Skip the fix in those cases (the diagnostic is still reported).
                 let parent = ctx.nodes().parent_node(node.id());
-                if let (
-                    AstKind::UnaryExpression(parent_unary),
-                    Expression::UnaryExpression(inner_unary),
-                ) = (parent.kind(), &expr.argument)
-                {
-                    parent_unary.operator == inner_unary.operator
-                } else {
-                    false
+                match (parent.kind(), &expr.argument) {
+                    (
+                        AstKind::UnaryExpression(parent_unary),
+                        Expression::UnaryExpression(inner_unary),
+                    ) => parent_unary.operator == inner_unary.operator,
+                    (
+                        AstKind::UnaryExpression(parent_unary),
+                        Expression::UpdateExpression(inner_update),
+                    ) => {
+                        inner_update.prefix
+                            && matches!(
+                                (parent_unary.operator, inner_update.operator),
+                                (UnaryOperator::UnaryPlus, UpdateOperator::Increment)
+                                    | (UnaryOperator::UnaryNegation, UpdateOperator::Decrement)
+                            )
+                    }
+                    _ => false,
                 }
             } {
                 ctx.diagnostic(no_unnecessary_await_diagnostic(Span::sized(expr.span.start, 5)));
@@ -157,6 +170,9 @@ fn test() {
         "async function foo() {+await +1}",
         "async function foo() {-await-1}",
         "async function foo() {+await -1}",
+        // `+await ++a` / `-await --a`: removing `await` would paste `+`+`++` into `+++` / `-`+`--` into `---`
+        "async function foo() {+await ++a}",
+        "async function foo() {-await --a}",
         // https://github.com/oxc-project/oxc/issues/1718
         "await await this.assertTotalDocumentCount(expectedFormattedTotalDocCount);",
     ];
@@ -170,6 +186,10 @@ fn test() {
         ("await class {}", "await class {}"),           // no autofix
         ("+await +1", "+await +1"),                     // no autofix
         ("-await -1", "-await -1"),                     // no autofix
+        ("+await ++a", "+await ++a"), // no autofix: `+++a` would be a syntax error
+        ("-await --a", "-await --a"), // no autofix: `---a` would be a syntax error
+        ("+await --a", "+--a"),       // safe: `+--a` parses as `+(--a)`
+        ("-await ++a", "-++a"),       // safe: `-++a` parses as `-(++a)`
     ];
 
     Tester::new(NoUnnecessaryAwait::NAME, NoUnnecessaryAwait::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/unicorn_no_unnecessary_await.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_unnecessary_await.snap
@@ -241,6 +241,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider removing the `await`
 
   ⚠ unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
+   ╭─[no_unnecessary_await.mjs:1:24]
+ 1 │ async function foo() {+await ++a}
+   ·                        ─────
+   ╰────
+  help: Consider removing the `await`
+
+  ⚠ unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
+   ╭─[no_unnecessary_await.mjs:1:24]
+ 1 │ async function foo() {-await --a}
+   ·                        ─────
+   ╰────
+  help: Consider removing the `await`
+
+  ⚠ unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.mjs:1:1]
  1 │ await await this.assertTotalDocumentCount(expectedFormattedTotalDocCount);
    · ─────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_unnecessary_await.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_unnecessary_await.snap
@@ -241,6 +241,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Consider removing the `await`
 
   ⚠ unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
+   ╭─[no_unnecessary_await.mjs:1:1]
+ 1 │ await await this.assertTotalDocumentCount(expectedFormattedTotalDocCount);
+   · ─────
+   ╰────
+  help: Consider removing the `await`
+
+  ⚠ unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
    ╭─[no_unnecessary_await.mjs:1:24]
  1 │ async function foo() {+await ++a}
    ·                        ─────
@@ -251,12 +258,5 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_unnecessary_await.mjs:1:24]
  1 │ async function foo() {-await --a}
    ·                        ─────
-   ╰────
-  help: Consider removing the `await`
-
-  ⚠ unicorn(no-unnecessary-await): Unexpected `await` on a non-Promise value
-   ╭─[no_unnecessary_await.mjs:1:1]
- 1 │ await await this.assertTotalDocumentCount(expectedFormattedTotalDocCount);
-   · ─────
    ╰────
   help: Consider removing the `await`


### PR DESCRIPTION
### Bug

`oxlint --fix` for `unicorn/no-unnecessary-await` removes `await` by splicing the argument's source in place. When the await expression is the argument of a `+`/`-` unary expression **and** its own argument is a **prefix** `++`/`--` update expression, the operators paste together into invalid syntax:

- `+await ++a` → `+++a` — tokenizes as `++ +a` → *"Cannot assign to this expression"*
- `-await --a` → `---a`

### Expected

The diagnostic should still be reported, but the unsafe autofix withheld — exactly how the rule already treats `+await +1` (which it does **not** rewrite to `++1`).

### Fix

The skip-guard only matched a same-operator inner `UnaryExpression`. Extend it to also skip a **prefix** `UpdateExpression` whose operator pastes with the parent unary operator (`+`+`++`, `-`+`--`). Mixed-direction cases stay fixed (`+await --a` → `+--a`, `-await ++a` → `-++a`), and postfix (`+await a++` → `+a++`) is unaffected.

### Test

Regression cases added in `no_unnecessary_await.rs`: `+await ++a` / `-await --a` → no autofix; `+await --a` / `-await ++a` → still fixed. oxc's fixer test harness rejects fixes that produce unparseable output, which is what flagged the original bug.

Prepared with AI assistance.