### PR TITLE
perf(linter): software-prefetch AST nodes during rule dispatch

### DIFF
--- a/crates/oxc_allocator/src/address.rs
+++ b/crates/oxc_allocator/src/address.rs
@@ -102,6 +102,15 @@ impl Address {
     pub unsafe fn from_ptr<T>(p: *const T) -> Self {
         Self(p as usize)
     }
+
+    /// Get this `Address` as a raw pointer.
+    ///
+    /// The pointer is only valid to dereference if this `Address` was obtained from a live AST node
+    /// in the arena. It is always valid as a software-prefetch target (prefetch never faults).
+    #[inline(always)] // Because it's a no-op
+    pub fn as_ptr(self) -> *const u8 {
+        self.0 as *const u8
+    }
 }
 
 /// Trait for getting the memory address of an AST node.

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
     string::ToString,
 };
 
-use oxc_allocator::{Allocator, AllocatorPool, CloneIn, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{Allocator, AllocatorPool, CloneIn, GetAddress, TakeIn, Vec as ArenaVec};
 use oxc_ast::{
     ast::{Comment, CommentContent, CommentKind, Program},
     ast_kind::AST_TYPE_MAX,
@@ -185,6 +185,35 @@ thread_local! {
     });
 }
 
+/// How many nodes ahead to software-prefetch in the rule-dispatch loop.
+const PREFETCH_DISTANCE: usize = 16;
+
+/// Issue a software prefetch hint for a read of `ptr` into the L1 cache.
+///
+/// Never faults regardless of the pointer value, and is a no-op on architectures without a
+/// supported prefetch instruction.
+#[inline]
+fn prefetch_read(ptr: *const u8) {
+    #[cfg(target_arch = "x86_64")]
+    // SAFETY: `_mm_prefetch` never faults, whatever the pointer value.
+    unsafe {
+        core::arch::x86_64::_mm_prefetch::<{ core::arch::x86_64::_MM_HINT_T0 }>(ptr.cast::<i8>());
+    }
+    #[cfg(target_arch = "aarch64")]
+    // SAFETY: `prfm` never faults, whatever the pointer value.
+    unsafe {
+        core::arch::asm!(
+            "prfm pldl1keep, [{p}]",
+            p = in(reg) ptr,
+            options(nostack, preserves_flags, readonly),
+        );
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    {
+        let _ = ptr;
+    }
+}
+
 fn execute_rules<'a, const TIMINGS: bool>(
     rules: &[(&RuleEnum, LintContext<'a>)],
     semantic: &Semantic<'a>,
@@ -221,7 +250,20 @@ fn execute_rules<'a, const TIMINGS: bool>(
                 }
             }
 
-            for node in semantic.nodes() {
+            // Software-prefetch each node's arena memory `PREFETCH_DISTANCE` iterations before a
+            // rule dereferences it. The flat node list holds the (fixed) arena address of every
+            // node up front, but the arena is laid out in allocation order (≈ reverse DFS), not
+            // node-id order, so these dereferences miss cache. Issuing the prefetch ahead of time
+            // hides that latency behind the per-node dispatch work.
+            let nodes = semantic.nodes();
+            let mut prefetch_ahead = nodes.iter();
+            for _ in 0..PREFETCH_DISTANCE {
+                prefetch_ahead.next();
+            }
+            for node in nodes.iter() {
+                if let Some(ahead) = prefetch_ahead.next() {
+                    prefetch_read(ahead.address().as_ptr());
+                }
                 for &rule_index in &buckets.by_type[node.kind().ty() as usize] {
                     let (rule, ctx) = &rules[rule_index];
                     let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);


### PR DESCRIPTION
## Idea 2 of 3 — exploiting fixed AST addresses to speed up the linter's node visit

Experiment from a brainstorm on whether the arena's fixed node addresses let us speed up AST visiting. Three independent ideas, each on its own branch/PR on top of `main`:

1. SoA: scan a dense node-type array (#23597)
2. **this PR** — prefetch the next node's arena memory
3. per-type node index (inverted dispatch)

### What this does

`Semantic::nodes()` is a flat array of `AstNode`, each holding a fixed arena pointer to the real node. But the arena is laid out in **allocation order (≈ reverse DFS)**, not node-id order — so when a rule dereferences a node's arena memory, it tends to miss cache, and the misses are effectively random relative to the node-id iteration order.

Because the flat list gives us every node's address *up front*, we can issue a software prefetch for the node `PREFETCH_DISTANCE` (= 16) iterations ahead of where the dispatch loop currently is, hiding the miss latency behind the per-node dispatch work. This is the textbook software-prefetch case: future addresses known, target likely to miss.

Adds:
- `Address::as_ptr` (escape hatch to get the raw pointer)
- a portable `prefetch_read` helper: `_mm_prefetch` on x86_64, `prfm pldl1keep` on aarch64, no-op elsewhere

Prefetch hints never fault and don't change diagnostics (the full linter suite, which compares optimized vs reference dispatch in debug, passes unchanged).

### ⚠️ Measurement caveat

**CodSpeed uses cachegrind, which does not model software prefetch instructions** — so the CodSpeed numbers on this PR will *not* reflect any benefit (and may show a tiny instruction-count increase). This one has to be measured with a wall-clock benchmark on real hardware. `PREFETCH_DISTANCE` is a single tunable constant.

Draft — companion to #23597 and the per-type-index PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
