### PR TITLE
perf(parser): remove string search from parsing JSX element name

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -244,10 +244,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
     }
 
-    /// Tell lexer to continue reading jsx identifier if the lexer character position is at `-` for `<component-name>`
-    pub(crate) fn continue_lex_jsx_identifier(&mut self) {
+    /// Tell lexer to continue reading jsx identifier if the lexer character position is at `-` for `<component-name>`.
+    ///
+    /// Returns `true` if was continued.
+    pub(crate) fn continue_lex_jsx_identifier(&mut self) -> bool {
         if let Some(token) = self.lexer.continue_lex_jsx_identifier(self.token.start()) {
             self.token = token;
+            true
+        } else {
+            false
         }
     }
 

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -141,11 +141,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   `JSXMemberExpression`
     fn parse_jsx_element_name(&mut self) -> JSXElementName<'a> {
         let span = self.start_span();
-        let identifier = self.parse_jsx_identifier();
+        let (identifier, contains_dash) = self.parse_jsx_identifier();
 
         // <namespace:property />
         if self.eat(Kind::Colon) {
-            let property = self.parse_jsx_identifier();
+            let (property, _) = self.parse_jsx_identifier();
             return self.ast.jsx_element_name_namespaced_name(
                 self.end_span(span),
                 identifier,
@@ -175,10 +175,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // we know it can only be `a-z`, `A-Z`, `_` or `$`.
         // Use a fast path for ASCII to avoid expensive Unicode operations in the common case.
         let name = identifier.name.as_str();
-        let is_reference = match name.as_bytes()[0] {
-            b if b.is_ascii() => !b.is_ascii_lowercase(), // Matches A-Z, _, $
-            _ => true, // Non-ASCII characters are always treated as references
-        } && !name.contains('-'); // Exclude hyphenated custom elements
+        let is_reference = !contains_dash // Exclude hyphenated custom elements
+            && match name.as_bytes()[0] {
+                b if b.is_ascii() => !b.is_ascii_lowercase(), // Matches A-Z, _, $
+                _ => true, // Non-ASCII characters are always treated as references
+            };
 
         if is_reference {
             let identifier = self.ast.alloc_identifier_reference(identifier.span, identifier.name);
@@ -215,9 +216,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
 
             // <foo.bar>
-            let ident = self.parse_jsx_identifier();
+            let (ident, contains_dash) = self.parse_jsx_identifier();
             // `<foo.bar- />` is a syntax error.
-            if ident.name.contains('-') {
+            if contains_dash {
                 let error = diagnostics::identifier_expected_jsx_no_hyphen(ident.span);
                 return self.fatal_error(error);
             }
@@ -439,10 +440,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   `JSXNamespacedName`
     fn parse_jsx_attribute_name(&mut self) -> JSXAttributeName<'a> {
         let span = self.start_span();
-        let identifier = self.parse_jsx_identifier();
+        let (identifier, _) = self.parse_jsx_identifier();
 
         if self.eat(Kind::Colon) {
-            let property = self.parse_jsx_identifier();
+            let (property, _) = self.parse_jsx_identifier();
             return self.ast.jsx_attribute_name_namespaced_name(
                 self.end_span(span),
                 identifier,
@@ -480,18 +481,24 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///   `IdentifierStart`
     ///   `JSXIdentifier` `IdentifierPart`
     ///   `JSXIdentifier` [no `WhiteSpace` or Comment here] -
-    fn parse_jsx_identifier(&mut self) -> JSXIdentifier<'a> {
+    fn parse_jsx_identifier(
+        &mut self,
+    ) -> (
+        JSXIdentifier<'a>, // JSX identifier
+        bool,              // `true` if contains `-`
+    ) {
         let span = self.start_span();
         let kind = self.cur_kind();
         if kind != Kind::Ident && !kind.is_any_keyword() {
-            return self.unexpected();
+            return (self.unexpected(), false);
         }
         // Currently at a valid normal Ident or Keyword, keep on lexing for `-` in `<component-name />`
-        self.continue_lex_jsx_identifier();
+        let contains_dash = self.continue_lex_jsx_identifier();
         self.bump_any();
         let span = self.end_span(span);
         let name = span.source_text(self.source_text);
-        self.ast.jsx_identifier(span, name)
+        let identifier = self.ast.jsx_identifier(span, name);
+        (identifier, contains_dash)
     }
 
     fn parse_jsx_text(&mut self) -> Box<'a, JSXText<'a>> {


### PR DESCRIPTION
Optimization to parsing JSX.

When parsing JSX element names `parse_jsx_element_name` has to determine if the identifier:

1. starts with a lowercase letter, and  
2. contains a `-`.

The 2nd check is relatively expensive - string search.

Avoid the search by making the lexer feed this information (which it already has) to the parser. This reduces the check in the parser to just `!contains_dash`.

(came across this while working on #23712)