### PR TITLE
chore(ci): assign CODEOWNERS across crates, apps, and tasks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,24 +7,83 @@
 Cargo.lock
 pnpm-lock.yaml
 
-/apps/oxfmt @leaysgur
+# Linter (@camc314)
+
+/crates/oxc_linter @camc314
+/crates/oxc_config @camc314
+/crates/oxc_language_server @camc314 @sysix
+/oxlintrc.json @camc314
 /apps/oxlint @camc314
 /apps/oxlint/conformance @camc314 @overlookmotel
 /apps/oxlint/src-js @camc314 @overlookmotel
 /apps/oxlint/src-js/package/config.generated.ts @camc314
 /apps/oxlint/test @camc314 @overlookmotel
 /apps/oxlint/tsdown_plugins @camc314 @overlookmotel
+/npm/oxlint @camc314
+/npm/oxlint-plugin-eslint @camc314
+/npm/oxlint-plugins @camc314
+/tasks/lint_rules @camc314
+/tasks/linter_codegen @camc314
+/tasks/rulegen @camc314
+/tasks/website_linter @camc314
+
+# Formatter (@leaysgur)
+
+/crates/oxc_formatter @leaysgur
+/crates/oxc_formatter_core @leaysgur
+/crates/oxc_formatter_json @leaysgur
+/crates/oxc_jsdoc @leaysgur
+/crates/oxc_regular_expression @leaysgur
+/oxfmtrc.jsonc @leaysgur
+/apps/oxfmt @leaysgur
+/npm/oxfmt @leaysgur
+/tasks/prettier_conformance @leaysgur
+/tasks/website_formatter @leaysgur
+
+# Shared application tooling (@camc314 @leaysgur)
+
+/apps/shared @camc314 @leaysgur
+
+# Transformer / Minifier / Semantic (@dunqing)
+
+/crates/oxc_transformer @dunqing
+/crates/oxc_transformer_plugins @dunqing
+/crates/oxc_minifier @dunqing
+/crates/oxc_mangler @dunqing
+/crates/oxc_semantic @dunqing
+/crates/oxc_isolated_declarations @dunqing
+/crates/oxc_ecmascript @dunqing
+/crates/oxc_cfg @dunqing
+/crates/oxc_compat @dunqing
+/crates/oxc_codegen @dunqing
+/crates/oxc_napi @dunqing
+/napi/transform @dunqing
+/napi/minify @dunqing
+/npm/runtime @dunqing
+/tasks/transform_conformance @dunqing
+/tasks/transform_checker @dunqing
+/tasks/minsize @dunqing
+/tasks/compat_data @dunqing
+
+# Core infrastructure crates (@overlookmotel)
 
 /crates/oxc_allocator @overlookmotel
 /crates/oxc_data_structures @overlookmotel
-/crates/oxc_formatter @dunqing @leaysgur
-/crates/oxc_isolated_declarations @dunqing
-/crates/oxc_language_server @camc314 @sysix
-/crates/oxc_linter @camc314
-/crates/oxc_regular_expression @leaysgur
-/crates/oxc_semantic @dunqing
-/crates/oxc_transformer @overlookmotel @dunqing
-/crates/oxc_transformer_plugins @overlookmotel @dunqing
 /crates/oxc_traverse @overlookmotel
-
+/crates/oxc_ast @overlookmotel
+/crates/oxc_ast_macros @overlookmotel
+/crates/oxc_ast_visit @overlookmotel
+/crates/oxc_macros @overlookmotel
+/crates/oxc_span @overlookmotel
+/crates/oxc_str @overlookmotel
+/crates/oxc_syntax @overlookmotel
+/crates/oxc_estree @overlookmotel
+/crates/oxc_estree_tokens @overlookmotel
+/npm/oxc-types @overlookmotel
 /tasks/ast_tools @overlookmotel
+/tasks/track_memory_allocations @overlookmotel
+
+# Everything else falls through to the default owner @Boshen, including:
+#   parser (crates/oxc_parser, napi/parser), umbrella crates (crates/oxc,
+#   crates/oxc_react_compiler), crates/oxc_diagnostics, CI/release config,
+#   .github, build/dev toolchain configs, and project documentation.


### PR DESCRIPTION
Reworks `.github/CODEOWNERS` to assign ownership by area. Only the exceptions are listed explicitly; everything else falls through to the default owner @Boshen.

## Explicit ownership

- **Linter → @camc314**: `oxc_linter`, `oxc_config`, `oxc_language_server` (+ @sysix), `apps/oxlint`, `npm/oxlint*`, linter tasks, and the repo's `oxlintrc.json`.
- **Formatter → @leaysgur**: `oxc_formatter{,_core,_json}`, `oxc_jsdoc`, `oxc_regular_expression`, `apps/oxfmt`, `npm/oxfmt`, formatter tasks, and the repo's `oxfmtrc.jsonc`.
- **Transformer / Minifier / Semantic → @dunqing**: `oxc_transformer{,_plugins}`, `oxc_minifier`, `oxc_mangler`, `oxc_semantic`, `oxc_isolated_declarations`, `oxc_ecmascript`, `oxc_cfg`, `oxc_compat`, `oxc_codegen`, `oxc_napi`, `napi/{transform,minify}`, `npm/runtime`, and transform/minify tasks.
- **Core infrastructure crates → @overlookmotel**: `oxc_allocator`, `oxc_data_structures`, `oxc_traverse`, `oxc_ast{,_macros,_visit}`, `oxc_macros`, `oxc_span`, `oxc_str`, `oxc_syntax`, `oxc_estree{,_tokens}`, `npm/oxc-types`, and the AST/memory tasks.
- **Shared app tooling**: `apps/shared` → @camc314 @leaysgur.

## Falls through to the default (@Boshen)

Everything not listed above, including: parser (`crates/oxc_parser`, `napi/parser`), umbrella crates (`crates/oxc`, `crates/oxc_react_compiler`), `crates/oxc_diagnostics`, CI/release config, `.github`, build/dev toolchain configs, and project documentation.
