### PR TITLE
test(data_structures): remove duplicate test

### DIFF
--- a/crates/oxc_data_structures/src/code_buffer.rs
+++ b/crates/oxc_data_structures/src/code_buffer.rs
@@ -746,15 +746,6 @@ mod test {
     }
 
     #[test]
-    fn string_isomorphism() {
-        let s = "Hello, world!";
-        let mut code = CodeBuffer::with_capacity(s.len());
-        code.print_str(s);
-        assert_eq!(code.len(), s.len());
-        assert_eq!(String::from(code), s.to_string());
-    }
-
-    #[test]
     fn into_string() {
         let s = "Hello, world!";
         let mut code = CodeBuffer::with_capacity(s.len());


### PR DESCRIPTION
This test does the same as `into_string` test just below. Remove it.