### PR TITLE
perf(isolated_declarations): allocate AST nodes in arena directly

### DIFF
--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -137,11 +137,11 @@ impl<'a> IsolatedDeclarations<'a> {
 
     pub(crate) fn transform_formal_parameters(
         &self,
-        params: &FormalParameters<'a>,
+        params: &ArenaBox<'a, FormalParameters<'a>>,
         in_private_constructor: bool,
     ) -> ArenaBox<'a, FormalParameters<'a>> {
         if params.kind.is_signature() || (params.rest.is_none() && params.items.is_empty()) {
-            return self.ast.alloc(params.clone_in(self.ast.allocator));
+            return params.clone_in(self.ast.allocator);
         }
 
         let items = self.ast.vec_from_iter(

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -277,11 +277,8 @@ impl<'a> IsolatedDeclarations<'a> {
                         ModuleDeclaration::ExportNamedDeclaration(decl) => {
                             if let Some(new_decl) = self.transform_export_named_declaration(decl) {
                                 self.scope.visit_export_named_declaration(&new_decl);
-                                transformed_stmts[idx] = Some(Statement::from(
-                                    ModuleDeclaration::ExportNamedDeclaration(
-                                        self.ast.alloc(new_decl),
-                                    ),
-                                ));
+                                transformed_stmts[idx] =
+                                    Some(Statement::ExportNamedDeclaration(new_decl));
                             } else if decl.declaration.is_none() {
                                 need_empty_export_marker = false;
                                 self.scope.visit_export_named_declaration(decl);
@@ -340,14 +337,13 @@ impl<'a> IsolatedDeclarations<'a> {
                                 transformed_variable_declarator.remove(&declarator.span).unwrap()
                             }),
                         );
-                        let decl = self.ast.variable_declaration(
+                        let decl = self.ast.alloc_variable_declaration(
                             declaration.span,
                             declaration.kind,
                             declarations,
                             self.is_declare(),
                         );
-                        transformed_stmts[idx] =
-                            Some(Statement::VariableDeclaration(self.ast.alloc(decl)));
+                        transformed_stmts[idx] = Some(Statement::VariableDeclaration(decl));
                         transformed_count += 1;
                     }
                 } else if let Some(new_decl) = self.transform_declaration(decl, true) {

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -9,10 +9,10 @@ impl<'a> IsolatedDeclarations<'a> {
     pub(crate) fn transform_export_named_declaration(
         &mut self,
         prev_decl: &ExportNamedDeclaration<'a>,
-    ) -> Option<ExportNamedDeclaration<'a>> {
+    ) -> Option<ArenaBox<'a, ExportNamedDeclaration<'a>>> {
         let decl = self.transform_declaration(prev_decl.declaration.as_ref()?, false)?;
 
-        Some(self.ast.export_named_declaration(
+        Some(self.ast.alloc_export_named_declaration(
             prev_decl.span,
             Some(decl),
             self.ast.vec(),


### PR DESCRIPTION
Small perf optimizations around AST builder calls.

- AST nodes which end up in `Box`es, allocate into the `Box` as early as possible, to increase chance compiler sees the type can be built directly in arena, rather than built on the stack, and then copied from stack into arena.
- Functions return `Box<T>` rather than `T` where the value needs to be boxed anyway. If function is not inlined, this avoids stack allocation + copy.

Also, shorten code where possible by using more specific `AstBuilder` methods.

In `transform_formal_parameters`, clone the `Box<FormalParameters>` instead of cloning `FormalParameters` on stack and then moving it into a `Box`.