### PR TITLE
test(benchmark): expand pipeline define and inject coverage

### DIFF
--- a/tasks/benchmark/benches/pipeline.rs
+++ b/tasks/benchmark/benches/pipeline.rs
@@ -11,6 +11,34 @@ use oxc::{
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use oxc_tasks_common::TestFiles;
 
+/// A representative Vite-style define config. Unlike a single dot define, this exercises every
+/// `ReplaceGlobalDefines` dispatch path — identifier, dot, specific `import.meta.env.*`, and
+/// trailing wildcards — so the benchmark reflects the per-node lookup cost of a real config.
+const DEFINES: &[(&str, &str)] = &[
+    // identifier defines
+    ("__DEV__", "false"),
+    ("__PROD__", "true"),
+    ("__VERSION__", "'1.2.3'"),
+    ("__TEST__", "false"),
+    ("DEBUG", "false"),
+    // dot defines
+    ("process.env.NODE_ENV", "'production'"),
+    ("process.env.PLATFORM", "'browser'"),
+    ("process.env.VERSION", "'1.2.3'"),
+    ("globalThis.__DEV__", "false"),
+    // specific `import.meta.env` entries
+    ("import.meta.env.MODE", "'production'"),
+    ("import.meta.env.BASE_URL", "'/'"),
+    ("import.meta.env.PROD", "true"),
+    ("import.meta.env.DEV", "false"),
+    ("import.meta.env.SSR", "false"),
+    ("import.meta.env.VITE_API_URL", "'https://example.com'"),
+    ("import.meta.env.VITE_APP_TITLE", "'app'"),
+    // trailing wildcards
+    ("import.meta.env.*", "undefined"),
+    ("import.meta.*", "undefined"),
+];
+
 /// A [`CompilerInterface`] that runs the complete compilation pipeline:
 /// parse -> semantic -> transform -> define -> inject -> minify -> mangle -> codegen.
 struct PipelineCompiler {
@@ -65,13 +93,21 @@ fn bench_pipeline(criterion: &mut Criterion) {
         // so the compiler and its options can be built once and reused.
         let mut compiler = PipelineCompiler {
             transform: TransformOptions::from_target("esnext").unwrap(),
-            define: ReplaceGlobalDefinesConfig::new(&[("process.env.NODE_ENV", "'production'")])
-                .unwrap(),
-            inject: InjectGlobalVariablesConfig::new(vec![InjectImport::named_specifier(
-                "node:buffer",
-                Some("Buffer"),
-                "Buffer",
-            )]),
+            define: ReplaceGlobalDefinesConfig::new(DEFINES).unwrap(),
+            // Common global-variable injections: Node.js polyfills (when bundling for the
+            // browser) plus a classic-runtime JSX auto-import. Like the defines, these exercise
+            // the per-reference inject matching rather than a single specifier.
+            inject: InjectGlobalVariablesConfig::new(vec![
+                InjectImport::named_specifier("node:buffer", Some("Buffer"), "Buffer"),
+                InjectImport::default_specifier("node:process", "process"),
+                InjectImport::named_specifier("node:timers", Some("setImmediate"), "setImmediate"),
+                InjectImport::named_specifier(
+                    "node:timers",
+                    Some("clearImmediate"),
+                    "clearImmediate",
+                ),
+                InjectImport::default_specifier("react", "React"),
+            ]),
             compress: CompressOptions::smallest(),
             mangle: MangleOptions::default(),
             codegen: CodegenOptions::default(),


### PR DESCRIPTION
## Summary

The `pipeline` benchmark configured only a single `process.env.NODE_ENV` dot define and a single `Buffer` inject, so it never exercised most of the work a real config triggers:

- **Defines** — only the dot path ran. Identifier defines, `import.meta.env.*`, and trailing wildcards were never matched, even though those are the common cases in a Vite/bundler setup and each adds per-node lookup cost.
- **Injects** — only one named specifier, so the per-reference inject matching was barely exercised.

This swaps in a representative configuration:

- A ~18-entry Vite-style **define** set covering all four dispatch paths: identifier (`__DEV__`, …), dot (`process.env.NODE_ENV`, …), specific `import.meta.env.*` (`MODE`, `PROD`, `VITE_*`, …), and trailing wildcards (`import.meta.env.*`, `import.meta.*`).
- A set of common **injects**: Node.js polyfills (`Buffer`, `process`, `setImmediate`, `clearImmediate`) and a classic-runtime JSX auto-import (`React`), covering both named and default specifiers.

No production code changes — benchmark configuration only. The pipeline runs end-to-end on the test files (verified locally); the added define/inject matching shows up as a small, expected increase in measured pipeline time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
