### PR TITLE
fix(codegen): wrap negative BigInt literal base of `**` in parentheses

### DIFF
--- a/crates/oxc_codegen/src/binary_expr_visitor.rs
+++ b/crates/oxc_codegen/src/binary_expr_visitor.rs
@@ -201,13 +201,15 @@ impl<'a> BinaryExpressionVisitor<'a> {
             }
             BinaryishOperator::Binary(BinaryOperator::Exponential) => {
                 // The base of `**` must be an `UpdateExpression`, so a unary/await base
-                // must be parenthesized. Negative numbers print as a unary operator.
+                // must be parenthesized. Negative numbers and BigInts print with a
+                // leading `-`, i.e. as a unary operator.
                 if matches!(
                     e.left(),
                     Expression::UnaryExpression(_)
                         | Expression::AwaitExpression(_)
                         | Expression::TSTypeAssertion(_)
                         | Expression::NumericLiteral(_)
+                        | Expression::BigIntLiteral(_)
                 ) {
                     self.left_precedence = Precedence::Call;
                 }

--- a/crates/oxc_minifier/tests/peephole/obscure_edge_cases.rs
+++ b/crates/oxc_minifier/tests/peephole/obscure_edge_cases.rs
@@ -664,3 +664,12 @@ fn test_annotation_comments_preserved_in_dynamic_import() {
         "export async function init() { let bar = 'some-url'; return await import(/* @vite-ignore */ /* webpackIgnore: true */ 'some-url'); }",
     );
 }
+
+#[test]
+fn test_exponentiation_negative_bigint_base() {
+    // `0n + -1n` folds to a negative BigInt literal. As the base of `**` it must stay
+    // parenthesized, otherwise the output `-1n ** 2n` is a SyntaxError.
+    test("x = (0n + -1n) ** 2n", "x = (-1n) ** 2n");
+    // A positive BigInt base needs no parentheses.
+    test_same("x = 2n ** 3n");
+}


### PR DESCRIPTION
### Summary

Fixes invalid codegen output where a negative `BigInt` literal used as the base of an exponentiation (`**`) expression was emitted without the required parentheses, producing code that the parser rejects.

### Problem

Minifying `x = (0n + -1n) ** 2n;` folds `0n + -1n` into a single negative `BigIntLiteral` and then prints `x = -1n ** 2n;`, which is a `SyntaxError` ("Unexpected exponentiation expression") — the same grammar restriction that makes `-1 ** 2` illegal. The equivalent number case already prints correctly as `x = (-1) ** 2;`.

### Root cause

In `crates/oxc_codegen/src/binary_expr_visitor.rs`, the `**` base special-case raises the left operand precedence to `Precedence::Call` (forcing parentheses) for `UnaryExpression`, `AwaitExpression`, `TSTypeAssertion` and `NumericLiteral`, but omitted `BigIntLiteral`, which also prints with a leading `-` for negative values. So a negative BigInt base kept `left_precedence = Exponentiation` and was emitted without parentheses.

### Fix

Add `BigIntLiteral` to that match so a negative BigInt base is parenthesized like a negative number base. A positive BigInt base (e.g. `2n ** 3n`) is unaffected and not over-parenthesized.

### Testing

- Added regression test `test_exponentiation_negative_bigint_base` in `crates/oxc_minifier/tests/peephole/obscure_edge_cases.rs` (a negative BigInt literal only arises from constant folding, not from parsing).
- `cargo test -p oxc_codegen` passes; the only failing snapshot, `sourcemap::stacktrace_is_correct`, is a pre-existing Node.js version mismatch unrelated to this change.
