### PR TITLE
fix(parser): string in AST reference arena

### DIFF
--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -712,8 +712,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let this_span = self.cur_token().span();
             self.error(diagnostics::identifier_reserved_word(this_span, "this"));
             self.bump_any();
-            // Recover by creating a dummy identifier
-            let ident = self.ast.alloc_identifier_reference(this_span, "this");
+            // Recover by creating an identifier
+            let this = this_span.source_text(self.source_text);
+            debug_assert_eq!(this, "this");
+            let ident = self.ast.alloc_identifier_reference(this_span, this);
             return TSModuleReference::IdentifierReference(ident);
         }
 


### PR DESCRIPTION
Fix a bug where a string in AST did not reference a string in the arena - it used a static string.

This breaks raw transfer, because it expects all `Str`s and `Ident`s to point to their string content in the arena - it doesn't know about any memory outside of the arena. The would have caused the string on JS side to be either an empty string, or garbage, instead of "this".

Fix by making the string reference a slice of the source text.

Unfortunately we have no way to enforce this at compile time at present - we'd likely need branded lifetimes for that.