### PR TITLE
fix(linter/prefer-numeric-literals): avoid panic on `parseInt` with a spread radix argument

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_numeric_literals.rs
@@ -135,7 +135,7 @@ fn check_arguments<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext<'a>) {
     }
 
     let radix_arg = &call_expr.arguments[1];
-    let Expression::NumericLiteral(numeric_lit) = &radix_arg.to_expression() else {
+    let Some(Expression::NumericLiteral(numeric_lit)) = radix_arg.as_expression() else {
         return;
     };
 
@@ -222,6 +222,8 @@ fn test() {
         "parseInt(`11`, 16n);",       // { "ecmaVersion": 2020 },
         "parseInt(1n, 2);",           // { "ecmaVersion": 2020 },
         r#"class C { #parseInt; foo() { Number.#parseInt("111110111", 2); } }"#, // { "ecmaVersion": 2022 }
+        "parseInt('ff', ...x);",
+        "Number.parseInt('ff', ...x);",
     ];
 
     let fail = vec![


### PR DESCRIPTION
### Summary

`eslint/prefer-numeric-literals` panicked (and aborted the whole lint run) on a `parseInt`/`Number.parseInt` call whose radix argument is a spread element.

### Problem

Linting `parseInt("ff", ...x)` crashed: after the `arguments.len() == 2` and string-first-argument checks pass, `radix_arg.to_expression()` (i.e. `as_expression().unwrap()`) panics on a `SpreadElement`.

### Fix

Match on `radix_arg.as_expression()` and return early when it is not a plain expression (e.g. a spread). No diagnostic is produced for a spread radix, and there is no panic.

### Testing

- Added pass cases `parseInt('ff', ...x)` and `Number.parseInt('ff', ...x)`.
- `cargo test -p oxc_linter --lib rules::eslint::prefer_numeric_literals` passes.
