### PR TITLE
fix(linter/consistent-vitest-vi): preserve import aliases when rewriting the import

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
-use oxc_ast::{AstKind, ast::ImportDeclarationSpecifier};
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
@@ -125,6 +125,10 @@ impl Rule for ConsistentVitestVi {
                 ctx.diagnostic_with_fix(
                     consistent_vitest_vi_diagnostic(vitest_import.span(), &self.function),
                     |fixer| {
+                        // Keep each specifier's full source text (e.g. `expect as toBe`,
+                        // `type Foo`) rather than just its local name, otherwise aliases and
+                        // `type` qualifiers are dropped and the rewritten import rebinds to a
+                        // different (often non-existent) export.
                         let mut specifiers_without_opposite_accessor: Vec<Cow<str>> = import
                             .specifiers
                             .as_ref()
@@ -132,7 +136,7 @@ impl Rule for ConsistentVitestVi {
                                 specs
                                     .iter()
                                     .filter(|spec| spec.name() != opposite.as_str())
-                                    .map(ImportDeclarationSpecifier::name)
+                                    .map(|spec| Cow::Borrowed(fixer.source_range(spec.span())))
                                     .collect()
                             })
                             .unwrap_or_default();
@@ -140,10 +144,18 @@ impl Rule for ConsistentVitestVi {
                         if specifiers_without_opposite_accessor.is_empty() {
                             fixer.replace(vitest_import.local().span, self.function.as_str())
                         } else {
-                            if !specifiers_without_opposite_accessor
-                                .iter()
-                                .any(|s| s.as_ref() == self.function.as_str())
-                            {
+                            // Only add the target accessor when no kept specifier already binds
+                            // it locally. Compare LOCAL names (`spec.name()`), not the kept full
+                            // text — otherwise an alias/`type` whose local name is the target
+                            // (e.g. `import { x as vi, vitest }`) would get a duplicate `vi`.
+                            let target_already_bound =
+                                import.specifiers.as_ref().is_some_and(|specs| {
+                                    specs.iter().any(|spec| {
+                                        spec.name() != opposite.as_str()
+                                            && spec.name() == self.function.as_str()
+                                    })
+                                });
+                            if !target_already_bound {
                                 specifiers_without_opposite_accessor
                                     .push(self.function.as_str().into());
                             }
@@ -162,10 +174,11 @@ impl Rule for ConsistentVitestVi {
                                 return fixer.noop();
                             };
 
-                            let specifiers_span = Span::new(
-                                first_specifier.local().span.start,
-                                last_specifier.local().span.end,
-                            );
+                            // Use the full specifier spans (not `local()`) so an alias/`type`
+                            // qualifier on the first or last specifier is included in the
+                            // replaced range instead of being left behind.
+                            let specifiers_span =
+                                Span::new(first_specifier.span().start, last_specifier.span().end);
 
                             fixer.replace(specifiers_span, import_text)
                         }
@@ -243,6 +256,28 @@ fn test() {
             r#"import { expect, vi, vitest } from "vitest";"#,
             r#"import { expect, vi } from "vitest";"#,
             None,
+        ),
+        // aliased specifiers must be preserved, not collapsed to their local name
+        (
+            r#"import { vitest, expect as toBe } from "vitest";"#,
+            r#"import { expect as toBe, vi } from "vitest";"#,
+            None,
+        ),
+        (
+            r#"import { expect as e, vitest } from "vitest";"#,
+            r#"import { expect as e, vi } from "vitest";"#,
+            None,
+        ),
+        // a kept specifier already bound to the target locally must not be duplicated
+        (
+            r#"import { x as vi, vitest } from "vitest";"#,
+            r#"import { x as vi } from "vitest";"#,
+            None,
+        ),
+        (
+            r#"import { x as vitest, vi } from "vitest";"#,
+            r#"import { x as vitest } from "vitest";"#,
+            Some(serde_json::json!([{ "fn": "vitest" }])),
         ),
         (
             r#"import { vitest } from "vitest";

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -255,27 +255,10 @@ fn test() {
             r#"import { expect, vi } from "vitest";"#,
             None,
         ),
-        // aliased specifiers must be preserved, not collapsed to their local name
         (
             r#"import { vitest, expect as toBe } from "vitest";"#,
             r#"import { expect as toBe, vi } from "vitest";"#,
             None,
-        ),
-        (
-            r#"import { expect as e, vitest } from "vitest";"#,
-            r#"import { expect as e, vi } from "vitest";"#,
-            None,
-        ),
-        // a kept specifier already bound to the target locally must not be duplicated
-        (
-            r#"import { x as vi, vitest } from "vitest";"#,
-            r#"import { x as vi } from "vitest";"#,
-            None,
-        ),
-        (
-            r#"import { x as vitest, vi } from "vitest";"#,
-            r#"import { x as vitest } from "vitest";"#,
-            Some(serde_json::json!([{ "fn": "vitest" }])),
         ),
         (
             r#"import { vitest } from "vitest";
@@ -289,6 +272,21 @@ fn test() {
 			vi.clearAllMocks();"#,
             r#"vitest.stubEnv("NODE_ENV", "production");
 			vitest.clearAllMocks();"#,
+            Some(serde_json::json!([{ "fn": "vitest" }])),
+        ),
+        (
+            r#"import { expect as e, vitest } from "vitest";"#,
+            r#"import { expect as e, vi } from "vitest";"#,
+            None,
+        ),
+        (
+            r#"import { x as vi, vitest } from "vitest";"#,
+            r#"import { x as vi } from "vitest";"#,
+            None,
+        ),
+        (
+            r#"import { x as vitest, vi } from "vitest";"#,
+            r#"import { x as vitest } from "vitest";"#,
             Some(serde_json::json!([{ "fn": "vitest" }])),
         ),
     ];

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -256,11 +256,6 @@ fn test() {
             None,
         ),
         (
-            r#"import { vitest, expect as toBe } from "vitest";"#,
-            r#"import { expect as toBe, vi } from "vitest";"#,
-            None,
-        ),
-        (
             r#"import { vitest } from "vitest";
 			vitest.stubEnv("NODE_ENV", "production");"#,
             r#"import { vi } from "vitest";
@@ -273,6 +268,11 @@ fn test() {
             r#"vitest.stubEnv("NODE_ENV", "production");
 			vitest.clearAllMocks();"#,
             Some(serde_json::json!([{ "fn": "vitest" }])),
+        ),
+        (
+            r#"import { vitest, expect as toBe } from "vitest";"#,
+            r#"import { expect as toBe, vi } from "vitest";"#,
+            None,
         ),
         (
             r#"import { expect as e, vitest } from "vitest";"#,

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -1,6 +1,5 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
@@ -129,14 +128,14 @@ impl Rule for ConsistentVitestVi {
                         // `type Foo`) rather than just its local name, otherwise aliases and
                         // `type` qualifiers are dropped and the rewritten import rebinds to a
                         // different (often non-existent) export.
-                        let mut specifiers_without_opposite_accessor: Vec<Cow<str>> = import
+                        let mut specifiers_without_opposite_accessor: Vec<&str> = import
                             .specifiers
                             .as_ref()
                             .map(|specs| {
                                 specs
                                     .iter()
                                     .filter(|spec| spec.name() != opposite.as_str())
-                                    .map(|spec| Cow::Borrowed(fixer.source_range(spec.span())))
+                                    .map(|spec| fixer.source_range(spec.span()))
                                     .collect()
                             })
                             .unwrap_or_default();
@@ -156,8 +155,7 @@ impl Rule for ConsistentVitestVi {
                                     })
                                 });
                             if !target_already_bound {
-                                specifiers_without_opposite_accessor
-                                    .push(self.function.as_str().into());
+                                specifiers_without_opposite_accessor.push(self.function.as_str());
                             }
 
                             let import_text = specifiers_without_opposite_accessor.join(", ");

--- a/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
+++ b/crates/oxc_linter/src/rules/vitest/consistent_vitest_vi.rs
@@ -124,10 +124,6 @@ impl Rule for ConsistentVitestVi {
                 ctx.diagnostic_with_fix(
                     consistent_vitest_vi_diagnostic(vitest_import.span(), &self.function),
                     |fixer| {
-                        // Keep each specifier's full source text (e.g. `expect as toBe`,
-                        // `type Foo`) rather than just its local name, otherwise aliases and
-                        // `type` qualifiers are dropped and the rewritten import rebinds to a
-                        // different (often non-existent) export.
                         let mut specifiers_without_opposite_accessor: Vec<&str> = import
                             .specifiers
                             .as_ref()
@@ -143,10 +139,6 @@ impl Rule for ConsistentVitestVi {
                         if specifiers_without_opposite_accessor.is_empty() {
                             fixer.replace(vitest_import.local().span, self.function.as_str())
                         } else {
-                            // Only add the target accessor when no kept specifier already binds
-                            // it locally. Compare LOCAL names (`spec.name()`), not the kept full
-                            // text — otherwise an alias/`type` whose local name is the target
-                            // (e.g. `import { x as vi, vitest }`) would get a duplicate `vi`.
                             let target_already_bound =
                                 import.specifiers.as_ref().is_some_and(|specs| {
                                     specs.iter().any(|spec| {
@@ -172,9 +164,6 @@ impl Rule for ConsistentVitestVi {
                                 return fixer.noop();
                             };
 
-                            // Use the full specifier spans (not `local()`) so an alias/`type`
-                            // qualifier on the first or last specifier is included in the
-                            // replaced range instead of being left behind.
                             let specifiers_span =
                                 Span::new(first_specifier.span().start, last_specifier.span().end);
 


### PR DESCRIPTION
### Bug

When `vitest/consistent-vitest-vi` rewrites a `vitest`/`vi` import to the configured accessor, it rebuilt the kept named specifiers from `ImportDeclarationSpecifier::name()` (the local binding name only) and replaced the range between the first/last `local()` spans. Any `imported as local` alias or `type` qualifier was dropped:

```ts
import { vitest, expect as toBe } from "vitest";
// → import { toBe, vi } from "vitest";   ❌ rebinds to a non-existent `toBe` export
```

### Fix

- Rebuild each kept specifier from its **full source text** (`fixer.source_range(spec.span())`) and use the full specifier spans for the replaced range, so aliases and `type` qualifiers are preserved:
  `import { vitest, expect as toBe }` → `import { expect as toBe, vi }`.
- Decide whether to append the target accessor by comparing **local** names, so an alias whose local name already is the target (`import { x as vi, vitest }`) is not duplicated into the invalid `import { x as vi, vi }`.

### Test

`expect_fix` regression cases added: aliases at first/last position, and the alias-already-bound-to-target dedup cases (both directions). Existing cases unchanged.

Prepared with AI assistance.