### PR TITLE
fix(linter/radix): detect a trailing comma only after the argument

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -143,7 +143,11 @@ impl Radix {
                 ctx.diagnostic_with_dangerous_fix(missing_radix(call_expr.span), |fixer| {
                     let first_arg = &call_expr.arguments[0];
                     let end = call_expr.span.end;
-                    let check_span = Span::new(first_arg.span().start, end);
+                    // Only scan AFTER the argument for a trailing comma. Scanning from the
+                    // argument's start also sees commas *inside* it (e.g. `parseInt((0, "10"))`,
+                    // `parseInt(f(a, b))`), which would wrongly pick the no-separator `" 10,"`
+                    // branch and paste the radix on without a comma -> invalid syntax.
+                    let check_span = Span::new(first_arg.span().end, end);
                     let insert_param = ctx
                         .source_range(check_span)
                         .chars()
@@ -274,6 +278,14 @@ fn test() {
             "parseInt(10, /** 213123 */ 10,)",
             Some(serde_json::json!(["always"])),
         ),
+        // a comma INSIDE the single argument must not be mistaken for a trailing comma
+        (
+            r#"parseInt((0, "10"))"#,
+            r#"parseInt((0, "10"), 10)"#,
+            Some(serde_json::json!(["always"])),
+        ),
+        ("parseInt(f(a, b))", "parseInt(f(a, b), 10)", Some(serde_json::json!(["always"]))),
+        ("parseInt([1, 2][0])", "parseInt([1, 2][0], 10)", Some(serde_json::json!(["always"]))),
     ];
 
     Tester::new(Radix::NAME, Radix::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -143,25 +143,12 @@ impl Radix {
                 ctx.diagnostic_with_dangerous_fix(missing_radix(call_expr.span), |fixer| {
                     let first_arg = &call_expr.arguments[0];
                     let end = call_expr.span.end;
-                    // Only scan AFTER the argument for a trailing comma. Scanning from the
-                    // argument's start also sees commas *inside* it (e.g. `parseInt((0, "10"))`,
-                    // `parseInt(f(a, b))`), which would wrongly pick the no-separator `" 10,"`
-                    // branch and paste the radix on without a comma -> invalid syntax.
-                    let arg_end = first_arg.span().end;
-                    let check_span = Span::new(arg_end, end);
-                    // A `,` inside a comment is not the trailing comma (e.g.
-                    // `parseInt("10" /* , */)`), so skip commas that fall within a comment
-                    // span -- otherwise we'd pick `" 10,"` and emit invalid syntax.
-                    let comment_spans: Vec<Span> =
-                        ctx.comments_range(arg_end..end).map(|c| c.span).collect();
+                    // Look only AFTER the argument for a trailing comma, and skip commas inside
+                    // comments (e.g. `parseInt("10" /* , */)`) -- otherwise we'd pick the
+                    // no-separator `" 10,"` branch and paste the radix on without a separator,
+                    // emitting invalid syntax. `find_next_token_within` already does both.
                     let has_trailing_comma =
-                        ctx.source_range(check_span).char_indices().any(|(i, c)| {
-                            c == ','
-                                && !comment_spans.iter().any(|s| {
-                                    let abs = arg_end + u32::try_from(i).unwrap_or(0);
-                                    s.start <= abs && abs < s.end
-                                })
-                        });
+                        ctx.find_next_token_within(first_arg.span().end, end, ",").is_some();
                     let insert_param = if has_trailing_comma { " 10," } else { ", 10" };
                     fixer.insert_text_before_range(Span::empty(end - 1), insert_param)
                 });

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -143,10 +143,6 @@ impl Radix {
                 ctx.diagnostic_with_dangerous_fix(missing_radix(call_expr.span), |fixer| {
                     let first_arg = &call_expr.arguments[0];
                     let end = call_expr.span.end;
-                    // Look only AFTER the argument for a trailing comma, and skip commas inside
-                    // comments (e.g. `parseInt("10" /* , */)`) -- otherwise we'd pick the
-                    // no-separator `" 10,"` branch and paste the radix on without a separator,
-                    // emitting invalid syntax. `find_next_token_within` already does both.
                     let has_trailing_comma =
                         ctx.find_next_token_within(first_arg.span().end, end, ",").is_some();
                     let insert_param = if has_trailing_comma { " 10," } else { ", 10" };
@@ -275,7 +271,6 @@ fn test() {
             "parseInt(10, /** 213123 */ 10,)",
             Some(serde_json::json!(["always"])),
         ),
-        // a comma INSIDE the single argument must not be mistaken for a trailing comma
         (
             r#"parseInt((0, "10"))"#,
             r#"parseInt((0, "10"), 10)"#,
@@ -283,20 +278,16 @@ fn test() {
         ),
         ("parseInt(f(a, b))", "parseInt(f(a, b), 10)", Some(serde_json::json!(["always"]))),
         ("parseInt([1, 2][0])", "parseInt([1, 2][0], 10)", Some(serde_json::json!(["always"]))),
-        // a comma inside a trailing comment is not a trailing comma: insert `, 10`,
-        // not ` 10,` (which would paste an unseparated radix -> invalid syntax).
         (
             r#"parseInt("10" /* , */)"#,
             r#"parseInt("10" /* , */, 10)"#,
             Some(serde_json::json!(["always"])),
         ),
-        // a single parenthesized/sequence argument with a comment comma inside it.
         (
             r#"parseInt((0 /* , */, "10"))"#,
             r#"parseInt((0 /* , */, "10"), 10)"#,
             Some(serde_json::json!(["always"])),
         ),
-        // a real trailing comma still wins even when a comment comma precedes it.
         (
             r#"parseInt("10" /* x */,)"#,
             r#"parseInt("10" /* x */, 10,)"#,

--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -147,12 +147,22 @@ impl Radix {
                     // argument's start also sees commas *inside* it (e.g. `parseInt((0, "10"))`,
                     // `parseInt(f(a, b))`), which would wrongly pick the no-separator `" 10,"`
                     // branch and paste the radix on without a comma -> invalid syntax.
-                    let check_span = Span::new(first_arg.span().end, end);
-                    let insert_param = ctx
-                        .source_range(check_span)
-                        .chars()
-                        .find_map(|c| if c == ',' { Some(" 10,") } else { None })
-                        .unwrap_or(", 10");
+                    let arg_end = first_arg.span().end;
+                    let check_span = Span::new(arg_end, end);
+                    // A `,` inside a comment is not the trailing comma (e.g.
+                    // `parseInt("10" /* , */)`), so skip commas that fall within a comment
+                    // span -- otherwise we'd pick `" 10,"` and emit invalid syntax.
+                    let comment_spans: Vec<Span> =
+                        ctx.comments_range(arg_end..end).map(|c| c.span).collect();
+                    let has_trailing_comma =
+                        ctx.source_range(check_span).char_indices().any(|(i, c)| {
+                            c == ','
+                                && !comment_spans.iter().any(|s| {
+                                    let abs = arg_end + u32::try_from(i).unwrap_or(0);
+                                    s.start <= abs && abs < s.end
+                                })
+                        });
+                    let insert_param = if has_trailing_comma { " 10," } else { ", 10" };
                     fixer.insert_text_before_range(Span::empty(end - 1), insert_param)
                 });
             }
@@ -286,6 +296,25 @@ fn test() {
         ),
         ("parseInt(f(a, b))", "parseInt(f(a, b), 10)", Some(serde_json::json!(["always"]))),
         ("parseInt([1, 2][0])", "parseInt([1, 2][0], 10)", Some(serde_json::json!(["always"]))),
+        // a comma inside a trailing comment is not a trailing comma: insert `, 10`,
+        // not ` 10,` (which would paste an unseparated radix -> invalid syntax).
+        (
+            r#"parseInt("10" /* , */)"#,
+            r#"parseInt("10" /* , */, 10)"#,
+            Some(serde_json::json!(["always"])),
+        ),
+        // a single parenthesized/sequence argument with a comment comma inside it.
+        (
+            r#"parseInt((0 /* , */, "10"))"#,
+            r#"parseInt((0 /* , */, "10"), 10)"#,
+            Some(serde_json::json!(["always"])),
+        ),
+        // a real trailing comma still wins even when a comment comma precedes it.
+        (
+            r#"parseInt("10" /* x */,)"#,
+            r#"parseInt("10" /* x */, 10,)"#,
+            Some(serde_json::json!(["always"])),
+        ),
     ];
 
     Tester::new(Radix::NAME, Radix::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();


### PR DESCRIPTION
### Bug

`radix`'s single-argument fix (`parseInt(x)` → add a radix) decides between inserting `" 10,"` (there's already a trailing comma) and `", 10"` (need a separator) by scanning the whole range from the **argument's start** for any `,`. A comma **inside** the single argument is mistaken for a trailing comma, so the radix is pasted on without a separator → **invalid syntax**:

```js
parseInt((0, "10"))  →  parseInt((0, "10") 10,)   // SyntaxError
parseInt(f(a, b))    →  parseInt(f(a, b) 10,)
parseInt([1, 2][0])  →  parseInt([1, 2][0] 10,)
```

### Fix

Scan only the range **after** the argument (`first_arg.span().end..call.end`) for the trailing comma, so commas inside the argument are ignored. This matches ESLint, which inspects only the token immediately before the closing `)`.

### Test

`expect_fix` regression cases added for sequence / call / array arguments containing inner commas. Existing trailing-comma cases (incl. `parseInt(10, /** comment */)`) are unchanged.

Prepared with AI assistance.