### PR TITLE
refactor(transformer): remove unnecessary `Str::from` calls

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -583,7 +583,7 @@ impl<'a> ConstructorParamsSuperReplacer<'a, '_> {
             Expression::from(ctx.ast.member_expression_static(
                 SPAN,
                 super_binding.create_read_expression(ctx),
-                ctx.ast.identifier_name(SPAN, Str::from("call")),
+                ctx.ast.identifier_name(SPAN, "call"),
                 false,
             )),
             NONE,

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -297,7 +297,7 @@ impl<'a> ClassProperties<'a> {
         call_expr.callee = Expression::from(ctx.ast.member_expression_static(
             SPAN,
             callee,
-            ctx.ast.identifier_name(SPAN, Str::from("call")),
+            ctx.ast.identifier_name(SPAN, "call"),
             // Make sure the `callee` can access `call` safely. i.e `callee?.()` -> `callee?.call()`
             mem::replace(&mut call_expr.optional, false),
         ));
@@ -1771,7 +1771,7 @@ impl<'a> ClassProperties<'a> {
         let callee = Expression::from(ctx.ast.member_expression_static(
             SPAN,
             callee,
-            ctx.ast.identifier_name(SPAN, Str::from("bind")),
+            ctx.ast.identifier_name(SPAN, "bind"),
             false,
         ));
         let arguments = ctx.ast.vec1(Argument::from(context));

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -362,7 +362,7 @@ impl<'a> ClassProperties<'a> {
                 ctx.ast.object_property_kind_object_property(
                     SPAN,
                     PropertyKind::Init,
-                    ctx.ast.property_key_static_identifier(SPAN, Str::from("writable")),
+                    ctx.ast.property_key_static_identifier(SPAN, "writable"),
                     ctx.ast.expression_boolean_literal(SPAN, true),
                     false,
                     false,
@@ -371,7 +371,7 @@ impl<'a> ClassProperties<'a> {
                 ctx.ast.object_property_kind_object_property(
                     SPAN,
                     PropertyKind::Init,
-                    ctx.ast.property_key_static_identifier(SPAN, Str::from("value")),
+                    ctx.ast.property_key_static_identifier(SPAN, "value"),
                     value,
                     false,
                     false,

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -40,7 +40,7 @@ where
 
 /// Create `IdentifierName` for `_`.
 pub(super) fn create_underscore_ident_name<'a>(ctx: &TraverseCtx<'a>) -> IdentifierName<'a> {
-    ctx.ast.identifier_name(SPAN, Str::from("_"))
+    ctx.ast.identifier_name(SPAN, "_")
 }
 
 /// Debug assert that an `Expression` is not `ParenthesizedExpression` or TS syntax

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -427,8 +427,8 @@ impl<'a> Pragma<'a> {
             Self::ImportMeta(parts) => {
                 let object = ctx.ast.expression_meta_property(
                     SPAN,
-                    ctx.ast.identifier_name(SPAN, Str::from("import")),
-                    ctx.ast.identifier_name(SPAN, Str::from("meta")),
+                    ctx.ast.identifier_name(SPAN, "import"),
+                    ctx.ast.identifier_name(SPAN, "meta"),
                 );
                 (object, parts.iter())
             }

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -83,7 +83,7 @@ pub fn create_prototype_member<'a>(
     span: Span,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, Str::from("prototype"));
+    let property = ctx.ast.identifier_name(SPAN, "prototype");
     let static_member = ctx.ast.member_expression_static(span, object, property, false);
     Expression::from(static_member)
 }
@@ -198,9 +198,7 @@ pub fn create_class_constructor_with_params<'a>(
 ) -> ClassElement<'a> {
     create_class_method(
         ctx.ast.vec(),
-        PropertyKey::StaticIdentifier(
-            ctx.ast.alloc_identifier_name(SPAN, Str::from("constructor")),
-        ),
+        PropertyKey::StaticIdentifier(ctx.ast.alloc_identifier_name(SPAN, "constructor")),
         MethodDefinitionKind::Constructor,
         params,
         None,


### PR DESCRIPTION
Remove `Str::from` conversion from `AstBuilder` methods call sites in transformer. `AstBuilder` methods convert `Str` to `Ident` automatically, but they also do the same for `&str`, so the extra conversion step is pointless, and makes code longer - just pass `&str`s.