### PR TITLE
chore(react_compiler): bump forked_react_compiler to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.6",
- "subtle",
 ]
 
 [[package]]
@@ -701,7 +700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -780,9 +779,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "forked_react_compiler"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6970d9da2347af882a10b88480d6b2f44caca55567d85c2b1fa35420b53c1cc"
+checksum = "ac2369cf719891033c9b17a8093c7cf83dbad40113d4a24513fe3d42e37050ea"
 dependencies = [
  "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
@@ -793,49 +792,59 @@ dependencies = [
  "forked_react_compiler_reactive_scopes",
  "forked_react_compiler_ssa",
  "forked_react_compiler_typeinference",
+ "forked_react_compiler_utils",
  "forked_react_compiler_validation",
  "indexmap",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "forked_react_compiler_ast"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f9465a3f9934ef1c1e76bdbab8e70c86b41016a8e7ca1b51fede63e47a6036"
+checksum = "daccd93f89b1bc808a485767928b80456711e2141e54722e478795c84e0d5c7b"
 dependencies = [
+ "forked_react_compiler_diagnostics",
+ "forked_react_compiler_utils",
  "indexmap",
+ "rustc-hash",
  "serde",
+ "serde-transcode",
  "serde_json",
 ]
 
 [[package]]
 name = "forked_react_compiler_diagnostics"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e282f5f7b9506e5055758e4ec9857cdc4873e530d3d381d3ecd0d0321e139ec"
+checksum = "8c3d5b1d76f01cd1cc64d016880380cada17c2e7e3fc2337ffd2db690cdb3b4e"
 dependencies = [
+ "rustc-hash",
  "serde",
 ]
 
 [[package]]
 name = "forked_react_compiler_hir"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df1312f02a4e7a90686a0fc301fb0dfb58a99cdf53a375922e65b8678dc9df7"
+checksum = "4668644f0b802b21e0a547e74cbf01dccb8f854c894800f9f1115fa5d0816383"
 dependencies = [
+ "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
+ "forked_react_compiler_utils",
  "indexmap",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "forked_react_compiler_inference"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9a5bd84db67b0958c414da69f38184fb60e7a55a63ce9f95b367497939b892"
+checksum = "b17f5d24f016fe5fab0b15e36fcaa54ef377a341dbcd747f1e4371e29acb3198"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
@@ -844,90 +853,101 @@ dependencies = [
  "forked_react_compiler_ssa",
  "forked_react_compiler_utils",
  "indexmap",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "forked_react_compiler_lowering"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036e4fb36420ed59df1f20a5bb4ae08b095e8e3e1e1c047b7ca4cb0abebd04d9"
+checksum = "6dc9d291addca587d64bc90b7d6e58fcd4ebc255aa9a97751e0058ba2a4c1dab"
 dependencies = [
  "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
+ "forked_react_compiler_utils",
  "indexmap",
+ "rustc-hash",
  "serde_json",
 ]
 
 [[package]]
 name = "forked_react_compiler_optimization"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ec9f8dfb36bcfab25f3f476ccdada95f55f1071e45d25f4549c7c3395aaffc"
+checksum = "717defb246a678ab851a46210d65e0c7604cc7944395d380338a3062924965c9"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
  "forked_react_compiler_lowering",
  "forked_react_compiler_ssa",
+ "forked_react_compiler_utils",
  "indexmap",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "forked_react_compiler_reactive_scopes"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc54d3b97369ae60549db1d7f792f585920ee451b09946a247cc25087eb384d"
+checksum = "928d6ae8021a1c8f5a32b20cf2ef4b20f76cf997ae753c4e958e896bcf64ae90"
 dependencies = [
  "forked_react_compiler_ast",
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
- "hmac",
+ "forked_react_compiler_utils",
+ "hmac-sha256",
  "indexmap",
+ "rustc-hash",
  "serde_json",
- "sha2",
 ]
 
 [[package]]
 name = "forked_react_compiler_ssa"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8edcb5fac346f6ad59478ca4b373a930bdc41fd073dccbb10ff69461bdc94423"
+checksum = "cd26c931f5a799188a2d7bb5960cfde048c91348a074876e49c9f7d6e8581d93"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
- "forked_react_compiler_lowering",
+ "forked_react_compiler_utils",
  "indexmap",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "forked_react_compiler_typeinference"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3191b89198d502e11f624a15086ba54ce2828ede7d56eb2b78650da7aef06c1"
+checksum = "4f603c0f89520b55e9c34fc6264df6f29bba60d7e94269f433dd13ba76c4d686"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
  "forked_react_compiler_ssa",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "forked_react_compiler_utils"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005055ef8bfe84dd5f766302bb39fc2d4a361c30abb8a49384d6aff9cc479028"
+checksum = "5390b90b48cf2aaab7e511009e10e6b8c2c5b750a8c873881b4014e4295cb128"
 dependencies = [
  "indexmap",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "forked_react_compiler_validation"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2699f361db2993828d9194af7f6942a8ae746a3688eb5847c70d28da672f4269"
+checksum = "7801bd3359181d53a99a06c43f76943f56736814f3dead0ce5fac9118391f18b"
 dependencies = [
  "forked_react_compiler_diagnostics",
  "forked_react_compiler_hir",
+ "forked_react_compiler_utils",
  "indexmap",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -1168,13 +1188,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
+name = "hmac-sha256"
+version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "http"
@@ -1716,7 +1733,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3306,7 +3323,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3401,7 +3418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3430,6 +3447,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-transcode"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3696,7 +3722,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4225,7 +4251,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -39,9 +39,9 @@ oxc_syntax = { workspace = true }
 
 # React Compiler core crates — frontend-agnostic (no oxc deps). Published fork of
 # the React Compiler (MIT). `package` keeps the in-code name `react_compiler*`.
-react_compiler = { package = "forked_react_compiler", version = "0.1.4" }
-react_compiler_ast = { package = "forked_react_compiler_ast", version = "0.1.4" }
-react_compiler_hir = { package = "forked_react_compiler_hir", version = "0.1.4" }
+react_compiler = { package = "forked_react_compiler", version = "0.2.0" }
+react_compiler_ast = { package = "forked_react_compiler_ast", version = "0.2.0" }
+react_compiler_hir = { package = "forked_react_compiler_hir", version = "0.2.0" }
 
 indexmap = { workspace = true, features = ["serde"] }
 rustc-hash = { workspace = true }

--- a/crates/oxc_react_compiler/src/convert_ast.rs
+++ b/crates/oxc_react_compiler/src/convert_ast.rs
@@ -15,6 +15,7 @@ use react_compiler_ast::common::BaseNode;
 use react_compiler_ast::common::Comment;
 use react_compiler_ast::common::CommentData;
 use react_compiler_ast::common::Position;
+use react_compiler_ast::common::RawNode;
 use react_compiler_ast::common::SourceLocation;
 use react_compiler_ast::declarations::*;
 use react_compiler_ast::expressions::*;
@@ -166,19 +167,19 @@ impl<'a> ConvertCtx<'a> {
     fn convert_ts_type_annotation_json(
         &self,
         type_annotation: &oxc::TSTypeAnnotation,
-    ) -> Box<serde_json::Value> {
+    ) -> RawNode {
         let mut obj = self.make_typed_json_base("TSTypeAnnotation", type_annotation.span);
         obj.insert(
             "typeAnnotation".to_string(),
             self.convert_ts_type_json_value(&type_annotation.type_annotation),
         );
-        Box::new(serde_json::Value::Object(obj))
+        RawNode::from_value(&serde_json::Value::Object(obj))
     }
 
     fn convert_ts_type_parameter_instantiation_json(
         &self,
         type_arguments: &oxc::TSTypeParameterInstantiation,
-    ) -> Box<serde_json::Value> {
+    ) -> RawNode {
         let mut obj =
             self.make_typed_json_base("TSTypeParameterInstantiation", type_arguments.span);
         obj.insert(
@@ -191,11 +192,11 @@ impl<'a> ConvertCtx<'a> {
                     .collect(),
             ),
         );
-        Box::new(serde_json::Value::Object(obj))
+        RawNode::from_value(&serde_json::Value::Object(obj))
     }
 
-    fn convert_ts_type_json(&self, ty: &oxc::TSType) -> Box<serde_json::Value> {
-        Box::new(self.convert_ts_type_json_value(ty))
+    fn convert_ts_type_json(&self, ty: &oxc::TSType) -> RawNode {
+        RawNode::from_value(&self.convert_ts_type_json_value(ty))
     }
 
     fn convert_ts_type_json_value(&self, ty: &oxc::TSType) -> serde_json::Value {
@@ -269,7 +270,7 @@ impl<'a> ConvertCtx<'a> {
                 if let Some(type_arguments) = &reference.type_arguments {
                     obj.insert(
                         "typeParameters".to_string(),
-                        *self.convert_ts_type_parameter_instantiation_json(type_arguments),
+                        self.convert_ts_type_parameter_instantiation_json(type_arguments).parse_value(),
                     );
                 }
             }
@@ -281,7 +282,7 @@ impl<'a> ConvertCtx<'a> {
                 if let Some(type_arguments) = &query.type_arguments {
                     obj.insert(
                         "typeParameters".to_string(),
-                        *self.convert_ts_type_parameter_instantiation_json(type_arguments),
+                        self.convert_ts_type_parameter_instantiation_json(type_arguments).parse_value(),
                     );
                 }
             }
@@ -888,7 +889,7 @@ impl<'a> ConvertCtx<'a> {
             type_parameters: func
                 .type_parameters
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
             predicate: None,
             component_declaration: false,
             hook_declaration: false,
@@ -902,7 +903,9 @@ impl<'a> ConvertCtx<'a> {
             params: self
                 .convert_formal_parameters(&func.params)
                 .into_iter()
-                .map(|param| serde_json::to_value(param).unwrap_or(serde_json::Value::Null))
+                .map(|param| {
+                    RawNode::from_value(&serde_json::to_value(param).unwrap_or(serde_json::Value::Null))
+                })
                 .collect(),
             is_async: if func.r#async { Some(true) } else { None },
             declare: if func.declare { Some(true) } else { None },
@@ -911,7 +914,7 @@ impl<'a> ConvertCtx<'a> {
             type_parameters: func
                 .type_parameters
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
         }
     }
 
@@ -922,28 +925,28 @@ impl<'a> ConvertCtx<'a> {
             super_class: class.super_class.as_ref().map(|s| Box::new(self.convert_expression(s))),
             body: ClassBody {
                 base: self.make_base_node(class.body.span),
-                body: class.body.body.iter().map(|_item| serde_json::Value::Null).collect(),
+                body: class.body.body.iter().map(|_item| RawNode::null()).collect(),
             },
             decorators: if class.decorators.is_empty() {
                 None
             } else {
-                Some(class.decorators.iter().map(|_d| serde_json::Value::Null).collect())
+                Some(class.decorators.iter().map(|_d| RawNode::null()).collect())
             },
             is_abstract: if class.r#abstract { Some(true) } else { None },
             declare: if class.declare { Some(true) } else { None },
             implements: if class.implements.is_empty() {
                 None
             } else {
-                Some(class.implements.iter().map(|_i| serde_json::Value::Null).collect())
+                Some(class.implements.iter().map(|_i| RawNode::null()).collect())
             },
             super_type_parameters: class
                 .super_type_arguments
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
             type_parameters: class
                 .type_parameters
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
             mixins: None,
         }
     }
@@ -963,7 +966,7 @@ impl<'a> ConvertCtx<'a> {
                 .unwrap_or_default(),
             source: StringLiteral {
                 base: self.make_base_node(import.source.span),
-                value: import.source.value.to_string(),
+                value: import.source.value.to_string().into(),
             },
             import_kind: match import.import_kind {
                 oxc::ImportOrExportKind::Value => None,
@@ -1024,7 +1027,7 @@ impl<'a> ConvertCtx<'a> {
             key: self.convert_import_attribute_key(&attr.key),
             value: StringLiteral {
                 base: self.make_base_node(attr.value.span),
-                value: attr.value.value.to_string(),
+                value: attr.value.value.to_string().into(),
             },
         }
     }
@@ -1059,7 +1062,7 @@ impl<'a> ConvertCtx<'a> {
             oxc::ModuleExportName::StringLiteral(s) => {
                 ModuleExportName::StringLiteral(StringLiteral {
                     base: self.make_base_node(s.span),
-                    value: s.value.to_string(),
+                    value: s.value.to_string().into(),
                 })
             }
         }
@@ -1073,7 +1076,7 @@ impl<'a> ConvertCtx<'a> {
             base: self.make_base_node(export.span),
             source: StringLiteral {
                 base: self.make_base_node(export.source.span),
-                value: export.source.value.to_string(),
+                value: export.source.value.to_string().into(),
             },
             export_kind: match export.export_kind {
                 oxc::ImportOrExportKind::Value => None,
@@ -1201,7 +1204,7 @@ impl<'a> ConvertCtx<'a> {
                 .collect(),
             source: export.source.as_ref().map(|s| StringLiteral {
                 base: self.make_base_node(s.span),
-                value: s.value.to_string(),
+                value: s.value.to_string().into(),
             }),
             export_kind: match export.export_kind {
                 oxc::ImportOrExportKind::Value => None,
@@ -1249,7 +1252,7 @@ impl<'a> ConvertCtx<'a> {
             type_parameters: type_alias
                 .type_parameters
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
             declare: if type_alias.declare { Some(true) } else { None },
         }
     }
@@ -1261,15 +1264,15 @@ impl<'a> ConvertCtx<'a> {
         TSInterfaceDeclaration {
             base: self.make_base_node(interface.span),
             id: self.convert_binding_identifier(&interface.id),
-            body: Box::new(serde_json::Value::Null),
+            body: RawNode::null(),
             type_parameters: interface
                 .type_parameters
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
             extends: if interface.extends.is_empty() {
                 None
             } else {
-                Some(interface.extends.iter().map(|_e| serde_json::Value::Null).collect())
+                Some(interface.extends.iter().map(|_e| RawNode::null()).collect())
             },
             declare: if interface.declare { Some(true) } else { None },
         }
@@ -1279,7 +1282,7 @@ impl<'a> ConvertCtx<'a> {
         TSEnumDeclaration {
             base: self.make_base_node(ts_enum.span),
             id: self.convert_binding_identifier(&ts_enum.id),
-            members: ts_enum.body.members.iter().map(|_m| serde_json::Value::Null).collect(),
+            members: ts_enum.body.members.iter().map(|_m| RawNode::null()).collect(),
             declare: if ts_enum.declare { Some(true) } else { None },
             is_const: if ts_enum.r#const { Some(true) } else { None },
         }
@@ -1291,8 +1294,8 @@ impl<'a> ConvertCtx<'a> {
     ) -> TSModuleDeclaration {
         TSModuleDeclaration {
             base: self.make_base_node(module.span),
-            id: Box::new(serde_json::Value::Null),
-            body: Box::new(serde_json::Value::Null),
+            id: RawNode::null(),
+            body: RawNode::null(),
             declare: if module.declare { Some(true) } else { None },
             global: None,
         }
@@ -1309,8 +1312,8 @@ impl<'a> ConvertCtx<'a> {
     fn convert_ts_declaration_passthrough(&self, span: Span, global: bool) -> TSModuleDeclaration {
         TSModuleDeclaration {
             base: self.make_base_node(span),
-            id: Box::new(serde_json::Value::Null),
-            body: Box::new(serde_json::Value::Null),
+            id: RawNode::null(),
+            body: RawNode::null(),
             declare: None,
             global: if global { Some(true) } else { None },
         }
@@ -1340,7 +1343,7 @@ impl<'a> ConvertCtx<'a> {
             }),
             oxc::Expression::StringLiteral(s) => Expression::StringLiteral(StringLiteral {
                 base: self.make_base_node(s.span),
-                value: s.value.to_string(),
+                value: s.value.to_string().into(),
             }),
             oxc::Expression::TemplateLiteral(t) => {
                 Expression::TemplateLiteral(self.convert_template_literal(t))
@@ -1578,7 +1581,7 @@ impl<'a> ConvertCtx<'a> {
             type_parameters: arrow
                 .type_parameters
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
             predicate: None,
         }
     }
@@ -1945,7 +1948,7 @@ impl<'a> ConvertCtx<'a> {
             type_parameters: call
                 .type_arguments
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
             type_arguments: None,
             optional: if call.optional { Some(true) } else { None },
         }
@@ -1973,7 +1976,7 @@ impl<'a> ConvertCtx<'a> {
                     type_parameters: c
                         .type_arguments
                         .as_ref()
-                        .map(|_t| Box::new(serde_json::Value::Null)),
+                        .map(|_t| RawNode::null()),
                     type_arguments: None,
                 })
             }
@@ -2064,7 +2067,7 @@ impl<'a> ConvertCtx<'a> {
                     type_parameters: c
                         .type_arguments
                         .as_ref()
-                        .map(|_t| Box::new(serde_json::Value::Null)),
+                        .map(|_t| RawNode::null()),
                     type_arguments: None,
                 })
             }
@@ -2102,7 +2105,7 @@ impl<'a> ConvertCtx<'a> {
                     type_parameters: c
                         .type_arguments
                         .as_ref()
-                        .map(|_t| Box::new(serde_json::Value::Null)),
+                        .map(|_t| RawNode::null()),
                     type_arguments: None,
                 })
             }
@@ -2143,26 +2146,26 @@ impl<'a> ConvertCtx<'a> {
             super_class: class.super_class.as_ref().map(|s| Box::new(self.convert_expression(s))),
             body: ClassBody {
                 base: self.make_base_node(class.body.span),
-                body: class.body.body.iter().map(|_item| serde_json::Value::Null).collect(),
+                body: class.body.body.iter().map(|_item| RawNode::null()).collect(),
             },
             decorators: if class.decorators.is_empty() {
                 None
             } else {
-                Some(class.decorators.iter().map(|_d| serde_json::Value::Null).collect())
+                Some(class.decorators.iter().map(|_d| RawNode::null()).collect())
             },
             implements: if class.implements.is_empty() {
                 None
             } else {
-                Some(class.implements.iter().map(|_i| serde_json::Value::Null).collect())
+                Some(class.implements.iter().map(|_i| RawNode::null()).collect())
             },
             super_type_parameters: class
                 .super_type_arguments
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
             type_parameters: class
                 .type_parameters
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
         }
     }
 
@@ -2194,7 +2197,7 @@ impl<'a> ConvertCtx<'a> {
             type_parameters: func
                 .type_parameters
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
             predicate: None,
         }
     }
@@ -2224,7 +2227,7 @@ impl<'a> ConvertCtx<'a> {
             type_parameters: new
                 .type_arguments
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
             type_arguments: None,
         }
     }
@@ -2284,7 +2287,7 @@ impl<'a> ConvertCtx<'a> {
                             type_parameters: func
                                 .type_parameters
                                 .as_ref()
-                                .map(|_| Box::new(serde_json::Value::Null)),
+                                .map(|_| RawNode::null()),
                             predicate: None,
                         });
                     }
@@ -2359,7 +2362,7 @@ impl<'a> ConvertCtx<'a> {
             type_parameters: tagged
                 .type_arguments
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
         }
     }
 
@@ -2564,7 +2567,7 @@ impl<'a> ConvertCtx<'a> {
             type_parameters: opening
                 .type_arguments
                 .as_ref()
-                .map(|_t| Box::new(serde_json::Value::Null)),
+                .map(|_t| RawNode::null()),
         }
     }
 
@@ -2700,7 +2703,7 @@ impl<'a> ConvertCtx<'a> {
             oxc::JSXAttributeValue::StringLiteral(s) => {
                 JSXAttributeValue::StringLiteral(StringLiteral {
                     base: self.make_base_node(s.span),
-                    value: decode_jsx_entities(s.value.as_str()),
+                    value: decode_jsx_entities(s.value.as_str()).into(),
                 })
             }
             oxc::JSXAttributeValue::ExpressionContainer(e) => {
@@ -2935,7 +2938,7 @@ impl<'a> ConvertCtx<'a> {
 
     fn set_pattern_type_annotation(
         pattern: &mut PatternLike,
-        type_annotation: Box<serde_json::Value>,
+        type_annotation: RawNode,
     ) {
         match pattern {
             PatternLike::Identifier(id) => {
@@ -3074,7 +3077,7 @@ macro_rules! impl_expression_like {
                     }),
                     Self::StringLiteral(e) => Expression::StringLiteral(StringLiteral {
                         base: ctx.make_base_node(e.span),
-                        value: e.value.to_string(),
+                        value: e.value.to_string().into(),
                     }),
                     Self::TemplateLiteral(e) => Expression::TemplateLiteral(ctx.convert_template_literal(e)),
                     Self::Identifier(e) => Expression::Identifier(ctx.convert_identifier_reference(e)),

--- a/crates/oxc_react_compiler/src/convert_ast.rs
+++ b/crates/oxc_react_compiler/src/convert_ast.rs
@@ -164,10 +164,7 @@ impl<'a> ConvertCtx<'a> {
         obj
     }
 
-    fn convert_ts_type_annotation_json(
-        &self,
-        type_annotation: &oxc::TSTypeAnnotation,
-    ) -> RawNode {
+    fn convert_ts_type_annotation_json(&self, type_annotation: &oxc::TSTypeAnnotation) -> RawNode {
         let mut obj = self.make_typed_json_base("TSTypeAnnotation", type_annotation.span);
         obj.insert(
             "typeAnnotation".to_string(),
@@ -270,7 +267,8 @@ impl<'a> ConvertCtx<'a> {
                 if let Some(type_arguments) = &reference.type_arguments {
                     obj.insert(
                         "typeParameters".to_string(),
-                        self.convert_ts_type_parameter_instantiation_json(type_arguments).parse_value(),
+                        self.convert_ts_type_parameter_instantiation_json(type_arguments)
+                            .parse_value(),
                     );
                 }
             }
@@ -282,7 +280,8 @@ impl<'a> ConvertCtx<'a> {
                 if let Some(type_arguments) = &query.type_arguments {
                     obj.insert(
                         "typeParameters".to_string(),
-                        self.convert_ts_type_parameter_instantiation_json(type_arguments).parse_value(),
+                        self.convert_ts_type_parameter_instantiation_json(type_arguments)
+                            .parse_value(),
                     );
                 }
             }
@@ -886,10 +885,7 @@ impl<'a> ConvertCtx<'a> {
             is_async: func.r#async,
             declare: if func.declare { Some(true) } else { None },
             return_type: func.return_type.as_ref().map(|t| self.convert_ts_type_annotation_json(t)),
-            type_parameters: func
-                .type_parameters
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            type_parameters: func.type_parameters.as_ref().map(|_t| RawNode::null()),
             predicate: None,
             component_declaration: false,
             hook_declaration: false,
@@ -904,17 +900,16 @@ impl<'a> ConvertCtx<'a> {
                 .convert_formal_parameters(&func.params)
                 .into_iter()
                 .map(|param| {
-                    RawNode::from_value(&serde_json::to_value(param).unwrap_or(serde_json::Value::Null))
+                    RawNode::from_value(
+                        &serde_json::to_value(param).unwrap_or(serde_json::Value::Null),
+                    )
                 })
                 .collect(),
             is_async: if func.r#async { Some(true) } else { None },
             declare: if func.declare { Some(true) } else { None },
             generator: if func.generator { Some(true) } else { None },
             return_type: func.return_type.as_ref().map(|t| self.convert_ts_type_annotation_json(t)),
-            type_parameters: func
-                .type_parameters
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            type_parameters: func.type_parameters.as_ref().map(|_t| RawNode::null()),
         }
     }
 
@@ -939,14 +934,8 @@ impl<'a> ConvertCtx<'a> {
             } else {
                 Some(class.implements.iter().map(|_i| RawNode::null()).collect())
             },
-            super_type_parameters: class
-                .super_type_arguments
-                .as_ref()
-                .map(|_t| RawNode::null()),
-            type_parameters: class
-                .type_parameters
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            super_type_parameters: class.super_type_arguments.as_ref().map(|_t| RawNode::null()),
+            type_parameters: class.type_parameters.as_ref().map(|_t| RawNode::null()),
             mixins: None,
         }
     }
@@ -1249,10 +1238,7 @@ impl<'a> ConvertCtx<'a> {
             base: self.make_base_node(type_alias.span),
             id: self.convert_binding_identifier(&type_alias.id),
             type_annotation: self.convert_ts_type_json(&type_alias.type_annotation),
-            type_parameters: type_alias
-                .type_parameters
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            type_parameters: type_alias.type_parameters.as_ref().map(|_t| RawNode::null()),
             declare: if type_alias.declare { Some(true) } else { None },
         }
     }
@@ -1265,10 +1251,7 @@ impl<'a> ConvertCtx<'a> {
             base: self.make_base_node(interface.span),
             id: self.convert_binding_identifier(&interface.id),
             body: RawNode::null(),
-            type_parameters: interface
-                .type_parameters
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            type_parameters: interface.type_parameters.as_ref().map(|_t| RawNode::null()),
             extends: if interface.extends.is_empty() {
                 None
             } else {
@@ -1578,10 +1561,7 @@ impl<'a> ConvertCtx<'a> {
                 .return_type
                 .as_ref()
                 .map(|t| self.convert_ts_type_annotation_json(t)),
-            type_parameters: arrow
-                .type_parameters
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            type_parameters: arrow.type_parameters.as_ref().map(|_t| RawNode::null()),
             predicate: None,
         }
     }
@@ -1945,10 +1925,7 @@ impl<'a> ConvertCtx<'a> {
             base: self.make_base_node(call.span),
             callee: Box::new(self.convert_expression(&call.callee)),
             arguments: call.arguments.iter().map(|a| self.convert_argument(a)).collect(),
-            type_parameters: call
-                .type_arguments
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            type_parameters: call.type_arguments.as_ref().map(|_t| RawNode::null()),
             type_arguments: None,
             optional: if call.optional { Some(true) } else { None },
         }
@@ -1973,10 +1950,7 @@ impl<'a> ConvertCtx<'a> {
                     callee: Box::new(self.convert_expression_in_chain(&c.callee)),
                     arguments: c.arguments.iter().map(|a| self.convert_argument(a)).collect(),
                     optional: c.optional,
-                    type_parameters: c
-                        .type_arguments
-                        .as_ref()
-                        .map(|_t| RawNode::null()),
+                    type_parameters: c.type_arguments.as_ref().map(|_t| RawNode::null()),
                     type_arguments: None,
                 })
             }
@@ -2064,10 +2038,7 @@ impl<'a> ConvertCtx<'a> {
                     callee: Box::new(self.convert_expression_in_chain(&c.callee)),
                     arguments: c.arguments.iter().map(|a| self.convert_argument(a)).collect(),
                     optional: true,
-                    type_parameters: c
-                        .type_arguments
-                        .as_ref()
-                        .map(|_t| RawNode::null()),
+                    type_parameters: c.type_arguments.as_ref().map(|_t| RawNode::null()),
                     type_arguments: None,
                 })
             }
@@ -2102,10 +2073,7 @@ impl<'a> ConvertCtx<'a> {
                     callee: Box::new(self.convert_expression_in_chain(&c.callee)),
                     arguments: c.arguments.iter().map(|a| self.convert_argument(a)).collect(),
                     optional: false,
-                    type_parameters: c
-                        .type_arguments
-                        .as_ref()
-                        .map(|_t| RawNode::null()),
+                    type_parameters: c.type_arguments.as_ref().map(|_t| RawNode::null()),
                     type_arguments: None,
                 })
             }
@@ -2158,14 +2126,8 @@ impl<'a> ConvertCtx<'a> {
             } else {
                 Some(class.implements.iter().map(|_i| RawNode::null()).collect())
             },
-            super_type_parameters: class
-                .super_type_arguments
-                .as_ref()
-                .map(|_t| RawNode::null()),
-            type_parameters: class
-                .type_parameters
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            super_type_parameters: class.super_type_arguments.as_ref().map(|_t| RawNode::null()),
+            type_parameters: class.type_parameters.as_ref().map(|_t| RawNode::null()),
         }
     }
 
@@ -2194,10 +2156,7 @@ impl<'a> ConvertCtx<'a> {
             generator: func.generator,
             is_async: func.r#async,
             return_type: func.return_type.as_ref().map(|t| self.convert_ts_type_annotation_json(t)),
-            type_parameters: func
-                .type_parameters
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            type_parameters: func.type_parameters.as_ref().map(|_t| RawNode::null()),
             predicate: None,
         }
     }
@@ -2224,10 +2183,7 @@ impl<'a> ConvertCtx<'a> {
             base: self.make_base_node(new.span),
             callee: Box::new(self.convert_expression(&new.callee)),
             arguments: new.arguments.iter().map(|a| self.convert_argument(a)).collect(),
-            type_parameters: new
-                .type_arguments
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            type_parameters: new.type_arguments.as_ref().map(|_t| RawNode::null()),
             type_arguments: None,
         }
     }
@@ -2284,10 +2240,7 @@ impl<'a> ConvertCtx<'a> {
                                 .return_type
                                 .as_ref()
                                 .map(|t| self.convert_ts_type_annotation_json(t)),
-                            type_parameters: func
-                                .type_parameters
-                                .as_ref()
-                                .map(|_| RawNode::null()),
+                            type_parameters: func.type_parameters.as_ref().map(|_| RawNode::null()),
                             predicate: None,
                         });
                     }
@@ -2359,10 +2312,7 @@ impl<'a> ConvertCtx<'a> {
             base: self.make_base_node(tagged.span),
             tag: Box::new(self.convert_expression(&tagged.tag)),
             quasi: self.convert_template_literal(&tagged.quasi),
-            type_parameters: tagged
-                .type_arguments
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            type_parameters: tagged.type_arguments.as_ref().map(|_t| RawNode::null()),
         }
     }
 
@@ -2564,10 +2514,7 @@ impl<'a> ConvertCtx<'a> {
                 .map(|a| self.convert_jsx_attribute_item(a))
                 .collect(),
             self_closing: false, // Will be set properly at JSXElement level if needed
-            type_parameters: opening
-                .type_arguments
-                .as_ref()
-                .map(|_t| RawNode::null()),
+            type_parameters: opening.type_arguments.as_ref().map(|_t| RawNode::null()),
         }
     }
 
@@ -2936,10 +2883,7 @@ impl<'a> ConvertCtx<'a> {
         pattern
     }
 
-    fn set_pattern_type_annotation(
-        pattern: &mut PatternLike,
-        type_annotation: RawNode,
-    ) {
+    fn set_pattern_type_annotation(pattern: &mut PatternLike, type_annotation: RawNode) {
         match pattern {
             PatternLike::Identifier(id) => {
                 id.type_annotation = Some(type_annotation);

--- a/crates/oxc_react_compiler/src/convert_ast_reverse.rs
+++ b/crates/oxc_react_compiler/src/convert_ast_reverse.rs
@@ -1334,7 +1334,7 @@ impl<'a> ReverseCtx<'a> {
                 self.builder.expression_identifier(SPAN, self.atom(&id.name))
             }
             Expression::StringLiteral(lit) => {
-                self.builder.expression_string_literal(SPAN, self.atom(&lit.value), None)
+                self.builder.expression_string_literal(SPAN, self.atom(&lit.value.to_string_lossy()), None)
             }
             Expression::NumericLiteral(lit) => self.builder.expression_numeric_literal(
                 SPAN,
@@ -1544,9 +1544,10 @@ impl<'a> ReverseCtx<'a> {
             // expression and recover only the type from the original source.
             Expression::TSAsExpression(e) => {
                 let expression = self.convert_expression(&e.expression);
+                let parsed_type = e.type_annotation.parse_value();
                 let type_annotation =
-                    self.convert_ts_type_from_json(&e.type_annotation).or_else(|| {
-                        if Self::ts_type_json_contains_type_query(&e.type_annotation) {
+                    self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+                        if Self::ts_type_json_contains_type_query(&parsed_type) {
                             None
                         } else {
                             self.extract_source_ts_as_type(&e.base)
@@ -1560,9 +1561,10 @@ impl<'a> ReverseCtx<'a> {
             }
             Expression::TSSatisfiesExpression(e) => {
                 let expression = self.convert_expression(&e.expression);
+                let parsed_type = e.type_annotation.parse_value();
                 let type_annotation =
-                    self.convert_ts_type_from_json(&e.type_annotation).or_else(|| {
-                        if Self::ts_type_json_contains_type_query(&e.type_annotation) {
+                    self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+                        if Self::ts_type_json_contains_type_query(&parsed_type) {
                             None
                         } else {
                             self.extract_source_ts_satisfies_type(&e.base)
@@ -1579,9 +1581,10 @@ impl<'a> ReverseCtx<'a> {
             }
             Expression::TSTypeAssertion(e) => {
                 let expression = self.convert_expression(&e.expression);
+                let parsed_type = e.type_annotation.parse_value();
                 let type_annotation =
-                    self.convert_ts_type_from_json(&e.type_annotation).or_else(|| {
-                        if Self::ts_type_json_contains_type_query(&e.type_annotation) {
+                    self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+                        if Self::ts_type_json_contains_type_query(&parsed_type) {
                             None
                         } else {
                             self.extract_source_ts_type_assertion_type(&e.base)
@@ -1855,7 +1858,7 @@ impl<'a> ReverseCtx<'a> {
                 self.builder.property_key_static_identifier(SPAN, self.atom(&id.name))
             }
             Expression::StringLiteral(s) => {
-                let lit = self.builder.string_literal(SPAN, self.atom(&s.value), None);
+                let lit = self.builder.string_literal(SPAN, self.atom(&s.value.to_string_lossy()), None);
                 oxc::PropertyKey::StringLiteral(self.builder.alloc(lit))
             }
             Expression::NumericLiteral(n) => {
@@ -1971,8 +1974,8 @@ impl<'a> ReverseCtx<'a> {
             None
         } else {
             f.return_type
-                .as_deref()
-                .and_then(|value| self.convert_ts_type_annotation_from_json(value))
+                .as_ref()
+                .and_then(|value| self.convert_ts_type_annotation_from_json(&value.parse_value()))
         };
         let mut func = self.builder.function(
             SPAN,
@@ -2003,8 +2006,8 @@ impl<'a> ReverseCtx<'a> {
             None
         } else {
             m.return_type
-                .as_deref()
-                .and_then(|value| self.convert_ts_type_annotation_from_json(value))
+                .as_ref()
+                .and_then(|value| self.convert_ts_type_annotation_from_json(&value.parse_value()))
         };
         let mut func = self.builder.function(
             SPAN,
@@ -2056,8 +2059,8 @@ impl<'a> ReverseCtx<'a> {
             } else {
                 arrow
                     .return_type
-                    .as_deref()
-                    .and_then(|value| self.convert_ts_type_annotation_from_json(value))
+                    .as_ref()
+                    .and_then(|value| self.convert_ts_type_annotation_from_json(&value.parse_value()))
             },
             body,
         );
@@ -2089,8 +2092,8 @@ impl<'a> ReverseCtx<'a> {
                     let rest_elem = self.builder.binding_rest_element(SPAN, arg);
                     let type_annotation = r
                         .type_annotation
-                        .as_deref()
-                        .and_then(|value| self.convert_ts_type_annotation_from_json(value));
+                        .as_ref()
+                        .and_then(|value| self.convert_ts_type_annotation_from_json(&value.parse_value()));
                     rest = Some(self.builder.formal_parameter_rest(
                         SPAN,
                         self.builder.vec(),
@@ -2172,11 +2175,11 @@ impl<'a> ReverseCtx<'a> {
         pattern: &PatternLike,
     ) -> Option<ArenaBox<'a, oxc::TSTypeAnnotation<'a>>> {
         let value = match pattern {
-            PatternLike::Identifier(id) => id.type_annotation.as_deref(),
-            PatternLike::ObjectPattern(obj) => obj.type_annotation.as_deref(),
-            PatternLike::ArrayPattern(arr) => arr.type_annotation.as_deref(),
-            PatternLike::AssignmentPattern(assign) => assign.type_annotation.as_deref(),
-            PatternLike::RestElement(rest) => rest.type_annotation.as_deref(),
+            PatternLike::Identifier(id) => id.type_annotation.as_ref(),
+            PatternLike::ObjectPattern(obj) => obj.type_annotation.as_ref(),
+            PatternLike::ArrayPattern(arr) => arr.type_annotation.as_ref(),
+            PatternLike::AssignmentPattern(assign) => assign.type_annotation.as_ref(),
+            PatternLike::RestElement(rest) => rest.type_annotation.as_ref(),
             PatternLike::MemberExpression(_)
             | PatternLike::TSAsExpression(_)
             | PatternLike::TSSatisfiesExpression(_)
@@ -2184,7 +2187,7 @@ impl<'a> ReverseCtx<'a> {
             | PatternLike::TSTypeAssertion(_)
             | PatternLike::TypeCastExpression(_) => None,
         }?;
-        self.convert_ts_type_annotation_from_json(value)
+        self.convert_ts_type_annotation_from_json(&value.parse_value())
     }
 
     // ===== Patterns → BindingPattern =====
@@ -2462,9 +2465,10 @@ impl<'a> ReverseCtx<'a> {
         expr: &TSAsExpression,
     ) -> oxc::SimpleAssignmentTarget<'a> {
         let expression = self.convert_expression(&expr.expression);
+        let parsed_type = expr.type_annotation.parse_value();
         if let Some(type_annotation) =
-            self.convert_ts_type_from_json(&expr.type_annotation).or_else(|| {
-                if Self::ts_type_json_contains_type_query(&expr.type_annotation) {
+            self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+                if Self::ts_type_json_contains_type_query(&parsed_type) {
                     None
                 } else {
                     self.extract_source_ts_as_type(&expr.base)
@@ -2486,9 +2490,10 @@ impl<'a> ReverseCtx<'a> {
         expr: &TSSatisfiesExpression,
     ) -> oxc::SimpleAssignmentTarget<'a> {
         let expression = self.convert_expression(&expr.expression);
+        let parsed_type = expr.type_annotation.parse_value();
         if let Some(type_annotation) =
-            self.convert_ts_type_from_json(&expr.type_annotation).or_else(|| {
-                if Self::ts_type_json_contains_type_query(&expr.type_annotation) {
+            self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+                if Self::ts_type_json_contains_type_query(&parsed_type) {
                     None
                 } else {
                     self.extract_source_ts_satisfies_type(&expr.base)
@@ -2518,9 +2523,10 @@ impl<'a> ReverseCtx<'a> {
         expr: &TSTypeAssertion,
     ) -> oxc::SimpleAssignmentTarget<'a> {
         let expression = self.convert_expression(&expr.expression);
+        let parsed_type = expr.type_annotation.parse_value();
         if let Some(type_annotation) =
-            self.convert_ts_type_from_json(&expr.type_annotation).or_else(|| {
-                if Self::ts_type_json_contains_type_query(&expr.type_annotation) {
+            self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+                if Self::ts_type_json_contains_type_query(&parsed_type) {
                     None
                 } else {
                     self.extract_source_ts_type_assertion_type(&expr.base)
@@ -2650,7 +2656,7 @@ impl<'a> ReverseCtx<'a> {
     fn convert_jsx_attribute_value(&self, value: &JSXAttributeValue) -> oxc::JSXAttributeValue<'a> {
         match value {
             JSXAttributeValue::StringLiteral(s) => {
-                self.builder.jsx_attribute_value_string_literal(SPAN, self.atom(&s.value), None)
+                self.builder.jsx_attribute_value_string_literal(SPAN, self.atom(&s.value.to_string_lossy()), None)
             }
             JSXAttributeValue::JSXExpressionContainer(ec) => {
                 let expr = self.convert_jsx_expression_container_expr(&ec.expression);
@@ -2739,7 +2745,7 @@ impl<'a> ReverseCtx<'a> {
             } else {
                 Some(specifiers)
             };
-        let source = self.builder.string_literal(SPAN, self.atom(&decl.source.value), None);
+        let source = self.builder.string_literal(SPAN, self.atom(&decl.source.value.to_string_lossy()), None);
         let import_kind = match decl.import_kind.as_ref() {
             Some(ImportKind::Type) => oxc::ImportOrExportKind::Type,
             _ => oxc::ImportOrExportKind::Value,
@@ -2777,7 +2783,7 @@ impl<'a> ReverseCtx<'a> {
         } else {
             self.builder.import_attribute_key_identifier(SPAN, self.atom(&attr.key.name))
         };
-        let value = self.builder.string_literal(SPAN, self.atom(&attr.value.value), None);
+        let value = self.builder.string_literal(SPAN, self.atom(&attr.value.value.to_string_lossy()), None);
         self.builder.import_attribute(SPAN, key, value)
     }
 
@@ -2822,7 +2828,7 @@ impl<'a> ReverseCtx<'a> {
             react_compiler_ast::declarations::ModuleExportName::StringLiteral(s) => {
                 oxc::ModuleExportName::StringLiteral(self.builder.string_literal(
                     SPAN,
-                    self.atom(&s.value),
+                    self.atom(&s.value.to_string_lossy()),
                     None,
                 ))
             }
@@ -2868,7 +2874,7 @@ impl<'a> ReverseCtx<'a> {
         let source = decl
             .source
             .as_ref()
-            .map(|s| self.builder.string_literal(SPAN, self.atom(&s.value), None));
+            .map(|s| self.builder.string_literal(SPAN, self.atom(&s.value.to_string_lossy()), None));
         let export_kind = match decl.export_kind.as_ref() {
             Some(ExportKind::Type) => oxc::ImportOrExportKind::Type,
             _ => oxc::ImportOrExportKind::Value,
@@ -2992,7 +2998,7 @@ impl<'a> ReverseCtx<'a> {
         &self,
         decl: &ExportAllDeclaration,
     ) -> oxc::ExportAllDeclaration<'a> {
-        let source = self.builder.string_literal(SPAN, self.atom(&decl.source.value), None);
+        let source = self.builder.string_literal(SPAN, self.atom(&decl.source.value.to_string_lossy()), None);
         let export_kind = match decl.export_kind.as_ref() {
             Some(ExportKind::Type) => oxc::ImportOrExportKind::Type,
             _ => oxc::ImportOrExportKind::Value,

--- a/crates/oxc_react_compiler/src/convert_ast_reverse.rs
+++ b/crates/oxc_react_compiler/src/convert_ast_reverse.rs
@@ -1333,9 +1333,11 @@ impl<'a> ReverseCtx<'a> {
             Expression::Identifier(id) => {
                 self.builder.expression_identifier(SPAN, self.atom(&id.name))
             }
-            Expression::StringLiteral(lit) => {
-                self.builder.expression_string_literal(SPAN, self.atom(&lit.value.to_string_lossy()), None)
-            }
+            Expression::StringLiteral(lit) => self.builder.expression_string_literal(
+                SPAN,
+                self.atom(&lit.value.to_string_lossy()),
+                None,
+            ),
             Expression::NumericLiteral(lit) => self.builder.expression_numeric_literal(
                 SPAN,
                 lit.value,
@@ -1545,14 +1547,13 @@ impl<'a> ReverseCtx<'a> {
             Expression::TSAsExpression(e) => {
                 let expression = self.convert_expression(&e.expression);
                 let parsed_type = e.type_annotation.parse_value();
-                let type_annotation =
-                    self.convert_ts_type_from_json(&parsed_type).or_else(|| {
-                        if Self::ts_type_json_contains_type_query(&parsed_type) {
-                            None
-                        } else {
-                            self.extract_source_ts_as_type(&e.base)
-                        }
-                    });
+                let type_annotation = self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+                    if Self::ts_type_json_contains_type_query(&parsed_type) {
+                        None
+                    } else {
+                        self.extract_source_ts_as_type(&e.base)
+                    }
+                });
                 if let Some(type_annotation) = type_annotation {
                     self.builder.expression_ts_as(SPAN, expression, type_annotation)
                 } else {
@@ -1562,14 +1563,13 @@ impl<'a> ReverseCtx<'a> {
             Expression::TSSatisfiesExpression(e) => {
                 let expression = self.convert_expression(&e.expression);
                 let parsed_type = e.type_annotation.parse_value();
-                let type_annotation =
-                    self.convert_ts_type_from_json(&parsed_type).or_else(|| {
-                        if Self::ts_type_json_contains_type_query(&parsed_type) {
-                            None
-                        } else {
-                            self.extract_source_ts_satisfies_type(&e.base)
-                        }
-                    });
+                let type_annotation = self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+                    if Self::ts_type_json_contains_type_query(&parsed_type) {
+                        None
+                    } else {
+                        self.extract_source_ts_satisfies_type(&e.base)
+                    }
+                });
                 if let Some(type_annotation) = type_annotation {
                     self.builder.expression_ts_satisfies(SPAN, expression, type_annotation)
                 } else {
@@ -1582,14 +1582,13 @@ impl<'a> ReverseCtx<'a> {
             Expression::TSTypeAssertion(e) => {
                 let expression = self.convert_expression(&e.expression);
                 let parsed_type = e.type_annotation.parse_value();
-                let type_annotation =
-                    self.convert_ts_type_from_json(&parsed_type).or_else(|| {
-                        if Self::ts_type_json_contains_type_query(&parsed_type) {
-                            None
-                        } else {
-                            self.extract_source_ts_type_assertion_type(&e.base)
-                        }
-                    });
+                let type_annotation = self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+                    if Self::ts_type_json_contains_type_query(&parsed_type) {
+                        None
+                    } else {
+                        self.extract_source_ts_type_assertion_type(&e.base)
+                    }
+                });
                 if let Some(type_annotation) = type_annotation {
                     self.builder.expression_ts_type_assertion(SPAN, type_annotation, expression)
                 } else {
@@ -1858,7 +1857,8 @@ impl<'a> ReverseCtx<'a> {
                 self.builder.property_key_static_identifier(SPAN, self.atom(&id.name))
             }
             Expression::StringLiteral(s) => {
-                let lit = self.builder.string_literal(SPAN, self.atom(&s.value.to_string_lossy()), None);
+                let lit =
+                    self.builder.string_literal(SPAN, self.atom(&s.value.to_string_lossy()), None);
                 oxc::PropertyKey::StringLiteral(self.builder.alloc(lit))
             }
             Expression::NumericLiteral(n) => {
@@ -2057,10 +2057,9 @@ impl<'a> ReverseCtx<'a> {
             if arrow_initializes_react_cache {
                 None
             } else {
-                arrow
-                    .return_type
-                    .as_ref()
-                    .and_then(|value| self.convert_ts_type_annotation_from_json(&value.parse_value()))
+                arrow.return_type.as_ref().and_then(|value| {
+                    self.convert_ts_type_annotation_from_json(&value.parse_value())
+                })
             },
             body,
         );
@@ -2090,10 +2089,9 @@ impl<'a> ReverseCtx<'a> {
                 PatternLike::RestElement(r) => {
                     let arg = self.convert_pattern_to_binding_pattern(&r.argument);
                     let rest_elem = self.builder.binding_rest_element(SPAN, arg);
-                    let type_annotation = r
-                        .type_annotation
-                        .as_ref()
-                        .and_then(|value| self.convert_ts_type_annotation_from_json(&value.parse_value()));
+                    let type_annotation = r.type_annotation.as_ref().and_then(|value| {
+                        self.convert_ts_type_annotation_from_json(&value.parse_value())
+                    });
                     rest = Some(self.builder.formal_parameter_rest(
                         SPAN,
                         self.builder.vec(),
@@ -2466,15 +2464,13 @@ impl<'a> ReverseCtx<'a> {
     ) -> oxc::SimpleAssignmentTarget<'a> {
         let expression = self.convert_expression(&expr.expression);
         let parsed_type = expr.type_annotation.parse_value();
-        if let Some(type_annotation) =
-            self.convert_ts_type_from_json(&parsed_type).or_else(|| {
-                if Self::ts_type_json_contains_type_query(&parsed_type) {
-                    None
-                } else {
-                    self.extract_source_ts_as_type(&expr.base)
-                }
-            })
-        {
+        if let Some(type_annotation) = self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+            if Self::ts_type_json_contains_type_query(&parsed_type) {
+                None
+            } else {
+                self.extract_source_ts_as_type(&expr.base)
+            }
+        }) {
             self.builder.simple_assignment_target_ts_as_expression(
                 SPAN,
                 expression,
@@ -2491,15 +2487,13 @@ impl<'a> ReverseCtx<'a> {
     ) -> oxc::SimpleAssignmentTarget<'a> {
         let expression = self.convert_expression(&expr.expression);
         let parsed_type = expr.type_annotation.parse_value();
-        if let Some(type_annotation) =
-            self.convert_ts_type_from_json(&parsed_type).or_else(|| {
-                if Self::ts_type_json_contains_type_query(&parsed_type) {
-                    None
-                } else {
-                    self.extract_source_ts_satisfies_type(&expr.base)
-                }
-            })
-        {
+        if let Some(type_annotation) = self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+            if Self::ts_type_json_contains_type_query(&parsed_type) {
+                None
+            } else {
+                self.extract_source_ts_satisfies_type(&expr.base)
+            }
+        }) {
             self.builder.simple_assignment_target_ts_satisfies_expression(
                 SPAN,
                 expression,
@@ -2524,15 +2518,13 @@ impl<'a> ReverseCtx<'a> {
     ) -> oxc::SimpleAssignmentTarget<'a> {
         let expression = self.convert_expression(&expr.expression);
         let parsed_type = expr.type_annotation.parse_value();
-        if let Some(type_annotation) =
-            self.convert_ts_type_from_json(&parsed_type).or_else(|| {
-                if Self::ts_type_json_contains_type_query(&parsed_type) {
-                    None
-                } else {
-                    self.extract_source_ts_type_assertion_type(&expr.base)
-                }
-            })
-        {
+        if let Some(type_annotation) = self.convert_ts_type_from_json(&parsed_type).or_else(|| {
+            if Self::ts_type_json_contains_type_query(&parsed_type) {
+                None
+            } else {
+                self.extract_source_ts_type_assertion_type(&expr.base)
+            }
+        }) {
             self.builder.simple_assignment_target_ts_type_assertion(
                 SPAN,
                 type_annotation,
@@ -2655,9 +2647,11 @@ impl<'a> ReverseCtx<'a> {
 
     fn convert_jsx_attribute_value(&self, value: &JSXAttributeValue) -> oxc::JSXAttributeValue<'a> {
         match value {
-            JSXAttributeValue::StringLiteral(s) => {
-                self.builder.jsx_attribute_value_string_literal(SPAN, self.atom(&s.value.to_string_lossy()), None)
-            }
+            JSXAttributeValue::StringLiteral(s) => self.builder.jsx_attribute_value_string_literal(
+                SPAN,
+                self.atom(&s.value.to_string_lossy()),
+                None,
+            ),
             JSXAttributeValue::JSXExpressionContainer(ec) => {
                 let expr = self.convert_jsx_expression_container_expr(&ec.expression);
                 self.builder.jsx_attribute_value_expression_container(SPAN, expr)
@@ -2745,7 +2739,11 @@ impl<'a> ReverseCtx<'a> {
             } else {
                 Some(specifiers)
             };
-        let source = self.builder.string_literal(SPAN, self.atom(&decl.source.value.to_string_lossy()), None);
+        let source = self.builder.string_literal(
+            SPAN,
+            self.atom(&decl.source.value.to_string_lossy()),
+            None,
+        );
         let import_kind = match decl.import_kind.as_ref() {
             Some(ImportKind::Type) => oxc::ImportOrExportKind::Type,
             _ => oxc::ImportOrExportKind::Value,
@@ -2783,7 +2781,8 @@ impl<'a> ReverseCtx<'a> {
         } else {
             self.builder.import_attribute_key_identifier(SPAN, self.atom(&attr.key.name))
         };
-        let value = self.builder.string_literal(SPAN, self.atom(&attr.value.value.to_string_lossy()), None);
+        let value =
+            self.builder.string_literal(SPAN, self.atom(&attr.value.value.to_string_lossy()), None);
         self.builder.import_attribute(SPAN, key, value)
     }
 
@@ -2871,10 +2870,9 @@ impl<'a> ReverseCtx<'a> {
         let specifiers = self.builder.vec_from_iter(
             decl.specifiers.iter().map(|s| self.convert_export_specifier(s, local_is_reference)),
         );
-        let source = decl
-            .source
-            .as_ref()
-            .map(|s| self.builder.string_literal(SPAN, self.atom(&s.value.to_string_lossy()), None));
+        let source = decl.source.as_ref().map(|s| {
+            self.builder.string_literal(SPAN, self.atom(&s.value.to_string_lossy()), None)
+        });
         let export_kind = match decl.export_kind.as_ref() {
             Some(ExportKind::Type) => oxc::ImportOrExportKind::Type,
             _ => oxc::ImportOrExportKind::Value,
@@ -2998,7 +2996,11 @@ impl<'a> ReverseCtx<'a> {
         &self,
         decl: &ExportAllDeclaration,
     ) -> oxc::ExportAllDeclaration<'a> {
-        let source = self.builder.string_literal(SPAN, self.atom(&decl.source.value.to_string_lossy()), None);
+        let source = self.builder.string_literal(
+            SPAN,
+            self.atom(&decl.source.value.to_string_lossy()),
+            None,
+        );
         let export_kind = match decl.export_kind.as_ref() {
             Some(ExportKind::Type) => oxc::ImportOrExportKind::Type,
             _ => oxc::ImportOrExportKind::Value,

--- a/crates/oxc_react_compiler/src/convert_scope.rs
+++ b/crates/oxc_react_compiler/src/convert_scope.rs
@@ -3,8 +3,6 @@
 // This source code is licensed under the MIT license found in the
 // LICENSE file in the root directory of this source tree.
 
-use std::collections::HashMap;
-
 use indexmap::IndexMap;
 use oxc_ast::AstKind;
 use oxc_ast::ast::Program;
@@ -12,7 +10,11 @@ use oxc_semantic::Semantic;
 use oxc_span::GetSpan;
 use oxc_syntax::symbol::SymbolFlags;
 use react_compiler_ast::scope::*;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
+
+/// `IndexMap` keyed with the deterministic Fx hasher, matching the `FxIndexMap`
+/// used by `react_compiler_ast::scope` fields (`react_compiler_utils::FxIndexMap`).
+type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 
 /// Convert OXC's semantic analysis into React Compiler's ScopeInfo.
 pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo {
@@ -21,11 +23,11 @@ pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo 
 
     let mut scopes: Vec<ScopeData> = Vec::new();
     let mut bindings: Vec<BindingData> = Vec::new();
-    let mut node_to_scope: HashMap<u32, ScopeId> = HashMap::new();
-    let mut node_to_scope_end: HashMap<u32, u32> = HashMap::new();
+    let mut node_to_scope: FxHashMap<u32, ScopeId> = FxHashMap::default();
+    let mut node_to_scope_end: FxHashMap<u32, u32> = FxHashMap::default();
     // In OXC, span.start is used as node_id (OXC spans are unique).
-    let mut node_id_to_scope: HashMap<u32, ScopeId> = HashMap::new();
-    let mut ref_node_id_to_binding: IndexMap<u32, BindingId> = IndexMap::new();
+    let mut node_id_to_scope: FxHashMap<u32, ScopeId> = FxHashMap::default();
+    let mut ref_node_id_to_binding: FxIndexMap<u32, BindingId> = FxIndexMap::default();
 
     let mut symbol_to_binding: FxHashMap<oxc_syntax::symbol::SymbolId, BindingId> =
         FxHashMap::default();
@@ -70,7 +72,7 @@ pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo 
 
         let kind = get_scope_kind(scope_flags, semantic, scope_id);
 
-        let mut scope_bindings: HashMap<String, BindingId> = HashMap::new();
+        let mut scope_bindings: FxHashMap<String, BindingId> = FxHashMap::default();
         for symbol_id in scoping.iter_bindings_in(scope_id) {
             if let Some(&binding_id) = symbol_to_binding.get(&symbol_id) {
                 let name = bindings[binding_id.0 as usize].name.clone();
@@ -215,7 +217,7 @@ pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo 
         bindings,
         node_to_scope,
         node_to_scope_end,
-        reference_to_binding: IndexMap::new(),
+        reference_to_binding: FxIndexMap::default(),
         ref_node_id_to_binding,
         node_id_to_scope,
         program_scope,

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -205,14 +205,12 @@ mod tests {
     use super::transform_source;
 
     fn options() -> PluginOptions {
-        // Only the non-`#[serde(default)]` fields are required; the rest default.
-        serde_json::from_value(serde_json::json!({
-            "shouldCompile": true,
-            "enableReanimated": false,
-            "isDev": false,
-            "filename": "Component.jsx",
-        }))
-        .unwrap()
+        // The upstream options type is constructed typed (it has no `Deserialize`);
+        // only `filename` differs from the compiler's standard defaults.
+        PluginOptions {
+            filename: Some("Component.jsx".to_string()),
+            ..super::default_plugin_options()
+        }
     }
 
     #[test]


### PR DESCRIPTION
Bumps `forked_react_compiler`, `forked_react_compiler_ast`, and `forked_react_compiler_hir` from `0.1.4` to the published `0.2.0` and adapts the OXC ↔ React Compiler AST bridge to the new API.

## API changes adapted

- **`RawNode`** — type-annotation and TS passthrough fields moved from `Box<serde_json::Value>` to the lazily-parsed `RawNode`. Construct via `RawNode::from_value` / `RawNode::null`; read back via `parse_value()`.
- **`StringLiteral.value`** is now a JS string type — write with `.into()`, read with `.to_string_lossy()`.
- **`ScopeInfo`** maps now use the deterministic Fx hasher (`FxHashMap` / `FxIndexMap`) to match the upstream field types.
- **`PluginOptions`** no longer derives `Deserialize`; the test constructs it typed via `default_plugin_options()`.

## Binary size (`napi/transform`)

Net **−533 KiB (−7.2%)** on the shipped binary, despite 0.2.0 pulling in new transitive deps. Measured as the release cdylib (fat-LTO, `--features allocator`, `aarch64-apple-darwin`, stripped); only the bump differs between the two builds.

| Segment | Before (`main`) | After (this PR) | Δ |
|---|--:|--:|--:|
| **Total file** | 7,554,352 B | 7,008,592 B | **−545,760 B (−7.2%)** |
| `__TEXT` (code) | 7,274,496 B | 6,750,208 B | −524,288 B |
| `__DATA_CONST` | 163,840 B | 147,456 B | −16,384 B |
| `__LINKEDIT` | 98,304 B | 81,920 B | −16,384 B |

Almost all of it is `__TEXT` — likely the eager `serde_json::Value` machinery dropped in favor of `RawNode`'s lazily-parsed raw JSON.

## Verification

- `cargo test -p oxc_react_compiler` — 17 passed
- `cargo check -p oxc_linter` and `cargo check -p oxc_transformer --features react_compiler` — both clean