### PR TITLE
fix(linter/radix): avoid panic on `parseInt` with a spread radix argument

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/radix.rs
+++ b/crates/oxc_linter/src/rules/eslint/radix.rs
@@ -160,7 +160,9 @@ impl Radix {
 }
 
 fn is_valid_radix(node: &Argument) -> bool {
-    let expr = node.to_expression();
+    let Some(expr) = node.as_expression() else {
+        return false;
+    };
 
     if let Expression::NumericLiteral(lit) = expr {
         return lit.value.fract() == 0.0 && lit.value >= 2.0 && lit.value <= 36.0;
@@ -218,6 +220,8 @@ fn test() {
         (r#"parseInt("10", 1);"#, None, None),
         (r#"parseInt("10", 37);"#, None, None),
         (r#"parseInt("10", 10.5);"#, None, None),
+        (r#"parseInt("10", ...bar);"#, None, None),
+        ("parseInt(foo, ...bar);", None, None),
         ("Number.parseInt();", None, None),
         (r#"Number.parseInt("10");"#, None, None),
         (r#"Number.parseInt("10", 1);"#, None, None),

--- a/crates/oxc_linter/src/snapshots/eslint_radix.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_radix.snap
@@ -93,6 +93,20 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
 
+  ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
+   ╭─[radix.tsx:1:16]
+ 1 │ parseInt("10", ...bar);
+   ·                ──────
+   ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
+
+  ⚠ eslint(radix): Invalid radix parameter, must be an integer between 2 and 36.
+   ╭─[radix.tsx:1:15]
+ 1 │ parseInt(foo, ...bar);
+   ·               ──────
+   ╰────
+  help: The radix parameter should be an integer between 2 and 36, or a variable that is not `undefined`.
+
   ⚠ eslint(radix): Missing parameters.
    ╭─[radix.tsx:1:1]
  1 │ Number.parseInt();


### PR DESCRIPTION
### Summary

`eslint/radix` panicked (and aborted the whole lint run) on a `parseInt`/`Number.parseInt` call whose radix argument is a spread element.

### Problem

Linting `parseInt(foo, ...bar)` or `parseInt("10", ...bar)` crashed. `is_valid_radix` called `node.to_expression()`, which is `as_expression().unwrap()`, and panics when the argument is a `SpreadElement` rather than an expression.

### Fix

Guard with `node.as_expression()` (`let ... else { return false }`). A spread radix is now treated as an invalid radix and reported as `invalid radix` — matching ESLint, with no panic.

### Testing

- Added fail cases `parseInt("10", ...bar)` and `parseInt(foo, ...bar)`; snapshot updated.
- `cargo test -p oxc_linter --lib rules::eslint::radix` passes.
