### PR TITLE
fix(linter/eslint/no-warning-comments): avoid dropping generated regex patterns

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_warning_comments.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_warning_comments.rs
@@ -209,7 +209,7 @@ impl NoWarningComments {
 
         terms
             .iter()
-            .filter_map(|term| {
+            .map(|term| {
                 let ends_with_word =
                     term.chars().last().is_some_and(|c| c.is_alphanumeric() || c == '_');
                 let suffix = if ends_with_word { r"\b" } else { "" };
@@ -228,7 +228,9 @@ impl NoWarningComments {
                     }
                 };
 
-                Regex::new(&pattern).ok()
+                Regex::new(&pattern).expect(
+                    "generated no-warning-comments regex should compile because user input is escaped",
+                )
             })
             .collect()
     }


### PR DESCRIPTION
This makes `eslint/no-warning-comments` fail explicitly if an internally generated regex ever stops compiling, rather than silently dropping that configured term from matching. User-provided terms and decorations are still escaped before interpolation, so matching behavior is unchanged for valid configurations.

Part of #23594.