### PR TITLE
perf(linter): scan node types from a dense parallel array

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -221,8 +221,16 @@ fn execute_rules<'a, const TIMINGS: bool>(
                 }
             }
 
-            for node in semantic.nodes() {
-                for &rule_index in &buckets.by_type[node.kind().ty() as usize] {
+            // Scan the dense `node_types` array (1 byte per node) and only load the full `AstNode`
+            // when some enabled rule is registered for that node's type (or runs on every node).
+            let nodes = semantic.nodes();
+            let any_type_empty = buckets.any_type.is_empty();
+            for (node, &ty) in nodes.iter().zip(nodes.node_types()) {
+                let by_type = &buckets.by_type[ty as usize];
+                if by_type.is_empty() && any_type_empty {
+                    continue;
+                }
+                for &rule_index in by_type {
                     let (rule, ctx) = &rules[rule_index];
                     let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
                     rule.run::<TIMINGS>(node, ctx, timing_stat);

--- a/crates/oxc_semantic/src/node/nodes.rs
+++ b/crates/oxc_semantic/src/node/nodes.rs
@@ -34,6 +34,13 @@ pub struct AstNodes<'a> {
     /// any nodes of that kind.
     #[cfg(feature = "linter")]
     node_kinds_set: AstTypesBitset,
+    /// `node` -> `AstType`.
+    ///
+    /// A dense parallel array of each node's [`AstType`], stored separately from `nodes` so the
+    /// linter's dispatch loop can scan node types (1 byte each) without loading the full 24-byte
+    /// [`AstNode`] (with its arena pointer) for nodes that no enabled rule cares about.
+    #[cfg(feature = "linter")]
+    node_types: IndexVec<NodeId, AstType>,
 }
 
 impl<'a> AstNodes<'a> {
@@ -45,6 +52,16 @@ impl<'a> AstNodes<'a> {
     /// Iterate over all [`AstNode`]s with their [`NodeId`].
     pub fn iter_enumerated(&self) -> impl Iterator<Item = (NodeId, &AstNode<'a>)> + '_ {
         self.nodes.iter_enumerated()
+    }
+
+    /// Dense parallel array of every node's [`AstType`], in [`NodeId`] order.
+    ///
+    /// `node_types()[i]` is the type of the node yielded i-th by [`iter`](AstNodes::iter), so the
+    /// two can be zipped to dispatch on node type without loading each [`AstNode`].
+    #[cfg(feature = "linter")]
+    #[inline]
+    pub fn node_types(&self) -> &[AstType] {
+        self.node_types.as_raw_slice()
     }
 
     /// Returns the number of node in this AST.
@@ -194,7 +211,11 @@ impl<'a> AstNodes<'a> {
         #[cfg(feature = "cfg")]
         self.cfg_ids.push(cfg_id);
         #[cfg(feature = "linter")]
-        self.node_kinds_set.set(kind.ty());
+        {
+            let ty = kind.ty();
+            self.node_kinds_set.set(ty);
+            self.node_types.push(ty);
+        }
     }
 
     /// Create and add an [`AstNode`] to the [`AstNodes`] tree and get its [`NodeId`].
@@ -221,7 +242,10 @@ impl<'a> AstNodes<'a> {
         #[cfg(feature = "cfg")]
         self.cfg_ids.push(cfg_id);
         #[cfg(feature = "linter")]
-        self.node_kinds_set.set(AstType::Program);
+        {
+            self.node_kinds_set.set(AstType::Program);
+            self.node_types.push(AstType::Program);
+        }
     }
 
     /// Reserve space for at least `additional` more nodes.
@@ -231,6 +255,8 @@ impl<'a> AstNodes<'a> {
         self.flags.reserve(additional);
         #[cfg(feature = "cfg")]
         self.cfg_ids.reserve(additional);
+        #[cfg(feature = "linter")]
+        self.node_types.reserve(additional);
     }
 
     /// Checks if the AST contains any nodes of the given types.


### PR DESCRIPTION
## Idea 1 of 3 — exploiting fixed AST addresses to speed up the linter's node visit

Experiment from a brainstorm on whether the arena's fixed node addresses let us speed up AST visiting. Three independent ideas, each on its own branch/PR on top of `main`:

1. **this PR** — SoA: scan a dense node-type array
2. prefetch the next node's arena memory
3. per-type node index (inverted dispatch)

### What this does

`AstNodes` already flattens the AST into a contiguous `nodes: IndexVec<NodeId, AstNode>`. Each `AstNode` is 24 bytes (`AstKind` = 8-byte arena pointer + tag, padded, plus `ScopeId`). The rule-dispatch loop in `execute_rules` previously did `node.kind().ty()` for **every** node — loading the node's cache line just to read a 1-byte type tag and index the rule buckets.

This adds a dense parallel `node_types: IndexVec<NodeId, AstType>` (1 byte/node, populated where we already compute `kind.ty()` for `node_kinds_set`, so no extra `ty()` calls). The loop zips `nodes.iter()` (which only yields a *reference* — no load) with this byte array, and only pulls the full `AstNode` when an enabled rule is registered for that type. The type tag is kept separate from the node pointer, so the common "no rule for this type" case touches **1 byte instead of 24**.

Memory: +1 byte/node, freed with `Semantic`. Gated behind the `linter` feature.

### Honest caveat on the benchmark

The skip only fires when a node's type has no enabled rule **and** the `any_type` bucket is empty. There are currently **74 rules with no declared `NODE_TYPES` that implement `run`** (mostly `RuleRunFunctionsImplemented::Unknown` where codegen couldn't infer types). In the `all()`-rules benchmark these populate `any_type`, so every node is visited regardless and this PR is ~neutral there.

The win materialises (a) for realistic rule subsets where `any_type` is empty, and (b) once those 74 rules get proper `NODE_TYPES` (a separate effort) — at which point the dense scan skips the majority of nodes cheaply. This PR is the substrate for that; #3 builds the full inverted index on the same idea.

Draft — for CodSpeed comparison against #2 and #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
