### PR TITLE
fix(minifier): keep side effects when folding a `typeof` equality comparison

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -662,6 +662,12 @@ impl<'a> PeepholeOptimizations {
         if let Expression::UnaryExpression(left) = &e.left
             && left.operator.is_typeof()
             && e.operator.is_equality()
+            // Folding to a boolean discards both operands, so only do it when neither side has
+            // side effects: `typeof foo === [bar()]` must still evaluate `bar()`, and
+            // `typeof bar() === 'x'` must still evaluate `bar()`. Use `e.left` (the whole
+            // `typeof X`) so the `typeof <identifier>` special case stays side-effect-free.
+            && !e.left.may_have_side_effects(ctx)
+            && !e.right.may_have_side_effects(ctx)
         {
             let right_ty = e.right.value_type(ctx);
 

--- a/crates/oxc_minifier/tests/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/tests/peephole/fold_constants.rs
@@ -1301,6 +1301,15 @@ fn test_fold_invalid_typeof_comparison() {
     fold("typeof foo != undefined", "!0");
     fold("typeof foo === 'string'", "typeof foo == 'string'");
     fold("typeof foo === 'number'", "typeof foo == 'number'");
+
+    // Operands with side effects must NOT be dropped by the fold-to-boolean.
+    fold_same("typeof foo === [bar()]");
+    fold_same("typeof foo === {[k()]: 1}");
+    fold_same("typeof bar() === 123");
+    fold("typeof bar() === 'asd'", "typeof bar() == 'asd'");
+    // `typeof <identifier>` reads no value (no ReferenceError), so it is side-effect free and
+    // an invalid string comparison still folds.
+    fold("typeof foo === 'asd'", "!1");
 }
 
 #[test]


### PR DESCRIPTION
### Summary

The minifier dropped operand side effects when folding a `typeof x === <something>` comparison to a boolean.

### Problem

`fold_binary_typeof_comparison` rewrites `typeof x === <determined non-string type>` and `typeof x === '<invalid-typeof-string>'` to a boolean, discarding both operands. When an operand had side effects they were silently lost: `typeof foo === [bar()]` became `false` without running `bar()`, and `typeof bar() === 'x'` dropped `bar()` on the left.

### Fix

Only perform the fold when neither operand may have side effects. The left side is checked through the whole `typeof X` unary expression, so the `typeof <identifier>` special case — which reads no value and cannot throw `ReferenceError` — stays side-effect-free and keeps folding (e.g. `typeof foo === 'asd'` still folds to `false`).

### Testing

- Added cases to `test_fold_invalid_typeof_comparison`: side-effectful operands (`[bar()]`, `{[k()]: 1}`, `typeof bar()`) are now preserved, while pure invalid comparisons (`typeof foo === 'asd'`) still fold.
- `cargo test -p oxc_minifier` (536 passed) and `cargo lint -- -D warnings` pass.
