### PR TITLE
perf(parser): allocate AST nodes in arena directly

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -1,6 +1,6 @@
 //! Code related to navigating `Token`s from the lexer
 
-use oxc_allocator::Vec;
+use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::{BindingRestElement, RegExpFlags};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
@@ -532,14 +532,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         parse_element: E,
         parse_rest: R,
         rest_last_diagnostic: D,
-    ) -> (Vec<'a, A>, Option<BindingRestElement<'a>>)
+    ) -> (Vec<'a, A>, Option<Box<'a, BindingRestElement<'a>>>)
     where
         E: Fn(&mut Self) -> A,
-        R: Fn(&mut Self) -> BindingRestElement<'a>,
+        R: Fn(&mut Self) -> Box<'a, BindingRestElement<'a>>,
         D: Fn(Span) -> OxcDiagnostic,
     {
         let mut list = self.ast.vec();
-        let mut rest: Option<BindingRestElement<'a>> = None;
+        let mut rest: Option<Box<'a, BindingRestElement<'a>>> = None;
         let mut first = true;
         loop {
             let kind = self.cur_kind();

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -59,11 +59,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         self.expect(Kind::RCurly);
-        self.ast.binding_pattern_object_pattern(
-            self.end_span(span),
-            list,
-            rest.map(|r| self.alloc(r)),
-        )
+        self.ast.binding_pattern_object_pattern(self.end_span(span), list, rest)
     }
 
     /// Section 14.3.3 Array Binding Pattern
@@ -79,11 +75,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::binding_rest_element_last,
         );
         self.expect(Kind::RBrack);
-        self.ast.binding_pattern_array_pattern(
-            self.end_span(span),
-            list,
-            rest.map(|r| self.alloc(r)),
-        )
+        self.ast.binding_pattern_array_pattern(self.end_span(span), list, rest)
     }
 
     fn parse_array_binding_element(&mut self) -> Option<BindingPattern<'a>> {
@@ -95,7 +87,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// Section 14.3.3 Binding Rest Property
-    pub(crate) fn parse_rest_element(&mut self) -> BindingRestElement<'a> {
+    pub(crate) fn parse_rest_element(&mut self) -> Box<'a, BindingRestElement<'a>> {
         let span = self.start_span();
         self.bump_any(); // advance `...`
         let init_span = self.start_span();
@@ -124,7 +116,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::a_rest_element_cannot_have_an_initializer(pat.span));
         }
 
-        self.ast.binding_rest_element(self.end_span(span), argument)
+        self.ast.alloc_binding_rest_element(self.end_span(span), argument)
     }
 
     /// Parse rest element for function parameters (type annotation NOT consumed)

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -64,7 +64,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if stmt_ctx.is_single_statement() {
             self.error(diagnostics::lexical_declaration_single_statement(decl.span));
         }
-        Statement::VariableDeclaration(self.alloc(decl))
+        Statement::VariableDeclaration(decl)
     }
 
     pub(crate) fn get_variable_declaration_kind(&self) -> VariableDeclarationKind {
@@ -182,7 +182,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_using_declaration(
         &mut self,
         statement_ctx: StatementContext,
-    ) -> VariableDeclaration<'a> {
+    ) -> Box<'a, VariableDeclaration<'a>> {
         let span = self.start_span();
 
         let is_await = self.eat(Kind::Await);
@@ -224,6 +224,6 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        self.ast.variable_declaration(self.end_span(span), kind, declarations, false)
+        self.ast.alloc_variable_declaration(self.end_span(span), kind, declarations, false)
     }
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -233,10 +233,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Kind::Super => self.parse_super(),
             Kind::Import => self.parse_import_meta_or_call(),
             Kind::LParen => self.parse_parenthesized_expression(),
-            Kind::Slash | Kind::SlashEq => {
-                let literal = self.parse_literal_regexp();
-                Expression::RegExpLiteral(self.alloc(literal))
-            }
+            Kind::Slash | Kind::SlashEq => Expression::RegExpLiteral(self.parse_literal_regexp()),
             Kind::At => self.parse_decorated_expression(),
             // Literal, RegularExpressionLiteral
             kind if kind.is_literal() => self.parse_literal_expression(),
@@ -324,27 +321,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let lit = self.parse_literal_string();
                 Expression::StringLiteral(self.alloc(lit))
             }
-            Kind::True | Kind::False => {
-                let lit = self.parse_literal_boolean();
-                Expression::BooleanLiteral(self.alloc(lit))
-            }
-            Kind::Null => {
-                let lit = self.parse_literal_null();
-                Expression::NullLiteral(self.alloc(lit))
-            }
+            Kind::True | Kind::False => Expression::BooleanLiteral(self.parse_literal_boolean()),
+            Kind::Null => Expression::NullLiteral(self.parse_literal_null()),
             Kind::DecimalBigInt | Kind::BinaryBigInt | Kind::OctalBigInt | Kind::HexBigInt => {
-                let lit = self.parse_literal_bigint();
-                Expression::BigIntLiteral(self.alloc(lit))
+                Expression::BigIntLiteral(self.parse_literal_bigint())
             }
-            kind if kind.is_number() => {
-                let lit = self.parse_literal_number();
-                Expression::NumericLiteral(self.alloc(lit))
-            }
+            kind if kind.is_number() => Expression::NumericLiteral(self.parse_literal_number()),
             _ => self.unexpected(),
         }
     }
 
-    pub(crate) fn parse_literal_boolean(&mut self) -> BooleanLiteral {
+    pub(crate) fn parse_literal_boolean(&mut self) -> Box<'a, BooleanLiteral> {
         let span = self.start_span();
         let value = match self.cur_kind() {
             Kind::True => true,
@@ -352,16 +339,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => return self.unexpected(),
         };
         self.bump_any();
-        self.ast.boolean_literal(self.end_span(span), value)
+        self.ast.alloc_boolean_literal(self.end_span(span), value)
     }
 
-    pub(crate) fn parse_literal_null(&mut self) -> NullLiteral {
+    pub(crate) fn parse_literal_null(&mut self) -> Box<'a, NullLiteral> {
         let span = self.cur_token().span();
         self.bump_any(); // bump `null`
-        self.ast.null_literal(span)
+        self.ast.alloc_null_literal(span)
     }
 
-    pub(crate) fn parse_literal_number(&mut self) -> NumericLiteral<'a> {
+    pub(crate) fn parse_literal_number(&mut self) -> Box<'a, NumericLiteral<'a>> {
         let token = self.cur_token();
         let span = token.span();
         let kind = token.kind();
@@ -396,10 +383,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => return self.unexpected(),
         };
         self.bump_any();
-        self.ast.numeric_literal(span, value, Some(Str::from(src)), base)
+        self.ast.alloc_numeric_literal(span, value, Some(Str::from(src)), base)
     }
 
-    pub(crate) fn parse_literal_bigint(&mut self) -> BigIntLiteral<'a> {
+    pub(crate) fn parse_literal_bigint(&mut self) -> Box<'a, BigIntLiteral<'a>> {
         let token = self.cur_token();
         let kind = token.kind();
         let has_separator = token.has_separator();
@@ -416,10 +403,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let value = parse_big_int(src, number_kind, has_separator, self.ast.allocator);
 
         self.bump_any();
-        self.ast.big_int_literal(span, value, Some(Str::from(raw)), base)
+        self.ast.alloc_big_int_literal(span, value, Some(Str::from(raw)), base)
     }
 
-    pub(crate) fn parse_literal_regexp(&mut self) -> RegExpLiteral<'a> {
+    pub(crate) fn parse_literal_regexp(&mut self) -> Box<'a, RegExpLiteral<'a>> {
         let (pattern_end, flags, flags_error) = self.read_regex();
         if !self.lexer.errors.is_empty() {
             return self.unexpected();
@@ -451,7 +438,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::reg_exp_flag_u_and_v(span));
         }
 
-        self.ast.reg_exp_literal(span, RegExp { pattern, flags }, Some(Str::from(raw)))
+        self.ast.alloc_reg_exp_literal(span, RegExp { pattern, flags }, Some(Str::from(raw)))
     }
 
     #[cfg(feature = "regular_expression")]

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -535,8 +535,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        let init_declaration = self.alloc(using_decl);
-        self.parse_any_for_loop(span, parenthesis_opening_span, init_declaration, r#await)
+        self.parse_any_for_loop(span, parenthesis_opening_span, using_decl, r#await)
     }
 
     fn parse_any_for_loop(

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1193,14 +1193,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let key_name = self.cur_string();
         let with_key_span = self.start_span();
         self.bump_any();
-        let with_key = self.ast.identifier_name(self.end_span(with_key_span), key_name);
+        let with_key = self.ast.alloc_identifier_name(self.end_span(with_key_span), key_name);
 
         self.expect(Kind::Colon);
 
         // Parse the value - if it's an object literal, validate it
         let value = if self.at(Kind::LCurly) {
-            let inner_object = self.parse_ts_import_type_attributes();
-            Expression::ObjectExpression(self.alloc(inner_object))
+            Expression::ObjectExpression(self.parse_ts_import_type_attributes())
         } else {
             // Allow any expression (e.g., super.foo)
             self.parse_assignment_expression_or_higher()
@@ -1210,7 +1209,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let with_property = self.ast.alloc_object_property(
             self.end_span(with_key_span),
             PropertyKind::Init,
-            PropertyKey::StaticIdentifier(self.alloc(with_key)),
+            PropertyKey::StaticIdentifier(with_key),
             value,
             false,
             false,
@@ -1228,7 +1227,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Parse TypeScript import type attributes object: `{ type: "json" }`
     /// Only allows static key-value pairs (no computed keys, no spread elements).
-    fn parse_ts_import_type_attributes(&mut self) -> ObjectExpression<'a> {
+    fn parse_ts_import_type_attributes(&mut self) -> Box<'a, ObjectExpression<'a>> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
 
@@ -1266,11 +1265,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.expect(Kind::RBrack);
                 self.expect(Kind::Colon);
                 let value = self.parse_assignment_expression_or_higher();
-                let key = PropertyKey::StringLiteral(self.alloc(self.ast.string_literal(
+                let key = PropertyKey::StringLiteral(self.ast.alloc_string_literal(
                     bracket_span,
                     "",
                     None,
-                )));
+                ));
                 properties.push(ObjectPropertyKind::ObjectProperty(
                     self.ast.alloc_object_property(
                         self.end_span(prop_span),
@@ -1309,7 +1308,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         self.expect(Kind::RCurly);
-        self.ast.object_expression(self.end_span(span), properties)
+        self.ast.alloc_object_expression(self.end_span(span), properties)
     }
 
     pub(crate) fn parse_ts_return_type_annotation(


### PR DESCRIPTION
Same as #23709.

Small perf optimizations around AST builder calls.

- AST nodes which end up in `Box`es, allocate into the `Box` as early as possible, to increase chance compiler sees the type can be built directly in arena, rather than built on the stack, and then copied from stack into arena.
- Functions return `Box<T>` rather than `T` where the value needs to be boxed anyway. If function is not inlined, this avoids stack allocation + copy.

Also, shorten code where possible by using more specific `AstBuilder` methods.