### PR TITLE
fix(language_server): exit when the editor is no longer alive

### DIFF
--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -13,6 +13,7 @@ mod position;
 #[cfg(test)]
 mod tests;
 mod tool;
+mod watchdog;
 mod worker;
 mod worker_manager;
 
@@ -44,6 +45,8 @@ pub async fn run_server(
     server_version: String,
     worker_manager: WorkerManager,
 ) {
+    watchdog::spawn();
+
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 

--- a/crates/oxc_language_server/src/watchdog.rs
+++ b/crates/oxc_language_server/src/watchdog.rs
@@ -1,0 +1,40 @@
+/// Spawn a background thread that checks every 10s whether the parent process
+/// is still alive. If the parent has exited (editor crash / force quit without
+/// sending LSP `shutdown`), the child is re-parented to PID 1. The watchdog
+/// detects this and terminates the entire process group.
+///
+/// See <https://github.com/microsoft/typescript-go/issues/2478>.
+#[cfg(unix)]
+pub(crate) fn spawn() {
+    let initial_ppid = std::os::unix::process::parent_id();
+    std::thread::Builder::new()
+        .name("oxlint-watchdog".into())
+        .spawn(move || loop {
+            std::thread::sleep(std::time::Duration::from_secs(10));
+            let current_ppid = std::os::unix::process::parent_id();
+            if current_ppid != initial_ppid {
+                tracing::warn!(
+                    "LSP parent process {initial_ppid} no longer alive \
+                     (re-parented to {current_ppid}); \
+                     terminating process group to stop orphaned CPU loop",
+                );
+                // kill(0, SIGKILL) terminates every process in the caller's process
+                // group: the LSP itself and all its children (e.g. tsgolint).
+                // SIGKILL cannot be caught or ignored.
+                unsafe { kill(0, SIGKILL) };
+                std::process::exit(0);
+            }
+        })
+        .expect("failed to spawn LSP parent-process watchdog thread");
+}
+
+#[cfg(not(unix))]
+pub(crate) fn spawn() {}
+
+#[cfg(unix)]
+extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
+}
+
+#[cfg(unix)]
+const SIGKILL: i32 = 9;


### PR DESCRIPTION
`ServerLinterBuilder::shutdown()` is a no-op and the Node.js wrapper never calls `process.exit()`. When the editor exits without LSP shutdown, `oxlint --lsp` and its children are orphaned to PID 1 and run indefinitely.

It adds a Unix watchdog thread that polls `getppid()` at 10s intervals so when the PPID changes (re-parented to 1), it calls `kill(0, SIGKILL)` to terminate the entire process group. I used a bare FFI declaration of `kill(2)`, so no new dependencies.

Related: https://github.com/oxc-project/tsgolint/pull/1019