### PR TITLE
ci(allocs): allocation tracker measure all transforms

### DIFF
--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||            162 |              5 ||         152742 |          28244
+checker.ts                 | 2.92 MB        ||            410 |              4 ||         157423 |          28738
 
-App.tsx                    | 415.34 kB      ||            113 |              8 ||          17010 |           2702
+App.tsx                    | 415.34 kB      ||            235 |              6 ||          25109 |           4093
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             24 |              0 ||             32 |              6
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             24 |              3 ||             80 |              8
 
-pdf.mjs                    | 567.30 kB      ||           2612 |            205 ||          47485 |           7740
+pdf.mjs                    | 567.30 kB      ||           1055 |            110 ||          62164 |          10951
 
-antd.js                    | 6.69 MB        ||           3084 |             56 ||         337232 |          69333
+antd.js                    | 6.69 MB        ||           3084 |             56 ||         337349 |          69358
 
-binder.ts                  | 193.08 kB      ||             41 |              1 ||           7083 |            824
+binder.ts                  | 193.08 kB      ||             59 |              1 ||          10617 |           1537
 
-kitchen-sink.tsx           | 732.90 kB      ||           2638 |            174 ||          90549 |          15823
+kitchen-sink.tsx           | 732.90 kB      ||           2422 |            140 ||          96429 |          14996
 

--- a/tasks/track_memory_allocations/allocs_transformer.snap
+++ b/tasks/track_memory_allocations/allocs_transformer.snap
@@ -1,16 +1,16 @@
 File                       | File size      || Sys allocs     | Sys reallocs   || Arena allocs   | Arena reallocs 
 ---------------------------------------------------------------------------------------------------------------------------
-checker.ts                 | 2.92 MB        ||             20 |              0 ||           4400 |              5
+checker.ts                 | 2.92 MB        ||            292 |            201 ||          13076 |             59
 
-App.tsx                    | 415.34 kB      ||             25 |              2 ||            719 |             17
+App.tsx                    | 415.34 kB      ||            782 |            377 ||          13028 |            270
 
-RadixUIAdoptionSection.jsx | 2.52 kB        ||             21 |              2 ||            259 |             13
+RadixUIAdoptionSection.jsx | 2.52 kB        ||             35 |              1 ||            535 |             13
 
-pdf.mjs                    | 567.30 kB      ||             15 |              0 ||              2 |              0
+pdf.mjs                    | 567.30 kB      ||            543 |            278 ||          17735 |            228
 
-antd.js                    | 6.69 MB        ||             15 |              0 ||              2 |              0
+antd.js                    | 6.69 MB        ||             50 |              7 ||           3582 |             10
 
-binder.ts                  | 193.08 kB      ||             17 |              0 ||            379 |              0
+binder.ts                  | 193.08 kB      ||             41 |              5 ||            662 |              1
 
-kitchen-sink.tsx           | 732.90 kB      ||            184 |              3 ||           6690 |            280
+kitchen-sink.tsx           | 732.90 kB      ||           1594 |            364 ||          34870 |            730
 

--- a/tasks/track_memory_allocations/src/lib.rs
+++ b/tasks/track_memory_allocations/src/lib.rs
@@ -12,7 +12,7 @@ use oxc_minifier::{CompressOptions, MangleOptions, Minifier, MinifierOptions};
 use oxc_parser::{ParseOptions, Parser};
 use oxc_semantic::SemanticBuilder;
 use oxc_tasks_common::{TestFiles, project_root};
-use oxc_transformer::{TransformOptions, Transformer};
+use oxc_transformer::{EnvOptions, TransformOptions, Transformer};
 
 use std::alloc::{GlobalAlloc, Layout};
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
@@ -151,14 +151,18 @@ pub fn run() -> Result<(), io::Error> {
             .parse();
         assert!(parsed.diagnostics.is_empty());
 
-        // Transform TypeScript to ESNext before minifying (minifier only works on esnext)
         let scoping = SemanticBuilder::new()
             .with_excess_capacity(2.0)
             .with_enum_eval(true)
             .build(&parsed.program)
             .semantic
             .into_scoping();
-        let transform_options = TransformOptions::from_target("esnext").unwrap();
+
+        let mut transform_options = TransformOptions::enable_all();
+        // Even the plugins are unfinished, we still want to enable all of them
+        // to track allocation changes during the development
+        transform_options.env = EnvOptions::enable_all(/* include_unfinished_plugins */ true);
+
         let _ =
             Transformer::new(&allocator, std::path::Path::new(&file.file_name), &transform_options)
                 .build_with_scoping(scoping, &mut parsed.program);
@@ -219,8 +223,11 @@ pub fn run() -> Result<(), io::Error> {
             .semantic
             .into_scoping();
 
-        // Transform TypeScript to ESNext before minifying (minifier only works on esnext)
-        let transform_options = TransformOptions::from_target("esnext").unwrap();
+        let mut transform_options = TransformOptions::enable_all();
+        // Even the plugins are unfinished, we still want to enable all of them
+        // to track allocation changes during the development
+        transform_options.env = EnvOptions::enable_all(/* include_unfinished_plugins */ true);
+
         let ((), transformer_stats) = record_stats_in(&allocator, || {
             let _ = Transformer::new(
                 &allocator,


### PR DESCRIPTION
Allocations tracker was only measuring the allocations in transformer with "esnext" target - i.e. most transforms skipped. Instead, run all transforms, same as we do in benchmarks, so improvements in number of allocations in any transform will register.