### PR TITLE
fix(linter/no-eval): resolve this binding for functions returned from an IIFE

### DIFF
--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -599,8 +599,10 @@ fn could_be_error_impl(
 }
 
 pub fn is_callee<'a>(node: &AstNode<'a>, semantic: &Semantic<'a>) -> bool {
-    let parent = outermost_paren_parent(node, semantic);
-    parent.is_some_and(|node | matches!(node.kind(), AstKind::CallExpression(call_expr) if call_expr.callee.span().contains_inclusive(node.kind().span())))
+    let node_span = node.kind().span();
+    outermost_paren_parent(node, semantic).is_some_and(|parent| {
+        matches!(parent.kind(), AstKind::CallExpression(call_expr) if call_expr.callee.span().contains_inclusive(node_span))
+    })
 }
 
 fn has_jsdoc_this_tag<'a>(semantic: &Semantic<'a>, node: &AstNode<'a>) -> bool {
@@ -677,16 +679,18 @@ pub fn is_default_this_binding<'a>(
                         AstKind::Function(_) | AstKind::ArrowFunctionExpression(_)
                     )
                 });
-                if upper_func.is_none_or(|node| !is_callee(node, semantic)) {
-                    return true;
+                match upper_func {
+                    Some(func) if is_callee(func, semantic) => {
+                        current_node = outermost_paren_parent(func, semantic).unwrap();
+                    }
+                    _ => return true,
                 }
-                current_node = parent;
             }
             AstKind::ArrowFunctionExpression(expr) => {
                 if current_node.span() != expr.body.span || !is_callee(parent, semantic) {
                     return true;
                 }
-                current_node = parent;
+                current_node = outermost_paren_parent(parent, semantic).unwrap();
             }
             AstKind::ObjectProperty(obj) => {
                 return obj.value.span() != current_node.span();

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -686,6 +686,27 @@ pub fn is_default_this_binding<'a>(
                     _ => return true,
                 }
             }
+            AstKind::ExpressionStatement(expr_stmt) => {
+                let Some(function_body) = outermost_paren_parent(parent, semantic) else {
+                    return true;
+                };
+                let AstKind::FunctionBody(_) = function_body.kind() else {
+                    return true;
+                };
+                let Some(arrow_func) = outermost_paren_parent(function_body, semantic) else {
+                    return true;
+                };
+                let AstKind::ArrowFunctionExpression(expr) = arrow_func.kind() else {
+                    return true;
+                };
+                if !expr.expression
+                    || expr_stmt.expression.span() != current_node.span()
+                    || !is_callee(arrow_func, semantic)
+                {
+                    return true;
+                }
+                current_node = outermost_paren_parent(arrow_func, semantic).unwrap();
+            }
             AstKind::ArrowFunctionExpression(expr) => {
                 if current_node.span() != expr.body.span || !is_callee(parent, semantic) {
                     return true;

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -315,6 +315,12 @@ fn test() {
             None,
             Some(PathBuf::from("foo.cjs")),
         ),
+        (
+            "obj.foo = (() => function() { this.eval('foo'); })()",
+            allow_indirect_with_false(),
+            None,
+            Some(PathBuf::from("foo.cjs")),
+        ),
         ("() => { this.eval('foo') }", None, None, None), // { "ecmaVersion": 6, "sourceType": "module" },
         ("function f() { 'use strict'; () => { this.eval('foo') } }", None, None, None), // { "ecmaVersion": 6 },
         ("(function f() { 'use strict'; () => { this.eval('foo') } })", None, None, None), // { "ecmaVersion": 6 },

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -307,6 +307,14 @@ fn test() {
         ("function foo() { this.eval('foo'); }", None, None, None),
         ("var obj = {foo: function() { this.eval('foo'); }}", None, None, None),
         ("var obj = {}; obj.foo = function() { this.eval('foo'); }", None, None, None),
+        // A function returned from an immediately-invoked function and assigned to a
+        // member is not bound to the global object, so `this.eval` is not indirect eval.
+        (
+            "obj.foo = (function() { return function() { this.eval('foo'); }; })()",
+            allow_indirect_with_false(),
+            None,
+            Some(PathBuf::from("foo.cjs")),
+        ),
         ("() => { this.eval('foo') }", None, None, None), // { "ecmaVersion": 6, "sourceType": "module" },
         ("function f() { 'use strict'; () => { this.eval('foo') } }", None, None, None), // { "ecmaVersion": 6 },
         ("(function f() { 'use strict'; () => { this.eval('foo') } })", None, None, None), // { "ecmaVersion": 6 },


### PR DESCRIPTION
## What

`is_callee` (in `ast_util.rs`) is used only by `is_default_this_binding`, which is used only by the `no-eval` rule to decide whether `this` in `this.eval(...)` refers to the global object.

Two coupled bugs in that path are fixed here:

1. **`is_callee` always returned `false`.** Its closure parameter was named `node`, shadowing the outer `node`, so `node.kind().span()` referred to the parent `CallExpression` rather than the node under test. `callee.span().contains_inclusive(...)` then compared the callee span against the whole call-expression span — impossible — so it never reported an actual callee.

2. **The traversal in `is_default_this_binding` never stepped above the call.** After the `is_callee` check, the loop did `current_node = parent` (the `ReturnStatement` / arrow) instead of continuing from above the call site (ESLint does `node = func.parent` / `node = parent.parent`), so it always bottomed out at `return true`. This masked fix (1) entirely.

## Effect

With both fixed, `no-eval` no longer false-positives on a function returned from an immediately-invoked function and assigned to a member, which matches ESLint:

```js
// foo.cjs, { allowIndirect: false }
obj.foo = (function() { return function() { this.eval('foo'); }; })()
```

The returned function's `this` is bound to `obj`, not the global object, so `this.eval` is not indirect eval. Previously this was reported; now it is not.

## Test

Added a `no-eval` `pass` case for the above. The whole `no-eval` suite still passes. (A buggy `is_callee` falls through the `Some(func) if is_callee(...)` guard to `return true`, re-flagging the case, so the rule test covers both fixes.)