### PR TITLE
fix(linter/curly): remove only the block's own braces

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/curly.rs
+++ b/crates/oxc_linter/src/rules/eslint/curly.rs
@@ -426,7 +426,15 @@ fn apply_rule_fix<'a>(
     let fixed = if should_have_braces {
         format!("{{{source}}}")
     } else {
-        let mut trimmed = source.trim_matches(|c| c == '{' || c == '}').to_string();
+        // Strip only the block's own outer braces (one leading `{`, one trailing `}`).
+        // `trim_matches` would remove EVERY boundary brace, eating an inner statement's
+        // braces too — e.g. `if (x) {while(y){}}` -> `if (x) while(y)` (invalid: the
+        // `while` loses its body).
+        let mut trimmed = source
+            .strip_prefix('{')
+            .and_then(|s| s.strip_suffix('}'))
+            .unwrap_or(source)
+            .to_string();
         if is_do_while {
             trimmed.insert(0, ' ');
         }
@@ -1494,6 +1502,9 @@ fn test() {
             None,
         ),
         ("if (foo) { bar() }", "if (foo)  bar() ", Some(serde_json::json!(["multi"]))),
+        // only the block's OWN braces are removed; an inner statement's braces survive
+        ("if (foo) {while(bar){}}", "if (foo) while(bar){}", Some(serde_json::json!(["multi"]))),
+        ("if (foo) {if(bar){}}", "if (foo) if(bar){}", Some(serde_json::json!(["multi"]))),
         (
             "if (foo) if (bar) { baz() }",
             "if (foo) if (bar)  baz() ",

--- a/crates/oxc_linter/src/rules/eslint/curly.rs
+++ b/crates/oxc_linter/src/rules/eslint/curly.rs
@@ -426,10 +426,6 @@ fn apply_rule_fix<'a>(
     let fixed = if should_have_braces {
         format!("{{{source}}}")
     } else {
-        // Strip only the block's own outer braces (one leading `{`, one trailing `}`).
-        // `trim_matches` would remove EVERY boundary brace, eating an inner statement's
-        // braces too — e.g. `if (x) {while(y){}}` -> `if (x) while(y)` (invalid: the
-        // `while` loses its body).
         let mut trimmed = source
             .strip_prefix('{')
             .and_then(|s| s.strip_suffix('}'))
@@ -1502,9 +1498,6 @@ fn test() {
             None,
         ),
         ("if (foo) { bar() }", "if (foo)  bar() ", Some(serde_json::json!(["multi"]))),
-        // only the block's OWN braces are removed; an inner statement's braces survive
-        ("if (foo) {while(bar){}}", "if (foo) while(bar){}", Some(serde_json::json!(["multi"]))),
-        ("if (foo) {if(bar){}}", "if (foo) if(bar){}", Some(serde_json::json!(["multi"]))),
         (
             "if (foo) if (bar) { baz() }",
             "if (foo) if (bar)  baz() ",
@@ -2086,6 +2079,8 @@ fn test() {
             None,
         ),
         ("if(I){if(t)s}þ", "if(I){if(t){s}}þ", None),
+        ("if (foo) {while(bar){}}", "if (foo) while(bar){}", Some(serde_json::json!(["multi"]))),
+        ("if (foo) {if(bar){}}", "if (foo) if(bar){}", Some(serde_json::json!(["multi"]))),
     ];
     Tester::new(Curly::NAME, Curly::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
 }


### PR DESCRIPTION
### Bug

When `curly` (`"multi"` mode) removes the braces of a single-statement block, it stripped them with `source.trim_matches('{' | '}')`, which removes **every** brace at the string boundaries. When the inner statement itself begins/ends with a brace, its braces are eaten too — producing invalid output:

```js
if (foo) {while(bar){}}  →  if (foo) while(bar)   // SyntaxError: `while` has no body
if (foo) {if(bar){}}     →  if (foo) if(bar)
```

### Fix

Strip exactly one leading `{` and one trailing `}` (the block's own braces), leaving inner braces intact:

```js
if (foo) {while(bar){}}  →  if (foo) while(bar){}
```

The block body's span always starts with `{` and ends with `}`, so this is precise; normal bodies (`if (foo) { bar() }` → `if (foo)  bar() `) are byte-identical to before.

### Test

`expect_fix` regression cases added for inner-brace statements (`while`/`if`). Existing cases unchanged.

Prepared with AI assistance.