### PR TITLE
fix(formatter): parenthesize a type assertion used as the base of `**`

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -876,7 +876,12 @@ impl NeedsParentheses<'_> for AstNode<'_, TSTypeAssertion<'_>> {
         match self.parent() {
             AstNodes::TSAsExpression(_) | AstNodes::TSSatisfiesExpression(_) => true,
             AstNodes::BinaryExpression(binary) => {
+                // The base of `**` must be an `UpdateExpression`; a type assertion `<T>x` is a
+                // unary-like expression, so as the left operand it must be parenthesized
+                // (`<T>x ** 2` is a syntax error, same restriction as `-2 ** 2`).
                 matches!(binary.operator, BinaryOperator::ShiftLeft)
+                    || (binary.operator == BinaryOperator::Exponential
+                        && binary.left.span() == self.span())
             }
             _ => type_cast_like_needs_parens(self.span(), self.parent()),
         }

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/type-assertion-exponentiation.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/type-assertion-exponentiation.ts
@@ -1,0 +1,7 @@
+// `<T>x` as the base of `**` must stay parenthesized (`<T>x ** 2` is a syntax error).
+a = (<T>x) ** 2;
+// As the `**` exponent it does not need parentheses.
+b = 2 ** (<T>x);
+// Other operators are unaffected: `<<` keeps parens, `+` drops them.
+c = (<T>x) << 2;
+d = (<T>x) + 2;

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/type-assertion-exponentiation.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/type-assertion-exponentiation.ts.snap
@@ -1,0 +1,37 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+assertion_line: 142
+---
+==================== Input ====================
+// `<T>x` as the base of `**` must stay parenthesized (`<T>x ** 2` is a syntax error).
+a = (<T>x) ** 2;
+// As the `**` exponent it does not need parentheses.
+b = 2 ** (<T>x);
+// Other operators are unaffected: `<<` keeps parens, `+` drops them.
+c = (<T>x) << 2;
+d = (<T>x) + 2;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// `<T>x` as the base of `**` must stay parenthesized (`<T>x ** 2` is a syntax error).
+a = (<T>x) ** 2;
+// As the `**` exponent it does not need parentheses.
+b = 2 ** <T>x;
+// Other operators are unaffected: `<<` keeps parens, `+` drops them.
+c = (<T>x) << 2;
+d = <T>x + 2;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// `<T>x` as the base of `**` must stay parenthesized (`<T>x ** 2` is a syntax error).
+a = (<T>x) ** 2;
+// As the `**` exponent it does not need parentheses.
+b = 2 ** <T>x;
+// Other operators are unaffected: `<<` keeps parens, `+` drops them.
+c = (<T>x) << 2;
+d = <T>x + 2;
+
+===================== End =====================


### PR DESCRIPTION
### Summary

The formatter stripped the required parentheses around a TypeScript type assertion used as the base of an exponentiation (`**`), producing output that `tsc` rejects.

### Problem

`(<T>x) ** 2` was formatted to `<T>x ** 2`. The base of `**` must be an `UpdateExpression`; a type assertion `<T>x` is a unary-like expression, so `<T>x ** 2` is a syntax error in `tsc` (the same restriction that makes `-2 ** 2` illegal). oxc's own lenient parser accepts the stripped form, so the output is idempotent, but it is not valid TypeScript. `TSTypeAssertion::needs_parentheses` only handled `<<` (ShiftLeft) among binary parents and omitted `**`.

### Fix

In the `BinaryExpression` arm, also require parentheses when the assertion is the left operand of `**`. The exponent position (`2 ** <T>x`) is unaffected, since `**`'s right operand may be a unary expression. (`as`/`satisfies` already parenthesize inside any binary expression due to their low precedence; this aligns the high-precedence `<T>x` form for the one operator that needs it.)

### Testing

- Added fixture `tests/fixtures/ts/parenthesis/type-assertion-exponentiation.ts` covering `**` (left/right operand), `<<`, and `+`.
- `cargo test -p oxc_formatter --test mod` and `cargo lint -- -D warnings` pass; no other snapshots changed.
