### PR TITLE
refactor(ast): reorder imports in generated code

### DIFF
--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -9,9 +9,8 @@
 use std::cell::Cell;
 
 use oxc_allocator::{Allocator, Box, IntoIn, Vec};
-use oxc_syntax::{reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
-
 use oxc_str::{Ident, Str};
+use oxc_syntax::{reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
 use crate::{AstBuilder, ast::*};
 

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -85,10 +85,8 @@ impl Generator for AstBuilderGenerator {
 
             ///@@line_break
             use oxc_allocator::{Allocator, Box, IntoIn, Vec};
-            use oxc_syntax::{scope::ScopeId, symbol::SymbolId, reference::ReferenceId};
-
-            ///@@line_break
             use oxc_str::{Ident, Str};
+            use oxc_syntax::{scope::ScopeId, symbol::SymbolId, reference::ReferenceId};
 
             ///@@line_break
             use crate::{AstBuilder, ast::*};


### PR DESCRIPTION
Pure refactor. Re-order imports in generated code for `AstBuilder`. There's no reason to put `use oxc_str` in a separate block from the other `use oxc_*` imports.

This is preparatory work for #23043.