### PR TITLE
refactor(ast): remove `AstBuilder::alloc` calls

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -137,12 +137,9 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn void_0(self, span: Span) -> Expression<'a> {
         let num = self.number_0();
-        Expression::UnaryExpression(self.alloc(self.unary_expression(
-            span,
-            UnaryOperator::Void,
-            num,
-        )))
+        Expression::UnaryExpression(self.alloc_unary_expression(span, UnaryOperator::Void, num))
     }
+
     /// `NaN`
     #[inline]
     pub fn nan(self, span: Span) -> Expression<'a> {
@@ -250,14 +247,14 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         declaration: Declaration<'a>,
     ) -> Box<'a, ExportNamedDeclaration<'a>> {
-        self.alloc(self.export_named_declaration(
+        self.alloc_export_named_declaration(
             span,
             Some(declaration),
             self.vec(),
             None,
             ImportOrExportKind::Value,
             NONE,
-        ))
+        )
     }
 
     /// Create an [`ExportNamedDeclaration`] with no modifiers that contains a
@@ -269,14 +266,14 @@ impl<'a> AstBuilder<'a> {
         specifiers: Vec<'a, ExportSpecifier<'a>>,
         source: Option<StringLiteral<'a>>,
     ) -> Box<'a, ExportNamedDeclaration<'a>> {
-        self.alloc(self.export_named_declaration(
+        self.alloc_export_named_declaration(
             span,
             None,
             specifiers,
             source,
             ImportOrExportKind::Value,
             NONE,
-        ))
+        )
     }
 
     /* ---------- Template literals ---------- */


### PR DESCRIPTION
Pure refactor. Use shorter `alloc_*` methods of `AstBuilder` instead of using methods which build an owned type, and then calling `ast.alloc(...)` separately.