### PR TITLE
chore(linter): mark unicorn/double-comparison as unsupported

### DIFF
--- a/tasks/lint_rules/src/unsupported-rules.json
+++ b/tasks/lint_rules/src/unsupported-rules.json
@@ -215,6 +215,7 @@
     "react/jsx-uses-vars": "Handled by `eslint/no-unused-vars`, which already evaluates whether vars are used in JSX.",
 
     "unicorn/no-named-default": "Implemented via `import/no-named-default`.",
+    "unicorn/no-double-comparison": "Use `oxc/double-comparisons` instead.",
 
     "vue/no-lone-template": "Not currently possible, as it requires Vue template parsing.",
     "vue/no-v-html": "Not currently possible, as it requires Vue template parsing.",


### PR DESCRIPTION
Unicorn have added a copy of oxc's rule here, https://github.com/sindresorhus/eslint-plugin-unicorn/commit/ae4d7d7601aab09449c360952d850eeb5460ccb5, it makes no sense to have a duplicate - lets encourage users to use the oxc one.