### PR TITLE
refactor(allocator): export `ArenaBox` and `ArenaVec` aliases

### DIFF
--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -73,17 +73,17 @@ pub use address::{Address, GetAddress, UnstableAddress};
 pub use allocator::Allocator;
 #[cfg(feature = "bitset")]
 pub use bitset::BitSet;
-pub use boxed::Box;
+pub use boxed::{Box, Box as ArenaBox};
 pub use clone_in::CloneIn;
 pub use convert::{FromIn, IntoIn};
-pub use hash_map::HashMap;
-pub use hash_set::HashSet;
+pub use hash_map::{HashMap, HashMap as ArenaHashMap};
+pub use hash_set::{HashSet, HashSet as ArenaHashSet};
 pub use ident_hasher::{IdentBuildHasher, ident_hash, pack_len_hash};
 #[cfg(feature = "pool")]
 pub use pool::*;
-pub use string_builder::StringBuilder;
+pub use string_builder::{StringBuilder, StringBuilder as ArenaStringBuilder};
 pub use take_in::{Dummy, TakeIn};
-pub use vec::Vec;
+pub use vec::{Vec, Vec as ArenaVec};
 
 // Fixed size allocators are only supported on 64-bit little-endian platforms at present.
 //

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -6,7 +6,7 @@ mod partitioned_chunk;
 mod sortable_imports;
 mod source_line;
 
-use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec};
 
 use crate::{
     Buffer, JsLabels, SortImportsOptions,

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/source_line.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 
 use crate::{
     JsLabels,

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 

--- a/crates/oxc_formatter/src/print/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/print/jsx/child_list.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 

--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -4,7 +4,7 @@ use unicode_width::UnicodeWidthStr;
 
 use std::cmp;
 
-use oxc_allocator::{StringBuilder, Vec as ArenaVec};
+use oxc_allocator::{ArenaVec, StringBuilder};
 use oxc_ast::ast::*;
 use oxc_formatter_core::IndentWidth;
 use oxc_span::{GetSpan, Span};

--- a/crates/oxc_formatter/src/utils/jsx.rs
+++ b/crates/oxc_formatter/src/utils/jsx.rs
@@ -4,7 +4,7 @@ use std::{
     str::Chars,
 };
 
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 
 use crate::QuoteStyle;

--- a/crates/oxc_formatter_core/src/buffer.rs
+++ b/crates/oxc_formatter_core/src/buffer.rs
@@ -7,7 +7,7 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{Allocator, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec, TakeIn};
 
 use crate::{
     Argument, Arguments, Format, FormatElement, FormatState,

--- a/crates/oxc_formatter_core/src/builders.rs
+++ b/crates/oxc_formatter_core/src/builders.rs
@@ -5,7 +5,7 @@
 
 use std::num::NonZeroU8;
 
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 
 use crate::{
     Argument, Arguments, Buffer, Format, FormatContext, FormatElement, FormatOptions, Formatter,

--- a/crates/oxc_formatter_core/src/format_element/document.rs
+++ b/crates/oxc_formatter_core/src/format_element/document.rs
@@ -1,7 +1,7 @@
 #![expect(clippy::mutable_key_type)]
 use std::ops::Deref;
 
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 use rustc_hash::FxHashMap;
 
 use super::{

--- a/crates/oxc_formatter_core/src/format_element/mod.rs
+++ b/crates/oxc_formatter_core/src/format_element/mod.rs
@@ -10,7 +10,7 @@ use std::{borrow::Cow, ops::Deref};
 
 use unicode_width::UnicodeWidthStr;
 
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 
 use crate::IndentWidth;
 

--- a/crates/oxc_formatter_core/src/formatter.rs
+++ b/crates/oxc_formatter_core/src/formatter.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 
-use oxc_allocator::{Allocator, GetAllocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
 
 use crate::{
     Argument, Arguments, Buffer, FormatContext, FormatElement, FormatState, VecBuffer,

--- a/crates/oxc_formatter_json/src/parse.rs
+++ b/crates/oxc_formatter_json/src/parse.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::{
     Comment,
     ast::{Expression, Statement},

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, Box as ArenaBox, CloneIn, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{ContentEq, GetSpan, SPAN};
 

--- a/crates/oxc_isolated_declarations/src/declaration.rs
+++ b/crates/oxc_isolated_declarations/src/declaration.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use oxc_allocator::{Box as ArenaBox, CloneIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec, CloneIn};
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, VisitMut, walk_mut::walk_ts_signatures};
 use oxc_ecmascript::BoundNames;

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box as ArenaBox, CloneIn};
+use oxc_allocator::{ArenaBox, CloneIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{SPAN, Span};
 

--- a/crates/oxc_isolated_declarations/src/inferrer.rs
+++ b/crates/oxc_isolated_declarations/src/inferrer.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box as ArenaBox, CloneIn};
+use oxc_allocator::{ArenaBox, CloneIn};
 use oxc_ast::ast::{
     ArrowFunctionExpression, Expression, FormalParameter, Function, Statement, TSType,
     TSTypeAnnotation, UnaryExpression,

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -9,7 +9,7 @@ use std::{cell::RefCell, iter::repeat_with, mem};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use oxc_allocator::{Allocator, CloneIn, GetAllocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};

--- a/crates/oxc_isolated_declarations/src/literal.rs
+++ b/crates/oxc_isolated_declarations/src/literal.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box as ArenaBox;
+use oxc_allocator::ArenaBox;
 use oxc_ast::ast::{StringLiteral, TemplateLiteral};
 
 use crate::IsolatedDeclarations;

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box as ArenaBox, CloneIn, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec, CloneIn, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{GetSpan, SPAN};
 use oxc_str::Str;

--- a/crates/oxc_isolated_declarations/src/signatures.rs
+++ b/crates/oxc_isolated_declarations/src/signatures.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{CloneIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaVec, CloneIn};
 use oxc_ast::ast::{TSMethodSignatureKind, TSSignature};
 use oxc_span::GetSpan;
 

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use oxc_allocator::Box as ArenaBox;
+use oxc_allocator::ArenaBox;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_parser::Token;
 use oxc_semantic::Semantic;

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
     string::ToString,
 };
 
-use oxc_allocator::{Allocator, AllocatorPool, CloneIn, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{Allocator, AllocatorPool, ArenaVec, CloneIn, TakeIn};
 use oxc_ast::{
     ast::{Comment, CommentContent, CommentKind, Program},
     ast_kind::AST_TYPE_MAX,

--- a/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use oxc_allocator::Box as ArenaBox;
+use oxc_allocator::ArenaBox;
 use oxc_ast::{
     AstKind,
     ast::{

--- a/crates/oxc_linter/src/rules/eslint/no_useless_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_return.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::AstKind;
 use oxc_cfg::{
     EdgeType, ErrorEdgeKind, InstructionKind,

--- a/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box as ArenaBox;
+use oxc_allocator::ArenaBox;
 use oxc_ast::{
     AstKind,
     ast::{Argument, CallExpression, Expression, FormalParameters},

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -5,7 +5,7 @@ use crate::{
     rule::{DefaultRuleConfig, Rule},
     utils::is_jsx_fragment,
 };
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::{
     AstKind,
     ast::{

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -19,7 +19,7 @@ use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet, FxHasher};
 use self_cell::self_cell;
 use smallvec::SmallVec;
 
-use oxc_allocator::{Allocator, AllocatorGuard, AllocatorPool, Box as ArenaBox};
+use oxc_allocator::{Allocator, AllocatorGuard, AllocatorPool, ArenaBox};
 use oxc_diagnostics::{DiagnosticSender, DiagnosticService, Error, OxcDiagnostic};
 use oxc_parser::{ParseOptions, Parser, Token, config::RuntimeParserConfig};
 use oxc_resolver::Resolver;

--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box as ArenaBox;
+use oxc_allocator::ArenaBox;
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_ecmascript::BoundNames;

--- a/crates/oxc_minifier/src/traverse_context/mod.rs
+++ b/crates/oxc_minifier/src/traverse_context/mod.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, Box as ArenaBox, GetAllocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator};
 use oxc_ast::{
     AstBuilder,
     ast::{Expression, IdentifierReference, Statement},

--- a/crates/oxc_minifier/src/traverse_context/scoping.rs
+++ b/crates/oxc_minifier/src/traverse_context/scoping.rs
@@ -1,6 +1,6 @@
 use std::str;
 
-use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_semantic::{NodeId, Reference, Scoping};

--- a/crates/oxc_minifier/src/traverse_context/uid.rs
+++ b/crates/oxc_minifier/src/traverse_context/uid.rs
@@ -3,7 +3,7 @@ use std::str;
 use itoa::Buffer as ItoaBuffer;
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{Allocator, StringBuilder as ArenaStringBuilder};
+use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_semantic::Scoping;
 use oxc_str::Ident;
 

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -9,7 +9,7 @@ use std::mem;
 
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::RegExpFlags;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{SourceType, Span};

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -1,5 +1,5 @@
 use memchr::memchr_iter;
-use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::{Comment, CommentContent, CommentKind, CommentPosition};
 use oxc_span::Span;
 

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -87,7 +87,7 @@ mod lexer;
 #[doc(hidden)]
 pub mod lexer;
 
-use oxc_allocator::{Allocator, Box as ArenaBox, Dummy, GetAllocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy, GetAllocator};
 use oxc_ast::{
     AstBuilder,
     ast::{Expression, Program},

--- a/crates/oxc_react_compiler/src/convert_ast_reverse.rs
+++ b/crates/oxc_react_compiler/src/convert_ast_reverse.rs
@@ -9,7 +9,7 @@
 //! (which represents the compiler's Babel-compatible output) and produces OXC AST
 //! nodes allocated in an OXC arena, suitable for code generation via `oxc_codegen`.
 
-use oxc_allocator::{Allocator, Box as ArenaBox};
+use oxc_allocator::{Allocator, ArenaBox};
 use oxc_ast::ast as oxc;
 use oxc_ast_visit::VisitMut;
 use oxc_span::SPAN;

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -3,7 +3,7 @@ use std::{collections::hash_map::Entry, fmt, mem};
 use rustc_hash::{FxHashMap, FxHashSet};
 use self_cell::self_cell;
 
-use oxc_allocator::{Allocator, BitSet, CloneIn, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec, BitSet, CloneIn};
 use oxc_index::IndexVec;
 use oxc_span::Span;
 use oxc_str::{ArenaIdentHashMap, Ident};

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -35,7 +35,7 @@ pub mod __internal {
     // Used by `format_compact_str!` macro defined in `oxc_str`
     pub use compact_str::format_compact;
     // Used by `format_str!` and `format_ident!` macros defined in `oxc_str`
-    pub use oxc_allocator::StringBuilder as ArenaStringBuilder;
+    pub use oxc_allocator::ArenaStringBuilder;
 }
 
 // Additional trait implementations for types re-exported from oxc_str

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -11,8 +11,7 @@ use std::{
 };
 
 use oxc_allocator::{
-    Allocator, CloneIn, Dummy, FromIn, IdentBuildHasher, StringBuilder as ArenaStringBuilder,
-    ident_hash,
+    Allocator, ArenaStringBuilder, CloneIn, Dummy, FromIn, IdentBuildHasher, ident_hash,
 };
 #[cfg(feature = "serialize")]
 use oxc_estree::{ESTree, JsonSafeString, Serializer as ESTreeSerializer};

--- a/crates/oxc_str/src/lib.rs
+++ b/crates/oxc_str/src/lib.rs
@@ -15,7 +15,7 @@ pub mod __internal {
     // Used by `format_compact_str!` macro defined in `compact_str.rs`
     pub use compact_str::format_compact;
     // Used by `format_str!` and `format_ident!` macros
-    pub use oxc_allocator::StringBuilder as ArenaStringBuilder;
+    pub use oxc_allocator::ArenaStringBuilder;
     // Used by `static_ident!` macro
     pub use crate::ident::new_const_ident;
 }

--- a/crates/oxc_str/src/str.rs
+++ b/crates/oxc_str/src/str.rs
@@ -4,7 +4,7 @@ use std::{
     ops::Deref,
 };
 
-use oxc_allocator::{Allocator, CloneIn, Dummy, FromIn, StringBuilder as ArenaStringBuilder};
+use oxc_allocator::{Allocator, ArenaStringBuilder, CloneIn, Dummy, FromIn};
 #[cfg(feature = "serialize")]
 use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
 #[cfg(feature = "serialize")]

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -91,7 +91,7 @@ use compact_str::CompactString;
 use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
-use oxc_allocator::{Box as ArenaBox, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::{VisitMut, walk_mut::walk_expression};
 use oxc_data_structures::stack::{NonEmptyStack, SparseStack};

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -70,7 +70,7 @@ use std::borrow::Cow;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 
-use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{
     NONE,
     ast::{Argument, CallExpression, Expression},

--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -1,7 +1,7 @@
 //! Utility transforms which are in common between other transforms.
 
 use arrow_function_converter::ArrowFunctionConverter;
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_traverse::{Ancestor, Traverse};
 

--- a/crates/oxc_transformer/src/common/statement_injector.rs
+++ b/crates/oxc_transformer/src/common/statement_injector.rs
@@ -17,7 +17,7 @@ use std::collections::hash_map::Entry;
 
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{Address, GetAddress, Vec as ArenaVec};
+use oxc_allocator::{Address, ArenaVec, GetAddress};
 use oxc_ast::{AstBuilder, ast::*};
 
 /// Store for statements to be added to the statements.

--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -14,7 +14,7 @@
 //! ctx.state.var_declarations.insert_let(name2, binding2, None, ctx.ast);
 //! ```
 
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_data_structures::stack::SparseStack;
 use oxc_span::SPAN;

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -77,7 +77,7 @@
 ///
 /// ## References
 /// * TypeScript's [emitDecoratorMetadata](https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata)
-use oxc_allocator::Box as ArenaBox;
+use oxc_allocator::ArenaBox;
 use oxc_ast::ast::*;
 use oxc_data_structures::stack::SparseStack;
 use oxc_semantic::{Reference, ReferenceFlags, SymbolId};

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -48,9 +48,7 @@ mod metadata;
 use std::borrow::Cow;
 use std::mem;
 
-use oxc_allocator::{
-    Address, Box as ArenaBox, CloneIn, GetAddress, TakeIn, UnstableAddress, Vec as ArenaVec,
-};
+use oxc_allocator::{Address, ArenaBox, ArenaVec, CloneIn, GetAddress, TakeIn, UnstableAddress};
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::{Visit, VisitMut};
 use oxc_data_structures::stack::NonEmptyStack;

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -32,7 +32,7 @@
 //! * Exponentiation operator TC39 proposal: <https://github.com/tc39/proposal-exponentiation-operator>
 //! * Exponentiation operator specification: <https://tc39.es/ecma262/#sec-exp-operator>
 
-use oxc_allocator::{CloneIn, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaVec, CloneIn, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::ReferenceFlags;
 use oxc_span::{SPAN, Span};

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -53,7 +53,7 @@
 
 use std::{borrow::Cow, mem};
 
-use oxc_allocator::{Box as ArenaBox, StringBuilder as ArenaStringBuilder, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaStringBuilder, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -1,6 +1,6 @@
 //! This module is responsible for transforming `for await` to `for` statement
 
-use oxc_allocator::{TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{SPAN, Span};

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -31,7 +31,7 @@ use std::mem;
 
 use serde::Deserialize;
 
-use oxc_allocator::{Address, Box as ArenaBox, GetAddress, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{BoundNames, ToJsString, WithoutGlobalReferenceInformation};

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -28,7 +28,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-nullish-coalescing-operator>
 //! * Nullish coalescing TC39 proposal: <https://github.com/tc39-transfer/proposal-nullish-coalescing>
 
-use oxc_allocator::{Box as ArenaBox, TakeIn};
+use oxc_allocator::{ArenaBox, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{ScopeFlags, SymbolFlags};
 use oxc_span::SPAN;

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -3,7 +3,7 @@
 
 use std::mem;
 
-use oxc_allocator::{Box as ArenaBox, TakeIn};
+use oxc_allocator::{ArenaBox, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::SPAN;
 use oxc_syntax::{reference::ReferenceId, symbol::SymbolId};

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -1,7 +1,7 @@
 //! ES2022: Class Properties
 //! Transform of `super` expressions.
 
-use oxc_allocator::{Box as ArenaBox, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_traverse::ast_operations::get_var_name_from_node;

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -37,7 +37,7 @@ use std::mem;
 
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{Address, Box as ArenaBox, GetAddress, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{NodeId, ScopeFlags, ScopeId, SymbolFlags, SymbolId};

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -88,9 +88,7 @@
 //!
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-helper-builder-react-jsx>
 
-use oxc_allocator::{
-    Box as ArenaBox, StringBuilder as ArenaStringBuilder, TakeIn, Vec as ArenaVec,
-};
+use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, TakeIn};
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_ecmascript::PropName;
 use oxc_span::{SPAN, Span};

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -7,10 +7,7 @@ use base64::{
 use hmac_sha1_compact::Hash as Sha1;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use oxc_allocator::{
-    CloneIn, GetAddress, StringBuilder as ArenaStringBuilder, TakeIn, UnstableAddress,
-    Vec as ArenaVec,
-};
+use oxc_allocator::{ArenaStringBuilder, ArenaVec, CloneIn, GetAddress, TakeIn, UnstableAddress};
 use oxc_ast::{AstBuilder, NONE, ast::*, match_expression};
 use oxc_ast_visit::{
     Visit,

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -7,7 +7,7 @@
 
 use std::path::Path;
 
-use oxc_allocator::{Allocator, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec, TakeIn};
 use oxc_ast::{AstBuilder, ast::*};
 use oxc_diagnostics::Diagnostics;
 #[cfg(feature = "react_compiler")]

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -63,7 +63,7 @@ use std::{
 use rustc_hash::FxHasher;
 use serde::Deserialize;
 
-use oxc_allocator::{TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_data_structures::{inline_string::InlineString, slice_iter::SliceIter};
 use oxc_semantic::SymbolId;

--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -40,7 +40,7 @@
 
 use std::iter;
 
-use oxc_allocator::{TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::SymbolFlags;
 use oxc_span::SPAN;

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::{Reference, SymbolFlags};

--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::{TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{ScopeFlags, ScopeId};
 use oxc_span::SPAN;

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use oxc_allocator::{TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_data_structures::stack::NonEmptyStack;

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec as ArenaVec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_traverse::Traverse;
 

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box as ArenaBox, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
 use oxc_span::{SPAN, Span};

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{GetSpan, SPAN};

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -50,7 +50,7 @@ use std::iter;
 use itoa::Buffer as ItoaBuffer;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use oxc_allocator::{Allocator, Box as ArenaBox, TakeIn, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, Scoping, SymbolFlags, SymbolId};

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, Box as ArenaBox, GetAllocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator};
 use oxc_ast::{
     AstBuilder,
     ast::{Expression, IdentifierReference, Statement},

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -1,6 +1,6 @@
 use std::str;
 
-use oxc_allocator::{Allocator, Vec as ArenaVec};
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_semantic::{NodeId, Reference, Scoping};

--- a/crates/oxc_traverse/src/context/uid.rs
+++ b/crates/oxc_traverse/src/context/uid.rs
@@ -3,7 +3,7 @@ use std::str;
 use itoa::Buffer as ItoaBuffer;
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{Allocator, StringBuilder as ArenaStringBuilder};
+use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_semantic::Scoping;
 use oxc_str::Ident;
 

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -12,7 +12,7 @@ use napi::{
 use napi_derive::napi;
 
 use oxc::{
-    allocator::{Allocator, FromIn, Vec as ArenaVec},
+    allocator::{Allocator, ArenaVec, FromIn},
     ast_visit::utf8_to_utf16::Utf8ToUtf16,
     semantic::SemanticBuilder,
 };


### PR DESCRIPTION
Pure refactor.

It's a common pattern in repo to import `Vec` and `Box` etc from `oxc_allocator` and alias them to `ArenaBox` / `ArenaVec`.

```rust
use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
```

Make this pattern less verbose by re-exporting `Box` and `Vec` as these aliases from `oxc_allocator`.

Ditto other arena types: `ArenaHashMap`, `ArenaHashSet`, `ArenaStringBuilder`.

Use those aliases in all other crates to shorten code.

```rust
use oxc_allocator::{ArenaBox, ArenaVec};
```