### PR TITLE
fix(linter/unicorn/prefer-modern-dom-apis): skip fixer for non identifier arguments

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -100,17 +100,7 @@ impl Rule for PreferModernDomApis {
             Some(&["replaceChild", "insertBefore"]),
             Some(2),
             Some(2),
-        ) && call_expr
-            .arguments
-            .iter()
-            // Both arguments must be plain (non-`undefined`) identifiers. `is_undefined()` only
-            // rejects the literal `undefined`, not "is an identifier" — so a complex argument
-            // (e.g. a ternary `a ? b : c`) would otherwise be spliced before `.replaceWith`,
-            // breaking precedence. Upstream eslint-plugin-unicorn restricts the fix to identifiers.
-            .all(|argument| {
-                matches!(argument.as_expression(), Some(expr @ Expression::Identifier(_)) if !expr.is_undefined())
-            })
-            && matches!(member_expr.object, Expression::Identifier(_))
+        ) && matches!(member_expr.object, Expression::Identifier(_))
             && !call_expr.optional
             && let Some(preferred_method) = get_replacement_for_disallowed_method(method)
         {
@@ -120,7 +110,12 @@ impl Rule for PreferModernDomApis {
                 member_expr.property.span,
             );
 
-            if is_value_not_usable(node, ctx) {
+            // Reordering complex arguments can change evaluation semantics.
+            let has_safe_arguments = call_expr.arguments.iter().all(|argument| {
+                matches!(argument, Argument::Identifier(identifier) if identifier.name != "undefined")
+            });
+
+            if has_safe_arguments && is_value_not_usable(node, ctx) {
                 ctx.diagnostic_with_suggestion(diagnostic, |fixer| {
                     let new_node = ctx.source_range(call_expr.arguments[0].span());
                     let old_node = ctx.source_range(call_expr.arguments[1].span());
@@ -210,17 +205,10 @@ fn test() {
         "parentNode.insertBefore(newNode, referenceNode, extra);",
         "referenceNode.insertAdjacentText('beforebegin', 'text', extra);",
         "referenceNode.insertAdjacentElement('beforebegin', newNode, extra);",
-        "parentNode.replaceChild(...argumentsArray1, ...argumentsArray2);",
-        "parentNode.insertBefore(...argumentsArray1, ...argumentsArray2);",
         "referenceNode.insertAdjacentText(...argumentsArray1, ...argumentsArray2);",
         "referenceNode.insertAdjacentElement(...argumentsArray1, ...argumentsArray2);",
         "referenceNode.insertAdjacentText('foo', 'text');",
         "referenceNode.insertAdjacentElement('foo', newNode);",
-        // Non-identifier arguments are not auto-fixable (rewriting them before `.replaceWith`
-        // would break precedence), so they are not reported.
-        "parentNode.replaceChild(newNode, cond ? c : d);",
-        "parentNode.insertBefore(newNode, p || q);",
-        "parentNode.replaceChild(getNode(), oldNode);",
     ];
 
     let fail = vec![
@@ -241,6 +229,14 @@ fn test() {
         "foo = parentNode.insertBefore(alfa, beta);",
         "new Dom(parentNode.insertBefore(alfa, beta))",
         "`${parentNode.insertBefore(alfa, beta)}`",
+        // Non-identifier arguments are reported without a suggestion. Rewriting them before
+        // `.replaceWith` or `.before` could change precedence or evaluation order.
+        "parentNode.replaceChild(newNode, cond ? c : d);",
+        "parentNode.insertBefore(newNode, p || q);",
+        "parentNode.replaceChild(getNode(), oldNode);",
+        "parentNode.replaceChild(...argumentsArray1, ...argumentsArray2);",
+        "parentNode.insertBefore(...argumentsArray1, ...argumentsArray2);",
+        "parentNode.replaceChild(newNode, undefined);",
         r#"referenceNode.insertAdjacentText("beforebegin", "text");"#,
         r#"referenceNode.insertAdjacentText("afterbegin", "text");"#,
         r#"referenceNode.insertAdjacentText("beforeend", "text");"#,

--- a/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_modern_dom_apis.rs
@@ -103,7 +103,13 @@ impl Rule for PreferModernDomApis {
         ) && call_expr
             .arguments
             .iter()
-            .all(|argument| matches!(argument.as_expression(), Some(expr) if !expr.is_undefined()))
+            // Both arguments must be plain (non-`undefined`) identifiers. `is_undefined()` only
+            // rejects the literal `undefined`, not "is an identifier" — so a complex argument
+            // (e.g. a ternary `a ? b : c`) would otherwise be spliced before `.replaceWith`,
+            // breaking precedence. Upstream eslint-plugin-unicorn restricts the fix to identifiers.
+            .all(|argument| {
+                matches!(argument.as_expression(), Some(expr @ Expression::Identifier(_)) if !expr.is_undefined())
+            })
             && matches!(member_expr.object, Expression::Identifier(_))
             && !call_expr.optional
             && let Some(preferred_method) = get_replacement_for_disallowed_method(method)
@@ -210,6 +216,11 @@ fn test() {
         "referenceNode.insertAdjacentElement(...argumentsArray1, ...argumentsArray2);",
         "referenceNode.insertAdjacentText('foo', 'text');",
         "referenceNode.insertAdjacentElement('foo', newNode);",
+        // Non-identifier arguments are not auto-fixable (rewriting them before `.replaceWith`
+        // would break precedence), so they are not reported.
+        "parentNode.replaceChild(newNode, cond ? c : d);",
+        "parentNode.insertBefore(newNode, p || q);",
+        "parentNode.replaceChild(getNode(), oldNode);",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/snapshots/unicorn_prefer_modern_dom_apis.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_prefer_modern_dom_apis.snap
@@ -80,6 +80,42 @@ source: crates/oxc_linter/src/tester.rs
    ·               ────────────
    ╰────
 
+  ⚠ unicorn(prefer-modern-dom-apis): Prefer using `replaceWith` over `replaceChild`.
+   ╭─[prefer_modern_dom_apis.tsx:1:12]
+ 1 │ parentNode.replaceChild(newNode, cond ? c : d);
+   ·            ────────────
+   ╰────
+
+  ⚠ unicorn(prefer-modern-dom-apis): Prefer using `before` over `insertBefore`.
+   ╭─[prefer_modern_dom_apis.tsx:1:12]
+ 1 │ parentNode.insertBefore(newNode, p || q);
+   ·            ────────────
+   ╰────
+
+  ⚠ unicorn(prefer-modern-dom-apis): Prefer using `replaceWith` over `replaceChild`.
+   ╭─[prefer_modern_dom_apis.tsx:1:12]
+ 1 │ parentNode.replaceChild(getNode(), oldNode);
+   ·            ────────────
+   ╰────
+
+  ⚠ unicorn(prefer-modern-dom-apis): Prefer using `replaceWith` over `replaceChild`.
+   ╭─[prefer_modern_dom_apis.tsx:1:12]
+ 1 │ parentNode.replaceChild(...argumentsArray1, ...argumentsArray2);
+   ·            ────────────
+   ╰────
+
+  ⚠ unicorn(prefer-modern-dom-apis): Prefer using `before` over `insertBefore`.
+   ╭─[prefer_modern_dom_apis.tsx:1:12]
+ 1 │ parentNode.insertBefore(...argumentsArray1, ...argumentsArray2);
+   ·            ────────────
+   ╰────
+
+  ⚠ unicorn(prefer-modern-dom-apis): Prefer using `replaceWith` over `replaceChild`.
+   ╭─[prefer_modern_dom_apis.tsx:1:12]
+ 1 │ parentNode.replaceChild(newNode, undefined);
+   ·            ────────────
+   ╰────
+
   ⚠ unicorn(prefer-modern-dom-apis): Prefer using `before` over `insertAdjacentText`.
    ╭─[prefer_modern_dom_apis.tsx:1:15]
  1 │ referenceNode.insertAdjacentText("beforebegin", "text");


### PR DESCRIPTION
### Summary

`unicorn/prefer-modern-dom-apis` reported (and offered a precedence-breaking suggestion for) `replaceChild`/`insertBefore` calls whose arguments are not plain identifiers.

### Problem

The argument guard was `arguments.all(|a| !a.is_undefined())`, which only excludes the literal `undefined` — it accepts any expression. For `parentNode.replaceChild(a, cond ? c : d)` the rule offered `cond ? c : d.replaceWith(a)`, which parses as `cond ? c : (d.replaceWith(a))` — wrong precedence and wrong semantics. The existing `Identifier` check applied to `member_expr.object` (the receiver), not to the arguments.

### Fix

Only provide a fixer if both arguments are non-`undefined` identifiers.