### PR TITLE
fix(lsp): normalize user config path to watch pattern

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -9,7 +9,7 @@ use tracing::{debug, error, warn};
 
 use oxc_language_server::{
     Capabilities, LanguageId, TextDocument, Tool, ToolBuilder, ToolRestartChanges,
-    offset_to_position,
+    offset_to_position, utils::normalize_user_config_path_to_watch_pattern,
 };
 
 use crate::core::{
@@ -169,7 +169,7 @@ impl Tool for ServerFormatter {
 
         let mut patterns: Vec<Pattern> =
             if let Some(config_path) = options.config_path.as_ref().filter(|s| !s.is_empty()) {
-                vec![config_path.clone()]
+                vec![normalize_user_config_path_to_watch_pattern(config_path)]
             } else {
                 // Watch for config files in all subdirectories (nested config support)
                 config_discovery()

--- a/apps/oxfmt/test/lsp/init/init.test.ts
+++ b/apps/oxfmt/test/lsp/init/init.test.ts
@@ -39,7 +39,7 @@ describe("LSP initialization", () => {
       { "fmt.configPath": "" },
       ["**/.oxfmtrc.json", "**/.oxfmtrc.jsonc", "**/oxfmt.config.ts", ".editorconfig"],
     ],
-    [{ "fmt.configPath": "./custom-config.json" }, ["./custom-config.json", ".editorconfig"]],
+    [{ "fmt.configPath": "./custom-config.json" }, ["custom-config.json", ".editorconfig"]],
   ])(
     "should send correct dynamic watch pattern registration for config: %s",
     async (lspConfig, expectedPatterns) => {

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -24,7 +24,7 @@ use oxc_linter::{
 
 use oxc_language_server::{
     Capabilities, ConcurrentHashMap, DiagnosticMode, DiagnosticResult, TextDocument, Tool,
-    ToolBuilder, ToolRestartChanges,
+    ToolBuilder, ToolRestartChanges, utils::normalize_user_config_path_to_watch_pattern,
 };
 
 use crate::{
@@ -459,7 +459,7 @@ impl Tool for ServerLinter {
             Some("") | None => {
                 config_file_names().into_iter().map(|name| format!("**/{name}")).collect()
             }
-            Some(v) => vec![v.to_string()],
+            Some(v) => vec![normalize_user_config_path_to_watch_pattern(v)],
         };
 
         for path in &self.extended_paths {

--- a/apps/oxlint/test/lsp/init/init.test.ts
+++ b/apps/oxlint/test/lsp/init/init.test.ts
@@ -57,7 +57,7 @@ describe("LSP initialization", () => {
   it.each([
     [undefined, ["**/.oxlintrc.json", "**/.oxlintrc.jsonc", "**/oxlint.config.ts"]],
     [{ configPath: "" }, ["**/.oxlintrc.json", "**/.oxlintrc.jsonc", "**/oxlint.config.ts"]],
-    [{ configPath: "./custom-config.json" }, ["./custom-config.json"]],
+    [{ configPath: "./custom-config.json" }, ["custom-config.json"]],
   ])(
     "should send correct dynamic watch pattern registration for config: %s",
     async (lspConfig, expectedPatterns) => {

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -13,6 +13,7 @@ mod position;
 #[cfg(test)]
 mod tests;
 mod tool;
+pub mod utils;
 mod worker;
 mod worker_manager;
 

--- a/crates/oxc_language_server/src/utils.rs
+++ b/crates/oxc_language_server/src/utils.rs
@@ -1,0 +1,47 @@
+use cow_utils::CowUtils;
+
+/// Normalize the user config path to a watch pattern that can be used to watch for changes.
+///
+/// Watch pattern like `./oxlintrc.json` is not supported by some editors (VS Code), so we need to normalize it to `oxlintrc.json`.
+pub fn normalize_user_config_path_to_watch_pattern(config_path: &str) -> String {
+    let path = config_path.cow_replace('\\', "/");
+    let path = path.cow_replace("/./", "/");
+    let path = path.strip_prefix("./").unwrap_or(&path);
+
+    let mut out = String::with_capacity(path.len());
+    for ch in path.chars() {
+        match ch {
+            // escape path characters that have special meaning in glob patterns
+            '*' | '?' | '[' | ']' | '{' | '}' | ',' | '!' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_user_config_path_to_watch_pattern() {
+        assert_eq!(normalize_user_config_path_to_watch_pattern("./oxlintrc.json"), "oxlintrc.json");
+        assert_eq!(
+            normalize_user_config_path_to_watch_pattern(".\\oxlintrc.json"),
+            "oxlintrc.json"
+        );
+        assert_eq!(normalize_user_config_path_to_watch_pattern("oxlintrc.json"), "oxlintrc.json");
+        assert_eq!(
+            normalize_user_config_path_to_watch_pattern("/home/oxlintrc.json"),
+            "/home/oxlintrc.json"
+        );
+        assert_eq!(
+            normalize_user_config_path_to_watch_pattern("C:\\home\\oxlintrc.json"),
+            "C:/home/oxlintrc.json"
+        );
+    }
+}


### PR DESCRIPTION
When a user defined a custom config path, like `fmt.configPath` or `configPath`, the watch pattern returned the same path. 
VS Code does not respect this as a valid pattern and does not watch for files defined like `./define-config.ts`.
Resulting into an LSP client, which will not send a watched-file-change requests to the server, when the user edited an important config path.