### PR TITLE
refactor(linter): remove `number_as_object_schema` helper

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -68,6 +68,7 @@ export type OptionsJsonEnum =
       line?: CommentConfigJson;
     };
 export type IgnoreClassWithImplements = "all" | "public-fields";
+export type ComplexityConfigEnum = number | ComplexityConfig;
 export type Variant = "classic" | "modified";
 /**
  * The enforcement type for the curly rule.
@@ -112,7 +113,14 @@ export type AltTextElements = "img" | "object" | "area" | 'input[type="image"]';
 export type AnchorIsValidAspect = "noHref" | "invalidHref" | "preferButton";
 export type Assert = "htmlFor" | "nesting" | "both" | "either";
 export type DistractingElement = "marquee" | "blink";
+export type MaxClassesPerFileConfigEnum = number | MaxClassesPerFileConfig;
+export type MaxDepthConfigEnum = number | MaxDepth;
+export type MaxLinesConfigEnum = number | MaxLinesConfig;
+export type MaxLinesPerFunctionConfigEnum = number | MaxLinesPerFunctionConfig;
+export type MaxNestedCallbacksConfigEnum = number | MaxNestedCallbacks;
+export type MaxParamsConfigEnum = number | MaxParamsConfig;
 export type CountThis = "always" | "never" | "except-void";
+export type MaxStatementsConfigEnum = number | MaxStatementsConfig;
 export type NoCondAssignConfig = "except-parens" | "always";
 export type CheckLoopsConfig = boolean | CheckLoops;
 export type CheckLoops = "all" | "allExceptWhileTrue" | "none";
@@ -856,7 +864,7 @@ export interface DummyRuleMap {
   "block-scoped-var"?: RuleNoConfig;
   "capitalized-comments"?: RuleNoConfig | [AllowWarnDeny, AlwaysNever] | [AllowWarnDeny, AlwaysNever, OptionsJsonEnum];
   "class-methods-use-this"?: RuleNoConfig | [AllowWarnDeny, ClassMethodsUseThisConfig];
-  complexity?: RuleNoConfig | ([AllowWarnDeny, number] | [AllowWarnDeny, ComplexityConfig]);
+  complexity?: RuleNoConfig | [AllowWarnDeny, ComplexityConfigEnum];
   "constructor-super"?: RuleNoConfig;
   curly?: RuleNoConfig | [AllowWarnDeny, CurlyType] | [AllowWarnDeny, CurlyType, CurlyConsistent];
   "default-case"?: RuleNoConfig | [AllowWarnDeny, DefaultCaseConfig];
@@ -1057,13 +1065,13 @@ export interface DummyRuleMap {
     | RuleNoConfig
     | [AllowWarnDeny, AlwaysNever]
     | [AllowWarnDeny, AlwaysNever, LogicalAssignmentOperatorsConfig];
-  "max-classes-per-file"?: RuleNoConfig | ([AllowWarnDeny, number] | [AllowWarnDeny, MaxClassesPerFileConfig]);
-  "max-depth"?: RuleNoConfig | ([AllowWarnDeny, number] | [AllowWarnDeny, MaxDepth]);
-  "max-lines"?: RuleNoConfig | ([AllowWarnDeny, number] | [AllowWarnDeny, MaxLinesConfig]);
-  "max-lines-per-function"?: RuleNoConfig | ([AllowWarnDeny, number] | [AllowWarnDeny, MaxLinesPerFunctionConfig]);
-  "max-nested-callbacks"?: RuleNoConfig | ([AllowWarnDeny, number] | [AllowWarnDeny, MaxNestedCallbacks]);
-  "max-params"?: RuleNoConfig | ([AllowWarnDeny, number] | [AllowWarnDeny, MaxParamsConfig]);
-  "max-statements"?: RuleNoConfig | ([AllowWarnDeny, number] | [AllowWarnDeny, MaxStatementsConfig]);
+  "max-classes-per-file"?: RuleNoConfig | [AllowWarnDeny, MaxClassesPerFileConfigEnum];
+  "max-depth"?: RuleNoConfig | [AllowWarnDeny, MaxDepthConfigEnum];
+  "max-lines"?: RuleNoConfig | [AllowWarnDeny, MaxLinesConfigEnum];
+  "max-lines-per-function"?: RuleNoConfig | [AllowWarnDeny, MaxLinesPerFunctionConfigEnum];
+  "max-nested-callbacks"?: RuleNoConfig | [AllowWarnDeny, MaxNestedCallbacksConfigEnum];
+  "max-params"?: RuleNoConfig | [AllowWarnDeny, MaxParamsConfigEnum];
+  "max-statements"?: RuleNoConfig | [AllowWarnDeny, MaxStatementsConfigEnum];
   "new-cap"?: RuleNoConfig | [AllowWarnDeny, NewCapConfig];
   "nextjs/google-font-display"?: RuleNoConfig;
   "nextjs/google-font-preconnect"?: RuleNoConfig;

--- a/crates/oxc_linter/src/rules/eslint/complexity.rs
+++ b/crates/oxc_linter/src/rules/eslint/complexity.rs
@@ -42,6 +42,14 @@ impl Default for ComplexityConfig {
     }
 }
 
+#[derive(Debug, JsonSchema)]
+#[serde(untagged)]
+#[expect(unused)]
+enum ComplexityConfigEnum {
+    Number(u32),
+    Object(ComplexityConfig),
+}
+
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum Variant {
@@ -61,18 +69,6 @@ impl Deref for Complexity {
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-#[cfg(feature = "ruledocs")]
-impl Complexity {
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn config_schema(
-        r#gen: &mut schemars::r#gen::SchemaGenerator,
-    ) -> Option<schemars::schema::Schema> {
-        let mut schema = r#gen.subschema_for::<ComplexityConfig>();
-        crate::utils::number_as_object_schema(r#gen, &mut schema, None);
-        Some(schema)
     }
 }
 
@@ -146,7 +142,7 @@ declare_oxc_lint!(
     Complexity,
     eslint,
     restriction,
-    config = ComplexityConfig,
+    config = ComplexityConfigEnum,
     version = "1.37.0",
     short_description = "Enforces a maximum cyclomatic complexity in a program, which is the number of linearly independent paths in a program.",
 );

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -29,18 +29,6 @@ pub struct MaxClassesPerFileConfig {
     pub ignore_expressions: bool,
 }
 
-#[cfg(feature = "ruledocs")]
-impl MaxClassesPerFile {
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn config_schema(
-        r#gen: &mut schemars::r#gen::SchemaGenerator,
-    ) -> Option<schemars::schema::Schema> {
-        let mut schema = r#gen.subschema_for::<MaxClassesPerFileConfig>();
-        crate::utils::number_as_object_schema(r#gen, &mut schema, None);
-        Some(schema)
-    }
-}
-
 impl std::ops::Deref for MaxClassesPerFile {
     type Target = MaxClassesPerFileConfig;
 
@@ -53,6 +41,14 @@ impl Default for MaxClassesPerFileConfig {
     fn default() -> Self {
         Self { max: 1, ignore_expressions: false }
     }
+}
+
+#[derive(Debug, JsonSchema, Deserialize)]
+#[serde(untagged)]
+#[expect(unused)]
+enum MaxClassesPerFileConfigEnum {
+    Number(u32),
+    Object(MaxClassesPerFileConfig),
 }
 
 declare_oxc_lint!(
@@ -84,7 +80,7 @@ declare_oxc_lint!(
     MaxClassesPerFile,
     eslint,
     pedantic,
-    config = MaxClassesPerFileConfig,
+    config = MaxClassesPerFileConfigEnum,
     version = "0.3.4",
     short_description = "Enforce a maximum number of classes per file.",
 );

--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -32,16 +32,12 @@ impl Default for MaxDepth {
     }
 }
 
-#[cfg(feature = "ruledocs")]
-impl MaxDepth {
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn config_schema(
-        r#gen: &mut schemars::r#gen::SchemaGenerator,
-    ) -> Option<schemars::schema::Schema> {
-        let mut schema = r#gen.subschema_for::<Self>();
-        crate::utils::number_as_object_schema(r#gen, &mut schema, None);
-        Some(schema)
-    }
+#[derive(Debug, JsonSchema, Deserialize)]
+#[serde(untagged)]
+#[expect(unused)]
+enum MaxDepthConfigEnum {
+    Number(u32),
+    Object(MaxDepth),
 }
 
 declare_oxc_lint!(
@@ -104,7 +100,7 @@ declare_oxc_lint!(
     MaxDepth,
     eslint,
     pedantic,
-    config = MaxDepth,
+    config = MaxDepthConfigEnum,
     version = "0.15.12",
     short_description = "Enforce a maximum depth that blocks can be nested.",
 );

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -45,16 +45,12 @@ impl Default for MaxLinesConfig {
     }
 }
 
-#[cfg(feature = "ruledocs")]
-impl MaxLines {
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn config_schema(
-        r#gen: &mut schemars::r#gen::SchemaGenerator,
-    ) -> Option<schemars::schema::Schema> {
-        let mut schema = r#gen.subschema_for::<MaxLinesConfig>();
-        crate::utils::number_as_object_schema(r#gen, &mut schema, None);
-        Some(schema)
-    }
+#[derive(Debug, JsonSchema, Deserialize)]
+#[serde(untagged)]
+#[expect(unused)]
+enum MaxLinesConfigEnum {
+    Number(u32),
+    Object(MaxLinesConfig),
 }
 
 declare_oxc_lint!(
@@ -72,7 +68,7 @@ declare_oxc_lint!(
     MaxLines,
     eslint,
     pedantic,
-    config = MaxLinesConfig,
+    config = MaxLinesConfigEnum,
     version = "0.2.14",
     short_description = "Enforce a maximum number of lines per file.",
 );

--- a/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines_per_function.rs
@@ -70,16 +70,12 @@ impl Deref for MaxLinesPerFunction {
     }
 }
 
-#[cfg(feature = "ruledocs")]
-impl MaxLinesPerFunction {
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn config_schema(
-        r#gen: &mut schemars::r#gen::SchemaGenerator,
-    ) -> Option<schemars::schema::Schema> {
-        let mut schema = r#gen.subschema_for::<MaxLinesPerFunctionConfig>();
-        crate::utils::number_as_object_schema(r#gen, &mut schema, None);
-        Some(schema)
-    }
+#[derive(Debug, JsonSchema, Deserialize)]
+#[serde(untagged)]
+#[expect(unused)]
+enum MaxLinesPerFunctionConfigEnum {
+    Number(u32),
+    Object(MaxLinesPerFunctionConfig),
 }
 
 declare_oxc_lint!(
@@ -130,7 +126,7 @@ declare_oxc_lint!(
     MaxLinesPerFunction,
     eslint,
     pedantic,
-    config = MaxLinesPerFunctionConfig,
+    config = MaxLinesPerFunctionConfigEnum,
     version = "0.15.12",
     short_description = "Enforce a maximum number of lines of code in a function.",
 );

--- a/crates/oxc_linter/src/rules/eslint/max_nested_callbacks.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_nested_callbacks.rs
@@ -35,16 +35,12 @@ impl Default for MaxNestedCallbacks {
     }
 }
 
-#[cfg(feature = "ruledocs")]
-impl MaxNestedCallbacks {
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn config_schema(
-        r#gen: &mut schemars::r#gen::SchemaGenerator,
-    ) -> Option<schemars::schema::Schema> {
-        let mut schema = r#gen.subschema_for::<Self>();
-        crate::utils::number_as_object_schema(r#gen, &mut schema, None);
-        Some(schema)
-    }
+#[derive(Debug, JsonSchema, Deserialize)]
+#[serde(untagged)]
+#[expect(unused)]
+enum MaxNestedCallbacksConfigEnum {
+    Number(u32),
+    Object(MaxNestedCallbacks),
 }
 
 declare_oxc_lint!(
@@ -99,7 +95,7 @@ declare_oxc_lint!(
     MaxNestedCallbacks,
     eslint,
     pedantic,
-    config = MaxNestedCallbacks,
+    config = MaxNestedCallbacksConfigEnum,
     version = "0.15.12",
     short_description = "Enforce a maximum depth that callbacks can be nested.",
 );

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -71,18 +71,6 @@ impl Default for MaxParamsConfig {
     }
 }
 
-#[cfg(feature = "ruledocs")]
-impl MaxParams {
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn config_schema(
-        r#gen: &mut schemars::r#gen::SchemaGenerator,
-    ) -> Option<schemars::schema::Schema> {
-        let mut schema = r#gen.subschema_for::<MaxParamsConfig>();
-        crate::utils::number_as_object_schema(r#gen, &mut schema, None);
-        Some(schema)
-    }
-}
-
 impl MaxParamsConfig {
     fn count_this(&self) -> CountThis {
         self.count_this.unwrap_or(if self.count_void_this {
@@ -91,6 +79,14 @@ impl MaxParamsConfig {
             CountThis::ExceptVoid
         })
     }
+}
+
+#[derive(Debug, JsonSchema, Deserialize)]
+#[serde(untagged)]
+#[expect(unused)]
+enum MaxParamsConfigEnum {
+    Number(u32),
+    Object(MaxParamsConfig),
 }
 
 impl MaxParams {
@@ -162,7 +158,7 @@ declare_oxc_lint!(
     MaxParams,
     eslint,
     style,
-    config = MaxParamsConfig,
+    config = MaxParamsConfigEnum,
     version = "0.2.14",
     short_description = "Enforce a maximum number of parameters in function definitions which by default is three.",
 );

--- a/crates/oxc_linter/src/rules/eslint/max_statements.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_statements.rs
@@ -61,16 +61,12 @@ impl std::ops::Deref for MaxStatements {
     }
 }
 
-#[cfg(feature = "ruledocs")]
-impl MaxStatements {
-    #[expect(clippy::unnecessary_wraps)]
-    pub fn config_schema(
-        r#gen: &mut schemars::r#gen::SchemaGenerator,
-    ) -> Option<schemars::schema::Schema> {
-        let mut schema = r#gen.subschema_for::<MaxStatementsConfig>();
-        crate::utils::number_as_object_schema(r#gen, &mut schema, None);
-        Some(schema)
-    }
+#[derive(Debug, JsonSchema, Deserialize)]
+#[serde(untagged)]
+#[expect(unused)]
+enum MaxStatementsConfigEnum {
+    Number(u32),
+    Object(MaxStatementsConfig),
 }
 
 declare_oxc_lint!(
@@ -208,7 +204,7 @@ declare_oxc_lint!(
     MaxStatements,
     eslint,
     style,
-    config = MaxStatementsConfig,
+    config = MaxStatementsConfigEnum,
     version = "1.35.0",
     short_description = "Enforce a maximum number of statements in a function.",
 );

--- a/crates/oxc_linter/src/utils/schemars.rs
+++ b/crates/oxc_linter/src/utils/schemars.rs
@@ -4,9 +4,6 @@ use schemars::{
 };
 
 #[cfg(feature = "ruledocs")]
-use schemars::schema::NumberValidation;
-
-#[cfg(feature = "ruledocs")]
 use crate::rules::RuleEnum;
 
 /// These rules are not verified to have a valid schema
@@ -65,32 +62,4 @@ pub fn object_with_nullable_string_schema(_gen: &mut SchemaGenerator) -> Schema 
         ..Default::default()
     }
     .into()
-}
-
-/// Converts an object schema into a schema that accepts both numbers and objects.
-/// Optionally, a number validation can be provided to further restrict the accepted values.
-#[cfg(feature = "ruledocs")]
-pub fn number_as_object_schema(
-    _gen: &mut SchemaGenerator,
-    schema: &mut Schema,
-    number_schema: Option<NumberValidation>,
-) {
-    let Schema::Object(object_schema) = schema.clone() else {
-        panic!("Expected an object schema to be converted");
-    };
-
-    let number_only_schema = SchemaObject {
-        instance_type: Some(InstanceType::Number.into()),
-        number: number_schema.map(Box::new),
-        ..Default::default()
-    };
-
-    *schema = SchemaObject {
-        subschemas: Some(Box::new(SubschemaValidation {
-            any_of: Some(vec![number_only_schema.into(), Schema::Object(object_schema)]),
-            ..Default::default()
-        })),
-        ..Default::default()
-    }
-    .into();
 }

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -1480,6 +1480,18 @@
       },
       "additionalProperties": false
     },
+    "ComplexityConfigEnum": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        {
+          "$ref": "#/definitions/ComplexityConfig"
+        }
+      ]
+    },
     "Config": {
       "type": "array",
       "items": [
@@ -2278,34 +2290,17 @@
               "$ref": "#/definitions/RuleNoConfig"
             },
             {
-              "anyOf": [
+              "type": "array",
+              "items": [
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "$ref": "#/definitions/ComplexityConfig"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/ComplexityConfigEnum"
                 }
-              ]
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           ]
         },
@@ -4133,34 +4128,17 @@
               "$ref": "#/definitions/RuleNoConfig"
             },
             {
-              "anyOf": [
+              "type": "array",
+              "items": [
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "$ref": "#/definitions/MaxClassesPerFileConfig"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/MaxClassesPerFileConfigEnum"
                 }
-              ]
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           ]
         },
@@ -4170,34 +4148,17 @@
               "$ref": "#/definitions/RuleNoConfig"
             },
             {
-              "anyOf": [
+              "type": "array",
+              "items": [
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "$ref": "#/definitions/MaxDepth"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/MaxDepthConfigEnum"
                 }
-              ]
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           ]
         },
@@ -4207,34 +4168,17 @@
               "$ref": "#/definitions/RuleNoConfig"
             },
             {
-              "anyOf": [
+              "type": "array",
+              "items": [
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "$ref": "#/definitions/MaxLinesConfig"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/MaxLinesConfigEnum"
                 }
-              ]
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           ]
         },
@@ -4244,34 +4188,17 @@
               "$ref": "#/definitions/RuleNoConfig"
             },
             {
-              "anyOf": [
+              "type": "array",
+              "items": [
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "$ref": "#/definitions/MaxLinesPerFunctionConfig"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/MaxLinesPerFunctionConfigEnum"
                 }
-              ]
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           ]
         },
@@ -4281,34 +4208,17 @@
               "$ref": "#/definitions/RuleNoConfig"
             },
             {
-              "anyOf": [
+              "type": "array",
+              "items": [
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "$ref": "#/definitions/MaxNestedCallbacks"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/MaxNestedCallbacksConfigEnum"
                 }
-              ]
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           ]
         },
@@ -4318,34 +4228,17 @@
               "$ref": "#/definitions/RuleNoConfig"
             },
             {
-              "anyOf": [
+              "type": "array",
+              "items": [
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "$ref": "#/definitions/MaxParamsConfig"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/MaxParamsConfigEnum"
                 }
-              ]
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           ]
         },
@@ -4355,34 +4248,17 @@
               "$ref": "#/definitions/RuleNoConfig"
             },
             {
-              "anyOf": [
+              "type": "array",
+              "items": [
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "type": "number"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/AllowWarnDeny"
                 },
                 {
-                  "type": "array",
-                  "items": [
-                    {
-                      "$ref": "#/definitions/AllowWarnDeny"
-                    },
-                    {
-                      "$ref": "#/definitions/MaxStatementsConfig"
-                    }
-                  ],
-                  "maxItems": 2,
-                  "minItems": 2
+                  "$ref": "#/definitions/MaxStatementsConfigEnum"
                 }
-              ]
+              ],
+              "maxItems": 2,
+              "minItems": 2
             }
           ]
         },
@@ -12458,6 +12334,18 @@
       },
       "additionalProperties": false
     },
+    "MaxClassesPerFileConfigEnum": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        {
+          "$ref": "#/definitions/MaxClassesPerFileConfig"
+        }
+      ]
+    },
     "MaxDependenciesConfig": {
       "type": "object",
       "properties": {
@@ -12504,6 +12392,18 @@
       },
       "additionalProperties": false
     },
+    "MaxDepthConfigEnum": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        {
+          "$ref": "#/definitions/MaxDepth"
+        }
+      ]
+    },
     "MaxExpectsConfig": {
       "type": "object",
       "properties": {
@@ -12544,6 +12444,18 @@
       },
       "additionalProperties": false
     },
+    "MaxLinesConfigEnum": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        {
+          "$ref": "#/definitions/MaxLinesConfig"
+        }
+      ]
+    },
     "MaxLinesPerFunctionConfig": {
       "type": "object",
       "properties": {
@@ -12576,6 +12488,18 @@
       },
       "additionalProperties": false
     },
+    "MaxLinesPerFunctionConfigEnum": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        {
+          "$ref": "#/definitions/MaxLinesPerFunctionConfig"
+        }
+      ]
+    },
     "MaxNestedCallbacks": {
       "type": "object",
       "properties": {
@@ -12589,6 +12513,18 @@
         }
       },
       "additionalProperties": false
+    },
+    "MaxNestedCallbacksConfigEnum": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        {
+          "$ref": "#/definitions/MaxNestedCallbacks"
+        }
+      ]
     },
     "MaxNestedCalls": {
       "type": "object",
@@ -12647,6 +12583,18 @@
       },
       "additionalProperties": false
     },
+    "MaxParamsConfigEnum": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        {
+          "$ref": "#/definitions/MaxParamsConfig"
+        }
+      ]
+    },
     "MaxProps": {
       "type": "object",
       "properties": {
@@ -12680,6 +12628,18 @@
         }
       },
       "additionalProperties": false
+    },
+    "MaxStatementsConfigEnum": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        {
+          "$ref": "#/definitions/MaxStatementsConfig"
+        }
+      ]
     },
     "MediaHasCaptionConfig": {
       "type": "object",


### PR DESCRIPTION
The helper generated just `number`. With the `Enum` approach, the generator creates a `u32` with `minimum: 0.0` for the JSON schema.