### PR TITLE
fix(linter): pre-compile jest assert-function patterns and skip invalid ones

### DIFF
--- a/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_ending_with_an_expect.rs
@@ -1,3 +1,4 @@
+use lazy_regex::Regex;
 use oxc_ast::{
     AstKind,
     ast::{Argument, Expression, FunctionBody, Statement},
@@ -14,8 +15,8 @@ use crate::{
     rule::Rule,
     rules::PossibleJestNode,
     utils::{
-        JestGeneralFnKind, convert_pattern, get_node_name, matches_assert_function_name,
-        parse_expect_jest_fn_call, parse_general_jest_fn_call,
+        JestGeneralFnKind, compile_assert_function_name_patterns, convert_pattern, get_node_name,
+        matches_assert_function_name, parse_expect_jest_fn_call, parse_general_jest_fn_call,
     },
 };
 
@@ -35,6 +36,11 @@ pub struct PreferEndingWithAnExpectConfig {
     additional_test_block_functions: Vec<CompactStr>,
     /// A list of function names that should be treated as assertion functions.
     assert_function_names: Vec<CompactStr>,
+    /// `assert_function_names` pre-compiled to regexes once, so the patterns are not
+    /// recompiled on every node visited.
+    #[serde(skip)]
+    #[schemars(skip)]
+    assert_function_name_patterns: Vec<Regex>,
 }
 
 impl std::ops::Deref for PreferEndingWithAnExpect {
@@ -47,8 +53,12 @@ impl std::ops::Deref for PreferEndingWithAnExpect {
 
 impl Default for PreferEndingWithAnExpectConfig {
     fn default() -> Self {
+        let assert_function_names = vec![CompactStr::from("expect")];
         Self {
-            assert_function_names: vec!["expect".into()],
+            assert_function_name_patterns: compile_assert_function_name_patterns(
+                &assert_function_names,
+            ),
+            assert_function_names,
             additional_test_block_functions: vec![],
         }
     }
@@ -179,6 +189,9 @@ impl Rule for PreferEndingWithAnExpect {
 
         Ok(Self(Box::new(PreferEndingWithAnExpectConfig {
             additional_test_block_functions,
+            assert_function_name_patterns: compile_assert_function_name_patterns(
+                &assert_function_names,
+            ),
             assert_function_names,
         })))
     }
@@ -274,7 +287,7 @@ impl PreferEndingWithAnExpect {
 
         let node_name = get_node_name(&call_expression.callee);
 
-        matches_assert_function_name(&node_name, &self.assert_function_names)
+        matches_assert_function_name(&node_name, &self.assert_function_name_patterns)
     }
 }
 
@@ -309,6 +322,11 @@ fn test() {
         (
             r#"it("should return undefined",() => expectSaga(mySaga).returns());"#,
             Some(serde_json::json!([{ "assertFunctionNames": ["expectSaga"] }])),
+        ),
+        // A malformed pattern is skipped without affecting the valid sibling pattern.
+        (
+            r#"it("should return undefined",() => expectSaga(mySaga).returns());"#,
+            Some(serde_json::json!([{ "assertFunctionNames": ["expectSaga", "["] }])),
         ),
         (
             "test('verifies expect method call', () => expect$(123));",
@@ -491,6 +509,12 @@ fn test() {
         (
             r#"test("should fail", () => { foo(true).toBe(true); })"#,
             Some(serde_json::json!([{ "assertFunctionNames": ["expect"] }])),
+        ),
+        // A malformed pattern (`[` expands to an invalid regex) must be skipped rather
+        // than panicking; with no valid assert function name, the block still fails.
+        (
+            r#"test("should fail", () => { foo(true).toBe(true); })"#,
+            Some(serde_json::json!([{ "assertFunctionNames": ["["] }])),
         ),
         (
             r#"it("should also fail",() => expectSaga(mySaga).returns());"#,

--- a/crates/oxc_linter/src/snapshots/jest_prefer_ending_with_an_expect.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_ending_with_an_expect.snap
@@ -39,6 +39,13 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ jest(prefer-ending-with-an-expect): Test must end with an assertion
    ╭─[prefer_ending_with_an_expect.tsx:1:1]
+ 1 │ test("should fail", () => { foo(true).toBe(true); })
+   · ────
+   ╰────
+  help: Add an `expect` or assertion call as the last statement in the test block.
+
+  ⚠ jest(prefer-ending-with-an-expect): Test must end with an assertion
+   ╭─[prefer_ending_with_an_expect.tsx:1:1]
  1 │ it("should also fail",() => expectSaga(mySaga).returns());
    · ──
    ╰────

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -319,9 +319,20 @@ pub fn is_equality_matcher(matcher: &KnownMemberExpressionProperty) -> bool {
         || matcher.is_name_equal("toStrictEqual")
 }
 
-/// Checks if node names returned by getNodeName matches any of the given star patterns
-pub fn matches_assert_function_name(name: &str, patterns: &[CompactStr]) -> bool {
-    patterns.iter().any(|pattern| Regex::new(pattern).unwrap().is_match(name))
+/// Compile assert-function-name patterns once, ahead of linting.
+///
+/// Invalid regular expressions (e.g. a user-supplied pattern that expands to a
+/// malformed regex) are skipped rather than triggering a panic.
+pub fn compile_assert_function_name_patterns(patterns: &[CompactStr]) -> Vec<Regex> {
+    patterns.iter().filter_map(|pattern| Regex::new(pattern).ok()).collect()
+}
+
+/// Checks if node names returned by getNodeName matches any of the given star patterns.
+///
+/// `patterns` must be pre-compiled with [`compile_assert_function_name_patterns`] so the
+/// regexes are built once rather than on every call.
+pub fn matches_assert_function_name(name: &str, patterns: &[Regex]) -> bool {
+    patterns.iter().any(|pattern| pattern.is_match(name))
 }
 
 pub fn convert_pattern(pattern: &str) -> CompactStr {


### PR DESCRIPTION
`matches_assert_function_name` (used by `jest/prefer-ending-with-an-expect`) recompiled every pattern with `Regex::new(...)` on **every node visited** — a hot path — and used `.unwrap()`, so a user-supplied `assertFunctionNames` pattern that expands to an invalid regex (e.g. `"["` → `(?ui)^[(\.|$)`) would **panic the linter**.

Patterns are now compiled once when the rule config is built (mirroring the existing `expect-expect` rule), stored in a `#[serde(skip)]` field, and `matches_assert_function_name` takes the pre-compiled `&[Regex]`. Invalid patterns are skipped via `Regex::new(...).ok()` instead of panicking. This fixes both the per-call recompilation and the panic.

Regression tests: a malformed pattern no longer panics and the test block is still reported; a valid pattern alongside a malformed one still matches.