### PR TITLE
perf(mangler): compile slot sort once instead of per CAPACITY

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -808,7 +808,7 @@ impl<'a, const CAPACITY: usize> NameTable<'a, CAPACITY> {
             debug_assert_eq!(symbols_renamed_in_this_batch.len(), slice_of_same_len_strings.len());
 
             // ...but hand the names out in source order, so neighbours get similar names.
-            symbols_renamed_in_this_batch.sort_unstable_by_key(|a: &&SlotFrequency| a.slot);
+            sort_batch_by_slot(&mut symbols_renamed_in_this_batch);
 
             for (symbol_to_rename, new_name) in
                 symbols_renamed_in_this_batch.iter().zip(slice_of_same_len_strings.iter())
@@ -820,6 +820,14 @@ impl<'a, const CAPACITY: usize> NameTable<'a, CAPACITY> {
             }
         }
     }
+}
+
+/// Sort a batch of renamed symbols into source order (by slot).
+///
+/// Non-generic free fn, so the sort implementation is compiled once, rather than once per
+/// `NameTable` `CAPACITY` instantiation (the `apply` caller is generic over `CAPACITY`).
+fn sort_batch_by_slot(symbols: &mut [&SlotFrequency<'_>]) {
+    symbols.sort_unstable_by_key(|a| a.slot);
 }
 
 fn collect_exported_symbols<'a>(


### PR DESCRIPTION
## What

`NameTable::apply` is generic over `const CAPACITY: usize` and is instantiated **twice** — `build_with_semantic` picks the name generator at runtime via the `debug` option (`debug_name` → `InlineString<15>` vs `base54`), so both `CAPACITY` instantiations are always compiled and ship in release. The `sort_unstable_by_key` inside `apply` was therefore monomorphized once per `CAPACITY`, even though the sort (over `&SlotFrequency` by `.slot`) is `CAPACITY`-independent.

This moves the sort into a non-generic `sort_batch_by_slot` helper, so the sort implementation is compiled once.

## Why it's safe

Pure refactor — identical key and comparator, behavior unchanged. Mangler tests pass.

## Impact

`cargo llvm-lines --lib -p oxc_mangler` (dev profile):

| | Lines | Copies |
|---|--:|--:|
| before | 30,908 | 1,626 |
| after | 29,297 | 1,594 |
| **delta** | **−1,611 (−5.2%)** | **−32** |

`quicksort` copies drop from 4 to 3.

Found via a `cargo llvm-lines` sweep of all published crates. Note: the same runtime `debug` flag also forces the *whole* `CAPACITY`-generic mangle pipeline to compile twice — a larger lever left for a follow-up (it touches a warmer path and wants a benchmark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
