### PR TITLE
perf(transformer): allocate AST nodes in arena directly

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -70,7 +70,7 @@ use std::borrow::Cow;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
 use oxc_ast::{
     NONE,
     ast::{Argument, CallExpression, Expression},
@@ -273,10 +273,10 @@ pub fn helper_call<'a>(
     helper: Helper,
     arguments: ArenaVec<'a, Argument<'a>>,
     ctx: &mut TraverseCtx<'a>,
-) -> CallExpression<'a> {
+) -> ArenaBox<'a, CallExpression<'a>> {
     let callee = helper_load(helper, ctx);
     let pure = helper.pure();
-    ctx.ast.call_expression_with_pure(SPAN, callee, NONE, arguments, false, pure)
+    ctx.ast.alloc_call_expression_with_pure(SPAN, callee, NONE, arguments, false, pure)
 }
 
 /// Same as [`helper_call`], but returns a `CallExpression` wrapped in an `Expression`.

--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -50,8 +50,11 @@ impl<'a> VarDeclarationsStore<'a> {
     /// given a `BoundIdentifier`.
     #[inline]
     pub fn insert_var(&mut self, binding: &BoundIdentifier<'a>, ast: AstBuilder<'a>) {
-        let ident = ast.binding_identifier_with_symbol_id(SPAN, binding.name, binding.symbol_id);
-        let pattern = BindingPattern::BindingIdentifier(ast.alloc(ident));
+        let pattern = ast.binding_pattern_binding_identifier_with_symbol_id(
+            SPAN,
+            binding.name,
+            binding.symbol_id,
+        );
         self.insert_var_binding_pattern(pattern, None, ast);
     }
 
@@ -64,8 +67,11 @@ impl<'a> VarDeclarationsStore<'a> {
         init: Expression<'a>,
         ast: AstBuilder<'a>,
     ) {
-        let ident = ast.binding_identifier_with_symbol_id(SPAN, binding.name, binding.symbol_id);
-        let pattern = BindingPattern::BindingIdentifier(ast.alloc(ident));
+        let pattern = ast.binding_pattern_binding_identifier_with_symbol_id(
+            SPAN,
+            binding.name,
+            binding.symbol_id,
+        );
         self.insert_var_binding_pattern(pattern, Some(init), ast);
     }
 
@@ -121,8 +127,11 @@ impl<'a> VarDeclarationsStore<'a> {
         init: Option<Expression<'a>>,
         ast: AstBuilder<'a>,
     ) {
-        let ident = ast.binding_identifier_with_symbol_id(SPAN, binding.name, binding.symbol_id);
-        let pattern = BindingPattern::BindingIdentifier(ast.alloc(ident));
+        let pattern = ast.binding_pattern_binding_identifier_with_symbol_id(
+            SPAN,
+            binding.name,
+            binding.symbol_id,
+        );
         self.insert_let_binding_pattern(pattern, init, ast);
     }
 

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -1353,13 +1353,13 @@ impl<'a> LegacyDecorator<'a> {
             PropertyKey::PrivateIdentifier(_) => ctx.ast.expression_string_literal(SPAN, "", None),
             // Copiable literals
             PropertyKey::NumericLiteral(literal) => {
-                Expression::NumericLiteral(ctx.ast.alloc(literal.clone()))
+                Expression::NumericLiteral(literal.clone_in(ctx.ast.allocator))
             }
             PropertyKey::StringLiteral(literal) => {
-                Expression::StringLiteral(ctx.ast.alloc(literal.clone()))
+                Expression::StringLiteral(literal.clone_in(ctx.ast.allocator))
             }
             PropertyKey::TemplateLiteral(literal) if literal.expressions.is_empty() => {
-                let quasis = ctx.ast.vec_from_iter(literal.quasis.iter().cloned());
+                let quasis = literal.quasis.clone_in(ctx.ast.allocator);
                 ctx.ast.expression_template_literal(SPAN, quasis, ctx.ast.vec())
             }
             PropertyKey::NullLiteral(_) => ctx.ast.expression_null_literal(SPAN),

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -546,7 +546,7 @@ impl<'a> ObjectRestSpread<'a> {
             ctx.ast.vec1(Argument::from(obj))
         };
         let new_expr = helper_call(Helper::ObjectSpread2, arguments, ctx);
-        expr.replace(ctx.ast.alloc(new_expr));
+        expr.replace(new_expr);
     }
 }
 
@@ -774,7 +774,7 @@ impl<'a> ObjectRestSpread<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         let decl = Self::create_temporary_reference_for_binding(kind, pat, scope_id, ctx);
-        body.insert(0, Statement::VariableDeclaration(ctx.ast.alloc(decl)));
+        body.insert(0, Statement::VariableDeclaration(decl));
     }
 
     fn create_temporary_reference_for_binding(
@@ -782,7 +782,7 @@ impl<'a> ObjectRestSpread<'a> {
         pat: &mut BindingPattern<'a>,
         scope_id: ScopeId,
         ctx: &mut TraverseCtx<'a>,
-    ) -> VariableDeclaration<'a> {
+    ) -> ArenaBox<'a, VariableDeclaration<'a>> {
         let mut flags = kind_to_symbol_flags(kind);
         if matches!(ctx.parent(), Ancestor::TryStatementHandler(_)) {
             // try {} catch (ref) {}
@@ -795,7 +795,7 @@ impl<'a> ObjectRestSpread<'a> {
         let init = bound_identifier.create_read_expression(ctx);
         let declarations =
             ctx.ast.vec1(ctx.ast.variable_declarator(SPAN, kind, id, NONE, Some(init), false));
-        let decl = ctx.ast.variable_declaration(SPAN, kind, declarations, false);
+        let decl = ctx.ast.alloc_variable_declaration(SPAN, kind, declarations, false);
         decl.bound_names(&mut |ident| {
             *ctx.scoping_mut().symbol_flags_mut(ident.symbol_id()) =
                 SymbolFlags::BlockScopedVariable;

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -137,10 +137,12 @@ impl<'a> LogicalAssignmentOperators {
         ident: &IdentifierReference<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (Expression<'a>, AssignmentTarget<'a>) {
-        let reference = ctx.scoping_mut().get_reference_mut(ident.reference_id());
+        let reference_id = ident.reference_id();
+        let reference = ctx.scoping_mut().get_reference_mut(reference_id);
         *reference.flags_mut() = ReferenceFlags::Read;
         let symbol_id = reference.symbol_id();
-        let left_expr = Expression::Identifier(ctx.alloc(ident.clone()));
+        let left_expr =
+            ctx.ast.expression_identifier_with_reference_id(ident.span, ident.name, reference_id);
 
         let ident = ctx.create_ident_reference(SPAN, ident.name, symbol_id, ReferenceFlags::Write);
         let assign_target = AssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(ident));

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -168,7 +168,10 @@ impl<'a> AutomaticScriptBindings<'a> {
         }
     }
 
-    fn require_create_element(&mut self, ctx: &mut TraverseCtx<'a>) -> IdentifierReference<'a> {
+    fn require_create_element(
+        &mut self,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> ArenaBox<'a, IdentifierReference<'a>> {
         if self.require_create_element.is_none() {
             let source =
                 get_import_source(self.jsx_runtime_importer.as_str(), self.react_importer_len);
@@ -178,17 +181,19 @@ impl<'a> AutomaticScriptBindings<'a> {
             let id = self.add_require_statement("react", source, true, ctx);
             self.require_create_element = Some(id);
         }
-        self.require_create_element.as_ref().unwrap().create_read_reference(ctx)
+        let ident = self.require_create_element.as_ref().unwrap().create_read_reference(ctx);
+        ctx.alloc(ident)
     }
 
-    fn require_jsx(&mut self, ctx: &mut TraverseCtx<'a>) -> IdentifierReference<'a> {
+    fn require_jsx(&mut self, ctx: &mut TraverseCtx<'a>) -> ArenaBox<'a, IdentifierReference<'a>> {
         if self.require_jsx.is_none() {
             let var_name =
                 if self.is_development { "reactJsxDevRuntime" } else { "reactJsxRuntime" };
             let id = self.add_require_statement(var_name, self.jsx_runtime_importer, false, ctx);
             self.require_jsx = Some(id);
         }
-        self.require_jsx.as_ref().unwrap().create_read_reference(ctx)
+        let ident = self.require_jsx.as_ref().unwrap().create_read_reference(ctx);
+        ctx.alloc(ident)
     }
 
     #[expect(clippy::unused_self)]
@@ -229,24 +234,32 @@ impl<'a> AutomaticModuleBindings<'a> {
         }
     }
 
-    fn import_create_element(&mut self, ctx: &mut TraverseCtx<'a>) -> IdentifierReference<'a> {
+    fn import_create_element(
+        &mut self,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> ArenaBox<'a, IdentifierReference<'a>> {
         if self.import_create_element.is_none() {
             let source =
                 get_import_source(self.jsx_runtime_importer.as_str(), self.react_importer_len);
             let id = self.add_import_statement("createElement", source, ctx);
             self.import_create_element = Some(id);
         }
-        self.import_create_element.as_ref().unwrap().create_read_reference(ctx)
+        let ident = self.import_create_element.as_ref().unwrap().create_read_reference(ctx);
+        ctx.alloc(ident)
     }
 
-    fn import_fragment(&mut self, ctx: &mut TraverseCtx<'a>) -> IdentifierReference<'a> {
+    fn import_fragment(
+        &mut self,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> ArenaBox<'a, IdentifierReference<'a>> {
         if self.import_fragment.is_none() {
             self.import_fragment = Some(self.add_jsx_import_statement("Fragment", ctx));
         }
-        self.import_fragment.as_ref().unwrap().create_read_reference(ctx)
+        let ident = self.import_fragment.as_ref().unwrap().create_read_reference(ctx);
+        ctx.alloc(ident)
     }
 
-    fn import_jsx(&mut self, ctx: &mut TraverseCtx<'a>) -> IdentifierReference<'a> {
+    fn import_jsx(&mut self, ctx: &mut TraverseCtx<'a>) -> ArenaBox<'a, IdentifierReference<'a>> {
         if self.import_jsx.is_none() {
             if self.is_development {
                 self.add_import_jsx_dev(ctx);
@@ -254,10 +267,11 @@ impl<'a> AutomaticModuleBindings<'a> {
                 self.import_jsx = Some(self.add_jsx_import_statement("jsx", ctx));
             }
         }
-        self.import_jsx.as_ref().unwrap().create_read_reference(ctx)
+        let ident = self.import_jsx.as_ref().unwrap().create_read_reference(ctx);
+        ctx.alloc(ident)
     }
 
-    fn import_jsxs(&mut self, ctx: &mut TraverseCtx<'a>) -> IdentifierReference<'a> {
+    fn import_jsxs(&mut self, ctx: &mut TraverseCtx<'a>) -> ArenaBox<'a, IdentifierReference<'a>> {
         if self.import_jsxs.is_none() {
             if self.is_development {
                 self.add_import_jsx_dev(ctx);
@@ -265,7 +279,8 @@ impl<'a> AutomaticModuleBindings<'a> {
                 self.import_jsxs = Some(self.add_jsx_import_statement("jsxs", ctx));
             }
         }
-        self.import_jsxs.as_ref().unwrap().create_read_reference(ctx)
+        let ident = self.import_jsxs.as_ref().unwrap().create_read_reference(ctx);
+        ctx.alloc(ident)
     }
 
     // Inline so that compiler can see in `import_jsx` and `import_jsxs` that fields
@@ -819,8 +834,7 @@ impl<'a> JsxImpl<'a> {
                 create_static_member_expression(object_ident, property_name, ctx)
             }
             Bindings::AutomaticModule(bindings) => {
-                let ident = bindings.import_fragment(ctx);
-                Expression::Identifier(ctx.alloc(ident))
+                Expression::Identifier(bindings.import_fragment(ctx))
             }
         }
     }
@@ -856,7 +870,7 @@ impl<'a> JsxImpl<'a> {
                 } else {
                     bindings.import_jsx(ctx)
                 };
-                Expression::Identifier(ctx.alloc(ident))
+                Expression::Identifier(ident)
             }
         }
     }
@@ -1211,11 +1225,11 @@ fn get_read_identifier_reference<'a>(
 }
 
 fn create_static_member_expression<'a>(
-    object_ident: IdentifierReference<'a>,
+    object_ident: ArenaBox<'a, IdentifierReference<'a>>,
     property_name: Str<'a>,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let object = Expression::Identifier(ctx.alloc(object_ident));
+    let object = Expression::Identifier(object_ident);
     let property = ctx.ast.identifier_name(SPAN, property_name);
     ctx.ast.member_expression_static(SPAN, object, property, false).into()
 }

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -625,7 +625,11 @@ impl<'a> Assignment<'a> {
     // Creates `this.name = name`
     fn create_this_property_assignment(&self, ctx: &mut TraverseCtx<'a>) -> Statement<'a> {
         let reference_id = ctx.create_bound_reference(self.symbol_id, ReferenceFlags::Read);
-        let id = ctx.ast.identifier_reference_with_reference_id(self.span, self.name, reference_id);
+        let id = ctx.ast.alloc_identifier_reference_with_reference_id(
+            self.span,
+            self.name,
+            reference_id,
+        );
 
         ctx.ast.statement_expression(
             SPAN,
@@ -639,7 +643,7 @@ impl<'a> Assignment<'a> {
                     false,
                 ))
                 .into(),
-                Expression::Identifier(ctx.alloc(id)),
+                Expression::Identifier(id),
             ),
         )
     }

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -283,8 +283,11 @@ impl<'a> TypeScriptEnum {
             VariableDeclarationKind::Var
         };
         let decls = {
-            let binding_identifier = decl.id.clone();
-            let binding = BindingPattern::BindingIdentifier(ctx.alloc(binding_identifier));
+            let binding = ast.binding_pattern_binding_identifier_with_symbol_id(
+                decl.id.span,
+                decl.id.name,
+                enum_symbol_id,
+            );
             let decl =
                 ast.variable_declarator(span, kind, binding, NONE, Some(call_expression), false);
             ast.vec1(decl)

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -2,6 +2,7 @@ use oxc_allocator::TakeIn;
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{Reference, SymbolFlags};
 use oxc_span::SPAN;
+use oxc_str::static_ident;
 use oxc_syntax::reference::ReferenceFlags;
 use oxc_traverse::Traverse;
 
@@ -120,10 +121,16 @@ impl<'a> TypeScriptModule {
             TSModuleReference::IdentifierReference(ident) => {
                 flags.insert(SymbolFlags::FunctionScopedVariable);
 
-                let ident = ident.clone();
-                let reference = ctx.scoping_mut().get_reference_mut(ident.reference_id());
+                let reference_id = ident.reference_id();
+                let reference = ctx.scoping_mut().get_reference_mut(reference_id);
                 *reference.flags_mut() = ReferenceFlags::Read;
-                (VariableDeclarationKind::Var, Expression::Identifier(ctx.alloc(ident)))
+
+                let ident = ctx.ast.expression_identifier_with_reference_id(
+                    ident.span,
+                    ident.name,
+                    reference_id,
+                );
+                (VariableDeclarationKind::Var, ident)
             }
             TSModuleReference::QualifiedName(qualified_name) => {
                 flags.insert(SymbolFlags::FunctionScopedVariable);
@@ -146,12 +153,18 @@ impl<'a> TypeScriptModule {
                     ctx.state.error(diagnostics::import_equals_cannot_be_used_in_esm(decl_span));
                 }
 
-                let require = ctx.ast.ident("require");
+                let require = static_ident!("require");
                 let require_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), require);
                 let callee =
                     ctx.create_ident_expr(SPAN, require, require_symbol_id, ReferenceFlags::Read);
-                let arguments =
-                    ctx.ast.vec1(Argument::StringLiteral(ctx.alloc(reference.expression.clone())));
+                let str_lit = &reference.expression;
+                let str_lit = ctx.ast.alloc_string_literal_with_lone_surrogates(
+                    str_lit.span,
+                    str_lit.value,
+                    str_lit.raw,
+                    str_lit.lone_surrogates,
+                );
+                let arguments = ctx.ast.vec1(Argument::StringLiteral(str_lit));
                 (
                     VariableDeclarationKind::Const,
                     ctx.ast.expression_call(SPAN, callee, NONE, arguments, false),
@@ -172,20 +185,23 @@ impl<'a> TypeScriptModule {
     ) -> Expression<'a> {
         match type_name {
             TSTypeName::IdentifierReference(ident) => {
-                let ident = ident.clone();
-                let reference = ctx.scoping_mut().get_reference_mut(ident.reference_id());
+                let reference_id = ident.reference_id();
+                let reference = ctx.scoping_mut().get_reference_mut(reference_id);
                 *reference.flags_mut() = ReferenceFlags::Read;
-                Expression::Identifier(ctx.alloc(ident))
+                ctx.ast.expression_identifier_with_reference_id(
+                    ident.span,
+                    ident.name,
+                    reference_id,
+                )
             }
-            TSTypeName::QualifiedName(qualified_name) => ctx
-                .ast
-                .member_expression_static(
+            TSTypeName::QualifiedName(qualified_name) => {
+                Expression::from(ctx.ast.member_expression_static(
                     SPAN,
                     self.transform_ts_type_name(&mut qualified_name.left, ctx),
                     qualified_name.right.clone(),
                     false,
-                )
-                .into(),
+                ))
+            }
             TSTypeName::ThisExpression(e) => ctx.ast.expression_this(e.span),
         }
     }

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -327,13 +327,13 @@ impl<'a> ModuleRunnerTransform<'a> {
                 };
 
                 // Reuse the `vue` binding identifier by renaming it to `__vite_ssr_import_0__`
-                let mut local = specifier.unbox().local;
+                let mut local = ctx.alloc(specifier.unbox().local);
                 local.name = self.generate_import_binding_name(ctx);
                 let binding = BoundIdentifier::from_binding_ident(&local);
                 ctx.scoping_mut().set_symbol_name(binding.symbol_id, binding.name);
                 self.import_bindings.insert(binding.symbol_id, (binding, None));
 
-                BindingPattern::BindingIdentifier(ctx.alloc(local))
+                BindingPattern::BindingIdentifier(local)
             } else {
                 let binding = self.generate_import_binding(ctx);
                 arguments.push(self.transform_import_specifiers(&binding, specifiers, ctx));
@@ -436,7 +436,7 @@ impl<'a> ModuleRunnerTransform<'a> {
                     ArrayExpressionElement::from(local_name_expr)
                 }));
                 let arguments = ctx.ast.vec_from_array([
-                    Argument::from(Expression::StringLiteral(ctx.ast.alloc(source))),
+                    Argument::StringLiteral(ctx.ast.alloc(source)),
                     Self::create_imported_names_object(imported_names, ctx),
                 ]);
                 hoist_imports.push(Self::create_import(SPAN, pattern, arguments, ctx));

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -12,5 +12,5 @@ antd.js                    | 6.69 MB        ||             15 |              0 |
 
 binder.ts                  | 193.08 kB      ||             17 |              0 ||            379 |              0
 
-kitchen-sink.tsx           | 732.90 kB      ||            184 |              3 ||           6690 |            280
+kitchen-sink.tsx           | 732.90 kB      ||            184 |              3 ||           6689 |            280
 


### PR DESCRIPTION
Same as #23709.

Small perf optimizations around AST builder calls.

- AST nodes which end up in `Box`es, allocate into the `Box` as early as possible, to increase chance compiler sees the type can be built directly in arena, rather than built on the stack, and then copied from stack into arena.
- Functions return `Box<T>` rather than `T` where the value needs to be boxed anyway. If function is not inlined, this avoids stack allocation + copy.

Also, shorten code where possible by using more specific `AstBuilder` methods.

In `transform_ts_import_equals`, additionally avoid unnecessarily allocating the string `"require"` into arena, by using `static_ident!` instead.