### PR TITLE
feat(estree)!: `ESTree` config use methods not consts

### DIFF
--- a/crates/oxc_ast/src/serialize/js.rs
+++ b/crates/oxc_ast/src/serialize/js.rs
@@ -407,7 +407,7 @@ impl ESTree for FormalParameterConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let param = self.0;
 
-        if S::INCLUDE_TS_FIELDS {
+        if serializer.include_ts_fields() {
             if param.has_modifier() {
                 let mut state = serializer.serialize_struct();
                 state.serialize_field("type", &JsonSafeString("TSParameterProperty"));
@@ -547,7 +547,7 @@ pub struct FunctionParams<'a, 'b>(pub &'b Function<'a>);
 impl ESTree for FunctionParams<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let func = self.0;
-        if S::INCLUDE_TS_FIELDS {
+        if serializer.include_ts_fields() {
             Concat2(&func.this_param, func.params.as_ref()).serialize(serializer);
         } else {
             func.params.serialize(serializer);

--- a/crates/oxc_ast/src/serialize/literal.rs
+++ b/crates/oxc_ast/src/serialize/literal.rs
@@ -219,7 +219,7 @@ impl ESTree for TemplateElementConverter<'_, '_> {
         state.serialize_field("tail", &element.tail);
 
         let mut span = element.span;
-        if S::INCLUDE_TS_FIELDS {
+        if state.include_ts_fields() {
             span.start -= 1;
             span.end += if element.tail { 1 } else { 2 };
         }

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -193,7 +193,7 @@ impl ESTree for ProgramConverter<'_, '_> {
         state.serialize_field("sourceType", &program.source_type.module_kind());
         state.serialize_field("hashbang", &program.hashbang);
 
-        let span = if S::INCLUDE_TS_FIELDS {
+        let span = if state.include_ts_fields() {
             Span::new(get_ts_start_span(program), program.span.end)
         } else {
             program.span

--- a/crates/oxc_estree/src/serialize/config.rs
+++ b/crates/oxc_estree/src/serialize/config.rs
@@ -1,11 +1,12 @@
 /// Trait for configs for AST serialization.
 pub trait Config {
-    /// `true` if output should contain TS fields
-    const INCLUDE_TS_FIELDS: bool;
-    /// `true` if should record paths to `Literal` nodes that need fixing on JS side
-    const FIXES: bool;
-
     fn new(ranges: bool) -> Self;
+
+    /// `true` if output should contain TS fields.
+    fn include_ts_fields(&self) -> bool;
+
+    /// `true` if should record paths to `Literal` nodes that need fixing on JS side.
+    fn fixes(&self) -> bool;
 
     /// Get whether output should contain `range` fields.
     fn ranges(&self) -> bool;
@@ -18,12 +19,19 @@ pub struct ConfigTS {
 }
 
 impl Config for ConfigTS {
-    const INCLUDE_TS_FIELDS: bool = true;
-    const FIXES: bool = false;
-
     #[inline(always)]
     fn new(ranges: bool) -> Self {
         Self { ranges }
+    }
+
+    #[inline(always)]
+    fn include_ts_fields(&self) -> bool {
+        true
+    }
+
+    #[inline(always)]
+    fn fixes(&self) -> bool {
+        false
     }
 
     #[inline(always)]
@@ -39,12 +47,19 @@ pub struct ConfigJS {
 }
 
 impl Config for ConfigJS {
-    const INCLUDE_TS_FIELDS: bool = false;
-    const FIXES: bool = false;
-
     #[inline(always)]
     fn new(ranges: bool) -> Self {
         Self { ranges }
+    }
+
+    #[inline(always)]
+    fn include_ts_fields(&self) -> bool {
+        false
+    }
+
+    #[inline(always)]
+    fn fixes(&self) -> bool {
+        false
     }
 
     #[inline(always)]
@@ -60,12 +75,19 @@ pub struct ConfigFixesTS {
 }
 
 impl Config for ConfigFixesTS {
-    const INCLUDE_TS_FIELDS: bool = true;
-    const FIXES: bool = true;
-
     #[inline(always)]
     fn new(ranges: bool) -> Self {
         Self { ranges }
+    }
+
+    #[inline(always)]
+    fn include_ts_fields(&self) -> bool {
+        true
+    }
+
+    #[inline(always)]
+    fn fixes(&self) -> bool {
+        true
     }
 
     #[inline(always)]
@@ -81,12 +103,19 @@ pub struct ConfigFixesJS {
 }
 
 impl Config for ConfigFixesJS {
-    const INCLUDE_TS_FIELDS: bool = false;
-    const FIXES: bool = true;
-
     #[inline(always)]
     fn new(ranges: bool) -> Self {
         Self { ranges }
+    }
+
+    #[inline(always)]
+    fn include_ts_fields(&self) -> bool {
+        false
+    }
+
+    #[inline(always)]
+    fn fixes(&self) -> bool {
+        true
     }
 
     #[inline(always)]

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -33,9 +33,6 @@ pub trait ESTree {
 
 /// Trait for serializers.
 pub trait Serializer {
-    /// `true` if output should contain TS fields.
-    const INCLUDE_TS_FIELDS: bool;
-
     /// `true` if serializer's formatter produces compact JSON (not pretty-printed JSON).
     const IS_COMPACT: bool = Self::Formatter::IS_COMPACT;
 
@@ -46,6 +43,9 @@ pub trait Serializer {
     type StructSerializer: StructSerializer;
     /// Type of sequence serializer this serializer uses.
     type SequenceSerializer: SequenceSerializer;
+
+    /// Get whether output should contain TS fields.
+    fn include_ts_fields(&self) -> bool;
 
     /// Get whether output should contain `range` fields.
     fn ranges(&self) -> bool;
@@ -133,13 +133,17 @@ impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
     /// The `value` field of these nodes cannot be serialized to JSON, because JSON doesn't support
     /// `BigInt`s or `RegExp`s. The `fixes` paths can be used on JS side to locate these nodes
     /// and set their `value` fields correctly.
+    ///
+    /// # Panics
+    ///
+    /// Panics if serializer's config does not enable fixes.
     pub fn serialize_with_fixes<T: ESTree>(mut self, node: &T) -> String {
-        const {
-            assert!(
-                C::FIXES,
-                "Cannot call `serialize_with_fixes` on a serializer without fixes enabled"
-            );
-        }
+        // For the built-in configs in this crate, `fixes()` is `#[inline(always)]` and returns a constant,
+        // so compiler will remove this assertion when fixes are enabled
+        assert!(
+            self.config.fixes(),
+            "Cannot call `serialize_with_fixes` on a serializer without fixes enabled"
+        );
 
         self.buffer.print_str("{\"node\":\n");
 
@@ -173,12 +177,15 @@ impl<C: Config, F: Formatter> Default for ESTreeSerializer<C, F> {
 }
 
 impl<'s, C: Config, F: Formatter> Serializer for &'s mut ESTreeSerializer<C, F> {
-    /// `true` if output should contain TS fields
-    const INCLUDE_TS_FIELDS: bool = C::INCLUDE_TS_FIELDS;
-
     type Formatter = F;
     type StructSerializer = ESTreeStructSerializer<'s, C, F>;
     type SequenceSerializer = ESTreeSequenceSerializer<'s, C, F>;
+
+    /// Get whether output should contain TS fields.
+    #[inline(always)]
+    fn include_ts_fields(&self) -> bool {
+        self.config.include_ts_fields()
+    }
 
     /// Get whether output should contain `range` fields.
     #[inline(always)]
@@ -204,7 +211,7 @@ impl<'s, C: Config, F: Formatter> Serializer for &'s mut ESTreeSerializer<C, F> 
     /// These nodes cannot be serialized to JSON, because JSON doesn't support `BigInt`s or `RegExp`s.
     /// "Fix paths" can be used on JS side to locate these nodes and set their `value` fields correctly.
     fn record_fix_path(&mut self) {
-        if !C::FIXES {
+        if !self.config.fixes() {
             return;
         }
 

--- a/crates/oxc_estree/src/serialize/sequences.rs
+++ b/crates/oxc_estree/src/serialize/sequences.rs
@@ -24,7 +24,7 @@ impl<'s, C: Config, F: Formatter> ESTreeSequenceSerializer<'s, C, F> {
     pub(super) fn new(mut serializer: &'s mut ESTreeSerializer<C, F>) -> Self {
         // Push item to `trace_path`. It will be replaced with a `TracePathPart::Index`
         // when serializing each item in the sequence, and popped off again in `end` method.
-        if C::FIXES {
+        if serializer.config.fixes() {
             serializer.trace_path.push(TracePathPart::DUMMY);
         }
 
@@ -38,7 +38,7 @@ impl<C: Config, F: Formatter> SequenceSerializer for ESTreeSequenceSerializer<'_
     /// Serialize sequence entry.
     fn serialize_element<T: ESTree + ?Sized>(&mut self, value: &T) {
         // Update last item in trace path to current sequence index
-        if C::FIXES {
+        if self.serializer.config.fixes() {
             *self.serializer.trace_path.last_mut() = TracePathPart::Index(self.len);
         }
 
@@ -57,7 +57,7 @@ impl<C: Config, F: Formatter> SequenceSerializer for ESTreeSequenceSerializer<'_
     /// Finish serializing sequence.
     fn end(mut self) {
         // Pop entry for this sequence from `trace_path`
-        if C::FIXES {
+        if self.serializer.config.fixes() {
             // SAFETY: `trace_path` is pushed to in `new`, which is only way to create an `ESTreeSequenceSerializer`.
             // This method consumes the `ESTreeSequenceSerializer`, so this method can't be called more
             // times than `new`. So there must be an item to pop.

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -18,9 +18,9 @@ pub trait StructSerializer {
     /// Serialize struct field which is JS syntax only (not in TS AST).
     ///
     /// This method behaves differently, depending on the serializer's `Config`:
-    /// * `INCLUDE_TS_FIELDS == false`: Behaves same as `serialize_field`
+    /// * `include_ts_fields() == false`: Behaves same as `serialize_field`
     ///   i.e. the field is included in JSON.
-    /// * `INCLUDE_TS_FIELDS == true`: Do nothing.
+    /// * `include_ts_fields() == true`: Do nothing.
     ///   i.e. the field is skipped.
     ///
     /// `key` must not contain any characters which require escaping in JSON.
@@ -29,9 +29,9 @@ pub trait StructSerializer {
     /// Serialize struct field which is TypeScript syntax.
     ///
     /// This method behaves differently, depending on the serializer's `Config`:
-    /// * `INCLUDE_TS_FIELDS == true`: Behaves same as `serialize_field`
+    /// * `include_ts_fields() == true`: Behaves same as `serialize_field`
     ///   i.e. the field is included in JSON.
-    /// * `INCLUDE_TS_FIELDS == false`: Do nothing.
+    /// * `include_ts_fields() == false`: Do nothing.
     ///   i.e. the field is skipped.
     ///
     /// `key` must not contain any characters which require escaping in JSON.
@@ -45,6 +45,9 @@ pub trait StructSerializer {
 
     /// Finish serializing struct.
     fn end(self);
+
+    /// Get whether output should contain TS fields.
+    fn include_ts_fields(&self) -> bool;
 
     /// Get whether output should contain `range` fields.
     fn ranges(&self) -> bool;
@@ -66,7 +69,7 @@ impl<'s, C: Config, F: Formatter> ESTreeStructSerializer<'s, C, F> {
     pub(super) fn new(mut serializer: &'s mut ESTreeSerializer<C, F>) -> Self {
         // Push item to `trace_path`. It will be replaced with a `TracePathPart::Key`
         // when serializing each field in the struct, and popped off again in `end` method.
-        if C::FIXES {
+        if serializer.config.fixes() {
             serializer.trace_path.push(TracePathPart::DUMMY);
         }
 
@@ -85,7 +88,7 @@ impl<C: Config, F: Formatter> StructSerializer for ESTreeStructSerializer<'_, C,
     /// `key` must not contain any characters which require escaping in JSON.
     fn serialize_field<T: ESTree + ?Sized>(&mut self, key: &'static str, value: &T) {
         // Update last item in trace path to current key
-        if C::FIXES {
+        if self.serializer.config.fixes() {
             *self.serializer.trace_path.last_mut() = TracePathPart::Key(key);
         }
 
@@ -106,15 +109,15 @@ impl<C: Config, F: Formatter> StructSerializer for ESTreeStructSerializer<'_, C,
     /// Serialize struct field which is JS syntax only (not in TS AST).
     ///
     /// This method behaves differently, depending on the serializer's `Config`:
-    /// * `INCLUDE_TS_FIELDS == false`: Behaves same as `serialize_field`
+    /// * `include_ts_fields() == false`: Behaves same as `serialize_field`
     ///   i.e. the field is included in JSON.
-    /// * `INCLUDE_TS_FIELDS == true`: Do nothing.
+    /// * `include_ts_fields() == true`: Do nothing.
     ///   i.e. the field is skipped.
     ///
     /// `key` must not contain any characters which require escaping in JSON.
     #[inline(always)]
     fn serialize_js_field<T: ESTree + ?Sized>(&mut self, key: &'static str, value: &T) {
-        if !C::INCLUDE_TS_FIELDS {
+        if !self.include_ts_fields() {
             self.serialize_field(key, value);
         }
     }
@@ -122,15 +125,15 @@ impl<C: Config, F: Formatter> StructSerializer for ESTreeStructSerializer<'_, C,
     /// Serialize struct field which is TypeScript syntax.
     ///
     /// This method behaves differently, depending on the serializer's `Config`:
-    /// * `INCLUDE_TS_FIELDS == true`: Behaves same as `serialize_field`
+    /// * `include_ts_fields() == true`: Behaves same as `serialize_field`
     ///   i.e. the field is included in JSON.
-    /// * `INCLUDE_TS_FIELDS == false`: Do nothing.
+    /// * `include_ts_fields() == false`: Do nothing.
     ///   i.e. the field is skipped.
     ///
     /// `key` must not contain any characters which require escaping in JSON.
     #[inline(always)]
     fn serialize_ts_field<T: ESTree + ?Sized>(&mut self, key: &'static str, value: &T) {
-        if C::INCLUDE_TS_FIELDS {
+        if self.include_ts_fields() {
             self.serialize_field(key, value);
         }
     }
@@ -153,7 +156,7 @@ impl<C: Config, F: Formatter> StructSerializer for ESTreeStructSerializer<'_, C,
         let mut serializer = self.serializer;
 
         // Pop entry for this struct from `trace_path`
-        if C::FIXES {
+        if serializer.config.fixes() {
             // SAFETY: `trace_path` is pushed to in `new`, which is only way to create an `ESTreeStructSerializer`.
             // This method consumes the `ESTreeStructSerializer`, so this method can't be called more
             // times than `new`. So there must be an item to pop.
@@ -165,6 +168,12 @@ impl<C: Config, F: Formatter> StructSerializer for ESTreeStructSerializer<'_, C,
             formatter.after_last_element(buffer);
         }
         buffer.print_ascii_byte(b'}');
+    }
+
+    /// Get whether output should contain TS fields.
+    #[inline(always)]
+    fn include_ts_fields(&self) -> bool {
+        self.serializer.include_ts_fields()
     }
 
     /// Get whether output should contain `range` fields.
@@ -219,9 +228,6 @@ pub(super) enum StructState {
 pub struct FlatStructSerializer<'p, P: StructSerializer>(pub &'p mut P);
 
 impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
-    /// `true` if output should contain TS fields
-    const INCLUDE_TS_FIELDS: bool = P::Config::INCLUDE_TS_FIELDS;
-
     type Formatter = P::Formatter;
     type StructSerializer = Self;
     type SequenceSerializer = ESTreeSequenceSerializer<'p, P::Config, P::Formatter>;
@@ -241,6 +247,12 @@ impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
         const {
             panic!("Cannot call `record_fix_path` on a `FlatStructSerializer`");
         }
+    }
+
+    /// Get whether output should contain TS fields.
+    #[inline(always)]
+    fn include_ts_fields(&self) -> bool {
+        self.0.include_ts_fields()
     }
 
     /// Get whether output should contain `range` fields.
@@ -278,9 +290,9 @@ impl<P: StructSerializer> StructSerializer for FlatStructSerializer<'_, P> {
     /// Serialize struct field which is JS syntax only (not in TS AST).
     ///
     /// This method behaves differently, depending on the serializer's `Config`:
-    /// * `INCLUDE_TS_FIELDS == false`: Behaves same as `serialize_field`
+    /// * `include_ts_fields() == false`: Behaves same as `serialize_field`
     ///   i.e. the field is included in JSON.
-    /// * `INCLUDE_TS_FIELDS == true`: Do nothing.
+    /// * `include_ts_fields() == true`: Do nothing.
     ///   i.e. the field is skipped.
     ///
     /// `key` must not contain any characters which require escaping in JSON.
@@ -293,9 +305,9 @@ impl<P: StructSerializer> StructSerializer for FlatStructSerializer<'_, P> {
     /// Serialize struct field which is TypeScript syntax.
     ///
     /// This method behaves differently, depending on the serializer's `Config`:
-    /// * `INCLUDE_TS_FIELDS == true`: Behaves same as `serialize_field`
+    /// * `include_ts_fields() == true`: Behaves same as `serialize_field`
     ///   i.e. the field is included in JSON.
-    /// * `INCLUDE_TS_FIELDS == false`: Do nothing.
+    /// * `include_ts_fields() == false`: Do nothing.
     ///   i.e. the field is skipped.
     ///
     /// `key` must not contain any characters which require escaping in JSON.
@@ -316,6 +328,12 @@ impl<P: StructSerializer> StructSerializer for FlatStructSerializer<'_, P> {
     /// Finish serializing struct.
     fn end(self) {
         // No-op - there may be more fields to be added to the struct in the parent
+    }
+
+    /// Get whether output should contain TS fields.
+    #[inline(always)]
+    fn include_ts_fields(&self) -> bool {
+        self.0.include_ts_fields()
     }
 
     /// Get whether output should contain `range` fields.

--- a/crates/oxc_estree_tokens/src/json/mod.rs
+++ b/crates/oxc_estree_tokens/src/json/mod.rs
@@ -27,13 +27,26 @@ use u32_string::U32String;
 struct TokenSerializerConfig;
 
 impl ESTreeConfig for TokenSerializerConfig {
-    const INCLUDE_TS_FIELDS: bool = false;
-    const FIXES: bool = false;
-
     #[expect(clippy::inline_always)] // It's a no-op
     #[inline(always)]
     fn new(_ranges: bool) -> Self {
         Self
+    }
+
+    // Never include TS fields, so always return `false`.
+    // `#[inline(always)]` to ensure compiler removes dead code resulting from the static value.
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn include_ts_fields(&self) -> bool {
+        false
+    }
+
+    // Never record fixes, so always return `false`.
+    // `#[inline(always)]` to ensure compiler removes dead code resulting from the static value.
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn fixes(&self) -> bool {
+        false
     }
 
     // Never include ranges, so always return `false`.


### PR DESCRIPTION
Previously `Config` passed to ESTree serializers inclused `INCLUDE_TS_FIELDS` and `FIXES` consts. Allow these options to be set either as compile time or at runtime by instead implementing them as methods.

This PR defines all these methods on all configs as returning static values, so it does not change behavior. Next PR (#23574) uses this to alter configs to make whether TS fields are included in output a runtime option instead of a compile time one.