### PR TITLE
fix(linter): make react/forbid-component-props lists optional

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -190,6 +190,65 @@ export type AllKeyword = "all";
  * A forbidden prop, either as a plain prop name string or with options.
  */
 export type ForbidItem = string | ForbidItemObject;
+export type ForbidItemObject =
+  | {
+      /**
+       * Component names for which this prop is **allowed** (all others are
+       * forbidden).
+       */
+      allowedFor?: string[];
+      /**
+       * Glob patterns for component names where the prop is **allowed**.
+       */
+      allowedForPatterns?: string[];
+      /**
+       * Component names for which this prop is **disallowed** (all others are
+       * allowed).
+       */
+      disallowedFor?: string[];
+      /**
+       * Glob patterns for component names where the prop is **disallowed**.
+       */
+      disallowedForPatterns?: string[];
+      /**
+       * Custom message to display.
+       */
+      message?: string;
+      /**
+       * Exact prop name to forbid.
+       */
+      propName: string;
+      propNamePattern?: never;
+    }
+  | {
+      /**
+       * Component names for which this prop is **allowed** (all others are
+       * forbidden).
+       */
+      allowedFor?: string[];
+      /**
+       * Glob patterns for component names where the prop is **allowed**.
+       */
+      allowedForPatterns?: string[];
+      /**
+       * Component names for which this prop is **disallowed** (all others are
+       * allowed).
+       */
+      disallowedFor?: string[];
+      /**
+       * Glob patterns for component names where the prop is **disallowed**.
+       */
+      disallowedForPatterns?: string[];
+      /**
+       * Custom message to display.
+       */
+      message?: string;
+      propName?: never;
+      /**
+       * Glob pattern to match prop names against.
+       */
+      propNamePattern: string;
+    };
 /**
  * A forbidden prop, either as a plain prop name string or with options.
  */
@@ -4339,38 +4398,6 @@ export interface ForbidComponentPropsConfig {
    * - `["error", { "forbid": [{ "propNamePattern": "**-**", "disallowedFor": ["Foo"] }] }]`
    */
   forbid?: ForbidItem[];
-}
-export interface ForbidItemObject {
-  /**
-   * Component names for which this prop is **allowed** (all others are
-   * forbidden).
-   */
-  allowedFor: string[];
-  /**
-   * Glob patterns for component names where the prop is **allowed**.
-   */
-  allowedForPatterns: string[];
-  /**
-   * Component names for which this prop is **disallowed** (all others are
-   * allowed).
-   */
-  disallowedFor: string[];
-  /**
-   * Glob patterns for component names where the prop is **disallowed**.
-   */
-  disallowedForPatterns: string[];
-  /**
-   * Custom message to display.
-   */
-  message?: string;
-  /**
-   * Exact prop name to forbid.
-   */
-  propName?: string;
-  /**
-   * Glob pattern to match prop names against.
-   */
-  propNamePattern?: string;
 }
 /**
  * Configuration for the `forbid-dom-props` rule.

--- a/crates/oxc_linter/src/rules/react/forbid_component_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_component_props.rs
@@ -5,7 +5,10 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use oxc_str::CompactStr;
-use schemars::JsonSchema;
+use schemars::{
+    JsonSchema, SchemaGenerator,
+    schema::{Schema, SchemaObject, SubschemaValidation},
+};
 use serde::Deserialize;
 
 use crate::utils::{get_jsx_element_name, is_react_component_name};
@@ -84,8 +87,7 @@ pub enum ForbidItem {
     Object(ForbidItemObject),
 }
 
-#[derive(Debug, Clone, JsonSchema)]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[derive(Debug, Default, Clone)]
 pub struct ForbidItemObject {
     /// Exact prop name to forbid.
     prop_name: Option<CompactStr>,
@@ -103,6 +105,91 @@ pub struct ForbidItemObject {
     disallowed_for_patterns: Vec<CompactStr>,
     /// Custom message to display.
     message: Option<String>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(rename_all = "camelCase", deny_unknown_fields)]
+#[expect(dead_code, reason = "schema-only type for `ForbidItemObject`")]
+struct ForbidItemObjectWithPropNameSchema {
+    /// Exact prop name to forbid.
+    prop_name: CompactStr,
+    /// Component names for which this prop is **allowed** (all others are
+    /// forbidden).
+    #[schemars(default)]
+    allowed_for: Vec<CompactStr>,
+    /// Glob patterns for component names where the prop is **allowed**.
+    #[schemars(default)]
+    allowed_for_patterns: Vec<CompactStr>,
+    /// Component names for which this prop is **disallowed** (all others are
+    /// allowed).
+    #[schemars(default)]
+    disallowed_for: Vec<CompactStr>,
+    /// Glob patterns for component names where the prop is **disallowed**.
+    #[schemars(default)]
+    disallowed_for_patterns: Vec<CompactStr>,
+    /// Custom message to display.
+    message: Option<String>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(rename_all = "camelCase", deny_unknown_fields)]
+#[expect(dead_code, reason = "schema-only type for `ForbidItemObject`")]
+struct ForbidItemObjectWithPropNamePatternSchema {
+    /// Glob pattern to match prop names against.
+    prop_name_pattern: CompactStr,
+    /// Component names for which this prop is **allowed** (all others are
+    /// forbidden).
+    #[schemars(default)]
+    allowed_for: Vec<CompactStr>,
+    /// Glob patterns for component names where the prop is **allowed**.
+    #[schemars(default)]
+    allowed_for_patterns: Vec<CompactStr>,
+    /// Component names for which this prop is **disallowed** (all others are
+    /// allowed).
+    #[schemars(default)]
+    disallowed_for: Vec<CompactStr>,
+    /// Glob patterns for component names where the prop is **disallowed**.
+    #[schemars(default)]
+    disallowed_for_patterns: Vec<CompactStr>,
+    /// Custom message to display.
+    message: Option<String>,
+}
+
+impl JsonSchema for ForbidItemObject {
+    fn schema_name() -> String {
+        "ForbidItemObject".to_string()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        Schema::Object(SchemaObject {
+            subschemas: Some(Box::new(SubschemaValidation {
+                one_of: Some(vec![
+                    schema_with_forbidden_property::<ForbidItemObjectWithPropNameSchema>(
+                        generator,
+                        "propNamePattern",
+                    ),
+                    schema_with_forbidden_property::<ForbidItemObjectWithPropNamePatternSchema>(
+                        generator, "propName",
+                    ),
+                ]),
+                ..Default::default()
+            })),
+            ..Default::default()
+        })
+    }
+}
+
+fn schema_with_forbidden_property<T: JsonSchema>(
+    generator: &mut SchemaGenerator,
+    property: &str,
+) -> Schema {
+    let mut schema = T::json_schema(generator).into_object();
+    schema
+        .object
+        .get_or_insert_with(Default::default)
+        .properties
+        .insert(property.to_string(), Schema::Bool(false));
+    Schema::Object(schema)
 }
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10895,63 +10895,120 @@
       "markdownDescription": "A forbidden element, either as a plain element name or with a custom message."
     },
     "ForbidItemObject": {
-      "type": "object",
-      "required": [
-        "allowedFor",
-        "allowedForPatterns",
-        "disallowedFor",
-        "disallowedForPatterns"
-      ],
-      "properties": {
-        "allowedFor": {
-          "description": "Component names for which this prop is **allowed** (all others are\nforbidden).",
-          "type": "array",
-          "items": {
-            "type": "string"
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "propName"
+          ],
+          "properties": {
+            "allowedFor": {
+              "description": "Component names for which this prop is **allowed** (all others are\nforbidden).",
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Component names for which this prop is **allowed** (all others are\nforbidden)."
+            },
+            "allowedForPatterns": {
+              "description": "Glob patterns for component names where the prop is **allowed**.",
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Glob patterns for component names where the prop is **allowed**."
+            },
+            "disallowedFor": {
+              "description": "Component names for which this prop is **disallowed** (all others are\nallowed).",
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Component names for which this prop is **disallowed** (all others are\nallowed)."
+            },
+            "disallowedForPatterns": {
+              "description": "Glob patterns for component names where the prop is **disallowed**.",
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Glob patterns for component names where the prop is **disallowed**."
+            },
+            "message": {
+              "description": "Custom message to display.",
+              "type": "string",
+              "markdownDescription": "Custom message to display."
+            },
+            "propName": {
+              "description": "Exact prop name to forbid.",
+              "type": "string",
+              "markdownDescription": "Exact prop name to forbid."
+            },
+            "propNamePattern": false
           },
-          "markdownDescription": "Component names for which this prop is **allowed** (all others are\nforbidden)."
+          "additionalProperties": false
         },
-        "allowedForPatterns": {
-          "description": "Glob patterns for component names where the prop is **allowed**.",
-          "type": "array",
-          "items": {
-            "type": "string"
+        {
+          "type": "object",
+          "required": [
+            "propNamePattern"
+          ],
+          "properties": {
+            "allowedFor": {
+              "description": "Component names for which this prop is **allowed** (all others are\nforbidden).",
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Component names for which this prop is **allowed** (all others are\nforbidden)."
+            },
+            "allowedForPatterns": {
+              "description": "Glob patterns for component names where the prop is **allowed**.",
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Glob patterns for component names where the prop is **allowed**."
+            },
+            "disallowedFor": {
+              "description": "Component names for which this prop is **disallowed** (all others are\nallowed).",
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Component names for which this prop is **disallowed** (all others are\nallowed)."
+            },
+            "disallowedForPatterns": {
+              "description": "Glob patterns for component names where the prop is **disallowed**.",
+              "default": [],
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "markdownDescription": "Glob patterns for component names where the prop is **disallowed**."
+            },
+            "message": {
+              "description": "Custom message to display.",
+              "type": "string",
+              "markdownDescription": "Custom message to display."
+            },
+            "propName": false,
+            "propNamePattern": {
+              "description": "Glob pattern to match prop names against.",
+              "type": "string",
+              "markdownDescription": "Glob pattern to match prop names against."
+            }
           },
-          "markdownDescription": "Glob patterns for component names where the prop is **allowed**."
-        },
-        "disallowedFor": {
-          "description": "Component names for which this prop is **disallowed** (all others are\nallowed).",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Component names for which this prop is **disallowed** (all others are\nallowed)."
-        },
-        "disallowedForPatterns": {
-          "description": "Glob patterns for component names where the prop is **disallowed**.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "markdownDescription": "Glob patterns for component names where the prop is **disallowed**."
-        },
-        "message": {
-          "description": "Custom message to display.",
-          "type": "string",
-          "markdownDescription": "Custom message to display."
-        },
-        "propName": {
-          "description": "Exact prop name to forbid.",
-          "type": "string",
-          "markdownDescription": "Exact prop name to forbid."
-        },
-        "propNamePattern": {
-          "description": "Glob pattern to match prop names against.",
-          "type": "string",
-          "markdownDescription": "Glob pattern to match prop names against."
+          "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      ]
     },
     "FragmentMode": {
       "oneOf": [


### PR DESCRIPTION
Marks the `react/forbid-component-props` allow/disallow selector lists as defaulted schema fields, so the generated config types treat them as optional and match the rule’s deserialization behavior.

Fixes #23732