### PR TITLE
fix(formatter): keep parens in chained `export default` type cast

### DIFF
--- a/crates/oxc_formatter/src/parentheses/expression.rs
+++ b/crates/oxc_formatter/src/parentheses/expression.rs
@@ -861,13 +861,13 @@ impl NeedsParentheses<'_> for AstNode<'_, JSXEmptyExpression> {
 
 impl NeedsParentheses<'_> for AstNode<'_, TSAsExpression<'_>> {
     fn needs_parentheses(&self, _f: &JsFormatter<'_, '_>) -> bool {
-        ts_as_or_satisfies_needs_parens(self.span(), &self.expression, self.parent())
+        ts_as_or_satisfies_needs_parens(self.span(), self.expression(), self.parent())
     }
 }
 
 impl NeedsParentheses<'_> for AstNode<'_, TSSatisfiesExpression<'_>> {
     fn needs_parentheses(&self, _f: &JsFormatter<'_, '_>) -> bool {
-        ts_as_or_satisfies_needs_parens(self.span(), &self.expression, self.parent())
+        ts_as_or_satisfies_needs_parens(self.span(), self.expression(), self.parent())
     }
 }
 
@@ -1175,7 +1175,7 @@ fn await_or_yield_needs_parens(span: Span, node: &AstNodes<'_>) -> bool {
 
 fn ts_as_or_satisfies_needs_parens(
     span: Span,
-    inner: &Expression<'_>,
+    inner: &AstNode<'_, Expression<'_>>,
     parent: &AstNodes<'_>,
 ) -> bool {
     match parent {
@@ -1183,9 +1183,15 @@ fn ts_as_or_satisfies_needs_parens(
         // Binary-like
         | AstNodes::LogicalExpression(_)
         | AstNodes::BinaryExpression(_) => true,
-        // `export default (function foo() {} as bar)` and `export default (class {} as bar)`
-        AstNodes::ExportDefaultDeclaration(_) =>
-            matches!(inner, Expression::FunctionExpression(_) | Expression::ClassExpression(_)),
+        // `export default (function foo() {} as bar)` and `export default (class {} as bar)`.
+        // The parens are load-bearing: without them the leading `function`/`class` token makes
+        // `export default` parse the right-hand side as a declaration, detaching the cast. The
+        // leftmost expression is used (not just `inner`) so chained casts are also covered, e.g.
+        // `export default (function foo() {} as unknown as bar)`.
+        AstNodes::ExportDefaultDeclaration(_) => matches!(
+            ExpressionLeftSide::leftmost(inner).as_ref(),
+            Expression::FunctionExpression(_) | Expression::ClassExpression(_)
+        ),
         _ => {
             type_cast_like_needs_parens(span, parent)
         }

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/export-default-as.ts
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/export-default-as.ts
@@ -1,0 +1,3 @@
+// Parens are load-bearing: without them the leading `function`/`class` makes
+// `export default` parse the right-hand side as a declaration, detaching the cast.
+export default (function foo() {} as unknown as Foo);

--- a/crates/oxc_formatter/tests/fixtures/ts/parenthesis/export-default-as.ts.snap
+++ b/crates/oxc_formatter/tests/fixtures/ts/parenthesis/export-default-as.ts.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_formatter/tests/fixtures/mod.rs
+---
+==================== Input ====================
+// Parens are load-bearing: without them the leading `function`/`class` makes
+// `export default` parse the right-hand side as a declaration, detaching the cast.
+export default (function foo() {} as unknown as Foo);
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+// Parens are load-bearing: without them the leading `function`/`class` makes
+// `export default` parse the right-hand side as a declaration, detaching the cast.
+export default (function foo() {} as unknown as Foo);
+
+-------------------
+{ printWidth: 100 }
+-------------------
+// Parens are load-bearing: without them the leading `function`/`class` makes
+// `export default` parse the right-hand side as a declaration, detaching the cast.
+export default (function foo() {} as unknown as Foo);
+
+===================== End =====================


### PR DESCRIPTION
Fixes #23501

### Problem

`oxfmt` drops the load-bearing outer parentheses in `export default (fn as T)` when the cast is chained:

```ts
// input
export default (function foo() {} as unknown as Foo);

// oxfmt output (wrong — parens lost)
export default function foo() {} as unknown as Foo;
```

Without the parens the leading `function`/`class` token makes `export default` parse the right-hand side as a *declaration*, so the trailing `as …` cast is no longer attached to anything. Downstream `new defaultExport(...)` then fails with TS7009.

### Cause

The `ExportDefaultDeclaration` arm of `ts_as_or_satisfies_needs_parens` only inspected the **direct** inner expression:

```rust
AstNodes::ExportDefaultDeclaration(_) =>
    matches!(inner, Expression::FunctionExpression(_) | Expression::ClassExpression(_)),
```

A single `as` worked, but for a chained cast the outer `as` node's inner is another `TSAsExpression`, so the `FunctionExpression`/`ClassExpression` check failed and the parens were dropped.

### Fix

Walk to the leftmost descendant via `ExpressionLeftSide::leftmost` before checking for `FunctionExpression`/`ClassExpression` — mirroring the existing `CallExpression` handler, which already does this for the same `export default` scenario. This matches the ECMAScript grammar: `export default` forbids a right-hand side whose leading token is `function`/`async function`/`class`, so parens are needed exactly when the leftmost leaf is a function/class expression.

### Tests

- New fixture `tests/fixtures/ts/parenthesis/export-default-as.ts`.
- Full `oxc_formatter` fixture suite passes (290 tests).
- Verified no over-parenthesization: identifiers, calls, object literals, and non-`export-default` contexts get no parens; `function`/`class` as leftmost (even chained or via member access) keep them.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)