### PR TITLE
feat(linter/vue): implement order-in-components rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -399,6 +399,11 @@ export type DeclarationStyle = "type-based" | "type-literal" | "runtime";
 export type DeclarationStyle2 = "type-based" | "runtime";
 export type Destructure = "only-when-assigned" | "always" | "never";
 export type NextTickOption = "promise" | "callback";
+/**
+ * One entry in the `order` option: either a single name or a group of names
+ * that share the same position.
+ */
+export type OrderEntry = string | string[];
 export type CaseType2 = "camelCase" | "snake_case";
 export type AllowYoda = "never" | "always";
 export type OxlintOverrides = OxlintOverride[];
@@ -1740,6 +1745,7 @@ export interface DummyRuleMap {
   "vue/no-side-effects-in-computed-properties"?: RuleNoConfig;
   "vue/no-this-in-before-route-enter"?: RuleNoConfig;
   "vue/no-watch-after-await"?: RuleNoConfig;
+  "vue/order-in-components"?: RuleNoConfig | [AllowWarnDeny, OrderInComponentsConfig];
   "vue/prefer-import-from-vue"?: RuleNoConfig;
   "vue/prop-name-casing"?: RuleNoConfig | [AllowWarnDeny, CaseType2] | [AllowWarnDeny, CaseType2, Options];
   "vue/require-default-export"?: RuleNoConfig;
@@ -6425,6 +6431,13 @@ export interface NoReservedPropsConfig {
    * more names (`is`, `slot`, `class`, `style`, ...) than Vue 3.
    */
   vueVersion?: number;
+}
+export interface OrderInComponentsConfig {
+  /**
+   * Custom property order. Each entry is a single property name or a group of
+   * names sharing the same rank. Defaults to Vue's recommended order.
+   */
+  order?: OrderEntry[];
 }
 export interface Options {
   ignoreProps?: string[];

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -5227,6 +5227,12 @@ impl RuleRunner for crate::rules::vue::no_watch_after_await::NoWatchAfterAwait {
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
+impl RuleRunner for crate::rules::vue::order_in_components::OrderInComponents {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::ObjectExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::vue::prefer_import_from_vue::PreferImportFromVue {
     const NODE_TYPES: Option<&AstTypesBitset> = None;
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::RunOnce;

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -832,6 +832,7 @@ pub use crate::rules::vue::no_shared_component_data::NoSharedComponentData as Vu
 pub use crate::rules::vue::no_side_effects_in_computed_properties::NoSideEffectsInComputedProperties as VueNoSideEffectsInComputedProperties;
 pub use crate::rules::vue::no_this_in_before_route_enter::NoThisInBeforeRouteEnter as VueNoThisInBeforeRouteEnter;
 pub use crate::rules::vue::no_watch_after_await::NoWatchAfterAwait as VueNoWatchAfterAwait;
+pub use crate::rules::vue::order_in_components::OrderInComponents as VueOrderInComponents;
 pub use crate::rules::vue::prefer_import_from_vue::PreferImportFromVue as VuePreferImportFromVue;
 pub use crate::rules::vue::prop_name_casing::PropNameCasing as VuePropNameCasing;
 pub use crate::rules::vue::require_default_export::RequireDefaultExport as VueRequireDefaultExport;
@@ -1688,6 +1689,7 @@ pub enum RuleEnum {
     VueNoSideEffectsInComputedProperties(VueNoSideEffectsInComputedProperties),
     VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter),
     VueNoWatchAfterAwait(VueNoWatchAfterAwait),
+    VueOrderInComponents(VueOrderInComponents),
     VuePreferImportFromVue(VuePreferImportFromVue),
     VuePropNameCasing(VuePropNameCasing),
     VueRequireDefaultExport(VueRequireDefaultExport),
@@ -2635,7 +2637,8 @@ const VUE_NO_SIDE_EFFECTS_IN_COMPUTED_PROPERTIES_ID: usize =
 const VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID: usize =
     VUE_NO_SIDE_EFFECTS_IN_COMPUTED_PROPERTIES_ID + 1usize;
 const VUE_NO_WATCH_AFTER_AWAIT_ID: usize = VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID + 1usize;
-const VUE_PREFER_IMPORT_FROM_VUE_ID: usize = VUE_NO_WATCH_AFTER_AWAIT_ID + 1usize;
+const VUE_ORDER_IN_COMPONENTS_ID: usize = VUE_NO_WATCH_AFTER_AWAIT_ID + 1usize;
+const VUE_PREFER_IMPORT_FROM_VUE_ID: usize = VUE_ORDER_IN_COMPONENTS_ID + 1usize;
 const VUE_PROP_NAME_CASING_ID: usize = VUE_PREFER_IMPORT_FROM_VUE_ID + 1usize;
 const VUE_REQUIRE_DEFAULT_EXPORT_ID: usize = VUE_PROP_NAME_CASING_ID + 1usize;
 const VUE_REQUIRE_DEFAULT_PROP_ID: usize = VUE_REQUIRE_DEFAULT_EXPORT_ID + 1usize;
@@ -3606,6 +3609,7 @@ impl RuleEnum {
             }
             Self::VueNoThisInBeforeRouteEnter(_) => VUE_NO_THIS_IN_BEFORE_ROUTE_ENTER_ID,
             Self::VueNoWatchAfterAwait(_) => VUE_NO_WATCH_AFTER_AWAIT_ID,
+            Self::VueOrderInComponents(_) => VUE_ORDER_IN_COMPONENTS_ID,
             Self::VuePreferImportFromVue(_) => VUE_PREFER_IMPORT_FROM_VUE_ID,
             Self::VuePropNameCasing(_) => VUE_PROP_NAME_CASING_ID,
             Self::VueRequireDefaultExport(_) => VUE_REQUIRE_DEFAULT_EXPORT_ID,
@@ -4562,6 +4566,7 @@ impl RuleEnum {
             }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::NAME,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::NAME,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::NAME,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::NAME,
             Self::VuePropNameCasing(_) => VuePropNameCasing::NAME,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::NAME,
@@ -5576,6 +5581,7 @@ impl RuleEnum {
             }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::CATEGORY,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::CATEGORY,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::CATEGORY,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::CATEGORY,
             Self::VuePropNameCasing(_) => VuePropNameCasing::CATEGORY,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::CATEGORY,
@@ -6533,6 +6539,7 @@ impl RuleEnum {
             }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::FIX,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::FIX,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::FIX,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::FIX,
             Self::VuePropNameCasing(_) => VuePropNameCasing::FIX,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::FIX,
@@ -7752,6 +7759,7 @@ impl RuleEnum {
             }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::documentation(),
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::documentation(),
+            Self::VueOrderInComponents(_) => VueOrderInComponents::documentation(),
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::documentation(),
             Self::VuePropNameCasing(_) => VuePropNameCasing::documentation(),
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::documentation(),
@@ -10143,6 +10151,8 @@ impl RuleEnum {
             }
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::config_schema(generator)
                 .or_else(|| VueNoWatchAfterAwait::schema(generator)),
+            Self::VueOrderInComponents(_) => VueOrderInComponents::config_schema(generator)
+                .or_else(|| VueOrderInComponents::schema(generator)),
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::config_schema(generator)
                 .or_else(|| VuePreferImportFromVue::schema(generator)),
             Self::VuePropNameCasing(_) => VuePropNameCasing::config_schema(generator)
@@ -11009,6 +11019,7 @@ impl RuleEnum {
             Self::VueNoSideEffectsInComputedProperties(_) => "vue",
             Self::VueNoThisInBeforeRouteEnter(_) => "vue",
             Self::VueNoWatchAfterAwait(_) => "vue",
+            Self::VueOrderInComponents(_) => "vue",
             Self::VuePreferImportFromVue(_) => "vue",
             Self::VuePropNameCasing(_) => "vue",
             Self::VueRequireDefaultExport(_) => "vue",
@@ -13682,6 +13693,9 @@ impl RuleEnum {
             Self::VueNoWatchAfterAwait(_) => {
                 Ok(Self::VueNoWatchAfterAwait(VueNoWatchAfterAwait::from_configuration(value)?))
             }
+            Self::VueOrderInComponents(_) => {
+                Ok(Self::VueOrderInComponents(VueOrderInComponents::from_configuration(value)?))
+            }
             Self::VuePreferImportFromVue(_) => {
                 Ok(Self::VuePreferImportFromVue(VuePreferImportFromVue::from_configuration(value)?))
             }
@@ -14560,6 +14574,7 @@ impl RuleEnum {
             Self::VueNoSideEffectsInComputedProperties(rule) => rule.to_configuration(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.to_configuration(),
             Self::VueNoWatchAfterAwait(rule) => rule.to_configuration(),
+            Self::VueOrderInComponents(rule) => rule.to_configuration(),
             Self::VuePreferImportFromVue(rule) => rule.to_configuration(),
             Self::VuePropNameCasing(rule) => rule.to_configuration(),
             Self::VueRequireDefaultExport(rule) => rule.to_configuration(),
@@ -15403,6 +15418,7 @@ impl RuleEnum {
             Self::VueNoSideEffectsInComputedProperties(rule) => rule.run(node, ctx),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run(node, ctx),
             Self::VueNoWatchAfterAwait(rule) => rule.run(node, ctx),
+            Self::VueOrderInComponents(rule) => rule.run(node, ctx),
             Self::VuePreferImportFromVue(rule) => rule.run(node, ctx),
             Self::VuePropNameCasing(rule) => rule.run(node, ctx),
             Self::VueRequireDefaultExport(rule) => rule.run(node, ctx),
@@ -16258,6 +16274,7 @@ impl RuleEnum {
             Self::VueNoSideEffectsInComputedProperties(rule) => rule.run_once(ctx),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_once(ctx),
             Self::VueNoWatchAfterAwait(rule) => rule.run_once(ctx),
+            Self::VueOrderInComponents(rule) => rule.run_once(ctx),
             Self::VuePreferImportFromVue(rule) => rule.run_once(ctx),
             Self::VuePropNameCasing(rule) => rule.run_once(ctx),
             Self::VueRequireDefaultExport(rule) => rule.run_once(ctx),
@@ -17230,6 +17247,7 @@ impl RuleEnum {
             }
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueNoWatchAfterAwait(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::VueOrderInComponents(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VuePreferImportFromVue(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VuePropNameCasing(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::VueRequireDefaultExport(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -18086,6 +18104,7 @@ impl RuleEnum {
             Self::VueNoSideEffectsInComputedProperties(rule) => rule.should_run(ctx),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.should_run(ctx),
             Self::VueNoWatchAfterAwait(rule) => rule.should_run(ctx),
+            Self::VueOrderInComponents(rule) => rule.should_run(ctx),
             Self::VuePreferImportFromVue(rule) => rule.should_run(ctx),
             Self::VuePropNameCasing(rule) => rule.should_run(ctx),
             Self::VueRequireDefaultExport(rule) => rule.should_run(ctx),
@@ -19304,6 +19323,7 @@ impl RuleEnum {
             }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::IS_TSGOLINT_RULE,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::IS_TSGOLINT_RULE,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::IS_TSGOLINT_RULE,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::IS_TSGOLINT_RULE,
             Self::VuePropNameCasing(_) => VuePropNameCasing::IS_TSGOLINT_RULE,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::IS_TSGOLINT_RULE,
@@ -20322,6 +20342,7 @@ impl RuleEnum {
             }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::VERSION,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::VERSION,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::VERSION,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::VERSION,
             Self::VuePropNameCasing(_) => VuePropNameCasing::VERSION,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::VERSION,
@@ -21375,6 +21396,7 @@ impl RuleEnum {
             }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::HAS_CONFIG,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::HAS_CONFIG,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::HAS_CONFIG,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::HAS_CONFIG,
             Self::VuePropNameCasing(_) => VuePropNameCasing::HAS_CONFIG,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::HAS_CONFIG,
@@ -22333,6 +22355,7 @@ impl RuleEnum {
             }
             Self::VueNoThisInBeforeRouteEnter(_) => VueNoThisInBeforeRouteEnter::INFO,
             Self::VueNoWatchAfterAwait(_) => VueNoWatchAfterAwait::INFO,
+            Self::VueOrderInComponents(_) => VueOrderInComponents::INFO,
             Self::VuePreferImportFromVue(_) => VuePreferImportFromVue::INFO,
             Self::VuePropNameCasing(_) => VuePropNameCasing::INFO,
             Self::VueRequireDefaultExport(_) => VueRequireDefaultExport::INFO,
@@ -23180,6 +23203,7 @@ impl RuleEnum {
             Self::VueNoSideEffectsInComputedProperties(rule) => rule.types_info(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.types_info(),
             Self::VueNoWatchAfterAwait(rule) => rule.types_info(),
+            Self::VueOrderInComponents(rule) => rule.types_info(),
             Self::VuePreferImportFromVue(rule) => rule.types_info(),
             Self::VuePropNameCasing(rule) => rule.types_info(),
             Self::VueRequireDefaultExport(rule) => rule.types_info(),
@@ -24022,6 +24046,7 @@ impl RuleEnum {
             Self::VueNoSideEffectsInComputedProperties(rule) => rule.run_info(),
             Self::VueNoThisInBeforeRouteEnter(rule) => rule.run_info(),
             Self::VueNoWatchAfterAwait(rule) => rule.run_info(),
+            Self::VueOrderInComponents(rule) => rule.run_info(),
             Self::VuePreferImportFromVue(rule) => rule.run_info(),
             Self::VuePropNameCasing(rule) => rule.run_info(),
             Self::VueRequireDefaultExport(rule) => rule.run_info(),
@@ -25000,6 +25025,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         ),
         RuleEnum::VueNoThisInBeforeRouteEnter(VueNoThisInBeforeRouteEnter::default()),
         RuleEnum::VueNoWatchAfterAwait(VueNoWatchAfterAwait::default()),
+        RuleEnum::VueOrderInComponents(VueOrderInComponents::default()),
         RuleEnum::VuePreferImportFromVue(VuePreferImportFromVue::default()),
         RuleEnum::VuePropNameCasing(VuePropNameCasing::default()),
         RuleEnum::VueRequireDefaultExport(VueRequireDefaultExport::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -882,6 +882,7 @@ pub(crate) mod vue {
     pub mod no_side_effects_in_computed_properties;
     pub mod no_this_in_before_route_enter;
     pub mod no_watch_after_await;
+    pub mod order_in_components;
     pub mod prefer_import_from_vue;
     pub mod prop_name_casing;
     pub mod require_default_export;

--- a/crates/oxc_linter/src/rules/vue/order_in_components.rs
+++ b/crates/oxc_linter/src/rules/vue/order_in_components.rs
@@ -1,0 +1,1741 @@
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use oxc_ast::{
+    AstKind, Comment,
+    ast::{
+        ArrayExpressionElement, ChainElement, Expression, ObjectExpression, ObjectProperty,
+        ObjectPropertyKind, UnaryOperator,
+    },
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+
+use crate::{
+    AstNode,
+    context::LintContext,
+    frameworks::FrameworkOptions,
+    rule::{DefaultRuleConfig, Rule},
+    utils::is_vue_component_options_object,
+};
+
+/// Lifecycle hooks expanded in place of the `LIFECYCLE_HOOKS` placeholder.
+const LIFECYCLE_HOOKS: &[&str] = &[
+    "beforeCreate",
+    "created",
+    "beforeMount",
+    "mounted",
+    "beforeUpdate",
+    "updated",
+    "activated",
+    "deactivated",
+    "beforeUnmount",
+    "unmounted",
+    "beforeDestroy",
+    "destroyed",
+    "renderTracked",
+    "renderTriggered",
+    "errorCaptured",
+];
+
+/// Router guards expanded in place of the `ROUTER_GUARDS` placeholder.
+const ROUTER_GUARDS: &[&str] = &["beforeRouteEnter", "beforeRouteUpdate", "beforeRouteLeave"];
+
+/// Default recommended order. Each inner slice is a group of names that share
+/// the same rank; `LIFECYCLE_HOOKS` / `ROUTER_GUARDS` are placeholders expanded
+/// at that rank.
+const DEFAULT_ORDER: &[&[&str]] = &[
+    &["el"],
+    &["name"],
+    &["key"],
+    &["parent"],
+    &["functional"],
+    &["delimiters", "comments"],
+    &["components", "directives", "filters"],
+    &["extends"],
+    &["mixins"],
+    &["provide", "inject"],
+    &["ROUTER_GUARDS"],
+    &["layout"],
+    &["middleware"],
+    &["validate"],
+    &["scrollToTop"],
+    &["transition"],
+    &["loading"],
+    &["inheritAttrs"],
+    &["model"],
+    &["props", "propsData"],
+    &["emits"],
+    &["slots"],
+    &["expose"],
+    &["setup"],
+    &["asyncData"],
+    &["data"],
+    &["fetch"],
+    &["head"],
+    &["computed"],
+    &["watch"],
+    &["watchQuery"],
+    &["LIFECYCLE_HOOKS"],
+    &["methods"],
+    &["template", "render"],
+    &["renderError"],
+];
+
+fn order_diagnostic(span: Span, name: &str, above: &str, line: usize) -> OxcDiagnostic {
+    OxcDiagnostic::warn(format!(
+        "The \"{name}\" property should be above the \"{above}\" property on line {line}."
+    ))
+    .with_label(span)
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", default, deny_unknown_fields)]
+struct OrderInComponentsConfig {
+    /// Custom property order. Each entry is a single property name or a group of
+    /// names sharing the same rank. Defaults to Vue's recommended order.
+    order: Option<Vec<OrderEntry>>,
+}
+
+/// One entry in the `order` option: either a single name or a group of names
+/// that share the same position.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+enum OrderEntry {
+    Single(String),
+    Group(Vec<String>),
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct OrderInComponents(Box<OrderInComponentsConfig>);
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces a consistent order for the properties of a component definition,
+    /// following the order recommended by the Vue style guide.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// A predictable property order makes components easier to scan and review.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   data() { return {}; },
+    ///   name: 'app',
+    /// }
+    /// </script>
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```vue
+    /// <script>
+    /// export default {
+    ///   name: 'app',
+    ///   data() { return {}; },
+    /// }
+    /// </script>
+    /// ```
+    OrderInComponents,
+    vue,
+    style,
+    conditional_fix_suggestion,
+    config = OrderInComponents,
+    version = "next",
+);
+
+impl Rule for OrderInComponents {
+    fn from_configuration(value: serde_json::Value) -> Result<Self, serde_json::error::Error> {
+        serde_json::from_value::<DefaultRuleConfig<Self>>(value).map(DefaultRuleConfig::into_inner)
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            // Options API: `export default {…}`, `defineComponent({…})`,
+            // `Vue.component('x', {…})`, `Vue.extend({…})`, `new Vue({…})`.
+            AstKind::ObjectExpression(obj) => {
+                if is_vue_component_options_object(node, ctx) {
+                    self.check_order(obj, ctx);
+                }
+            }
+            // `<script setup>`: `defineOptions({…})`.
+            AstKind::CallExpression(call) => {
+                if ctx.frameworks_options() != FrameworkOptions::VueSetup {
+                    return;
+                }
+                if !call
+                    .callee
+                    .get_identifier_reference()
+                    .is_some_and(|i| i.name == "defineOptions")
+                {
+                    return;
+                }
+                if let Some(Expression::ObjectExpression(obj)) = call
+                    .arguments
+                    .first()
+                    .and_then(|a| a.as_expression())
+                    .map(Expression::get_inner_expression)
+                {
+                    self.check_order(obj, ctx);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+impl OrderInComponents {
+    fn order_map(&self) -> FxHashMap<String, usize> {
+        let mut map = FxHashMap::default();
+        let insert = |map: &mut FxHashMap<String, usize>, name: &str, rank: usize| match name {
+            "LIFECYCLE_HOOKS" => {
+                for hook in LIFECYCLE_HOOKS {
+                    map.insert((*hook).to_string(), rank);
+                }
+            }
+            "ROUTER_GUARDS" => {
+                for guard in ROUTER_GUARDS {
+                    map.insert((*guard).to_string(), rank);
+                }
+            }
+            _ => {
+                map.insert(name.to_string(), rank);
+            }
+        };
+        match &self.0.order {
+            Some(order) => {
+                for (rank, entry) in order.iter().enumerate() {
+                    match entry {
+                        OrderEntry::Single(name) => insert(&mut map, name, rank),
+                        OrderEntry::Group(names) => {
+                            for name in names {
+                                insert(&mut map, name, rank);
+                            }
+                        }
+                    }
+                }
+            }
+            None => {
+                for (rank, group) in DEFAULT_ORDER.iter().enumerate() {
+                    for name in *group {
+                        insert(&mut map, name, rank);
+                    }
+                }
+            }
+        }
+        map
+    }
+
+    fn check_order<'a>(&self, obj: &ObjectExpression<'a>, ctx: &LintContext<'a>) {
+        let order_map = self.order_map();
+        let position = |name: &str| order_map.get(name).copied();
+
+        // Keep the original index so the side-effect range can include spreads.
+        let properties: Vec<(usize, &ObjectProperty<'a>, String)> = obj
+            .properties
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, prop)| match prop {
+                ObjectPropertyKind::ObjectProperty(p) => {
+                    // Mirrors upstream: a static name, else the bare identifier of a
+                    // computed key like `[name]`, else empty.
+                    let name = p.key.static_name().map_or_else(
+                        || match p.key.as_expression().map(Expression::get_inner_expression) {
+                            Some(Expression::Identifier(ident)) => ident.name.to_string(),
+                            _ => String::new(),
+                        },
+                        std::borrow::Cow::into_owned,
+                    );
+                    Some((idx, p.as_ref(), name))
+                }
+                ObjectPropertyKind::SpreadProperty(_) => None,
+            })
+            .collect();
+
+        for (list_idx, (orig_idx, prop, name)) in properties.iter().enumerate() {
+            let Some(order_pos) = position(name) else { continue };
+
+            let mut unordered: Vec<&(usize, &ObjectProperty<'a>, String)> = properties[..list_idx]
+                .iter()
+                .filter(|(_, _, n)| position(n).is_some_and(|p| p > order_pos))
+                .collect();
+            unordered.sort_by_key(|(_, _, n)| position(n).unwrap_or(0));
+
+            let Some(first) = unordered.first() else { continue };
+            let (first_idx, first_node, first_name) = *first;
+            let line = source_line(ctx.source_text(), first_node.span().start);
+
+            // A property between the target slot and the current one whose value
+            // may run side effects makes auto-reordering unsafe; downgrade to a
+            // manual suggestion in that case.
+            let has_side_effects = obj.properties[*first_idx..=*orig_idx]
+                .iter()
+                .any(|p| !property_is_side_effect_free(p));
+
+            // Upstream always reports the `order` message; the side-effect variant
+            // is only used as the description of the manual suggestion.
+            let diagnostic = order_diagnostic(prop.span(), name, first_name, line);
+
+            let prop_span = prop.span();
+            let target_span = first_node.span();
+            let message = if has_side_effects {
+                format!(
+                    "Manually move \"{name}\" property above \"{first_name}\" property on line {line} (might break side effects)."
+                )
+            } else {
+                format!("Move \"{name}\" property above \"{first_name}\"")
+            };
+            let make_fix = move |fixer: crate::fixer::RuleFixer<'_, 'a>| {
+                build_move_fix(fixer, ctx, prop_span, target_span, &message)
+            };
+
+            if has_side_effects {
+                ctx.diagnostic_with_suggestion(diagnostic, make_fix);
+            } else {
+                ctx.diagnostic_with_fix(diagnostic, make_fix);
+            }
+        }
+    }
+}
+
+/// 1-based line number of `offset` within `source`.
+fn source_line(source: &str, offset: u32) -> usize {
+    source[..offset as usize].bytes().filter(|&b| b == b'\n').count() + 1
+}
+
+/// Move the property at `prop_span` to just before `target_span`, mirroring the
+/// upstream fixer's comma handling.
+fn build_move_fix<'a>(
+    fixer: crate::fixer::RuleFixer<'_, 'a>,
+    ctx: &LintContext<'a>,
+    prop_span: Span,
+    target_span: Span,
+    message: &str,
+) -> crate::fixer::RuleFix {
+    let src = ctx.source_text();
+    let comments = ctx.comments();
+    let code_start = delimiter_before(src, comments, prop_span.start) + 1;
+    let after_comma = comma_after(src, comments, prop_span.end);
+    let has_after_comma = after_comma.is_some();
+    let code_end = after_comma.unwrap_or(prop_span.end);
+    let remove_start =
+        if has_after_comma { code_start } else { delimiter_before(src, comments, prop_span.start) };
+
+    let mut property_code = src[code_start as usize..code_end as usize].to_string();
+    if !has_after_comma {
+        property_code.push(',');
+    }
+    let insert_pos = delimiter_before(src, comments, target_span.start) + 1;
+
+    let multi = fixer.for_multifix();
+    let mut fixes = multi.new_fix_with_capacity(2);
+    fixes.push(fixer.delete_range(Span::new(remove_start, code_end)));
+    fixes.push(fixer.insert_text_after(&Span::empty(insert_pos), property_code));
+    fixes.with_message(message.to_string())
+}
+
+/// Byte offset of the `{` or `,` immediately before `start`, skipping whitespace
+/// and comments (so a property's leading comment moves with it, mirroring
+/// upstream `getTokenBefore`). Comments come from the parser, so `//` and `*/`
+/// inside string literals are not mistaken for comment delimiters.
+#[expect(clippy::cast_possible_truncation)] // byte offsets within a source file fit in u32
+fn delimiter_before(src: &str, comments: &[Comment], start: u32) -> u32 {
+    let bytes = src.as_bytes();
+    let mut i = start as usize;
+    loop {
+        while i > 0 && bytes[i - 1].is_ascii_whitespace() {
+            i -= 1;
+        }
+        if let Some(comment) = comments.iter().find(|c| c.span.end as usize == i) {
+            i = comment.span.start as usize;
+            continue;
+        }
+        if i == 0 {
+            return 0;
+        }
+        return i as u32 - 1;
+    }
+}
+
+/// Byte offset just after the `,` that follows `end` (skipping whitespace and
+/// comments), or `None` when the next token is not a comma.
+#[expect(clippy::cast_possible_truncation)] // byte offsets within a source file fit in u32
+fn comma_after(src: &str, comments: &[Comment], end: u32) -> Option<u32> {
+    let bytes = src.as_bytes();
+    let mut i = end as usize;
+    loop {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if let Some(comment) = comments.iter().find(|c| c.span.start as usize == i) {
+            i = comment.span.end as usize;
+            continue;
+        }
+        if i < bytes.len() && bytes[i] == b',' {
+            return Some(i as u32 + 1);
+        }
+        return None;
+    }
+}
+
+fn property_is_side_effect_free(prop: &ObjectPropertyKind) -> bool {
+    match prop {
+        ObjectPropertyKind::ObjectProperty(p) => {
+            // A computed key such as `[obj.fn()]` can run side effects too, so it
+            // is part of the property the same way the value is.
+            p.key.as_expression().is_none_or(expr_is_side_effect_free)
+                && expr_is_side_effect_free(&p.value)
+        }
+        ObjectPropertyKind::SpreadProperty(s) => expr_is_side_effect_free(&s.argument),
+    }
+}
+
+/// A link in an optional chain is safe unless it (or anything inside it) is a
+/// call. Mirrors upstream traversing the whole `ChainExpression` for calls.
+fn chain_element_is_side_effect_free(element: &ChainElement) -> bool {
+    match element {
+        ChainElement::CallExpression(_) => false,
+        ChainElement::TSNonNullExpression(e) => expr_is_side_effect_free(&e.expression),
+        ChainElement::StaticMemberExpression(m) => expr_is_side_effect_free(&m.object),
+        ChainElement::ComputedMemberExpression(m) => {
+            expr_is_side_effect_free(&m.object) && expr_is_side_effect_free(&m.expression)
+        }
+        ChainElement::PrivateFieldExpression(m) => expr_is_side_effect_free(&m.object),
+    }
+}
+
+/// Mirrors upstream `isNotSideEffectsNode`: a value is safe to move when it is
+/// free of side effects. Functions are leaves (not invoked here), so their
+/// bodies are not inspected.
+fn expr_is_side_effect_free(expr: &Expression) -> bool {
+    match expr {
+        // Leaves / non-invoked nodes. `as` casts are skipped wholesale upstream.
+        Expression::Identifier(_)
+        | Expression::FunctionExpression(_)
+        | Expression::ArrowFunctionExpression(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::TSAsExpression(_) => true,
+        Expression::TemplateLiteral(t) => t.expressions.iter().all(expr_is_side_effect_free),
+        Expression::ObjectExpression(o) => o.properties.iter().all(property_is_side_effect_free),
+        Expression::ArrayExpression(a) => a.elements.iter().all(|el| match el {
+            // `[...load()]` runs the spread argument, like `{...load()}` does.
+            ArrayExpressionElement::SpreadElement(s) => expr_is_side_effect_free(&s.argument),
+            _ => el.as_expression().is_none_or(expr_is_side_effect_free),
+        }),
+        Expression::UnaryExpression(u) => {
+            matches!(
+                u.operator,
+                UnaryOperator::LogicalNot
+                    | UnaryOperator::BitwiseNot
+                    | UnaryOperator::UnaryPlus
+                    | UnaryOperator::UnaryNegation
+                    | UnaryOperator::Typeof
+            ) && expr_is_side_effect_free(&u.argument)
+        }
+        Expression::BinaryExpression(b) => {
+            expr_is_side_effect_free(&b.left) && expr_is_side_effect_free(&b.right)
+        }
+        Expression::LogicalExpression(l) => {
+            expr_is_side_effect_free(&l.left) && expr_is_side_effect_free(&l.right)
+        }
+        Expression::ConditionalExpression(c) => {
+            expr_is_side_effect_free(&c.test)
+                && expr_is_side_effect_free(&c.consequent)
+                && expr_is_side_effect_free(&c.alternate)
+        }
+        Expression::StaticMemberExpression(m) => expr_is_side_effect_free(&m.object),
+        Expression::ComputedMemberExpression(m) => {
+            expr_is_side_effect_free(&m.object) && expr_is_side_effect_free(&m.expression)
+        }
+        // `a?.b` is safe, but a call anywhere in the chain (`a?.b()`, `a?.b().c`)
+        // is not.
+        Expression::ChainExpression(c) => chain_element_is_side_effect_free(&c.expression),
+        Expression::ParenthesizedExpression(p) => expr_is_side_effect_free(&p.expression),
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use std::path::PathBuf;
+
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "<script>\n
+                    export default {
+                      name: 'app',
+                      props: {
+                        propA: Number,
+                      },
+                      ...a,
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                    }
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      el,
+                      name,
+                      parent,
+                      functional,
+                      delimiters, comments,
+                      components, directives, filters,
+                      extends: MyComp,
+                      mixins,
+                      provide, inject,
+                      inheritAttrs,
+                      model,
+                      props, propsData,
+                      emits,
+                      slots,
+                      expose,
+                      setup,
+                      data,
+                      computed,
+                      watch,
+                      beforeCreate,
+                      created,
+                      beforeMount,
+                      mounted,
+                      beforeUpdate,
+                      updated,
+                      activated,
+                      deactivated,
+                      beforeUnmount,
+                      unmounted,
+                      beforeDestroy,
+                      destroyed,
+                      renderTracked,
+                      renderTriggered,
+                      errorCaptured,
+                      methods,
+                      template, render,
+                      renderError,
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {}
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default 'example-text'
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                    }
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      computed: {
+                        ...mapStates(['foo'])
+                      },
+                    }
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "
+                    Vue.component('smart-list', {
+                      name: 'app',
+                      components: {},
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      }
+                    })
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "
+                    Vue.component('example')
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "
+                    const { component } = Vue;
+                    component('smart-list', {
+                      name: 'app',
+                      components: {},
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      }
+                    })
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "
+                    new Vue({
+                      el: '#app',
+                      name: 'app',
+                      components: {},
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      }
+                    })
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "
+                    new Vue()
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "
+                  <script setup>
+                    defineOptions({
+                      name: 'Foo',
+                      inheritAttrs: true,
+                    })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // { "parser": vueEslintParser }
+    ];
+
+    let fail = vec![
+        (
+            "<script>\n
+                    export default {
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      props: {
+                        propA: Number,
+                      },
+                    }
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    import { defineComponent } from 'vue'
+                    export default defineComponent({
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      props: {
+                        propA: Number,
+                      },
+                    })
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    import { defineNuxtComponent } from '#app'
+                    export default defineNuxtComponent({
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      props: {
+                        propA: Number,
+                      },
+                    })
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // languageOptions,
+        (
+            "<script lang=\"tsx\">\n
+                    export default {
+                      render (h) {
+                        return (
+                          <span>{ this.msg }</span>
+                        )
+                      },
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      props: {
+                        propA: Number,
+                      },
+                    }
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("test.vue")),
+        ), // { "ecmaVersion": 6, "sourceType": "module", "parserOptions": { "ecmaFeatures": { "jsx": true } } },
+        (
+            "
+                    Vue.component('smart-list', {
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      components: {},
+                      template: '<div></div>'
+                    })
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "
+                    app.component('smart-list', {
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      components: {},
+                      template: '<div></div>'
+                    })
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "
+                    const { component } = Vue;
+                    component('smart-list', {
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      components: {},
+                      template: '<div></div>'
+                    })
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "
+                    new Vue({
+                      name: 'app',
+                      el: '#app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      components: {},
+                      template: '<div></div>'
+                    })
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("test.js")),
+        ), // { "ecmaVersion": 6 },
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                        return {
+                          isActive: false,
+                        };
+                      },
+                      methods: {
+                        toggleMenu() {
+                          this.isActive = !this.isActive;
+                        },
+                        closeMenu() {
+                          this.isActive = false;
+                        }
+                      },
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      name: 'burger',
+                      test: 'ok'
+                    };
+                  \n</script>",
+            Some(serde_json::json!([{ "order": ["data", "test", "name"] }])),
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      /** data provider */
+                      data() {
+                      },
+                      /** name of vue component */
+                      name: 'burger'
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      /** data provider */
+                      data() {
+                      }/*test*/,
+                      /** name of vue component */
+                      name: 'burger'
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\nexport default {data(){},name:'burger'};\n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      // data provider
+                      data() {
+                      },
+                      // name of vue component
+                      name: 'burger'
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: obj.fn(),
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: new MyClass(),
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: i++,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: i = 0,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: template`${foo}`,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      [obj.fn()]: 'test',
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: {test: obj.fn()},
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: [obj.fn(), 1],
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: [...load()],
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      [name]: 'x',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: obj.fn().prop,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: delete obj.prop,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: fn() + a + b,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: a ? fn() : null,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: a?.b().c,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: `test ${fn()} ${a}`,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      computed: {
+                        ...mapStates(['foo'])
+                      },
+                      data() {
+                      },
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      name: 'burger',
+                      test: fn(),
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      testArray: [1, 2, 3, true, false, 'a', 'b', 'c'],
+                      testRegExp: /[a-z]*/,
+                      testSpreadElement: [...array],
+                      testOperator: (!!(a - b + c * d / e % f)) || (a && b),
+                      testArrow: (a) => a,
+                      testConditional: a ? b : c,
+                      testYield: function* () {},
+                      testTemplate: `a:${a},b:${b},c:${c}.`,
+                      testNullish: a ?? b,
+                      testOptionalChaining: a?.b?.c,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            r#"
+                    <script lang="ts">
+                      export default {
+                        setup () {},
+                        props: {
+                          foo: { type: Array as PropType<number[]> },
+                        },
+                      };
+                    </script>
+                  "#,
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // { "parser": vueEslintParser, ...languageOptions, "parserOptions": { "parser": { "ts": require.resolve("@typescript-eslint/parser") } } },
+        (
+            "
+                  <script setup>
+                    defineOptions({
+                      inheritAttrs: true,
+                      name: 'Foo',
+                    })
+                  </script>
+                  ",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // { "parser": vueEslintParser },
+        (
+            "<script>\n
+                    export default {
+                      setup,
+                      slots,
+                      expose,
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions,
+        (
+            "<script>\n
+                    export default {
+                      slots,
+                      setup,
+                      expose,
+                    };
+                  \n</script>",
+            None,
+            None,
+            Some(PathBuf::from("example.vue")),
+        ), // languageOptions
+    ];
+
+    let fix = vec![
+        (
+            "<script>\n
+                    export default {
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      props: {
+                        propA: Number,
+                      },
+                    }
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      name: 'app',
+                      props: {
+                        propA: Number,
+                      },
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                    }
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script>\n
+                    import { defineComponent } from 'vue'
+                    export default defineComponent({
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      props: {
+                        propA: Number,
+                      },
+                    })
+                  \n</script>",
+            "<script>\n
+                    import { defineComponent } from 'vue'
+                    export default defineComponent({
+                      name: 'app',
+                      props: {
+                        propA: Number,
+                      },
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                    })
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script>\n
+                    import { defineNuxtComponent } from '#app'
+                    export default defineNuxtComponent({
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      props: {
+                        propA: Number,
+                      },
+                    })
+                  \n</script>",
+            "<script>\n
+                    import { defineNuxtComponent } from '#app'
+                    export default defineNuxtComponent({
+                      name: 'app',
+                      props: {
+                        propA: Number,
+                      },
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                    })
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script lang=\"tsx\">\n
+                    export default {
+                      render (h) {
+                        return (
+                          <span>{ this.msg }</span>
+                        )
+                      },
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      props: {
+                        propA: Number,
+                      },
+                    }
+                  \n</script>",
+            "<script lang=\"tsx\">\n
+                    export default {
+                      name: 'app',
+                      render (h) {
+                        return (
+                          <span>{ this.msg }</span>
+                        )
+                      },
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      props: {
+                        propA: Number,
+                      },
+                    }
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script lang=\"tsx\">\n
+                    Vue.component('smart-list', {
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      components: {},
+                      template: '<div></div>'
+                    })
+                  \n</script>",
+            "<script lang=\"tsx\">\n
+                    Vue.component('smart-list', {
+                      name: 'app',
+                      components: {},
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      template: '<div></div>'
+                    })
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script lang=\"tsx\">\n
+                    app.component('smart-list', {
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      components: {},
+                      template: '<div></div>'
+                    })
+                  \n</script>",
+            "<script lang=\"tsx\">\n
+                    app.component('smart-list', {
+                      name: 'app',
+                      components: {},
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      template: '<div></div>'
+                    })
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script lang=\"tsx\">\n
+                    const { component } = Vue;
+                    component('smart-list', {
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      components: {},
+                      template: '<div></div>'
+                    })
+                  \n</script>",
+            "<script lang=\"tsx\">\n
+                    const { component } = Vue;
+                    component('smart-list', {
+                      name: 'app',
+                      components: {},
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      template: '<div></div>'
+                    })
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script lang=\"tsx\">\n
+                    new Vue({
+                      name: 'app',
+                      el: '#app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      components: {},
+                      template: '<div></div>'
+                    })
+                  \n</script>",
+            "<script lang=\"tsx\">\n
+                    new Vue({
+                      el: '#app',
+                      name: 'app',
+                      data () {
+                        return {
+                          msg: 'Welcome to Your Vue.js App'
+                        }
+                      },
+                      components: {},
+                      template: '<div></div>'
+                    })
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                        return {
+                          isActive: false,
+                        };
+                      },
+                      methods: {
+                        toggleMenu() {
+                          this.isActive = !this.isActive;
+                        },
+                        closeMenu() {
+                          this.isActive = false;
+                        }
+                      },
+                      name: 'burger',
+                    };
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      name: 'burger',
+                      data() {
+                        return {
+                          isActive: false,
+                        };
+                      },
+                      methods: {
+                        toggleMenu() {
+                          this.isActive = !this.isActive;
+                        },
+                        closeMenu() {
+                          this.isActive = false;
+                        }
+                      },
+                    };
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      name: 'burger',
+                      test: 'ok'
+                    };
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      test: 'ok',
+                      name: 'burger'
+                    };
+                  \n</script>",
+            Some(serde_json::json!([{ "order": ["data", "test", "name"] }])),
+        ),
+        (
+            "<script>\n
+                    export default {
+                      /** data provider */
+                      data() {
+                      },
+                      /** name of vue component */
+                      name: 'burger'
+                    };
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      /** name of vue component */
+                      name: 'burger',
+                      /** data provider */
+                      data() {
+                      }
+                    };
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script>\n
+                    export default {
+                      /** data provider */
+                      data() {
+                      }/*test*/,
+                      /** name of vue component */
+                      name: 'burger'
+                    };
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      /** name of vue component */
+                      name: 'burger',
+                      /** data provider */
+                      data() {
+                      }/*test*/
+                    };
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script>\nexport default {data(){},name:'burger'};\n</script>",
+            "<script>\nexport default {name:'burger',data(){}};\n</script>",
+            None,
+        ),
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      url: 'https://example.com',
+                      name: 'burger',
+                    };
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      name: 'burger',
+                      data() {
+                      },
+                      url: 'https://example.com',
+                    };
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script>\n
+                    export default {
+                      // data provider
+                      data() {
+                      },
+                      // name of vue component
+                      name: 'burger'
+                    };
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      // name of vue component
+                      name: 'burger',
+                      // data provider
+                      data() {
+                      }
+                    };
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      name: 'burger',
+                      test: fn(),
+                    };
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      name: 'burger',
+                      data() {
+                      },
+                      test: fn(),
+                    };
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script>\n
+                    export default {
+                      data() {
+                      },
+                      testArray: [1, 2, 3, true, false, 'a', 'b', 'c'],
+                      testRegExp: /[a-z]*/,
+                      testSpreadElement: [...array],
+                      testOperator: (!!(a - b + c * d / e % f)) || (a && b),
+                      testArrow: (a) => a,
+                      testConditional: a ? b : c,
+                      testYield: function* () {},
+                      testTemplate: `a:${a},b:${b},c:${c}.`,
+                      testNullish: a ?? b,
+                      testOptionalChaining: a?.b?.c,
+                      name: 'burger',
+                    };
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      name: 'burger',
+                      data() {
+                      },
+                      testArray: [1, 2, 3, true, false, 'a', 'b', 'c'],
+                      testRegExp: /[a-z]*/,
+                      testSpreadElement: [...array],
+                      testOperator: (!!(a - b + c * d / e % f)) || (a && b),
+                      testArrow: (a) => a,
+                      testConditional: a ? b : c,
+                      testYield: function* () {},
+                      testTemplate: `a:${a},b:${b},c:${c}.`,
+                      testNullish: a ?? b,
+                      testOptionalChaining: a?.b?.c,
+                    };
+                  \n</script>",
+            None,
+        ),
+        (
+            r#"
+                    <script lang="ts">
+                      export default {
+                        setup () {},
+                        props: {
+                          foo: { type: Array as PropType<number[]> },
+                        },
+                      };
+                    </script>
+                  "#,
+            r#"
+                    <script lang="ts">
+                      export default {
+                        props: {
+                          foo: { type: Array as PropType<number[]> },
+                        },
+                        setup () {},
+                      };
+                    </script>
+                  "#,
+            None,
+        ),
+        (
+            "
+                  <script setup>
+                    defineOptions({
+                      inheritAttrs: true,
+                      name: 'Foo',
+                    })
+                  </script>
+                  ",
+            "
+                  <script setup>
+                    defineOptions({
+                      name: 'Foo',
+                      inheritAttrs: true,
+                    })
+                  </script>
+                  ",
+            None,
+        ),
+        (
+            "<script>\n
+                    export default {
+                      setup,
+                      slots,
+                      expose,
+                    };
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      slots,
+                      setup,
+                      expose,
+                    };
+                  \n</script>",
+            None,
+        ),
+        (
+            "<script>\n
+                    export default {
+                      slots,
+                      setup,
+                      expose,
+                    };
+                  \n</script>",
+            "<script>\n
+                    export default {
+                      slots,
+                      expose,
+                      setup,
+                    };
+                  \n</script>",
+            None,
+        ),
+    ];
+
+    Tester::new(OrderInComponents::NAME, OrderInComponents::PLUGIN, pass, fail)
+        .change_rule_path_extension("vue")
+        .expect_fix(fix)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/vue_order_in_components.snap
+++ b/crates/oxc_linter/src/snapshots/vue_order_in_components.snap
@@ -1,0 +1,380 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ vue(order-in-components): The "props" property should be above the "data" property on line 5.
+    ╭─[order_in_components.vue:10:23]
+  9 │                           },
+ 10 │ ╭─▶                       props: {
+ 11 │ │                           propA: Number,
+ 12 │ ╰─▶                       },
+ 13 │                         }
+    ╰────
+  help: Move "props" property above "data"
+
+  ⚠ vue(order-in-components): The "props" property should be above the "data" property on line 6.
+    ╭─[order_in_components.vue:11:23]
+ 10 │                           },
+ 11 │ ╭─▶                       props: {
+ 12 │ │                           propA: Number,
+ 13 │ ╰─▶                       },
+ 14 │                         })
+    ╰────
+  help: Move "props" property above "data"
+
+  ⚠ vue(order-in-components): The "props" property should be above the "data" property on line 6.
+    ╭─[order_in_components.vue:11:23]
+ 10 │                           },
+ 11 │ ╭─▶                       props: {
+ 12 │ │                           propA: Number,
+ 13 │ ╰─▶                       },
+ 14 │                         })
+    ╰────
+  help: Move "props" property above "data"
+
+  ⚠ vue(order-in-components): The "name" property should be above the "render" property on line 4.
+    ╭─[order_in_components.vue:9:23]
+  8 │                       },
+  9 │                       name: 'app',
+    ·                       ───────────
+ 10 │                       data () {
+    ╰────
+  help: Move "name" property above "render"
+
+  ⚠ vue(order-in-components): The "data" property should be above the "render" property on line 4.
+    ╭─[order_in_components.vue:10:23]
+  9 │                           name: 'app',
+ 10 │ ╭─▶                       data () {
+ 11 │ │                           return {
+ 12 │ │                             msg: 'Welcome to Your Vue.js App'
+ 13 │ │                           }
+ 14 │ ╰─▶                       },
+ 15 │                           props: {
+    ╰────
+  help: Move "data" property above "render"
+
+  ⚠ vue(order-in-components): The "props" property should be above the "data" property on line 10.
+    ╭─[order_in_components.vue:15:23]
+ 14 │                           },
+ 15 │ ╭─▶                       props: {
+ 16 │ │                           propA: Number,
+ 17 │ ╰─▶                       },
+ 18 │                         }
+    ╰────
+  help: Move "props" property above "data"
+
+  ⚠ vue(order-in-components): The "components" property should be above the "data" property on line 4.
+    ╭─[order_in_components.vue:9:23]
+  8 │                       },
+  9 │                       components: {},
+    ·                       ──────────────
+ 10 │                       template: '<div></div>'
+    ╰────
+  help: Move "components" property above "data"
+
+  ⚠ vue(order-in-components): The "components" property should be above the "data" property on line 4.
+    ╭─[order_in_components.vue:9:23]
+  8 │                       },
+  9 │                       components: {},
+    ·                       ──────────────
+ 10 │                       template: '<div></div>'
+    ╰────
+  help: Move "components" property above "data"
+
+  ⚠ vue(order-in-components): The "components" property should be above the "data" property on line 5.
+    ╭─[order_in_components.vue:10:23]
+  9 │                       },
+ 10 │                       components: {},
+    ·                       ──────────────
+ 11 │                       template: '<div></div>'
+    ╰────
+  help: Move "components" property above "data"
+
+  ⚠ vue(order-in-components): The "el" property should be above the "name" property on line 3.
+   ╭─[order_in_components.vue:4:23]
+ 3 │                       name: 'app',
+ 4 │                       el: '#app',
+   ·                       ──────────
+ 5 │                       data () {
+   ╰────
+  help: Move "el" property above "name"
+
+  ⚠ vue(order-in-components): The "components" property should be above the "data" property on line 5.
+    ╭─[order_in_components.vue:10:23]
+  9 │                       },
+ 10 │                       components: {},
+    ·                       ──────────────
+ 11 │                       template: '<div></div>'
+    ╰────
+  help: Move "components" property above "data"
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+    ╭─[order_in_components.vue:17:23]
+ 16 │                       },
+ 17 │                       name: 'burger',
+    ·                       ──────────────
+ 18 │                     };
+    ╰────
+  help: Move "name" property above "data"
+
+  ⚠ vue(order-in-components): The "test" property should be above the "name" property on line 6.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       name: 'burger',
+ 7 │                       test: 'ok'
+   ·                       ──────────
+ 8 │                     };
+   ╰────
+  help: Move "test" property above "name"
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 5.
+   ╭─[order_in_components.vue:8:23]
+ 7 │                       /** name of vue component */
+ 8 │                       name: 'burger'
+   ·                       ──────────────
+ 9 │                     };
+   ╰────
+  help: Move "name" property above "data"
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 5.
+   ╭─[order_in_components.vue:8:23]
+ 7 │                       /** name of vue component */
+ 8 │                       name: 'burger'
+   ·                       ──────────────
+ 9 │                     };
+   ╰────
+  help: Move "name" property above "data"
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 2.
+   ╭─[order_in_components.vue:2:26]
+ 1 │ <script>
+ 2 │ export default {data(){},name:'burger'};
+   ·                          ─────────────
+ 3 │ </script>
+   ╰────
+  help: Move "name" property above "data"
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 5.
+   ╭─[order_in_components.vue:8:23]
+ 7 │                       // name of vue component
+ 8 │                       name: 'burger'
+   ·                       ──────────────
+ 9 │                     };
+   ╰────
+  help: Move "name" property above "data"
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: obj.fn(),
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: new MyClass(),
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: i++,
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: i = 0,
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: template`${foo}`,
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       [obj.fn()]: 'test',
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: {test: obj.fn()},
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: [obj.fn(), 1],
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: [...load()],
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:6:23]
+ 5 │                       },
+ 6 │                       [name]: 'x',
+   ·                       ───────────
+ 7 │                     };
+   ╰────
+  help: Move "name" property above "data"
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: obj.fn().prop,
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: delete obj.prop,
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: fn() + a + b,
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: a ? fn() : null,
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: a?.b().c,
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                       test: `test ${fn()} ${a}`,
+ 7 │                       name: 'burger',
+   ·                       ──────────────
+ 8 │                     };
+   ╰────
+  help: Manually move "name" property above "data" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "data" property should be above the "computed" property on line 4.
+   ╭─[order_in_components.vue:7:23]
+ 6 │                           },
+ 7 │ ╭─▶                       data() {
+ 8 │ ╰─▶                       },
+ 9 │                         };
+   ╰────
+  help: Manually move "data" property above "computed" property on line 4 (might break side effects).
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+   ╭─[order_in_components.vue:6:23]
+ 5 │                       },
+ 6 │                       name: 'burger',
+   ·                       ──────────────
+ 7 │                       test: fn(),
+   ╰────
+  help: Move "name" property above "data"
+
+  ⚠ vue(order-in-components): The "name" property should be above the "data" property on line 4.
+    ╭─[order_in_components.vue:16:23]
+ 15 │                       testOptionalChaining: a?.b?.c,
+ 16 │                       name: 'burger',
+    ·                       ──────────────
+ 17 │                     };
+    ╰────
+  help: Move "name" property above "data"
+
+  ⚠ vue(order-in-components): The "props" property should be above the "setup" property on line 3.
+   ╭─[order_in_components.vue:5:25]
+ 4 │                             setup () {},
+ 5 │ ╭─▶                         props: {
+ 6 │ │                             foo: { type: Array as PropType<number[]> },
+ 7 │ ╰─▶                         },
+ 8 │                           };
+   ╰────
+  help: Move "props" property above "setup"
+
+  ⚠ vue(order-in-components): The "name" property should be above the "inheritAttrs" property on line 3.
+   ╭─[order_in_components.vue:5:23]
+ 4 │                       inheritAttrs: true,
+ 5 │                       name: 'Foo',
+   ·                       ───────────
+ 6 │                     })
+   ╰────
+  help: Move "name" property above "inheritAttrs"
+
+  ⚠ vue(order-in-components): The "slots" property should be above the "setup" property on line 4.
+   ╭─[order_in_components.vue:5:23]
+ 4 │                       setup,
+ 5 │                       slots,
+   ·                       ─────
+ 6 │                       expose,
+   ╰────
+  help: Move "slots" property above "setup"
+
+  ⚠ vue(order-in-components): The "expose" property should be above the "setup" property on line 4.
+   ╭─[order_in_components.vue:6:23]
+ 5 │                       slots,
+ 6 │                       expose,
+   ·                       ──────
+ 7 │                     };
+   ╰────
+  help: Move "expose" property above "setup"
+
+  ⚠ vue(order-in-components): The "expose" property should be above the "setup" property on line 5.
+   ╭─[order_in_components.vue:6:23]
+ 5 │                       setup,
+ 6 │                       expose,
+   ·                       ──────
+ 7 │                     };
+   ╰────
+  help: Move "expose" property above "setup"

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10239,6 +10239,26 @@
         "vue/no-watch-after-await": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "vue/order-in-components": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuleNoConfig"
+            },
+            {
+              "type": "array",
+              "items": [
+                {
+                  "$ref": "#/definitions/AllowWarnDeny"
+                },
+                {
+                  "$ref": "#/definitions/OrderInComponents"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          ]
+        },
         "vue/prefer-import-from-vue": {
           "$ref": "#/definitions/RuleNoConfig"
         },
@@ -16157,6 +16177,39 @@
           "additionalProperties": false
         }
       ]
+    },
+    "OrderEntry": {
+      "description": "One entry in the `order` option: either a single name or a group of names\nthat share the same position.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ],
+      "markdownDescription": "One entry in the `order` option: either a single name or a group of names\nthat share the same position."
+    },
+    "OrderInComponents": {
+      "$ref": "#/definitions/OrderInComponentsConfig"
+    },
+    "OrderInComponentsConfig": {
+      "type": "object",
+      "properties": {
+        "order": {
+          "description": "Custom property order. Each entry is a single property name or a group of\nnames sharing the same rank. Defaults to Vue's recommended order.",
+          "default": null,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OrderEntry"
+          },
+          "markdownDescription": "Custom property order. Each entry is a single property name or a group of\nnames sharing the same rank. Defaults to Vue's recommended order."
+        }
+      },
+      "additionalProperties": false
     },
     "Override": {
       "type": "object",


### PR DESCRIPTION
Implements `vue/order-in-components` from eslint-plugin-vue.

Part of #11440.

eslint-plugin-vue reference: https://eslint.vuejs.org/rules/order-in-components.html

AI disclosure: implemented with Claude Code.