### PR TITLE
fix(linter/no-compare-neg-zero): delete the `-` of a parenthesized `-0`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -98,10 +98,6 @@ impl Rule for NoCompareNegZero {
                     ctx.diagnostic_with_fix(
                         no_compare_neg_zero_diagnostic(op, expr.span),
                         |fixer| {
-                            // Delete the `-` of the `-0` unary. `is_neg_zero` looks through
-                            // parentheses, so use the inner expression's span start (the `-`),
-                            // not the operand's outer span start — otherwise for `x > (-0)` the
-                            // `(` is deleted, leaving the unbalanced `x > -0)`.
                             let neg_zero = if is_left_neg_zero {
                                 expr.left.get_inner_expression()
                             } else {
@@ -203,10 +199,11 @@ fn test() {
         ("x <= -0", "x <= 0", None),
         ("-0 <= x", "0 <= x", None),
         ("-0n <= x", "0n <= x", None),
-        // a parenthesized `-0` operand: delete the `-`, not the `(`
         ("x > (-0)", "x > (0)", None),
         ("(-0) > x", "(0) > x", None),
         ("x <= (-0n)", "x <= (0n)", None),
+        ("x > (-0 as number)", "x > (0 as number)", None),
+        ("(-0 satisfies number) > x", "(0 satisfies number) > x", None),
     ];
 
     Tester::new(NoCompareNegZero::NAME, NoCompareNegZero::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -98,13 +98,17 @@ impl Rule for NoCompareNegZero {
                     ctx.diagnostic_with_fix(
                         no_compare_neg_zero_diagnostic(op, expr.span),
                         |fixer| {
-                            let start = if is_left_neg_zero {
-                                expr.left.span().start
+                            // Delete the `-` of the `-0` unary. `is_neg_zero` looks through
+                            // parentheses, so use the inner expression's span start (the `-`),
+                            // not the operand's outer span start — otherwise for `x > (-0)` the
+                            // `(` is deleted, leaving the unbalanced `x > -0)`.
+                            let neg_zero = if is_left_neg_zero {
+                                expr.left.get_inner_expression()
                             } else {
-                                expr.right.span().start
+                                expr.right.get_inner_expression()
                             };
-                            let end = start + 1;
-                            let span = Span::new(start, end);
+                            let start = neg_zero.span().start;
+                            let span = Span::new(start, start + 1);
                             fixer.delete(&span)
                         },
                     );
@@ -199,6 +203,10 @@ fn test() {
         ("x <= -0", "x <= 0", None),
         ("-0 <= x", "0 <= x", None),
         ("-0n <= x", "0n <= x", None),
+        // a parenthesized `-0` operand: delete the `-`, not the `(`
+        ("x > (-0)", "x > (0)", None),
+        ("(-0) > x", "(0) > x", None),
+        ("x <= (-0n)", "x <= (0n)", None),
     ];
 
     Tester::new(NoCompareNegZero::NAME, NoCompareNegZero::PLUGIN, pass, fail)


### PR DESCRIPTION
### Bug

For a relational comparison against `-0` (`<`, `<=`, `>`, `>=`), the autofix removes the `-` by deleting one character at the operand's **outer** span start. But `is_neg_zero` looks through parentheses (`get_inner_expression`), so when the `-0` operand is parenthesized the outer span starts at `(`, and the fix deletes the paren instead — producing **invalid, unbalanced** output:

```js
x > (-0)  →  x > -0)   // SyntaxError
(-0) > x  →  -0) > x
```

### Fix

Delete at the **inner** expression's span start (the `-` of the `-0` unary, via `get_inner_expression()`), so `x > (-0)` becomes `x > (0)`. Since `is_neg_zero` and the fix now use the same inner expression, the deleted byte is always the `-`.

### Test

`expect_fix` regression cases added for parenthesized operands (`x > (-0)`, `(-0) > x`, `x <= (-0n)`); existing bare-`-0` cases unchanged. The strict-equality `Object.is(...)` suggestion path is untouched.

Prepared with AI assistance.