### PR TITLE
fix(linter/eslint/no-restricted-globals): handle shadowed locals

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -195,7 +195,7 @@ impl Rule for NoRestrictedGlobals {
                     return;
                 };
                 let reference = ctx.scoping().get_reference(ident.reference_id());
-                if reference.symbol_id().is_none() && reference.is_type() {
+                if reference.symbol_id().is_some() || reference.is_type() {
                     return;
                 }
                 ctx.diagnostic(no_restricted_globals(&ident.name, message, ident.span));
@@ -439,6 +439,12 @@ fn test() {
         ("foo.bar", Some(serde_json::json!(["bar"])), None),
         ("foo.globalThis.bar", Some(serde_json::json!(["bar"])), None),
         ("foo.globalThis.bar()", Some(serde_json::json!(["bar"])), None),
+        (
+            "function handler(event) { return event.target; }",
+            Some(serde_json::json!(["event"])),
+            None,
+        ),
+        ("function handler(name) { return name.length; }", Some(serde_json::json!(["name"])), None),
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_restricted_globals.snap
@@ -451,23 +451,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a local variable or function parameter instead of the restricted global.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'event'.
-   ╭─[no_restricted_globals.tsx:1:39]
- 1 │ function onClick(event) { console.log(event); console.log(window.event); }
-   ·                                       ─────
-   ╰────
-  help: Use a local variable or function parameter instead of the restricted global.
-
-  ⚠ eslint(no-restricted-globals): Unexpected use of 'event'.
    ╭─[no_restricted_globals.tsx:1:66]
  1 │ function onClick(event) { console.log(event); console.log(window.event); }
    ·                                                                  ─────
-   ╰────
-  help: Use a local variable or function parameter instead of the restricted global.
-
-  ⚠ eslint(no-restricted-globals): Unexpected use of 'event'.
-   ╭─[no_restricted_globals.tsx:1:39]
- 1 │ function onClick(event) { console.log(event); console.log(self.event); }
-   ·                                       ─────
    ╰────
   help: Use a local variable or function parameter instead of the restricted global.
 
@@ -479,23 +465,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a local variable or function parameter instead of the restricted global.
 
   ⚠ eslint(no-restricted-globals): Unexpected use of 'event'.
-   ╭─[no_restricted_globals.tsx:1:39]
- 1 │ function onClick(event) { console.log(event); console.log(globalThis.event); }
-   ·                                       ─────
-   ╰────
-  help: Use a local variable or function parameter instead of the restricted global.
-
-  ⚠ eslint(no-restricted-globals): Unexpected use of 'event'.
    ╭─[no_restricted_globals.tsx:1:70]
  1 │ function onClick(event) { console.log(event); console.log(globalThis.event); }
    ·                                                                      ─────
-   ╰────
-  help: Use a local variable or function parameter instead of the restricted global.
-
-  ⚠ eslint(no-restricted-globals): Unexpected use of 'event'.
-   ╭─[no_restricted_globals.tsx:1:39]
- 1 │ function onClick(event) { console.log(event); console.log(myGlobal.event); }
-   ·                                       ─────
    ╰────
   help: Use a local variable or function parameter instead of the restricted global.
 


### PR DESCRIPTION
Restore `no-restricted-globals` to only report restricted names that resolve to actual globals. The recent option rewrite accidentally reported resolved local value references too, so function parameters like `event` and `name` were flagged when they shadowed restricted globals.

This keeps the new global-object access handling intact while skipping resolved local references, and adds regression coverage for shadowing parameters.

Regressed in https://github.com/oxc-project/oxc/pull/23663

Fixes #23724