### PR TITLE
fix(parser): preserve fatal error across top-level await reparse

### DIFF
--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -814,6 +814,11 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         let original_tokens =
             if self.lexer.config.tokens() { Some(self.lexer.take_tokens()) } else { None };
 
+        // `rewind` resets `self.fatal_error` to each checkpoint's value, all taken before any later
+        // statement could fail. Reparsing only re-derives already-valid `await` statements, so a
+        // fatal error from a later statement must survive it. Hold it aside, restore below.
+        let fatal_error = self.fatal_error.take();
+
         let checkpoints = std::mem::take(&mut self.state.potential_await_reparse);
         for (stmt_index, checkpoint) in checkpoints {
             // Rewind to the checkpoint
@@ -833,6 +838,9 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
         if let Some(original_tokens) = original_tokens {
             self.lexer.set_tokens(original_tokens);
         }
+
+        // A fatal error from reparsing comes earlier in source order and wins; else restore.
+        self.fatal_error = self.fatal_error.take().or(fatal_error);
     }
 
     fn default_context(source_type: SourceType, options: ParseOptions) -> Context {

--- a/tasks/coverage/misc/fail/oxc-23673.js
+++ b/tasks/coverage/misc/fail/oxc-23673.js
@@ -1,0 +1,1 @@
+await(E);import

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 69/69 (100.00%)
 Positive Passed: 69/69 (100.00%)
-Negative Passed: 149/149 (100.00%)
+Negative Passed: 150/150 (100.00%)
 
   × Cannot assign to 'arguments' in strict mode
    ╭─[misc/fail/arguments-eval.ts:1:10]
@@ -3600,6 +3600,11 @@ Negative Passed: 149/149 (100.00%)
    ╭─[misc/fail/oxc-232.js:1:5]
  1 │ x = (/* a */)
    ·     ─────────
+   ╰────
+
+  × Expected `from` but found `EOF`
+   ╭─[misc/fail/oxc-23673.js:2:1]
+ 1 │ await(E);import
    ╰────
 
   × Expected 'with' in import type options


### PR DESCRIPTION
### Summary

Fixes #23673. `oxfmt` panicked with `string must start with a quote` (`oxc_formatter/src/utils/string.rs`) on input like `await(E);import`. The root cause is in the parser: a fatal parse error was silently discarded, so a file that should be rejected was reported as parsed successfully with a malformed AST.

### Problem

`await(E);import` is invalid — the trailing `import` is incomplete, which is a fatal error. On its own (`import`, or `x;import`) the parser reports it correctly. But `await(E)` is a top-level `await`: in unambiguous mode the parser first parses `await` as an identifier, records a checkpoint, and once the `import` proves the file is a module, reparses that statement with `await` enabled (`reparse_potential_top_level_awaits`).

That reparse calls `rewind(checkpoint)`, and `rewind` restores **all** saved state — including `self.fatal_error`. The checkpoint was taken *before* the `import`, so rewinding reset `fatal_error` back to `None`, erasing it. The parser then returned no diagnostics and a malformed `ImportDeclaration` whose `source` is a synthetic `StringLiteral { span: 0..0, value: "", raw: None }`. Because `oxc_formatter::format` only runs when parsing reports no diagnostics, this malformed program reached the formatter, which sliced the empty source text and tripped the assertion (and would index-underflow in release).

### Fix

Stash `self.fatal_error` before the reparse loop and restore it afterward. Reparsing only re-derives the AST for already-valid `await` statements, so a fatal error from a later statement is unrelated to them and must outlive the reparse. A fatal error newly surfaced by reparsing comes earlier in source order and takes priority; otherwise the first-pass error is restored.

This cannot cause false positives: the reparse only triggers after an `import`/`export` parsed successfully (parsing never stopped earlier), so any surviving `fatal_error` necessarily came from a statement *after* the reparsed awaits — which the reparse cannot fix anyway. It also fixes the class of bug generally, not just the empty-import-source symptom.

### Example

```js
await(E);import
```

Before: parsed "successfully" → `oxfmt` panics. After: `Expected `from` but found `EOF``, and valid files like `await(E); import x from "y";` still format normally.

### Testing

- Added `tasks/coverage/misc/fail/oxc-23673.js` (negative parser fixture).
- `cargo coverage -- parser`: 100% AST-parsed, no regressions; the only snapshot change is the new fixture counted as a correctly-failing test (`Negative Passed: 149 → 150`).
- `cargo test -p oxc_parser`, clippy, and rustfmt pass.

---

> **AI usage disclosure:** this change was investigated and drafted with the help of Claude Code, then reviewed and tested by the contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
