### PR TITLE
fix(linter/unicorn/prefer-at): correct two-argument `slice().pop()` index

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_at.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_at.rs
@@ -397,8 +397,7 @@ impl PreferAt {
             // `slice(start, end).pop()` returns the slice's LAST element. `.at()` can only
             // express that when the slice is exactly one element (`end == start + 1`), in which
             // case the element is at `start`. For a multi-element slice `.at()` cannot replicate
-            // `.pop()` (which takes the last element), so don't report — matching
-            // eslint-plugin-unicorn. (`slice(-9, -8).pop()` is `at(-9)`, not `at(-8)`.)
+            // `.pop()` (which takes the last element), so skip reporting in this case.
             if second_negative == first_negative + 1 {
                 ctx.diagnostic_with_fix(
                     prefer_at_diagnostic(call_expr.span, "slice().pop/shift"),
@@ -739,8 +738,6 @@ fn test() {
         ("array.slice(-9, 0)[0]", None),
         ("array.slice(-5, 0).pop()", None),
         ("array.slice(-3, 0).shift()", None),
-        // multi-element `slice(start, end).pop()` (`end != start + 1`) can't be expressed
-        // by `.at()` (pop takes the slice's last element), so it is not reported
         ("array.slice(-5, -3).pop()", None),
         ("array.slice(-9, -2).pop()", None),
         ("++array[1]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
@@ -892,8 +889,6 @@ fn test() {
         // Two-arg slice patterns
         ("array.slice(-9, -8)[0]", "array.at(-9)", None),
         ("array.slice(-3, -2).shift()", "array.at(-3)", None),
-        // `slice(start, end).pop()` of a one-element slice (`end == start + 1`) is the element
-        // at `start`, not at `end`. (Multi-element `slice().pop()` is no longer reported — see `pass`.)
         ("array.slice(-9, -8).pop()", "array.at(-9)", None),
         ("array.slice(-2, -1).pop()", "array.at(-2)", None),
         // Lodash patterns

--- a/crates/oxc_linter/src/rules/unicorn/prefer_at.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_at.rs
@@ -394,20 +394,27 @@ impl PreferAt {
                 },
             );
         } else if let Some(second_negative) = get_negative_integer(second_arg, None) {
-            ctx.diagnostic_with_fix(
-                prefer_at_diagnostic(call_expr.span, "slice().pop/shift"),
-                |fixer| {
-                    if is_arguments_object(&slice_static.object) {
-                        return fixer.noop();
-                    }
-                    create_at_fix(
-                        &fixer,
-                        slice_static.object.span(),
-                        Span::new(slice_static.object.span().start, call_expr.span.end),
-                        second_negative,
-                    )
-                },
-            );
+            // `slice(start, end).pop()` returns the slice's LAST element. `.at()` can only
+            // express that when the slice is exactly one element (`end == start + 1`), in which
+            // case the element is at `start`. For a multi-element slice `.at()` cannot replicate
+            // `.pop()` (which takes the last element), so don't report — matching
+            // eslint-plugin-unicorn. (`slice(-9, -8).pop()` is `at(-9)`, not `at(-8)`.)
+            if second_negative == first_negative + 1 {
+                ctx.diagnostic_with_fix(
+                    prefer_at_diagnostic(call_expr.span, "slice().pop/shift"),
+                    |fixer| {
+                        if is_arguments_object(&slice_static.object) {
+                            return fixer.noop();
+                        }
+                        create_at_fix(
+                            &fixer,
+                            slice_static.object.span(),
+                            Span::new(slice_static.object.span().start, call_expr.span.end),
+                            first_negative,
+                        )
+                    },
+                );
+            }
         }
     }
 
@@ -732,6 +739,10 @@ fn test() {
         ("array.slice(-9, 0)[0]", None),
         ("array.slice(-5, 0).pop()", None),
         ("array.slice(-3, 0).shift()", None),
+        // multi-element `slice(start, end).pop()` (`end != start + 1`) can't be expressed
+        // by `.at()` (pop takes the slice's last element), so it is not reported
+        ("array.slice(-5, -3).pop()", None),
+        ("array.slice(-9, -2).pop()", None),
         ("++array[1]", Some(serde_json::json!([{ "checkAllIndexAccess": true }]))),
         (
             "const offset = 5;const extraArgument = 6;string.charAt(offset + 9, extraArgument)",
@@ -881,8 +892,10 @@ fn test() {
         // Two-arg slice patterns
         ("array.slice(-9, -8)[0]", "array.at(-9)", None),
         ("array.slice(-3, -2).shift()", "array.at(-3)", None),
-        ("array.slice(-9, -8).pop()", "array.at(-8)", None),
-        ("array.slice(-5, -3).pop()", "array.at(-3)", None),
+        // `slice(start, end).pop()` of a one-element slice (`end == start + 1`) is the element
+        // at `start`, not at `end`. (Multi-element `slice().pop()` is no longer reported — see `pass`.)
+        ("array.slice(-9, -8).pop()", "array.at(-9)", None),
+        ("array.slice(-2, -1).pop()", "array.at(-2)", None),
         // Lodash patterns
         ("_.last(array)", "array.at(-1)", None),
         ("lodash.last(array)", "array.at(-1)", None),


### PR DESCRIPTION
### Bug

`unicorn/prefer-at`'s autofix for `array.slice(start, end).pop()` (two negative-integer args) emitted `array.at(end)`. But `.pop()` returns the slice's **last** element, and the last element of `slice(start, end)` is at `end - 1`, so the rewrite returned the wrong element:

- `array.slice(-9, -8).pop()` → `array.at(-8)`  — but it is `array.at(-9)` (the one-element slice `[arr[len-9]]`)
- `array.slice(-5, -3).pop()` → `array.at(-3)`  — a 2-element slice whose `.pop()` (`arr[len-4]`) `.at()` can't express

The sibling `[0]`-access path already (correctly) rewrites `array.slice(-9, -8)[0]` to `array.at(-9)`, so `pop` emitting `at(-8)` was inconsistent.

### Fix

Only report/fix the **one-element** case (`end == start + 1`), where the element is at `start`, emitting `array.at(start)`. Multi-element `slice().pop()` is no longer reported, because `.at()` cannot express popping the last element of a multi-element (or possibly-empty) slice. This matches [eslint-plugin-unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/prefer-at.js), which autofixes two-arg `pop` only when `-end === start + 1` and bails otherwise. The `shift()` path (first element = `at(start)`) is unchanged.

### Test

`expect_fix` corrected (`slice(-9, -8).pop()` → `at(-9)`; added `slice(-2, -1).pop()` → `at(-2)`); multi-element `slice(-5, -3).pop()` / `slice(-9, -2).pop()` added to `pass` (no longer reported). Verified against the prior behavior.

Prepared with AI assistance.