### PR TITLE
perf(diagnostics): gate the graphical renderer behind a `fancy` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,9 +207,11 @@ language-tags = "0.3.2" # Language tag parsing
 lazy-regex = "3.5.1" # Lazy regex compilation
 markdown = "1.0.0" # Markdown parsing
 memchr = "2.7.6" # Fast byte searching
-miette = { package = "oxc-miette", version = "3.0.0", features = [
-  "fancy-no-syscall",
-] } # Error reporting
+# `fancy` (graphical/JSON renderer: owo-colors + textwrap) is NOT enabled here so that
+# crates which only *produce* diagnostics (the parser/semantic/bundler graph) don't pull
+# the renderer. Tools that *render* opt in via `oxc_diagnostics`'s `fancy` feature, or
+# `miette = { workspace = true, features = ["fancy-no-syscall"] }` for direct miette use.
+miette = { package = "oxc-miette", version = "3.0.0" } # Error reporting
 mimalloc-safe = "0.1.62" # Fast allocator
 nodejs-built-in-modules = "1.0.0" # Node.js built-in modules
 nonmax = "0.5.5" # Non-maximum numbers

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -29,7 +29,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true, features = ["pool"] }
 oxc_config = { workspace = true }
-oxc_diagnostics = { workspace = true }
+oxc_diagnostics = { workspace = true, features = ["fancy"] }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }
 oxc_formatter_json = { workspace = true }
@@ -43,7 +43,7 @@ editorconfig-parser = { workspace = true }
 fast-glob = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
 json-strip-comments = { workspace = true }
-miette = { workspace = true }
+miette = { workspace = true, features = ["fancy-no-syscall"] }
 phf = { workspace = true, features = ["macros"] }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -31,7 +31,7 @@ oxc_allocator = { workspace = true, features = ["fixed_size"] }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_config = { workspace = true }
-oxc_diagnostics = { workspace = true }
+oxc_diagnostics = { workspace = true, features = ["fancy"] }
 oxc_estree_tokens = { workspace = true }
 oxc_language_server = { workspace = true }
 oxc_linter = { workspace = true }
@@ -44,7 +44,7 @@ oxc_str = { workspace = true }
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
 cow-utils = { workspace = true }
 ignore = { workspace = true, features = ["simd-accel"] }
-miette = { workspace = true }
+miette = { workspace = true, features = ["fancy-no-syscall"] }
 napi = { workspace = true, features = ["async"], optional = true }
 tracing = { workspace = true }
 napi-derive = { workspace = true, optional = true }

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -46,6 +46,10 @@ oxc_transformer_plugins = { workspace = true, optional = true }
 [features]
 default = ["regular_expression"]
 
+# Re-export miette's graphical report handlers (`oxc::diagnostics::GraphicalReportHandler`)
+# and render fancy codeframes. Off by default; only tools that render diagnostics enable it.
+fancy = ["oxc_diagnostics/fancy"]
+
 full = [
   "codegen",
   "mangler",

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -21,5 +21,11 @@ cow-utils = { workspace = true }
 miette = { workspace = true }
 percent-encoding = { workspace = true }
 
+[features]
+# Re-export miette's graphical / JSON report handlers (pulls owo-colors + textwrap).
+# Off by default: only tools that render diagnostics (oxlint, oxfmt, test harnesses)
+# enable it, so the bundler/parser dependency graph stays free of the renderer.
+fancy = ["miette/fancy-no-syscall"]
+
 [lib]
 doctest = false

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -64,7 +64,12 @@ pub type Severity = miette::Severity;
 pub type Result<T> = std::result::Result<T, OxcDiagnostic>;
 
 use miette::{Diagnostic, SourceCode};
-pub use miette::{GraphicalReportHandler, GraphicalTheme, LabeledSpan, Labels, NamedSource};
+pub use miette::{LabeledSpan, Labels, NamedSource};
+// The graphical report handlers pull miette's `fancy-base` (owo-colors + textwrap), so they
+// are only re-exported under the `fancy` feature. Crates that merely produce `OxcDiagnostic`s
+// never touch these, keeping the renderer out of non-reporting builds (e.g. the bundler).
+#[cfg(feature = "fancy")]
+pub use miette::{GraphicalReportHandler, GraphicalTheme};
 
 /// A collection of [`OxcDiagnostic`]s.
 ///

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -81,3 +81,6 @@ url = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 markdown = { workspace = true }
+# The linter test harness (`src/tester.rs`, `#[cfg(test)]`) renders diagnostics, so it
+# needs the `fancy` renderer — only in tests, never in the published library.
+oxc_diagnostics = { workspace = true, features = ["fancy"] }

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -31,6 +31,12 @@ oxc_syntax = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 
+[features]
+# Render the diagnostic codeframe with miette's graphical handler (owo-colors + textwrap).
+# Off by default so embedders that don't render diagnostics (e.g. bundlers) don't link the
+# renderer; the oxc napi binaries (parser/minify/transform/playground) opt in.
+fancy = ["oxc_diagnostics/fancy"]
+
 [build-dependencies]
 napi-build = { workspace = true }
 

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -33,6 +33,8 @@ unicode-id-start = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+# tests/diagnostics.rs renders diagnostics with the fancy handler (tests-only).
+oxc_diagnostics = { workspace = true, features = ["fancy"] }
 
 [package.metadata.cargo-shear]
 ignored-paths = ["src/generated/derive_get_address.rs"]

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -41,6 +41,8 @@ smallvec = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["glob"] }
+# Conformance tests + the `semantic` example render diagnostics (fancy), tests-only.
+oxc_diagnostics = { workspace = true, features = ["fancy"] }
 oxc_parser = { workspace = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -27,7 +27,7 @@ oxc_codegen = { workspace = true, features = ["sourcemap"] }
 oxc_compat = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_minifier = { workspace = true }
-oxc_napi = { workspace = true }
+oxc_napi = { workspace = true, features = ["fancy"] }
 oxc_parser = { workspace = true }
 oxc_sourcemap = { workspace = true, features = ["napi"] }
 oxc_span = { workspace = true }

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -26,7 +26,7 @@ oxc = { workspace = true, features = ["ast_visit", "regular_expression", "semant
 oxc_ast_macros = { workspace = true }
 oxc_estree = { workspace = true }
 oxc_estree_tokens = { workspace = true, optional = true }
-oxc_napi = { workspace = true }
+oxc_napi = { workspace = true, features = ["fancy"] }
 oxc_str = { workspace = true }
 
 rustc-hash = { workspace = true }

--- a/napi/playground/Cargo.toml
+++ b/napi/playground/Cargo.toml
@@ -38,7 +38,7 @@ oxc_compat = { workspace = true }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }
 oxc_linter = { workspace = true }
-oxc_napi = { workspace = true }
+oxc_napi = { workspace = true, features = ["fancy"] }
 oxc_transformer_plugins = { workspace = true }
 
 napi = { workspace = true, features = ["async"] }

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 
 [dependencies]
 oxc = { workspace = true, features = ["full"] }
-oxc_napi = { workspace = true }
+oxc_napi = { workspace = true, features = ["fancy"] }
 oxc_sourcemap = { workspace = true, features = ["napi"] }
 
 rustc-hash = { workspace = true }

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 
 [dependencies]
 cow-utils = { workspace = true }
-oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize", "conformance"] }
+oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize", "conformance", "fancy"] }
 oxc_estree_tokens = { workspace = true }
 oxc_formatter = { workspace = true }
 oxc_formatter_core = { workspace = true }


### PR DESCRIPTION
## What

`oxc_diagnostics` re-exports miette's `GraphicalReportHandler` / `GraphicalTheme`, and the workspace forces `oxc-miette`'s `fancy-no-syscall` feature globally. As a result **every** consumer of `oxc_diagnostics` — including crates that only *produce* diagnostics (`oxc_parser`, `oxc_semantic`, `oxc_codegen`, `oxc_minifier`, `oxc_transformer`, …) — links the graphical renderer plus `owo-colors` + `textwrap`, even though only the CLIs actually render.

This matters for downstream embedders (e.g. bundlers using oxc as a library) that never render diagnostics graphically: they pay for the renderer in their binary for nothing.

## Change

- Add a default-off `fancy` feature to `oxc_diagnostics`: `fancy = ["miette/fancy-no-syscall"]`.
- Gate the `GraphicalReportHandler` / `GraphicalTheme` re-exports behind `#[cfg(feature = "fancy")]`. `LabeledSpan`, `Labels`, `NamedSource`, `Error`, `OxcDiagnostic`, the `DiagnosticService`/reporter machinery stay ungated (they don't pull `fancy-base`).
- Drop the global `fancy-no-syscall` from the workspace `miette` dependency.
- Opt the renderers back in:
  - **oxlint**, **oxfmt** (production): `oxc_diagnostics = { …, features = ["fancy"] }` and `miette = { …, features = ["fancy-no-syscall"] }` (they use `miette::{JSONReportHandler, GraphicalTheme, MietteHandlerOpts, set_hook}` directly).
  - **oxc_linter**, **oxc_semantic**, **oxc_regular_expression**: `oxc_diagnostics` with `fancy` as a **dev-dependency** only (their test harness / conformance tests / example render diagnostics; nothing in their libraries does).

## Effect / verification

- `cargo tree -e normal` for `oxc`, `oxc_semantic`, `oxc_regular_expression`, `oxc_diagnostics` is now free of `owo-colors` / `textwrap` / `fancy-base`. Library consumers no longer link the renderer.
- `oxc_diagnostics` compiles both with and without `fancy`; `oxlint` + `oxfmt` and all dev/test/example targets that use the graphical handler compile; `oxlint`'s tree still resolves `fancy-base`.
- No `Cargo.lock` change (`owo-colors`/`textwrap` are still pulled by the CLIs).

Motivated by binary-size work on a native addon that embeds the oxc parser/semantic/codegen libraries — the always-on graphical renderer was ~50 KiB of otherwise-dead code in that build.