### PR TITLE
fix(refactor/node/handle-callback-err): reject invalid regex config

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -177,6 +177,7 @@ export type CallbackReturn = string[];
  * - a regexp pattern (e.g. `"^(err|error)$"`)
  *
  * If the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.
+ * Invalid regexp patterns are rejected during configuration parsing.
  *
  * Default: `"err"`.
  */

--- a/crates/oxc_linter/src/rules/node/handle_callback_err.rs
+++ b/crates/oxc_linter/src/rules/node/handle_callback_err.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use lazy_regex::Regex;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, de::Error as _};
 
 use oxc_ast::{AstKind, ast::FormalParameters};
 use oxc_diagnostics::OxcDiagnostic;
@@ -48,12 +48,12 @@ where
 {
     let s = <Cow<str>>::deserialize(deserializer)?;
 
-    let pattern = {
-        if s.starts_with('^') {
-            Regex::new(&s).map_or_else(|_| ErrorPattern::Plain(s.to_string()), ErrorPattern::Regex)
-        } else {
-            ErrorPattern::Plain(s.to_string())
-        }
+    let pattern = if s.starts_with('^') {
+        Regex::new(&s).map(ErrorPattern::Regex).map_err(|err| {
+            D::Error::custom(format!("invalid error parameter regex `{s}`: {err}"))
+        })?
+    } else {
+        ErrorPattern::Plain(s.to_string())
     };
 
     Ok(Box::new(pattern))
@@ -66,6 +66,7 @@ where
 /// - a regexp pattern (e.g. `"^(err|error)$"`)
 ///
 /// If the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.
+/// Invalid regexp patterns are rejected during configuration parsing.
 ///
 /// Default: `"err"`.
 #[derive(Debug, Clone, Default, JsonSchema, Deserialize)]

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -11169,9 +11169,9 @@
       "additionalProperties": false
     },
     "HandleCallbackErrConfig": {
-      "description": "The rule takes a single string option: the name of the error parameter.\n\nThis can be either:\n- an exact name (e.g. `\"err\"`, `\"error\"`)\n- a regexp pattern (e.g. `\"^(err|error)$\"`)\n\nIf the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.\n\nDefault: `\"err\"`.",
+      "description": "The rule takes a single string option: the name of the error parameter.\n\nThis can be either:\n- an exact name (e.g. `\"err\"`, `\"error\"`)\n- a regexp pattern (e.g. `\"^(err|error)$\"`)\n\nIf the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.\nInvalid regexp patterns are rejected during configuration parsing.\n\nDefault: `\"err\"`.",
       "type": "string",
-      "markdownDescription": "The rule takes a single string option: the name of the error parameter.\n\nThis can be either:\n- an exact name (e.g. `\"err\"`, `\"error\"`)\n- a regexp pattern (e.g. `\"^(err|error)$\"`)\n\nIf the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.\n\nDefault: `\"err\"`."
+      "markdownDescription": "The rule takes a single string option: the name of the error parameter.\n\nThis can be either:\n- an exact name (e.g. `\"err\"`, `\"error\"`)\n- a regexp pattern (e.g. `\"^(err|error)$\"`)\n\nIf the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.\nInvalid regexp patterns are rejected during configuration parsing.\n\nDefault: `\"err\"`."
     },
     "HeadingHasContentConfig": {
       "type": "object",


### PR DESCRIPTION
Reject invalid caret-prefixed `node/handle-callback-err` patterns during configuration parsing instead of falling back to literal string matching.

`^`-prefixed options are documented as regex patterns, so malformed regex input should surface as a config error.

Part of #23594