### PR TITLE
refactor(linter): replace icu_segmenter with unicode-segmentation in id-length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,15 +337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core_maths"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,21 +1189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locale"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_locale_data",
- "icu_provider",
- "potential_utf",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,17 +1196,10 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
- "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
-
-[[package]]
-name = "icu_locale_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -1280,36 +1249,12 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "serde",
- "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "icu_segmenter"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
-dependencies = [
- "core_maths",
- "icu_collections",
- "icu_locale",
- "icu_provider",
- "icu_segmenter_data",
- "potential_utf",
- "utf8_iter",
- "zerovec",
-]
-
-[[package]]
-name = "icu_segmenter_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "ident_case"
@@ -2298,7 +2243,6 @@ dependencies = [
  "convert_case",
  "cow-utils",
  "fast-glob",
- "icu_segmenter",
  "ignore",
  "indexmap",
  "insta",
@@ -2342,6 +2286,7 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "smallvec",
+ "unicode-segmentation",
  "url",
 ]
 
@@ -3111,8 +3056,6 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
- "serde_core",
- "writeable",
  "zerovec",
 ]
 
@@ -3830,7 +3773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
- "serde_core",
  "zerovec",
 ]
 
@@ -4517,7 +4459,6 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
- "zerovec",
 ]
 
 [[package]]
@@ -4526,7 +4467,6 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
- "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ serde = "1" # Serialization framework
 serde_json = "1" # JSON serialization
 syn = { version = "2", default-features = false } # Rust parser for macros
 unicode-id-start = "1" # Unicode identifier validation
+unicode-segmentation = "1.12.0" # Unicode grapheme segmentation
 
 #
 javascript-globals = "1.5.0" # JavaScript global definitions
@@ -201,7 +202,6 @@ handlebars = "6.4.0" # Template engine
 hashbrown = { version = "0.17.0", default-features = false } # Fast hash map
 hmac-sha1-compact = "1.1.7" # Self-contained, zero-dependency SHA-1
 humansize = "2.1.3" # Human-readable sizes
-icu_segmenter = "2.1.2" # Unicode segmentation
 ignore = "0.4.25" # Gitignore matching
 insta = "1.43.2" # Snapshot testing
 itertools = "0.15.0" # Iterator utilities

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -53,7 +53,6 @@ constcat = { workspace = true }
 convert_case = { workspace = true }
 cow-utils = { workspace = true }
 fast-glob = { workspace = true }
-icu_segmenter = { workspace = true }
 ignore = { workspace = true }
 indexmap = { workspace = true, features = ["rayon"] }
 itertools = { workspace = true }
@@ -76,6 +75,7 @@ serde_json = { workspace = true, features = [
 ] } # preserve_order: print config with ordered keys.
 simdutf8 = { workspace = true }
 smallvec = { workspace = true }
+unicode-segmentation = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/oxc_linter/src/rules/eslint/id_length.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_length.rs
@@ -1,10 +1,10 @@
 use std::ops::Deref;
 
-use icu_segmenter::GraphemeClusterSegmenter;
 use lazy_regex::Regex;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
+use unicode_segmentation::UnicodeSegmentation;
 
 use oxc_ast::AstKind;
 use oxc_ast::ast::{
@@ -202,8 +202,7 @@ impl IdLength {
             let ident_length = ident_name.len();
             (self.is_too_long(ident_length), self.is_too_short(ident_length))
         } else {
-            let segmenter = GraphemeClusterSegmenter::new();
-            let graphemes_length = segmenter.segment_str(&ident_name).count() - 1;
+            let graphemes_length = ident_name.graphemes(true).count();
             (self.is_too_long(graphemes_length), self.is_too_short(graphemes_length))
         };
 
@@ -265,8 +264,7 @@ impl IdLength {
             let ident_length = ident_name.len();
             (self.is_too_long(ident_length), self.is_too_short(ident_length))
         } else {
-            let segmenter = GraphemeClusterSegmenter::new();
-            let graphemes_length = segmenter.segment_str(&ident_name).count() - 1;
+            let graphemes_length = ident_name.graphemes(true).count();
             (self.is_too_long(graphemes_length), self.is_too_short(graphemes_length))
         };
 
@@ -372,8 +370,7 @@ impl IdLength {
             let ident_length = ident_name.len();
             (self.is_too_long(ident_length), self.is_too_short(ident_length))
         } else {
-            let segmenter = GraphemeClusterSegmenter::new();
-            let graphemes_length = segmenter.segment_str(&ident_name).count() - 1;
+            let graphemes_length = ident_name.graphemes(true).count();
             (self.is_too_long(graphemes_length), self.is_too_short(graphemes_length))
         };
 


### PR DESCRIPTION
## What

The `id-length` rule counts grapheme clusters for non-ASCII identifiers (`crates/oxc_linter/src/rules/eslint/id_length.rs`), which pulled the full ICU stack into `oxlint`. This replaces `icu_segmenter`'s `GraphemeClusterSegmenter` with the lightweight [`unicode-segmentation`](https://crates.io/crates/unicode-segmentation) crate (`name.graphemes(true).count()`).

## Why

- Removes **4 crates** from the `oxlint` dependency tree: `icu_segmenter`, `icu_segmenter_data`, `icu_locale`, `icu_locale_data`. (The other `icu_*` crates stay — they're pulled independently by `url` → `idna_adapter`.)
- The release `oxlint` binary shrinks by **~16 KB** (16,310,000 → 16,293,472 bytes, measured with the release profile: fat-LTO + `strip`).

## Behavior

Unchanged — both `icu_segmenter` and `unicode-segmentation` implement UAX #29 *extended* grapheme clusters. The existing `id-length` tests pass unchanged, including the cases that distinguish grapheme-cluster counting from naive `char` counting:

- `葛󠄀` — base CJK char + variation selector `U+E0100` = **1 grapheme cluster** (2 code points)
- `𠮟` — astral-plane identifier

Note: ICU's `segment_str()` yields boundary indices (count = graphemes + 1), so the old code subtracted 1; `unicode-segmentation`'s `graphemes()` yields the clusters directly, so the `- 1` is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
