### PR TITLE
fix(linter/valid-title): escape disallowed words regex

### DIFF
--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -223,6 +223,11 @@ fn test() {
             None,
         ),
         ("it(String.raw`foo`, () => {})", None),
+        (
+            "test('fooobar', () => {});",
+            Some(serde_json::json!([{ "disallowedWords": ["foo+bar"] }])),
+        ),
+        ("test('foo', () => {});", Some(serde_json::json!([{ "disallowedWords": ["foo|bar"] }]))),
     ];
 
     let fail = vec![
@@ -250,6 +255,18 @@ fn test() {
         (
             "test(`that the value is set properly`, function () {})",
             Some(serde_json::json!([{ "disallowedWords": ["properly"] }])),
+        ),
+        (
+            "test('foo+bar', () => {});",
+            Some(serde_json::json!([{ "disallowedWords": ["foo+bar"] }])),
+        ),
+        (
+            "test('foo|bar', () => {});",
+            Some(serde_json::json!([{ "disallowedWords": ["foo|bar"] }])),
+        ),
+        (
+            "test('foo[bar', () => {});",
+            Some(serde_json::json!([{ "disallowedWords": ["foo[bar"] }])),
         ),
         // TODO: The regex `(?:#(?!unit|e2e))\w+` in those test cases is not valid in Rust
         // (

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_title.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
-use cow_utils::CowUtils;
-use lazy_regex::Regex;
+use itertools::Itertools;
+use lazy_regex::{Regex, regex};
 use rustc_hash::FxHashMap;
 
 use oxc_ast::{
@@ -408,12 +408,10 @@ fn validate_title(
     }
 
     if !config.disallowed_words.is_empty() {
-        let Ok(disallowed_words_reg) = Regex::new(&format!(
-            r"(?iu)\b(?:{})\b",
-            config.disallowed_words.join("|").cow_replace('.', r"\.")
-        )) else {
-            return;
-        };
+        let disallowed_words_pattern =
+            config.disallowed_words.iter().map(|word| regex::escape(word)).join("|");
+        let disallowed_words_reg = Regex::new(&format!(r"(?iu)\b(?:{disallowed_words_pattern})\b"))
+            .expect("escaped disallowed words should form a valid regex");
 
         if let Some(matched) = disallowed_words_reg.find(title) {
             ctx.diagnostic(disallowed_word_diagnostic(matched.as_str(), span));

--- a/crates/oxc_linter/src/rules/vitest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/vitest/valid_title.rs
@@ -224,6 +224,11 @@ fn test() {
         ),
         // https://github.com/oxc-project/oxc/issues/22268
         ("it(String.raw`foo`, () => {})", None),
+        (
+            "test('fooobar', () => {});",
+            Some(serde_json::json!([{ "disallowedWords": ["foo+bar"] }])),
+        ),
+        ("test('foo', () => {});", Some(serde_json::json!([{ "disallowedWords": ["foo|bar"] }]))),
     ];
 
     let fail = vec![
@@ -251,6 +256,18 @@ fn test() {
         (
             "test(`that the value is set properly`, function () {})",
             Some(serde_json::json!([{ "disallowedWords": ["properly"] }])),
+        ),
+        (
+            "test('foo+bar', () => {});",
+            Some(serde_json::json!([{ "disallowedWords": ["foo+bar"] }])),
+        ),
+        (
+            "test('foo|bar', () => {});",
+            Some(serde_json::json!([{ "disallowedWords": ["foo|bar"] }])),
+        ),
+        (
+            "test('foo[bar', () => {});",
+            Some(serde_json::json!([{ "disallowedWords": ["foo[bar"] }])),
         ),
         // TODO: The regex `(?:#(?!unit|e2e))\w+` in those test cases is not valid in Rust
         // (

--- a/crates/oxc_linter/src/snapshots/jest_valid_title.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_title.snap
@@ -51,6 +51,27 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: It is included in the `disallowedWords` of your config file, try to remove it from your title
 
+  ⚠ jest(valid-title): foo+bar is not allowed in test title
+   ╭─[valid_title.tsx:1:6]
+ 1 │ test('foo+bar', () => {});
+   ·      ─────────
+   ╰────
+  help: It is included in the `disallowedWords` of your config file, try to remove it from your title
+
+  ⚠ jest(valid-title): foo|bar is not allowed in test title
+   ╭─[valid_title.tsx:1:6]
+ 1 │ test('foo|bar', () => {});
+   ·      ─────────
+   ╰────
+  help: It is included in the `disallowedWords` of your config file, try to remove it from your title
+
+  ⚠ jest(valid-title): foo[bar is not allowed in test title
+   ╭─[valid_title.tsx:1:6]
+ 1 │ test('foo[bar', () => {});
+   ·      ─────────
+   ╰────
+  help: It is included in the `disallowedWords` of your config file, try to remove it from your title
+
   ⚠ jest(valid-title): test should match (?u)#(?:unit|integration|e2e)
    ╭─[valid_title.tsx:1:6]
  1 │ test('the correct way to properly handle all things', () => {});

--- a/crates/oxc_linter/src/snapshots/vitest_valid_title.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_valid_title.snap
@@ -51,6 +51,27 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: It is included in the `disallowedWords` of your config file, try to remove it from your title
 
+  ⚠ vitest(valid-title): foo+bar is not allowed in test title
+   ╭─[valid_title.tsx:1:6]
+ 1 │ test('foo+bar', () => {});
+   ·      ─────────
+   ╰────
+  help: It is included in the `disallowedWords` of your config file, try to remove it from your title
+
+  ⚠ vitest(valid-title): foo|bar is not allowed in test title
+   ╭─[valid_title.tsx:1:6]
+ 1 │ test('foo|bar', () => {});
+   ·      ─────────
+   ╰────
+  help: It is included in the `disallowedWords` of your config file, try to remove it from your title
+
+  ⚠ vitest(valid-title): foo[bar is not allowed in test title
+   ╭─[valid_title.tsx:1:6]
+ 1 │ test('foo[bar', () => {});
+   ·      ─────────
+   ╰────
+  help: It is included in the `disallowedWords` of your config file, try to remove it from your title
+
   ⚠ vitest(valid-title): test should match (?u)#(?:unit|integration|e2e)
    ╭─[valid_title.tsx:1:6]
  1 │ test('the correct way to properly handle all things', () => {});


### PR DESCRIPTION
- Escape `jest/valid-title` and `vitest/valid-title` `disallowedWords` before building the generated regex.
- Replace the silent generated-regex compile skip with an `expect`, since escaped user words should produce a valid pattern.

Part of #23594