### PR TITLE
fix(ast): preserve TS index signature name span instead of discarding

### DIFF
--- a/apps/oxlint/src-js/generated/deserialize.js
+++ b/apps/oxlint/src-js/generated/deserialize.js
@@ -4887,22 +4887,24 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start,
-    end,
-    previousParent = parent,
+  let previousParent = parent,
+    name = deserializeIdentifierName(pos + 16),
+    typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 48),
+    start = name.start,
+    end = typeAnnotation.end,
     node = (parent = {
       __proto__: NodeProto,
       type: "Identifier",
       decorators: [],
-      name: deserializeStr(pos + 16),
+      name: name.name,
       optional: false,
-      typeAnnotation: null,
-      start: (start = deserializeI32(pos)),
-      end: (end = deserializeI32(pos + 4)),
+      typeAnnotation,
+      start,
+      end,
       range: [start, end],
       parent,
     });
-  node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
+  typeAnnotation.parent = node;
   parent = previousParent;
   return node;
 }
@@ -6980,10 +6982,10 @@ function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
   pos = int32[pos32];
-  let endPos = pos + int32[pos32 + 2] * 40;
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
-    pos += 40;
+    pos += 56;
   }
   return arr;
 }

--- a/apps/oxlint/src-js/generated/types.d.ts
+++ b/apps/oxlint/src-js/generated/types.d.ts
@@ -1417,7 +1417,7 @@ export type TSSignature =
 
 export interface TSIndexSignature extends Span {
   type: "TSIndexSignature";
-  parameters: Array<TSIndexSignatureName>;
+  parameters: Array<Identifier>;
   typeAnnotation: TSTypeAnnotation;
   readonly: boolean;
   static: boolean;
@@ -1455,15 +1455,6 @@ export interface TSConstructSignatureDeclaration extends Span {
   typeParameters: TSTypeParameterDeclaration | null;
   params: ParamPattern[];
   returnType: TSTypeAnnotation | null;
-  parent: Node;
-}
-
-export interface TSIndexSignatureName extends Span {
-  type: "Identifier";
-  decorators: [];
-  name: string;
-  optional: false;
-  typeAnnotation: TSTypeAnnotation;
   parent: Node;
 }
 
@@ -1882,7 +1873,6 @@ export type Node =
   | TSCallSignatureDeclaration
   | TSMethodSignature
   | TSConstructSignatureDeclaration
-  | TSIndexSignatureName
   | TSInterfaceHeritage
   | TSTypePredicate
   | TSModuleDeclaration

--- a/apps/oxlint/src-js/generated/visitor.d.ts
+++ b/apps/oxlint/src-js/generated/visitor.d.ts
@@ -146,8 +146,7 @@ interface StrictVisitorObject {
       | ESTree.IdentifierReference
       | ESTree.BindingIdentifier
       | ESTree.LabelIdentifier
-      | ESTree.TSThisParameter
-      | ESTree.TSIndexSignatureName,
+      | ESTree.TSThisParameter,
   ) => void;
   "Identifier:exit"?: (
     node:
@@ -155,8 +154,7 @@ interface StrictVisitorObject {
       | ESTree.IdentifierReference
       | ESTree.BindingIdentifier
       | ESTree.LabelIdentifier
-      | ESTree.TSThisParameter
-      | ESTree.TSIndexSignatureName,
+      | ESTree.TSThisParameter,
   ) => void;
   IfStatement?: (node: ESTree.IfStatement) => void;
   "IfStatement:exit"?: (node: ESTree.IfStatement) => void;

--- a/apps/oxlint/src-js/plugins/scope.ts
+++ b/apps/oxlint/src-js/plugins/scope.ts
@@ -91,8 +91,7 @@ type Identifier =
   | ESTree.IdentifierReference
   | ESTree.BindingIdentifier
   | ESTree.LabelIdentifier
-  | ESTree.TSThisParameter
-  | ESTree.TSIndexSignatureName;
+  | ESTree.TSThisParameter;
 
 // TS-ESLint `ScopeManager` for current file.
 // Created lazily only when needed.

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -25,7 +25,6 @@ use oxc_allocator::{Box, CloneIn, Dummy, GetAddress, TakeIn, UnstableAddress, Ve
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::{ContentEq, GetSpan, GetSpanMut, Span};
-use oxc_str::Str;
 use oxc_syntax::{node::NodeId, scope::ScopeId};
 
 use super::{inherit_variants, js::*, literal::*};
@@ -1143,15 +1142,14 @@ pub struct TSConstructSignatureDeclaration<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree, UnstableAddress)]
 #[estree(
-    rename = "Identifier",
+    via = TSIndexSignatureNameConverter,
     add_fields(decorators = EmptyArray, optional = False),
     field_order(decorators, name, optional, type_annotation, span),
 )]
 pub struct TSIndexSignatureName<'a> {
     pub node_id: Cell<NodeId>,
     pub span: Span,
-    #[estree(json_safe)]
-    pub name: Str<'a>,
+    pub name: IdentifierName<'a>,
     pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1533,12 +1533,12 @@ const _: () = {
     assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 32);
 
     // Padding: 4 bytes
-    assert!(size_of::<TSIndexSignatureName>() == 40);
+    assert!(size_of::<TSIndexSignatureName>() == 56);
     assert!(align_of::<TSIndexSignatureName>() == 8);
     assert!(offset_of!(TSIndexSignatureName, span) == 0);
     assert!(offset_of!(TSIndexSignatureName, node_id) == 8);
     assert!(offset_of!(TSIndexSignatureName, name) == 16);
-    assert!(offset_of!(TSIndexSignatureName, type_annotation) == 32);
+    assert!(offset_of!(TSIndexSignatureName, type_annotation) == 48);
 
     // Padding: 4 bytes
     assert!(size_of::<TSInterfaceHeritage>() == 40);
@@ -3344,12 +3344,12 @@ const _: () = if cfg!(target_family = "wasm") || align_of::<u64>() == 8 {
     assert!(offset_of!(TSConstructSignatureDeclaration, return_type) == 24);
 
     // Padding: 0 bytes
-    assert!(size_of::<TSIndexSignatureName>() == 24);
+    assert!(size_of::<TSIndexSignatureName>() == 40);
     assert!(align_of::<TSIndexSignatureName>() == 4);
     assert!(offset_of!(TSIndexSignatureName, span) == 0);
     assert!(offset_of!(TSIndexSignatureName, node_id) == 8);
     assert!(offset_of!(TSIndexSignatureName, name) == 12);
-    assert!(offset_of!(TSIndexSignatureName, type_annotation) == 20);
+    assert!(offset_of!(TSIndexSignatureName, type_annotation) == 36);
 
     // Padding: 0 bytes
     assert!(size_of::<TSInterfaceHeritage>() == 24);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -13654,20 +13654,19 @@ impl<'a> AstBuilder<'a> {
     /// * `name`
     /// * `type_annotation`
     #[inline]
-    pub fn ts_index_signature_name<S1, T1>(
+    pub fn ts_index_signature_name<T1>(
         self,
         span: Span,
-        name: S1,
+        name: IdentifierName<'a>,
         type_annotation: T1,
     ) -> TSIndexSignatureName<'a>
     where
-        S1: Into<Str<'a>>,
         T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
     {
         TSIndexSignatureName {
             node_id: Default::default(),
             span,
-            name: name.into(),
+            name,
             type_annotation: type_annotation.into_in(self.allocator),
         }
     }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2830,14 +2830,7 @@ impl ESTree for TSConstructSignatureDeclaration<'_> {
 
 impl ESTree for TSIndexSignatureName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("Identifier"));
-        state.serialize_field("decorators", &crate::serialize::basic::EmptyArray(self));
-        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
-        state.serialize_field("optional", &crate::serialize::basic::False(self));
-        state.serialize_field("typeAnnotation", &self.type_annotation);
-        state.serialize_span(self.span);
-        state.end();
+        crate::serialize::ts::TSIndexSignatureNameConverter(self).serialize(serializer)
     }
 }
 

--- a/crates/oxc_ast/src/serialize/ts.rs
+++ b/crates/oxc_ast/src/serialize/ts.rs
@@ -2,6 +2,7 @@ use std::cell::Cell;
 
 use oxc_ast_macros::ast_meta;
 use oxc_estree::{Concat2, ESTree, JsonSafeString, Serializer, StructSerializer};
+use oxc_str::Str;
 use oxc_syntax::node::NodeId;
 
 use crate::ast::*;
@@ -423,6 +424,55 @@ impl ESTree for TSCallSignatureDeclarationParams<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let decl = self.0;
         Concat2(&decl.this_param, decl.params.as_ref()).serialize(serializer);
+    }
+}
+
+/// Serializer for `TSIndexSignatureName`.
+///
+/// Internally, `name` is an `IdentifierName` so its token span is available. In ESTree,
+/// the whole parameter is represented as one `Identifier` with a `typeAnnotation`.
+#[ast_meta]
+#[estree(
+    ts_type = "Identifier",
+    raw_deser = "
+        const previousParent = parent,
+            name = DESER[IdentifierName](POS_OFFSET.name),
+            typeAnnotation = DESER[Box<TSTypeAnnotation>](POS_OFFSET.type_annotation),
+            start = name.start,
+            end = typeAnnotation.end;
+
+        const node = parent = {
+            type: 'Identifier',
+            decorators: [],
+            name: name.name,
+            optional: false,
+            typeAnnotation,
+            start,
+            end,
+            ...(RANGE && { range: [start, end] }),
+            ...(PARENT && { parent }),
+        };
+
+        if (PARENT) typeAnnotation.parent = node;
+        if (PARENT) parent = previousParent;
+        node
+    "
+)]
+pub struct TSIndexSignatureNameConverter<'a, 'b>(pub &'b TSIndexSignatureName<'a>);
+
+impl ESTree for TSIndexSignatureNameConverter<'_, '_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let name = &self.0.name;
+        let type_annotation = self.0.type_annotation.as_ref();
+
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &JsonSafeString("Identifier"));
+        state.serialize_field("decorators", &crate::serialize::basic::EmptyArray(self));
+        state.serialize_field("name", &JsonSafeString(name.name.as_str()));
+        state.serialize_field("optional", &crate::serialize::basic::False(self));
+        state.serialize_field("typeAnnotation", type_annotation);
+        state.serialize_span(name.span.merge(type_annotation.span));
+        state.end();
     }
 }
 

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -3802,6 +3802,7 @@ pub mod walk {
         let kind = AstKind::TSIndexSignatureName(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
+        visitor.visit_identifier_name(&it.name);
         visitor.visit_ts_type_annotation(&it.type_annotation);
         visitor.leave_node(kind);
     }

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -4008,6 +4008,7 @@ pub mod walk_mut {
         let kind = AstType::TSIndexSignatureName;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
+        visitor.visit_identifier_name(&mut it.name);
         visitor.visit_ts_type_annotation(&mut it.type_annotation);
         visitor.leave_node(kind);
     }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3907,7 +3907,7 @@ impl Gen for TSIndexSignature<'_> {
                 p.print_ascii_byte(b',');
                 p.print_soft_space();
             }
-            p.print_str(parameter.name.as_str());
+            p.print_str(parameter.name.name.as_str());
             p.print_colon();
             p.print_soft_space();
             parameter.type_annotation.print(p, ctx);

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -9285,8 +9285,14 @@ impl<'a> AstNode<'a, TSIndexSignatureName<'a>> {
     }
 
     #[inline]
-    pub fn name(&self) -> Str<'a> {
-        self.inner.name
+    pub fn name(&self) -> &AstNode<'a, IdentifierName<'a>> {
+        let following_span_start = self.inner.type_annotation.span().start;
+        self.allocator.alloc(AstNode {
+            inner: &self.inner.name,
+            allocator: self.allocator,
+            parent: AstNodes::TSIndexSignatureName(transmute_self(self)),
+            following_span_start,
+        })
     }
 
     #[inline]

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -206,7 +206,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, TSIndexSignatur
 
 impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexSignatureName<'a>> {
     fn write(&self, f: &mut JsFormatter<'_, 'a>) {
-        write!(f, [text_without_whitespace(self.name().as_str()), self.type_annotation()]);
+        write!(f, [text_without_whitespace(self.name().name.as_str()), self.type_annotation()]);
     }
 }
 

--- a/crates/oxc_minifier/src/generated/ancestor.rs
+++ b/crates/oxc_minifier/src/generated/ancestor.rs
@@ -273,56 +273,57 @@ pub(crate) enum AncestorType {
     TSConstructSignatureDeclarationTypeParameters = 249,
     TSConstructSignatureDeclarationParams = 250,
     TSConstructSignatureDeclarationReturnType = 251,
-    TSIndexSignatureNameTypeAnnotation = 252,
-    TSInterfaceHeritageExpression = 253,
-    TSInterfaceHeritageTypeArguments = 254,
-    TSTypePredicateParameterName = 255,
-    TSTypePredicateTypeAnnotation = 256,
-    TSModuleDeclarationId = 257,
-    TSModuleDeclarationBody = 258,
-    TSGlobalDeclarationBody = 259,
-    TSModuleBlockDirectives = 260,
-    TSModuleBlockBody = 261,
-    TSTypeLiteralMembers = 262,
-    TSInferTypeTypeParameter = 263,
-    TSTypeQueryExprName = 264,
-    TSTypeQueryTypeArguments = 265,
-    TSImportTypeSource = 266,
-    TSImportTypeOptions = 267,
-    TSImportTypeQualifier = 268,
-    TSImportTypeTypeArguments = 269,
-    TSImportTypeQualifiedNameLeft = 270,
-    TSImportTypeQualifiedNameRight = 271,
-    TSFunctionTypeTypeParameters = 272,
-    TSFunctionTypeThisParam = 273,
-    TSFunctionTypeParams = 274,
-    TSFunctionTypeReturnType = 275,
-    TSConstructorTypeTypeParameters = 276,
-    TSConstructorTypeParams = 277,
-    TSConstructorTypeReturnType = 278,
-    TSMappedTypeKey = 279,
-    TSMappedTypeConstraint = 280,
-    TSMappedTypeNameType = 281,
-    TSMappedTypeTypeAnnotation = 282,
-    TSTemplateLiteralTypeQuasis = 283,
-    TSTemplateLiteralTypeTypes = 284,
-    TSAsExpressionExpression = 285,
-    TSAsExpressionTypeAnnotation = 286,
-    TSSatisfiesExpressionExpression = 287,
-    TSSatisfiesExpressionTypeAnnotation = 288,
-    TSTypeAssertionTypeAnnotation = 289,
-    TSTypeAssertionExpression = 290,
-    TSImportEqualsDeclarationId = 291,
-    TSImportEqualsDeclarationModuleReference = 292,
-    TSExternalModuleReferenceExpression = 293,
-    TSNonNullExpressionExpression = 294,
-    DecoratorExpression = 295,
-    TSExportAssignmentExpression = 296,
-    TSNamespaceExportDeclarationId = 297,
-    TSInstantiationExpressionExpression = 298,
-    TSInstantiationExpressionTypeArguments = 299,
-    JSDocNullableTypeTypeAnnotation = 300,
-    JSDocNonNullableTypeTypeAnnotation = 301,
+    TSIndexSignatureNameName = 252,
+    TSIndexSignatureNameTypeAnnotation = 253,
+    TSInterfaceHeritageExpression = 254,
+    TSInterfaceHeritageTypeArguments = 255,
+    TSTypePredicateParameterName = 256,
+    TSTypePredicateTypeAnnotation = 257,
+    TSModuleDeclarationId = 258,
+    TSModuleDeclarationBody = 259,
+    TSGlobalDeclarationBody = 260,
+    TSModuleBlockDirectives = 261,
+    TSModuleBlockBody = 262,
+    TSTypeLiteralMembers = 263,
+    TSInferTypeTypeParameter = 264,
+    TSTypeQueryExprName = 265,
+    TSTypeQueryTypeArguments = 266,
+    TSImportTypeSource = 267,
+    TSImportTypeOptions = 268,
+    TSImportTypeQualifier = 269,
+    TSImportTypeTypeArguments = 270,
+    TSImportTypeQualifiedNameLeft = 271,
+    TSImportTypeQualifiedNameRight = 272,
+    TSFunctionTypeTypeParameters = 273,
+    TSFunctionTypeThisParam = 274,
+    TSFunctionTypeParams = 275,
+    TSFunctionTypeReturnType = 276,
+    TSConstructorTypeTypeParameters = 277,
+    TSConstructorTypeParams = 278,
+    TSConstructorTypeReturnType = 279,
+    TSMappedTypeKey = 280,
+    TSMappedTypeConstraint = 281,
+    TSMappedTypeNameType = 282,
+    TSMappedTypeTypeAnnotation = 283,
+    TSTemplateLiteralTypeQuasis = 284,
+    TSTemplateLiteralTypeTypes = 285,
+    TSAsExpressionExpression = 286,
+    TSAsExpressionTypeAnnotation = 287,
+    TSSatisfiesExpressionExpression = 288,
+    TSSatisfiesExpressionTypeAnnotation = 289,
+    TSTypeAssertionTypeAnnotation = 290,
+    TSTypeAssertionExpression = 291,
+    TSImportEqualsDeclarationId = 292,
+    TSImportEqualsDeclarationModuleReference = 293,
+    TSExternalModuleReferenceExpression = 294,
+    TSNonNullExpressionExpression = 295,
+    DecoratorExpression = 296,
+    TSExportAssignmentExpression = 297,
+    TSNamespaceExportDeclarationId = 298,
+    TSInstantiationExpressionExpression = 299,
+    TSInstantiationExpressionTypeArguments = 300,
+    JSDocNullableTypeTypeAnnotation = 301,
+    JSDocNonNullableTypeTypeAnnotation = 302,
 }
 
 /// Ancestor type used in AST traversal.
@@ -809,6 +810,8 @@ pub enum Ancestor<'a, 't> {
     TSConstructSignatureDeclarationReturnType(
         TSConstructSignatureDeclarationWithoutReturnType<'a, 't>,
     ) = AncestorType::TSConstructSignatureDeclarationReturnType as u16,
+    TSIndexSignatureNameName(TSIndexSignatureNameWithoutName<'a, 't>) =
+        AncestorType::TSIndexSignatureNameName as u16,
     TSIndexSignatureNameTypeAnnotation(TSIndexSignatureNameWithoutTypeAnnotation<'a, 't>) =
         AncestorType::TSIndexSignatureNameTypeAnnotation as u16,
     TSInterfaceHeritageExpression(TSInterfaceHeritageWithoutExpression<'a, 't>) =
@@ -1729,7 +1732,10 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_ts_index_signature_name(self) -> bool {
-        matches!(self, Self::TSIndexSignatureNameTypeAnnotation(_))
+        matches!(
+            self,
+            Self::TSIndexSignatureNameName(_) | Self::TSIndexSignatureNameTypeAnnotation(_)
+        )
     }
 
     #[inline]
@@ -2509,6 +2515,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSConstructSignatureDeclarationTypeParameters(a) => a.address(),
             Self::TSConstructSignatureDeclarationParams(a) => a.address(),
             Self::TSConstructSignatureDeclarationReturnType(a) => a.address(),
+            Self::TSIndexSignatureNameName(a) => a.address(),
             Self::TSIndexSignatureNameTypeAnnotation(a) => a.address(),
             Self::TSInterfaceHeritageExpression(a) => a.address(),
             Self::TSInterfaceHeritageTypeArguments(a) => a.address(),
@@ -16124,6 +16131,43 @@ pub(crate) const OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION: usize =
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
+pub struct TSIndexSignatureNameWithoutName<'a, 't>(
+    pub(crate) *const TSIndexSignatureName<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSIndexSignatureNameWithoutName<'a, 't> {
+    #[inline]
+    pub fn node_id(self) -> &'t Cell<NodeId> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NODE_ID)
+                as *const Cell<NodeId>)
+        }
+    }
+
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn type_annotation(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION)
+                as *const Box<'a, TSTypeAnnotation<'a>>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for TSIndexSignatureNameWithoutName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        unsafe { Address::from_ptr(self.0) }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
 pub struct TSIndexSignatureNameWithoutTypeAnnotation<'a, 't>(
     pub(crate) *const TSIndexSignatureName<'a>,
     pub(crate) PhantomData<&'t ()>,
@@ -16144,9 +16188,10 @@ impl<'a, 't> TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn name(self) -> &'t Str<'a> {
+    pub fn name(self) -> &'t IdentifierName<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Str<'a>)
+            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME)
+                as *const IdentifierName<'a>)
         }
     }
 }

--- a/crates/oxc_minifier/src/generated/walk.rs
+++ b/crates/oxc_minifier/src/generated/walk.rs
@@ -4924,9 +4924,15 @@ unsafe fn walk_ts_index_signature_name<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_ts_index_signature_name(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSIndexSignatureNameTypeAnnotation(
-        ancestor::TSIndexSignatureNameWithoutTypeAnnotation(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSIndexSignatureNameName(
+        ancestor::TSIndexSignatureNameWithoutName(node, PhantomData),
     ));
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *mut IdentifierName,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSIndexSignatureNameTypeAnnotation);
     walk_ts_type_annotation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION)

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1570,7 +1570,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_ts_index_signature_name(&mut self) -> TSIndexSignatureName<'a> {
         let span = self.start_span();
-        let name = self.parse_identifier_name().name;
+        let name = self.parse_identifier_name();
         if self.at(Kind::Question) {
             self.error(diagnostics::index_signature_question_mark(self.cur_token().span()));
             self.bump_any();

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -273,56 +273,57 @@ pub(crate) enum AncestorType {
     TSConstructSignatureDeclarationTypeParameters = 249,
     TSConstructSignatureDeclarationParams = 250,
     TSConstructSignatureDeclarationReturnType = 251,
-    TSIndexSignatureNameTypeAnnotation = 252,
-    TSInterfaceHeritageExpression = 253,
-    TSInterfaceHeritageTypeArguments = 254,
-    TSTypePredicateParameterName = 255,
-    TSTypePredicateTypeAnnotation = 256,
-    TSModuleDeclarationId = 257,
-    TSModuleDeclarationBody = 258,
-    TSGlobalDeclarationBody = 259,
-    TSModuleBlockDirectives = 260,
-    TSModuleBlockBody = 261,
-    TSTypeLiteralMembers = 262,
-    TSInferTypeTypeParameter = 263,
-    TSTypeQueryExprName = 264,
-    TSTypeQueryTypeArguments = 265,
-    TSImportTypeSource = 266,
-    TSImportTypeOptions = 267,
-    TSImportTypeQualifier = 268,
-    TSImportTypeTypeArguments = 269,
-    TSImportTypeQualifiedNameLeft = 270,
-    TSImportTypeQualifiedNameRight = 271,
-    TSFunctionTypeTypeParameters = 272,
-    TSFunctionTypeThisParam = 273,
-    TSFunctionTypeParams = 274,
-    TSFunctionTypeReturnType = 275,
-    TSConstructorTypeTypeParameters = 276,
-    TSConstructorTypeParams = 277,
-    TSConstructorTypeReturnType = 278,
-    TSMappedTypeKey = 279,
-    TSMappedTypeConstraint = 280,
-    TSMappedTypeNameType = 281,
-    TSMappedTypeTypeAnnotation = 282,
-    TSTemplateLiteralTypeQuasis = 283,
-    TSTemplateLiteralTypeTypes = 284,
-    TSAsExpressionExpression = 285,
-    TSAsExpressionTypeAnnotation = 286,
-    TSSatisfiesExpressionExpression = 287,
-    TSSatisfiesExpressionTypeAnnotation = 288,
-    TSTypeAssertionTypeAnnotation = 289,
-    TSTypeAssertionExpression = 290,
-    TSImportEqualsDeclarationId = 291,
-    TSImportEqualsDeclarationModuleReference = 292,
-    TSExternalModuleReferenceExpression = 293,
-    TSNonNullExpressionExpression = 294,
-    DecoratorExpression = 295,
-    TSExportAssignmentExpression = 296,
-    TSNamespaceExportDeclarationId = 297,
-    TSInstantiationExpressionExpression = 298,
-    TSInstantiationExpressionTypeArguments = 299,
-    JSDocNullableTypeTypeAnnotation = 300,
-    JSDocNonNullableTypeTypeAnnotation = 301,
+    TSIndexSignatureNameName = 252,
+    TSIndexSignatureNameTypeAnnotation = 253,
+    TSInterfaceHeritageExpression = 254,
+    TSInterfaceHeritageTypeArguments = 255,
+    TSTypePredicateParameterName = 256,
+    TSTypePredicateTypeAnnotation = 257,
+    TSModuleDeclarationId = 258,
+    TSModuleDeclarationBody = 259,
+    TSGlobalDeclarationBody = 260,
+    TSModuleBlockDirectives = 261,
+    TSModuleBlockBody = 262,
+    TSTypeLiteralMembers = 263,
+    TSInferTypeTypeParameter = 264,
+    TSTypeQueryExprName = 265,
+    TSTypeQueryTypeArguments = 266,
+    TSImportTypeSource = 267,
+    TSImportTypeOptions = 268,
+    TSImportTypeQualifier = 269,
+    TSImportTypeTypeArguments = 270,
+    TSImportTypeQualifiedNameLeft = 271,
+    TSImportTypeQualifiedNameRight = 272,
+    TSFunctionTypeTypeParameters = 273,
+    TSFunctionTypeThisParam = 274,
+    TSFunctionTypeParams = 275,
+    TSFunctionTypeReturnType = 276,
+    TSConstructorTypeTypeParameters = 277,
+    TSConstructorTypeParams = 278,
+    TSConstructorTypeReturnType = 279,
+    TSMappedTypeKey = 280,
+    TSMappedTypeConstraint = 281,
+    TSMappedTypeNameType = 282,
+    TSMappedTypeTypeAnnotation = 283,
+    TSTemplateLiteralTypeQuasis = 284,
+    TSTemplateLiteralTypeTypes = 285,
+    TSAsExpressionExpression = 286,
+    TSAsExpressionTypeAnnotation = 287,
+    TSSatisfiesExpressionExpression = 288,
+    TSSatisfiesExpressionTypeAnnotation = 289,
+    TSTypeAssertionTypeAnnotation = 290,
+    TSTypeAssertionExpression = 291,
+    TSImportEqualsDeclarationId = 292,
+    TSImportEqualsDeclarationModuleReference = 293,
+    TSExternalModuleReferenceExpression = 294,
+    TSNonNullExpressionExpression = 295,
+    DecoratorExpression = 296,
+    TSExportAssignmentExpression = 297,
+    TSNamespaceExportDeclarationId = 298,
+    TSInstantiationExpressionExpression = 299,
+    TSInstantiationExpressionTypeArguments = 300,
+    JSDocNullableTypeTypeAnnotation = 301,
+    JSDocNonNullableTypeTypeAnnotation = 302,
 }
 
 /// Ancestor type used in AST traversal.
@@ -809,6 +810,8 @@ pub enum Ancestor<'a, 't> {
     TSConstructSignatureDeclarationReturnType(
         TSConstructSignatureDeclarationWithoutReturnType<'a, 't>,
     ) = AncestorType::TSConstructSignatureDeclarationReturnType as u16,
+    TSIndexSignatureNameName(TSIndexSignatureNameWithoutName<'a, 't>) =
+        AncestorType::TSIndexSignatureNameName as u16,
     TSIndexSignatureNameTypeAnnotation(TSIndexSignatureNameWithoutTypeAnnotation<'a, 't>) =
         AncestorType::TSIndexSignatureNameTypeAnnotation as u16,
     TSInterfaceHeritageExpression(TSInterfaceHeritageWithoutExpression<'a, 't>) =
@@ -1729,7 +1732,10 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_ts_index_signature_name(self) -> bool {
-        matches!(self, Self::TSIndexSignatureNameTypeAnnotation(_))
+        matches!(
+            self,
+            Self::TSIndexSignatureNameName(_) | Self::TSIndexSignatureNameTypeAnnotation(_)
+        )
     }
 
     #[inline]
@@ -2509,6 +2515,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSConstructSignatureDeclarationTypeParameters(a) => a.address(),
             Self::TSConstructSignatureDeclarationParams(a) => a.address(),
             Self::TSConstructSignatureDeclarationReturnType(a) => a.address(),
+            Self::TSIndexSignatureNameName(a) => a.address(),
             Self::TSIndexSignatureNameTypeAnnotation(a) => a.address(),
             Self::TSInterfaceHeritageExpression(a) => a.address(),
             Self::TSInterfaceHeritageTypeArguments(a) => a.address(),
@@ -16124,6 +16131,43 @@ pub(crate) const OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION: usize =
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
+pub struct TSIndexSignatureNameWithoutName<'a, 't>(
+    pub(crate) *const TSIndexSignatureName<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSIndexSignatureNameWithoutName<'a, 't> {
+    #[inline]
+    pub fn node_id(self) -> &'t Cell<NodeId> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NODE_ID)
+                as *const Cell<NodeId>)
+        }
+    }
+
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn type_annotation(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION)
+                as *const Box<'a, TSTypeAnnotation<'a>>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for TSIndexSignatureNameWithoutName<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        unsafe { Address::from_ptr(self.0) }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
 pub struct TSIndexSignatureNameWithoutTypeAnnotation<'a, 't>(
     pub(crate) *const TSIndexSignatureName<'a>,
     pub(crate) PhantomData<&'t ()>,
@@ -16144,9 +16188,10 @@ impl<'a, 't> TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn name(self) -> &'t Str<'a> {
+    pub fn name(self) -> &'t IdentifierName<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *const Str<'a>)
+            &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_NAME_NAME)
+                as *const IdentifierName<'a>)
         }
     }
 }

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -4924,9 +4924,15 @@ unsafe fn walk_ts_index_signature_name<'a, State, Tr: Traverse<'a, State>>(
     ctx: &mut TraverseCtx<'a, State>,
 ) {
     traverser.enter_ts_index_signature_name(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSIndexSignatureNameTypeAnnotation(
-        ancestor::TSIndexSignatureNameWithoutTypeAnnotation(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSIndexSignatureNameName(
+        ancestor::TSIndexSignatureNameWithoutName(node, PhantomData),
     ));
+    walk_identifier_name(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_NAME_NAME) as *mut IdentifierName,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::TSIndexSignatureNameTypeAnnotation);
     walk_ts_type_annotation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION)

--- a/napi/parser/src-js/generated/deserialize/js.js
+++ b/napi/parser/src-js/generated/deserialize/js.js
@@ -3579,17 +3579,17 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let node = {
+  let name = deserializeIdentifierName(pos + 16),
+    typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 48);
+  return {
     type: "Identifier",
     decorators: [],
-    name: deserializeStr(pos + 16),
+    name: name.name,
     optional: false,
-    typeAnnotation: null,
-    start: deserializeI32(pos),
-    end: deserializeI32(pos + 4),
+    typeAnnotation,
+    start: name.start,
+    end: typeAnnotation.end,
   };
-  node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  return node;
 }
 
 function deserializeTSInterfaceHeritage(pos) {
@@ -5713,10 +5713,10 @@ function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
   pos = int32[pos32];
-  let endPos = pos + int32[pos32 + 2] * 40;
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
-    pos += 40;
+    pos += 56;
   }
   return arr;
 }

--- a/napi/parser/src-js/generated/deserialize/js_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_parent.js
@@ -3996,17 +3996,19 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 
 function deserializeTSIndexSignatureName(pos) {
   let previousParent = parent,
+    name = deserializeIdentifierName(pos + 16),
+    typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 48),
     node = (parent = {
       type: "Identifier",
       decorators: [],
-      name: deserializeStr(pos + 16),
+      name: name.name,
       optional: false,
-      typeAnnotation: null,
-      start: deserializeI32(pos),
-      end: deserializeI32(pos + 4),
+      typeAnnotation,
+      start: name.start,
+      end: typeAnnotation.end,
       parent,
     });
-  node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
+  typeAnnotation.parent = node;
   parent = previousParent;
   return node;
 }
@@ -6226,10 +6228,10 @@ function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
   pos = int32[pos32];
-  let endPos = pos + int32[pos32 + 2] * 40;
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
-    pos += 40;
+    pos += 56;
   }
   return arr;
 }

--- a/napi/parser/src-js/generated/deserialize/js_range.js
+++ b/napi/parser/src-js/generated/deserialize/js_range.js
@@ -4005,20 +4005,20 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start,
+  let name = deserializeIdentifierName(pos + 16),
+    typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 48),
+    start = name.start,
+    end = typeAnnotation.end;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: name.name,
+    optional: false,
+    typeAnnotation,
+    start,
     end,
-    node = {
-      type: "Identifier",
-      decorators: [],
-      name: deserializeStr(pos + 16),
-      optional: false,
-      typeAnnotation: null,
-      start: (start = deserializeI32(pos)),
-      end: (end = deserializeI32(pos + 4)),
-      range: [start, end],
-    };
-  node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  return node;
+    range: [start, end],
+  };
 }
 
 function deserializeTSInterfaceHeritage(pos) {
@@ -6254,10 +6254,10 @@ function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
   pos = int32[pos32];
-  let endPos = pos + int32[pos32 + 2] * 40;
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
-    pos += 40;
+    pos += 56;
   }
   return arr;
 }

--- a/napi/parser/src-js/generated/deserialize/js_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/js_range_parent.js
@@ -4419,21 +4419,23 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start,
-    end,
-    previousParent = parent,
+  let previousParent = parent,
+    name = deserializeIdentifierName(pos + 16),
+    typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 48),
+    start = name.start,
+    end = typeAnnotation.end,
     node = (parent = {
       type: "Identifier",
       decorators: [],
-      name: deserializeStr(pos + 16),
+      name: name.name,
       optional: false,
-      typeAnnotation: null,
-      start: (start = deserializeI32(pos)),
-      end: (end = deserializeI32(pos + 4)),
+      typeAnnotation,
+      start,
+      end,
       range: [start, end],
       parent,
     });
-  node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
+  typeAnnotation.parent = node;
   parent = previousParent;
   return node;
 }
@@ -6766,10 +6768,10 @@ function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
   pos = int32[pos32];
-  let endPos = pos + int32[pos32 + 2] * 40;
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
-    pos += 40;
+    pos += 56;
   }
   return arr;
 }

--- a/napi/parser/src-js/generated/deserialize/ts.js
+++ b/napi/parser/src-js/generated/deserialize/ts.js
@@ -3852,17 +3852,17 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let node = {
+  let name = deserializeIdentifierName(pos + 16),
+    typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 48);
+  return {
     type: "Identifier",
     decorators: [],
-    name: deserializeStr(pos + 16),
+    name: name.name,
     optional: false,
-    typeAnnotation: null,
-    start: deserializeI32(pos),
-    end: deserializeI32(pos + 4),
+    typeAnnotation,
+    start: name.start,
+    end: typeAnnotation.end,
   };
-  node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  return node;
 }
 
 function deserializeTSInterfaceHeritage(pos) {
@@ -6005,10 +6005,10 @@ function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
   pos = int32[pos32];
-  let endPos = pos + int32[pos32 + 2] * 40;
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
-    pos += 40;
+    pos += 56;
   }
   return arr;
 }

--- a/napi/parser/src-js/generated/deserialize/ts_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_parent.js
@@ -4299,17 +4299,19 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 
 function deserializeTSIndexSignatureName(pos) {
   let previousParent = parent,
+    name = deserializeIdentifierName(pos + 16),
+    typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 48),
     node = (parent = {
       type: "Identifier",
       decorators: [],
-      name: deserializeStr(pos + 16),
+      name: name.name,
       optional: false,
-      typeAnnotation: null,
-      start: deserializeI32(pos),
-      end: deserializeI32(pos + 4),
+      typeAnnotation,
+      start: name.start,
+      end: typeAnnotation.end,
       parent,
     });
-  node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
+  typeAnnotation.parent = node;
   parent = previousParent;
   return node;
 }
@@ -6548,10 +6550,10 @@ function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
   pos = int32[pos32];
-  let endPos = pos + int32[pos32 + 2] * 40;
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
-    pos += 40;
+    pos += 56;
   }
   return arr;
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range.js
@@ -4306,20 +4306,20 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start,
+  let name = deserializeIdentifierName(pos + 16),
+    typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 48),
+    start = name.start,
+    end = typeAnnotation.end;
+  return {
+    type: "Identifier",
+    decorators: [],
+    name: name.name,
+    optional: false,
+    typeAnnotation,
+    start,
     end,
-    node = {
-      type: "Identifier",
-      decorators: [],
-      name: deserializeStr(pos + 16),
-      optional: false,
-      typeAnnotation: null,
-      start: (start = deserializeI32(pos)),
-      end: (end = deserializeI32(pos + 4)),
-      range: [start, end],
-    };
-  node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
-  return node;
+    range: [start, end],
+  };
 }
 
 function deserializeTSInterfaceHeritage(pos) {
@@ -6574,10 +6574,10 @@ function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
   pos = int32[pos32];
-  let endPos = pos + int32[pos32 + 2] * 40;
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
-    pos += 40;
+    pos += 56;
   }
   return arr;
 }

--- a/napi/parser/src-js/generated/deserialize/ts_range_parent.js
+++ b/napi/parser/src-js/generated/deserialize/ts_range_parent.js
@@ -4750,21 +4750,23 @@ function deserializeTSConstructSignatureDeclaration(pos) {
 }
 
 function deserializeTSIndexSignatureName(pos) {
-  let start,
-    end,
-    previousParent = parent,
+  let previousParent = parent,
+    name = deserializeIdentifierName(pos + 16),
+    typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 48),
+    start = name.start,
+    end = typeAnnotation.end,
     node = (parent = {
       type: "Identifier",
       decorators: [],
-      name: deserializeStr(pos + 16),
+      name: name.name,
       optional: false,
-      typeAnnotation: null,
-      start: (start = deserializeI32(pos)),
-      end: (end = deserializeI32(pos + 4)),
+      typeAnnotation,
+      start,
+      end,
       range: [start, end],
       parent,
     });
-  node.typeAnnotation = deserializeBoxTSTypeAnnotation(pos + 32);
+  typeAnnotation.parent = node;
   parent = previousParent;
   return node;
 }
@@ -7116,10 +7118,10 @@ function deserializeVecTSIndexSignatureName(pos) {
   let arr = [],
     pos32 = pos >> 2;
   pos = int32[pos32];
-  let endPos = pos + int32[pos32 + 2] * 40;
+  let endPos = pos + int32[pos32 + 2] * 56;
   for (; pos !== endPos; ) {
     arr.push(deserializeTSIndexSignatureName(pos));
-    pos += 40;
+    pos += 56;
   }
   return arr;
 }

--- a/napi/parser/src-js/generated/lazy/constructors.js
+++ b/napi/parser/src-js/generated/lazy/constructors.js
@@ -10163,7 +10163,7 @@ export class TSIndexSignatureName {
     const cached = nodes.get(pos);
     if (cached !== void 0) return cached;
 
-    this.#internal = { pos, ast, $name: void 0 };
+    this.#internal = { pos, ast };
     nodes.set(pos, this);
   }
 
@@ -10178,15 +10178,13 @@ export class TSIndexSignatureName {
   }
 
   get name() {
-    const internal = this.#internal,
-      cached = internal.$name;
-    if (cached !== void 0) return cached;
-    return (internal.$name = constructStr(internal.pos + 16, internal.ast));
+    const internal = this.#internal;
+    return new IdentifierName(internal.pos + 16, internal.ast);
   }
 
   get typeAnnotation() {
     const internal = this.#internal;
-    return constructBoxTSTypeAnnotation(internal.pos + 32, internal.ast);
+    return constructBoxTSTypeAnnotation(internal.pos + 48, internal.ast);
   }
 
   toJSON() {
@@ -13727,7 +13725,7 @@ function constructBoxTSMethodSignature(pos, ast) {
 function constructVecTSIndexSignatureName(pos, ast) {
   const { int32 } = ast.buffer,
     pos32 = pos >> 2;
-  return new NodeArray(int32[pos32], int32[pos32 + 2], 40, constructTSIndexSignatureName, ast);
+  return new NodeArray(int32[pos32], int32[pos32 + 2], 56, constructTSIndexSignatureName, ast);
 }
 
 function constructTSIndexSignatureName(pos, ast) {

--- a/napi/parser/src-js/generated/lazy/walk.js
+++ b/napi/parser/src-js/generated/lazy/walk.js
@@ -4185,7 +4185,8 @@ function walkTSIndexSignatureName(pos, ast, visitors) {
     if (enter !== null) enter(node);
   }
 
-  walkBoxTSTypeAnnotation(pos + 32, ast, visitors);
+  walkIdentifierName(pos + 16, ast, visitors);
+  walkBoxTSTypeAnnotation(pos + 48, ast, visitors);
 
   if (exit !== null) exit(node);
 }
@@ -5773,10 +5774,10 @@ function walkVecTSIndexSignatureName(pos, ast, visitors) {
   const { int32 } = ast.buffer,
     pos32 = pos >> 2;
   pos = int32[pos32];
-  const endPos = pos + int32[pos32 + 2] * 40;
+  const endPos = pos + int32[pos32 + 2] * 56;
   while (pos < endPos) {
     walkTSIndexSignatureName(pos, ast, visitors);
-    pos += 40;
+    pos += 56;
   }
 }
 

--- a/napi/parser/src-js/generated/visit/visitor.d.ts
+++ b/napi/parser/src-js/generated/visit/visitor.d.ts
@@ -140,8 +140,7 @@ export interface VisitorObject {
       | ESTree.IdentifierReference
       | ESTree.BindingIdentifier
       | ESTree.LabelIdentifier
-      | ESTree.TSThisParameter
-      | ESTree.TSIndexSignatureName,
+      | ESTree.TSThisParameter,
   ) => void;
   "Identifier:exit"?: (
     node:
@@ -149,8 +148,7 @@ export interface VisitorObject {
       | ESTree.IdentifierReference
       | ESTree.BindingIdentifier
       | ESTree.LabelIdentifier
-      | ESTree.TSThisParameter
-      | ESTree.TSIndexSignatureName,
+      | ESTree.TSThisParameter,
   ) => void;
   IfStatement?: (node: ESTree.IfStatement) => void;
   "IfStatement:exit"?: (node: ESTree.IfStatement) => void;

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1410,7 +1410,7 @@ export type TSSignature =
 
 export interface TSIndexSignature extends Span {
   type: "TSIndexSignature";
-  parameters: Array<TSIndexSignatureName>;
+  parameters: Array<Identifier>;
   typeAnnotation: TSTypeAnnotation;
   readonly: boolean;
   static: boolean;
@@ -1448,15 +1448,6 @@ export interface TSConstructSignatureDeclaration extends Span {
   typeParameters: TSTypeParameterDeclaration | null;
   params: ParamPattern[];
   returnType: TSTypeAnnotation | null;
-  parent?: Node;
-}
-
-export interface TSIndexSignatureName extends Span {
-  type: "Identifier";
-  decorators: [];
-  name: string;
-  optional: false;
-  typeAnnotation: TSTypeAnnotation;
   parent?: Node;
 }
 
@@ -1881,7 +1872,6 @@ export type Node =
   | TSCallSignatureDeclaration
   | TSMethodSignature
   | TSConstructSignatureDeclaration
-  | TSIndexSignatureName
   | TSInterfaceHeritage
   | TSTypePredicate
   | TSModuleDeclaration

--- a/tasks/ast_tools/src/generators/estree_visit.rs
+++ b/tasks/ast_tools/src/generators/estree_visit.rs
@@ -339,7 +339,6 @@ fn generate(codegen: &Codegen) -> Codes {
                 "BindingIdentifier",
                 "LabelIdentifier",
                 "TSThisParameter",
-                "TSIndexSignatureName",
             ]),
             "Property" => Some(&[
                 "ObjectProperty",


### PR DESCRIPTION
Doing some downstream work in https://github.com/camchenry/oxc_checker, I noticed that the span for `TSIndexSignatureName` refers to the entire `foo: string`, but there's no subspan for the name specifically, even though we do parse this information. See https://github.com/camchenry/oxc_checker/commit/e2105ae2e9aea103b8599c2ad03d01239b9ecf23 for how I'm working around this instead. (This makes it difficult to compare types with `tsc`, since it has a type for this location, but that's beside the point)

So, this PR changes the type for the name from just plain `Str` to an actual `IdentifierName`, which means we store both the `Str` and the `Span` for the name. There is a custom ESTree converter added so that we don't change the existing ESTree output however.