### PR TITLE
feat(linter/unicorn): implement no-confusing-array-with rule

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3104,6 +3104,12 @@ impl RuleRunner for crate::rules::unicorn::no_await_in_promise_methods::NoAwaitI
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_confusing_array_with::NoConfusingArrayWith {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::no_console_spaces::NoConsoleSpaces {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -622,6 +622,7 @@ pub use crate::rules::unicorn::no_array_reverse::NoArrayReverse as UnicornNoArra
 pub use crate::rules::unicorn::no_array_sort::NoArraySort as UnicornNoArraySort;
 pub use crate::rules::unicorn::no_await_expression_member::NoAwaitExpressionMember as UnicornNoAwaitExpressionMember;
 pub use crate::rules::unicorn::no_await_in_promise_methods::NoAwaitInPromiseMethods as UnicornNoAwaitInPromiseMethods;
+pub use crate::rules::unicorn::no_confusing_array_with::NoConfusingArrayWith as UnicornNoConfusingArrayWith;
 pub use crate::rules::unicorn::no_console_spaces::NoConsoleSpaces as UnicornNoConsoleSpaces;
 pub use crate::rules::unicorn::no_document_cookie::NoDocumentCookie as UnicornNoDocumentCookie;
 pub use crate::rules::unicorn::no_empty_file::NoEmptyFile as UnicornNoEmptyFile;
@@ -1342,6 +1343,7 @@ pub enum RuleEnum {
     UnicornNoArraySort(UnicornNoArraySort),
     UnicornNoAwaitExpressionMember(UnicornNoAwaitExpressionMember),
     UnicornNoAwaitInPromiseMethods(UnicornNoAwaitInPromiseMethods),
+    UnicornNoConfusingArrayWith(UnicornNoConfusingArrayWith),
     UnicornNoConsoleSpaces(UnicornNoConsoleSpaces),
     UnicornNoDocumentCookie(UnicornNoDocumentCookie),
     UnicornNoEmptyFile(UnicornNoEmptyFile),
@@ -2246,7 +2248,8 @@ const UNICORN_NO_ARRAY_SORT_ID: usize = UNICORN_NO_ARRAY_REVERSE_ID + 1usize;
 const UNICORN_NO_AWAIT_EXPRESSION_MEMBER_ID: usize = UNICORN_NO_ARRAY_SORT_ID + 1usize;
 const UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID: usize =
     UNICORN_NO_AWAIT_EXPRESSION_MEMBER_ID + 1usize;
-const UNICORN_NO_CONSOLE_SPACES_ID: usize = UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID + 1usize;
+const UNICORN_NO_CONFUSING_ARRAY_WITH_ID: usize = UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID + 1usize;
+const UNICORN_NO_CONSOLE_SPACES_ID: usize = UNICORN_NO_CONFUSING_ARRAY_WITH_ID + 1usize;
 const UNICORN_NO_DOCUMENT_COOKIE_ID: usize = UNICORN_NO_CONSOLE_SPACES_ID + 1usize;
 const UNICORN_NO_EMPTY_FILE_ID: usize = UNICORN_NO_DOCUMENT_COOKIE_ID + 1usize;
 const UNICORN_NO_HEX_ESCAPE_ID: usize = UNICORN_NO_EMPTY_FILE_ID + 1usize;
@@ -3218,6 +3221,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(_) => UNICORN_NO_ARRAY_SORT_ID,
             Self::UnicornNoAwaitExpressionMember(_) => UNICORN_NO_AWAIT_EXPRESSION_MEMBER_ID,
             Self::UnicornNoAwaitInPromiseMethods(_) => UNICORN_NO_AWAIT_IN_PROMISE_METHODS_ID,
+            Self::UnicornNoConfusingArrayWith(_) => UNICORN_NO_CONFUSING_ARRAY_WITH_ID,
             Self::UnicornNoConsoleSpaces(_) => UNICORN_NO_CONSOLE_SPACES_ID,
             Self::UnicornNoDocumentCookie(_) => UNICORN_NO_DOCUMENT_COOKIE_ID,
             Self::UnicornNoEmptyFile(_) => UNICORN_NO_EMPTY_FILE_ID,
@@ -4184,6 +4188,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::NAME,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::NAME,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::NAME,
+            Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::NAME,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::NAME,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::NAME,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::NAME,
@@ -5168,6 +5173,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::CATEGORY,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::CATEGORY,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::CATEGORY,
+            Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::CATEGORY,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::CATEGORY,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::CATEGORY,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::CATEGORY,
@@ -6155,6 +6161,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::FIX,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::FIX,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::FIX,
+            Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::FIX,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::FIX,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::FIX,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::FIX,
@@ -7246,6 +7253,7 @@ impl RuleEnum {
             Self::UnicornNoAwaitInPromiseMethods(_) => {
                 UnicornNoAwaitInPromiseMethods::documentation()
             }
+            Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::documentation(),
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::documentation(),
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::documentation(),
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::documentation(),
@@ -9146,6 +9154,10 @@ impl RuleEnum {
                 UnicornNoAwaitInPromiseMethods::config_schema(generator)
                     .or_else(|| UnicornNoAwaitInPromiseMethods::schema(generator))
             }
+            Self::UnicornNoConfusingArrayWith(_) => {
+                UnicornNoConfusingArrayWith::config_schema(generator)
+                    .or_else(|| UnicornNoConfusingArrayWith::schema(generator))
+            }
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::config_schema(generator)
                 .or_else(|| UnicornNoConsoleSpaces::schema(generator)),
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::config_schema(generator)
@@ -10669,6 +10681,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(_) => "unicorn",
             Self::UnicornNoAwaitExpressionMember(_) => "unicorn",
             Self::UnicornNoAwaitInPromiseMethods(_) => "unicorn",
+            Self::UnicornNoConfusingArrayWith(_) => "unicorn",
             Self::UnicornNoConsoleSpaces(_) => "unicorn",
             Self::UnicornNoDocumentCookie(_) => "unicorn",
             Self::UnicornNoEmptyFile(_) => "unicorn",
@@ -12582,6 +12595,9 @@ impl RuleEnum {
             Self::UnicornNoAwaitInPromiseMethods(_) => Ok(Self::UnicornNoAwaitInPromiseMethods(
                 UnicornNoAwaitInPromiseMethods::from_configuration(value)?,
             )),
+            Self::UnicornNoConfusingArrayWith(_) => Ok(Self::UnicornNoConfusingArrayWith(
+                UnicornNoConfusingArrayWith::from_configuration(value)?,
+            )),
             Self::UnicornNoConsoleSpaces(_) => {
                 Ok(Self::UnicornNoConsoleSpaces(UnicornNoConsoleSpaces::from_configuration(value)?))
             }
@@ -14218,6 +14234,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(rule) => rule.to_configuration(),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.to_configuration(),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.to_configuration(),
+            Self::UnicornNoConfusingArrayWith(rule) => rule.to_configuration(),
             Self::UnicornNoConsoleSpaces(rule) => rule.to_configuration(),
             Self::UnicornNoDocumentCookie(rule) => rule.to_configuration(),
             Self::UnicornNoEmptyFile(rule) => rule.to_configuration(),
@@ -15063,6 +15080,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(rule) => rule.run(node, ctx),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.run(node, ctx),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.run(node, ctx),
+            Self::UnicornNoConfusingArrayWith(rule) => rule.run(node, ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.run(node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run(node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run(node, ctx),
@@ -15918,6 +15936,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(rule) => rule.run_once(ctx),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.run_once(ctx),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.run_once(ctx),
+            Self::UnicornNoConfusingArrayWith(rule) => rule.run_once(ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.run_once(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_once(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_once(ctx),
@@ -16852,6 +16871,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoConfusingArrayWith(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornNoEmptyFile(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17746,6 +17766,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(rule) => rule.should_run(ctx),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.should_run(ctx),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.should_run(ctx),
+            Self::UnicornNoConfusingArrayWith(rule) => rule.should_run(ctx),
             Self::UnicornNoConsoleSpaces(rule) => rule.should_run(ctx),
             Self::UnicornNoDocumentCookie(rule) => rule.should_run(ctx),
             Self::UnicornNoEmptyFile(rule) => rule.should_run(ctx),
@@ -18798,6 +18819,7 @@ impl RuleEnum {
             Self::UnicornNoAwaitInPromiseMethods(_) => {
                 UnicornNoAwaitInPromiseMethods::IS_TSGOLINT_RULE
             }
+            Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::IS_TSGOLINT_RULE,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::IS_TSGOLINT_RULE,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::IS_TSGOLINT_RULE,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::IS_TSGOLINT_RULE,
@@ -19914,6 +19936,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::VERSION,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::VERSION,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::VERSION,
+            Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::VERSION,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::VERSION,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::VERSION,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::VERSION,
@@ -20949,6 +20972,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::HAS_CONFIG,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::HAS_CONFIG,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::HAS_CONFIG,
+            Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::HAS_CONFIG,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::HAS_CONFIG,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::HAS_CONFIG,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::HAS_CONFIG,
@@ -21955,6 +21979,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(_) => UnicornNoArraySort::INFO,
             Self::UnicornNoAwaitExpressionMember(_) => UnicornNoAwaitExpressionMember::INFO,
             Self::UnicornNoAwaitInPromiseMethods(_) => UnicornNoAwaitInPromiseMethods::INFO,
+            Self::UnicornNoConfusingArrayWith(_) => UnicornNoConfusingArrayWith::INFO,
             Self::UnicornNoConsoleSpaces(_) => UnicornNoConsoleSpaces::INFO,
             Self::UnicornNoDocumentCookie(_) => UnicornNoDocumentCookie::INFO,
             Self::UnicornNoEmptyFile(_) => UnicornNoEmptyFile::INFO,
@@ -22840,6 +22865,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(rule) => rule.types_info(),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.types_info(),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.types_info(),
+            Self::UnicornNoConfusingArrayWith(rule) => rule.types_info(),
             Self::UnicornNoConsoleSpaces(rule) => rule.types_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.types_info(),
             Self::UnicornNoEmptyFile(rule) => rule.types_info(),
@@ -23682,6 +23708,7 @@ impl RuleEnum {
             Self::UnicornNoArraySort(rule) => rule.run_info(),
             Self::UnicornNoAwaitExpressionMember(rule) => rule.run_info(),
             Self::UnicornNoAwaitInPromiseMethods(rule) => rule.run_info(),
+            Self::UnicornNoConfusingArrayWith(rule) => rule.run_info(),
             Self::UnicornNoConsoleSpaces(rule) => rule.run_info(),
             Self::UnicornNoDocumentCookie(rule) => rule.run_info(),
             Self::UnicornNoEmptyFile(rule) => rule.run_info(),
@@ -24622,6 +24649,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::UnicornNoArraySort(UnicornNoArraySort::default()),
         RuleEnum::UnicornNoAwaitExpressionMember(UnicornNoAwaitExpressionMember::default()),
         RuleEnum::UnicornNoAwaitInPromiseMethods(UnicornNoAwaitInPromiseMethods::default()),
+        RuleEnum::UnicornNoConfusingArrayWith(UnicornNoConfusingArrayWith::default()),
         RuleEnum::UnicornNoConsoleSpaces(UnicornNoConsoleSpaces::default()),
         RuleEnum::UnicornNoDocumentCookie(UnicornNoDocumentCookie::default()),
         RuleEnum::UnicornNoEmptyFile(UnicornNoEmptyFile::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -511,6 +511,7 @@ pub(crate) mod unicorn {
     pub mod no_array_sort;
     pub mod no_await_expression_member;
     pub mod no_await_in_promise_methods;
+    pub mod no_confusing_array_with;
     pub mod no_console_spaces;
     pub mod no_document_cookie;
     pub mod no_empty_file;

--- a/crates/oxc_linter/src/rules/unicorn/no_confusing_array_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_confusing_array_with.rs
@@ -1,0 +1,244 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, UnaryOperator},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    AstNode, ast_util::is_method_call, context::LintContext, rule::Rule, utils::is_same_expression,
+};
+
+fn negative_index_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Avoid using a negative index with `Array#with()`.").with_label(span)
+}
+
+fn length_index_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Avoid using `.length` as the index in `Array#with()`.").with_label(span)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfusingWithIndex {
+    Negative,
+    Length,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoConfusingArrayWith;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallows confusing uses of [`Array#with()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/with).
+    ///
+    /// ### Why is this bad?
+    ///
+    /// `Array#with()` treats a negative index as an offset from the end of the array, unlike
+    /// methods such as `slice()` or `splice()`. Using a negative static index is usually a mistake.
+    /// Using `.length` as the index always produces `undefined`, since valid indices are
+    /// `0 .. length - 1`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// array.with(-1, value);
+    /// array.with(array.length, value);
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// array.with(array.length - 1, value);
+    /// array.with(index, value);
+    /// ```
+    NoConfusingArrayWith,
+    unicorn,
+    correctness,
+    version = "next",
+    short_description = "Disallow confusing uses of `Array#with()`.",
+);
+
+impl Rule for NoConfusingArrayWith {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(call_expr) = node.kind() else {
+            return;
+        };
+
+        if call_expr.optional || !is_method_call(call_expr, None, Some(&["with"]), Some(1), None) {
+            return;
+        }
+
+        let Some(member_expr) = call_expr.callee.get_member_expr() else {
+            return;
+        };
+
+        if member_expr.is_computed() || member_expr.optional() {
+            return;
+        }
+
+        let Some(index_argument) = call_expr.arguments.first().and_then(|arg| arg.as_expression())
+        else {
+            return;
+        };
+
+        let object = member_expr.object();
+        let Some(confusing_index) = get_confusing_with_index(index_argument, object, ctx) else {
+            return;
+        };
+
+        let Some((property_span, _)) = member_expr.static_property_info() else {
+            return;
+        };
+
+        let diagnostic = match confusing_index {
+            ConfusingWithIndex::Negative => negative_index_diagnostic(property_span),
+            ConfusingWithIndex::Length => length_index_diagnostic(property_span),
+        };
+        ctx.diagnostic(diagnostic);
+    }
+}
+
+fn get_confusing_with_index<'a>(
+    index: &Expression<'a>,
+    object: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> Option<ConfusingWithIndex> {
+    let index = index.without_parentheses();
+
+    if let Some(value) = get_static_number_value(index)
+        && value.is_finite()
+        && value.trunc() < 0.0
+    {
+        return Some(ConfusingWithIndex::Negative);
+    }
+
+    if is_length_member_for(index, object, ctx) {
+        return Some(ConfusingWithIndex::Length);
+    }
+
+    None
+}
+
+fn get_static_number_value(expression: &Expression) -> Option<f64> {
+    let expression = unwrap_typescript_expression(expression);
+
+    match expression {
+        Expression::NumericLiteral(literal) => Some(literal.value),
+        Expression::UnaryExpression(unary)
+            if matches!(
+                unary.operator,
+                UnaryOperator::UnaryPlus | UnaryOperator::UnaryNegation
+            ) =>
+        {
+            let value = get_static_number_value(&unary.argument)?;
+            Some(if unary.operator == UnaryOperator::UnaryNegation { -value } else { value })
+        }
+        _ => None,
+    }
+}
+
+fn unwrap_typescript_expression<'a>(expression: &'a Expression<'a>) -> &'a Expression<'a> {
+    match expression.get_inner_expression() {
+        Expression::TSAsExpression(as_expression) => {
+            unwrap_typescript_expression(&as_expression.expression)
+        }
+        Expression::TSSatisfiesExpression(satisfies_expression) => {
+            unwrap_typescript_expression(&satisfies_expression.expression)
+        }
+        Expression::TSNonNullExpression(non_null_expression) => {
+            unwrap_typescript_expression(&non_null_expression.expression)
+        }
+        Expression::TSTypeAssertion(type_assertion) => {
+            unwrap_typescript_expression(&type_assertion.expression)
+        }
+        other => other,
+    }
+}
+
+fn is_length_member_for<'a>(
+    index: &Expression<'a>,
+    object: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> bool {
+    let index = index.without_parentheses().get_inner_expression();
+    let object = object.without_parentheses().get_inner_expression();
+
+    let Some(member) = index.get_member_expr() else {
+        return false;
+    };
+
+    if member.is_computed() || member.optional() {
+        return false;
+    }
+
+    if member.static_property_name() != Some("length") {
+        return false;
+    }
+
+    is_same_expression(
+        unwrap_typescript_expression(member.object()),
+        unwrap_typescript_expression(object),
+        ctx,
+    )
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "array.with(index, value)",
+        "array.with(0, value)",
+        "array.with(1, value)",
+        "array.with(+1, value)",
+        "array.with(-0, value)",
+        "array.with(-0.5, value)",
+        "array.with(array.length - 1, value)",
+        "array.with(otherArray.length, value)",
+        "object.items.with(other.items.length, value)",
+        "array.with(-1e400, value)",
+        "array.with(- -1, value)",
+        "array.with(-(-(1)), value)",
+        "array.with(index)",
+        "array.with(index, value, extra)",
+        "array['with'](-1, value)",
+        "array?.with(-1, value)",
+        "array.with?.(-1, value)",
+        "with_(-1, value)",
+        "array.with(0 as const, value)",
+        " array.with(0, value)",
+        "array.with(0!, value)",
+        "array.with(0 satisfies number, value)",
+    ];
+
+    let fail = vec![
+        "array.with(-1, value)",
+        "array.with(-2, value)",
+        "array.with(-1.5, value)",
+        "array.with(- 1, value)",
+        "array.with(- - -1, value)",
+        "array.with(-(-(-1)), value)",
+        "array.with(-1)",
+        "array.with(-1, value, extra)",
+        "array.with(array.length, value)",
+        "array.with(array.length)",
+        "array.with(array.length, value, extra)",
+        "object.items.with(object.items.length, value)",
+        "array.with(-1 as const, value)",
+        "array.with( -1, value)",
+        "array.with(-1!, value)",
+        "array.with(-1 satisfies number, value)",
+        "array.with(array.length as number, value)",
+        "array.with( array.length, value)",
+        "array.with(array.length!, value)",
+        "array.with(array.length satisfies number, value)",
+        "array.with((array satisfies number[]).length, value)",
+        "(array satisfies number[]).with(array.length, value)",
+        "object.items.with((object satisfies {items: unknown[]}).items.length, value)",
+        "(object satisfies {items: unknown[]}).items.with(object.items.length, value)",
+    ];
+
+    Tester::new(NoConfusingArrayWith::NAME, NoConfusingArrayWith::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_confusing_array_with.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_confusing_array_with.snap
@@ -1,0 +1,147 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(-1, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(-2, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(-1.5, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(- 1, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(- - -1, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(-(-(-1)), value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(-1)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(-1, value, extra)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(array.length, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(array.length)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(array.length, value, extra)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:14]
+ 1 │ object.items.with(object.items.length, value)
+   ·              ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(-1 as const, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with( -1, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(-1!, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using a negative index with `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(-1 satisfies number, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(array.length as number, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with( array.length, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(array.length!, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with(array.length satisfies number, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:7]
+ 1 │ array.with((array satisfies number[]).length, value)
+   ·       ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:28]
+ 1 │ (array satisfies number[]).with(array.length, value)
+   ·                            ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:14]
+ 1 │ object.items.with((object satisfies {items: unknown[]}).items.length, value)
+   ·              ────
+   ╰────
+
+  ⚠ unicorn(no-confusing-array-with): Avoid using `.length` as the index in `Array#with()`.
+   ╭─[no_confusing_array_with.tsx:1:45]
+ 1 │ (object satisfies {items: unknown[]}).items.with(object.items.length, value)
+   ·                                             ────
+   ╰────


### PR DESCRIPTION
Implements `unicorn/no-confusing-array-with`, which flags two ways `Array#with()` calls can silently misbehave:

- A literal negative index (`array.with(-1, value)`). Unlike `slice()`/`splice()`, `with()` treats a negative index as an offset from the end of the array, which is easy to assume incorrectly.
- `.length` used as the index (`array.with(array.length, value)`), which is always out of bounds and always produces a `RangeError` / unintended result, since valid indices run `0 .. length - 1`.