### PR TITLE
fix(minifier): preserve side-effectful `let`/`const` for-init when the test is always false

### DIFF
--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -195,6 +195,20 @@ impl<'a> PeepholeOptimizations {
         match test_boolean {
             Some(false) => match &for_stmt.init {
                 Some(ForStatementInit::VariableDeclaration(_)) => {
+                    // The for-init runs exactly once before the (false) test. A `var` binding is
+                    // hoisted and merged below, but a `let`/`const` binding is block-scoped to the
+                    // now-dead loop and cannot be kept; we may only drop it when its initializers
+                    // are side-effect free. Otherwise removing the loop would silently discard
+                    // those side effects (e.g. `for (let i = foo(); false;) {}` drops `foo()`),
+                    // so bail and keep the loop, which still runs the init exactly once.
+                    if let Some(ForStatementInit::VariableDeclaration(var_init)) = &for_stmt.init
+                        && !var_init.kind.is_var()
+                        && var_init.declarations.iter().any(|d| {
+                            d.init.as_ref().is_some_and(|init| init.may_have_side_effects(ctx))
+                        })
+                    {
+                        return;
+                    }
                     let mut keep_var = KeepVar::new();
                     keep_var.visit_statement(&for_stmt.body);
                     let mut var_decl = keep_var.get_variable_declaration(&ctx.ast);

--- a/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/tests/peephole/remove_dead_code.rs
@@ -87,6 +87,15 @@ fn test_fold_useless_for() {
 
     test("for (foo = bar; false;) {}", "for (foo = bar; !1;);");
     // test("l1:for(;false;) {  }", "");
+
+    // A `let`/`const` for-init runs exactly once before the `false` test; its side effects must
+    // be preserved. The binding is block-scoped to the (dead) loop and cannot be hoisted out
+    // like `var`, so keep the whole loop rather than dropping the initializer.
+    test("for (let i = foo(); false;) {}", "for (let i = foo(); !1;);");
+    test("for (let i = 0, j = bar(); false;) {}", "for (let i = 0, j = bar(); !1;);");
+    // A pure `let`/`const` init has no side effects to keep, so the loop is still dropped.
+    test("for (let i = 0; false;) {}", "");
+    test("for (const a = 1; false;) {}", "");
 }
 
 #[test]


### PR DESCRIPTION
### Summary

The minifier dropped a side-effectful `let`/`const` `for`-loop initializer when the loop test is always `false`.

### Problem

`for (let i = foo(); false;) {}` was folded to an empty statement, discarding `foo()`. A `for` initializer runs exactly once before the first test, even when the test is immediately `false`, so `foo()` must still execute. The `var` case was handled (the declaration is hoisted and kept), but the `let`/`const` branch dropped the declaration — and with it the initializer's side effects.

### Fix

A `let`/`const` binding is block-scoped to the (now-dead) loop and cannot be hoisted out like `var`. When any of its initializers may have side effects, keep the whole loop (whose init still runs exactly once) instead of dropping it. Pure `let`/`const` inits are still folded away.

### Testing

- Added cases to `test_fold_useless_for`: `for (let i = foo(); false;) {}` and `for (let i = 0, j = bar(); false;) {}` now keep their side effects; `for (let i = 0; false;) {}` and `for (const a = 1; false;) {}` still fold to nothing.
- `cargo test -p oxc_minifier` (536 passed) and `cargo lint -- -D warnings` pass.
