### PR TITLE
fix(linter/prefer-called-exactly-once-with): avoid out-of-bounds slice panic at end of file

### DIFF
--- a/crates/oxc_linter/src/rules/vitest/prefer_called_exactly_once_with.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_exactly_once_with.rs
@@ -424,23 +424,14 @@ fn is_mock_reset_call_expression(call_expr: &CallExpression<'_>) -> bool {
  * Currently the method is asumming after the end of the statement, the next span position is the following line.
  * Even doing it safely the end check, this fix will remain dangerous as it removes code.
  */
+#[expect(clippy::cast_possible_truncation)]
 fn get_source_code_line_span(statement_span: Span, ctx: &LintContext<'_>) -> Span {
-    // Clamp the line end to the source length: when the statement is the last line with no
-    // trailing newline, `statement_span.end == source.len()`, so `end + 1` would slice out
-    // of bounds and panic. Only extend past the statement when a trailing byte exists.
-    let line_end = if (statement_span.end as usize) < ctx.source_text().len() {
-        statement_span.end + 1
-    } else {
-        statement_span.end
-    };
-    let mut column_0_span_index = statement_span.start;
+    let line_end = std::cmp::min(statement_span.end + 1, ctx.source_text().len() as u32);
 
-    // Guard against underflow when statement is at the beginning of the file
-    while column_0_span_index > 0
-        && !ctx.source_range(Span::new(column_0_span_index - 1, line_end)).starts_with('\n')
-    {
-        column_0_span_index -= 1;
-    }
+    let column_0_span_index = (0..statement_span.start)
+        .rev()
+        .find(|&index| ctx.source_range(Span::new(index, line_end)).starts_with('\n'))
+        .map_or(statement_span.start, |index| index + 1);
 
     Span::new(column_0_span_index, line_end)
 }
@@ -513,9 +504,6 @@ fn test() {
     ];
 
     let fail = vec![
-        // Last statement ends at EOF with no trailing newline — previously panicked with an
-        // out-of-bounds slice in `get_source_code_line_span`.
-        "expect(x).toHaveBeenCalledOnce();\nexpect(x).toHaveBeenCalledWith('hoge');",
         "
 			      expect(x).toHaveBeenCalledOnce();
 			      expect(x).toHaveBeenCalledWith('hoge');
@@ -587,6 +575,7 @@ fn test() {
 			      y.mockClear();
 			      expect(x).toHaveBeenCalledWith<[string]>('hoge');
 			      ",
+        "expect(x).toHaveBeenCalledOnce();\nexpect(x).toHaveBeenCalledWith('hoge');",
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_exactly_once_with.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_exactly_once_with.rs
@@ -425,18 +425,24 @@ fn is_mock_reset_call_expression(call_expr: &CallExpression<'_>) -> bool {
  * Even doing it safely the end check, this fix will remain dangerous as it removes code.
  */
 fn get_source_code_line_span(statement_span: Span, ctx: &LintContext<'_>) -> Span {
+    // Clamp the line end to the source length: when the statement is the last line with no
+    // trailing newline, `statement_span.end == source.len()`, so `end + 1` would slice out
+    // of bounds and panic. Only extend past the statement when a trailing byte exists.
+    let line_end = if (statement_span.end as usize) < ctx.source_text().len() {
+        statement_span.end + 1
+    } else {
+        statement_span.end
+    };
     let mut column_0_span_index = statement_span.start;
 
     // Guard against underflow when statement is at the beginning of the file
     while column_0_span_index > 0
-        && !ctx
-            .source_range(Span::new(column_0_span_index - 1, statement_span.end + 1))
-            .starts_with('\n')
+        && !ctx.source_range(Span::new(column_0_span_index - 1, line_end)).starts_with('\n')
     {
         column_0_span_index -= 1;
     }
 
-    Span::new(column_0_span_index, statement_span.end + 1)
+    Span::new(column_0_span_index, line_end)
 }
 
 fn get_test_callback<'a>(call_expr: &'a CallExpression<'a>) -> Option<&'a Expression<'a>> {
@@ -507,6 +513,9 @@ fn test() {
     ];
 
     let fail = vec![
+        // Last statement ends at EOF with no trailing newline — previously panicked with an
+        // out-of-bounds slice in `get_source_code_line_span`.
+        "expect(x).toHaveBeenCalledOnce();\nexpect(x).toHaveBeenCalledWith('hoge');",
         "
 			      expect(x).toHaveBeenCalledOnce();
 			      expect(x).toHaveBeenCalledWith('hoge');

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_called_exactly_once_with.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_called_exactly_once_with.snap
@@ -3,6 +3,17 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ vitest(prefer-called-exactly-once-with): Prefer `toHaveBeenCalledExactlyOnceWith` over `toHaveBeenCalledOnce` and `toHaveBeenCalledWith` on the same target.
+   ╭─[prefer_called_exactly_once_with.tsx:1:1]
+ 1 │ expect(x).toHaveBeenCalledOnce();
+   · ────────────────┬───────────────
+   ·                 ╰── Replace with `toHaveBeenCalledExactlyOnceWith`
+ 2 │ expect(x).toHaveBeenCalledWith('hoge');
+   · ───────────────────┬───────────────────
+   ·                    ╰── Remove this expect
+   ╰────
+  help: Replace with `toHaveBeenCalledExactlyOnceWith` and remove redundant expect
+
+  ⚠ vitest(prefer-called-exactly-once-with): Prefer `toHaveBeenCalledExactlyOnceWith` over `toHaveBeenCalledOnce` and `toHaveBeenCalledWith` on the same target.
    ╭─[prefer_called_exactly_once_with.tsx:2:10]
  1 │ 
  2 │                   expect(x).toHaveBeenCalledOnce();

--- a/crates/oxc_linter/src/snapshots/vitest_prefer_called_exactly_once_with.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_prefer_called_exactly_once_with.snap
@@ -3,17 +3,6 @@ source: crates/oxc_linter/src/tester.rs
 ---
 
   ⚠ vitest(prefer-called-exactly-once-with): Prefer `toHaveBeenCalledExactlyOnceWith` over `toHaveBeenCalledOnce` and `toHaveBeenCalledWith` on the same target.
-   ╭─[prefer_called_exactly_once_with.tsx:1:1]
- 1 │ expect(x).toHaveBeenCalledOnce();
-   · ────────────────┬───────────────
-   ·                 ╰── Replace with `toHaveBeenCalledExactlyOnceWith`
- 2 │ expect(x).toHaveBeenCalledWith('hoge');
-   · ───────────────────┬───────────────────
-   ·                    ╰── Remove this expect
-   ╰────
-  help: Replace with `toHaveBeenCalledExactlyOnceWith` and remove redundant expect
-
-  ⚠ vitest(prefer-called-exactly-once-with): Prefer `toHaveBeenCalledExactlyOnceWith` over `toHaveBeenCalledOnce` and `toHaveBeenCalledWith` on the same target.
    ╭─[prefer_called_exactly_once_with.tsx:2:10]
  1 │ 
  2 │                   expect(x).toHaveBeenCalledOnce();
@@ -229,5 +218,16 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────────────────┬─────────────────────────────────
    ·                                   ╰── Remove this expect
  5 │                   
+   ╰────
+  help: Replace with `toHaveBeenCalledExactlyOnceWith` and remove redundant expect
+
+  ⚠ vitest(prefer-called-exactly-once-with): Prefer `toHaveBeenCalledExactlyOnceWith` over `toHaveBeenCalledOnce` and `toHaveBeenCalledWith` on the same target.
+   ╭─[prefer_called_exactly_once_with.tsx:1:1]
+ 1 │ expect(x).toHaveBeenCalledOnce();
+   · ────────────────┬───────────────
+   ·                 ╰── Replace with `toHaveBeenCalledExactlyOnceWith`
+ 2 │ expect(x).toHaveBeenCalledWith('hoge');
+   · ───────────────────┬───────────────────
+   ·                    ╰── Remove this expect
    ╰────
   help: Replace with `toHaveBeenCalledExactlyOnceWith` and remove redundant expect


### PR DESCRIPTION
### Summary

`vitest/prefer-called-exactly-once-with` panicked (aborting the whole lint run) when the redundant `expect` pair is the last line of a file with no trailing newline.

### Problem

`get_source_code_line_span` built `Span::new(.., statement_span.end + 1)`. When the matched statement is the last line with no trailing newline, `statement_span.end == source.len()`, so `end + 1` slices one byte past the source and `Span::source_text` panics (`end byte index ... out of bounds`). This span is built during analysis (lines feeding the diagnostic, not only the fixer), so plain linting crashes — `--fix` is not required.

### Fix

Only extend the span one byte past the statement when a trailing byte actually exists; at end of file use `statement_span.end` itself. The bounds check is done in `usize` to avoid an unnecessary `usize -> u32` cast.

### Testing

- Added fail case `expect(x).toHaveBeenCalledOnce();\nexpect(x).toHaveBeenCalledWith('hoge');` (no trailing newline), which previously panicked; snapshot updated.
- `cargo test -p oxc_linter --lib rules::vitest::prefer_called_exactly_once_with` passes; `cargo lint -- -D warnings` passes.
