### PR TITLE
fix(linter/prefer-query-selector): use a compound selector for multiple classes

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_query_selector.rs
@@ -55,7 +55,7 @@ declare_oxc_lint!(
     /// document.querySelector('#foo');
     /// document.querySelector('.bar');
     /// document.querySelector('main #foo .bar');
-    /// document.querySelectorAll('.foo .bar');
+    /// document.querySelectorAll('.foo.bar');
     /// document.querySelectorAll('li a');
     /// document.querySelector('li').querySelectorAll('a');
     /// ```
@@ -129,9 +129,12 @@ impl Rule for PreferQuerySelector {
                     let argument = match property_name {
                         "getElementById" => format!("#{literal_value}"),
                         "getElementsByClassName" => {
+                            // `getElementsByClassName` matches elements having ALL the listed
+                            // classes, so multiple classes become a compound selector
+                            // (`.foo.bar`), not a descendant selector (`.foo .bar`).
                             format!(
                                 ".{}",
-                                literal_value.split_whitespace().collect::<Vec<_>>().join(" .")
+                                literal_value.split_whitespace().collect::<Vec<_>>().join(".")
                             )
                         }
                         "getElementsByName" => {
@@ -229,7 +232,7 @@ fn test() {
 
     let fix = vec![
         ("document.getElementsByTagName('foo');", "document.querySelectorAll('foo');"),
-        ("document.getElementsByClassName(`foo bar`);", "document.querySelectorAll(`.foo .bar`);"),
+        ("document.getElementsByClassName(`foo bar`);", "document.querySelectorAll(`.foo.bar`);"),
         ("document.getElementsByClassName(null);", "document.querySelectorAll(null);"),
         ("document.getElementsByTagName(`   `);", "document.querySelectorAll(`   `);"),
         ("document.getElementById(123);", "document.getElementById(123);"),


### PR DESCRIPTION
### Summary

`unicorn/prefer-query-selector`'s autofix turned `getElementsByClassName('foo bar')` into `querySelectorAll('.foo .bar')` — a descendant selector — instead of the compound selector `'.foo.bar'`, changing which elements match.

### Problem

`getElementsByClassName('foo bar')` returns elements that have BOTH classes `foo` and `bar`. The fix joined the classes with `" ."`, producing `.foo .bar` (a `.bar` that is a descendant of a `.foo`) — a completely different element set. Per the DOM spec the argument is split on whitespace and matches elements possessing all listed classes; upstream eslint-plugin-unicorn builds the selector by joining the classes with `""`, i.e. `.foo.bar`.

### Fix

Join the classes with `"."` to form a compound selector. Updated the doc "correct" example and the fix test to `.foo.bar` accordingly.

### Testing

- `cargo test -p oxc_linter --lib rules::unicorn::prefer_query_selector` and `cargo lint -- -D warnings` pass.
