### PR TITLE
refactor(formatter_core): unify `arena_cow_str` usage

### DIFF
--- a/crates/oxc_formatter/src/formatter/token/number.rs
+++ b/crates/oxc_formatter/src/formatter/token/number.rs
@@ -1,5 +1,4 @@
-use std::borrow::Cow;
-
+use oxc_formatter_core::arena_cow_str;
 pub use oxc_formatter_core::spec::{format_trimmed_number, is_simple_number};
 
 use crate::formatter::{Format, JsFormatter, prelude::*};
@@ -23,10 +22,6 @@ impl<'a> Format<'a, JsFormatContext<'a>> for CleanedNumberLiteralText<'a> {
         // returns a `Cow::Borrowed` slice of the source (lifetime `'a`); pass it straight
         // through and only copy into the arena for the owned (reformatted) case. Mirrors the
         // borrowed-passthrough for string literals in `utils/string.rs`.
-        let text_str: &'a str = match &text {
-            Cow::Borrowed(borrowed) => borrowed,
-            Cow::Owned(owned) => f.allocator().alloc_str(owned),
-        };
-        text_without_whitespace(text_str).fmt(f);
+        text_without_whitespace(arena_cow_str(&text, f)).fmt(f);
     }
 }

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -41,12 +41,11 @@ pub use binary_like_expression::{BinaryLikeExpression, should_flatten};
 pub use fragment::{FormatFunctionParams, FormatTypeParameters};
 pub use function::FormatFunctionOptions;
 
-use std::borrow::Cow;
-
 use cow_utils::CowUtils;
 
 use oxc_allocator::Vec;
 use oxc_ast::ast::*;
+use oxc_formatter_core::arena_cow_str;
 use oxc_span::GetSpan;
 
 use crate::{
@@ -1079,11 +1078,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, BigIntLiteral<'a>> {
         // Already-lowercase bigints (the common case, e.g. `123n`) stay `Cow::Borrowed`, so the
         // arena copy is avoided; only an uppercase literal (e.g. `0xFFn`) is copied.
         let lowered = self.raw().unwrap().as_str().cow_to_ascii_lowercase();
-        let text_str: &'a str = match lowered {
-            Cow::Borrowed(borrowed) => borrowed,
-            Cow::Owned(owned) => f.allocator().alloc_str(&owned),
-        };
-        write!(f, text(text_str));
+        write!(f, text(arena_cow_str(&lowered, f)));
     }
 }
 

--- a/crates/oxc_formatter/src/utils/string.rs
+++ b/crates/oxc_formatter/src/utils/string.rs
@@ -1,9 +1,10 @@
 use std::{borrow::Cow, ops::Deref};
 
-use oxc_formatter_core::spec::normalize_string;
+use unicode_width::UnicodeWidthStr;
+
+use oxc_formatter_core::{arena_cow_str, spec::normalize_string};
 use oxc_span::SourceType;
 use oxc_syntax::identifier::is_identifier_name_patched;
-use unicode_width::UnicodeWidthStr;
 
 use crate::{
     QuoteProperties, QuoteStyle,
@@ -85,11 +86,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for CleanedStringLiteralText<'a> {
         // In the common case the literal needs no normalization, so `text` borrows a slice of the
         // source (`Cow::Borrowed`) which already outlives the buffer; pass it straight through and
         // only copy into the arena for the owned (normalized) case.
-        let text_str: &'a str = match &self.text {
-            Cow::Borrowed(borrowed) => borrowed,
-            Cow::Owned(owned) => f.allocator().alloc_str(owned),
-        };
-        text(text_str).fmt(f);
+        text(arena_cow_str(&self.text, f)).fmt(f);
     }
 }
 

--- a/crates/oxc_formatter_core/src/formatter.rs
+++ b/crates/oxc_formatter_core/src/formatter.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::module_inception)]
 
+use std::borrow::Cow;
+
 use oxc_allocator::{Allocator, GetAllocator, Vec as ArenaVec};
 
 use crate::{
@@ -8,6 +10,15 @@ use crate::{
     format::{Format, write},
     format_element::Interned,
 };
+
+/// Lifts a `Cow<'ast, str>` to `&'ast str`, allocating in the arena only for the owned case.
+/// Borrowed Cows already point into arena-resident source, so they pass through unchanged.
+pub fn arena_cow_str<'ast, C>(cow: &Cow<'ast, str>, f: &Formatter<'_, 'ast, C>) -> &'ast str {
+    match cow {
+        Cow::Borrowed(s) => s,
+        Cow::Owned(s) => f.allocator().alloc_str(s),
+    }
+}
 
 /// Handles the formatting of a CST and stores the context how the CST should be formatted (user preferences).
 ///

--- a/crates/oxc_formatter_core/src/lib.rs
+++ b/crates/oxc_formatter_core/src/lib.rs
@@ -54,7 +54,7 @@ pub use format_element::{
 };
 pub use format_extensions::{MemoizeFormat, Memoized};
 pub use formatted::Formatted;
-pub use formatter::Formatter;
+pub use formatter::{Formatter, arena_cow_str};
 pub use group_id::{GroupId, UniqueGroupIdBuilder};
 pub use options::{
     IndentStyle, IndentWidth, IndentWidthFromIntError, LineEnding, LineWidth,

--- a/crates/oxc_formatter_json/src/print/literal.rs
+++ b/crates/oxc_formatter_json/src/print/literal.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use oxc_ast::ast::{NumericLiteral, StringLiteral};
 use oxc_formatter_core::{
-    Buffer, Format, FormatContext,
+    Buffer, Format, FormatContext, arena_cow_str,
     builders::text,
     spec::{format_trimmed_number, normalize_string},
     write,
@@ -10,7 +10,7 @@ use oxc_formatter_core::{
 
 use crate::context::JsonFormatContext;
 
-use super::{JsonFormatter, arena_cow_str, write_quoted_str};
+use super::{JsonFormatter, write_quoted_str};
 
 pub struct FmtJsonString<'a, 'b> {
     pub lit: &'b StringLiteral<'a>,
@@ -44,7 +44,7 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FmtJsonString<'a, '_> {
             return;
         }
 
-        write_quoted_str(f, chosen_quote, arena_cow_str(normalized, f));
+        write_quoted_str(f, chosen_quote, arena_cow_str(&normalized, f));
     }
 }
 
@@ -71,6 +71,6 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for FmtJsonNumber<'a, '_> {
         // `keep_one_trailing_decimal_zero` matches Prettier's JS/JSON behavior (`1.00000` → `1.0`, not `1`).
         let normalized =
             format_trimmed_number(raw.as_str(), /* keep_one_trailing_decimal_zero */ true);
-        write!(f, text(arena_cow_str(normalized, f)));
+        write!(f, text(arena_cow_str(&normalized, f)));
     }
 }

--- a/crates/oxc_formatter_json/src/print/mod.rs
+++ b/crates/oxc_formatter_json/src/print/mod.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use oxc_ast::ast::Expression;
 use oxc_formatter_core::{Buffer, Format, Formatter, builders::FormatWith, builders::text, write};
 use oxc_span::{GetSpan, Span};
@@ -26,15 +24,6 @@ impl<'a> Format<'a, JsonFormatContext<'a>> for &'static str {
     #[inline]
     fn fmt(&self, f: &mut JsonFormatter<'_, 'a>) {
         write!(f, oxc_formatter_core::builders::token(self));
-    }
-}
-
-/// Lifts a `Cow<'a, str>` to `&'a str`, allocating in the arena only for the owned case.
-/// Borrowed Cows already point into arena-resident source, so they pass through unchanged.
-pub fn arena_cow_str<'a>(cow: Cow<'a, str>, f: &JsonFormatter<'_, 'a>) -> &'a str {
-    match cow {
-        Cow::Borrowed(s) => s,
-        Cow::Owned(s) => f.allocator().alloc_str(&s),
     }
 }
 

--- a/crates/oxc_formatter_json/src/print/object.rs
+++ b/crates/oxc_formatter_json/src/print/object.rs
@@ -2,7 +2,7 @@ use oxc_ast::ast::{
     NumericLiteral, ObjectExpression, ObjectPropertyKind, PropertyKey, StringLiteral,
 };
 use oxc_formatter_core::{
-    Buffer, Format, FormatContext,
+    Buffer, Format, FormatContext, arena_cow_str,
     builders::{block_indent, group, soft_block_indent_with_maybe_space, space, text},
     spec::{format_trimmed_number, is_simple_number, normalize_string},
     write,
@@ -21,8 +21,8 @@ use crate::{
 };
 
 use super::{
-    FmtJsonValue, FormatInvalidJson, JsonFormatter, arena_cow_str, format_with,
-    literal::FmtJsonString, number_string_round_trips, write_quoted_str,
+    FmtJsonValue, FormatInvalidJson, JsonFormatter, format_with, literal::FmtJsonString,
+    number_string_round_trips, write_quoted_str,
 };
 
 pub struct FmtJsonObject<'a, 'b> {
@@ -237,7 +237,7 @@ fn json5_unquoted_key<'a>(lit: &StringLiteral<'a>) -> Option<&'a str> {
 fn json5_write_quoted_key<'a>(content: &'a str, f: &mut JsonFormatter<'_, 'a>) {
     let quote_byte = f.context().options().preferred_quote(content);
     let normalized = normalize_string(content, quote_byte, /* quotes_will_change */ false);
-    write_quoted_str(f, quote_byte, arena_cow_str(normalized, f));
+    write_quoted_str(f, quote_byte, arena_cow_str(&normalized, f));
 }
 
 /// Resolves Prettier's `quoteProps: "consistent"` for `object`:
@@ -264,7 +264,7 @@ fn normalized_numeric_key<'a>(lit: &NumericLiteral<'a>, f: &JsonFormatter<'_, 'a
     let raw = lit.raw.as_ref().map_or("", oxc_ast::ast::Str::as_str);
     // JSON keeps one trailing decimal zero (`x.00000` -> `x.0`); see `format_trimmed_number`.
     let printed = format_trimmed_number(raw, /* keep_one_trailing_decimal_zero */ true);
-    arena_cow_str(printed, f)
+    arena_cow_str(&printed, f)
 }
 
 /// Returns `true` if a normalized numeric key should be wrapped in double quotes.

--- a/crates/oxc_formatter_json/src/print/stringify.rs
+++ b/crates/oxc_formatter_json/src/print/stringify.rs
@@ -11,7 +11,7 @@ use oxc_ast::ast::{
     ObjectPropertyKind, PropertyKey, StringLiteral, TemplateLiteral,
 };
 use oxc_formatter_core::{
-    Buffer, Format,
+    Buffer, Format, arena_cow_str,
     builders::{block_indent, hard_line_break, space, text},
     write,
 };
@@ -21,7 +21,7 @@ use oxc_syntax::operator::UnaryOperator;
 use crate::context::JsonFormatContext;
 
 use super::{
-    FormatInvalidJson, JsonFormatter, arena_cow_str, format_with, literal::FmtJsonString,
+    FormatInvalidJson, JsonFormatter, format_with, literal::FmtJsonString,
     number_string_round_trips, write_quoted_str,
 };
 
@@ -90,7 +90,7 @@ fn write_number_value<'a>(lit: &NumericLiteral<'a>, f: &mut JsonFormatter<'_, 'a
 fn write_string<'a>(lit: &StringLiteral<'a>, f: &mut JsonFormatter<'_, 'a>) {
     if COMPAT_PRE_18405 {
         let body = json_stringify_escape(lit.value.as_str(), lit.lone_surrogates);
-        write_quoted_str(f, b'"', arena_cow_str(body, f));
+        write_quoted_str(f, b'"', arena_cow_str(&body, f));
     } else {
         // `preferred_quote` already pins `json-stringify` to `"`.
         FmtJsonString { lit }.fmt(f);
@@ -212,7 +212,7 @@ fn write_template<'a>(template: &TemplateLiteral<'a>, f: &mut JsonFormatter<'_, 
         return;
     };
     let body = json_stringify_escape(cooked.as_str(), quasi.lone_surrogates);
-    write_quoted_str(f, b'"', arena_cow_str(body, f));
+    write_quoted_str(f, b'"', arena_cow_str(&body, f));
 }
 
 /// Escapes `content` the way `JSON.stringify` does for a string body


### PR DESCRIPTION
Closes #23528.
(I will confirm this (should be lived in `oxc_allocator` side?) later, then refactor all callsites)
