### PR TITLE
refactor(str): relax lifetime on `PartialEq` for `Ident`

### DIFF
--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -333,7 +333,7 @@ impl<'a> From<Ident<'a>> for Cow<'a, str> {
 impl PartialEq for Ident<'_> {
     /// Fast-reject equality: compare packed len+hash first, then bytes.
     #[inline]
-    fn eq(&self, other: &Self) -> bool {
+    fn eq(&self, other: &Ident<'_>) -> bool {
         self.len_and_hash == other.len_and_hash && self.as_str() == other.as_str()
     }
 }


### PR DESCRIPTION
`PartialEq` impl for `Ident` had an unnecessarily restrictive lifetime bound - both `Ident`s had to have same lifetime (i.e. both `Ident<'a>`, not e.g. `Ident<'a>` and `Ident<'static>`).

As the type is covariant, this caused little problem in practice, but it suggested that lifetime equivalence is important, which it isn't - only the _contents_ of the 2 `Ident`s matters, not how long they live for.

Fix by making the 2 lifetime bounds separate and independent.