### PR TITLE
refactor(linter): make `unicorn/numeric-separators-style` options `u32`

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
+++ b/crates/oxc_linter/src/rules/unicorn/numeric_separators_style.rs
@@ -85,19 +85,19 @@ struct NumericBaseConfig {
     only_if_contains_separator: Option<bool>,
     /// The number of digits per group when inserting numeric separators.
     /// For example, a `groupLength` of 3 formats `1234567` as `1_234_567`.
-    group_length: usize,
+    group_length: u32,
     /// The minimum number of digits required before grouping is applied.
     /// Values with fewer digits than this threshold will not be grouped.
-    minimum_digits: usize,
+    minimum_digits: u32,
 }
 
 impl NumericBaseConfig {
     pub(self) fn set_numeric_base_from_config(&mut self, val: &serde_json::Value) {
         if let Some(group_length) = val.get("groupLength").and_then(serde_json::Value::as_u64) {
-            self.group_length = usize::try_from(group_length).unwrap();
+            self.group_length = u32::try_from(group_length).unwrap();
         }
         if let Some(minimum_digits) = val.get("minimumDigits").and_then(serde_json::Value::as_u64) {
-            self.minimum_digits = usize::try_from(minimum_digits).unwrap();
+            self.minimum_digits = u32::try_from(minimum_digits).unwrap();
         }
 
         if let Some(val) = val.get("onlyIfContainsSeparator").map(serde_json::Value::as_bool) {
@@ -112,7 +112,7 @@ struct NumericNumberConfig {
     #[serde(flatten)]
     base: NumericBaseConfig,
     /// The size a group of digits in the fractional part (after the decimal point) should be.
-    fraction_group_length: usize,
+    fraction_group_length: u32,
 }
 
 impl NumericNumberConfig {
@@ -121,7 +121,7 @@ impl NumericNumberConfig {
         if let Some(fraction_group_length) =
             val.get("fractionGroupLength").and_then(serde_json::Value::as_u64)
         {
-            self.fraction_group_length = usize::try_from(fraction_group_length).unwrap();
+            self.fraction_group_length = u32::try_from(fraction_group_length).unwrap();
         }
     }
 }
@@ -134,7 +134,7 @@ impl Default for NumericNumberConfig {
                 minimum_digits: 5,
                 only_if_contains_separator: None,
             },
-            fraction_group_length: usize::MAX,
+            fraction_group_length: u32::MAX,
         }
     }
 }
@@ -410,15 +410,18 @@ fn add_separators(
     s: &mut String,
     dir: &SeparatorDir,
     config: &NumericBaseConfig,
-    fraction_group_length: Option<usize>,
+    fraction_group_length: Option<u32>,
 ) {
     let length = if *dir == SeparatorDir::Left && fraction_group_length.is_some() {
-        fraction_group_length.unwrap_or(usize::MAX)
+        usize::try_from(fraction_group_length.unwrap_or(u32::MAX))
+            .expect("u32 size must fit into usize for fraction group length")
     } else {
-        config.group_length
+        usize::try_from(config.group_length).expect("u32 size must fit into usize for group length")
     };
 
-    if s.len() < config.minimum_digits || s.len() < length.saturating_add(1) {
+    if s.len() < usize::try_from(config.minimum_digits).expect("u32 size must fit into usize")
+        || s.len() < length.saturating_add(1)
+    {
         return;
     }
 

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -15660,7 +15660,7 @@
           "description": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`.",
           "default": 0,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`."
         },
@@ -15668,7 +15668,7 @@
           "description": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped.",
           "default": 0,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped."
         },
@@ -15685,9 +15685,9 @@
       "properties": {
         "fractionGroupLength": {
           "description": "The size a group of digits in the fractional part (after the decimal point) should be.",
-          "default": 18446744073709551615,
+          "default": 4294967295,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The size a group of digits in the fractional part (after the decimal point) should be."
         },
@@ -15695,7 +15695,7 @@
           "description": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`.",
           "default": 0,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The number of digits per group when inserting numeric separators.\nFor example, a `groupLength` of 3 formats `1234567` as `1_234_567`."
         },
@@ -15703,7 +15703,7 @@
           "description": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped.",
           "default": 0,
           "type": "integer",
-          "format": "uint",
+          "format": "uint32",
           "minimum": 0.0,
           "markdownDescription": "The minimum number of digits required before grouping is applied.\nValues with fewer digits than this threshold will not be grouped."
         },


### PR DESCRIPTION
I hope we do not support 16bit systems 😅 
Fixes the 32bit snapshot test:
https://github.com/oxc-project/oxc/actions/runs/27706245542/job/81955398728