### PR TITLE
perf(linter): dispatch rules via a per-type node index

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -221,16 +221,40 @@ fn execute_rules<'a, const TIMINGS: bool>(
                 }
             }
 
-            for node in semantic.nodes() {
-                for &rule_index in &buckets.by_type[node.kind().ty() as usize] {
-                    let (rule, ctx) = &rules[rule_index];
-                    let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                    rule.run::<TIMINGS>(node, ctx, timing_stat);
+            let nodes = semantic.nodes();
+            if buckets.any_type.is_empty() && nodes.has_type_index() {
+                // Fast path: no rule runs on every node, so visit only the nodes whose type has an
+                // enabled rule, via the per-type index — skipping every other node entirely. Nodes
+                // are visited grouped by type (and in source order within each type) rather than in
+                // global source order; this changes only the order diagnostics are produced, not the
+                // set (verified against the reference path in debug builds).
+                for ast_type in nodes.present_node_types() {
+                    let by_type = &buckets.by_type[ast_type as usize];
+                    if by_type.is_empty() {
+                        continue;
+                    }
+                    for &node_id in nodes.nodes_of_type(ast_type) {
+                        let node = nodes.get_node(node_id);
+                        for &rule_index in by_type {
+                            let (rule, ctx) = &rules[rule_index];
+                            let timing_stat =
+                                get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                            rule.run::<TIMINGS>(node, ctx, timing_stat);
+                        }
+                    }
                 }
-                for &rule_index in &buckets.any_type {
-                    let (rule, ctx) = &rules[rule_index];
-                    let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
-                    rule.run::<TIMINGS>(node, ctx, timing_stat);
+            } else {
+                for node in nodes.iter() {
+                    for &rule_index in &buckets.by_type[node.kind().ty() as usize] {
+                        let (rule, ctx) = &rules[rule_index];
+                        let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                        rule.run::<TIMINGS>(node, ctx, timing_stat);
+                    }
+                    for &rule_index in &buckets.any_type {
+                        let (rule, ctx) = &rules[rule_index];
+                        let timing_stat = get_timing_stat::<TIMINGS>(&mut timing_stats, rule_index);
+                        rule.run::<TIMINGS>(node, ctx, timing_stat);
+                    }
                 }
             }
 

--- a/crates/oxc_linter/src/snapshots/eslint_accessor_pairs.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_accessor_pairs.snap
@@ -1367,19 +1367,19 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Define a setter for this property
 
-  ⚠ eslint(accessor-pairs): Getter is defined without a setter
-   ╭─[accessor_pairs.tsx:1:17]
- 1 │ A = class { get a() {} }, { set a(foo) {} }
-   ·                 ─
-   ╰────
-  help: Define a setter for this property
-
   ⚠ eslint(accessor-pairs): Setter is defined without a getter
    ╭─[accessor_pairs.tsx:1:33]
  1 │ A = class { get a() {} }, { set a(foo) {} }
    ·                                 ─
    ╰────
   help: Define a getter for this property
+
+  ⚠ eslint(accessor-pairs): Getter is defined without a setter
+   ╭─[accessor_pairs.tsx:1:17]
+ 1 │ A = class { get a() {} }, { set a(foo) {} }
+   ·                 ─
+   ╰────
+  help: Define a setter for this property
 
   ⚠ eslint(accessor-pairs): Getter is defined without a setter
    ╭─[accessor_pairs.tsx:1:11]

--- a/crates/oxc_linter/src/snapshots/eslint_complexity.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_complexity.snap
@@ -530,16 +530,16 @@ source: crates/oxc_linter/src/tester.rs
    · ─────────────────────────────────────
    ╰────
 
-  ⚠ eslint(complexity): function `b` has a complexity of 3. Maximum allowed is 2.
-   ╭─[complexity.tsx:1:18]
- 1 │ const obj = { b: (a) => a?.b?.c, c: function (a) { return a?.b?.c; } };
-   ·                  ──────────────
-   ╰────
-
   ⚠ eslint(complexity): function `c` has a complexity of 3. Maximum allowed is 2.
    ╭─[complexity.tsx:1:37]
  1 │ const obj = { b: (a) => a?.b?.c, c: function (a) { return a?.b?.c; } };
    ·                                     ────────────────────────────────
+   ╰────
+
+  ⚠ eslint(complexity): function `b` has a complexity of 3. Maximum allowed is 2.
+   ╭─[complexity.tsx:1:18]
+ 1 │ const obj = { b: (a) => a?.b?.c, c: function (a) { return a?.b?.c; } };
+   ·                  ──────────────
    ╰────
 
   ⚠ eslint(complexity): function `a` has a complexity of 2. Maximum allowed is 1.

--- a/crates/oxc_linter/src/snapshots/eslint_curly.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_curly.snap
@@ -433,13 +433,6 @@ source: crates/oxc_linter/src/tester.rs
         			 doSomething();
         			 `.
 
-  ⚠ eslint(curly): Expected { after 'for-in'.
-   ╭─[curly.tsx:1:22]
- 1 │ for (var foo in bar) if (foo) console.log(1); else console.log(2);
-   ·                      ─────────────────────────────────────────────
-   ╰────
-  help: Replace `if (foo) console.log(1); else console.log(2);` with `{if (foo) console.log(1); else console.log(2);}`.
-
   ⚠ eslint(curly): Expected { after 'if' condition.
    ╭─[curly.tsx:1:31]
  1 │ for (var foo in bar) if (foo) console.log(1); else console.log(2);
@@ -453,6 +446,13 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                    ───────────────
    ╰────
   help: Replace `console.log(2);` with `{console.log(2);}`.
+
+  ⚠ eslint(curly): Expected { after 'for-in'.
+   ╭─[curly.tsx:1:22]
+ 1 │ for (var foo in bar) if (foo) console.log(1); else console.log(2);
+   ·                      ─────────────────────────────────────────────
+   ╰────
+  help: Replace `if (foo) console.log(1); else console.log(2);` with `{if (foo) console.log(1); else console.log(2);}`.
 
   ⚠ eslint(curly): Expected { after 'for-in'.
    ╭─[curly.tsx:2:5]

--- a/crates/oxc_linter/src/snapshots/eslint_id_match.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_id_match.snap
@@ -194,16 +194,16 @@ source: crates/oxc_linter/src/tester.rs
    ·                ─────────────
    ╰────
 
-  ⚠ eslint(id-match): Identifier 'no_camelcased' does not match the pattern '^[^_]+$'.
-   ╭─[id_match.tsx:1:7]
- 1 │ const no_camelcased = 0; function foo({ camelcased_value = no_camelcased }) {}
-   ·       ─────────────
-   ╰────
-
   ⚠ eslint(id-match): Identifier 'camelcased_value' does not match the pattern '^[^_]+$'.
    ╭─[id_match.tsx:1:41]
  1 │ const no_camelcased = 0; function foo({ camelcased_value = no_camelcased }) {}
    ·                                         ────────────────
+   ╰────
+
+  ⚠ eslint(id-match): Identifier 'no_camelcased' does not match the pattern '^[^_]+$'.
+   ╭─[id_match.tsx:1:7]
+ 1 │ const no_camelcased = 0; function foo({ camelcased_value = no_camelcased }) {}
+   ·       ─────────────
    ╰────
 
   ⚠ eslint(id-match): Identifier 'no_camelcased' does not match the pattern '^[^_]+$'.
@@ -236,6 +236,24 @@ source: crates/oxc_linter/src/tester.rs
    ·         ─────────────
    ╰────
 
+  ⚠ eslint(id-match): Identifier 'Array' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
+   ╭─[id_match.tsx:1:221]
+ 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
+   ·                                                                                                                                                                                                                             ─────
+   ╰────
+
+  ⚠ eslint(id-match): Identifier 'Object' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
+   ╭─[id_match.tsx:1:151]
+ 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
+   ·                                                                                                                                                       ──────
+   ╰────
+
+  ⚠ eslint(id-match): Identifier 'Array' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
+   ╭─[id_match.tsx:1:194]
+ 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
+   ·                                                                                                                                                                                                  ─────
+   ╰────
+
   ⚠ eslint(id-match): Identifier 'foo_variable' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
    ╭─[id_match.tsx:1:7]
  1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
@@ -254,28 +272,10 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                                                                                                            ──────
    ╰────
 
-  ⚠ eslint(id-match): Identifier 'Object' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
-   ╭─[id_match.tsx:1:151]
- 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
-   ·                                                                                                                                                       ──────
-   ╰────
-
   ⚠ eslint(id-match): Identifier 'Array' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
    ╭─[id_match.tsx:1:184]
  1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
    ·                                                                                                                                                                                        ─────
-   ╰────
-
-  ⚠ eslint(id-match): Identifier 'Array' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
-   ╭─[id_match.tsx:1:194]
- 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
-   ·                                                                                                                                                                                                  ─────
-   ╰────
-
-  ⚠ eslint(id-match): Identifier 'Array' does not match the pattern '^\$?[a-z]+([A-Z0-9][a-z0-9]+)*$'.
-   ╭─[id_match.tsx:1:221]
- 1 │ const foo_variable = 1; class MyClass {} let a = new MyClass(); let b = { id: 1 }; let c = Object.keys(b); let d = Array.from(b); let e = (Object) => Object.keys(obj, prop); let f = (Array) => Array.from(obj, prop); foo.Array = 5;
-   ·                                                                                                                                                                                                                             ─────
    ╰────
 
   ⚠ eslint(id-match): Identifier '_foo' does not match the pattern '^[^_]+$'.
@@ -459,12 +459,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
-   ╭─[id_match.tsx:1:7]
- 1 │ const bad_name = 1; export { bad_name };
-   ·       ────────
-   ╰────
-
-  ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
    ╭─[id_match.tsx:1:30]
  1 │ const bad_name = 1; export { bad_name };
    ·                              ────────
@@ -472,14 +466,8 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
    ╭─[id_match.tsx:1:7]
- 1 │ const bad_name = 1; export { bad_name as bad_name };
+ 1 │ const bad_name = 1; export { bad_name };
    ·       ────────
-   ╰────
-
-  ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
-   ╭─[id_match.tsx:1:30]
- 1 │ const bad_name = 1; export { bad_name as bad_name };
-   ·                              ────────
    ╰────
 
   ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
@@ -489,8 +477,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
+   ╭─[id_match.tsx:1:30]
+ 1 │ const bad_name = 1; export { bad_name as bad_name };
+   ·                              ────────
+   ╰────
+
+  ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
    ╭─[id_match.tsx:1:7]
- 1 │ const bad_name = 1; export { bad_name as goodName };
+ 1 │ const bad_name = 1; export { bad_name as bad_name };
    ·       ────────
    ╰────
 
@@ -498,6 +492,12 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[id_match.tsx:1:30]
  1 │ const bad_name = 1; export { bad_name as goodName };
    ·                              ────────
+   ╰────
+
+  ⚠ eslint(id-match): Identifier 'bad_name' does not match the pattern '^[^_]+$'.
+   ╭─[id_match.tsx:1:7]
+ 1 │ const bad_name = 1; export { bad_name as goodName };
+   ·       ────────
    ╰────
 
   ⚠ eslint(id-match): Identifier 'bad_label' does not match the pattern '^[^_]+$'.

--- a/crates/oxc_linter/src/snapshots/eslint_no_constant_condition.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_constant_condition.snap
@@ -1099,14 +1099,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Update the condition to not be constant, or remove the condition entirely
 
   ⚠ eslint(no-constant-condition): Unexpected constant condition
-   ╭─[no_constant_condition.tsx:1:23]
- 1 │ function* foo(){while(true){if (true) {yield 'foo';}}}
-   ·                       ──┬─
-   ·                         ╰── this expression will always evaluate to the same value
-   ╰────
-  help: Update the condition to not be constant, or remove the condition entirely
-
-  ⚠ eslint(no-constant-condition): Unexpected constant condition
    ╭─[no_constant_condition.tsx:1:33]
  1 │ function* foo(){while(true){if (true) {yield 'foo';}}}
    ·                                 ──┬─
@@ -1127,6 +1119,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ function* foo(){while(true){if (true) {yield 'foo';}}}
    ·                                 ──┬─
    ·                                   ╰── this expression will always evaluate to the same value
+   ╰────
+  help: Update the condition to not be constant, or remove the condition entirely
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:23]
+ 1 │ function* foo(){while(true){if (true) {yield 'foo';}}}
+   ·                       ──┬─
+   ·                         ╰── this expression will always evaluate to the same value
    ╰────
   help: Update the condition to not be constant, or remove the condition entirely
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_extra_boolean_cast.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_extra_boolean_cast.snap
@@ -2935,13 +2935,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the double negation as it will already be coerced to a boolean
 
-  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
-   ╭─[no_extra_boolean_cast.tsx:1:5]
- 1 │ if (!!a && Boolean(b)) {}
-   ·     ───
-   ╰────
-  help: Remove the double negation as it will already be coerced to a boolean
-
   ⚠ eslint(no-extra-boolean-cast): Redundant Boolean call
    ╭─[no_extra_boolean_cast.tsx:1:12]
  1 │ if (!!a && Boolean(b)) {}
@@ -2950,9 +2943,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the Boolean call as it will already be coerced to a boolean
 
   ⚠ eslint(no-extra-boolean-cast): Redundant double negation
-   ╭─[no_extra_boolean_cast.tsx:1:6]
- 1 │ if ((!!a) || (Boolean(b))) {}
-   ·      ───
+   ╭─[no_extra_boolean_cast.tsx:1:5]
+ 1 │ if (!!a && Boolean(b)) {}
+   ·     ───
    ╰────
   help: Remove the double negation as it will already be coerced to a boolean
 
@@ -2962,6 +2955,13 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────
    ╰────
   help: Remove the Boolean call as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:6]
+ 1 │ if ((!!a) || (Boolean(b))) {}
+   ·      ───
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
 
   ⚠ eslint(no-extra-boolean-cast): Redundant Boolean call
    ╭─[no_extra_boolean_cast.tsx:1:5]
@@ -3425,13 +3425,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the double negation as it will already be coerced to a boolean
 
-  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
-   ╭─[no_extra_boolean_cast.tsx:1:5]
- 1 │ if (!!a && Boolean(b)) {}
-   ·     ───
-   ╰────
-  help: Remove the double negation as it will already be coerced to a boolean
-
   ⚠ eslint(no-extra-boolean-cast): Redundant Boolean call
    ╭─[no_extra_boolean_cast.tsx:1:12]
  1 │ if (!!a && Boolean(b)) {}
@@ -3440,9 +3433,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the Boolean call as it will already be coerced to a boolean
 
   ⚠ eslint(no-extra-boolean-cast): Redundant double negation
-   ╭─[no_extra_boolean_cast.tsx:1:6]
- 1 │ if ((!!a) || (Boolean(b))) {}
-   ·      ───
+   ╭─[no_extra_boolean_cast.tsx:1:5]
+ 1 │ if (!!a && Boolean(b)) {}
+   ·     ───
    ╰────
   help: Remove the double negation as it will already be coerced to a boolean
 
@@ -3452,6 +3445,13 @@ source: crates/oxc_linter/src/tester.rs
    ·               ──────────
    ╰────
   help: Remove the Boolean call as it will already be coerced to a boolean
+
+  ⚠ eslint(no-extra-boolean-cast): Redundant double negation
+   ╭─[no_extra_boolean_cast.tsx:1:6]
+ 1 │ if ((!!a) || (Boolean(b))) {}
+   ·      ───
+   ╰────
+  help: Remove the double negation as it will already be coerced to a boolean
 
   ⚠ eslint(no-extra-boolean-cast): Redundant Boolean call
    ╭─[no_extra_boolean_cast.tsx:1:5]

--- a/crates/oxc_linter/src/snapshots/eslint_no_inner_declarations.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_inner_declarations.snap
@@ -24,13 +24,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Move variable declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:11]
- 1 │ if (foo){ function f(){ if(bar){ var a; } } }
-   ·           ────────
-   ╰────
-  help: Move function declaration to program root
-
-  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
    ╭─[no_inner_declarations.mjs:1:34]
  1 │ if (foo){ function f(){ if(bar){ var a; } } }
    ·                                  ───
@@ -38,9 +31,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Move variable declaration to function body root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
-   ╭─[no_inner_declarations.mjs:1:10]
- 1 │ if (foo) function f(){ if(bar) var a; }
-   ·          ────────
+   ╭─[no_inner_declarations.mjs:1:11]
+ 1 │ if (foo){ function f(){ if(bar){ var a; } } }
+   ·           ────────
    ╰────
   help: Move function declaration to program root
 
@@ -50,6 +43,13 @@ source: crates/oxc_linter/src/tester.rs
    ·                                ───
    ╰────
   help: Move variable declaration to function body root
+
+  ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
+   ╭─[no_inner_declarations.mjs:1:10]
+ 1 │ if (foo) function f(){ if(bar) var a; }
+   ·          ────────
+   ╰────
+  help: Move function declaration to program root
 
   ⚠ eslint(no-inner-declarations): Variable or `function` declarations are not allowed in nested blocks
    ╭─[no_inner_declarations.mjs:1:12]

--- a/crates/oxc_linter/src/snapshots/eslint_no_labels.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_labels.snap
@@ -9,13 +9,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
 
-  ⚠ eslint(no-labels): Labeled statement is not allowed
-   ╭─[no_labels.tsx:1:1]
- 1 │ label: while (true) { break label; }
-   · ─────
-   ╰────
-  help: Consider refactoring the code to eliminate the need for labels.
-
   ⚠ eslint(no-labels): Label in break statement is not allowed
    ╭─[no_labels.tsx:1:29]
  1 │ label: while (true) { break label; }
@@ -25,7 +18,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ label: while (true) { continue label; }
+ 1 │ label: while (true) { break label; }
    · ─────
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -39,14 +32,14 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: var foo = 0;
-   · ─
+ 1 │ label: while (true) { continue label; }
+   · ─────
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: break A;
+ 1 │ A: var foo = 0;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -60,7 +53,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: { if (foo()) { break A; } bar(); };
+ 1 │ A: break A;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -74,7 +67,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: if (a) { if (foo()) { break A; } bar(); };
+ 1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -88,7 +81,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: switch (a) { case 0: break A; default: break; };
+ 1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -102,15 +95,8 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: switch (a) { case 0: B: { break A; } default: break; };
+ 1 │ A: switch (a) { case 0: break A; default: break; };
    · ─
-   ╰────
-  help: Consider refactoring the code to eliminate the need for labels.
-
-  ⚠ eslint(no-labels): Labeled statement is not allowed
-   ╭─[no_labels.tsx:1:25]
- 1 │ A: switch (a) { case 0: B: { break A; } default: break; };
-   ·                         ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
 
@@ -123,14 +109,21 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: var foo = 0;
+ 1 │ A: switch (a) { case 0: B: { break A; } default: break; };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
+   ╭─[no_labels.tsx:1:25]
+ 1 │ A: switch (a) { case 0: B: { break A; } default: break; };
+   ·                         ─
+   ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
+
+  ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: break A;
+ 1 │ A: var foo = 0;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -144,7 +137,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: { if (foo()) { break A; } bar(); };
+ 1 │ A: break A;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -158,7 +151,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: if (a) { if (foo()) { break A; } bar(); };
+ 1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -172,7 +165,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: switch (a) { case 0: break A; default: break; };
+ 1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -186,14 +179,14 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: var foo = 0;
+ 1 │ A: switch (a) { case 0: break A; default: break; };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: break A;
+ 1 │ A: var foo = 0;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -207,7 +200,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: { if (foo()) { break A; } bar(); };
+ 1 │ A: break A;
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -221,7 +214,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: if (a) { if (foo()) { break A; } bar(); };
+ 1 │ A: { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -235,7 +228,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: while (a) { break A; }
+ 1 │ A: if (a) { if (foo()) { break A; } bar(); };
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -249,7 +242,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: do { if (b) { break A; } } while (a);
+ 1 │ A: while (a) { break A; }
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -263,7 +256,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-labels): Labeled statement is not allowed
    ╭─[no_labels.tsx:1:1]
- 1 │ A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }
+ 1 │ A: do { if (b) { break A; } } while (a);
    · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.
@@ -272,5 +265,12 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_labels.tsx:1:63]
  1 │ A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }
    ·                                                               ─
+   ╰────
+  help: Consider refactoring the code to eliminate the need for labels.
+
+  ⚠ eslint(no-labels): Labeled statement is not allowed
+   ╭─[no_labels.tsx:1:1]
+ 1 │ A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }
+   · ─
    ╰────
   help: Consider refactoring the code to eliminate the need for labels.

--- a/crates/oxc_linter/src/snapshots/eslint_no_multi_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_multi_assign.snap
@@ -10,13 +10,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Separate each assignment into its own statement
 
   ⚠ eslint(no-multi-assign): Do not use chained assignment
-   ╭─[no_multi_assign.tsx:1:9]
- 1 │ var a = b = c = d;
-   ·         ─────────
-   ╰────
-  help: Separate each assignment into its own statement
-
-  ⚠ eslint(no-multi-assign): Do not use chained assignment
    ╭─[no_multi_assign.tsx:1:13]
  1 │ var a = b = c = d;
    ·             ─────
@@ -24,9 +17,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Separate each assignment into its own statement
 
   ⚠ eslint(no-multi-assign): Do not use chained assignment
-   ╭─[no_multi_assign.tsx:1:11]
- 1 │ let foo = bar = cee = 100;
-   ·           ───────────────
+   ╭─[no_multi_assign.tsx:1:9]
+ 1 │ var a = b = c = d;
+   ·         ─────────
    ╰────
   help: Separate each assignment into its own statement
 
@@ -34,6 +27,13 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_multi_assign.tsx:1:17]
  1 │ let foo = bar = cee = 100;
    ·                 ─────────
+   ╰────
+  help: Separate each assignment into its own statement
+
+  ⚠ eslint(no-multi-assign): Do not use chained assignment
+   ╭─[no_multi_assign.tsx:1:11]
+ 1 │ let foo = bar = cee = 100;
+   ·           ───────────────
    ╰────
   help: Separate each assignment into its own statement
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_undefined.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_undefined.snap
@@ -159,15 +159,15 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`
-   ╭─[no_undefined.tsx:1:5]
- 1 │ var undefined = true; undefined = false;
-   ·     ─────────
-   ╰────
-
-  ⚠ eslint(no-undefined): Unexpected use of `undefined`
    ╭─[no_undefined.tsx:1:23]
  1 │ var undefined = true; undefined = false;
    ·                       ─────────
+   ╰────
+
+  ⚠ eslint(no-undefined): Unexpected use of `undefined`
+   ╭─[no_undefined.tsx:1:5]
+ 1 │ var undefined = true; undefined = false;
+   ·     ─────────
    ╰────
 
   ⚠ eslint(no-undefined): Unexpected use of `undefined`

--- a/crates/oxc_linter/src/snapshots/eslint_no_useless_backreference.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_useless_backreference.snap
@@ -555,17 +555,17 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider revising the pattern to remove or relocate the backreference so it points to a group that can be matched at the time of evaluation.
 
-  ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(b)' which appears before in the same lookbehind.
-   ╭─[no_useless_backreference.tsx:1:5]
- 1 │ /(a)\2(b)/; RegExp('(\\1)');
-   ·     ──
-   ╰────
-  help: Consider revising the pattern to remove or relocate the backreference so it points to a group that can be matched at the time of evaluation.
-
   ⚠ eslint(no-useless-backreference): Backreference '\\1' will be ignored. It references group '(\\1)' from within that group.
    ╭─[no_useless_backreference.tsx:1:22]
  1 │ /(a)\2(b)/; RegExp('(\\1)');
    ·                      ───
+   ╰────
+  help: Consider revising the pattern to remove or relocate the backreference so it points to a group that can be matched at the time of evaluation.
+
+  ⚠ eslint(no-useless-backreference): Backreference '\2' will be ignored. It references group '(b)' which appears before in the same lookbehind.
+   ╭─[no_useless_backreference.tsx:1:5]
+ 1 │ /(a)\2(b)/; RegExp('(\\1)');
+   ·     ──
    ╰────
   help: Consider revising the pattern to remove or relocate the backreference so it points to a group that can be matched at the time of evaluation.
 

--- a/crates/oxc_linter/src/snapshots/eslint_prefer_regex_literals.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_prefer_regex_literals.snap
@@ -687,12 +687,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ eslint(prefer-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
-   ╭─[prefer_regex_literals.tsx:1:1]
- 1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")**RegExp('a')
-   · ─────────────────────────────────
-   ╰────
-
-  ⚠ eslint(prefer-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
    ╭─[prefer_regex_literals.tsx:1:36]
  1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")**RegExp('a')
    ·                                    ───────────
@@ -700,7 +694,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(prefer-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
    ╭─[prefer_regex_literals.tsx:1:1]
- 1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")%RegExp('a')
+ 1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")**RegExp('a')
    · ─────────────────────────────────
    ╰────
 
@@ -708,6 +702,12 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[prefer_regex_literals.tsx:1:35]
  1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")%RegExp('a')
    ·                                   ───────────
+   ╰────
+
+  ⚠ eslint(prefer-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.
+   ╭─[prefer_regex_literals.tsx:1:1]
+ 1 │ new RegExp("\\S+@(\\S+\\.)+\\S+")%RegExp('a')
+   · ─────────────────────────────────
    ╰────
 
   ⚠ eslint(prefer-regex-literals): Use a regular expression literal instead of the `RegExp` constructor.

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
@@ -57,20 +57,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
-    ╭─[explicit_function_return_type.tsx:11:15]
- 10 │               }
- 11 │               arrow = () => 'arrow';
-    ·               ────────
- 12 │               private method() {
-    ╰────
-  help: Require explicit return types on functions and class methods.
-
-  ⚠ typescript(explicit-function-return-type): Missing return type on function.
     ╭─[explicit_function_return_type.tsx:12:15]
  11 │               arrow = () => 'arrow';
  12 │               private method() {
     ·               ──────────────
  13 │                 return;
+    ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
+    ╭─[explicit_function_return_type.tsx:11:15]
+ 10 │               }
+ 11 │               arrow = () => 'arrow';
+    ·               ────────
+ 12 │               private method() {
     ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -112,15 +112,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:3:15]
- 2 │             class Foo {
- 3 │               public a = () => {};
-   ·               ───────────
- 4 │               public b = function () {};
-   ╰────
-  help: Require explicit return types on functions and class methods.
-
-  ⚠ typescript(explicit-function-return-type): Missing return type on function.
    ╭─[explicit_function_return_type.tsx:4:15]
  3 │               public a = () => {};
  4 │               public b = function () {};
@@ -139,20 +130,29 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:7:15]
- 6 │ 
- 7 │               static d = () => {};
-   ·               ───────────
- 8 │               static e = function () {};
-   ╰────
-  help: Require explicit return types on functions and class methods.
-
-  ⚠ typescript(explicit-function-return-type): Missing return type on function.
    ╭─[explicit_function_return_type.tsx:8:15]
  7 │               static d = () => {};
  8 │               static e = function () {};
    ·               ────────────────────
  9 │             }
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:3:15]
+ 2 │             class Foo {
+ 3 │               public a = () => {};
+   ·               ───────────
+ 4 │               public b = function () {};
+   ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:7:15]
+ 6 │ 
+ 7 │               static d = () => {};
+   ·               ───────────
+ 8 │               static e = function () {};
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -554,15 +554,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:5:28]
- 4 │             }
- 5 │             const foo = () => {
-   ·                            ──
- 6 │               return;
-   ╰────
-  help: Require explicit return types on functions and class methods.
-
-  ⚠ typescript(explicit-function-return-type): Missing return type on function.
    ╭─[explicit_function_return_type.tsx:8:25]
  7 │             };
  8 │             const baz = function () {
@@ -596,6 +587,15 @@ source: crates/oxc_linter/src/tester.rs
     ·               ────────────
  21 │                 return;
     ╰────
+  help: Require explicit return types on functions and class methods.
+
+  ⚠ typescript(explicit-function-return-type): Missing return type on function.
+   ╭─[explicit_function_return_type.tsx:5:28]
+ 4 │             }
+ 5 │             const foo = () => {
+   ·                            ──
+ 6 │               return;
+   ╰────
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript(explicit-function-return-type): Missing return type on function.

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_member_accessibility.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_member_accessibility.snap
@@ -56,21 +56,21 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
-  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:15]
- 2 │             class Test {
- 3 │               x?: number;
-   ·               ─
- 4 │               getX?() {
-   ╰────
-  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
-
   ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on method definition getX.
    ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               x?: number;
  4 │               getX?() {
    ·               ────
  5 │                 return this.x;
+   ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             class Test {
+ 3 │               x?: number;
+   ·               ─
+ 4 │               getX?() {
    ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
@@ -92,21 +92,21 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
-  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:3:15]
- 2 │             class Test {
- 3 │               public x: number;
-   ·               ──────
- 4 │               public getX() {
-   ╰────
-  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
-
   ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on method definition getX.
    ╭─[explicit_member_accessibility.tsx:4:15]
  3 │               public x: number;
  4 │               public getX() {
    ·               ──────
  5 │                 return this.x;
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             class Test {
+ 3 │               public x: number;
+   ·               ──────
+ 4 │               public getX() {
    ╰────
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
@@ -281,24 +281,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
-  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property foo.
-   ╭─[explicit_member_accessibility.tsx:3:15]
- 2 │             class Test {
- 3 │               public 'foo' = 1;
-   ·               ──────
- 4 │               public 'foo foo' = 2;
-   ╰────
-  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
-
-  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property foo foo.
-   ╭─[explicit_member_accessibility.tsx:4:15]
- 3 │               public 'foo' = 1;
- 4 │               public 'foo foo' = 2;
-   ·               ──────
- 5 │               public 'bar'() {}
-   ╰────
-  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
-
   ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on method definition bar.
    ╭─[explicit_member_accessibility.tsx:5:15]
  4 │               public 'foo foo' = 2;
@@ -314,6 +296,24 @@ source: crates/oxc_linter/src/tester.rs
  6 │               public 'bar bar'() {}
    ·               ──────
  7 │             }
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property foo.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             class Test {
+ 3 │               public 'foo' = 1;
+   ·               ──────
+ 4 │               public 'foo foo' = 2;
+   ╰────
+  help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
+
+  ⚠ typescript(explicit-member-accessibility): Public accessibility modifier on class property foo foo.
+   ╭─[explicit_member_accessibility.tsx:4:15]
+ 3 │               public 'foo' = 1;
+ 4 │               public 'foo foo' = 2;
+   ·               ──────
+ 5 │               public 'bar'() {}
    ╰────
   help: Remove the 'public' modifier. Members are public by default, so the modifier is redundant.
 
@@ -371,15 +371,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
-  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
-   ╭─[explicit_member_accessibility.tsx:3:15]
- 2 │             class DecoratedClass {
- 3 │               constructor(@foo @bar() readonly arg: string) {}
-   ·               ───────────
- 4 │               @foo @bar() x: string;
-   ╰────
-  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
-
   ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on parameter property arg.
    ╭─[explicit_member_accessibility.tsx:3:48]
  2 │             class DecoratedClass {
@@ -389,12 +380,12 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
-  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on class property x.
-   ╭─[explicit_member_accessibility.tsx:4:27]
+  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on method definition constructor.
+   ╭─[explicit_member_accessibility.tsx:3:15]
+ 2 │             class DecoratedClass {
  3 │               constructor(@foo @bar() readonly arg: string) {}
+   ·               ───────────
  4 │               @foo @bar() x: string;
-   ·                           ─
- 5 │               @foo @bar() getX() {
    ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
@@ -423,6 +414,15 @@ source: crates/oxc_linter/src/tester.rs
     ·                               ─
  14 │                 this.x = x;
     ╰────
+  help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
+
+  ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on class property x.
+   ╭─[explicit_member_accessibility.tsx:4:27]
+ 3 │               constructor(@foo @bar() readonly arg: string) {}
+ 4 │               @foo @bar() x: string;
+   ·                           ─
+ 5 │               @foo @bar() getX() {
+   ╰────
   help: Add an explicit 'public', 'private', or 'protected' modifier. Members without a modifier are implicitly public, which may not be intentional.
 
   ⚠ typescript(explicit-member-accessibility): Missing accessibility modifier on method definition computed-method-name.

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_array_find.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_array_find.snap
@@ -454,32 +454,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:1:19]
- 1 │ const quz = array.filter(fn);
-   ·                   ──────
- 2 │             const [foo] = array.filter(quz[0]);
-   ╰────
-  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
-
-  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:2:33]
- 1 │ const quz = array.filter(fn);
- 2 │             const [foo] = array.filter(quz[0]);
-   ·                                 ──────
- 3 │             [{bar: baz}] = foo[
-   ╰────
-  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
-
-  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
-   ╭─[prefer_array_find.tsx:5:15]
- 4 │                 array.filter(fn)[0]
- 5 │             ].filter(
-   ·               ──────
- 6 │                 array.filter(fn).shift()
-   ╰────
-  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
-
-  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
    ╭─[prefer_array_find.tsx:4:23]
  3 │             [{bar: baz}] = foo[
  4 │                 array.filter(fn)[0]
@@ -498,11 +472,28 @@ source: crates/oxc_linter/src/tester.rs
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
   ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
+   ╭─[prefer_array_find.tsx:5:15]
+ 4 │                 array.filter(fn)[0]
+ 5 │             ].filter(
+   ·               ──────
+ 6 │                 array.filter(fn).shift()
+   ╰────
+  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
+
+  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
+   ╭─[prefer_array_find.tsx:1:19]
+ 1 │ const quz = array.filter(fn);
+   ·                   ──────
+ 2 │             const [foo] = array.filter(quz[0]);
+   ╰────
+  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
+
+  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
    ╭─[prefer_array_find.tsx:2:33]
- 1 │ const quz = array.find(fn);
- 2 │             const [foo] = array.filter(quz);
+ 1 │ const quz = array.filter(fn);
+ 2 │             const [foo] = array.filter(quz[0]);
    ·                                 ──────
- 3 │             ({bar: baz} = foo[
+ 3 │             [{bar: baz}] = foo[
    ╰────
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 
@@ -521,6 +512,15 @@ source: crates/oxc_linter/src/tester.rs
  6 │                 array.filter(fn).shift()
    ·                       ──────
  7 │             ));
+   ╰────
+  help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
+
+  ⚠ unicorn(prefer-array-find): Prefer `find` over filtering and accessing the first result.
+   ╭─[prefer_array_find.tsx:2:33]
+ 1 │ const quz = array.find(fn);
+ 2 │             const [foo] = array.filter(quz);
+   ·                                 ──────
+ 3 │             ({bar: baz} = foo[
    ╰────
   help: Use `find(predicate)` instead of `filter(predicate)[0]` or similar patterns.
 

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_keyboard_event_key.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_keyboard_event_key.snap
@@ -349,16 +349,6 @@ source: crates/oxc_linter/src/tester.rs
   help: The `keyCode` property is deprecated.
   note: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
 
-  ⚠ unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
-   ╭─[prefer_keyboard_event_key.tsx:7:41]
- 6 │                             {
- 7 │                                 const { charCode } = e;
-   ·                                         ────────
- 8 │                                 console.log(e.keyCode, charCode);
-   ╰────
-  help: The `charCode` property is deprecated.
-  note: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
-
   ⚠ unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`
    ╭─[prefer_keyboard_event_key.tsx:8:47]
  7 │                                 const { charCode } = e;
@@ -367,6 +357,16 @@ source: crates/oxc_linter/src/tester.rs
  9 │                             }
    ╰────
   help: The `keyCode` property is deprecated.
+  note: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+
+  ⚠ unicorn(prefer-keyboard-event-key): Use `.key` instead of `.charCode`
+   ╭─[prefer_keyboard_event_key.tsx:7:41]
+ 6 │                             {
+ 7 │                                 const { charCode } = e;
+   ·                                         ────────
+ 8 │                                 console.log(e.keyCode, charCode);
+   ╰────
+  help: The `charCode` property is deprecated.
   note: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
 
   ⚠ unicorn(prefer-keyboard-event-key): Use `.key` instead of `.keyCode`

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_math_trunc.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_math_trunc.snap
@@ -284,19 +284,19 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Replace `~ /* will remove 1 */ ~ /* will remove 2 */ 3.4` with `Math.trunc(3.4)`.
 
-  ⚠ unicorn(prefer-math-trunc): Prefer `Math.trunc()` over instead of `| 0`.
-   ╭─[prefer_math_trunc.tsx:1:13]
- 1 │ const foo = ~~bar | 0;
-   ·             ─────────
-   ╰────
-  help: Replace `~~bar | 0` with `Math.trunc(~~bar)`.
-
   ⚠ unicorn(prefer-math-trunc): Prefer `Math.trunc()` over instead of `~ 0`.
    ╭─[prefer_math_trunc.tsx:1:13]
  1 │ const foo = ~~bar | 0;
    ·             ─────
    ╰────
   help: Replace `~~bar` with `Math.trunc(bar)`.
+
+  ⚠ unicorn(prefer-math-trunc): Prefer `Math.trunc()` over instead of `| 0`.
+   ╭─[prefer_math_trunc.tsx:1:13]
+ 1 │ const foo = ~~bar | 0;
+   ·             ─────────
+   ╰────
+  help: Replace `~~bar | 0` with `Math.trunc(~~bar)`.
 
   ⚠ unicorn(prefer-math-trunc): Prefer `Math.trunc()` over instead of `~ 0`.
    ╭─[prefer_math_trunc.tsx:1:13]

--- a/crates/oxc_linter/src/snapshots/vitest_consistent_vitest_vi.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_consistent_vitest_vi.snap
@@ -17,18 +17,18 @@ source: crates/oxc_linter/src/tester.rs
   help: Prefer using `vi` instead of `vitest`.
 
   ⚠ vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
-   ╭─[consistent_vitest_vi.tsx:1:10]
- 1 │ import { vitest } from "vitest";
-   ·          ──────
- 2 │             vitest.stubEnv("NODE_ENV", "production");
-   ╰────
-  help: Prefer using `vi` instead of `vitest`.
-
-  ⚠ vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
    ╭─[consistent_vitest_vi.tsx:2:4]
  1 │ import { vitest } from "vitest";
  2 │             vitest.stubEnv("NODE_ENV", "production");
    ·             ──────
+   ╰────
+  help: Prefer using `vi` instead of `vitest`.
+
+  ⚠ vitest(consistent-vitest-vi): The vitest function accessor used is not allowed
+   ╭─[consistent_vitest_vi.tsx:1:10]
+ 1 │ import { vitest } from "vitest";
+   ·          ──────
+ 2 │             vitest.stubEnv("NODE_ENV", "production");
    ╰────
   help: Prefer using `vi` instead of `vitest`.
 

--- a/crates/oxc_linter/src/snapshots/vue_next_tick_style.snap
+++ b/crates/oxc_linter/src/snapshots/vue_next_tick_style.snap
@@ -3,48 +3,12 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
-   ╭─[next_tick_style.tsx:5:26]
- 4 │                 mounted() {
- 5 │                     this.$nextTick(() => callback());
-   ·                          ─────────
- 6 │                     Vue.nextTick(() => callback());
-   ╰────
-  help: Insert `().then`
-
-  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
-   ╭─[next_tick_style.tsx:6:25]
- 5 │                     this.$nextTick(() => callback());
- 6 │                     Vue.nextTick(() => callback());
-   ·                         ────────
- 7 │                     nt(() => callback());
-   ╰────
-  help: Insert `().then`
-
-  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
    ╭─[next_tick_style.tsx:7:21]
  6 │                     Vue.nextTick(() => callback());
  7 │                     nt(() => callback());
    ·                     ──
  8 │                     this.$nextTick(callback);
    ╰────
-  help: Insert `().then`
-
-  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
-   ╭─[next_tick_style.tsx:8:26]
- 7 │                     nt(() => callback());
- 8 │                     this.$nextTick(callback);
-   ·                          ─────────
- 9 │                     Vue.nextTick(callback);
-   ╰────
-  help: Insert `().then`
-
-  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
-    ╭─[next_tick_style.tsx:9:25]
-  8 │                     this.$nextTick(callback);
-  9 │                     Vue.nextTick(callback);
-    ·                         ────────
- 10 │                     nt(callback);
-    ╰────
   help: Insert `().then`
 
   ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
@@ -75,11 +39,56 @@ source: crates/oxc_linter/src/tester.rs
   help: Insert `().then`
 
   ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
+   ╭─[next_tick_style.tsx:8:26]
+ 7 │                     nt(() => callback());
+ 8 │                     this.$nextTick(callback);
+   ·                          ─────────
+ 9 │                     Vue.nextTick(callback);
+   ╰────
+  help: Insert `().then`
+
+  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
+    ╭─[next_tick_style.tsx:9:25]
+  8 │                     this.$nextTick(callback);
+  9 │                     Vue.nextTick(callback);
+    ·                         ────────
+ 10 │                     nt(callback);
+    ╰────
+  help: Insert `().then`
+
+  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
    ╭─[next_tick_style.tsx:7:21]
  6 │                     Vue.nextTick(() => callback());
  7 │                     nt(() => callback());
    ·                     ──
  8 │                     this.$nextTick(callback);
+   ╰────
+  help: Insert `().then`
+
+  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
+    ╭─[next_tick_style.tsx:10:21]
+  9 │                     Vue.nextTick(callback);
+ 10 │                     nt(callback);
+    ·                     ──
+ 11 │                 }
+    ╰────
+  help: Insert `().then`
+
+  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
+   ╭─[next_tick_style.tsx:5:26]
+ 4 │                 mounted() {
+ 5 │                     this.$nextTick(() => callback());
+   ·                          ─────────
+ 6 │                     Vue.nextTick(() => callback());
+   ╰────
+  help: Insert `().then`
+
+  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
+   ╭─[next_tick_style.tsx:6:25]
+ 5 │                     this.$nextTick(() => callback());
+ 6 │                     Vue.nextTick(() => callback());
+   ·                         ────────
+ 7 │                     nt(() => callback());
    ╰────
   help: Insert `().then`
 
@@ -101,14 +110,21 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Insert `().then`
 
-  ⚠ vue(next-tick-style): Use the Promise returned by `nextTick` instead of passing a callback function.
-    ╭─[next_tick_style.tsx:10:21]
-  9 │                     Vue.nextTick(callback);
- 10 │                     nt(callback);
-    ·                     ──
+  ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
+   ╭─[next_tick_style.tsx:7:21]
+ 6 │                     Vue.nextTick().then(() => callback());
+ 7 │                     nt().then(() => callback());
+   ·                     ──
+ 8 │                     await this.$nextTick(); callback();
+   ╰────
+
+  ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
+    ╭─[next_tick_style.tsx:10:27]
+  9 │                     await Vue.nextTick(); callback();
+ 10 │                     await nt(); callback();
+    ·                           ──
  11 │                 }
     ╰────
-  help: Insert `().then`
 
   ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
    ╭─[next_tick_style.tsx:5:26]
@@ -127,14 +143,6 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
-   ╭─[next_tick_style.tsx:7:21]
- 6 │                     Vue.nextTick().then(() => callback());
- 7 │                     nt().then(() => callback());
-   ·                     ──
- 8 │                     await this.$nextTick(); callback();
-   ╰────
-
-  ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
    ╭─[next_tick_style.tsx:8:32]
  7 │                     nt().then(() => callback());
  8 │                     await this.$nextTick(); callback();
@@ -148,12 +156,4 @@ source: crates/oxc_linter/src/tester.rs
   9 │                     await Vue.nextTick(); callback();
     ·                               ────────
  10 │                     await nt(); callback();
-    ╰────
-
-  ⚠ vue(next-tick-style): Pass a callback function to `nextTick` instead of using the returned Promise.
-    ╭─[next_tick_style.tsx:10:27]
-  9 │                     await Vue.nextTick(); callback();
- 10 │                     await nt(); callback();
-    ·                           ──
- 11 │                 }
     ╰────

--- a/crates/oxc_linter/src/snapshots/vue_no_async_in_computed_properties.snap
+++ b/crates/oxc_linter/src/snapshots/vue_no_async_in_computed_properties.snap
@@ -2,15 +2,6 @@
 source: crates/oxc_linter/src/tester.rs
 ---
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
-   ╭─[no_async_in_computed_properties.tsx:5:30]
- 4 │                           computed: {
- 5 │ ╭─▶                         foo: async function () {
- 6 │ │                             return await someFunc()
- 7 │ ╰─▶                         }
- 8 │                           }
-   ╰────
-
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in "foo" computed property.
    ╭─[no_async_in_computed_properties.tsx:6:34]
  5 │                         foo: async function () {
@@ -23,7 +14,7 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_async_in_computed_properties.tsx:5:30]
  4 │                           computed: {
  5 │ ╭─▶                         foo: async function () {
- 6 │ │                             return new Promise((resolve, reject) => {})
+ 6 │ │                             return await someFunc()
  7 │ ╰─▶                         }
  8 │                           }
    ╰────
@@ -34,6 +25,15 @@ source: crates/oxc_linter/src/tester.rs
  6 │                           return new Promise((resolve, reject) => {})
    ·                                  ────────────────────────────────────
  7 │                         }
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:5:30]
+ 4 │                           computed: {
+ 5 │ ╭─▶                         foo: async function () {
+ 6 │ │                             return new Promise((resolve, reject) => {})
+ 7 │ ╰─▶                         }
+ 8 │                           }
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
@@ -156,30 +156,27 @@ source: crates/oxc_linter/src/tester.rs
  8 │                         return 'foo'
    ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
-    ╭─[no_async_in_computed_properties.tsx:5:33]
-  4 │                         computed: {
-  5 │ ╭─▶                       async foo () {
-  6 │ │                           await this.$nextTick()
-  7 │ │                           await Vue.nextTick()
-  8 │ │                           return 'foo'
-  9 │ ╰─▶                       }
- 10 │                         }
-    ╰────
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:6:31]
+ 5 │                       async foo () {
+ 6 │                         await this.$nextTick()
+   ·                               ────────────────
+ 7 │                         await Vue.nextTick()
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
+   ╭─[no_async_in_computed_properties.tsx:7:31]
+ 6 │                         await this.$nextTick()
+ 7 │                         await Vue.nextTick()
+   ·                               ──────────────
+ 8 │                         return 'foo'
+   ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in "foo" computed property.
    ╭─[no_async_in_computed_properties.tsx:6:25]
  5 │                       async foo () {
  6 │                         await this.$nextTick()
    ·                         ──────────────────────
- 7 │                         await Vue.nextTick()
-   ╰────
-
-  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
-   ╭─[no_async_in_computed_properties.tsx:6:31]
- 5 │                       async foo () {
- 6 │                         await this.$nextTick()
-   ·                               ────────────────
  7 │                         await Vue.nextTick()
    ╰────
 
@@ -191,13 +188,16 @@ source: crates/oxc_linter/src/tester.rs
  8 │                         return 'foo'
    ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in "foo" computed property.
-   ╭─[no_async_in_computed_properties.tsx:7:31]
- 6 │                         await this.$nextTick()
- 7 │                         await Vue.nextTick()
-   ·                               ──────────────
- 8 │                         return 'foo'
-   ╰────
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in "foo" computed property.
+    ╭─[no_async_in_computed_properties.tsx:5:33]
+  4 │                         computed: {
+  5 │ ╭─▶                       async foo () {
+  6 │ │                           await this.$nextTick()
+  7 │ │                           await Vue.nextTick()
+  8 │ │                           return 'foo'
+  9 │ ╰─▶                       }
+ 10 │                         }
+    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected timed function in "foo" computed property.
    ╭─[no_async_in_computed_properties.tsx:6:25]
@@ -391,15 +391,6 @@ source: crates/oxc_linter/src/tester.rs
  14 │                       }
     ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-   ╭─[no_async_in_computed_properties.tsx:6:46]
- 5 │                         setup() {
- 6 │ ╭─▶                       const test1 = computed(async () => {
- 7 │ │                           return await someFunc()
- 8 │ ╰─▶                       })
- 9 │                           const test2 = computed(async () => await someFunc())
-   ╰────
-
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
    ╭─[no_async_in_computed_properties.tsx:7:32]
  6 │                       const test1 = computed(async () => {
@@ -408,29 +399,12 @@ source: crates/oxc_linter/src/tester.rs
  8 │                       })
    ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-    ╭─[no_async_in_computed_properties.tsx:9:46]
-  8 │                       })
-  9 │                       const test2 = computed(async () => await someFunc())
-    ·                                              ────────────────────────────
- 10 │                       const test3 = computed(async function () {
-    ╰────
-
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
     ╭─[no_async_in_computed_properties.tsx:9:58]
   8 │                       })
   9 │                       const test2 = computed(async () => await someFunc())
     ·                                                          ────────────────
  10 │                       const test3 = computed(async function () {
-    ╰────
-
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-    ╭─[no_async_in_computed_properties.tsx:10:46]
-  9 │                           const test2 = computed(async () => await someFunc())
- 10 │ ╭─▶                       const test3 = computed(async function () {
- 11 │ │                           return await someFunc()
- 12 │ ╰─▶                       })
- 13 │                         }
     ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
@@ -442,13 +416,30 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-   ╭─[no_async_in_computed_properties.tsx:6:45]
+    ╭─[no_async_in_computed_properties.tsx:10:46]
+  9 │                           const test2 = computed(async () => await someFunc())
+ 10 │ ╭─▶                       const test3 = computed(async function () {
+ 11 │ │                           return await someFunc()
+ 12 │ ╰─▶                       })
+ 13 │                         }
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:6:46]
  5 │                         setup() {
- 6 │ ╭─▶                       const test = computed(async () => {
- 7 │ │                           return new Promise((resolve, reject) => {})
+ 6 │ ╭─▶                       const test1 = computed(async () => {
+ 7 │ │                           return await someFunc()
  8 │ ╰─▶                       })
- 9 │                         }
+ 9 │                           const test2 = computed(async () => await someFunc())
    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+    ╭─[no_async_in_computed_properties.tsx:9:46]
+  8 │                       })
+  9 │                       const test2 = computed(async () => await someFunc())
+    ·                                              ────────────────────────────
+ 10 │                       const test3 = computed(async function () {
+    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected Promise object in computed function.
    ╭─[no_async_in_computed_properties.tsx:7:32]
@@ -456,6 +447,15 @@ source: crates/oxc_linter/src/tester.rs
  7 │                         return new Promise((resolve, reject) => {})
    ·                                ────────────────────────────────────
  8 │                       })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:6:45]
+ 5 │                         setup() {
+ 6 │ ╭─▶                       const test = computed(async () => {
+ 7 │ │                           return new Promise((resolve, reject) => {})
+ 8 │ ╰─▶                       })
+ 9 │                         }
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.
@@ -563,29 +563,12 @@ source: crates/oxc_linter/src/tester.rs
  9 │                         }
    ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-   ╭─[no_async_in_computed_properties.tsx:4:42]
- 3 │                       import {computed} from 'vue'
- 4 │ ╭─▶                   const test1 = computed(async () => {
- 5 │ │                       return await someFunc()
- 6 │ ╰─▶                   })
- 7 │                       const test2 = computed(async () => await someFunc())
-   ╰────
-
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
    ╭─[no_async_in_computed_properties.tsx:5:28]
  4 │                   const test1 = computed(async () => {
  5 │                     return await someFunc()
    ·                            ────────────────
  6 │                   })
-   ╰────
-
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-   ╭─[no_async_in_computed_properties.tsx:7:42]
- 6 │                   })
- 7 │                   const test2 = computed(async () => await someFunc())
-   ·                                          ────────────────────────────
- 8 │                   const test3 = computed(async function () {
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
@@ -596,15 +579,6 @@ source: crates/oxc_linter/src/tester.rs
  8 │                   const test3 = computed(async function () {
    ╰────
 
-  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-    ╭─[no_async_in_computed_properties.tsx:8:42]
-  7 │                       const test2 = computed(async () => await someFunc())
-  8 │ ╭─▶                   const test3 = computed(async function () {
-  9 │ │                       return await someFunc()
- 10 │ ╰─▶                   })
- 11 │                       </script>
-    ╰────
-
   ⚠ vue(no-async-in-computed-properties): Unexpected await operator in computed function.
     ╭─[no_async_in_computed_properties.tsx:9:28]
   8 │                   const test3 = computed(async function () {
@@ -614,12 +588,29 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
-   ╭─[no_async_in_computed_properties.tsx:4:41]
+    ╭─[no_async_in_computed_properties.tsx:8:42]
+  7 │                       const test2 = computed(async () => await someFunc())
+  8 │ ╭─▶                   const test3 = computed(async function () {
+  9 │ │                       return await someFunc()
+ 10 │ ╰─▶                   })
+ 11 │                       </script>
+    ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:4:42]
  3 │                       import {computed} from 'vue'
- 4 │ ╭─▶                   const test = computed(async () => {
- 5 │ │                       return new Promise((resolve, reject) => {})
+ 4 │ ╭─▶                   const test1 = computed(async () => {
+ 5 │ │                       return await someFunc()
  6 │ ╰─▶                   })
- 7 │                       </script>
+ 7 │                       const test2 = computed(async () => await someFunc())
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:7:42]
+ 6 │                   })
+ 7 │                   const test2 = computed(async () => await someFunc())
+   ·                                          ────────────────────────────
+ 8 │                   const test3 = computed(async function () {
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected Promise object in computed function.
@@ -628,6 +619,15 @@ source: crates/oxc_linter/src/tester.rs
  5 │                     return new Promise((resolve, reject) => {})
    ·                            ────────────────────────────────────
  6 │                   })
+   ╰────
+
+  ⚠ vue(no-async-in-computed-properties): Unexpected async function declaration in computed function.
+   ╭─[no_async_in_computed_properties.tsx:4:41]
+ 3 │                       import {computed} from 'vue'
+ 4 │ ╭─▶                   const test = computed(async () => {
+ 5 │ │                       return new Promise((resolve, reject) => {})
+ 6 │ ╰─▶                   })
+ 7 │                       </script>
    ╰────
 
   ⚠ vue(no-async-in-computed-properties): Unexpected asynchronous action in computed function.

--- a/crates/oxc_linter/src/snapshots/vue_return_in_computed_property.snap
+++ b/crates/oxc_linter/src/snapshots/vue_return_in_computed_property.snap
@@ -85,20 +85,20 @@ source: crates/oxc_linter/src/tester.rs
   help: All code paths inside a computed getter must return a value.
 
   ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
-   ╭─[return_in_computed_property.tsx:6:42]
- 5 │                   setup() {
- 6 │                     const foo = computed(() => {})
-   ·                                          ────────
- 7 │                     const foo2 = computed(function() {})
-   ╰────
-  help: All code paths inside a computed getter must return a value.
-
-  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
    ╭─[return_in_computed_property.tsx:7:43]
  6 │                     const foo = computed(() => {})
  7 │                     const foo2 = computed(function() {})
    ·                                           ─────────────
  8 │                     const foo3 = computed(() => {
+   ╰────
+  help: All code paths inside a computed getter must return a value.
+
+  ⚠ vue(return-in-computed-property): Expected to return a value in computed property.
+   ╭─[return_in_computed_property.tsx:6:42]
+ 5 │                   setup() {
+ 6 │                     const foo = computed(() => {})
+   ·                                          ────────
+ 7 │                     const foo2 = computed(function() {})
    ╰────
   help: All code paths inside a computed getter must return a value.
 

--- a/crates/oxc_linter/src/snapshots/vue_valid_next_tick.snap
+++ b/crates/oxc_linter/src/snapshots/vue_valid_next_tick.snap
@@ -36,6 +36,15 @@ source: crates/oxc_linter/src/tester.rs
   help: Insert `()`
 
   ⚠ vue(valid-next-tick): `nextTick` is a function.
+   ╭─[valid_next_tick.tsx:8:23]
+ 7 │ 
+ 8 │                       nt.then(callback);
+   ·                       ──
+ 9 │                       Vue.nextTick.then(callback);
+   ╰────
+  help: Insert `()`
+
+  ⚠ vue(valid-next-tick): `nextTick` is a function.
    ╭─[valid_next_tick.tsx:5:27]
  4 │                       nt;
  5 │                       Vue.nextTick;
@@ -50,15 +59,6 @@ source: crates/oxc_linter/src/tester.rs
  6 │                       this.$nextTick;
    ·                            ─────────
  7 │ 
-   ╰────
-  help: Insert `()`
-
-  ⚠ vue(valid-next-tick): `nextTick` is a function.
-   ╭─[valid_next_tick.tsx:8:23]
- 7 │ 
- 8 │                       nt.then(callback);
-   ·                       ──
- 9 │                       Vue.nextTick.then(callback);
    ╰────
   help: Insert `()`
 
@@ -167,6 +167,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
 
   ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
+   ╭─[valid_next_tick.tsx:8:29]
+ 7 │ 
+ 8 │                       await nt(callback);
+   ·                             ──
+ 9 │                       await Vue.nextTick(callback);
+   ╰────
+
+  ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
    ╭─[valid_next_tick.tsx:5:27]
  4 │                       nt(callback).then(anotherCallback);
  5 │                       Vue.nextTick(callback).then(anotherCallback);
@@ -180,14 +188,6 @@ source: crates/oxc_linter/src/tester.rs
  6 │                       this.$nextTick(callback).then(anotherCallback);
    ·                            ─────────
  7 │ 
-   ╰────
-
-  ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.
-   ╭─[valid_next_tick.tsx:8:29]
- 7 │ 
- 8 │                       await nt(callback);
-   ·                             ──
- 9 │                       await Vue.nextTick(callback);
    ╰────
 
   ⚠ vue(valid-next-tick): Either await the Promise or pass a callback function to `nextTick`.

--- a/crates/oxc_semantic/src/node/nodes.rs
+++ b/crates/oxc_semantic/src/node/nodes.rs
@@ -8,7 +8,7 @@ use oxc_syntax::{
 };
 
 #[cfg(feature = "linter")]
-use oxc_ast::AstType;
+use oxc_ast::{AstType, ast_kind::AST_TYPE_MAX};
 
 #[cfg(feature = "cfg")]
 use oxc_cfg::BlockNodeId;
@@ -34,6 +34,17 @@ pub struct AstNodes<'a> {
     /// any nodes of that kind.
     #[cfg(feature = "linter")]
     node_kinds_set: AstTypesBitset,
+    /// CSR (compressed-sparse-row) inverted index mapping each [`AstType`] to its nodes.
+    ///
+    /// `type_node_ids[type_node_offsets[ty]..type_node_offsets[ty + 1]]` are the [`NodeId`]s of all
+    /// nodes of type `ty`, in ascending (source) order. Empty until [`build_type_index`] runs.
+    /// Lets the linter visit only the nodes whose type has an enabled rule, skipping the rest.
+    ///
+    /// [`build_type_index`]: AstNodes::build_type_index
+    #[cfg(feature = "linter")]
+    type_node_offsets: Vec<u32>,
+    #[cfg(feature = "linter")]
+    type_node_ids: Vec<NodeId>,
 }
 
 impl<'a> AstNodes<'a> {
@@ -45,6 +56,62 @@ impl<'a> AstNodes<'a> {
     /// Iterate over all [`AstNode`]s with their [`NodeId`].
     pub fn iter_enumerated(&self) -> impl Iterator<Item = (NodeId, &AstNode<'a>)> + '_ {
         self.nodes.iter_enumerated()
+    }
+
+    /// Iterate the [`AstType`]s that occur at least once in this AST.
+    #[cfg(feature = "linter")]
+    pub fn present_node_types(&self) -> impl Iterator<Item = AstType> + '_ {
+        self.node_kinds_set.iter()
+    }
+
+    /// Whether the per-type node index has been built (see [`nodes_of_type`](AstNodes::nodes_of_type)).
+    #[cfg(feature = "linter")]
+    #[inline]
+    pub fn has_type_index(&self) -> bool {
+        !self.type_node_offsets.is_empty()
+    }
+
+    /// [`NodeId`]s of every node of type `ty`, in ascending (source) order.
+    ///
+    /// Returns an empty slice if the index has not been built (see [`has_type_index`]).
+    ///
+    /// [`has_type_index`]: AstNodes::has_type_index
+    #[cfg(feature = "linter")]
+    #[inline]
+    pub fn nodes_of_type(&self, ty: AstType) -> &[NodeId] {
+        if self.type_node_offsets.is_empty() {
+            return &[];
+        }
+        let ty = ty as usize;
+        let start = self.type_node_offsets[ty] as usize;
+        let end = self.type_node_offsets[ty + 1] as usize;
+        &self.type_node_ids[start..end]
+    }
+
+    /// Build the per-type node index ([`nodes_of_type`](AstNodes::nodes_of_type)) with a counting
+    /// sort over the already-populated `nodes`. Call once, after all nodes have been added.
+    #[cfg(feature = "linter")]
+    pub(crate) fn build_type_index(&mut self) {
+        const LEN: usize = AST_TYPE_MAX as usize + 2;
+        let node_count = self.nodes.len();
+        // `offsets[ty + 1]` counts nodes of type `ty`, then prefix-summed into CSR row starts.
+        let mut offsets = vec![0u32; LEN];
+        for node in &self.nodes {
+            offsets[node.kind().ty() as usize + 1] += 1;
+        }
+        for i in 1..LEN {
+            offsets[i] += offsets[i - 1];
+        }
+        // Scatter each node id into its type's row, advancing a per-type write cursor.
+        let mut ids = vec![NodeId::new(0); node_count];
+        let mut cursor = offsets.clone();
+        for (node_id, node) in self.nodes.iter_enumerated() {
+            let ty = node.kind().ty() as usize;
+            ids[cursor[ty] as usize] = node_id;
+            cursor[ty] += 1;
+        }
+        self.type_node_offsets = offsets;
+        self.type_node_ids = ids;
     }
 
     /// Returns the number of node in this AST.

--- a/crates/oxc_semantic/src/node/store.rs
+++ b/crates/oxc_semantic/src/node/store.rs
@@ -99,7 +99,13 @@ impl<'a> AstNodeStore<'a> {
     #[inline]
     pub fn into_nodes(self) -> AstNodes<'a> {
         match self.kind {
-            AstNodeStoreKind::Full(nodes) => nodes,
+            AstNodeStoreKind::Full(nodes) => {
+                #[cfg(feature = "linter")]
+                let mut nodes = nodes;
+                #[cfg(feature = "linter")]
+                nodes.build_type_index();
+                nodes
+            }
             AstNodeStoreKind::Ancestry(_) => AstNodes::default(),
         }
     }


### PR DESCRIPTION
## Idea 3 of 3 — exploiting fixed AST addresses to speed up the linter's node visit

Experiment from a brainstorm on whether the arena's fixed node addresses let us speed up AST visiting. Three independent ideas, each on its own branch/PR on top of `main`:

1. SoA: scan a dense node-type array (#23597)
2. prefetch the next node's arena memory (#23598)
3. **this PR** — per-type node index (inverted dispatch)

### What this does

Builds a CSR (compressed-sparse-row) inverted index `AstType -> [NodeId]` during semantic finalization (`into_nodes`, via a counting sort). When **no enabled rule runs on every node** (empty `any_type` bucket), `execute_rules` visits *only* the nodes whose type has an enabled rule — walking the index per present-type — and skips every other node entirely, instead of scanning all N nodes. Falls back to the original full scan when an `any_type` rule is present.

Index cost: one O(n) build + ~4 bytes/node (`type_node_ids`) + a 760-byte offsets array, gated behind the `linter` feature.

### Two important caveats

**1. Gated by the `any_type` bucket.** There are currently **74 rules with no declared `NODE_TYPES` that implement `run`** (mostly cases codegen couldn't infer). They populate `any_type`, which forces a full scan — so with the default / `all()` rule set the fast path is **not taken**, and this PR is pure overhead there (index build with no payoff → expect a small regression on the `all()` CodSpeed bench). The win is for rule subsets with **no** any_type rule (e.g. typed-only configs, single-rule runs, and once those 74 rules get proper `NODE_TYPES`).

**2. Emission order changes.** The fast path visits nodes grouped by type (source order *within* each type) rather than global source order. This changes only the **order** diagnostics are produced, **not the set** — the debug reference-path assertion verifies set-equality, and oxlint sorts diagnostics by span for output, so real output is unchanged. The 22 regenerated Tester snapshots are pure reordering (verified: identical diagnostic counts per file). This snapshot churn is the cost of the inverted-index approach; an order-preserving variant would require a k-way merge and collapse into ≈ #23597 + overhead.

Draft — companion to #23597 and #23598, for CodSpeed comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
