### PR TITLE
fix(linter/import/namespace): avoid panic on destructuring of an unresolvable namespace re-export

### DIFF
--- a/crates/oxc_linter/fixtures/import/unresolvable-namespace.js
+++ b/crates/oxc_linter/fixtures/import/unresolvable-namespace.js
@@ -1,0 +1,1 @@
+export * as missing from './does-not-exist'

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -319,6 +319,14 @@ fn check_deep_namespace_for_object_pattern(
         if let BindingPattern::ObjectPattern(pattern) = &property.value
             && let Some(module_source) = get_module_request_name(&name, module)
         {
+            // The request resolves to a name in `module`'s export entries, but the remote
+            // module may itself be unresolvable (e.g. re-exporting an external/missing module),
+            // in which case it is absent from `loaded_modules`. Skip rather than unwrap-panic,
+            // mirroring `check_deep_namespace_for_node`'s `?` handling.
+            let Some(next_module) = module.get_loaded_module(module_source.as_str()) else {
+                continue;
+            };
+
             let mut next_namespaces = namespaces.to_owned();
             next_namespaces.push(name.to_string());
 
@@ -326,7 +334,7 @@ fn check_deep_namespace_for_object_pattern(
                 pattern,
                 source,
                 next_namespaces.as_slice(),
-                &module.get_loaded_module(module_source.as_str()).unwrap(),
+                &next_module,
                 ctx,
             );
             continue;
@@ -479,6 +487,9 @@ fn test() {
         (r#"import * as a from "./deep/a"; console.log(a.b.c.d.e.f)"#, None),
         (r#"import * as a from "./deep/a"; var {b:{c:{d:{e}}}} = a"#, None),
         (r#"import { b } from "./deep/a"; var {c:{d:{e}}} = b"#, None),
+        // Object-pattern destructuring through a namespace whose remote module is unresolvable
+        // must not panic (previously `.unwrap()` on `get_loaded_module`).
+        (r#"import * as a from "./unresolvable-namespace"; var {missing:{x}} = a"#, None),
         (r#"import * as a from "./deep-es7/a"; console.log(a.b.c.d.e)"#, None),
         (r#"import { b } from "./deep-es7/a"; console.log(b.c.d.e)"#, None),
         (r#"import * as a from "./deep-es7/a"; console.log(a.b.c.d.e.f)"#, None),

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -483,8 +483,6 @@ fn test() {
         (r#"import * as a from "./deep/a"; console.log(a.b.c.d.e.f)"#, None),
         (r#"import * as a from "./deep/a"; var {b:{c:{d:{e}}}} = a"#, None),
         (r#"import { b } from "./deep/a"; var {c:{d:{e}}} = b"#, None),
-        // Object-pattern destructuring through a namespace whose remote module is unresolvable
-        // must not panic (previously `.unwrap()` on `get_loaded_module`).
         (r#"import * as a from "./unresolvable-namespace"; var {missing:{x}} = a"#, None),
         (r#"import * as a from "./deep-es7/a"; console.log(a.b.c.d.e)"#, None),
         (r#"import { b } from "./deep-es7/a"; console.log(b.c.d.e)"#, None),

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -319,10 +319,6 @@ fn check_deep_namespace_for_object_pattern(
         if let BindingPattern::ObjectPattern(pattern) = &property.value
             && let Some(module_source) = get_module_request_name(&name, module)
         {
-            // The request resolves to a name in `module`'s export entries, but the remote
-            // module may itself be unresolvable (e.g. re-exporting an external/missing module),
-            // in which case it is absent from `loaded_modules`. Skip rather than unwrap-panic,
-            // mirroring `check_deep_namespace_for_node`'s `?` handling.
             let Some(next_module) = module.get_loaded_module(module_source.as_str()) else {
                 continue;
             };


### PR DESCRIPTION
### Summary

`import/namespace` panicked (aborting the lint run) when object-pattern destructuring recurses into a namespace whose remote module is unresolvable.

### Problem

For `import * as a from "./m"; var {ns:{x}} = a` where `m` does `export * as ns from './unresolvable'`, `check_deep_namespace_for_object_pattern` finds `ns` among the export entries (`get_module_request_name` returns the request), then calls `module.get_loaded_module(request).unwrap()`. Unresolvable modules are never inserted into `loaded_modules`, so `get_loaded_module` returns `None` and `.unwrap()` panics. The sibling `check_deep_namespace_for_node` already handles the same situation with `?`.

### Fix

Replace `.unwrap()` with a `let Some(..) else { continue }` guard, skipping the unresolvable namespace exactly like the node path does.

### Testing

- Added fixture `fixtures/import/unresolvable-namespace.js` (`export * as missing from './does-not-exist'`) and a pass case `import * as a from "./unresolvable-namespace"; var {missing:{x}} = a`. Reverting the fix makes this case panic at `namespace.rs:329` (`Option::unwrap()` on `None`); with the fix it lints cleanly.
- `cargo test -p oxc_linter --lib rules::import::namespace` and `cargo lint -- -D warnings` pass.
