### PR TITLE
refactor(ast): reorganise imports and exports

### DIFF
--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -41,15 +41,15 @@
 //! [`Visit`]: <http://docs.rs/oxc_ast_visit>
 //! [`VisitMut`]: <http://docs.rs/oxc_ast_visit>
 
-#[cfg(feature = "serialize")]
-mod serialize;
-
 pub mod ast;
 mod ast_builder_impl;
 mod ast_impl;
 mod ast_kind_impl;
 pub mod precedence;
 mod trivia;
+
+#[cfg(feature = "serialize")]
+mod serialize;
 
 mod generated {
     pub mod ast_kind;
@@ -69,17 +69,14 @@ mod generated {
     mod derive_unstable_address;
     mod get_id;
 }
-
 pub use generated::ast_kind;
 
-pub use crate::{
-    ast::comment::{Comment, CommentContent, CommentKind, CommentPosition},
-    ast_builder_impl::{AstBuilder, NONE},
-    ast_kind::{AstKind, AstType},
-    ast_kind_impl::{MemberExpressionKind, ModuleDeclarationKind},
-    trivia::{
-        CommentsRange, comments_range, get_comment_at, has_comments_between, is_inside_comment,
-    },
+pub use ast::comment::{Comment, CommentContent, CommentKind, CommentPosition};
+pub use ast_builder_impl::{AstBuilder, NONE};
+pub use ast_kind::{AstKind, AstType};
+pub use ast_kind_impl::{MemberExpressionKind, ModuleDeclarationKind};
+pub use trivia::{
+    CommentsRange, comments_range, get_comment_at, has_comments_between, is_inside_comment,
 };
 
 // After experimenting with two types of boxed enum variants:


### PR DESCRIPTION
Pure refactor. Just rearrange imports in root of `oxc_ast` crate to match our usual convention.

This is preparatory work for #23043.