### PR TITLE
feat(estree)!: make whether to include TS fields a runtime option

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -363,12 +363,12 @@ mod test {
     #[cfg(feature = "serialize")]
     #[test]
     fn box_serialize_estree() {
-        use oxc_estree::{CompactTSSerializer, ESTree};
+        use oxc_estree::{CompactSerializer, ESTree};
 
         let allocator = Allocator::default();
         let b = Box::new_in("x", &allocator);
 
-        let mut serializer = CompactTSSerializer::default();
+        let mut serializer = CompactSerializer::default();
         b.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(s, r#""x""#);

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -388,13 +388,13 @@ mod test {
     #[cfg(feature = "serialize")]
     #[test]
     fn vec_serialize_estree() {
-        use oxc_estree::{CompactTSSerializer, ESTree};
+        use oxc_estree::{CompactSerializer, ESTree};
 
         let allocator = Allocator::default();
         let mut v = Vec::new_in(&allocator);
         v.push("x");
 
-        let mut serializer = CompactTSSerializer::default();
+        let mut serializer = CompactSerializer::default();
         v.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(s, r#"["x"]"#);

--- a/crates/oxc_ast/src/serialize/mod.rs
+++ b/crates/oxc_ast/src/serialize/mod.rs
@@ -2,9 +2,8 @@ use std::cmp;
 
 use oxc_ast_macros::ast_meta;
 use oxc_estree::{
-    CompactFixesJSSerializer, CompactFixesTSSerializer, CompactJSSerializer, CompactTSSerializer,
-    Concat2, ESTree, JsonSafeString, PrettyFixesJSSerializer, PrettyFixesTSSerializer,
-    PrettyJSSerializer, PrettyTSSerializer, Serializer, StructSerializer,
+    CompactFixesSerializer, CompactSerializer, Concat2, ESTree, JsonSafeString,
+    PrettyFixesSerializer, PrettySerializer, Serializer, StructSerializer,
 };
 use oxc_span::GetSpan;
 
@@ -19,13 +18,13 @@ use basic::{EmptyArray, Null};
 
 /// Main serialization methods for `Program`.
 ///
-/// Note: 8 separate methods for the different serialization options, rather than 1 method
+/// Note: 4 separate methods for the different serialization options, rather than 1 method
 /// with behavior controlled by flags
 /// (e.g. `fn to_estree_json(&self, with_ts: bool, pretty: bool, fixes: bool)`)
 /// to avoid bloating binary size.
 ///
 /// Most consumers (and Oxc crates) will use only 1 of these methods, so we don't want to needlessly
-/// compile all 8 serializers when only 1 is used.
+/// compile all 4 serializers when only 1 is used.
 ///
 /// Initial capacity for serializer's buffer is an estimate based on our benchmark fixtures
 /// of ratio of source text size to JSON size.
@@ -45,63 +44,37 @@ const JSON_CAPACITY_RATIO_COMPACT: usize = 16;
 const JSON_CAPACITY_RATIO_PRETTY: usize = 80;
 
 impl Program<'_> {
-    /// Serialize AST to ESTree JSON, including TypeScript fields.
-    pub fn to_estree_ts_json(&self, ranges: bool) -> String {
+    /// Serialize AST to ESTree JSON.
+    pub fn to_estree_json(&self, include_ts_fields: bool, ranges: bool) -> String {
         let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_COMPACT;
-        let mut serializer = CompactTSSerializer::with_capacity(capacity, ranges);
+        let mut serializer = CompactSerializer::with_capacity(capacity, include_ts_fields, ranges);
         self.serialize(&mut serializer);
         serializer.into_string()
     }
 
-    /// Serialize AST to ESTree JSON, without TypeScript fields.
-    pub fn to_estree_js_json(&self, ranges: bool) -> String {
-        let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_COMPACT;
-        let mut serializer = CompactJSSerializer::with_capacity(capacity, ranges);
-        self.serialize(&mut serializer);
-        serializer.into_string()
-    }
-
-    /// Serialize AST to pretty-printed ESTree JSON, including TypeScript fields.
-    pub fn to_pretty_estree_ts_json(&self, ranges: bool) -> String {
+    /// Serialize AST to pretty-printed ESTree JSON.
+    pub fn to_pretty_estree_json(&self, include_ts_fields: bool, ranges: bool) -> String {
         let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_PRETTY;
-        let mut serializer = PrettyTSSerializer::with_capacity(capacity, ranges);
+        let mut serializer = PrettySerializer::with_capacity(capacity, include_ts_fields, ranges);
         self.serialize(&mut serializer);
         serializer.into_string()
     }
 
-    /// Serialize AST to pretty-printed ESTree JSON, without TypeScript fields.
-    pub fn to_pretty_estree_js_json(&self, ranges: bool) -> String {
-        let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_PRETTY;
-        let mut serializer = PrettyJSSerializer::with_capacity(capacity, ranges);
-        self.serialize(&mut serializer);
-        serializer.into_string()
-    }
-
-    /// Serialize AST to ESTree JSON, including TypeScript fields, with list of fixes.
-    pub fn to_estree_ts_json_with_fixes(&self, ranges: bool) -> String {
+    /// Serialize AST to ESTree JSON, with list of fixes.
+    pub fn to_estree_json_with_fixes(&self, include_ts_fields: bool, ranges: bool) -> String {
         let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_COMPACT;
-        let serializer = CompactFixesTSSerializer::with_capacity(capacity, ranges);
+        let serializer = CompactFixesSerializer::with_capacity(capacity, include_ts_fields, ranges);
         serializer.serialize_with_fixes(self)
     }
 
-    /// Serialize AST to ESTree JSON, without TypeScript fields, with list of fixes.
-    pub fn to_estree_js_json_with_fixes(&self, ranges: bool) -> String {
-        let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_COMPACT;
-        let serializer = CompactFixesJSSerializer::with_capacity(capacity, ranges);
-        serializer.serialize_with_fixes(self)
-    }
-
-    /// Serialize AST to pretty-printed ESTree JSON, including TypeScript fields, with list of fixes.
-    pub fn to_pretty_estree_ts_json_with_fixes(&self, ranges: bool) -> String {
+    /// Serialize AST to pretty-printed ESTree JSON, with list of fixes.
+    pub fn to_pretty_estree_json_with_fixes(
+        &self,
+        include_ts_fields: bool,
+        ranges: bool,
+    ) -> String {
         let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_PRETTY;
-        let serializer = PrettyFixesTSSerializer::with_capacity(capacity, ranges);
-        serializer.serialize_with_fixes(self)
-    }
-
-    /// Serialize AST to pretty-printed ESTree JSON, without TypeScript fields, with list of fixes.
-    pub fn to_pretty_estree_js_json_with_fixes(&self, ranges: bool) -> String {
-        let capacity = self.source_text.len() * JSON_CAPACITY_RATIO_PRETTY;
-        let serializer = PrettyFixesJSSerializer::with_capacity(capacity, ranges);
+        let serializer = PrettyFixesSerializer::with_capacity(capacity, include_ts_fields, ranges);
         serializer.serialize_with_fixes(self)
     }
 }

--- a/crates/oxc_estree/src/serialize/blanket.rs
+++ b/crates/oxc_estree/src/serialize/blanket.rs
@@ -48,7 +48,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::super::CompactTSSerializer;
+    use super::super::CompactSerializer;
     use super::*;
 
     #[expect(clippy::needless_borrow)]
@@ -57,7 +57,7 @@ mod tests {
         let cases = [(&"foo", r#""foo""#), (&&"bar", r#""bar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::default();
+            let mut serializer = CompactSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -69,7 +69,7 @@ mod tests {
         let cases = [(&mut "foo", r#""foo""#), (&mut &mut "bar", r#""bar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::default();
+            let mut serializer = CompactSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -81,7 +81,7 @@ mod tests {
         let cases = [(None, "null"), (Some(123.0f64), "123")];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::default();
+            let mut serializer = CompactSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -94,7 +94,7 @@ mod tests {
             [(Cow::Borrowed("foo"), r#""foo""#), (Cow::Owned("bar".to_string()), r#""bar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::default();
+            let mut serializer = CompactSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);

--- a/crates/oxc_estree/src/serialize/config.rs
+++ b/crates/oxc_estree/src/serialize/config.rs
@@ -1,6 +1,6 @@
 /// Trait for configs for AST serialization.
 pub trait Config {
-    fn new(ranges: bool) -> Self;
+    fn new(include_ts_fields: bool, ranges: bool) -> Self;
 
     /// `true` if output should contain TS fields.
     fn include_ts_fields(&self) -> bool;
@@ -12,21 +12,21 @@ pub trait Config {
     fn ranges(&self) -> bool;
 }
 
-/// Config for serializing AST with TypeScript fields.
-#[repr(transparent)]
-pub struct ConfigTS {
+/// Config for serializing AST without fixes.
+pub struct ConfigNoFixes {
+    include_ts_fields: bool,
     ranges: bool,
 }
 
-impl Config for ConfigTS {
+impl Config for ConfigNoFixes {
     #[inline(always)]
-    fn new(ranges: bool) -> Self {
-        Self { ranges }
+    fn new(include_ts_fields: bool, ranges: bool) -> Self {
+        Self { include_ts_fields, ranges }
     }
 
     #[inline(always)]
     fn include_ts_fields(&self) -> bool {
-        true
+        self.include_ts_fields
     }
 
     #[inline(always)]
@@ -40,77 +40,21 @@ impl Config for ConfigTS {
     }
 }
 
-/// Config for serializing AST without TypeScript fields.
-#[repr(transparent)]
-pub struct ConfigJS {
+/// Config for serializing AST with fixes.
+pub struct ConfigFixes {
+    include_ts_fields: bool,
     ranges: bool,
 }
 
-impl Config for ConfigJS {
+impl Config for ConfigFixes {
     #[inline(always)]
-    fn new(ranges: bool) -> Self {
-        Self { ranges }
+    fn new(include_ts_fields: bool, ranges: bool) -> Self {
+        Self { include_ts_fields, ranges }
     }
 
     #[inline(always)]
     fn include_ts_fields(&self) -> bool {
-        false
-    }
-
-    #[inline(always)]
-    fn fixes(&self) -> bool {
-        false
-    }
-
-    #[inline(always)]
-    fn ranges(&self) -> bool {
-        self.ranges
-    }
-}
-
-/// Config for serializing AST with TypeScript fields, with fixes.
-#[repr(transparent)]
-pub struct ConfigFixesTS {
-    ranges: bool,
-}
-
-impl Config for ConfigFixesTS {
-    #[inline(always)]
-    fn new(ranges: bool) -> Self {
-        Self { ranges }
-    }
-
-    #[inline(always)]
-    fn include_ts_fields(&self) -> bool {
-        true
-    }
-
-    #[inline(always)]
-    fn fixes(&self) -> bool {
-        true
-    }
-
-    #[inline(always)]
-    fn ranges(&self) -> bool {
-        self.ranges
-    }
-}
-
-/// Config for serializing AST without TypeScript fields, with fixes.
-#[repr(transparent)]
-pub struct ConfigFixesJS {
-    ranges: bool,
-}
-
-impl Config for ConfigFixesJS {
-    #[inline(always)]
-    fn new(ranges: bool) -> Self {
-        Self { ranges }
-    }
-
-    #[inline(always)]
-    fn include_ts_fields(&self) -> bool {
-        false
+        self.include_ts_fields
     }
 
     #[inline(always)]

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -20,7 +20,7 @@ use sequences::ESTreeSequenceSerializer;
 use structs::ESTreeStructSerializer;
 
 pub use concat::{Concat2, Concat3, ConcatElement};
-pub use config::{Config, ConfigFixesJS, ConfigFixesTS, ConfigJS, ConfigTS};
+pub use config::{Config, ConfigFixes, ConfigNoFixes};
 pub use formatter::{CompactFormatter, Formatter, PrettyFormatter};
 pub use sequences::SequenceSerializer;
 pub use strings::{JsonSafeString, LoneSurrogatesString};
@@ -70,29 +70,17 @@ pub trait Serializer {
     fn buffer_and_formatter_mut(&mut self) -> (&mut CodeBuffer, &mut Self::Formatter);
 }
 
-/// ESTree serializer which produces compact JSON, including TypeScript fields.
-pub type CompactTSSerializer = ESTreeSerializer<ConfigTS, CompactFormatter>;
+/// ESTree serializer which produces compact JSON.
+pub type CompactSerializer = ESTreeSerializer<ConfigNoFixes, CompactFormatter>;
 
-/// ESTree serializer which produces compact JSON, excluding TypeScript fields.
-pub type CompactJSSerializer = ESTreeSerializer<ConfigJS, CompactFormatter>;
+/// ESTree serializer which produces pretty JSON.
+pub type PrettySerializer = ESTreeSerializer<ConfigNoFixes, PrettyFormatter>;
 
-/// ESTree serializer which produces pretty JSON, including TypeScript fields.
-pub type PrettyTSSerializer = ESTreeSerializer<ConfigTS, PrettyFormatter>;
+/// ESTree serializer which produces compact JSON.
+pub type CompactFixesSerializer = ESTreeSerializer<ConfigFixes, CompactFormatter>;
 
-/// ESTree serializer which produces pretty JSON, excluding TypeScript fields.
-pub type PrettyJSSerializer = ESTreeSerializer<ConfigJS, PrettyFormatter>;
-
-/// ESTree serializer which produces compact JSON, including TypeScript fields.
-pub type CompactFixesTSSerializer = ESTreeSerializer<ConfigFixesTS, CompactFormatter>;
-
-/// ESTree serializer which produces compact JSON, excluding TypeScript fields.
-pub type CompactFixesJSSerializer = ESTreeSerializer<ConfigFixesJS, CompactFormatter>;
-
-/// ESTree serializer which produces pretty JSON, including TypeScript fields.
-pub type PrettyFixesTSSerializer = ESTreeSerializer<ConfigFixesTS, PrettyFormatter>;
-
-/// ESTree serializer which produces pretty JSON, excluding TypeScript fields.
-pub type PrettyFixesJSSerializer = ESTreeSerializer<ConfigFixesJS, PrettyFormatter>;
+/// ESTree serializer which produces pretty JSON.
+pub type PrettyFixesSerializer = ESTreeSerializer<ConfigFixes, PrettyFormatter>;
 
 /// ESTree serializer.
 pub struct ESTreeSerializer<C: Config, F: Formatter> {
@@ -105,24 +93,24 @@ pub struct ESTreeSerializer<C: Config, F: Formatter> {
 
 impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
     /// Create new [`ESTreeSerializer`].
-    pub fn new(ranges: bool) -> Self {
+    pub fn new(include_ts_fields: bool, ranges: bool) -> Self {
         Self {
             buffer: CodeBuffer::with_indent(IndentChar::Space, 2),
             formatter: F::new(),
             trace_path: NonEmptyStack::new(TracePathPart::Index(0)),
             fixes_buffer: CodeBuffer::new(),
-            config: C::new(ranges),
+            config: C::new(include_ts_fields, ranges),
         }
     }
 
     /// Create new [`ESTreeSerializer`] with specified buffer capacity.
-    pub fn with_capacity(capacity: usize, ranges: bool) -> Self {
+    pub fn with_capacity(capacity: usize, include_ts_fields: bool, ranges: bool) -> Self {
         Self {
             buffer: CodeBuffer::with_capacity_and_indent(capacity, IndentChar::Space, 2),
             formatter: F::new(),
             trace_path: NonEmptyStack::new(TracePathPart::Index(0)),
             fixes_buffer: CodeBuffer::new(),
-            config: C::new(ranges),
+            config: C::new(include_ts_fields, ranges),
         }
     }
 
@@ -172,7 +160,7 @@ impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
 impl<C: Config, F: Formatter> Default for ESTreeSerializer<C, F> {
     #[inline(always)]
     fn default() -> Self {
-        Self::new(false)
+        Self::new(true, false)
     }
 }
 

--- a/crates/oxc_estree/src/serialize/primitives.rs
+++ b/crates/oxc_estree/src/serialize/primitives.rs
@@ -66,12 +66,12 @@ impl ESTree for () {
 
 #[cfg(test)]
 mod tests {
-    use super::super::CompactTSSerializer;
+    use super::super::CompactSerializer;
     use super::*;
 
     fn run_test<T: ESTree>(cases: &[(T, &str)]) {
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::default();
+            let mut serializer = CompactSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);

--- a/crates/oxc_estree/src/serialize/sequences.rs
+++ b/crates/oxc_estree/src/serialize/sequences.rs
@@ -96,7 +96,7 @@ impl<T: ESTree, const N: usize> ESTree for [T; N] {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{CompactTSSerializer, PrettyTSSerializer, StructSerializer};
+    use super::super::{CompactSerializer, PrettySerializer, StructSerializer};
     use super::*;
 
     #[test]
@@ -119,12 +119,12 @@ mod tests {
 
         let foo = Foo { none: &[], one: &["one"], two: ["two one", "two two"] };
 
-        let mut serializer = CompactTSSerializer::default();
+        let mut serializer = CompactSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(&s, r#"{"none":[],"one":["one"],"two":["two one","two two"]}"#);
 
-        let mut serializer = PrettyTSSerializer::default();
+        let mut serializer = PrettySerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(

--- a/crates/oxc_estree/src/serialize/strings.rs
+++ b/crates/oxc_estree/src/serialize/strings.rs
@@ -434,7 +434,7 @@ fn write_char_escape(escape: Escape, byte: u8, buffer: &mut CodeBuffer) {
 
 #[cfg(test)]
 mod tests {
-    use super::super::CompactTSSerializer;
+    use super::super::CompactSerializer;
     use super::*;
 
     #[test]
@@ -462,7 +462,7 @@ mod tests {
         ];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::default();
+            let mut serializer = CompactSerializer::default();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -474,7 +474,7 @@ mod tests {
         let cases = [(String::new(), r#""""#), ("foobar".to_string(), r#""foobar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::default();
+            let mut serializer = CompactSerializer::default();
             input.clone().serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -486,7 +486,7 @@ mod tests {
         let cases = [("", r#""""#), ("a", r#""a""#), ("abc", r#""abc""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::default();
+            let mut serializer = CompactSerializer::default();
             JsonSafeString(input).serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -509,7 +509,7 @@ mod tests {
         ];
 
         for (input, output) in cases {
-            let mut serializer = CompactTSSerializer::default();
+            let mut serializer = CompactSerializer::default();
             LoneSurrogatesString(input).serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -353,10 +353,7 @@ pub trait ESTreeSpan: Copy {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{
-        CompactJSSerializer, CompactTSSerializer, FlatStructSerializer, PrettyJSSerializer,
-        PrettyTSSerializer, Serializer,
-    };
+    use super::super::{CompactSerializer, FlatStructSerializer, PrettySerializer, Serializer};
     use super::*;
 
     #[test]
@@ -418,7 +415,7 @@ mod tests {
             maybe_not_bar: None,
         };
 
-        let mut serializer = CompactTSSerializer::default();
+        let mut serializer = CompactSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -426,7 +423,7 @@ mod tests {
             r#"{"n":123,"u":12345,"bar":{"yes":"yup","no":"nope"},"empty":{},"hello":"hi!","maybe_bar":{"yes":"hell yeah!","no":"not a chance in a million, mate"},"maybe_not_bar":null}"#
         );
 
-        let mut serializer = PrettyTSSerializer::default();
+        let mut serializer = PrettySerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -507,7 +504,7 @@ mod tests {
             outer2: "out2",
         };
 
-        let mut serializer = CompactTSSerializer::default();
+        let mut serializer = CompactSerializer::default();
         outer.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -515,7 +512,7 @@ mod tests {
             r#"{"outer1":"out1","inner1":"in1","innermost1":"inin1","innermost2":"inin2","inner2":"in2","outer2":"out2"}"#
         );
 
-        let mut serializer = PrettyTSSerializer::default();
+        let mut serializer = PrettySerializer::default();
         outer.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -553,12 +550,12 @@ mod tests {
 
         let foo = Foo { js: 1, ts: 2, js_only: 3, more_js: 4 };
 
-        let mut serializer = CompactTSSerializer::default();
+        let mut serializer = CompactSerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(&s, r#"{"js":1,"ts":2,"moreJs":4}"#);
 
-        let mut serializer = PrettyTSSerializer::default();
+        let mut serializer = PrettySerializer::default();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -570,12 +567,12 @@ mod tests {
 }"#
         );
 
-        let mut serializer = CompactJSSerializer::default();
+        let mut serializer = CompactSerializer::new(false, false);
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(&s, r#"{"js":1,"jsOnly":3,"moreJs":4}"#);
 
-        let mut serializer = PrettyJSSerializer::default();
+        let mut serializer = PrettySerializer::new(false, false);
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(

--- a/crates/oxc_estree_tokens/src/json/mod.rs
+++ b/crates/oxc_estree_tokens/src/json/mod.rs
@@ -29,7 +29,7 @@ struct TokenSerializerConfig;
 impl ESTreeConfig for TokenSerializerConfig {
     #[expect(clippy::inline_always)] // It's a no-op
     #[inline(always)]
-    fn new(_ranges: bool) -> Self {
+    fn new(_include_ts_fields: bool, _ranges: bool) -> Self {
         Self
     }
 
@@ -79,7 +79,7 @@ pub fn to_estree_tokens_json<O: ESTreeTokenConfig>(
     options: O,
 ) -> String {
     let capacity = estimate_json_len(tokens.len(), source_text.len(), true);
-    let mut serializer = CompactTokenSerializer::with_capacity(capacity, false);
+    let mut serializer = CompactTokenSerializer::with_capacity(capacity, false, false);
     serialize_tokens(&mut serializer, tokens, program, source_text, span_converter, options);
     serializer.into_string()
 }
@@ -99,7 +99,7 @@ pub fn to_estree_tokens_pretty_json<O: ESTreeTokenConfig>(
     options: O,
 ) -> String {
     let capacity = estimate_json_len(tokens.len(), source_text.len(), false);
-    let mut serializer = PrettyTokenSerializer::with_capacity(capacity, false);
+    let mut serializer = PrettyTokenSerializer::with_capacity(capacity, false, false);
     serialize_tokens(&mut serializer, tokens, program, source_text, span_converter, options);
     serializer.into_string()
 }

--- a/crates/oxc_parser/examples/parser.rs
+++ b/crates/oxc_parser/examples/parser.rs
@@ -71,11 +71,10 @@ fn main() -> Result<(), String> {
         Utf8ToUtf16::new(&source_text).convert_program(&mut program);
         if source_type.is_javascript() {
             println!("ESTree AST:");
-            println!("{}", program.to_pretty_estree_js_json(false));
         } else {
             println!("TS-ESTree AST:");
-            println!("{}", program.to_pretty_estree_ts_json(false));
         }
+        println!("{}", program.to_pretty_estree_json(!source_type.is_javascript(), false));
     }
 
     // Report parsing results

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -118,31 +118,26 @@ fn parse_with_return(filename: &str, source_text: &str, options: &ParserOptions)
     let mut comments =
         convert_utf8_to_utf16(source_text, &mut program, &mut module_record, &mut errors);
 
-    let program_and_fixes = match ast_type {
-        AstType::JavaScript => {
-            // Add hashbang to start of comments
-            if let Some(hashbang) = &program.hashbang {
-                comments.insert(
-                    0,
-                    Comment {
-                        r#type: "Line".to_string(),
-                        value: hashbang.value.to_string(),
-                        start: hashbang.span.start,
-                        end: hashbang.span.end,
-                    },
-                );
-            }
+    if ast_type == AstType::JavaScript {
+        // Add hashbang to start of comments.
+        // Note: `@typescript-eslint/parser` ignores hashbangs, despite appearances to the contrary in AST explorers.
+        // So we ignore them too for TS.
+        // See: https://github.com/typescript-eslint/typescript-eslint/issues/6500
+        if let Some(hashbang) = &program.hashbang {
+            comments.insert(
+                0,
+                Comment {
+                    r#type: "Line".to_string(),
+                    value: hashbang.value.to_string(),
+                    start: hashbang.span.start,
+                    end: hashbang.span.end,
+                },
+            );
+        }
+    }
 
-            program.to_estree_js_json_with_fixes(ranges)
-        }
-        AstType::TypeScript => {
-            // Note: `@typescript-eslint/parser` ignores hashbangs,
-            // despite appearances to the contrary in AST explorers.
-            // So we ignore them too.
-            // See: https://github.com/typescript-eslint/typescript-eslint/issues/6500
-            program.to_estree_ts_json_with_fixes(ranges)
-        }
-    };
+    let include_ts_fields = ast_type == AstType::TypeScript;
+    let program_and_fixes = program.to_estree_json_with_fixes(include_ts_fields, ranges);
 
     let module = EcmaScriptModule::from(&module_record);
 

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -360,7 +360,7 @@ impl Oxc {
         self.ir = format!("{:#?}", program.body);
         let mut comments = convert_utf8_to_utf16(source_text, program, module_record, &mut []);
 
-        self.ast_json = if source_type.is_javascript() {
+        if source_type.is_javascript() {
             // Add hashbang to start of comments
             if let Some(hashbang) = &program.hashbang {
                 comments.insert(
@@ -373,11 +373,10 @@ impl Oxc {
                     },
                 );
             }
+        }
 
-            program.to_pretty_estree_js_json_with_fixes(false)
-        } else {
-            program.to_pretty_estree_ts_json_with_fixes(false)
-        };
+        let include_ts_fields = !source_type.is_javascript();
+        self.ast_json = program.to_pretty_estree_json_with_fixes(include_ts_fields, false);
         self.comments = comments;
     }
 

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -60,7 +60,7 @@ fn bench_estree(criterion: &mut Criterion) {
                     span_converter.convert_program(&mut program);
                     span_converter.convert_comments(&mut program.comments);
 
-                    black_box(program.to_estree_ts_json_with_fixes(false));
+                    black_box(program.to_estree_json_with_fixes(true, false));
                     program
                 });
             });

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -89,7 +89,7 @@ impl CompilerInterface for Driver {
             self.errors.push(OxcDiagnostic::error("SourceType must not be unambiguous."));
         }
         // Make sure serialization doesn't crash; also for code coverage.
-        program.to_estree_ts_json_with_fixes(false);
+        program.to_estree_json_with_fixes(true, false);
         ControlFlow::Continue(())
     }
 

--- a/tasks/coverage/src/tools.rs
+++ b/tasks/coverage/src/tools.rs
@@ -712,7 +712,7 @@ pub fn run_estree_test262(files: &[Test262File]) -> Vec<CoverageResult> {
             let mut program = parser_ret.program;
             let source_text = program.source_text;
             Utf8ToUtf16::new(source_text).convert_program_with_ascending_order_checks(&mut program);
-            program.to_pretty_estree_js_json(false)
+            program.to_pretty_estree_json(false, false)
         },
     )
 }
@@ -804,7 +804,7 @@ pub fn run_estree_acorn_jsx(files: &[AcornJsxFile]) -> Vec<CoverageResult> {
             let mut program = parser_ret.program;
             let source_text = program.source_text;
             Utf8ToUtf16::new(source_text).convert_program_with_ascending_order_checks(&mut program);
-            program.to_pretty_estree_js_json(false)
+            program.to_pretty_estree_json(false, false)
         },
     )
 }
@@ -914,7 +914,7 @@ pub fn run_estree_typescript(files: &[TypeScriptFile]) -> Vec<CoverageResult> {
         let mut program = ret.program;
         let source_text = program.source_text;
         Utf8ToUtf16::new(source_text).convert_program_with_ascending_order_checks(&mut program);
-        program.to_pretty_estree_ts_json(false)
+        program.to_pretty_estree_json(true, false)
     })
 }
 


### PR DESCRIPTION
Previously, whether to serialize AST to ESTree JSON with/without TS fields was a compile-time option - via 2 different configs `CompactTSSerializer` and `CompactJSSerializer` (and their pretty-printing and with-fixes counterparts).

Turn this into a runtime option instead.

This makes serialization a little slower (more branches in either mode, and dead code in JS-only mode) but reduces the size of `oxc-parser` binary as only one `ESTreeSerializer` is generated, instead of 2 (JS-only, and with-TS).