### PR TITLE
perf(linter/expect-expect): avoid recompiling matches on every traversal

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
@@ -1,4 +1,6 @@
+use lazy_regex::Regex;
 use rustc_hash::FxHashSet;
+use schemars::JsonSchema;
 
 use oxc_ast::{
     AstKind,
@@ -9,14 +11,13 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 use oxc_str::CompactStr;
 use oxc_syntax::scope::ScopeFlags;
-use schemars::JsonSchema;
 
 use crate::{
     ast_util::get_declaration_of_variable,
     context::LintContext,
     utils::{
         JestFnKind, JestGeneralFnKind, PossibleJestNode, convert_pattern, get_node_name,
-        is_type_of_jest_fn_call, matches_assert_function_name,
+        is_type_of_jest_fn_call,
     },
 };
 
@@ -53,22 +54,28 @@ pub struct ExpectExpectConfig {
     /// `["expect", "expectTypeOf", "assert", "assertType"]` for Vitest.
     #[serde(rename = "assertFunctionNames")]
     assert_function_names_jest: Vec<CompactStr>,
-    #[schemars(skip)] // Skipped because this field isn't exposed to the user.
-    assert_function_names_vitest: Vec<CompactStr>,
+    #[serde(skip)]
+    #[schemars(skip)]
+    assert_function_matchers_jest: Vec<AssertFunctionMatcher>,
+    #[serde(skip)]
+    #[schemars(skip)]
+    assert_function_matchers_vitest: Vec<AssertFunctionMatcher>,
     /// An array of function names that should also be treated as test blocks.
     additional_test_block_functions: Vec<CompactStr>,
 }
 
 impl Default for ExpectExpectConfig {
     fn default() -> Self {
+        let assert_function_names_jest = default_assert_function_names_jest();
+        let assert_function_names_vitest = default_assert_function_names_vitest();
         Self {
-            assert_function_names_jest: vec!["expect".into()],
-            assert_function_names_vitest: vec![
-                "expect".into(),
-                "expectTypeOf".into(),
-                "assert".into(),
-                "assertType".into(),
-            ],
+            assert_function_matchers_jest: compile_assert_function_matchers(
+                &assert_function_names_jest,
+            ),
+            assert_function_matchers_vitest: compile_assert_function_matchers(
+                &assert_function_names_vitest,
+            ),
+            assert_function_names_jest,
             additional_test_block_functions: vec![],
         }
     }
@@ -80,6 +87,51 @@ fn default_assert_function_names_jest() -> Vec<CompactStr> {
 
 fn default_assert_function_names_vitest() -> Vec<CompactStr> {
     vec!["expect".into(), "expectTypeOf".into(), "assert".into(), "assertType".into()]
+}
+
+#[derive(Debug, Clone)]
+enum AssertFunctionMatcher {
+    Exact(CompactStr),
+    Pattern(Regex),
+}
+
+impl AssertFunctionMatcher {
+    fn new(name: &CompactStr) -> Self {
+        if is_exact_assert_function_name(name) {
+            Self::Exact(name.clone())
+        } else {
+            Self::Pattern(
+                Regex::new(&convert_pattern(name))
+                    .expect("failed to compile expect-expect assert function pattern"),
+            )
+        }
+    }
+
+    fn is_match(&self, name: &str) -> bool {
+        match self {
+            Self::Exact(expected) => is_exact_assert_function_match(name, expected),
+            Self::Pattern(pattern) => pattern.is_match(name),
+        }
+    }
+}
+
+fn is_exact_assert_function_name(name: &str) -> bool {
+    name.bytes().all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.'))
+}
+
+fn is_exact_assert_function_match(name: &str, expected: &str) -> bool {
+    if name.len() == expected.len() {
+        return name.eq_ignore_ascii_case(expected);
+    }
+
+    name.as_bytes().get(expected.len()).is_some_and(|byte| *byte == b'.')
+        && name.get(..expected.len()).is_some_and(|prefix| prefix.eq_ignore_ascii_case(expected))
+}
+
+fn compile_assert_function_matchers(
+    assert_function_names: &[CompactStr],
+) -> Vec<AssertFunctionMatcher> {
+    assert_function_names.iter().map(AssertFunctionMatcher::new).collect()
 }
 
 impl ExpectExpectConfig {
@@ -111,8 +163,13 @@ impl ExpectExpectConfig {
             .unwrap_or_default();
 
         Ok(ExpectExpectConfig {
+            assert_function_matchers_jest: compile_assert_function_matchers(
+                &assert_function_names_jest,
+            ),
+            assert_function_matchers_vitest: compile_assert_function_matchers(
+                &assert_function_names_vitest,
+            ),
             assert_function_names_jest,
-            assert_function_names_vitest,
             additional_test_block_functions,
         })
     }
@@ -153,15 +210,13 @@ fn run<'a>(
                 }
             }
 
-            let assert_function_names = if ctx.frameworks().is_vitest() {
-                &rule.assert_function_names_vitest
+            let assert_function_matchers = if ctx.frameworks().is_vitest() {
+                &rule.assert_function_matchers_vitest
             } else {
-                &rule.assert_function_names_jest
+                &rule.assert_function_matchers_jest
             };
-            let assert_function_names =
-                assert_function_names.iter().map(|name| convert_pattern(name)).collect::<Vec<_>>();
 
-            let mut visitor = AssertionVisitor::new(ctx, &assert_function_names);
+            let mut visitor = AssertionVisitor::new(ctx, assert_function_matchers);
 
             // Visit each argument of the test call
             for argument in &call_expr.arguments {
@@ -182,14 +237,22 @@ fn run<'a>(
 
 struct AssertionVisitor<'a, 'b> {
     ctx: &'b LintContext<'a>,
-    assert_function_names: &'b [CompactStr],
+    assert_function_matchers: &'b [AssertFunctionMatcher],
     visited: FxHashSet<Span>,
     found_assertion: bool,
 }
 
 impl<'a, 'b> AssertionVisitor<'a, 'b> {
-    fn new(ctx: &'b LintContext<'a>, assert_function_names: &'b [CompactStr]) -> Self {
-        Self { ctx, assert_function_names, visited: FxHashSet::default(), found_assertion: false }
+    fn new(
+        ctx: &'b LintContext<'a>,
+        assert_function_matchers: &'b [AssertFunctionMatcher],
+    ) -> Self {
+        Self {
+            ctx,
+            assert_function_matchers,
+            visited: FxHashSet::default(),
+            found_assertion: false,
+        }
     }
 
     fn check_expression(&mut self, expr: &Expression<'a>) {
@@ -246,7 +309,7 @@ impl<'a, 'b> AssertionVisitor<'a, 'b> {
 impl<'a> Visit<'a> for AssertionVisitor<'a, '_> {
     fn visit_call_expression(&mut self, call_expr: &CallExpression<'a>) {
         let name = get_node_name(&call_expr.callee);
-        if matches_assert_function_name(&name, self.assert_function_names) {
+        if self.assert_function_matchers.iter().any(|matcher| matcher.is_match(&name)) {
             self.found_assertion = true;
             return;
         }


### PR DESCRIPTION
- Speed up `jest/expect-expect` by compiling configured assertion matchers once during rule configuration instead of rebuilding regexes while walking each test body.
- Add a fast exact-name matcher for common assertion names like `expect`, while preserving wildcard pattern behavior for custom `assertFunctionNames`.

- The previous hot path converted assertion names into regex strings and compiled regexes during each candidate test traversal.
- On a synthetic stress fixture with 1,000 tests and 50,000 non-assertion calls, `--debug timings` showed `jest/expect-expect` dropping from about `~7400 ms` to `~60 ms` with the same `3000` rule invocations.
- The rule now stores precomputed Jest/Vitest assertion matchers on `ExpectExpectConfig`, so per-call work is reduced to exact string matching or a reused regex match.


fixes #23592