### PR TITLE
fix(traverse): fix unsoundness in `Traverse` walk functions

### DIFF
--- a/crates/oxc_minifier/src/generated/walk.rs
+++ b/crates/oxc_minifier/src/generated/walk.rs
@@ -13,7 +13,7 @@
 
 use std::{cell::Cell, marker::PhantomData};
 
-use oxc_allocator::Vec;
+use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::*;
 use oxc_syntax::scope::ScopeId;
 

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -13,7 +13,7 @@
 
 use std::{cell::Cell, marker::PhantomData};
 
-use oxc_allocator::Vec;
+use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::*;
 use oxc_syntax::scope::ScopeId;
 

--- a/tasks/ast_tools/src/generators/traverse/walk.rs
+++ b/tasks/ast_tools/src/generators/traverse/walk.rs
@@ -89,7 +89,7 @@ pub(super) fn generate_walk(schema: &Schema, config: &WalkConfig) -> TokenStream
         use std::{cell::Cell, marker::PhantomData};
 
         ///@@line_break
-        use oxc_allocator::Vec;
+        use oxc_allocator::{Box, Vec};
         use oxc_ast::ast::*;
         use oxc_syntax::scope::ScopeId;
 


### PR DESCRIPTION
`Box` in `walk.rs` referred to `std::boxed::Box` instead of `oxc_allocator::Box`.

`Box`es are temporarily dereferenced in walk functions before being cast back to pointers. This may be UB, as `std`'s `Box` contains a `Unique<T>` pointer which guarantees that it's the only pointer pointing to the `T` (same semantics as `&mut T`). But `Traverse` intentionally violates that invariant when looking back up the tree - it uses pointers rather than references everywhere precisely to avoid aliasing hazards.

I'm unclear whether `Unique` passes the "uniqueness" guarantee to LLVM at present. If it doesn't, I don't think this mistake could have caused miscompilation. But certainly `Unique` could (and probably will) do so in future, so this was an accident waiting to happen.

Fix this by using `oxc_allocator::Box` instead of `std::boxed::Box`.