### PR TITLE
chore(formatter): fix `.gitattributes` pattern for CLRF fixtures

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 crates/oxc_formatter/tests/fixtures/** text=auto eol=lf
-crates/oxc_formatter/tests/fixtures/js/crlf text=auto eol=crlf
+crates/oxc_formatter/tests/fixtures/js/crlf/** text=auto eol=crlf
 apps/oxfmt/test/**/fixtures/** text=auto eol=lf
 apps/oxlint/test/fixtures/** text=auto eol=lf
 


### PR DESCRIPTION
There was an error in the path specification...
