### PR TITLE
chore(deps): bump oxc_sourcemap to 8.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_sourcemap"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "174d2498c2390ccfab0a9caaf47ef5accda1d509aaa34a5be8f45e00e5299f04"
+checksum = "9ac6db7d8c33f46a0b9ebb702c077364abcd6b64c3a3a97bb86b9f5b3554833c"
 dependencies = [
  "base64-simd",
  "json-escape-simd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ json-strip-comments = "3.1.0" # Strip JSON comments
 oxc-browserslist = "3.0.0" # Browser compatibility queries
 oxc_index = { version = "5.0.0", features = ["nonmax", "serde"] } # Type-safe indices
 oxc_resolver = "11.16.3" # Module resolution
-oxc_sourcemap = "8.0.1" # Source map generation
+oxc_sourcemap = "8.0.2" # Source map generation
 
 #
 allocator-api2 = "=0.2.21" # Allocator trait


### PR DESCRIPTION
Bumps `oxc_sourcemap` from `8.0.1` to `8.0.2` (latest on crates.io).