### PR TITLE
fix(react_compiler): don’t treat TypeScript type parameters as value bindings

### DIFF
--- a/crates/oxc_linter/src/rules/react/react_compiler.rs
+++ b/crates/oxc_linter/src/rules/react/react_compiler.rs
@@ -309,6 +309,18 @@ function Component(props) {
             }",
             None,
         ),
+        // Components/hooks must not bail out due to generics, so ensure TS type
+        // parameters aren't collected as value bindings.
+        // https://github.com/oxc-project/oxc/issues/23611
+        (
+            "
+function Select<T extends string>(props: { value: T; onChange: (value: T) => void }) {
+  const handleChange = (value: T) => props.onChange(value);
+  return <button onClick={() => handleChange(props.value)}>{props.value}</button>;
+}
+",
+            Some(json!([{ "reportAllBailouts": true }])),
+        ),
     ];
 
     let fail = vec![

--- a/crates/oxc_react_compiler/src/convert_scope.rs
+++ b/crates/oxc_react_compiler/src/convert_scope.rs
@@ -35,6 +35,15 @@ pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo 
     // First pass: Create all bindings from symbols
     for symbol_id in scoping.symbol_ids() {
         let symbol_flags = scoping.symbol_flags(symbol_id);
+
+        // Skip type-only symbols (type parameters, interfaces, type aliases):
+        // the React Compiler models value semantics only, so a type parameter
+        // would otherwise become a value binding and trip the hoisting pass.
+        // https://github.com/oxc-project/oxc/issues/23611
+        if symbol_flags.is_type() && !symbol_flags.is_value() {
+            continue;
+        }
+
         let name = scoping.symbol_name(symbol_id).to_string();
 
         let kind = get_binding_kind(symbol_flags, semantic, symbol_id);

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -228,6 +228,44 @@ mod tests {
         );
     }
 
+    /// Generic components/hooks must compile: a TS type parameter was collected
+    /// as a value binding and tripped the HIR hoisting pass with a spurious
+    /// bail-out. Regression test for <https://github.com/oxc-project/oxc/issues/23611>.
+    #[test]
+    fn generic_component_does_not_bail_out_on_type_parameter_hoisting() {
+        let source = r#"
+export function Select<T extends string>({
+  options,
+  onChange,
+}: {
+  options: T[];
+  onChange: (value: T) => void;
+}) {
+  const handleChange = (value: T) => {
+    onChange(value);
+  };
+  return (
+    <select onChange={(event) => handleChange(event.target.value as T)}>
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  );
+}
+"#;
+
+        let allocator = oxc_allocator::Allocator::default();
+        let result = transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+
+        let report = format!("{:?}", result.diagnostics);
+        assert!(
+            !report.contains("Unsupported declaration type for hoisting"),
+            "generic component wrongly bailed out on type-parameter hoisting:\n{report}"
+        );
+    }
+
     #[test]
     fn skips_non_react_code() {
         let source = "function add(a, b) {\n  return a + b;\n}\n";


### PR DESCRIPTION
`convert_scope` created a binding for every symbol, including type-only ones. A TypeScript type parameter therefore became a value binding (`kind: Unknown`, `declaration_type: "Unknown"`); when referenced in a type annotation inside a nested function it was treated as a hoistable value binding and tripped the HIR builder's hoisting pass, producing a spurious `react/react-compiler` `Todo: Unsupported declaration type for hoisting` bail-out on generic components/hooks. `babel-plugin-react-compiler` compiles the same code fine.

Skip type-only symbols (`is_type() && !is_value()`) when building `ScopeInfo`. The reference and scope passes already gate on `symbol_to_binding`, so a skipped symbol drops out everywhere.

Closes #23611