### PR TITLE
feat(ast,codegen,diagnostics,semantic): make returned Iterator cloneable

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1501,7 +1501,7 @@ impl<'a> FormalParameters<'a> {
     }
 
     /// Iterates over all bound parameters, including rest parameters.
-    pub fn iter_bindings(&self) -> impl Iterator<Item = &BindingPattern<'a>> + '_ {
+    pub fn iter_bindings(&self) -> impl Iterator<Item = &BindingPattern<'a>> + Clone + '_ {
         self.items
             .iter()
             .map(|param| &param.pattern)

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -526,7 +526,7 @@ impl<'a> Codegen<'a> {
     }
 
     #[inline]
-    fn current_class_ids(&self) -> impl Iterator<Item = ClassId> {
+    fn current_class_ids(&self) -> impl Iterator<Item = ClassId> + Clone {
         self.class_stack.iter().rev().copied()
     }
 

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -89,12 +89,12 @@ impl Diagnostics {
     }
 
     /// Iterate over the [error](Severity::Error)-severity diagnostics.
-    pub fn errors(&self) -> impl Iterator<Item = &OxcDiagnostic> {
+    pub fn errors(&self) -> impl Iterator<Item = &OxcDiagnostic> + Clone {
         self.0.iter().filter(|diagnostic| diagnostic.severity == Severity::Error)
     }
 
     /// Iterate over the [warning](Severity::Warning)-severity diagnostics.
-    pub fn warnings(&self) -> impl Iterator<Item = &OxcDiagnostic> {
+    pub fn warnings(&self) -> impl Iterator<Item = &OxcDiagnostic> + Clone {
         self.0.iter().filter(|diagnostic| diagnostic.severity == Severity::Warning)
     }
 

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -57,7 +57,7 @@ pub struct ClassTable<'a> {
 }
 
 impl<'a> ClassTable<'a> {
-    pub fn ancestors(&self, class_id: ClassId) -> impl Iterator<Item = ClassId> + '_ {
+    pub fn ancestors(&self, class_id: ClassId) -> impl Iterator<Item = ClassId> + Clone + '_ {
         std::iter::successors(Some(class_id), |class_id| self.parent_ids.get(class_id).copied())
     }
 
@@ -65,14 +65,14 @@ impl<'a> ClassTable<'a> {
         self.declarations.raw.len()
     }
 
-    pub fn iter_enumerated(&self) -> impl Iterator<Item = (ClassId, &NodeId)> + '_ {
+    pub fn iter_enumerated(&self) -> impl Iterator<Item = (ClassId, &NodeId)> + Clone + '_ {
         self.declarations.iter_enumerated()
     }
 
     pub fn iter_private_identifiers(
         &self,
         class_id: ClassId,
-    ) -> impl Iterator<Item = &PrivateIdentifierReference<'_>> + '_ {
+    ) -> impl Iterator<Item = &PrivateIdentifierReference<'_>> + Clone + '_ {
         self.private_identifier_references[class_id].iter()
     }
 

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -251,7 +251,7 @@ impl<'a> Semantic<'a> {
     pub fn symbol_references(
         &self,
         symbol_id: SymbolId,
-    ) -> impl Iterator<Item = &Reference> + '_ + use<'_> {
+    ) -> impl Iterator<Item = &Reference> + Clone + '_ + use<'_> {
         self.scoping.get_resolved_references(symbol_id)
     }
 

--- a/crates/oxc_semantic/src/multi_index_vec.rs
+++ b/crates/oxc_semantic/src/multi_index_vec.rs
@@ -220,7 +220,7 @@ macro_rules! multi_index_vec {
             }
 
             /// Iterate over all valid indices.
-            $vis fn iter_ids(&self) -> impl Iterator<Item = $idx> {
+            $vis fn iter_ids(&self) -> impl Iterator<Item = $idx> + Clone {
                 let len = self.len as usize;
                 // SAFETY: Valid indices are `0..len`, and by invariant `len <= Idx::MAX + 1`.
                 (0..len).map(|i| unsafe { <$idx as ::oxc_index::Idx>::from_usize_unchecked(i) })

--- a/crates/oxc_semantic/src/node/nodes.rs
+++ b/crates/oxc_semantic/src/node/nodes.rs
@@ -38,12 +38,12 @@ pub struct AstNodes<'a> {
 
 impl<'a> AstNodes<'a> {
     /// Iterate over all [`AstNode`]s in this AST.
-    pub fn iter(&self) -> impl Iterator<Item = &AstNode<'a>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = &AstNode<'a>> + Clone + '_ {
         self.nodes.iter()
     }
 
     /// Iterate over all [`AstNode`]s with their [`NodeId`].
-    pub fn iter_enumerated(&self) -> impl Iterator<Item = (NodeId, &AstNode<'a>)> + '_ {
+    pub fn iter_enumerated(&self) -> impl Iterator<Item = (NodeId, &AstNode<'a>)> + Clone + '_ {
         self.nodes.iter_enumerated()
     }
 

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -309,12 +309,14 @@ impl Scoping {
     }
 
     /// Iterate all symbol names in insertion order.
-    pub fn symbol_names(&self) -> impl Iterator<Item = &str> + '_ {
+    pub fn symbol_names(&self) -> impl Iterator<Item = &str> + Clone + '_ {
         self.cell.borrow_dependent().symbol_names.iter().map(Ident::as_str)
     }
 
     /// Iterate resolved reference ID lists for each symbol.
-    pub fn resolved_references(&self) -> impl Iterator<Item = &ArenaVec<'_, ReferenceId>> + '_ {
+    pub fn resolved_references(
+        &self,
+    ) -> impl Iterator<Item = &ArenaVec<'_, ReferenceId>> + Clone + '_ {
         self.cell.borrow_dependent().resolved_references.iter()
     }
 
@@ -324,7 +326,7 @@ impl Scoping {
     /// scope.
     ///
     /// [`ScopeTree::iter_bindings_in`]: crate::scoping::Scoping::iter_bindings_in
-    pub fn symbol_ids(&self) -> impl Iterator<Item = SymbolId> + '_ {
+    pub fn symbol_ids(&self) -> impl Iterator<Item = SymbolId> + Clone + '_ {
         self.symbol_table.iter_ids()
     }
 
@@ -423,7 +425,10 @@ impl Scoping {
     /// declarations (e.g. `interface Foo {}` + `const Foo = ...`).
     /// This iterator yields all declaration nodes in those cases.
     #[inline]
-    pub fn symbol_declarations(&self, symbol_id: SymbolId) -> impl Iterator<Item = NodeId> + '_ {
+    pub fn symbol_declarations(
+        &self,
+        symbol_id: SymbolId,
+    ) -> impl Iterator<Item = NodeId> + Clone + '_ {
         let redeclarations = self.symbol_redeclarations(symbol_id);
         std::iter::once(self.symbol_declaration(symbol_id))
             .filter(move |_| redeclarations.is_empty())
@@ -551,7 +556,7 @@ impl Scoping {
     pub fn get_resolved_references(
         &self,
         symbol_id: SymbolId,
-    ) -> impl DoubleEndedIterator<Item = &Reference> + '_ {
+    ) -> impl DoubleEndedIterator<Item = &Reference> + Clone + '_ {
         self.get_resolved_reference_ids(symbol_id)
             .iter()
             .map(|&reference_id| &self.references[reference_id])
@@ -690,7 +695,7 @@ impl Scoping {
     ///
     /// The first element of this iterator will be the scope itself. This
     /// guarantees the iterator will have at least 1 element.
-    pub fn scope_ancestors(&self, scope_id: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
+    pub fn scope_ancestors(&self, scope_id: ScopeId) -> impl Iterator<Item = ScopeId> + Clone + '_ {
         std::iter::successors(Some(scope_id), |&scope_id| *self.scope_table.parent_ids(scope_id))
     }
 
@@ -702,7 +707,7 @@ impl Scoping {
     }
 
     /// Iterate all scope IDs from the root scope through all descendants.
-    pub fn scope_descendants_from_root(&self) -> impl Iterator<Item = ScopeId> + '_ {
+    pub fn scope_descendants_from_root(&self) -> impl Iterator<Item = ScopeId> + Clone + '_ {
         self.scope_table.iter_ids()
     }
 
@@ -732,7 +737,7 @@ impl Scoping {
     /// Iterate unresolved reference IDs grouped by unresolved identifier name.
     pub fn root_unresolved_references_ids(
         &self,
-    ) -> impl Iterator<Item = impl Iterator<Item = ReferenceId> + '_> + '_ {
+    ) -> impl Iterator<Item = impl Iterator<Item = ReferenceId> + '_> + Clone + '_ {
         self.cell.borrow_dependent().root_unresolved_references.values().map(|v| v.iter().copied())
     }
 
@@ -862,13 +867,16 @@ impl Scoping {
     /// If you only want bindings in a specific scope, use [`iter_bindings_in`].
     ///
     /// [`iter_bindings_in`]: Scoping::iter_bindings_in
-    pub fn iter_bindings(&self) -> impl Iterator<Item = (ScopeId, &Bindings<'_>)> + '_ {
+    pub fn iter_bindings(&self) -> impl Iterator<Item = (ScopeId, &Bindings<'_>)> + Clone + '_ {
         self.cell.borrow_dependent().bindings.iter_enumerated()
     }
 
     /// Iterate over bindings declared inside a scope.
     #[inline]
-    pub fn iter_bindings_in(&self, scope_id: ScopeId) -> impl Iterator<Item = SymbolId> + '_ {
+    pub fn iter_bindings_in(
+        &self,
+        scope_id: ScopeId,
+    ) -> impl Iterator<Item = SymbolId> + Clone + '_ {
         self.cell.borrow_dependent().bindings[scope_id].values().copied()
     }
 


### PR DESCRIPTION
Made the returned Iterator cloneable so that I can write codes like
```rust
let ret = Parser::new(...).parse();
let errs = ret.diagnostics.errors();
let errs1 = errs.clone().filter(...);
let errs2 = errs.filter(...);
```