### PR TITLE
refactor(parser): switch parser to new `AstBuilder`

### DIFF
--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true }
+oxc_ast = { workspace = true, features = ["builder_new"] }
 oxc_data_structures = { workspace = true, features = ["assert_unchecked", "fieldless_enum"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -390,7 +390,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     {
         let opening_span = self.cur_token().span();
         self.expect(open);
-        let mut list = self.ast.vec();
+        let mut list = ArenaVec::new_in(self);
         loop {
             let kind = self.cur_kind();
             if kind == close
@@ -416,7 +416,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     {
         let opening_span = self.cur_token().span();
         self.expect(open);
-        let mut list = self.ast.vec();
+        let mut list = ArenaVec::new_in(self);
         loop {
             if self.at(close) || self.has_fatal_error() {
                 break;
@@ -441,7 +441,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     where
         F: FnMut(&mut Self) -> T,
     {
-        let mut list = self.ast.vec();
+        let mut list = ArenaVec::new_in(self);
         // Cache cur_kind() to avoid redundant calls in compound checks
         let kind = self.cur_kind();
         if kind == close
@@ -538,7 +538,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         R: Fn(&mut Self) -> ArenaBox<'a, BindingRestElement<'a>>,
         D: Fn(Span) -> OxcDiagnostic,
     {
-        let mut list = self.ast.vec();
+        let mut list = ArenaVec::new_in(self);
         let mut rest: Option<ArenaBox<'a, BindingRestElement<'a>>> = None;
         let mut first = true;
         loop {

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::ArenaBox;
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{FileExtension, GetSpan};
 use oxc_syntax::precedence::Precedence;
@@ -232,15 +232,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         r#async: bool,
         allow_return_type_in_arrow_function: bool,
     ) -> Expression<'a> {
-        let pattern = BindingPattern::BindingIdentifier(
-            self.ast.alloc_binding_identifier(ident.span, ident.name),
-        );
-        let formal_parameter = self.ast.plain_formal_parameter(ident.span, pattern);
-        let params = self.ast.alloc_formal_parameters(
+        let pattern = BindingPattern::new_binding_identifier(ident.span, ident.name, self);
+        let formal_parameter = FormalParameter::new_plain(ident.span, pattern, self);
+        let params = FormalParameters::boxed(
             ident.span,
             FormalParameterKind::ArrowFormalParameters,
-            self.ast.vec1(formal_parameter),
+            ArenaVec::from_value_in(formal_parameter, self),
             NONE,
+            self,
         );
 
         if self.cur_token().is_on_new_line() {
@@ -320,15 +319,20 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 p.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function)
             });
             let span = expr.span();
-            let expr_stmt = self.ast.statement_expression(span, expr);
-            self.ast.alloc_function_body(span, self.ast.vec(), self.ast.vec1(expr_stmt))
+            let expr_stmt = Statement::new_expression_statement(span, expr, self);
+            FunctionBody::boxed(
+                span,
+                ArenaVec::new_in(self),
+                ArenaVec::from_value_in(expr_stmt, self),
+                self,
+            )
         } else {
             self.parse_function_body()
         };
 
         self.ctx = self.ctx.and_await(has_await).and_yield(has_yield);
 
-        self.ast.expression_arrow_function(
+        Expression::new_arrow_function_expression(
             self.end_span(span),
             expression,
             r#async,
@@ -336,6 +340,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             params,
             return_type,
             body,
+            self,
         )
     }
 

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -59,7 +59,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         self.expect(Kind::RCurly);
-        self.ast.binding_pattern_object_pattern(self.end_span(span), list, rest)
+        BindingPattern::new_object_pattern(self.end_span(span), list, rest, self)
     }
 
     /// Section 14.3.3 Array Binding Pattern
@@ -75,7 +75,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::binding_rest_element_last,
         );
         self.expect(Kind::RBrack);
-        self.ast.binding_pattern_array_pattern(self.end_span(span), list, rest)
+        BindingPattern::new_array_pattern(self.end_span(span), list, rest, self)
     }
 
     fn parse_array_binding_element(&mut self) -> Option<BindingPattern<'a>> {
@@ -116,7 +116,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::a_rest_element_cannot_have_an_initializer(pat.span));
         }
 
-        self.ast.alloc_binding_rest_element(self.end_span(span), argument)
+        BindingRestElement::boxed(self.end_span(span), argument, self)
     }
 
     /// Parse rest element for function parameters (type annotation NOT consumed)
@@ -145,7 +145,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::a_rest_parameter_cannot_have_an_initializer(pat.span));
         }
 
-        self.ast.binding_rest_element(self.end_span(span), argument)
+        BindingRestElement::new(self.end_span(span), argument, self)
     }
 
     /// `BindingProperty`[Yield, Await] :
@@ -167,7 +167,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 shorthand = true;
                 self.check_identifier_with_span(key_cur_kind, self.ctx, ident.span);
                 let identifier =
-                    self.ast.binding_pattern_binding_identifier(ident.span, ident.name);
+                    BindingPattern::new_binding_identifier(ident.span, ident.name, self);
                 self.context_add(Context::In, |p| p.parse_initializer(span, identifier))
             } else {
                 return self.unexpected();
@@ -179,7 +179,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.parse_binding_pattern_with_initializer()
         };
 
-        self.ast.binding_property(self.end_span(span), key, value, shorthand, computed)
+        BindingProperty::new(self.end_span(span), key, value, shorthand, computed, self)
     }
 
     /// Initializer[In, Yield, Await] :
@@ -187,7 +187,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_initializer(&mut self, span: u32, left: BindingPattern<'a>) -> BindingPattern<'a> {
         if self.eat(Kind::Eq) {
             let expr = self.parse_assignment_expression_or_higher();
-            self.ast.binding_pattern_assignment_pattern(self.end_span(span), left, expr)
+            BindingPattern::new_assignment_pattern(self.end_span(span), left, expr, self)
         } else {
             left
         }

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -113,7 +113,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        self.ast.alloc_class(
+        Class::boxed(
             self.end_span(start_span),
             r#type,
             decorators,
@@ -121,10 +121,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             type_parameters,
             super_class,
             super_type_parameters,
-            implements.map_or_else(|| self.ast.vec(), |(_, implements)| implements),
+            implements.map_or_else(|| ArenaVec::new_in(self), |(_, implements)| implements),
             body,
             modifiers.contains_abstract(),
             modifiers.contains_declare(),
+            self,
         )
     }
 
@@ -179,7 +180,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_extends_clause(&mut self) -> ArenaVec<'a, TSInterfaceHeritage<'a>> {
         self.bump_any(); // bump `extends`
 
-        let mut extends = self.ast.vec_with_capacity(1);
+        let mut extends = ArenaVec::with_capacity_in(1, self);
         loop {
             let span = self.start_span();
             let mut extend = self.parse_lhs_expression_or_higher();
@@ -195,10 +196,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 type_argument = self.try_parse_type_arguments();
             }
 
-            extends.push(self.ast.ts_interface_heritage(
+            extends.push(TSInterfaceHeritage::new(
                 self.end_span(span),
                 extend,
                 type_argument,
+                self,
             ));
 
             if !self.eat(Kind::Comma) {
@@ -221,7 +223,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             Some(Self::parse_class_element(p))
         });
-        self.ast.alloc_class_body(self.end_span(span), class_elements)
+        ClassBody::boxed(self.end_span(span), class_elements, self)
     }
 
     fn parse_class_element(&mut self) -> ClassElement<'a> {
@@ -385,7 +387,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Context::Yield | Context::Return,
             Self::parse_block,
         );
-        self.ast.class_element_static_block(self.end_span(span), block.unbox().body)
+        ClassElement::new_static_block(self.end_span(span), block.unbox().body, self)
     }
 
     /// <https://github.com/tc39/proposal-decorators>
@@ -432,7 +434,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 1,
             )));
         }
-        self.ast.class_element_accessor_property(
+        ClassElement::new_accessor_property(
             self.end_span(span),
             r#type,
             decorators,
@@ -444,6 +446,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             modifiers.contains(ModifierKind::Override),
             definite.is_some(),
             modifiers.accessibility(),
+            self,
         )
     }
 
@@ -461,7 +464,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             false,
             FunctionKind::ClassMethod,
         );
-        let method_definition = self.ast.alloc_method_definition(
+        let method_definition = MethodDefinition::boxed(
             self.end_span(span),
             r#type,
             decorators,
@@ -473,6 +476,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             modifiers.contains(ModifierKind::Override),
             false,
             modifiers.accessibility(),
+            self,
         );
         self.check_method_definition_accessor(&method_definition);
         self.verify_modifiers(
@@ -501,7 +505,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             false,
             FunctionKind::Constructor,
         );
-        let method_definition = self.ast.alloc_method_definition(
+        let method_definition = MethodDefinition::boxed(
             self.end_span(span),
             r#type,
             decorators,
@@ -513,6 +517,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             modifiers.contains(ModifierKind::Override),
             false,
             modifiers.accessibility(),
+            self,
         );
         self.check_method_definition_constructor(&method_definition);
         ClassElement::MethodDefinition(method_definition)
@@ -633,7 +638,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             generator,
             FunctionKind::ClassMethod,
         );
-        let method_definition = self.ast.alloc_method_definition(
+        let method_definition = MethodDefinition::boxed(
             self.end_span(span),
             r#type,
             decorators,
@@ -645,6 +650,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             modifiers.contains(ModifierKind::Override),
             optional,
             modifiers.accessibility(),
+            self,
         );
         self.check_method_definition_method(&method_definition);
         ClassElement::MethodDefinition(method_definition)
@@ -723,7 +729,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::definite_assignment_assertion_not_permitted(definite_span));
             }
         }
-        self.ast.class_element_property_definition(
+        ClassElement::new_property_definition(
             self.end_span(span),
             r#type,
             decorators,
@@ -738,6 +744,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             definite.is_some(),
             modifiers.contains(ModifierKind::Readonly),
             modifiers.accessibility(),
+            self,
         )
     }
 

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::ArenaBox;
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 
@@ -83,7 +83,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         decl_parent: VariableDeclarationParent,
         declare: bool,
     ) -> ArenaBox<'a, VariableDeclaration<'a>> {
-        let mut declarations = self.ast.vec();
+        let mut declarations = ArenaVec::new_in(self);
         loop {
             let declaration = self.parse_variable_declarator(decl_parent, kind);
             declarations.push(declaration);
@@ -95,7 +95,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if matches!(decl_parent, VariableDeclarationParent::Statement) {
             self.asi();
         }
-        self.ast.alloc_variable_declaration(self.end_span(start_span), kind, declarations, declare)
+        VariableDeclaration::boxed(self.end_span(start_span), kind, declarations, declare, self)
     }
 
     fn parse_variable_declarator(
@@ -132,13 +132,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // `const foo /* #__PURE__ */ = bar()` - pure comment before `=` cannot be applied
         self.lexer.trivia_builder.mark_current_pure_comment_not_applied();
         let init = self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher());
-        let decl = self.ast.variable_declarator(
+        let decl = VariableDeclarator::new(
             self.end_span(span),
             kind,
             id,
             type_annotation,
             init,
             definite.is_some(),
+            self,
         );
         if self.ctx.has_ambient()
             && let Some(init) = &decl.init
@@ -203,7 +204,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         // BindingList[?In, ?Yield, ?Await, ~Pattern]
-        let mut declarations = self.ast.vec();
+        let mut declarations = ArenaVec::new_in(self);
         loop {
             let decl_parent = if matches!(statement_ctx, StatementContext::For) {
                 VariableDeclarationParent::For
@@ -224,6 +225,6 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        self.ast.alloc_variable_declaration(self.end_span(span), kind, declarations, false)
+        VariableDeclaration::boxed(self.end_span(span), kind, declarations, false, self)
     }
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -73,7 +73,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         self.check_identifier(kind, self.ctx);
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
-        self.ast.identifier_reference(span, name)
+        IdentifierReference::new(span, name, self)
     }
 
     /// `BindingIdentifier` : Identifier
@@ -90,7 +90,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         self.check_identifier(cur, self.ctx);
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
-        self.ast.binding_identifier(span, name)
+        BindingIdentifier::new(span, name, self)
     }
 
     pub(crate) fn parse_label_identifier(&mut self) -> LabelIdentifier<'a> {
@@ -100,7 +100,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         self.check_identifier(kind, self.ctx);
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
-        self.ast.label_identifier(span, name)
+        LabelIdentifier::new(span, name, self)
     }
 
     pub(crate) fn parse_identifier_name(&mut self) -> IdentifierName<'a> {
@@ -108,13 +108,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return self.unexpected();
         }
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
-        self.ast.identifier_name(span, name)
+        IdentifierName::new(span, name, self)
     }
 
     /// Parse keyword kind as identifier
     pub(crate) fn parse_keyword_identifier(&mut self, kind: Kind) -> IdentifierName<'a> {
         let (span, name) = self.parse_identifier_kind(kind);
-        self.ast.identifier_name(span, name)
+        IdentifierName::new(span, name, self)
     }
 
     #[inline]
@@ -161,7 +161,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.cur_token().span();
         let name = Str::from(self.cur_string());
         self.bump_any();
-        self.ast.private_identifier(span, name)
+        PrivateIdentifier::new(span, name, self)
     }
 
     /// [+In] PrivateIdentifier in ShiftExpression[?Yield, ?Await]
@@ -182,7 +182,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if let Expression::PrivateInExpression(private_in_expr) = right {
             return self.fatal_error(diagnostics::private_in_private(private_in_expr.span));
         }
-        self.ast.expression_private_in(self.end_span(lhs_span), left, right)
+        Expression::new_private_in_expression(self.end_span(lhs_span), left, right, self)
     }
 
     /// Section [Primary Expression](https://tc39.es/ecma262/#sec-primary-expression)
@@ -217,9 +217,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             // ObjectLiteral
             Kind::LCurly => Expression::ObjectExpression(self.parse_object_expression()),
             // ClassExpression
-            Kind::Class => {
-                self.parse_class_expression(self.start_span(), &Modifiers::empty(), self.ast.vec())
-            }
+            Kind::Class => self.parse_class_expression(
+                self.start_span(),
+                &Modifiers::empty(),
+                ArenaVec::new_in(self),
+            ),
             // This
             Kind::This => self.parse_this_expression(),
             // TemplateLiteral
@@ -279,7 +281,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let mut expression = if expressions.len() == 1 {
             expressions.remove(0)
         } else {
-            self.ast.expression_sequence(expr_span, expressions)
+            Expression::new_sequence_expression(expr_span, expressions, self)
         };
 
         match &mut expression {
@@ -299,7 +301,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         if self.options.preserve_parens {
-            self.ast.expression_parenthesized(self.end_span(span), expression)
+            Expression::new_parenthesized_expression(self.end_span(span), expression, self)
         } else {
             expression
         }
@@ -309,7 +311,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_this_expression(&mut self) -> Expression<'a> {
         let span = self.start_span();
         self.bump_any();
-        self.ast.expression_this(self.end_span(span))
+        Expression::new_this_expression(self.end_span(span), self)
     }
 
     /// [Literal Expression](https://tc39.es/ecma262/#prod-Literal)
@@ -339,13 +341,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => return self.unexpected(),
         };
         self.bump_any();
-        self.ast.alloc_boolean_literal(self.end_span(span), value)
+        BooleanLiteral::boxed(self.end_span(span), value, self)
     }
 
     pub(crate) fn parse_literal_null(&mut self) -> ArenaBox<'a, NullLiteral> {
         let span = self.cur_token().span();
         self.bump_any(); // bump `null`
-        self.ast.alloc_null_literal(span)
+        NullLiteral::boxed(span, self)
     }
 
     pub(crate) fn parse_literal_number(&mut self) -> ArenaBox<'a, NumericLiteral<'a>> {
@@ -383,7 +385,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => return self.unexpected(),
         };
         self.bump_any();
-        self.ast.alloc_numeric_literal(span, value, Some(Str::from(src)), base)
+        NumericLiteral::boxed(span, value, Some(Str::from(src)), base, self)
     }
 
     pub(crate) fn parse_literal_bigint(&mut self) -> ArenaBox<'a, BigIntLiteral<'a>> {
@@ -403,7 +405,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let value = parse_big_int(src, number_kind, has_separator, self.ast.allocator);
 
         self.bump_any();
-        self.ast.alloc_big_int_literal(span, value, Some(Str::from(raw)), base)
+        BigIntLiteral::boxed(span, value, Some(Str::from(raw)), base, self)
     }
 
     pub(crate) fn parse_literal_regexp(&mut self) -> ArenaBox<'a, RegExpLiteral<'a>> {
@@ -438,7 +440,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::reg_exp_flag_u_and_v(span));
         }
 
-        self.ast.alloc_reg_exp_literal(span, RegExp { pattern, flags }, Some(Str::from(raw)))
+        RegExpLiteral::boxed(span, RegExp { pattern, flags }, Some(Str::from(raw)), self)
     }
 
     #[cfg(feature = "regular_expression")]
@@ -475,7 +477,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let value = self.cur_string();
         let lone_surrogates = self.cur_token().lone_surrogates();
         self.bump_any();
-        self.ast.string_literal_with_lone_surrogates(span, value, Some(raw), lone_surrogates)
+        StringLiteral::new_with_lone_surrogates(span, value, Some(raw), lone_surrogates, self)
     }
 
     /// Section [Array Expression](https://tc39.es/ecma262/#prod-ArrayLiteral)
@@ -499,7 +501,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.state.trailing_commas.insert(span, self.end_span(comma_span));
         }
         self.expect(Kind::RBrack);
-        self.ast.expression_array(self.end_span(span), elements)
+        Expression::new_array_expression(self.end_span(span), elements, self)
     }
 
     fn parse_array_expression_element(&mut self) -> ArrayExpressionElement<'a> {
@@ -514,7 +516,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     ,
     ///    Elision ,
     pub(crate) fn parse_elision(&self) -> ArrayExpressionElement<'a> {
-        self.ast.array_expression_element_elision(self.cur_token().span())
+        ArrayExpressionElement::new_elision(self.cur_token().span(), self)
     }
 
     /// Section [Template Literal](https://tc39.es/ecma262/#prod-TemplateLiteral)
@@ -526,12 +528,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let (quasis, expressions) = match self.cur_kind() {
             Kind::NoSubstitutionTemplate => {
-                let quasis = self.ast.vec1(self.parse_template_element(tagged));
-                (quasis, self.ast.vec())
+                let quasis = ArenaVec::from_value_in(self.parse_template_element(tagged), self);
+                (quasis, ArenaVec::new_in(self))
             }
             Kind::TemplateHead => {
-                let mut expressions = self.ast.vec_with_capacity(1);
-                let mut quasis = self.ast.vec_with_capacity(2);
+                let mut expressions = ArenaVec::with_capacity_in(1, self);
+                let mut quasis = ArenaVec::with_capacity_in(2, self);
 
                 quasis.push(self.parse_template_element(tagged));
                 // TemplateHead Expression[+In, ?Yield, ?Await]
@@ -563,7 +565,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => unreachable!("parse_template_literal"),
         };
 
-        self.ast.template_literal(self.end_span(span), quasis, expressions)
+        TemplateLiteral::new(self.end_span(span), quasis, expressions, self)
     }
 
     pub(crate) fn parse_template_literal_expression(&mut self, tagged: bool) -> Expression<'a> {
@@ -588,7 +590,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if in_optional_chain {
             self.error(diagnostics::optional_chain_tagged_template(quasi.span));
         }
-        self.ast.expression_tagged_template(span, lhs, type_arguments, quasi)
+        Expression::new_tagged_template_expression(span, lhs, type_arguments, quasi, self)
     }
 
     pub(crate) fn parse_template_element(&mut self, tagged: bool) -> TemplateElement<'a> {
@@ -614,7 +616,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             // `cooked = None` when template literal has invalid escape sequence
             let cooked = self.cur_template_string().map(Str::from);
             if cooked.is_some() && raw.contains('\r') {
-                raw = self.ast.str(&raw.cow_replace("\r\n", "\n").cow_replace('\r', "\n"));
+                raw =
+                    Str::from_str_in(&raw.cow_replace("\r\n", "\n").cow_replace('\r', "\n"), self);
             }
             (cooked, self.cur_token().lone_surrogates())
         } else {
@@ -633,11 +636,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let tail = matches!(cur_kind, Kind::TemplateTail | Kind::NoSubstitutionTemplate);
         // Parser provides already-escaped values from source, so no escaping needed here
-        self.ast.template_element_with_lone_surrogates(
+        TemplateElement::new_with_lone_surrogates(
             span,
             TemplateElementValue { raw, cooked },
             tail,
             lone_surrogates,
+            self,
         )
     }
 
@@ -658,7 +662,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         if !self.source_type.is_module() {
                             self.error_on_script(diagnostics::import_meta(span));
                         }
-                        self.ast.expression_meta_property(span, meta, property)
+                        Expression::new_meta_property(span, meta, property, self)
                     }
                     // `import.source(expr)`
                     Kind::Source => {
@@ -699,7 +703,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             )
         });
         self.expect(Kind::RParen);
-        self.ast.expression_v8_intrinsic(self.end_span(span), name, arguments)
+        Expression::new_v8_intrinsic_expression(self.end_span(span), name, arguments, self)
     }
 
     fn parse_v8_intrinsic_argument(&mut self) -> Argument<'a> {
@@ -752,13 +756,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         match expr {
             match_member_expression!(Expression) => {
                 let member_expr = expr.into_member_expression();
-                self.ast.expression_chain(span, ChainElement::from(member_expr))
+                Expression::new_chain_expression(span, ChainElement::from(member_expr), self)
             }
             Expression::CallExpression(e) => {
-                self.ast.expression_chain(span, ChainElement::CallExpression(e))
+                Expression::new_chain_expression(span, ChainElement::CallExpression(e), self)
             }
             Expression::TSNonNullExpression(e) => {
-                self.ast.expression_chain(span, ChainElement::TSNonNullExpression(e))
+                Expression::new_chain_expression(span, ChainElement::TSNonNullExpression(e), self)
             }
             expr => expr,
         }
@@ -780,7 +784,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::unexpected_super(span));
         }
 
-        self.ast.expression_super(span)
+        Expression::new_super(span, self)
     }
 
     /// An instantiation expression (`MemberExpression TypeArguments`) directly followed by a
@@ -864,14 +868,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 }
                 Kind::Bang if self.is_ts && !self.cur_token().is_on_new_line() => {
                     self.bump_any();
-                    lhs = self.ast.expression_ts_non_null(self.end_span(lhs_span), lhs);
+                    lhs =
+                        Expression::new_ts_non_null_expression(self.end_span(lhs_span), lhs, self);
                 }
                 Kind::LAngle | Kind::ShiftLeft if self.is_ts => {
                     if let Some(arguments) = self.parse_type_arguments_in_expression() {
-                        lhs = self.ast.expression_ts_instantiation(
+                        lhs = Expression::new_ts_instantiation_expression(
                             self.end_span(lhs_span),
                             lhs,
                             arguments,
+                            self,
                         );
                     } else {
                         // `re_lex_as_typescript_l_angle` may have popped the original token
@@ -920,10 +926,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if lhs.is_super() {
                 self.error(diagnostics::super_private(span));
             }
-            self.ast.member_expression_private_field_expression(span, lhs, private_ident, optional)
+            MemberExpression::new_private_field_expression(span, lhs, private_ident, optional, self)
         } else {
             let ident = self.parse_identifier_name();
-            self.ast.member_expression_static(self.end_span(lhs_span), lhs, ident, optional)
+            MemberExpression::new_static_member_expression(
+                self.end_span(lhs_span),
+                lhs,
+                ident,
+                optional,
+                self,
+            )
         })
     }
 
@@ -939,7 +951,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.bump_any(); // advance `[`
         let property = self.context_add(Context::In, Self::parse_expr);
         self.expect(Kind::RBrack);
-        self.ast.member_expression_computed(self.end_span(lhs_span), lhs, property, optional).into()
+        Expression::new_computed_member_expression(
+            self.end_span(lhs_span),
+            lhs,
+            property,
+            optional,
+            self,
+        )
     }
 
     /// [NewExpression](https://tc39.es/ecma262/#sec-new-operator)
@@ -954,7 +972,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 if !self.ctx.has_new_target() {
                     self.error(diagnostics::new_target_outside_function(span));
                 }
-                self.ast.expression_meta_property(span, identifier, property)
+                Expression::new_meta_property(span, identifier, property, self)
             } else {
                 self.bump_any();
                 self.fatal_error(diagnostics::new_target(self.end_span(span)))
@@ -1003,7 +1021,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.expect(Kind::RParen);
             call_arguments
         } else {
-            self.ast.vec()
+            ArenaVec::new_in(self)
         };
 
         if is_import && matches!(callee, Expression::ImportExpression(_)) {
@@ -1020,7 +1038,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::new_optional_chain(span));
         }
 
-        self.ast.expression_new(span, callee, type_arguments, arguments)
+        Expression::new_new_expression(span, callee, type_arguments, arguments, self)
     }
 
     /// Section 13.3 Call Expression
@@ -1119,12 +1137,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             )
         });
         self.expect(Kind::RParen);
-        self.ast.expression_call(
+        Expression::new_call_expression(
             self.end_span(lhs_span),
             lhs,
             type_parameters,
             call_arguments,
             optional,
+            self,
         )
     }
 
@@ -1145,7 +1164,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.bump_any();
             let argument = self.parse_unary_expression_or_higher(lhs_span);
             let argument = SimpleAssignmentTarget::cover(argument, self);
-            return self.ast.expression_update(self.end_span(lhs_span), operator, true, argument);
+            return Expression::new_update_expression(
+                self.end_span(lhs_span),
+                operator,
+                true,
+                argument,
+                self,
+            );
         }
 
         if self.source_type.is_jsx() && self.at(Kind::LAngle) {
@@ -1160,7 +1185,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let operator = map_update_operator(post_kind);
             self.bump_any();
             let lhs = SimpleAssignmentTarget::cover(lhs, self);
-            return self.ast.expression_update(self.end_span(span), operator, false, lhs);
+            return Expression::new_update_expression(
+                self.end_span(span),
+                operator,
+                false,
+                lhs,
+                self,
+            );
         }
         lhs
     }
@@ -1226,7 +1257,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         {
             self.lexer.trivia_builder.mark_pure_comment_not_applied(index);
         }
-        self.ast.expression_unary(self.end_span(span), operator, argument)
+        Expression::new_unary_expression(self.end_span(span), operator, argument, self)
     }
 
     pub(crate) fn parse_binary_expression_or_higher(
@@ -1303,12 +1334,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     if !self.is_ts {
                         self.error(diagnostics::as_in_ts(span));
                     }
-                    self.ast.expression_ts_as(span, lhs, type_annotation)
+                    Expression::new_ts_as_expression(span, lhs, type_annotation, self)
                 } else {
                     if !self.is_ts {
                         self.error(diagnostics::satisfies_in_ts(span));
                     }
-                    self.ast.expression_ts_satisfies(span, lhs, type_annotation)
+                    Expression::new_ts_satisfies_expression(span, lhs, type_annotation, self)
                 };
                 // When we have `a ## b as T` or `a ## b satisfies T`, where `##` is some binary
                 // operator, stop parsing on any following operator with higher precedence than `##`
@@ -1349,7 +1380,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         self.error(diagnostics::mixed_coalesce(span));
                     }
                 }
-                self.ast.expression_logical(span, lhs, op, rhs)
+                Expression::new_logical_expression(span, lhs, op, rhs, self)
             } else if kind.is_binary_operator() {
                 let span = self.end_span(lhs_span);
                 let op = map_binary_operator(kind);
@@ -1363,7 +1394,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 {
                     self.error(diagnostics::unexpected_exponential(key, lhs.span()));
                 }
-                self.ast.expression_binary(span, lhs, op, rhs)
+                Expression::new_binary_expression(span, lhs, op, rhs, self)
             } else {
                 break;
             };
@@ -1395,7 +1426,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect_conditional_alternative(question_span);
         let alternate =
             self.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function);
-        self.ast.expression_conditional(self.end_span(lhs_span), lhs, consequent, alternate)
+        Expression::new_conditional_expression(
+            self.end_span(lhs_span),
+            lhs,
+            consequent,
+            alternate,
+            self,
+        )
     }
 
     /// `AssignmentExpression`[In, Yield, Await] :
@@ -1572,7 +1609,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.bump_any();
         let right =
             self.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function);
-        self.ast.expression_assignment(self.end_span(span), operator, left, right)
+        Expression::new_assignment_expression(self.end_span(span), operator, left, right, self)
     }
 
     /// Section 13.16 Sequence Expression
@@ -1581,13 +1618,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         first_expression: Expression<'a>,
     ) -> Expression<'a> {
-        let mut expressions = self.ast.vec_with_capacity(2);
+        let mut expressions = ArenaVec::with_capacity_in(2, self);
         expressions.push(first_expression);
         while self.eat(Kind::Comma) {
             let expression = self.parse_assignment_expression_or_higher();
             expressions.push(expression);
         }
-        self.ast.expression_sequence(self.end_span(span), expressions)
+        Expression::new_sequence_expression(self.end_span(span), expressions, self)
     }
 
     /// Check if the current `await` token is unambiguously an await expression.
@@ -1637,7 +1674,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let span = self.start_span();
             self.bump_any(); // consume `await`
             let argument = self.parse_unary_expression_or_higher(self.start_span());
-            return self.ast.expression_await(self.end_span(span), argument);
+            return Expression::new_await_expression(self.end_span(span), argument, self);
         }
 
         // Case 2: Not in await context, but unambiguously an await expression
@@ -1668,7 +1705,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.ctx = self.ctx.and_await(true);
             let argument = self.parse_unary_expression_or_higher(self.start_span());
             self.ctx = self.ctx.and_await(false);
-            return self.ast.expression_await(self.end_span(span), argument);
+            return Expression::new_await_expression(self.end_span(span), argument, self);
         }
 
         // Case 3: Ambiguous - parse `await` as identifier
@@ -1690,13 +1727,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_decorators(&mut self) -> ArenaVec<'a, Decorator<'a>> {
         if self.at(Kind::At) {
-            let mut decorators = self.ast.vec_with_capacity(1);
+            let mut decorators = ArenaVec::with_capacity_in(1, self);
             while self.at(Kind::At) {
                 decorators.push(self.parse_decorator());
             }
             decorators
         } else {
-            self.ast.vec()
+            ArenaVec::new_in(self)
         }
     }
 
@@ -1708,7 +1745,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         self.bump_any(); // bump @
         let expr = self.context_add(Context::Decorator, Self::parse_lhs_expression_or_higher);
-        self.ast.decorator(self.end_span(span), expr)
+        Decorator::new(self.end_span(span), expr, self)
     }
 
     fn is_yield_expression(&mut self) -> bool {

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -39,7 +39,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         });
 
         self.expect_closing(Kind::RCurly, opening_span);
-        self.ast.alloc_function_body(self.end_span(span), directives, statements)
+        FunctionBody::boxed(self.end_span(span), directives, statements, self)
     }
 
     pub(crate) fn parse_formal_parameters(
@@ -61,7 +61,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::RParen);
 
         let formal_parameters =
-            self.ast.alloc_formal_parameters(self.end_span(span), params_kind, list, rest);
+            FormalParameters::boxed(self.end_span(span), params_kind, list, rest, self);
         (this_param, formal_parameters)
     }
 
@@ -70,7 +70,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         func_kind: FunctionKind,
         opening_span: Span,
     ) -> (ArenaVec<'a, FormalParameter<'a>>, Option<ArenaBox<'a, FormalParameterRest<'a>>>) {
-        let mut list = self.ast.vec();
+        let mut list = ArenaVec::new_in(self);
         let mut rest: Option<ArenaBox<'a, FormalParameterRest<'a>>> = None;
         let mut first = true;
 
@@ -135,11 +135,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     }
                 }
 
-                rest = Some(self.ast.alloc_formal_parameter_rest(
+                rest = Some(FormalParameterRest::boxed(
                     self.end_span(span),
                     decorators,
                     rest_element,
                     type_annotation,
+                    self,
                 ));
             } else {
                 list.push(self.parse_formal_parameter_with_decorators(func_kind, span, decorators));
@@ -227,7 +228,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::decorators_are_not_valid_here(decorator.span));
             }
         }
-        self.ast.formal_parameter(
+        FormalParameter::new(
             self.end_span(span),
             decorators,
             pattern,
@@ -237,6 +238,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             modifiers.accessibility(),
             modifiers.contains_readonly(),
             modifiers.contains_override(),
+            self,
         )
     }
 
@@ -330,7 +332,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        self.ast.alloc_function(
+        Function::boxed(
             self.end_span(span),
             function_type,
             id,
@@ -342,6 +344,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             params,
             return_type,
             body,
+            self,
         )
     }
 
@@ -495,7 +498,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        self.ast.expression_yield(self.end_span(span), delegate, argument)
+        Expression::new_yield_expression(self.end_span(span), delegate, argument, self)
     }
 
     // id: None - for AnonymousDefaultExportedFunctionDeclaration
@@ -514,7 +517,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.check_identifier(kind, ctx);
 
             let (span, name) = self.parse_identifier_kind(Kind::Ident);
-            Some(self.ast.binding_identifier(span, name))
+            Some(BindingIdentifier::new(span, name, self))
         } else {
             if func_kind.is_id_required() {
                 match self.cur_kind() {

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -1,5 +1,6 @@
 //! Cover Grammar for Destructuring Assignment
 
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -96,7 +97,7 @@ impl<'a, C: Config> CoverGrammar<'a, ArrayExpression<'a>, C> for ArrayAssignment
     // would otherwise carry this body's large stack frame + callee-saved spills on every call.
     #[inline(never)]
     fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
-        let mut elements = p.ast.vec();
+        let mut elements = ArenaVec::new_in(p);
         let mut rest = None;
 
         let len = expr.elements.len();
@@ -123,7 +124,7 @@ impl<'a, C: Config> CoverGrammar<'a, ArrayExpression<'a>, C> for ArrayAssignment
                             p.error(diagnostics::invalid_rest_assignment_target(argument.span()));
                         }
                         let target = AssignmentTarget::cover(argument, p);
-                        rest = Some(p.ast.alloc_assignment_target_rest(span, target));
+                        rest = Some(AssignmentTargetRest::boxed(span, target, p));
                         if let Some(span) = p.state.trailing_commas.get(&expr.span.start) {
                             p.error(diagnostics::rest_element_trailing_comma(*span));
                         }
@@ -136,7 +137,7 @@ impl<'a, C: Config> CoverGrammar<'a, ArrayExpression<'a>, C> for ArrayAssignment
             }
         }
 
-        p.ast.array_assignment_target(expr.span, elements, rest)
+        ArrayAssignmentTarget::new(expr.span, elements, rest, p)
     }
 }
 
@@ -164,7 +165,7 @@ impl<'a, C: Config> CoverGrammar<'a, AssignmentExpression<'a>, C>
     for AssignmentTargetWithDefault<'a>
 {
     fn cover(expr: AssignmentExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
-        p.ast.assignment_target_with_default(expr.span, expr.left, expr.right)
+        AssignmentTargetWithDefault::new(expr.span, expr.left, expr.right, p)
     }
 }
 
@@ -173,7 +174,7 @@ impl<'a, C: Config> CoverGrammar<'a, ObjectExpression<'a>, C> for ObjectAssignme
     // inlining this large body into the hot `AssignmentTarget::cover` dispatcher.
     #[inline(never)]
     fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a, C>) -> Self {
-        let mut properties = p.ast.vec();
+        let mut properties = ArenaVec::new_in(p);
         let mut rest = None;
 
         let len = expr.properties.len();
@@ -200,7 +201,7 @@ impl<'a, C: Config> CoverGrammar<'a, ObjectExpression<'a>, C> for ObjectAssignme
                             p.error(diagnostics::rest_element_trailing_comma(*span));
                         }
                         let target = AssignmentTarget::cover(argument, p);
-                        rest = Some(p.ast.alloc_assignment_target_rest(span, target));
+                        rest = Some(AssignmentTargetRest::boxed(span, target, p));
                     } else {
                         return p.fatal_error(diagnostics::spread_last_element(spread.span));
                     }
@@ -208,7 +209,7 @@ impl<'a, C: Config> CoverGrammar<'a, ObjectExpression<'a>, C> for ObjectAssignme
             }
         }
 
-        p.ast.object_assignment_target(expr.span, properties, rest)
+        ObjectAssignmentTarget::new(expr.span, properties, rest, p)
     }
 }
 
@@ -218,24 +219,26 @@ impl<'a, C: Config> CoverGrammar<'a, ObjectProperty<'a>, C> for AssignmentTarget
             let binding = match property.key {
                 PropertyKey::StaticIdentifier(ident) => {
                     let ident = ident.unbox();
-                    p.ast.identifier_reference(ident.span, ident.name)
+                    IdentifierReference::new(ident.span, ident.name, p)
                 }
                 _ => return p.unexpected(),
             };
             // convert `CoverInitializedName`
             let init = p.state.cover_initialized_name.remove(&property.span.start).map(|e| e.right);
-            p.ast.assignment_target_property_assignment_target_property_identifier(
+            AssignmentTargetProperty::new_assignment_target_property_identifier(
                 property.span,
                 binding,
                 init,
+                p,
             )
         } else {
             let binding = AssignmentTargetMaybeDefault::cover(property.value, p);
-            p.ast.assignment_target_property_assignment_target_property_property(
+            AssignmentTargetProperty::new_assignment_target_property_property(
                 property.span,
                 property.key,
                 binding,
                 property.computed,
+                p,
             )
         }
     }

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -54,8 +54,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             return self.fatal_error(error);
         }
         self.ctx = self.ctx.and_in(has_in);
-        let expr =
-            self.ast.alloc_import_expression(self.end_span(span), expression, arguments, phase);
+        let expr = ImportExpression::boxed(self.end_span(span), expression, arguments, phase, self);
         self.module_record_builder.visit_import_expression(&expr);
         Expression::ImportExpression(expr)
     }
@@ -204,11 +203,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 match identifier_after_import {
                     Some(identifier_after_import) => {
                         // Special case: `import type from 'source'` where we already consumed `type` and `from`
-                        Some(self.ast.vec1(
-                            self.ast.import_declaration_specifier_import_default_specifier(
+                        Some(ArenaVec::from_value_in(
+                            ImportDeclarationSpecifier::new_import_default_specifier(
                                 identifier_after_import.span,
                                 identifier_after_import,
+                                self,
                             ),
+                            self,
                         ))
                     }
                     None => unreachable!(),
@@ -232,13 +233,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.asi();
         let span = self.end_span(span);
 
-        let import_decl = self.ast.alloc_import_declaration(
+        let import_decl = ImportDeclaration::boxed(
             span,
             specifiers,
             source,
             phase,
             with_clause,
             import_kind,
+            self,
         );
 
         if should_record_module_record {
@@ -258,16 +260,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // If there is a default specifier, create a Vec with the default specifier in it,
         // otherwise, create an empty Vec.
         let mut specifiers = if default_specifier.is_some() {
-            self.ast.vec_with_capacity(1)
+            ArenaVec::with_capacity_in(1, self)
         } else {
-            self.ast.vec()
+            ArenaVec::new_in(self)
         };
 
         if let Some(default_specifier) = default_specifier {
             let default_span = default_specifier.span;
-            specifiers.push(self.ast.import_declaration_specifier_import_default_specifier(
+            specifiers.push(ImportDeclarationSpecifier::new_import_default_specifier(
                 default_specifier.span,
                 default_specifier,
+                self,
             ));
             if self.eat(Kind::Comma) {
                 match self.cur_kind() {
@@ -322,7 +325,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::As);
         let local = self.parse_binding_identifier();
         let span = self.end_span(span);
-        self.ast.import_declaration_specifier_import_namespace_specifier(span, local)
+        ImportDeclarationSpecifier::new_import_namespace_specifier(span, local, self)
     }
 
     // import { export1 , export2 as alias2 , [...] } from "module-name";
@@ -377,7 +380,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         }
 
-        Some(self.ast.with_clause(self.end_span(span), keyword, with_entries))
+        Some(WithClause::new(self.end_span(span), keyword, with_entries, self))
     }
 
     fn parse_import_attribute(&mut self) -> ImportAttribute<'a> {
@@ -393,7 +396,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             ));
         }
         let value = self.parse_literal_string();
-        self.ast.import_attribute(self.end_span(span), key, value)
+        ImportAttribute::new(self.end_span(span), key, value, self)
     }
 
     pub(crate) fn parse_ts_export_assignment_declaration(
@@ -406,7 +409,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.ctx.has_top_level() {
             self.module_record_builder.set_module_syntax();
         }
-        self.ast.alloc_ts_export_assignment(self.end_span(start_span), expression)
+        TSExportAssignment::boxed(self.end_span(start_span), expression, self)
     }
 
     pub(crate) fn parse_ts_export_namespace(
@@ -420,7 +423,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.ctx.has_top_level() {
             self.module_record_builder.set_module_syntax();
         }
-        self.ast.alloc_ts_namespace_export_declaration(self.end_span(start_span), id)
+        TSNamespaceExportDeclaration::boxed(self.end_span(start_span), id, self)
     }
 
     /// [Exports](https://tc39.es/ecma262/#sec-exports)
@@ -445,13 +448,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 // being created. It's an export not an import.
                 let stmt = self.parse_import_declaration(import_span, false);
                 if stmt.is_declaration() {
-                    let export_named_decl = self.ast.alloc_export_named_declaration(
+                    let export_named_decl = ExportNamedDeclaration::boxed(
                         self.end_span(span),
                         Some(stmt.into_declaration()),
-                        self.ast.vec(),
+                        ArenaVec::new_in(self),
                         None,
                         ImportOrExportKind::Value,
                         NONE,
+                        self,
                     );
                     if self.ctx.has_top_level() {
                         self.module_record_builder
@@ -474,13 +478,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let modifiers = self.parse_modifiers(false, false);
                 let class_decl = self.parse_class_declaration(class_span, &modifiers, decorators);
                 let decl = Declaration::ClassDeclaration(class_decl);
-                let export_named_decl = self.ast.alloc_export_named_declaration(
+                let export_named_decl = ExportNamedDeclaration::boxed(
                     self.end_span(span),
                     Some(decl),
-                    self.ast.vec(),
+                    ArenaVec::new_in(self),
                     None,
                     ImportOrExportKind::Value,
                     NONE,
+                    self,
                 );
                 if self.ctx.has_top_level() {
                     self.module_record_builder.visit_export_named_declaration(&export_named_decl);
@@ -597,8 +602,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         }
 
                         // `local` becomes a reference for `export { local }`.
-                        specifier.local = ModuleExportName::IdentifierReference(
-                            self.ast.identifier_reference(ident.span, ident.name),
+                        specifier.local = ModuleExportName::new_identifier_reference(
+                            ident.span, ident.name, self,
                         );
                     }
                     // No prior code path should lead to parsing `ModuleExportName` as `IdentifierReference`.
@@ -609,13 +614,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         self.asi();
         let span = self.end_span(span);
-        let export_named_decl = self.ast.alloc_export_named_declaration(
+        let export_named_decl = ExportNamedDeclaration::boxed(
             span,
             None,
             specifiers,
             source,
             export_kind,
             with_clause,
+            self,
         );
         if self.ctx.has_top_level() {
             self.module_record_builder.visit_export_named_declaration(&export_named_decl);
@@ -642,13 +648,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             ImportOrExportKind::Value
         };
         self.ctx = reserved_ctx;
-        let export_named_decl = self.ast.alloc_export_named_declaration(
+        let export_named_decl = ExportNamedDeclaration::boxed(
             self.end_span(span),
             Some(declaration),
-            self.ast.vec(),
+            ArenaVec::new_in(self),
             None,
             export_kind,
             NONE,
+            self,
         );
         if self.ctx.has_top_level() {
             self.module_record_builder.visit_export_named_declaration(&export_named_decl);
@@ -668,7 +675,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.advance(Kind::Default);
         let declaration = self.parse_export_default_declaration_kind(decorators);
         let span = self.end_span(span);
-        let export_default_decl = self.ast.alloc_export_default_declaration(span, declaration);
+        let export_default_decl = ExportDefaultDeclaration::boxed(span, declaration, self);
         if self.ctx.has_top_level() {
             self.module_record_builder
                 .visit_export_default_declaration(&export_default_decl, default_keyword_span);
@@ -807,7 +814,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.asi();
         let span = self.end_span(span);
         let export_all_decl =
-            self.ast.alloc_export_all_declaration(span, exported, source, with_clause, export_kind);
+            ExportAllDeclaration::boxed(span, exported, source, with_clause, export_kind, self);
         if self.ctx.has_top_level() {
             self.module_record_builder.visit_export_all_declaration(&export_all_decl);
         }
@@ -823,11 +830,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> ImportDeclarationSpecifier<'a> {
         match self.parse_import_or_export_specifier(ImportOrExport::Import, parent_import_kind) {
             ImportOrExportSpecifier::Import(specifier) => {
-                self.ast.import_declaration_specifier_import_specifier(
+                ImportDeclarationSpecifier::new_import_specifier(
                     specifier.span,
                     specifier.imported,
                     specifier.local,
                     specifier.import_kind,
+                    self,
                 )
             }
             ImportOrExportSpecifier::Export(_) => unreachable!(),
@@ -867,22 +875,26 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         // { type as as something }
                         // { type as as "something" }
                         kind = ImportOrExportKind::Type;
-                        property_name = Some(
-                            self.ast
-                                .module_export_name_identifier_name(second_as.span, second_as.name),
-                        );
+                        property_name = Some(ModuleExportName::new_identifier_name(
+                            second_as.span,
+                            second_as.name,
+                            self,
+                        ));
                         check_identifier_token = self.cur_token();
                         name = self.parse_module_export_name();
                         can_parse_as_keyword = false;
                     } else {
                         // { type as as }
-                        property_name = Some(self.ast.module_export_name_identifier_name(
+                        property_name = Some(ModuleExportName::new_identifier_name(
                             type_or_name_token.span(),
                             self.token_source(&type_or_name_token),
+                            self,
                         ));
-                        name = self
-                            .ast
-                            .module_export_name_identifier_name(second_as.span, second_as.name);
+                        name = ModuleExportName::new_identifier_name(
+                            second_as.span,
+                            second_as.name,
+                            self,
+                        );
                         can_parse_as_keyword = false;
                     }
                 } else if self.can_parse_module_export_name() {
@@ -896,7 +908,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     // { type as }
                     kind = ImportOrExportKind::Type;
                     name =
-                        self.ast.module_export_name_identifier_name(first_as.span, first_as.name);
+                        ModuleExportName::new_identifier_name(first_as.span, first_as.name, self);
                 }
             } else if self.can_parse_module_export_name() {
                 // { type something ...? }
@@ -935,11 +947,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     ));
                 }
 
-                ImportOrExportSpecifier::Import(self.ast.import_specifier(
+                ImportOrExportSpecifier::Import(ImportSpecifier::new(
                     self.end_span(specifier_span),
                     property_name.unwrap_or_else(|| name.clone()),
-                    self.ast.binding_identifier(name.span(), name.name()),
+                    BindingIdentifier::new(name.span(), name.name(), self),
                     kind,
+                    self,
                 ))
             }
             ImportOrExport::Export => {
@@ -954,11 +967,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     Some(property_name) => property_name,
                     None => name.clone(),
                 };
-                ImportOrExportSpecifier::Export(self.ast.export_specifier(
+                ImportOrExportSpecifier::Export(ExportSpecifier::new(
                     self.end_span(specifier_span),
                     exported,
                     name,
                     kind,
+                    self,
                 ))
             }
         }

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -32,7 +32,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.state.trailing_commas.insert(span, self.end_span(comma_span));
         }
         self.expect(Kind::RCurly);
-        self.ast.alloc_object_expression(self.end_span(span), object_expression_properties)
+        ObjectExpression::boxed(self.end_span(span), object_expression_properties, self)
     }
 
     fn parse_object_expression_property(&mut self) -> ObjectPropertyKind<'a> {
@@ -76,7 +76,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 asterisk_token,
                 FunctionKind::ObjectMethod,
             );
-            return self.ast.alloc_object_property(
+            return ObjectProperty::boxed(
                 self.end_span(span),
                 PropertyKind::Init,
                 key,
@@ -84,6 +84,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 /* method */ true,
                 /* shorthand */ false,
                 computed,
+                self,
             );
         }
 
@@ -101,22 +102,23 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 // CoverInitializedName ({ foo = bar })
                 if self.eat(Kind::Eq) {
                     let right = self.parse_assignment_expression_or_higher();
-                    let left = AssignmentTarget::AssignmentTargetIdentifier(
-                        self.ast
-                            .alloc_identifier_reference(identifier_name.span, identifier_name.name),
+                    let left = AssignmentTarget::new_assignment_target_identifier(
+                        identifier_name.span,
+                        identifier_name.name,
+                        self,
                     );
-                    let expr = self.ast.assignment_expression(
+                    let expr = AssignmentExpression::new(
                         self.end_span(span),
                         AssignmentOperator::Assign,
                         left,
                         right,
+                        self,
                     );
                     self.state.cover_initialized_name.insert(span, expr);
                 }
-                let value = Expression::Identifier(
-                    self.ast.alloc_identifier_reference(identifier_name.span, identifier_name.name),
-                );
-                self.ast.alloc_object_property(
+                let value =
+                    Expression::new_identifier(identifier_name.span, identifier_name.name, self);
+                ObjectProperty::boxed(
                     self.end_span(span),
                     PropertyKind::Init,
                     PropertyKey::StaticIdentifier(identifier_name),
@@ -124,6 +126,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     /* method */ false,
                     /* shorthand */ true,
                     computed,
+                    self,
                 )
             } else {
                 self.unexpected()
@@ -139,7 +142,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         self.bump_any(); // advance `...`
         let argument = self.parse_assignment_expression_or_higher();
-        self.ast.alloc_spread_element(self.end_span(span), argument)
+        SpreadElement::boxed(self.end_span(span), argument, self)
     }
 
     /// `PropertyDefinition`[Yield, Await] :
@@ -152,7 +155,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> ArenaBox<'a, ObjectProperty<'a>> {
         self.expect(Kind::Colon);
         let value = self.parse_assignment_expression_or_higher();
-        self.ast.alloc_object_property(
+        ObjectProperty::boxed(
             self.end_span(span),
             PropertyKind::Init,
             key,
@@ -160,6 +163,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             /* method */ false,
             /* shorthand */ false,
             /* computed */ computed,
+            self,
         )
     }
 
@@ -224,7 +228,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
-        self.ast.alloc_object_property(
+        ObjectProperty::boxed(
             self.end_span(span),
             kind,
             key,
@@ -232,6 +236,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             /* method */ false,
             /* shorthand */ false,
             /* computed */ computed,
+            self,
         )
     }
 }

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -20,7 +20,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.bump_any();
             let span = self.end_span(span);
             let src = &self.source_text[span.start as usize + 2..span.end as usize];
-            Some(self.ast.hashbang(span, Str::from(src)))
+            Some(Hashbang::new(span, Str::from(src), self))
         } else {
             None
         }
@@ -34,8 +34,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_ts_namespace_body: bool,
     ) -> (ArenaVec<'a, Directive<'a>>, ArenaVec<'a, Statement<'a>>) {
-        let mut directives = self.ast.vec();
-        let mut statements = self.ast.vec();
+        let mut directives = ArenaVec::new_in(self);
+        let mut statements = ArenaVec::new_in(self);
 
         let is_top_level = self.ctx.has_top_level();
         let stmt_ctx = StatementContext::StatementList;
@@ -92,7 +92,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         let src = &self.source_text
                             [string.span.start as usize + 1..string.span.end as usize - 1];
                         let directive =
-                            self.ast.directive(expr.span, (*string).clone(), Str::from(src));
+                            Directive::new(expr.span, (*string).clone(), Str::from(src), self);
                         directives.push(directive);
                         continue;
                     }
@@ -147,9 +147,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.start_span(),
                 stmt_ctx,
                 &Modifiers::empty(),
-                self.ast.vec(),
+                ArenaVec::new_in(self),
             ),
-            Kind::Export => self.parse_export_declaration(self.start_span(), self.ast.vec()),
+            Kind::Export => {
+                self.parse_export_declaration(self.start_span(), ArenaVec::new_in(self))
+            }
             // [+Return] ReturnStatement[?Yield, ?Await]
             Kind::Return => self.parse_return_statement(),
             Kind::Var => {
@@ -247,9 +249,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             // Section 14.13 Labelled Statement
             // Avoids lookahead for a labeled statement, which is on a hot path
             if self.eat(Kind::Colon) {
-                let label = self.ast.label_identifier(ident.span, ident.name);
+                let label = LabelIdentifier::new(ident.span, ident.name, self);
                 let body = self.parse_statement_list_item(StatementContext::Label);
-                return self.ast.statement_labeled(self.end_span(span), label, body);
+                return Statement::new_labeled_statement(self.end_span(span), label, body, self);
             }
         }
         self.parse_expression_statement(span, expr)
@@ -261,7 +263,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let body = self.parse_normal_list(Kind::LCurly, Kind::RCurly, |p| {
             p.parse_statement_list_item(StatementContext::StatementList)
         });
-        self.ast.alloc_block_statement(self.end_span(span), body)
+        BlockStatement::boxed(self.end_span(span), body, self)
     }
 
     pub(crate) fn parse_block_statement(&mut self) -> Statement<'a> {
@@ -294,7 +296,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_empty_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `;`
-        self.ast.statement_empty(self.end_span(span))
+        Statement::new_empty_statement(self.end_span(span), self)
     }
 
     /// Section 14.5 Expression Statement
@@ -304,7 +306,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         expression: Expression<'a>,
     ) -> Statement<'a> {
         self.asi();
-        self.ast.statement_expression(self.end_span(span), expression)
+        Statement::new_expression_statement(self.end_span(span), expression, self)
     }
 
     /// Section 14.6 If Statement
@@ -315,7 +317,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let consequent = self.parse_statement_list_item(StatementContext::If);
         let alternate =
             self.eat(Kind::Else).then(|| self.parse_statement_list_item(StatementContext::If));
-        self.ast.statement_if(self.end_span(span), test, consequent, alternate)
+        Statement::new_if_statement(self.end_span(span), test, consequent, alternate, self)
     }
 
     /// Section 14.7.2 Do-While Statement
@@ -326,7 +328,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::While);
         let test = self.parse_paren_expression();
         self.bump(Kind::Semicolon);
-        self.ast.statement_do_while(self.end_span(span), body, test)
+        Statement::new_do_while_statement(self.end_span(span), body, test, self)
     }
 
     /// Section 14.7.3 While Statement
@@ -335,7 +337,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.bump_any(); // bump `while`
         let test = self.parse_paren_expression();
         let body = self.parse_statement_list_item(StatementContext::While);
-        self.ast.statement_while(self.end_span(span), test, body)
+        Statement::new_while_statement(self.end_span(span), test, body, self)
     }
 
     /// Section 14.7.4 For Statement
@@ -596,7 +598,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::for_await(self.end_span(span)));
         }
         let body = self.parse_statement_list_item(StatementContext::For);
-        self.ast.statement_for(self.end_span(span), init, test, update, body)
+        Statement::new_for_statement(self.end_span(span), init, test, update, body, self)
     }
 
     fn parse_for_in_loop(
@@ -616,7 +618,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let body = self.parse_statement_list_item(StatementContext::For);
         let span = self.end_span(span);
-        self.ast.statement_for_in(span, left, right, body)
+        Statement::new_for_in_statement(span, left, right, body, self)
     }
 
     fn parse_for_of_loop(
@@ -632,7 +634,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let body = self.parse_statement_list_item(StatementContext::For);
         let span = self.end_span(span);
-        self.ast.statement_for_of(span, r#await, left, right, body)
+        Statement::new_for_of_statement(span, r#await, left, right, body, self)
     }
 
     /// Section 14.8 Continue Statement
@@ -642,7 +644,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let label =
             if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()) };
         self.asi();
-        self.ast.statement_continue(self.end_span(span), label)
+        Statement::new_continue_statement(self.end_span(span), label, self)
     }
 
     /// Section 14.9 Break Statement
@@ -652,7 +654,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let label =
             if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()) };
         self.asi();
-        self.ast.statement_break(self.end_span(span), label)
+        Statement::new_break_statement(self.end_span(span), label, self)
     }
 
     /// Section 14.10 Return Statement
@@ -672,7 +674,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if !self.ctx.has_return() {
             self.error(diagnostics::return_statement_only_in_function_body(Span::sized(span, 6)));
         }
-        self.ast.statement_return(self.end_span(span), argument)
+        Statement::new_return_statement(self.end_span(span), argument, self)
     }
 
     /// Section 14.11 With Statement
@@ -682,7 +684,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let object = self.parse_paren_expression();
         let body = self.parse_statement_list_item(StatementContext::With);
         let span = self.end_span(span);
-        self.ast.statement_with(span, object, body)
+        Statement::new_with_statement(span, object, body, self)
     }
 
     /// Section 14.12 Switch Statement
@@ -708,7 +710,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             case
         });
-        self.ast.statement_switch(self.end_span(span), discriminant, cases)
+        Statement::new_switch_statement(self.end_span(span), discriminant, cases, self)
     }
 
     pub(crate) fn parse_switch_case(&mut self) -> SwitchCase<'a> {
@@ -729,7 +731,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
         };
         self.expect(Kind::Colon);
-        let mut consequent = self.ast.vec();
+        let mut consequent = ArenaVec::new_in(self);
         loop {
             let kind = self.cur_kind();
             if matches!(
@@ -751,7 +753,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             consequent.push(stmt);
         }
-        self.ast.switch_case(self.end_span(span), test, consequent)
+        SwitchCase::new(self.end_span(span), test, consequent, self)
     }
 
     /// Section 14.14 Throw Statement
@@ -767,7 +769,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         let argument = self.parse_expr();
         self.asi();
-        self.ast.statement_throw(self.end_span(span), argument)
+        Statement::new_throw_statement(self.end_span(span), argument, self)
     }
 
     /// Section 14.15 Try Statement
@@ -786,7 +788,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::expect_catch_finally(range));
         }
 
-        self.ast.statement_try(self.end_span(span), block, handler, finalizer)
+        Statement::new_try_statement(self.end_span(span), block, handler, finalizer, self)
     }
 
     fn parse_catch_clause(&mut self) -> ArenaBox<'a, CatchClause<'a>> {
@@ -801,16 +803,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
         let body = self.parse_block();
         let param = pattern.map(|(pattern, type_annotation)| {
-            self.ast.catch_parameter(
+            CatchParameter::new(
                 Span::new(
                     pattern.span().start,
                     type_annotation.as_ref().map_or(pattern.span().end, |ta| ta.span.end),
                 ),
                 pattern,
                 type_annotation,
+                self,
             )
         });
-        self.ast.alloc_catch_clause(self.end_span(span), param, body)
+        CatchClause::boxed(self.end_span(span), param, body, self)
     }
 
     /// Section 14.16 Debugger Statement
@@ -818,7 +821,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         self.bump_any();
         self.asi();
-        self.ast.statement_debugger(self.end_span(span))
+        Statement::new_debugger_statement(self.end_span(span), self)
     }
 
     /// Parse const declaration or `const enum`.

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -52,7 +52,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         in_jsx_child: bool,
     ) -> ArenaBox<'a, JSXFragment<'a>> {
         self.expect_jsx_child(Kind::RAngle);
-        let opening_fragment = self.ast.jsx_opening_fragment(self.end_span(span));
+        let opening_fragment = JSXOpeningFragment::new(self.end_span(span), self);
         let (children, closing) = self.parse_jsx_children_and_closing(in_jsx_child);
         let closing_fragment = match closing {
             JSXClosing::Fragment(f) => f,
@@ -62,15 +62,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     opening_fragment.span,
                     e.name.span(),
                 ));
-                self.ast.jsx_closing_fragment(e.span)
+                JSXClosingFragment::new(e.span, self)
             }
         };
-        self.ast.alloc_jsx_fragment(
-            self.end_span(span),
-            opening_fragment,
-            children,
-            closing_fragment,
-        )
+        JSXFragment::boxed(self.end_span(span), opening_fragment, children, closing_fragment, self)
     }
 
     /// `JSXElement` :
@@ -82,7 +77,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_jsx_element(&mut self, span: u32, in_jsx_child: bool) -> ArenaBox<'a, JSXElement<'a>> {
         let (opening_element, self_closing) = self.parse_jsx_opening_element(span, in_jsx_child);
         let (children, closing_element) = if self_closing {
-            (self.ast.vec(), None)
+            (ArenaVec::new_in(self), None)
         } else {
             let (children, closing) = self.parse_jsx_children_and_closing(in_jsx_child);
             let closing_element = match closing {
@@ -107,7 +102,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             };
             (children, Some(closing_element))
         };
-        self.ast.alloc_jsx_element(self.end_span(span), opening_element, children, closing_element)
+        JSXElement::boxed(self.end_span(span), opening_element, children, closing_element, self)
     }
 
     /// `JSXOpeningElement` :
@@ -130,12 +125,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         } else {
             self.expect(Kind::RAngle);
         }
-        let elem = self.ast.alloc_jsx_opening_element(
-            self.end_span(span),
-            name,
-            type_arguments,
-            attributes,
-        );
+        let elem =
+            JSXOpeningElement::boxed(self.end_span(span), name, type_arguments, attributes, self);
         (elem, self_closing)
     }
 
@@ -150,10 +141,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // <namespace:property />
         if self.eat(Kind::Colon) {
             let (property, _) = self.parse_jsx_identifier();
-            return self.ast.jsx_element_name_namespaced_name(
+            return JSXElementName::new_namespaced_name(
                 self.end_span(span),
                 identifier,
                 property,
+                self,
             );
         }
 
@@ -186,10 +178,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             };
 
         if is_reference {
-            let identifier = self.ast.alloc_identifier_reference(identifier.span, identifier.name);
-            JSXElementName::IdentifierReference(identifier)
+            JSXElementName::new_identifier_reference(identifier.span, identifier.name, self)
         } else if name == "this" {
-            JSXElementName::ThisExpression(self.ast.alloc_this_expression(identifier.span))
+            JSXElementName::new_this_expression(identifier.span, self)
         } else {
             JSXElementName::Identifier(self.alloc(identifier))
         }
@@ -204,9 +195,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         object: &JSXIdentifier<'a>,
     ) -> ArenaBox<'a, JSXMemberExpression<'a>> {
         let mut object = if object.name == "this" {
-            self.ast.jsx_member_expression_object_this_expression(object.span)
+            JSXMemberExpressionObject::new_this_expression(object.span, self)
         } else {
-            self.ast.jsx_member_expression_object_identifier_reference(object.span, object.name)
+            JSXMemberExpressionObject::new_identifier_reference(object.span, object.name, self)
         };
 
         let mut span = Span::new(span, 0);
@@ -215,8 +206,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         while self.eat(Kind::Dot) && self.fatal_error.is_none() {
             // <foo.bar.baz>
             if let Some(prop) = property {
-                object =
-                    self.ast.jsx_member_expression_object_member_expression(span, object, prop);
+                object = JSXMemberExpressionObject::new_member_expression(span, object, prop, self);
             }
 
             // <foo.bar>
@@ -231,11 +221,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         if let Some(property) = property {
-            return self.ast.alloc_jsx_member_expression(
-                self.end_span(span.start),
-                object,
-                property,
-            );
+            return JSXMemberExpression::boxed(self.end_span(span.start), object, property, self);
         }
 
         self.unexpected()
@@ -249,11 +235,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         in_jsx_child: bool,
     ) -> (ArenaVec<'a, JSXChild<'a>>, JSXClosing<'a>) {
-        let mut children = self.ast.vec();
+        let mut children = ArenaVec::new_in(self);
         loop {
             if self.fatal_error.is_some() {
                 // Return dummy closing fragment on fatal error
-                let closing = self.ast.jsx_closing_fragment(self.cur_token().span());
+                let closing = JSXClosingFragment::new(self.cur_token().span(), self);
                 return (children, JSXClosing::Fragment(closing));
             }
 
@@ -326,7 +312,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             } else {
                 self.expect(Kind::RAngle);
             }
-            JSXClosing::Fragment(self.ast.jsx_closing_fragment(self.end_span(open_angle_span)))
+            JSXClosing::Fragment(JSXClosingFragment::new(self.end_span(open_angle_span), self))
         } else {
             // Closing element: </name>
             let name = self.parse_jsx_element_name();
@@ -335,9 +321,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             } else {
                 self.expect(Kind::RAngle);
             }
-            JSXClosing::Element(
-                self.ast.alloc_jsx_closing_element(self.end_span(open_angle_span), name),
-            )
+            JSXClosing::Element(JSXClosingElement::boxed(
+                self.end_span(open_angle_span),
+                name,
+                self,
+            ))
         }
     }
 
@@ -363,7 +351,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
             // Handle comment between curly braces (ex. `{/* comment */}`)
             //                                            ^^^^^^^^^^^^^ span
-            self.ast.jsx_expression_empty_expression(Span::new(span.start + 1, span.end - 1))
+            JSXExpression::new_empty_expression(Span::new(span.start + 1, span.end - 1), self)
         } else {
             let expr = JSXExpression::from(self.parse_expr());
             // JSX expressions may not use the comma operator.
@@ -380,7 +368,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             expr
         };
 
-        self.ast.alloc_jsx_expression_container(self.end_span(span_start), expr)
+        JSXExpressionContainer::boxed(self.end_span(span_start), expr, self)
     }
 
     /// `JSXChildExpression` :
@@ -388,14 +376,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_jsx_spread_child(&mut self, span_start: u32) -> ArenaBox<'a, JSXSpreadChild<'a>> {
         let expr = self.parse_expr();
         self.expect_jsx_child(Kind::RCurly);
-        self.ast.alloc_jsx_spread_child(self.end_span(span_start), expr)
+        JSXSpreadChild::boxed(self.end_span(span_start), expr, self)
     }
 
     /// `JSXAttributes` :
     ///   `JSXSpreadAttribute` `JSXAttributes_opt`
     ///   `JSXAttribute` `JSXAttributes_opt`
     fn parse_jsx_attributes(&mut self) -> ArenaVec<'a, JSXAttributeItem<'a>> {
-        let mut attributes = self.ast.vec();
+        let mut attributes = ArenaVec::new_in(self);
         loop {
             let kind = self.cur_kind();
             if matches!(kind, Kind::LAngle | Kind::RAngle | Kind::Slash)
@@ -425,7 +413,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         } else {
             None
         };
-        self.ast.alloc_jsx_attribute(self.end_span(span), name, value)
+        JSXAttribute::boxed(self.end_span(span), name, value, self)
     }
 
     /// `JSXSpreadAttribute` :
@@ -436,7 +424,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.expect(Kind::Dot3);
         let argument = self.parse_expr();
         self.expect(Kind::RCurly);
-        self.ast.alloc_jsx_spread_attribute(self.end_span(span), argument)
+        JSXSpreadAttribute::boxed(self.end_span(span), argument, self)
     }
 
     /// `JSXAttributeName` :
@@ -448,10 +436,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         if self.eat(Kind::Colon) {
             let (property, _) = self.parse_jsx_identifier();
-            return self.ast.jsx_attribute_name_namespaced_name(
+            return JSXAttributeName::new_namespaced_name(
                 self.end_span(span),
                 identifier,
                 property,
+                self,
             );
         }
 
@@ -501,7 +490,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.bump_any();
         let span = self.end_span(span);
         let name = span.source_text(self.source_text);
-        let identifier = self.ast.jsx_identifier(span, name);
+        let identifier = JSXIdentifier::new(span, name, self);
         (identifier, contains_dash)
     }
 
@@ -510,7 +499,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let raw = Str::from(self.cur_src());
         let value = Str::from(self.cur_string());
         self.bump_any();
-        self.ast.alloc_jsx_text(span, value, Some(raw))
+        JSXText::boxed(span, value, Some(raw), self)
     }
 
     fn jsx_element_name_eq(lhs: &JSXElementName<'a>, rhs: &JSXElementName<'a>) -> bool {

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -89,8 +89,8 @@ pub mod lexer;
 
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy, GetAllocator};
 use oxc_ast::{
-    AstBuilder,
     ast::{Expression, Program, Statement},
+    builder::{AstBuilder, GetAstBuilder},
 };
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::{SourceType, Span};
@@ -785,8 +785,8 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
 
         let span = Span::new(0, self.source_text.len() as u32);
         // Populated at the end of `parse` after `flow_error` has read from `trivia_builder.comments`.
-        let comments = self.ast.vec();
-        self.ast.program(
+        let comments = ArenaVec::new_in(self);
+        Program::new(
             span,
             self.source_type,
             self.source_text,
@@ -794,6 +794,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
             hashbang,
             directives,
             statements,
+            self,
         )
     }
 
@@ -882,7 +883,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
 
     #[inline]
     fn alloc<T>(&self, value: T) -> ArenaBox<'a, T> {
-        self.ast.alloc(value)
+        ArenaBox::new_in(value, self)
     }
 }
 
@@ -890,6 +891,15 @@ impl<'a, C: ParserConfig> GetAllocator<'a> for ParserImpl<'a, C> {
     #[inline]
     fn allocator(&self) -> &'a Allocator {
         self.ast.allocator()
+    }
+}
+
+impl<'a, C: ParserConfig> GetAstBuilder<'a> for ParserImpl<'a, C> {
+    type Builder = AstBuilder<'a>;
+
+    #[inline]
+    fn builder(&self) -> &AstBuilder<'a> {
+        &self.ast
     }
 }
 

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -34,12 +34,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
-        self.ast.declaration_ts_enum(
+        Declaration::new_ts_enum_declaration(
             span,
             id,
             body,
             modifiers.contains_const(),
             modifiers.contains_declare(),
+            self,
         )
     }
 
@@ -54,7 +55,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Self::parse_ts_enum_member,
         );
         self.expect(Kind::RCurly);
-        self.ast.ts_enum_body(self.end_span(span), members)
+        TSEnumBody::new(self.end_span(span), members, self)
     }
 
     pub(crate) fn parse_ts_enum_member(&mut self) -> TSEnumMember<'a> {
@@ -65,7 +66,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         } else {
             None
         };
-        self.ast.ts_enum_member(self.end_span(span), id, initializer)
+        TSEnumMember::new(self.end_span(span), id, initializer, self)
     }
 
     fn parse_ts_enum_member_name(&mut self) -> TSEnumMemberName<'a> {
@@ -121,7 +122,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         self.bump_any(); // bump ':'
         let type_annotation = self.parse_ts_type();
-        Some(self.ast.alloc_ts_type_annotation(self.end_span(span), type_annotation))
+        Some(TSTypeAnnotation::boxed(self.end_span(span), type_annotation, self))
     }
 
     pub(crate) fn parse_ts_type_alias_declaration(
@@ -150,21 +151,23 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.bump_any();
             if self.at(Kind::Dot) {
                 // `type something = intrinsic. ...`
-                let left_name = self.ast.ts_type_name_identifier_reference(
+                let left_name = TSTypeName::new_identifier_reference(
                     intrinsic_token.span(),
                     self.token_source(&intrinsic_token),
+                    self,
                 );
                 let type_name =
                     self.parse_ts_qualified_type_name(intrinsic_token.start(), left_name);
                 let type_parameters = self.parse_type_arguments_of_type_reference();
-                self.ast.ts_type_type_reference(
+                TSType::new_ts_type_reference(
                     self.end_span(intrinsic_token.start()),
                     type_name,
                     type_parameters,
+                    self,
                 )
             } else {
                 // `type something = intrinsic`
-                self.ast.ts_type_intrinsic_keyword(intrinsic_token.span())
+                TSType::new_ts_intrinsic_keyword(intrinsic_token.span(), self)
             }
         } else {
             // `type something = ...`
@@ -181,7 +184,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        self.ast.declaration_ts_type_alias(span, id, params, ty, modifiers.contains_declare())
+        Declaration::new_ts_type_alias_declaration(
+            span,
+            id,
+            params,
+            ty,
+            modifiers.contains_declare(),
+            self,
+        )
     }
 
     /* ---------------------  Interface  ------------------------ */
@@ -228,7 +238,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         let (extends, implements) = self.parse_heritage_clause();
         let body = self.parse_ts_interface_body();
-        let extends = extends.unwrap_or_else(|| self.ast.vec());
+        let extends = extends.unwrap_or_else(|| ArenaVec::new_in(self));
         self.verify_modifiers(
             modifiers,
             ModifierKinds::new([ModifierKind::Declare]),
@@ -246,13 +256,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.error(diagnostics::interface_extend(extend.span));
             }
         }
-        self.ast.declaration_ts_interface(
+        Declaration::new_ts_interface_declaration(
             self.end_span(span),
             id,
             type_parameters,
             extends,
             body,
             modifiers.contains_declare(),
+            self,
         )
     }
 
@@ -260,7 +271,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         let body_list =
             self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature);
-        self.ast.alloc_ts_interface_body(self.end_span(span), body_list)
+        TSInterfaceBody::boxed(self.end_span(span), body_list, self)
     }
 
     pub(crate) fn parse_ts_type_signature(&mut self) -> TSSignature<'a> {
@@ -380,12 +391,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
-        self.ast.alloc_ts_module_declaration(
+        TSModuleDeclaration::boxed(
             self.end_span(span),
             id,
             body,
             TSModuleDeclarationKind::Module,
             modifiers.contains_declare(),
+            self,
         )
     }
 
@@ -441,7 +453,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             p.parse_directives_and_statements(in_ts_namespace_body)
         });
         self.expect(Kind::RCurly);
-        self.ast.alloc_ts_module_block(self.end_span(span), directives, statements)
+        TSModuleBlock::boxed(self.end_span(span), directives, statements, self)
     }
 
     fn parse_module_or_namespace_declaration(
@@ -467,12 +479,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             true,
             diagnostics::modifier_cannot_be_used_here,
         );
-        self.ast.alloc_ts_module_declaration(
+        TSModuleDeclaration::boxed(
             self.end_span(span),
             id,
             Some(body),
             kind,
             modifiers.contains_declare(),
+            self,
         )
     }
 
@@ -494,11 +507,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        self.ast.alloc_ts_global_declaration(
+        TSGlobalDeclaration::boxed(
             self.end_span(span),
             keyword_span,
             body,
             modifiers.contains_declare(),
+            self,
         )
     }
 
@@ -521,7 +535,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             .ctx
             .union_ambient_if(modifiers.contains_declare())
             .and_await(modifiers.contains_async());
-        let decl = self.parse_declaration(start_span, &modifiers, self.ast.vec());
+        let decl = self.parse_declaration(start_span, &modifiers, ArenaVec::new_in(self));
         self.ctx = reserved_ctx;
         // A TypeScript declaration (`interface`, `type`, `enum`, `namespace`, …) is a
         // `Declaration`, not a `Statement`, so it cannot stand alone as the body of
@@ -669,7 +683,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::jsx_type_assertion_in_mts_cts(span));
         }
 
-        self.ast.expression_ts_type_assertion(span, type_annotation, expression)
+        Expression::new_ts_type_assertion(span, type_annotation, expression, self)
     }
 
     pub(crate) fn parse_ts_import_equals_declaration(
@@ -685,9 +699,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.expect(Kind::LParen);
             let expression = self.parse_literal_string();
             self.expect(Kind::RParen);
-            self.ast.ts_module_reference_external_module_reference(
+            TSModuleReference::new_external_module_reference(
                 self.end_span(reference_span),
                 expression,
+                self,
             )
         } else {
             self.parse_ts_module_reference(reference_span)
@@ -705,7 +720,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.error(diagnostics::import_alias_cannot_use_import_type(span));
         }
 
-        self.ast.declaration_ts_import_equals(span, identifier, module_reference, import_kind)
+        Declaration::new_ts_import_equals_declaration(
+            span,
+            identifier,
+            module_reference,
+            import_kind,
+            self,
+        )
     }
 
     /// Parse `TSModuleReference` for `import x = foo` or `import x = foo.bar`.
@@ -720,12 +741,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             // Recover by creating an identifier
             let this = this_span.source_text(self.source_text);
             debug_assert_eq!(this, "this");
-            let ident = self.ast.alloc_identifier_reference(this_span, this);
+            let ident = IdentifierReference::boxed(this_span, this, self);
             return TSModuleReference::IdentifierReference(ident);
         }
 
         let ident = self.parse_identifier_name();
-        let left = self.ast.ts_type_name_identifier_reference(ident.span, ident.name);
+        let left = TSTypeName::new_identifier_reference(ident.span, ident.name, self);
 
         // Parse qualified name: foo.bar.baz
         let type_name =
@@ -749,7 +770,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let this_span = self.end_span(span);
 
         let type_annotation = self.parse_ts_type_annotation();
-        self.ast.ts_this_parameter(self.end_span(span), this_span, type_annotation)
+        TSThisParameter::new(self.end_span(span), this_span, type_annotation, self)
     }
 
     pub(crate) fn at_start_of_ts_declaration(&mut self) -> bool {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -31,12 +31,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.expect_conditional_alternative(question_span);
             let false_type =
                 self.context_remove(Context::DisallowConditionalTypes, Self::parse_ts_type);
-            return self.ast.ts_type_conditional_type(
+            return TSType::new_ts_conditional_type(
                 self.end_span(span),
                 ty,
                 extends_type,
                 true_type,
                 false_type,
+                self,
             );
         }
         ty
@@ -53,7 +54,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let return_type = {
             let return_type_span = self.start_span();
             let return_type = self.parse_return_type();
-            self.ast.ts_type_annotation(self.end_span(return_type_span), return_type)
+            TSTypeAnnotation::new(self.end_span(return_type_span), return_type, self)
         };
 
         let span = self.end_span(span);
@@ -62,15 +63,23 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 // type Foo = new (this: number) => any;
                 self.error(diagnostics::ts_constructor_this_parameter(this_param.span));
             }
-            self.ast.ts_type_constructor_type(
+            TSType::new_ts_constructor_type(
                 span,
                 r#abstract,
                 type_parameters,
                 params,
                 return_type,
+                self,
             )
         } else {
-            self.ast.ts_type_function_type(span, type_parameters, this_param, params, return_type)
+            TSType::new_ts_function_type(
+                span,
+                type_parameters,
+                this_param,
+                params,
+                return_type,
+                self,
+            )
         }
     }
 
@@ -190,13 +199,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if params.is_empty() {
             self.error(diagnostics::ts_empty_type_parameter_list(span));
         }
-        (Some(self.ast.alloc_ts_type_parameter_declaration(span, params)), trailing_comma.is_some())
+        (Some(TSTypeParameterDeclaration::boxed(span, params, self)), trailing_comma.is_some())
     }
 
     pub(crate) fn parse_ts_implements_clause(&mut self) -> ArenaVec<'a, TSClassImplements<'a>> {
         self.expect(Kind::Implements);
         let first = self.parse_ts_implement_name();
-        let mut implements = self.ast.vec1(first);
+        let mut implements = ArenaVec::from_value_in(first, self);
         while self.eat(Kind::Comma) {
             implements.push(self.parse_ts_implement_name());
         }
@@ -232,7 +241,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let constraint = self.parse_ts_type_constraint();
         let default = self.parse_ts_default_type();
 
-        self.ast.ts_type_parameter(
+        TSTypeParameter::new(
             self.end_span(span),
             name,
             constraint,
@@ -240,6 +249,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             modifiers.contains(ModifierKind::In),
             modifiers.contains(ModifierKind::Out),
             modifiers.contains(ModifierKind::Const),
+            self,
         )
     }
 
@@ -267,7 +277,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         /* hasLeadingOperator && parseFunctionOrConstructorTypeToError(isUnionType) ||*/
         let mut ty = parse_constituent_type(self);
         if self.at(kind) || has_leading_operator {
-            let mut types = self.ast.vec1(ty);
+            let mut types = ArenaVec::from_value_in(ty, self);
             while self.eat(kind) {
                 types.push(
                     /*parseFunctionOrConstructorTypeToError(isUnionType) || */
@@ -276,8 +286,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
             let span = self.end_span(span);
             ty = match kind {
-                Kind::Pipe => self.ast.ts_type_union_type(span, types),
-                Kind::Amp => self.ast.ts_type_intersection_type(span, types),
+                Kind::Pipe => TSType::new_ts_union_type(span, types, self),
+                Kind::Amp => TSType::new_ts_intersection_type(span, types, self),
                 _ => unreachable!(),
             };
         }
@@ -308,14 +318,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         {
             self.error(diagnostics::readonly_in_array_or_tuple_type(operator_span));
         }
-        self.ast.ts_type_type_operator_type(self.end_span(span), operator, ty)
+        TSType::new_ts_type_operator_type(self.end_span(span), operator, ty, self)
     }
 
     fn parse_infer_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `infer`
         let type_parameter = self.parse_type_parameter_of_infer_type();
-        self.ast.ts_type_infer_type(self.end_span(span), type_parameter)
+        TSType::new_ts_infer_type(self.end_span(span), type_parameter, self)
     }
 
     fn parse_type_parameter_of_infer_type(&mut self) -> ArenaBox<'a, TSTypeParameter<'a>> {
@@ -325,7 +335,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let constraint = self.parse_constraint_of_infer_type();
         let span = self.end_span(span);
 
-        self.ast.alloc_ts_type_parameter(span, name, constraint, None, false, false, false)
+        TSTypeParameter::boxed(span, name, constraint, None, false, false, false, self)
     }
 
     /// Parse the `extends U` constraint of an `infer T extends U` type.
@@ -368,10 +378,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             match self.cur_kind() {
                 Kind::Bang => {
                     self.bump_any();
-                    ty = self.ast.ts_type_js_doc_non_nullable_type(
+                    ty = TSType::new_js_doc_non_nullable_type(
                         self.end_span(span),
                         ty,
                         /* postfix */ true,
+                        self,
                     );
                 }
                 Kind::Question => {
@@ -383,10 +394,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                         return ty;
                     }
                     self.bump_any();
-                    ty = self.ast.ts_type_js_doc_nullable_type(
+                    ty = TSType::new_js_doc_nullable_type(
                         self.end_span(span),
                         ty,
                         /* postfix */ true,
+                        self,
                     );
                 }
                 Kind::LBrack => {
@@ -394,14 +406,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                     if self.is_start_of_type(/* in_start_of_parameter */ false) {
                         let index_type = self.parse_ts_type();
                         self.expect(Kind::RBrack);
-                        ty = self.ast.ts_type_indexed_access_type(
+                        ty = TSType::new_ts_indexed_access_type(
                             self.end_span(span),
                             ty,
                             index_type,
+                            self,
                         );
                     } else {
                         self.expect(Kind::RBrack);
-                        ty = self.ast.ts_type_array_type(self.end_span(span), ty);
+                        ty = TSType::new_ts_array_type(self.end_span(span), ty, self);
                     }
                 }
                 _ => return ty,
@@ -452,7 +465,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 let span = self.start_span();
                 let literal = self.parse_template_literal(false);
                 let span = self.end_span(span);
-                self.ast.ts_type_literal_type(span, TSLiteral::TemplateLiteral(self.alloc(literal)))
+                TSType::new_ts_literal_type(span, TSLiteral::TemplateLiteral(self.alloc(literal)), self)
             }
             Kind::Minus => {
                 if self.lexer.peek_token().kind().is_number() {
@@ -466,12 +479,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Kind::Void => {
                 let span = self.start_span();
                 self.bump_any();
-                self.ast.ts_type_void_keyword(self.end_span(span))
+                TSType::new_ts_void_keyword(self.end_span(span), self)
             }
             Kind::This => {
                 let span = self.start_span();
                 self.bump_any(); // bump `this`
-                let this_type = self.ast.alloc_ts_this_type(self.end_span(span));
+                let this_type = TSThisType::boxed(self.end_span(span), self);
                 if self.at(Kind::Is) && !self.cur_token().is_on_new_line() {
                     self.parse_this_type_predicate(span, this_type)
                 } else {
@@ -512,47 +525,47 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         match self.cur_kind() {
             Kind::Any => {
                 self.bump_any();
-                self.ast.ts_type_any_keyword(self.end_span(span))
+                TSType::new_ts_any_keyword(self.end_span(span), self)
             }
             Kind::BigInt => {
                 self.bump_any();
-                self.ast.ts_type_big_int_keyword(self.end_span(span))
+                TSType::new_ts_big_int_keyword(self.end_span(span), self)
             }
             Kind::Boolean => {
                 self.bump_any();
-                self.ast.ts_type_boolean_keyword(self.end_span(span))
+                TSType::new_ts_boolean_keyword(self.end_span(span), self)
             }
             Kind::Never => {
                 self.bump_any();
-                self.ast.ts_type_never_keyword(self.end_span(span))
+                TSType::new_ts_never_keyword(self.end_span(span), self)
             }
             Kind::Number => {
                 self.bump_any();
-                self.ast.ts_type_number_keyword(self.end_span(span))
+                TSType::new_ts_number_keyword(self.end_span(span), self)
             }
             Kind::Object => {
                 self.bump_any();
-                self.ast.ts_type_object_keyword(self.end_span(span))
+                TSType::new_ts_object_keyword(self.end_span(span), self)
             }
             Kind::String => {
                 self.bump_any();
-                self.ast.ts_type_string_keyword(self.end_span(span))
+                TSType::new_ts_string_keyword(self.end_span(span), self)
             }
             Kind::Symbol => {
                 self.bump_any();
-                self.ast.ts_type_symbol_keyword(self.end_span(span))
+                TSType::new_ts_symbol_keyword(self.end_span(span), self)
             }
             Kind::Undefined => {
                 self.bump_any();
-                self.ast.ts_type_undefined_keyword(self.end_span(span))
+                TSType::new_ts_undefined_keyword(self.end_span(span), self)
             }
             Kind::Unknown => {
                 self.bump_any();
-                self.ast.ts_type_unknown_keyword(self.end_span(span))
+                TSType::new_ts_unknown_keyword(self.end_span(span), self)
             }
             Kind::Null => {
                 self.bump_any();
-                self.ast.ts_type_null_keyword(self.end_span(span))
+                TSType::new_ts_null_keyword(self.end_span(span), self)
             }
             _ => self.unexpected(),
         }
@@ -684,7 +697,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.bump(Kind::Semicolon);
         self.expect(Kind::RCurly);
 
-        self.ast.ts_type_mapped_type(
+        TSType::new_ts_mapped_type(
             self.end_span(span),
             key,
             constraint,
@@ -692,6 +705,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             type_annotation,
             optional,
             readonly,
+            self,
         )
     }
 
@@ -699,7 +713,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         let member_list =
             self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature);
-        self.ast.ts_type_type_literal(self.end_span(span), member_list)
+        TSType::new_ts_type_literal(self.end_span(span), member_list, self)
     }
 
     fn parse_type_query(&mut self) -> TSType<'a> {
@@ -718,7 +732,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             };
             (entity_name, type_arguments)
         };
-        self.ast.ts_type_type_query(self.end_span(span), entity_name, type_arguments)
+        TSType::new_ts_type_query(self.end_span(span), entity_name, type_arguments, self)
     }
 
     fn parse_this_type_predicate(
@@ -728,19 +742,20 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> TSType<'a> {
         self.bump_any(); // bump `is`
         let ty = self.parse_ts_type();
-        let type_annotation = Some(self.ast.ts_type_annotation(ty.span(), ty));
-        self.ast.ts_type_type_predicate(
+        let type_annotation = Some(TSTypeAnnotation::new(ty.span(), ty, self));
+        TSType::new_ts_type_predicate(
             self.end_span(span),
             TSTypePredicateName::This(this_ty),
             false,
             type_annotation,
+            self,
         )
     }
 
     fn parse_this_type_node(&mut self) -> ArenaBox<'a, TSThisType> {
         let span = self.start_span();
         self.bump_any(); // bump `this`
-        self.ast.alloc_ts_this_type(self.end_span(span))
+        TSThisType::boxed(self.end_span(span), self)
     }
 
     fn parse_ts_type_constraint(&mut self) -> Option<TSType<'a>> {
@@ -761,8 +776,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_template_type(&mut self, tagged: bool) -> TSType<'a> {
         let span = self.start_span();
-        let mut types = self.ast.vec();
-        let mut quasis = self.ast.vec();
+        let mut types = ArenaVec::new_in(self);
+        let mut quasis = ArenaVec::new_in(self);
         match self.cur_kind() {
             Kind::NoSubstitutionTemplate => {
                 quasis.push(self.parse_template_element(tagged));
@@ -794,7 +809,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             _ => unreachable!("parse_template_literal"),
         }
 
-        self.ast.ts_type_template_literal_type(self.end_span(span), quasis, types)
+        TSType::new_ts_template_literal_type(self.end_span(span), quasis, types, self)
     }
 
     fn parse_asserts_type_predicate(&mut self, asserts_start_span: u32) -> TSType<'a> {
@@ -808,13 +823,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if self.eat(Kind::Is) {
             let type_span = self.start_span();
             let ty = self.parse_ts_type();
-            type_annotation = Some(self.ast.ts_type_annotation(self.end_span(type_span), ty));
+            type_annotation = Some(TSTypeAnnotation::new(self.end_span(type_span), ty, self));
         }
-        self.ast.ts_type_type_predicate(
+        TSType::new_ts_type_predicate(
             self.end_span(asserts_start_span),
             parameter_name,
             /* asserts */ true,
             type_annotation,
+            self,
         )
     }
 
@@ -822,24 +838,24 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         let type_name = self.parse_ts_type_name();
         let type_parameters = self.parse_type_arguments_of_type_reference();
-        self.ast.ts_type_type_reference(self.end_span(span), type_name, type_parameters)
+        TSType::new_ts_type_reference(self.end_span(span), type_name, type_parameters, self)
     }
 
     fn parse_ts_implement_name(&mut self) -> TSClassImplements<'a> {
         let span = self.start_span();
         let type_name = self.parse_ts_type_name();
         let type_parameters = self.parse_type_arguments_of_type_reference();
-        self.ast.ts_class_implements(self.end_span(span), type_name, type_parameters)
+        TSClassImplements::new(self.end_span(span), type_name, type_parameters, self)
     }
 
     pub(crate) fn parse_ts_type_name(&mut self) -> TSTypeName<'a> {
         let span = self.start_span();
         let left = if self.at(Kind::This) {
             self.bump_any();
-            self.ast.ts_type_name_this_expression(self.end_span(span))
+            TSTypeName::new_this_expression(self.end_span(span), self)
         } else {
             let ident = self.parse_identifier_name();
-            self.ast.ts_type_name_identifier_reference(ident.span, ident.name)
+            TSTypeName::new_identifier_reference(ident.span, ident.name, self)
         };
         if self.at(Kind::Dot) { self.parse_ts_qualified_type_name(span, left) } else { left }
     }
@@ -851,7 +867,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> TSTypeName<'a> {
         while self.eat(Kind::Dot) {
             let right = self.parse_identifier_name();
-            left_name = self.ast.ts_type_name_qualified_name(self.end_span(span), left_name, right);
+            left_name = TSTypeName::new_qualified_name(self.end_span(span), left_name, right, self);
         }
         left_name
     }
@@ -874,7 +890,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if params.is_empty() {
                 self.error(diagnostics::ts_empty_type_argument_list(span));
             }
-            return Some(self.ast.alloc_ts_type_parameter_instantiation(span, params));
+            return Some(TSTypeParameterInstantiation::boxed(span, params, self));
         }
         None
     }
@@ -897,7 +913,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             if params.is_empty() {
                 self.error(diagnostics::ts_empty_type_argument_list(span));
             }
-            return Some(self.ast.alloc_ts_type_parameter_instantiation(span, params));
+            return Some(TSTypeParameterInstantiation::boxed(span, params, self));
         }
         None
     }
@@ -944,7 +960,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         if params.is_empty() {
             self.error(diagnostics::ts_empty_type_argument_list(span));
         }
-        Some(self.ast.alloc_ts_type_parameter_instantiation(span, params))
+        Some(TSTypeParameterInstantiation::boxed(span, params, self))
     }
 
     fn can_follow_type_arguments_in_expr(&mut self) -> bool {
@@ -1022,7 +1038,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 tuple
             });
         self.expect(Kind::RBrack);
-        self.ast.ts_type_tuple_type(self.end_span(span), elements)
+        TSType::new_ts_tuple_type(self.end_span(span), elements, self)
     }
 
     pub(super) fn parse_tuple_element(&mut self) -> TSTupleElement<'a> {
@@ -1042,8 +1058,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             let optional_after_tuple_member_name = matches!(ty, TSType::JSDocNullableType(_));
             let tuple_element = self.convert_type_to_tuple_element(ty);
             let member_span = self.end_span(member_span_start);
-            let named_tuple_member =
-                self.ast.ts_type_named_tuple_member(member_span, label, tuple_element, optional);
+            let named_tuple_member = TSType::new_ts_named_tuple_member(
+                member_span,
+                label,
+                tuple_element,
+                optional,
+                self,
+            );
             if rest_after_tuple_member_name {
                 self.error(diagnostics::rest_after_tuple_member_name(
                     self.end_span(type_span_start),
@@ -1059,14 +1080,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 if optional {
                     self.error(diagnostics::optional_and_rest_tuple_member(span));
                 }
-                self.ast.ts_tuple_element_rest_type(span, named_tuple_member)
+                TSTupleElement::new_ts_rest_type(span, named_tuple_member, self)
             } else {
                 TSTupleElement::from(named_tuple_member)
             }
         } else {
             let ty = self.parse_ts_type();
             if is_rest_type {
-                self.ast.ts_tuple_element_rest_type(self.end_span(span_start), ty)
+                TSTupleElement::new_ts_rest_type(self.end_span(span_start), ty, self)
             } else {
                 self.convert_type_to_tuple_element(ty)
             }
@@ -1082,7 +1103,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn convert_type_to_tuple_element(&self, ty: TSType<'a>) -> TSTupleElement<'a> {
         if let TSType::JSDocNullableType(ty) = ty {
             if ty.postfix {
-                self.ast.ts_tuple_element_optional_type(ty.span, ty.unbox().type_annotation)
+                TSTupleElement::new_ts_optional_type(ty.span, ty.unbox().type_annotation, self)
             } else {
                 TSTupleElement::JSDocNullableType(ty)
             }
@@ -1097,7 +1118,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let ty = self.parse_ts_type();
         self.expect(Kind::RParen);
         if self.options.preserve_parens {
-            self.ast.ts_type_parenthesized_type(self.end_span(span), ty)
+            TSType::new_ts_parenthesized_type(self.end_span(span), ty, self)
         } else {
             ty
         }
@@ -1114,18 +1135,15 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             Expression::StringLiteral(literal) => TSLiteral::StringLiteral(literal),
             _ => return self.unexpected(),
         };
-        self.ast.ts_type_literal_type(span, literal)
+        TSType::new_ts_literal_type(span, literal, self)
     }
 
     fn parse_literal_type_negative(&mut self, span: u32) -> TSType<'a> {
         let literal_expr = self.parse_literal_expression();
         let span = self.end_span(span);
-        let literal = TSLiteral::UnaryExpression(self.ast.alloc_unary_expression(
-            span,
-            UnaryOperator::UnaryNegation,
-            literal_expr,
-        ));
-        self.ast.ts_type_literal_type(span, literal)
+        let literal =
+            TSLiteral::new_unary_expression(span, UnaryOperator::UnaryNegation, literal_expr, self);
+        TSType::new_ts_literal_type(span, literal, self)
     }
 
     fn parse_ts_import_type(&mut self) -> ArenaBox<'a, TSImportType<'a>> {
@@ -1144,7 +1162,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 span = self.cur_token().span();
             }
             self.error(diagnostics::ts_string_literal_expected(span));
-            self.ast.string_literal(span, "", None)
+            StringLiteral::new(span, "", None, self)
         };
 
         let options =
@@ -1153,24 +1171,18 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let qualifier =
             if self.eat(Kind::Dot) { Some(self.parse_ts_import_type_qualifier()) } else { None };
         let type_arguments = self.parse_type_arguments_of_type_reference();
-        self.ast.alloc_ts_import_type(
-            self.end_span(span),
-            source,
-            options,
-            qualifier,
-            type_arguments,
-        )
+        TSImportType::boxed(self.end_span(span), source, options, qualifier, type_arguments, self)
     }
 
     fn parse_ts_import_type_qualifier(&mut self) -> TSImportTypeQualifier<'a> {
         let span = self.start_span();
         let ident = self.parse_identifier_name();
-        let mut left = self.ast.ts_import_type_qualifier_identifier(ident.span, ident.name);
+        let mut left = TSImportTypeQualifier::new_identifier(ident.span, ident.name, self);
 
         while self.eat(Kind::Dot) {
             let right = self.parse_identifier_name();
             left =
-                self.ast.ts_import_type_qualifier_qualified_name(self.end_span(span), left, right);
+                TSImportTypeQualifier::new_qualified_name(self.end_span(span), left, right, self);
         }
 
         left
@@ -1197,7 +1209,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let key_name = self.cur_string();
         let with_key_span = self.start_span();
         self.bump_any();
-        let with_key = self.ast.alloc_identifier_name(self.end_span(with_key_span), key_name);
+        let with_key = IdentifierName::boxed(self.end_span(with_key_span), key_name, self);
 
         self.expect(Kind::Colon);
 
@@ -1210,7 +1222,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         };
 
         // Create the outer `with: { ... }` property
-        let with_property = self.ast.alloc_object_property(
+        let with_property = ObjectProperty::boxed(
             self.end_span(with_key_span),
             PropertyKind::Init,
             PropertyKey::StaticIdentifier(with_key),
@@ -1218,15 +1230,17 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             false,
             false,
             false,
+            self,
         );
 
-        let outer_properties = self.ast.vec1(ObjectPropertyKind::ObjectProperty(with_property));
+        let outer_properties =
+            ArenaVec::from_value_in(ObjectPropertyKind::ObjectProperty(with_property), self);
 
         // Allow optional trailing comma: `{ with: { type: "json" }, }`
         let _ = self.eat(Kind::Comma);
 
         self.expect(Kind::RCurly);
-        self.ast.alloc_object_expression(self.end_span(span), outer_properties)
+        ObjectExpression::boxed(self.end_span(span), outer_properties, self)
     }
 
     /// Parse TypeScript import type attributes object: `{ type: "json" }`
@@ -1235,7 +1249,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
 
-        let mut properties = self.ast.vec();
+        let mut properties = ArenaVec::new_in(self);
         let mut first = true;
         while !self.at(Kind::RCurly) && !self.at(Kind::Eof) {
             if first {
@@ -1269,21 +1283,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 self.expect(Kind::RBrack);
                 self.expect(Kind::Colon);
                 let value = self.parse_assignment_expression_or_higher();
-                let key = PropertyKey::StringLiteral(self.ast.alloc_string_literal(
-                    bracket_span,
-                    "",
-                    None,
-                ));
-                properties.push(ObjectPropertyKind::ObjectProperty(
-                    self.ast.alloc_object_property(
-                        self.end_span(prop_span),
-                        PropertyKind::Init,
-                        key,
-                        value,
-                        false,
-                        false,
-                        true, // computed
-                    ),
+                let key = PropertyKey::new_string_literal(bracket_span, "", None, self);
+                properties.push(ObjectPropertyKind::new_object_property(
+                    self.end_span(prop_span),
+                    PropertyKind::Init,
+                    key,
+                    value,
+                    false,
+                    false,
+                    true, /* computed */
+                    self,
                 ));
                 continue;
             }
@@ -1300,7 +1309,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.expect(Kind::Colon);
             let value = self.parse_assignment_expression_or_higher();
 
-            properties.push(ObjectPropertyKind::ObjectProperty(self.ast.alloc_object_property(
+            properties.push(ObjectPropertyKind::new_object_property(
                 self.end_span(prop_span),
                 PropertyKind::Init,
                 key,
@@ -1308,11 +1317,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 false,
                 false,
                 false,
-            )));
+                self,
+            ));
         }
 
         self.expect(Kind::RCurly);
-        self.ast.alloc_object_expression(self.end_span(span), properties)
+        ObjectExpression::boxed(self.end_span(span), properties, self)
     }
 
     pub(crate) fn parse_ts_return_type_annotation(
@@ -1323,7 +1333,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         let span = self.start_span();
         let return_type = self.parse_return_type();
-        Some(self.ast.alloc_ts_type_annotation(self.end_span(span), return_type))
+        Some(TSTypeAnnotation::boxed(self.end_span(span), return_type, self))
     }
 
     fn parse_return_type(&mut self) -> TSType<'a> {
@@ -1337,12 +1347,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
         let ty = self.parse_ts_type();
         if let Some(parameter_name) = type_predicate_variable {
-            let type_annotation = Some(self.ast.ts_type_annotation(ty.span(), ty));
-            return self.ast.ts_type_type_predicate(
+            let type_annotation = Some(TSTypeAnnotation::new(ty.span(), ty, self));
+            return TSType::new_ts_type_predicate(
                 self.end_span(span),
                 parameter_name,
                 false,
                 type_annotation,
+                self,
             );
         }
         ty
@@ -1389,19 +1400,21 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let return_type = self.parse_ts_return_type_annotation();
         self.parse_type_member_semicolon();
         match kind {
-            CallOrConstructorSignature::Call => self.ast.ts_signature_call_signature_declaration(
+            CallOrConstructorSignature::Call => TSSignature::new_ts_call_signature_declaration(
                 self.end_span(span),
                 type_parameters,
                 this_param,
                 params,
                 return_type,
+                self,
             ),
             CallOrConstructorSignature::Constructor => {
-                self.ast.ts_signature_construct_signature_declaration(
+                TSSignature::new_ts_construct_signature_declaration(
                     self.end_span(span),
                     type_parameters,
                     params,
                     return_type,
+                    self,
                 )
             }
         }
@@ -1451,7 +1464,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             TSMethodSignatureKind::Method => {}
         }
 
-        self.ast.ts_signature_method_signature(
+        TSSignature::new_ts_method_signature(
             self.end_span(span),
             key,
             computed,
@@ -1461,6 +1474,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             this_param,
             params,
             return_type,
+            self,
         )
     }
 
@@ -1486,7 +1500,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 .parse_formal_parameters(FunctionKind::Declaration, FormalParameterKind::Signature);
             let return_type = self.parse_ts_return_type_annotation();
             self.parse_type_member_semicolon();
-            self.ast.ts_signature_method_signature(
+            TSSignature::new_ts_method_signature(
                 self.end_span(span),
                 key,
                 computed,
@@ -1496,17 +1510,19 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 this_param,
                 params,
                 return_type,
+                self,
             )
         } else {
             let type_annotation = self.parse_ts_type_annotation();
             self.parse_type_member_semicolon();
-            self.ast.ts_signature_property_signature(
+            TSSignature::new_ts_property_signature(
                 self.end_span(span),
                 computed,
                 optional,
                 modifiers.contains_readonly(),
                 key,
                 type_annotation,
+                self,
             )
         }
     }
@@ -1552,12 +1568,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
                 .fatal_error(diagnostics::index_signature_type_annotation(self.end_span(span)));
         };
         self.parse_type_member_semicolon();
-        self.ast.alloc_ts_index_signature(
+        TSIndexSignature::boxed(
             self.end_span(span),
             params,
             type_annotation,
             modifiers.contains(ModifierKind::Readonly),
             modifiers.contains(ModifierKind::Static),
+            self,
         )
     }
 
@@ -1580,7 +1597,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
         let type_annotation = self.parse_ts_type_annotation();
         if let Some(type_annotation) = type_annotation {
-            self.ast.ts_index_signature_name(self.end_span(span), name, type_annotation)
+            TSIndexSignatureName::new(self.end_span(span), name, type_annotation, self)
         } else {
             self.unexpected()
         }
@@ -1593,13 +1610,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             self.cur_kind(),
             Kind::Comma | Kind::RCurly | Kind::RParen | Kind::RAngle | Kind::Eq | Kind::Pipe
         ) {
-            return self.ast.ts_type_js_doc_unknown_type(self.end_span(span));
+            return TSType::new_js_doc_unknown_type(self.end_span(span), self);
         }
         let type_annotation = self.parse_ts_type();
-        self.ast.ts_type_js_doc_nullable_type(
+        TSType::new_js_doc_nullable_type(
             self.end_span(span),
             type_annotation,
             /* postfix */ false,
+            self,
         )
     }
 
@@ -1607,7 +1625,12 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = self.start_span();
         self.bump_any(); // bump `!`
         let ty = self.parse_non_array_type();
-        self.ast.ts_type_js_doc_non_nullable_type(self.end_span(span), ty, /* postfix */ false)
+        TSType::new_js_doc_non_nullable_type(
+            self.end_span(span),
+            ty,
+            /* postfix */ false,
+            self,
+        )
     }
 
     fn is_binary_operator(&self) -> bool {


### PR DESCRIPTION
Part of #23043.

Switch over `oxc_parser` to use the new `AstBuilder` and builder methods on AST types themselves.

Vast majority performed by an ast-grep codemod generated by Claude (2nd commit - [codemod here](https://github.com/oxc-project/oxc/tree/overlookmotel/ast-builder-codemod)).

The last 2 commits are a few small fixes, and some manual changes to shorten code.