### PR TITLE
feat(allocator)!: rename `AllocatorAccessor` trait to `GetAllocator`

### DIFF
--- a/crates/oxc_allocator/src/accessor.rs
+++ b/crates/oxc_allocator/src/accessor.rs
@@ -1,12 +1,12 @@
 use crate::Allocator;
 
 /// Accessor for getting the underlying allocator.
-pub trait AllocatorAccessor<'a> {
+pub trait GetAllocator<'a> {
     /// Get the underlying allocator.
     fn allocator(self) -> &'a Allocator;
 }
 
-impl<'a> AllocatorAccessor<'a> for &'a Allocator {
+impl<'a> GetAllocator<'a> for &'a Allocator {
     #[inline]
     fn allocator(self) -> &'a Allocator {
         self

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -68,7 +68,7 @@ mod arena;
 #[cfg(feature = "testing")]
 pub mod arena;
 
-pub use accessor::AllocatorAccessor;
+pub use accessor::GetAllocator;
 pub use address::{Address, GetAddress, UnstableAddress};
 pub use allocator::Allocator;
 #[cfg(feature = "bitset")]

--- a/crates/oxc_allocator/src/take_in.rs
+++ b/crates/oxc_allocator/src/take_in.rs
@@ -1,12 +1,12 @@
 use std::{cell::Cell, mem, num};
 
-use crate::{Allocator, AllocatorAccessor, Box, Vec};
+use crate::{Allocator, Box, GetAllocator, Vec};
 
 /// A trait to replace an existing AST node with a dummy.
 pub trait TakeIn<'a>: Dummy<'a> {
     /// Replace node with a dummy.
     #[must_use]
-    fn take_in<A: AllocatorAccessor<'a>>(&mut self, allocator_accessor: A) -> Self {
+    fn take_in<A: GetAllocator<'a>>(&mut self, allocator_accessor: A) -> Self {
         let allocator = allocator_accessor.allocator();
         let dummy = Dummy::dummy(allocator);
         mem::replace(self, dummy)
@@ -14,7 +14,7 @@ pub trait TakeIn<'a>: Dummy<'a> {
 
     /// Replace node with a boxed dummy.
     #[must_use]
-    fn take_in_box<A: AllocatorAccessor<'a>>(&mut self, allocator_accessor: A) -> Box<'a, Self> {
+    fn take_in_box<A: GetAllocator<'a>>(&mut self, allocator_accessor: A) -> Box<'a, Self> {
         let allocator = allocator_accessor.allocator();
         let dummy = Dummy::dummy(allocator);
         Box::new_in(mem::replace(self, dummy), allocator)

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -1,6 +1,6 @@
 use std::{alloc::Layout, borrow::Cow, mem::MaybeUninit, slice, str};
 
-use oxc_allocator::{Allocator, AllocatorAccessor, Box, FromIn, IntoIn, Vec};
+use oxc_allocator::{Allocator, Box, FromIn, GetAllocator, IntoIn, Vec};
 use oxc_span::{SPAN, Span};
 use oxc_str::{Ident, Str};
 use oxc_syntax::{number::NumberBase, operator::UnaryOperator, scope::ScopeId};
@@ -18,7 +18,7 @@ impl<'a, T> FromIn<'a, NONE> for Option<Box<'a, T>> {
     }
 }
 
-impl<'a> AllocatorAccessor<'a> for AstBuilder<'a> {
+impl<'a> GetAllocator<'a> for AstBuilder<'a> {
     #[inline]
     fn allocator(self) -> &'a Allocator {
         self.allocator


### PR DESCRIPTION
Pure refactor.

Rename `AllocatorAccessor` trait to `GetAllocator`.

Rust's naming convention is that trait names are verbs, describing what you can _do_ with the trait (e.g. `Clone`, not `Cloneable`). `GetAllocator` follows this convention, and also follows the naming convention we have for other traits e.g. `GetSpan`.