### PR TITLE
perf(linter): compute `apply_overrides` rule set lazily

### DIFF
--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -173,14 +173,11 @@ impl Config {
             .cloned()
             .collect::<FxHashMap<_, _>>();
 
-        let all_rules = RULES
-            .iter()
-            .filter(|rule| {
-                LintPlugins::try_from(rule.plugin_name())
-                    .is_ok_and(|plugin| builtin_rule_plugins.contains(plugin))
-            })
-            .cloned()
-            .collect::<Vec<_>>();
+        // The full set of rules for the enabled plugins is only needed when an override
+        // introduces a new, unconfigured plugin (to apply its category rules). Compute it
+        // lazily so the common case — overrides that only tweak rule severities — doesn't
+        // clone every rule in `RULES` on each call (i.e. for every linted file).
+        let mut all_rules: Option<Vec<RuleEnum>> = None;
 
         // Build a hashmap of existing external rules keyed by rule id with value (options_id, severity)
         let mut external_rules = self
@@ -204,6 +201,16 @@ impl Config {
                 let unconfigured_plugins = plugins & !configured_plugins;
 
                 if !unconfigured_plugins.is_empty() {
+                    let all_rules = all_rules.get_or_insert_with(|| {
+                        RULES
+                            .iter()
+                            .filter(|rule| {
+                                LintPlugins::try_from(rule.plugin_name())
+                                    .is_ok_and(|plugin| builtin_rule_plugins.contains(plugin))
+                            })
+                            .cloned()
+                            .collect::<Vec<_>>()
+                    });
                     for (rule, severity) in all_rules.iter().filter_map(|rule| {
                         let rule_plugin = LintPlugins::try_from(rule.plugin_name())
                             .unwrap_or(LintPlugins::empty());

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -173,10 +173,7 @@ impl Config {
             .cloned()
             .collect::<FxHashMap<_, _>>();
 
-        // The full set of rules for the enabled plugins is only needed when an override
-        // introduces a new, unconfigured plugin (to apply its category rules). Compute it
-        // lazily so the common case — overrides that only tweak rule severities — doesn't
-        // clone every rule in `RULES` on each call (i.e. for every linted file).
+        // Build this only if an override adds a plugin whose category rules need applying.
         let mut all_rules: Option<Vec<RuleEnum>> = None;
 
         // Build a hashmap of existing external rules keyed by rule id with value (options_id, severity)


### PR DESCRIPTION
`Config::apply_overrides` is called for every linted file. It eagerly built `all_rules` by filtering and cloning every entry in `RULES` (~837 rules) into a `Vec` on each call.

But `all_rules` is only used when an override introduces a new, unconfigured plugin (to apply that plugin's category rules). In the common case — overrides that only tweak rule severities for certain file globs — it was computed and never used, cloning ~837 rules per file for nothing.

This computes `all_rules` lazily (`Option<Vec<RuleEnum>>` + `get_or_insert_with`), so it is only built when a new plugin actually requires it, and reused across override iterations exactly as before. Behavior is unchanged.

Both code paths are covered by existing tests: the common path (`test_remove_rule`, `test_change_rule_severity`, …) and the lazy path (`test_categories_only_applied_to_new_plugins_not_in_root`, `test_categories_not_reapplied_to_root_plugins`, …).