### PR TITLE
fix(linter/vitest/expect-expect): handle global vitest detection correctly

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/expect_expect.rs
@@ -179,7 +179,15 @@ impl ExpectExpectConfig {
         jest_node: &PossibleJestNode<'a, 'c>,
         ctx: &'c LintContext<'a>,
     ) {
-        run(self, jest_node, ctx);
+        run(self, jest_node, ctx, ctx.frameworks().is_vitest());
+    }
+
+    pub fn run_on_vitest_node<'a, 'c>(
+        &self,
+        jest_node: &PossibleJestNode<'a, 'c>,
+        ctx: &'c LintContext<'a>,
+    ) {
+        run(self, jest_node, ctx, true);
     }
 }
 
@@ -187,6 +195,7 @@ fn run<'a>(
     rule: &ExpectExpectConfig,
     possible_jest_node: &PossibleJestNode<'a, '_>,
     ctx: &LintContext<'a>,
+    use_vitest_assertions: bool,
 ) {
     let node = possible_jest_node.node;
     if let AstKind::CallExpression(call_expr) = node.kind() {
@@ -205,12 +214,12 @@ fn run<'a>(
                 if property_name == "todo" {
                     return;
                 }
-                if property_name == "skip" && ctx.frameworks().is_vitest() {
+                if property_name == "skip" && use_vitest_assertions {
                     return;
                 }
             }
 
-            let assert_function_matchers = if ctx.frameworks().is_vitest() {
+            let assert_function_matchers = if use_vitest_assertions {
                 &rule.assert_function_matchers_vitest
             } else {
                 &rule.assert_function_matchers_jest

--- a/crates/oxc_linter/src/rules/vitest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/vitest/expect_expect.rs
@@ -29,7 +29,7 @@ impl Rule for ExpectExpect {
         jest_node: &PossibleJestNode<'a, 'c>,
         ctx: &'c LintContext<'a>,
     ) {
-        self.0.run_on_jest_node(jest_node, ctx);
+        self.0.run_on_vitest_node(jest_node, ctx);
     }
 }
 
@@ -347,4 +347,20 @@ fn test() {
     Tester::new(ExpectExpect::NAME, ExpectExpect::PLUGIN, pass, fail)
         .with_vitest_plugin(true)
         .test_and_snapshot();
+
+    Tester::new(
+        ExpectExpect::NAME,
+        ExpectExpect::PLUGIN,
+        vec![(
+            "
+                it(\"should work\", () => {
+                    expectTypeOf({ a: 1 }).toEqualTypeOf<{ a: number }>();
+                });
+            ",
+            None,
+        )],
+        Vec::new(),
+    )
+    .with_jest_plugin(true)
+    .test();
 }


### PR DESCRIPTION
fixes #23547