### PR TITLE
refactor(ast): remove unnecessary conversion to `Ident`

### DIFF
--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -355,13 +355,13 @@ impl AstKind<'_> {
     pub fn debug_name(&self) -> std::borrow::Cow<'_, str> {
         use std::borrow::Cow;
 
-        const COMPUTED: Cow<'static, str> = Cow::Borrowed("<computed>");
-        const ANONYMOUS: Cow<'static, str> = Cow::Borrowed("<anonymous>");
-        const DESTRUCTURE: Cow<'static, str> = Cow::Borrowed("<destructure>");
+        const COMPUTED: &str = "<computed>";
+        const ANONYMOUS: &str = "<anonymous>";
+        const DESTRUCTURE: &str = "<destructure>";
 
         #[inline]
         fn or_anonymous<'a>(id: Option<&BindingIdentifier<'a>>) -> Cow<'a, str> {
-            id.map_or_else(|| ANONYMOUS.as_ref(), |id| id.name.as_str()).into()
+            id.map_or(ANONYMOUS, |id| id.name.as_str()).into()
         }
 
         match self {
@@ -393,7 +393,7 @@ impl AstKind<'_> {
             Self::VariableDeclaration(_) => "VariableDeclaration".into(),
             Self::VariableDeclarator(v) => format!(
                 "VariableDeclarator({})",
-                v.id.get_identifier_name().unwrap_or(Ident::from(DESTRUCTURE.as_ref()))
+                v.id.get_identifier_name().map_or(DESTRUCTURE, |name| name.as_str())
             )
             .into(),
 
@@ -431,7 +431,7 @@ impl AstKind<'_> {
                 format!("BinaryExpression({})", b.operator.as_str()).into()
             }
             Self::CallExpression(c) => {
-                format!("CallExpression({})", c.callee_name().unwrap_or(&COMPUTED)).into()
+                format!("CallExpression({})", c.callee_name().unwrap_or(COMPUTED)).into()
             }
             Self::ChainExpression(_) => "ChainExpression".into(),
             Self::ComputedMemberExpression(_) => "ComputedMemberExpression".into(),
@@ -445,7 +445,7 @@ impl AstKind<'_> {
                     }
                     _ => None,
                 };
-                format!("NewExpression({})", callee.unwrap_or(&COMPUTED)).into()
+                format!("NewExpression({})", callee.unwrap_or(COMPUTED)).into()
             }
             Self::ObjectExpression(_) => "ObjectExpression".into(),
             Self::ParenthesizedExpression(_) => "ParenthesizedExpression".into(),
@@ -461,7 +461,7 @@ impl AstKind<'_> {
             Self::PrivateInExpression(_) => "PrivateInExpression".into(),
 
             Self::ObjectProperty(p) => {
-                format!("ObjectProperty({})", p.key.name().unwrap_or(COMPUTED)).into()
+                format!("ObjectProperty({})", p.key.name().as_deref().unwrap_or(COMPUTED)).into()
             }
             Self::ArrayAssignmentTarget(_) => "ArrayAssignmentTarget".into(),
             Self::ObjectAssignmentTarget(_) => "ObjectAssignmentTarget".into(),
@@ -475,7 +475,7 @@ impl AstKind<'_> {
             Self::FormalParameters(_) => "FormalParameters".into(),
             Self::FormalParameter(p) => format!(
                 "FormalParameter({})",
-                p.pattern.get_identifier_name().unwrap_or(Ident::from(DESTRUCTURE.as_ref()))
+                p.pattern.get_identifier_name().map_or(DESTRUCTURE, |name| name.as_str())
             )
             .into(),
             Self::FormalParameterRest(_) => "FormalParameterRest".into(),


### PR DESCRIPTION
`AstKind::debug_name` pointlessly converted `Cow<'static, str>` to `Ident<'static>` to `&'static str` in some places. Cut out all this conversion by just using `&'static str`s.

Probably this conversion was all const-folded out by compiler, but it was unnecessary complication for no gain.