### PR TITLE
refactor(ast): rename generic params in `AstBuilder`

### DIFF
--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -138,15 +138,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
     #[inline]
-    pub fn expression_big_int_literal<A1>(
+    pub fn expression_big_int_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         base: BigintBase,
     ) -> Expression<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         Expression::BigIntLiteral(self.alloc_big_int_literal(span, value, raw, base))
     }
@@ -178,14 +178,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn expression_string_literal<A1>(
+    pub fn expression_string_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> Expression<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         Expression::StringLiteral(self.alloc_string_literal(span, value, raw))
     }
@@ -200,15 +200,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
-    pub fn expression_string_literal_with_lone_surrogates<A1>(
+    pub fn expression_string_literal_with_lone_surrogates<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> Expression<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         Expression::StringLiteral(self.alloc_string_literal_with_lone_surrogates(
             span,
@@ -244,9 +244,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn expression_identifier<A1>(self, span: Span, name: A1) -> Expression<'a>
+    pub fn expression_identifier<S1>(self, span: Span, name: S1) -> Expression<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         Expression::Identifier(self.alloc_identifier_reference(span, name))
     }
@@ -260,14 +260,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
     #[inline]
-    pub fn expression_identifier_with_reference_id<A1>(
+    pub fn expression_identifier_with_reference_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         reference_id: ReferenceId,
     ) -> Expression<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         Expression::Identifier(self.alloc_identifier_reference_with_reference_id(
             span,
@@ -1221,9 +1221,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn identifier_name<A1>(self, span: Span, name: A1) -> IdentifierName<'a>
+    pub fn identifier_name<S1>(self, span: Span, name: S1) -> IdentifierName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         IdentifierName { node_id: Default::default(), span, name: name.into() }
     }
@@ -1237,9 +1237,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn alloc_identifier_name<A1>(self, span: Span, name: A1) -> Box<'a, IdentifierName<'a>>
+    pub fn alloc_identifier_name<S1>(self, span: Span, name: S1) -> Box<'a, IdentifierName<'a>>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         Box::new_in(self.identifier_name(span, name), self.allocator)
     }
@@ -1253,9 +1253,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn identifier_reference<A1>(self, span: Span, name: A1) -> IdentifierReference<'a>
+    pub fn identifier_reference<S1>(self, span: Span, name: S1) -> IdentifierReference<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         IdentifierReference {
             node_id: Default::default(),
@@ -1274,13 +1274,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn alloc_identifier_reference<A1>(
+    pub fn alloc_identifier_reference<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> Box<'a, IdentifierReference<'a>>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         Box::new_in(self.identifier_reference(span, name), self.allocator)
     }
@@ -1295,14 +1295,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
     #[inline]
-    pub fn identifier_reference_with_reference_id<A1>(
+    pub fn identifier_reference_with_reference_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         reference_id: ReferenceId,
     ) -> IdentifierReference<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         IdentifierReference {
             node_id: Default::default(),
@@ -1322,14 +1322,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
     #[inline]
-    pub fn alloc_identifier_reference_with_reference_id<A1>(
+    pub fn alloc_identifier_reference_with_reference_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         reference_id: ReferenceId,
     ) -> Box<'a, IdentifierReference<'a>>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         Box::new_in(
             self.identifier_reference_with_reference_id(span, name, reference_id),
@@ -1346,9 +1346,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     #[inline]
-    pub fn binding_identifier<A1>(self, span: Span, name: A1) -> BindingIdentifier<'a>
+    pub fn binding_identifier<S1>(self, span: Span, name: S1) -> BindingIdentifier<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         BindingIdentifier {
             node_id: Default::default(),
@@ -1367,13 +1367,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     #[inline]
-    pub fn alloc_binding_identifier<A1>(
+    pub fn alloc_binding_identifier<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> Box<'a, BindingIdentifier<'a>>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         Box::new_in(self.binding_identifier(span, name), self.allocator)
     }
@@ -1388,14 +1388,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The identifier name being bound.
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
-    pub fn binding_identifier_with_symbol_id<A1>(
+    pub fn binding_identifier_with_symbol_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         symbol_id: SymbolId,
     ) -> BindingIdentifier<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         BindingIdentifier {
             node_id: Default::default(),
@@ -1415,14 +1415,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The identifier name being bound.
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
-    pub fn alloc_binding_identifier_with_symbol_id<A1>(
+    pub fn alloc_binding_identifier_with_symbol_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         symbol_id: SymbolId,
     ) -> Box<'a, BindingIdentifier<'a>>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         Box::new_in(self.binding_identifier_with_symbol_id(span, name, symbol_id), self.allocator)
     }
@@ -1433,9 +1433,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn label_identifier<A1>(self, span: Span, name: A1) -> LabelIdentifier<'a>
+    pub fn label_identifier<S1>(self, span: Span, name: S1) -> LabelIdentifier<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         LabelIdentifier { node_id: Default::default(), span, name: name.into() }
     }
@@ -1701,9 +1701,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn property_key_static_identifier<A1>(self, span: Span, name: A1) -> PropertyKey<'a>
+    pub fn property_key_static_identifier<S1>(self, span: Span, name: S1) -> PropertyKey<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         PropertyKey::StaticIdentifier(self.alloc_identifier_name(span, name))
     }
@@ -1716,9 +1716,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn property_key_private_identifier<A1>(self, span: Span, name: A1) -> PropertyKey<'a>
+    pub fn property_key_private_identifier<S1>(self, span: Span, name: S1) -> PropertyKey<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         PropertyKey::PrivateIdentifier(self.alloc_private_identifier(span, name))
     }
@@ -2674,13 +2674,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn simple_assignment_target_assignment_target_identifier<A1>(
+    pub fn simple_assignment_target_assignment_target_identifier<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> SimpleAssignmentTarget<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         SimpleAssignmentTarget::AssignmentTargetIdentifier(
             self.alloc_identifier_reference(span, name),
@@ -2696,14 +2696,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
     #[inline]
-    pub fn simple_assignment_target_assignment_target_identifier_with_reference_id<A1>(
+    pub fn simple_assignment_target_assignment_target_identifier_with_reference_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         reference_id: ReferenceId,
     ) -> SimpleAssignmentTarget<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         SimpleAssignmentTarget::AssignmentTargetIdentifier(
             self.alloc_identifier_reference_with_reference_id(span, name, reference_id),
@@ -3839,14 +3839,14 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: Directive with any escapes unescaped
     /// * `directive`: Raw content of directive as it appears in source, any escapes left as is
     #[inline]
-    pub fn directive<A1>(
+    pub fn directive<S1>(
         self,
         span: Span,
         expression: StringLiteral<'a>,
-        directive: A1,
+        directive: S1,
     ) -> Directive<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         Directive { node_id: Default::default(), span, expression, directive: directive.into() }
     }
@@ -3857,9 +3857,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `value`
     #[inline]
-    pub fn hashbang<A1>(self, span: Span, value: A1) -> Hashbang<'a>
+    pub fn hashbang<S1>(self, span: Span, value: S1) -> Hashbang<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         Hashbang { node_id: Default::default(), span, value: value.into() }
     }
@@ -5699,9 +5699,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     #[inline]
-    pub fn binding_pattern_binding_identifier<A1>(self, span: Span, name: A1) -> BindingPattern<'a>
+    pub fn binding_pattern_binding_identifier<S1>(self, span: Span, name: S1) -> BindingPattern<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         BindingPattern::BindingIdentifier(self.alloc_binding_identifier(span, name))
     }
@@ -5715,14 +5715,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The identifier name being bound.
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
-    pub fn binding_pattern_binding_identifier_with_symbol_id<A1>(
+    pub fn binding_pattern_binding_identifier_with_symbol_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         symbol_id: SymbolId,
     ) -> BindingPattern<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         BindingPattern::BindingIdentifier(
             self.alloc_binding_identifier_with_symbol_id(span, name, symbol_id),
@@ -7356,9 +7356,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn private_identifier<A1>(self, span: Span, name: A1) -> PrivateIdentifier<'a>
+    pub fn private_identifier<S1>(self, span: Span, name: S1) -> PrivateIdentifier<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         PrivateIdentifier { node_id: Default::default(), span, name: name.into() }
     }
@@ -7372,13 +7372,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn alloc_private_identifier<A1>(
+    pub fn alloc_private_identifier<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> Box<'a, PrivateIdentifier<'a>>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         Box::new_in(self.private_identifier(span, name), self.allocator)
     }
@@ -8046,9 +8046,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn import_attribute_key_identifier<A1>(self, span: Span, name: A1) -> ImportAttributeKey<'a>
+    pub fn import_attribute_key_identifier<S1>(self, span: Span, name: S1) -> ImportAttributeKey<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         ImportAttributeKey::Identifier(self.identifier_name(span, name))
     }
@@ -8060,14 +8060,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn import_attribute_key_string_literal<A1>(
+    pub fn import_attribute_key_string_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> ImportAttributeKey<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         ImportAttributeKey::StringLiteral(self.string_literal(span, value, raw))
     }
@@ -8080,15 +8080,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
-    pub fn import_attribute_key_string_literal_with_lone_surrogates<A1>(
+    pub fn import_attribute_key_string_literal_with_lone_surrogates<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> ImportAttributeKey<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         ImportAttributeKey::StringLiteral(self.string_literal_with_lone_surrogates(
             span,
@@ -8595,13 +8595,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn module_export_name_identifier_name<A1>(
+    pub fn module_export_name_identifier_name<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> ModuleExportName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         ModuleExportName::IdentifierName(self.identifier_name(span, name))
     }
@@ -8612,13 +8612,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn module_export_name_identifier_reference<A1>(
+    pub fn module_export_name_identifier_reference<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> ModuleExportName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         ModuleExportName::IdentifierReference(self.identifier_reference(span, name))
     }
@@ -8630,14 +8630,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
     #[inline]
-    pub fn module_export_name_identifier_reference_with_reference_id<A1>(
+    pub fn module_export_name_identifier_reference_with_reference_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         reference_id: ReferenceId,
     ) -> ModuleExportName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         ModuleExportName::IdentifierReference(self.identifier_reference_with_reference_id(
             span,
@@ -8653,14 +8653,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn module_export_name_string_literal<A1>(
+    pub fn module_export_name_string_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> ModuleExportName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         ModuleExportName::StringLiteral(self.string_literal(span, value, raw))
     }
@@ -8673,15 +8673,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
-    pub fn module_export_name_string_literal_with_lone_surrogates<A1>(
+    pub fn module_export_name_string_literal_with_lone_surrogates<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> ModuleExportName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         ModuleExportName::StringLiteral(self.string_literal_with_lone_surrogates(
             span,
@@ -8831,14 +8831,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn string_literal<A1>(
+    pub fn string_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> StringLiteral<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         StringLiteral {
             node_id: Default::default(),
@@ -8859,14 +8859,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn alloc_string_literal<A1>(
+    pub fn alloc_string_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> Box<'a, StringLiteral<'a>>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         Box::new_in(self.string_literal(span, value, raw), self.allocator)
     }
@@ -8882,15 +8882,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
-    pub fn string_literal_with_lone_surrogates<A1>(
+    pub fn string_literal_with_lone_surrogates<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> StringLiteral<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         StringLiteral {
             node_id: Default::default(),
@@ -8912,15 +8912,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
-    pub fn alloc_string_literal_with_lone_surrogates<A1>(
+    pub fn alloc_string_literal_with_lone_surrogates<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> Box<'a, StringLiteral<'a>>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         Box::new_in(
             self.string_literal_with_lone_surrogates(span, value, raw, lone_surrogates),
@@ -8939,15 +8939,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
     #[inline]
-    pub fn big_int_literal<A1>(
+    pub fn big_int_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         base: BigintBase,
     ) -> BigIntLiteral<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         BigIntLiteral { node_id: Default::default(), span, value: value.into(), raw, base }
     }
@@ -8963,15 +8963,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
     #[inline]
-    pub fn alloc_big_int_literal<A1>(
+    pub fn alloc_big_int_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         base: BigintBase,
     ) -> Box<'a, BigIntLiteral<'a>>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         Box::new_in(self.big_int_literal(span, value, raw, base), self.allocator)
     }
@@ -9241,9 +9241,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_element_name_identifier<A1>(self, span: Span, name: A1) -> JSXElementName<'a>
+    pub fn jsx_element_name_identifier<S1>(self, span: Span, name: S1) -> JSXElementName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         JSXElementName::Identifier(self.alloc_jsx_identifier(span, name))
     }
@@ -9256,13 +9256,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn jsx_element_name_identifier_reference<A1>(
+    pub fn jsx_element_name_identifier_reference<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> JSXElementName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         JSXElementName::IdentifierReference(self.alloc_identifier_reference(span, name))
     }
@@ -9276,14 +9276,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
     #[inline]
-    pub fn jsx_element_name_identifier_reference_with_reference_id<A1>(
+    pub fn jsx_element_name_identifier_reference_with_reference_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         reference_id: ReferenceId,
     ) -> JSXElementName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         JSXElementName::IdentifierReference(self.alloc_identifier_reference_with_reference_id(
             span,
@@ -9423,13 +9423,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn jsx_member_expression_object_identifier_reference<A1>(
+    pub fn jsx_member_expression_object_identifier_reference<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> JSXMemberExpressionObject<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         JSXMemberExpressionObject::IdentifierReference(self.alloc_identifier_reference(span, name))
     }
@@ -9443,14 +9443,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
     #[inline]
-    pub fn jsx_member_expression_object_identifier_reference_with_reference_id<A1>(
+    pub fn jsx_member_expression_object_identifier_reference_with_reference_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         reference_id: ReferenceId,
     ) -> JSXMemberExpressionObject<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         JSXMemberExpressionObject::IdentifierReference(
             self.alloc_identifier_reference_with_reference_id(span, name, reference_id),
@@ -9674,9 +9674,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_attribute_name_identifier<A1>(self, span: Span, name: A1) -> JSXAttributeName<'a>
+    pub fn jsx_attribute_name_identifier<S1>(self, span: Span, name: S1) -> JSXAttributeName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         JSXAttributeName::Identifier(self.alloc_jsx_identifier(span, name))
     }
@@ -9708,14 +9708,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn jsx_attribute_value_string_literal<A1>(
+    pub fn jsx_attribute_value_string_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> JSXAttributeValue<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         JSXAttributeValue::StringLiteral(self.alloc_string_literal(span, value, raw))
     }
@@ -9730,15 +9730,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
-    pub fn jsx_attribute_value_string_literal_with_lone_surrogates<A1>(
+    pub fn jsx_attribute_value_string_literal_with_lone_surrogates<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> JSXAttributeValue<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         JSXAttributeValue::StringLiteral(self.alloc_string_literal_with_lone_surrogates(
             span,
@@ -9829,9 +9829,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_identifier<A1>(self, span: Span, name: A1) -> JSXIdentifier<'a>
+    pub fn jsx_identifier<S1>(self, span: Span, name: S1) -> JSXIdentifier<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         JSXIdentifier { node_id: Default::default(), span, name: name.into() }
     }
@@ -9845,9 +9845,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn alloc_jsx_identifier<A1>(self, span: Span, name: A1) -> Box<'a, JSXIdentifier<'a>>
+    pub fn alloc_jsx_identifier<S1>(self, span: Span, name: S1) -> Box<'a, JSXIdentifier<'a>>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         Box::new_in(self.jsx_identifier(span, name), self.allocator)
     }
@@ -9861,9 +9861,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn jsx_child_text<A1>(self, span: Span, value: A1, raw: Option<Str<'a>>) -> JSXChild<'a>
+    pub fn jsx_child_text<S1>(self, span: Span, value: S1, raw: Option<Str<'a>>) -> JSXChild<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         JSXChild::Text(self.alloc_jsx_text(span, value, raw))
     }
@@ -9985,9 +9985,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn jsx_text<A1>(self, span: Span, value: A1, raw: Option<Str<'a>>) -> JSXText<'a>
+    pub fn jsx_text<S1>(self, span: Span, value: S1, raw: Option<Str<'a>>) -> JSXText<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         JSXText { node_id: Default::default(), span, value: value.into(), raw }
     }
@@ -10002,14 +10002,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn alloc_jsx_text<A1>(
+    pub fn alloc_jsx_text<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> Box<'a, JSXText<'a>>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         Box::new_in(self.jsx_text(span, value, raw), self.allocator)
     }
@@ -10164,9 +10164,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn ts_enum_member_name_identifier<A1>(self, span: Span, name: A1) -> TSEnumMemberName<'a>
+    pub fn ts_enum_member_name_identifier<S1>(self, span: Span, name: S1) -> TSEnumMemberName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         TSEnumMemberName::Identifier(self.alloc_identifier_name(span, name))
     }
@@ -10180,14 +10180,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn ts_enum_member_name_string<A1>(
+    pub fn ts_enum_member_name_string<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> TSEnumMemberName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         TSEnumMemberName::String(self.alloc_string_literal(span, value, raw))
     }
@@ -10202,15 +10202,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
-    pub fn ts_enum_member_name_string_with_lone_surrogates<A1>(
+    pub fn ts_enum_member_name_string_with_lone_surrogates<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> TSEnumMemberName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         TSEnumMemberName::String(self.alloc_string_literal_with_lone_surrogates(
             span,
@@ -10229,14 +10229,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn ts_enum_member_name_computed_string<A1>(
+    pub fn ts_enum_member_name_computed_string<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> TSEnumMemberName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         TSEnumMemberName::ComputedString(self.alloc_string_literal(span, value, raw))
     }
@@ -10251,15 +10251,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
-    pub fn ts_enum_member_name_computed_string_with_lone_surrogates<A1>(
+    pub fn ts_enum_member_name_computed_string_with_lone_surrogates<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> TSEnumMemberName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         TSEnumMemberName::ComputedString(self.alloc_string_literal_with_lone_surrogates(
             span,
@@ -10397,15 +10397,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
     #[inline]
-    pub fn ts_literal_big_int_literal<A1>(
+    pub fn ts_literal_big_int_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         base: BigintBase,
     ) -> TSLiteral<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         TSLiteral::BigIntLiteral(self.alloc_big_int_literal(span, value, raw, base))
     }
@@ -10419,14 +10419,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn ts_literal_string_literal<A1>(
+    pub fn ts_literal_string_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> TSLiteral<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         TSLiteral::StringLiteral(self.alloc_string_literal(span, value, raw))
     }
@@ -10441,15 +10441,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
-    pub fn ts_literal_string_literal_with_lone_surrogates<A1>(
+    pub fn ts_literal_string_literal_with_lone_surrogates<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> TSLiteral<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         TSLiteral::StringLiteral(self.alloc_string_literal_with_lone_surrogates(
             span,
@@ -12148,9 +12148,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn ts_type_name_identifier_reference<A1>(self, span: Span, name: A1) -> TSTypeName<'a>
+    pub fn ts_type_name_identifier_reference<S1>(self, span: Span, name: S1) -> TSTypeName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         TSTypeName::IdentifierReference(self.alloc_identifier_reference(span, name))
     }
@@ -12164,14 +12164,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
     #[inline]
-    pub fn ts_type_name_identifier_reference_with_reference_id<A1>(
+    pub fn ts_type_name_identifier_reference_with_reference_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         reference_id: ReferenceId,
     ) -> TSTypeName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         TSTypeName::IdentifierReference(self.alloc_identifier_reference_with_reference_id(
             span,
@@ -13654,14 +13654,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`
     /// * `type_annotation`
     #[inline]
-    pub fn ts_index_signature_name<A1, T1>(
+    pub fn ts_index_signature_name<S1, T1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         type_annotation: T1,
     ) -> TSIndexSignatureName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSIndexSignatureName {
@@ -13761,13 +13761,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn ts_type_predicate_name_identifier<A1>(
+    pub fn ts_type_predicate_name_identifier<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> TSTypePredicateName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         TSTypePredicateName::Identifier(self.alloc_identifier_name(span, name))
     }
@@ -13904,13 +13904,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     #[inline]
-    pub fn ts_module_declaration_name_identifier<A1>(
+    pub fn ts_module_declaration_name_identifier<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> TSModuleDeclarationName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         TSModuleDeclarationName::Identifier(self.binding_identifier(span, name))
     }
@@ -13922,14 +13922,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The identifier name being bound.
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
-    pub fn ts_module_declaration_name_identifier_with_symbol_id<A1>(
+    pub fn ts_module_declaration_name_identifier_with_symbol_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         symbol_id: SymbolId,
     ) -> TSModuleDeclarationName<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         TSModuleDeclarationName::Identifier(
             self.binding_identifier_with_symbol_id(span, name, symbol_id),
@@ -13943,14 +13943,14 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn ts_module_declaration_name_string_literal<A1>(
+    pub fn ts_module_declaration_name_string_literal<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
     ) -> TSModuleDeclarationName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         TSModuleDeclarationName::StringLiteral(self.string_literal(span, value, raw))
     }
@@ -13963,15 +13963,15 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
-    pub fn ts_module_declaration_name_string_literal_with_lone_surrogates<A1>(
+    pub fn ts_module_declaration_name_string_literal_with_lone_surrogates<S1>(
         self,
         span: Span,
-        value: A1,
+        value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
     ) -> TSModuleDeclarationName<'a>
     where
-        A1: Into<Str<'a>>,
+        S1: Into<Str<'a>>,
     {
         TSModuleDeclarationName::StringLiteral(self.string_literal_with_lone_surrogates(
             span,
@@ -14415,13 +14415,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn ts_import_type_qualifier_identifier<A1>(
+    pub fn ts_import_type_qualifier_identifier<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> TSImportTypeQualifier<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         TSImportTypeQualifier::Identifier(self.alloc_identifier_name(span, name))
     }
@@ -15162,13 +15162,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn ts_module_reference_identifier_reference<A1>(
+    pub fn ts_module_reference_identifier_reference<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
     ) -> TSModuleReference<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         TSModuleReference::IdentifierReference(self.alloc_identifier_reference(span, name))
     }
@@ -15182,14 +15182,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
     #[inline]
-    pub fn ts_module_reference_identifier_reference_with_reference_id<A1>(
+    pub fn ts_module_reference_identifier_reference_with_reference_id<S1>(
         self,
         span: Span,
-        name: A1,
+        name: S1,
         reference_id: ReferenceId,
     ) -> TSModuleReference<'a>
     where
-        A1: Into<Ident<'a>>,
+        S1: Into<Ident<'a>>,
     {
         TSModuleReference::IdentifierReference(self.alloc_identifier_reference_with_reference_id(
             span,

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -118,7 +118,7 @@ struct Param<'d> {
     is_node_id: bool,
     /// * `None` if param is not generic.
     /// * `Some(GenericType::Into)` if is generic and uses `Into`
-    ///   e.g. `name: A where A: Into<Str<'a>>`.
+    ///   e.g. `name: S1 where S1: Into<Str<'a>>`.
     /// * `Some(GenericType::IntoIn)` if is generic and uses `IntoIn`
     ///   e.g. `type_annotation: T1 where T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>`.
     generic_type: Option<GenericType>,
@@ -347,7 +347,7 @@ fn get_struct_params<'s>(
                     if matches!(primitive_def.name(), "Str" | "Ident") =>
                 {
                     str_generic_count += 1;
-                    Some((format_ident!("A{str_generic_count}"), GenericType::Into))
+                    Some((format_ident!("S{str_generic_count}"), GenericType::Into))
                 }
                 TypeDef::Box(_) => {
                     generic_count += 1;


### PR DESCRIPTION
Pure refactor. Naming generic params for strings in `AstBuilder` methods `A1`, `A2` etc is a hangover from when our main string type was called `Atom`. Switch to `S1`, `S2` etc - "S" for "String".

This is preparatory work for #23043.