### PR TITLE
refactor(all): import arena `Box` and `Vec` as `ArenaBox` / `ArenaVec`

### DIFF
--- a/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
+++ b/apps/oxfmt/src/prettier_compat/from_prettier_doc.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroU8;
 use rustc_hash::FxHashMap;
 use serde_json::Value;
 
-use oxc_allocator::{Allocator, StringBuilder};
+use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_formatter::EmbeddedDocResult;
 use oxc_formatter_core::{
     Align, Condition, DedentMode, FormatElement, Group, GroupId, GroupMode, IndentWidth, LineMode,
@@ -523,7 +523,7 @@ fn postprocess<'a>(
                 let FormatElement::Text { text, .. } = &ir[run_start] else { unreachable!() };
                 text
             } else {
-                let mut sb = StringBuilder::new_in(allocator);
+                let mut sb = ArenaStringBuilder::new_in(allocator);
                 for element in &ir[run_start..read] {
                     if let FormatElement::Text { text, .. } = element {
                         sb.push_str(text);
@@ -612,7 +612,7 @@ fn escape_template_characters<'a>(s: &'a str, allocator: &'a Allocator) -> &'a s
     };
 
     // Slow path: build escaped string in the arena, reusing the clean prefix.
-    let mut result = StringBuilder::with_capacity_in(len + 1, allocator);
+    let mut result = ArenaStringBuilder::with_capacity_in(len + 1, allocator);
     result.push_str(&s[..first]);
 
     // Iterate by chars (not bytes) to correctly handle multi-byte UTF-8.
@@ -647,7 +647,7 @@ fn escape_backticks_raw_str<'a>(s: &'a str, allocator: &'a Allocator) -> &'a str
     if !s.contains('`') {
         return s;
     }
-    let mut result = StringBuilder::with_capacity_in(s.len() + 1, allocator);
+    let mut result = ArenaStringBuilder::with_capacity_in(s.len() + 1, allocator);
     let mut bs_count: usize = 0;
     for ch in s.chars() {
         if ch == '\\' {

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -1,6 +1,6 @@
 use std::{alloc::Layout, borrow::Cow, mem::MaybeUninit, slice, str};
 
-use oxc_allocator::{Allocator, Box, FromIn, GetAllocator, IntoIn, Vec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, FromIn, GetAllocator, IntoIn};
 use oxc_span::{SPAN, Span};
 use oxc_str::{Ident, Str};
 use oxc_syntax::{number::NumberBase, operator::UnaryOperator, scope::ScopeId};
@@ -12,7 +12,7 @@ use crate::ast::*;
 #[expect(clippy::upper_case_acronyms)]
 pub struct NONE;
 
-impl<'a, T> FromIn<'a, NONE> for Option<Box<'a, T>> {
+impl<'a, T> FromIn<'a, NONE> for Option<ArenaBox<'a, T>> {
     fn from_in(_: NONE, _: &'a Allocator) -> Self {
         None
     }
@@ -41,34 +41,42 @@ impl<'a> AstBuilder<'a> {
 
     /// Move a value into the memory arena.
     #[inline]
-    pub fn alloc<T>(self, value: T) -> Box<'a, T> {
-        Box::new_in(value, self.allocator)
+    pub fn alloc<T>(self, value: T) -> ArenaBox<'a, T> {
+        ArenaBox::new_in(value, self.allocator)
     }
 
     /// Create a new empty [`Vec`] that stores its elements in the memory arena.
+    ///
+    /// [`Vec`]: ArenaVec
     #[inline]
-    pub fn vec<T>(self) -> Vec<'a, T> {
-        Vec::new_in(self.allocator)
+    pub fn vec<T>(self) -> ArenaVec<'a, T> {
+        ArenaVec::new_in(self.allocator)
     }
 
     /// Create a new empty [`Vec`] that stores its elements in the memory arena.
     /// Enough memory will be pre-allocated to store at least `capacity`
     /// elements.
+    ///
+    /// [`Vec`]: ArenaVec
     #[inline]
-    pub fn vec_with_capacity<T>(self, capacity: usize) -> Vec<'a, T> {
-        Vec::with_capacity_in(capacity, self.allocator)
+    pub fn vec_with_capacity<T>(self, capacity: usize) -> ArenaVec<'a, T> {
+        ArenaVec::with_capacity_in(capacity, self.allocator)
     }
 
     /// Create a new arena-allocated [`Vec`] initialized with a single element.
+    ///
+    /// [`Vec`]: ArenaVec
     #[inline]
-    pub fn vec1<T>(self, value: T) -> Vec<'a, T> {
-        Vec::from_value_in(value, self.allocator)
+    pub fn vec1<T>(self, value: T) -> ArenaVec<'a, T> {
+        ArenaVec::from_value_in(value, self.allocator)
     }
 
     /// Collect an iterator into a new arena-allocated [`Vec`].
+    ///
+    /// [`Vec`]: ArenaVec
     #[inline]
-    pub fn vec_from_iter<T, I: IntoIterator<Item = T>>(self, iter: I) -> Vec<'a, T> {
-        Vec::from_iter_in(iter, self.allocator)
+    pub fn vec_from_iter<T, I: IntoIterator<Item = T>>(self, iter: I) -> ArenaVec<'a, T> {
+        ArenaVec::from_iter_in(iter, self.allocator)
     }
 
     /// Create [`Vec`] from a fixed-size array.
@@ -76,9 +84,11 @@ impl<'a> AstBuilder<'a> {
     /// This is preferable to `vec_from_iter` where source is an array, as size is statically known,
     /// and compiler is more likely to construct the values directly in arena, rather than constructing
     /// on stack and then copying to arena.
+    ///
+    /// [`Vec`]: ArenaVec
     #[inline]
-    pub fn vec_from_array<T, const N: usize>(self, array: [T; N]) -> Vec<'a, T> {
-        Vec::from_array_in(array, self.allocator)
+    pub fn vec_from_array<T, const N: usize>(self, array: [T; N]) -> ArenaVec<'a, T> {
+        ArenaVec::from_array_in(array, self.allocator)
     }
 
     /// Allocate an [`Ident`] from a string slice.
@@ -177,7 +187,7 @@ impl<'a> AstBuilder<'a> {
         params: FormalParameters<'a>,
         body: FunctionBody<'a>,
         scope_id: ScopeId,
-    ) -> Box<'a, Function<'a>> {
+    ) -> ArenaBox<'a, Function<'a>> {
         self.alloc_function_with_scope_id_and_pure_and_pife(
             span,
             r#type,
@@ -212,13 +222,13 @@ impl<'a> AstBuilder<'a> {
         return_type: T4,
         body: T5,
         scope_id: ScopeId,
-    ) -> Box<'a, Function<'a>>
+    ) -> ArenaBox<'a, Function<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
         self.alloc_function_with_scope_id_and_pure_and_pife(
             span,
@@ -246,7 +256,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         declaration: Declaration<'a>,
-    ) -> Box<'a, ExportNamedDeclaration<'a>> {
+    ) -> ArenaBox<'a, ExportNamedDeclaration<'a>> {
         self.alloc_export_named_declaration(
             span,
             Some(declaration),
@@ -263,9 +273,9 @@ impl<'a> AstBuilder<'a> {
     pub fn plain_export_named_declaration(
         self,
         span: Span,
-        specifiers: Vec<'a, ExportSpecifier<'a>>,
+        specifiers: ArenaVec<'a, ExportSpecifier<'a>>,
         source: Option<StringLiteral<'a>>,
-    ) -> Box<'a, ExportNamedDeclaration<'a>> {
+    ) -> ArenaBox<'a, ExportNamedDeclaration<'a>> {
         self.alloc_export_named_declaration(
             span,
             None,

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -8,7 +8,7 @@
 
 use std::borrow::Cow;
 
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_syntax::number::ToJsString;
 
@@ -27,7 +27,7 @@ use super::{ConstantEvaluation, ConstantEvaluationCtx, ConstantValue};
 
 fn try_fold_global_functions<'a>(
     ident: &IdentifierReference<'a>,
-    arguments: &Vec<'a, Argument<'a>>,
+    arguments: &ArenaVec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     match ident.name.as_str() {
@@ -51,7 +51,7 @@ fn try_fold_global_functions<'a>(
 
 pub fn try_fold_known_global_methods<'a>(
     callee: &Expression<'a>,
-    arguments: &Vec<'a, Argument<'a>>,
+    arguments: &ArenaVec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if let Expression::Identifier(ident) = callee {
@@ -98,7 +98,7 @@ pub fn try_fold_known_global_methods<'a>(
 }
 
 fn try_fold_string_casing<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     name: &str,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
@@ -129,7 +129,7 @@ fn try_fold_string_casing<'a>(
 }
 
 fn try_fold_string_index_of<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     name: &str,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
@@ -164,7 +164,7 @@ fn try_fold_string_index_of<'a>(
 }
 
 fn try_fold_string_substring_or_slice<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
@@ -201,7 +201,7 @@ fn try_fold_string_substring_or_slice<'a>(
 }
 
 fn try_fold_string_char_at<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
@@ -226,7 +226,7 @@ fn try_fold_string_char_at<'a>(
 }
 
 fn try_fold_string_char_code_at<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
@@ -244,7 +244,7 @@ fn try_fold_string_char_code_at<'a>(
 }
 
 fn try_fold_starts_with<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     object: &Expression<'a>,
     _ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
@@ -257,7 +257,7 @@ fn try_fold_starts_with<'a>(
 }
 
 fn try_fold_string_replace<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     name: &str,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
@@ -296,7 +296,7 @@ fn try_fold_string_replace<'a>(
 }
 
 fn try_fold_string_from_char_code<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
@@ -315,7 +315,7 @@ fn try_fold_string_from_char_code<'a>(
 }
 
 fn try_fold_to_string<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
@@ -386,12 +386,12 @@ fn format_radix(mut x: u32, radix: u32) -> String {
     result.into_iter().rev().collect()
 }
 
-fn validate_arguments(args: &Vec<'_, Argument<'_>>, expected_len: usize) -> bool {
+fn validate_arguments(args: &ArenaVec<'_, Argument<'_>>, expected_len: usize) -> bool {
     (args.len() == expected_len) && args.iter().all(Argument::is_expression)
 }
 
 fn try_fold_number_methods<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     object: &Expression<'a>,
     name: &str,
     ctx: &impl ConstantEvaluationCtx<'a>,
@@ -422,7 +422,7 @@ fn try_fold_number_methods<'a>(
 }
 
 fn try_fold_roots<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     name: &str,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
@@ -446,7 +446,7 @@ fn try_fold_roots<'a>(
 }
 
 fn try_fold_math_unary<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     name: &str,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
@@ -488,7 +488,7 @@ fn try_fold_math_unary<'a>(
 }
 
 fn try_fold_math_variadic<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     name: &str,
     object: &Expression<'a>,
     ctx: &impl ConstantEvaluationCtx<'a>,
@@ -539,7 +539,7 @@ fn try_fold_math_variadic<'a>(
 }
 
 fn try_fold_encode_uri<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if args.is_empty() {
@@ -568,7 +568,7 @@ fn try_fold_encode_uri<'a>(
 }
 
 fn try_fold_encode_uri_component<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if args.is_empty() {
@@ -593,7 +593,7 @@ fn try_fold_encode_uri_component<'a>(
 }
 
 fn try_fold_decode_uri<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if args.is_empty() {
@@ -615,7 +615,7 @@ fn try_fold_decode_uri<'a>(
 }
 
 fn try_fold_decode_uri_component<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if args.is_empty() {
@@ -638,7 +638,7 @@ fn try_fold_decode_uri_component<'a>(
 }
 
 fn try_fold_global_is_nan<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if args.is_empty() {
@@ -654,7 +654,7 @@ fn try_fold_global_is_nan<'a>(
 }
 
 fn try_fold_global_is_finite<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if args.is_empty() {
@@ -670,7 +670,7 @@ fn try_fold_global_is_finite<'a>(
 }
 
 fn try_fold_global_parse_float<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if args.is_empty() {
@@ -794,7 +794,7 @@ fn find_str_decimal_literal_prefix(input: &str) -> Option<&str> {
 }
 
 fn try_fold_global_parse_int<'a>(
-    args: &Vec<'a, Argument<'a>>,
+    args: &ArenaVec<'a, Argument<'a>>,
     ctx: &impl ConstantEvaluationCtx<'a>,
 ) -> Option<ConstantValue<'a>> {
     if args.is_empty() {

--- a/crates/oxc_formatter/src/ast_nodes/iterator.rs
+++ b/crates/oxc_formatter/src/ast_nodes/iterator.rs
@@ -1,4 +1,4 @@
-//! Iterator implementations for `Vec<T>` in AstNode.
+//! Iterator implementations for `ArenaVec<T>` in AstNode.
 //!
 //! This module provides two macros for generating iterator implementations:
 //! - `impl_ast_node_vec!` - For non-Option types (uses `.map()`)
@@ -6,13 +6,13 @@
 
 use std::cmp::min;
 
-use oxc_allocator::{Allocator, Vec};
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
 use super::{AstNode, AstNodes};
 
-/// Iterator for `AstNode<Vec<T>>`.
+/// Iterator for `AstNode<ArenaVec<T>>`.
 pub struct AstNodeIterator<'a, T> {
     inner: std::iter::Peekable<std::slice::Iter<'a, T>>,
     parent: AstNodes<'a>,
@@ -72,7 +72,7 @@ macro_rules! impl_ast_node_vec {
         impl_ast_node_vec!($type, true, |n: &$type| n.span().start);
     };
     ($type:ty, $has_following_span_in_the_last_item:tt, $get_span:expr) => {
-        impl<'a> AstNode<'a, Vec<'a, $type>> {
+        impl<'a> AstNode<'a, ArenaVec<'a, $type>> {
             pub fn iter(&self) -> AstNodeIterator<'a, $type> {
                 AstNodeIterator {
                     inner: self.inner.iter().peekable(),
@@ -139,7 +139,7 @@ macro_rules! impl_ast_node_vec {
             }
         }
 
-        impl<'a> IntoIterator for &AstNode<'a, Vec<'a, $type>> {
+        impl<'a> IntoIterator for &AstNode<'a, ArenaVec<'a, $type>> {
             type Item = &'a AstNode<'a, $type>;
             type IntoIter = AstNodeIterator<'a, $type>;
             fn into_iter(self) -> Self::IntoIter {
@@ -167,7 +167,7 @@ macro_rules! impl_ast_node_vec_for_option {
         impl_ast_node_vec_for_option!($type, true);
     };
     ($type:ty, $has_following_span_in_the_last_item:tt) => {
-        impl<'a> AstNode<'a, Vec<'a, $type>> {
+        impl<'a> AstNode<'a, ArenaVec<'a, $type>> {
             pub fn iter(&self) -> AstNodeIterator<'a, $type> {
                 AstNodeIterator {
                     inner: self.inner.iter().peekable(),
@@ -252,7 +252,7 @@ macro_rules! impl_ast_node_vec_for_option {
             }
         }
 
-        impl<'a> IntoIterator for &AstNode<'a, Vec<'a, $type>> {
+        impl<'a> IntoIterator for &AstNode<'a, ArenaVec<'a, $type>> {
             type Item = &'a AstNode<'a, $type>;
             type IntoIter = AstNodeIterator<'a, $type>;
             fn into_iter(self) -> Self::IntoIter {

--- a/crates/oxc_formatter/src/ast_nodes/node.rs
+++ b/crates/oxc_formatter/src/ast_nodes/node.rs
@@ -4,7 +4,7 @@ use std::{
     ops::Deref,
 };
 
-use oxc_allocator::{Allocator, Vec};
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 
@@ -156,18 +156,18 @@ impl<'a> AstNode<'a, ExpressionStatement<'a>> {
 impl<'a> AstNode<'a, ImportExpression<'a>> {
     /// Converts the arguments of the ImportExpression into an `AstNode` representing a `Vec` of `Argument`.
     #[inline]
-    pub fn to_arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
-        // Convert ImportExpression's source and options to Vec<'a, Argument<'a>>.
+    pub fn to_arguments(&self) -> &AstNode<'a, ArenaVec<'a, Argument<'a>>> {
+        // Convert ImportExpression's source and options to ArenaVec<'a, Argument<'a>>.
         // This allows us to reuse CallExpression's argument formatting logic when printing
         // import expressions, since import(source, options) has the same structure as
         // a function call with arguments.
-        let mut arguments = Vec::new_in(self.allocator);
+        let mut arguments = ArenaVec::new_in(self.allocator);
 
         // SAFETY: Argument inherits all Expression variants through the inherit_variants! macro,
         // so Expression and Argument have identical memory layout for shared variants.
         // Both are discriminated unions where each Expression variant (e.g., Expression::Identifier)
         // has a corresponding Argument variant (e.g., Argument::Identifier) with the same discriminant
-        // and the same inner type (Box<'a, T>). Transmuting Expression to Argument via transmute_copy
+        // and the same inner type (ArenaBox<'a, T>). Transmuting Expression to Argument via transmute_copy
         // is safe because we're just copying the bits (discriminant + pointer).
         unsafe {
             arguments.push(transmute_copy(&self.inner.source));

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -56,7 +56,7 @@
 //! 2. Applies indentation based on container type (block, soft, none)
 //! 3. Preserves comment relationships and spacing
 //! 4. Advances cursor for processed comments
-use oxc_allocator::StringBuilder;
+use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::{Comment, CommentContent, CommentKind};
 use oxc_span::Span;
 use oxc_syntax::line_terminator::LineTerminatorSplitter;
@@ -478,7 +478,8 @@ impl<'a> Format<'a, JsFormatContext<'a>> for Comment {
                     }
                 } else {
                     // Normalize line endings `\r\n` to `\n`
-                    let mut string = StringBuilder::with_capacity_in(content.len(), f.allocator());
+                    let mut string =
+                        ArenaStringBuilder::with_capacity_in(content.len(), f.allocator());
                     // `unwrap` is safe because `content` contains at least one line.
                     string.push_str(lines.next().unwrap().trim_end());
 

--- a/crates/oxc_formatter/src/print/array_element_list.rs
+++ b/crates/oxc_formatter/src/print/array_element_list.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -14,13 +14,13 @@ use crate::{
 };
 
 pub struct ArrayElementList<'a, 'b> {
-    elements: &'b AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>>,
+    elements: &'b AstNode<'a, ArenaVec<'a, ArrayExpressionElement<'a>>>,
     group_id: Option<GroupId>,
 }
 
 impl<'a, 'b> ArrayElementList<'a, 'b> {
     pub fn new(
-        elements: &'b AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>>,
+        elements: &'b AstNode<'a, ArenaVec<'a, ArrayExpressionElement<'a>>>,
         group_id: GroupId,
     ) -> Self {
         Self { elements, group_id: Some(group_id) }

--- a/crates/oxc_formatter/src/print/assignment_pattern_property_list.rs
+++ b/crates/oxc_formatter/src/print/assignment_pattern_property_list.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -49,13 +49,13 @@ impl<'a, 'b> Iterator for AssignmentTargetPropertyListIter<'a, 'b> {
 }
 
 pub struct AssignmentTargetPropertyList<'a, 'b> {
-    properties: &'b AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>>,
+    properties: &'b AstNode<'a, ArenaVec<'a, AssignmentTargetProperty<'a>>>,
     rest: Option<&'b AstNode<'a, AssignmentTargetRest<'a>>>,
 }
 
 impl<'a, 'b> AssignmentTargetPropertyList<'a, 'b> {
     pub fn new(
-        properties: &'b AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>>,
+        properties: &'b AstNode<'a, ArenaVec<'a, AssignmentTargetProperty<'a>>>,
         rest: Option<&'b AstNode<'a, AssignmentTargetRest<'a>>>,
     ) -> Self {
         Self { properties, rest }

--- a/crates/oxc_formatter/src/print/binding_property_list.rs
+++ b/crates/oxc_formatter/src/print/binding_property_list.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -9,7 +9,7 @@ use crate::{
 };
 
 pub struct BindingPropertyList<'a, 'b> {
-    properties: &'b AstNode<'a, Vec<'a, BindingProperty<'a>>>,
+    properties: &'b AstNode<'a, ArenaVec<'a, BindingProperty<'a>>>,
     rest: Option<&'b AstNode<'a, BindingRestElement<'a>>>,
 }
 
@@ -55,7 +55,7 @@ impl<'a, 'b> Iterator for BindingPropertyListIter<'a, 'b> {
 
 impl<'a, 'b> BindingPropertyList<'a, 'b> {
     pub fn new(
-        properties: &'b AstNode<'a, Vec<'a, BindingProperty<'a>>>,
+        properties: &'b AstNode<'a, ArenaVec<'a, BindingProperty<'a>>>,
         rest: Option<&'b AstNode<'a, BindingRestElement<'a>>>,
     ) -> Self {
         Self { properties, rest }

--- a/crates/oxc_formatter/src/print/block_statement.rs
+++ b/crates/oxc_formatter/src/print/block_statement.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 
 use super::FormatWrite;
@@ -9,7 +9,7 @@ use crate::{
     write,
 };
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, Statement<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, Statement<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         f.join_nodes_with_hardline().entries(
             self.iter().filter(|stmt| !matches!(stmt.as_ref(), Statement::EmptyStatement(_))),

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -1136,7 +1136,7 @@ fn is_huggable_html_embed_single_arg(arguments: &[Argument], f: &JsFormatter<'_,
 /// useMemo(() => {}, [])
 /// ```
 fn is_react_hook_with_deps_array(
-    arguments: &AstNode<ArenaVec<Argument>>,
+    arguments: &AstNode<'_, ArenaVec<'_, Argument<'_>>>,
     comments: &Comments,
 ) -> bool {
     if arguments.len() > 3 || arguments.len() < 2 {

--- a/crates/oxc_formatter/src/print/class.rs
+++ b/crates/oxc_formatter/src/print/class.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -53,7 +53,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ClassBody<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, ClassElement<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, ClassElement<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         // Join class elements with hard line breaks between them
         let mut join = f.join_nodes_with_hardline();
@@ -194,7 +194,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexSignature<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSIndexSignatureName<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         f.join_with(&soft_line_break_or_space()).entries_with_trailing_separator(
             self.iter(),
@@ -210,7 +210,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSIndexSignatureName<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, TSClassImplements<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSClassImplements<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let last_index = self.len().saturating_sub(1);
         let mut joiner = f.join_with(soft_line_break_or_space());

--- a/crates/oxc_formatter/src/print/decorators.rs
+++ b/crates/oxc_formatter/src/print/decorators.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -12,7 +12,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, Decorator<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, Decorator<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         if self.is_empty() {
             return;
@@ -98,7 +98,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Decorator<'a>> {
 /// Check if decorators should expand (have newlines between them)
 #[inline]
 fn should_expand_decorators<'a>(
-    decorators: &AstNode<'a, Vec<'a, Decorator<'a>>>,
+    decorators: &AstNode<'a, ArenaVec<'a, Decorator<'a>>>,
     f: &JsFormatter<'_, 'a>,
 ) -> bool {
     decorators

--- a/crates/oxc_formatter/src/print/export_declarations.rs
+++ b/crates/oxc_formatter/src/print/export_declarations.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -173,7 +173,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ExportNamedDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, ExportSpecifier<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_with(soft_line_break_or_space()).entries(

--- a/crates/oxc_formatter/src/print/import_declaration.rs
+++ b/crates/oxc_formatter/src/print/import_declaration.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 use oxc_syntax::identifier::is_identifier_name_patched;
@@ -74,7 +74,9 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ImportDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>>
+    for AstNode<'a, ArenaVec<'a, ImportDeclarationSpecifier<'a>>>
+{
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let mut specifiers_iter = self.iter().peekable();
 
@@ -204,7 +206,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, WithClause<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, ImportAttribute<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         if self.is_empty() {
             return write!(f, "{}");

--- a/crates/oxc_formatter/src/print/intersection_type.rs
+++ b/crates/oxc_formatter/src/print/intersection_type.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -16,7 +16,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSIntersectionType<'a>> {
 
 // [Prettier applies]: https://github.com/prettier/prettier/blob/cd3e530c2e51fb8296c0fb7738a9afdd3a3a4410/src/language-js/print/type-annotation.js#L93-L120
 fn format_intersection_types<'a>(
-    node: &AstNode<'a, Vec<'a, TSType<'a>>>,
+    node: &AstNode<'a, ArenaVec<'a, TSType<'a>>>,
     f: &mut JsFormatter<'_, 'a>,
 ) {
     let last_index = node.len().saturating_sub(1);

--- a/crates/oxc_formatter/src/print/jsx/element.rs
+++ b/crates/oxc_formatter/src/print/jsx/element.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::{JSXChild, JSXElement, JSXExpression, JSXExpressionContainer, JSXFragment};
 use oxc_span::{GetSpan, Span};
 
@@ -297,7 +297,7 @@ impl<'a, 'b> AnyJsxTagWithChildren<'a, 'b> {
         }
     }
 
-    fn children(&self) -> &'b AstNode<'a, Vec<'a, JSXChild<'a>>> {
+    fn children(&self) -> &'b AstNode<'a, ArenaVec<'a, JSXChild<'a>>> {
         match self {
             Self::Element(element) => element.children(),
             Self::Fragment(fragment) => fragment.children(),

--- a/crates/oxc_formatter/src/print/jsx/mod.rs
+++ b/crates/oxc_formatter/src/print/jsx/mod.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 
 pub mod child_list;
@@ -308,7 +308,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, JSXEmptyExpression> {
     fn write(&self, _f: &mut JsFormatter<'_, 'a>) {}
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, JSXAttributeItem<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let line_break = if f.options().attribute_position == AttributePosition::Multiline {
             hard_line_break()

--- a/crates/oxc_formatter/src/print/mod.rs
+++ b/crates/oxc_formatter/src/print/mod.rs
@@ -43,7 +43,7 @@ pub use function::FormatFunctionOptions;
 
 use cow_utils::CowUtils;
 
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_formatter_core::arena_cow_str;
 use oxc_span::GetSpan;
@@ -171,7 +171,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, ObjectExpression<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, ObjectPropertyKind<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_nodes_with_soft_line().entries_with_trailing_separator(
@@ -1124,7 +1124,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSEnumBody<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSEnumMember<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_nodes_with_soft_line().entries_with_trailing_separator(
@@ -1595,7 +1595,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for FormatTSSignature<'a, '_> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, TSSignature<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSSignature<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         if f.options().quote_properties.is_consistent() {
             let quote_needed = self.as_ref().iter().any(|signature| {
@@ -1625,7 +1625,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, TSSignature<'a>
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let last_index = self.len().saturating_sub(1);
         let mut joiner = f.join_with(soft_line_break_or_space());

--- a/crates/oxc_formatter/src/print/program.rs
+++ b/crates/oxc_formatter/src/print/program.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 use oxc_syntax::identifier::ZWNBSP;
@@ -45,10 +45,12 @@ impl<'a> FormatWrite<'a> for AstNode<'a, Program<'a>> {
     }
 }
 
-pub(super) struct FormatStatementsWithImports<'a, 'b>(pub &'b AstNode<'a, Vec<'a, Statement<'a>>>);
+pub(super) struct FormatStatementsWithImports<'a, 'b>(
+    pub &'b AstNode<'a, ArenaVec<'a, Statement<'a>>>,
+);
 
 impl<'a> Deref for FormatStatementsWithImports<'a, '_> {
-    type Target = AstNode<'a, Vec<'a, Statement<'a>>>;
+    type Target = AstNode<'a, ArenaVec<'a, Statement<'a>>>;
     fn deref(&self) -> &Self::Target {
         self.0
     }
@@ -172,7 +174,7 @@ fn is_import_suppressed(stmt: &AstNode<'_, Statement<'_>>, f: &JsFormatter<'_, '
     comments.is_suppressed(span.start) || comments.has_trailing_suppression_comment(span.end)
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, Directive<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, Directive<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let Some(last_directive) = self.last() else {
             // No directives, no extra new line

--- a/crates/oxc_formatter/src/print/switch_statement.rs
+++ b/crates/oxc_formatter/src/print/switch_statement.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -40,7 +40,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, SwitchStatement<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, SwitchCase<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, SwitchCase<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         f.join_nodes_with_hardline().entries(self);
     }

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::StringBuilder;
+use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -55,7 +55,7 @@ pub(super) fn format_css_doc<'a>(
     // quasis[0].raw + "@prettier-placeholder-0-id" + quasis[1].raw + ...
     let allocator = f.allocator();
     let joined = {
-        let mut sb = StringBuilder::new_in(allocator);
+        let mut sb = ArenaStringBuilder::new_in(allocator);
         for (idx, quasi_elem) in quasis.iter().enumerate() {
             if idx > 0 {
                 sb.push_str(PLACEHOLDER_PREFIX);

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -1,6 +1,6 @@
 use cow_utils::CowUtils;
 
-use oxc_allocator::StringBuilder;
+use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 use oxc_syntax::line_terminator::LineTerminatorSplitter;
@@ -86,7 +86,7 @@ pub(super) fn format_html_doc<'a>(
     // quasis[0].cooked + "PRETTIER_HTML_PLACEHOLDER_0_0_IN_JS" + quasis[1].cooked + ...
     let allocator = f.allocator();
     let joined = {
-        let mut sb = StringBuilder::new_in(allocator);
+        let mut sb = ArenaStringBuilder::new_in(allocator);
         for (idx, quasi_elem) in quasis.iter().enumerate() {
             if idx > 0 {
                 sb.push_str(PLACEHOLDER_PREFIX);

--- a/crates/oxc_formatter/src/print/template/embed/markdown.rs
+++ b/crates/oxc_formatter/src/print/template/embed/markdown.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, StringBuilder};
+use oxc_allocator::{Allocator, ArenaStringBuilder};
 use oxc_ast::ast::*;
 
 use crate::{ast_nodes::AstNode, format_args, formatter::prelude::*, write};
@@ -67,7 +67,7 @@ fn unescape_backticks<'a>(raw: &'a str, allocator: &'a Allocator) -> &'a str {
         return raw;
     }
 
-    let mut result = StringBuilder::with_capacity_in(raw.len(), allocator);
+    let mut result = ArenaStringBuilder::with_capacity_in(raw.len(), allocator);
     let mut chars = raw.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '\\' {
@@ -114,7 +114,7 @@ fn get_indentation(text: &str) -> &str {
 /// `text.replaceAll(new RegExp(\`^${indentation}\`, "gm"), "")`
 /// <https://github.com/prettier/prettier/blob/90983f40dce5e20beea4e5618b5e0426a6a7f4f0/src/language-js/embed/markdown.js#L17-L19>
 fn strip_indentation<'a>(text: &'a str, indent: &str, allocator: &'a Allocator) -> &'a str {
-    let mut result = StringBuilder::with_capacity_in(text.len(), allocator);
+    let mut result = ArenaStringBuilder::with_capacity_in(text.len(), allocator);
     for (i, line) in text.split('\n').enumerate() {
         if i > 0 {
             result.push('\n');

--- a/crates/oxc_formatter/src/print/template/mod.rs
+++ b/crates/oxc_formatter/src/print/template/mod.rs
@@ -4,7 +4,7 @@ use unicode_width::UnicodeWidthStr;
 
 use std::cmp;
 
-use oxc_allocator::{ArenaVec, StringBuilder};
+use oxc_allocator::{ArenaStringBuilder, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_formatter_core::IndentWidth;
 use oxc_span::{GetSpan, Span};
@@ -747,9 +747,12 @@ impl<'a> Format<'a, JsFormatContext<'a>> for EachTemplateTable<'a> {
                         let mut content = if current_column != 0
                             && (!is_last_in_row || !column.text.is_empty())
                         {
-                            StringBuilder::from_strs_array_in([" ", column.text], f.allocator())
+                            ArenaStringBuilder::from_strs_array_in(
+                                [" ", column.text],
+                                f.allocator(),
+                            )
                         } else {
-                            StringBuilder::from_str_in(column.text, f.allocator())
+                            ArenaStringBuilder::from_str_in(column.text, f.allocator())
                         };
 
                         // align the column based on the maximum column width in the table

--- a/crates/oxc_formatter/src/print/tuple_type.rs
+++ b/crates/oxc_formatter/src/print/tuple_type.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 
 use crate::{
@@ -10,7 +10,7 @@ use crate::{
 
 use super::FormatWrite;
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSTupleElement<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let trailing_separator = FormatTrailingCommas::ES5.trailing_separator(f.options());
         f.join_nodes_with_soft_line().entries_with_trailing_separator(

--- a/crates/oxc_formatter/src/print/type_parameters.rs
+++ b/crates/oxc_formatter/src/print/type_parameters.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::FileExtension;
 
@@ -66,7 +66,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, TSTypeParameter<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, TSTypeParameter<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         // Type parameter lists of arrow function expressions have to include at least one comma
         // to avoid any ambiguity with JSX elements, and in `.mts`/`.cts` sources.
@@ -91,7 +91,7 @@ impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, TSTypeParameter
 ///
 /// <https://github.com/prettier/prettier/blob/070c89bba46235f4948560ed612a11e89ccd2da9/src/language-js/print/type-parameters.js#L33-L42>
 fn should_force_trailing_comma_for_arrow_function(
-    params: &AstNode<'_, Vec<'_, TSTypeParameter<'_>>>,
+    params: &AstNode<'_, ArenaVec<'_, TSTypeParameter<'_>>>,
     f: &JsFormatter<'_, '_>,
 ) -> bool {
     if params.len() != 1 {

--- a/crates/oxc_formatter/src/print/union_type.rs
+++ b/crates/oxc_formatter/src/print/union_type.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -246,7 +246,7 @@ fn should_indent_alias_union<'a>(
 }
 
 fn format_union_types<'a>(
-    node: &AstNode<'a, Vec<'a, TSType<'a>>>,
+    node: &AstNode<'a, ArenaVec<'a, TSType<'a>>>,
     mut suppressed_node_span: Span,
     should_hug: bool,
     f: &mut JsFormatter<'_, 'a>,
@@ -318,7 +318,7 @@ fn format_union_types<'a>(
             //            ^^^^^^^^^^^ the following logic is to print comment2,
             // )[]; // comment 3
             //```
-            // TODO: We may need to tweak `AstNode<'a, Vec<'a, T>>` iterator as some of Vec's last elements should have the following span.
+            // TODO: We may need to tweak `AstNode<'a, ArenaVec<'a, T>>` iterator as some of Vec's last elements should have the following span.
             let comments = f.context().comments().end_of_line_comments_after(element_span.end);
             write!(f, FormatTrailingComments::Comments(comments));
         }

--- a/crates/oxc_formatter/src/print/variable_declaration.rs
+++ b/crates/oxc_formatter/src/print/variable_declaration.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -44,7 +44,7 @@ impl<'a> FormatWrite<'a> for AstNode<'a, VariableDeclaration<'a>> {
     }
 }
 
-impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
+impl<'a> Format<'a, JsFormatContext<'a>> for AstNode<'a, ArenaVec<'a, VariableDeclarator<'a>>> {
     fn fmt(&self, f: &mut JsFormatter<'_, 'a>) {
         let length = self.len();
 

--- a/crates/oxc_formatter_json/src/comments.rs
+++ b/crates/oxc_formatter_json/src/comments.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use oxc_allocator::StringBuilder;
+use oxc_allocator::ArenaStringBuilder;
 use oxc_ast::Comment;
 use oxc_formatter_core::{
     Buffer, Format, LINE_TERMINATORS, SourceText, arena_cow_str,
@@ -96,7 +96,7 @@ pub fn write_single_comment(comment: &Comment, f: &mut JsonFormatter<'_, '_>) {
         }
     } else {
         // Normalize line endings (`\r\n` → `\n`) but otherwise preserve the body.
-        let mut builder = StringBuilder::with_capacity_in(content.len(), f.allocator());
+        let mut builder = ArenaStringBuilder::with_capacity_in(content.len(), f.allocator());
         // `unwrap` is safe because `content` contains at least one line.
         builder.push_str(lines.next().unwrap().trim_end());
         for line in lines {

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::GetAddress;
+use oxc_allocator::{ArenaVec, GetAddress};
 use oxc_ast::{
     AstKind,
     ast::{BindingIdentifier, *},
@@ -296,9 +296,7 @@ pub fn get_symbol_id_of_variable(
     semantic.scoping().get_reference(ident.reference_id()).symbol_id()
 }
 
-pub fn extract_regex_flags<'a>(
-    args: &'a oxc_allocator::Vec<'a, Argument<'a>>,
-) -> Option<RegExpFlags> {
+pub fn extract_regex_flags<'a>(args: &'a ArenaVec<'a, Argument<'a>>) -> Option<RegExpFlags> {
     if args.len() <= 1 {
         return Some(RegExpFlags::empty());
     }

--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/return_checker.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec as AllocatorVec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::{ArrowFunctionExpression, Function, FunctionBody, ReturnStatement, Statement};
 use oxc_ast_visit::Visit;
 use oxc_cfg::{
@@ -231,7 +231,7 @@ impl Visit<'_> for ReturnStatementFinder {
     fn visit_arrow_function_expression(&mut self, _it: &ArrowFunctionExpression<'_>) {}
 }
 
-pub fn is_void_arrow_return(statements: &AllocatorVec<'_, Statement>) -> bool {
+pub fn is_void_arrow_return(statements: &ArenaVec<'_, Statement>) -> bool {
     if statements.is_empty() {
         return false;
     }

--- a/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
@@ -194,8 +194,10 @@ impl Rule for GroupedAccessorPairs {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::ObjectExpression(obj_expr) => {
-                let mut prop_map =
-                    FxHashMap::<(String, bool), Vec<(usize, &ArenaBox<ObjectProperty>)>>::default();
+                let mut prop_map = FxHashMap::<
+                    (String, bool),
+                    Vec<(usize, &ArenaBox<'_, ObjectProperty<'_>>)>,
+                >::default();
                 let properties = &obj_expr.properties;
 
                 for (idx, v) in properties.iter().enumerate() {
@@ -253,7 +255,7 @@ impl Rule for GroupedAccessorPairs {
                 let method_defines = &class_body.body;
                 let mut prop_map = FxHashMap::<
                     (String, bool, bool, bool),
-                    Vec<(usize, &ArenaBox<MethodDefinition>)>,
+                    Vec<(usize, &ArenaBox<'_, MethodDefinition<'_>>)>,
                 >::default();
 
                 for (idx, v) in method_defines.iter().enumerate() {
@@ -344,8 +346,10 @@ impl GroupedAccessorPairs {
     }
 
     fn check_ts_signatures<'a>(&self, signatures: &[TSSignature<'a>], ctx: &LintContext<'a>) {
-        let mut prop_map =
-            FxHashMap::<(String, bool), Vec<(usize, &ArenaBox<TSMethodSignature>)>>::default();
+        let mut prop_map = FxHashMap::<
+            (String, bool),
+            Vec<(usize, &ArenaBox<'_, TSMethodSignature<'_>>)>,
+        >::default();
 
         for (idx, signature) in signatures.iter().enumerate() {
             let TSSignature::TSMethodSignature(method_sig) = signature else {

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::ArenaBox;
 use oxc_ast::{
     AstKind,
     ast::{Expression, IdentifierReference, MemberExpression, match_member_expression},
@@ -77,7 +78,7 @@ fn global_this_member<'a>(expr: &'a MemberExpression<'_>) -> Option<&'a str> {
 }
 
 fn resolve_global_binding<'a, 'b: 'a>(
-    ident: &'a oxc_allocator::Box<'a, IdentifierReference<'a>>,
+    ident: &'a ArenaBox<'a, IdentifierReference<'a>>,
     scope_id: ScopeId,
     ctx: &LintContext<'a>,
 ) -> Option<&'a str> {

--- a/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_regex_spaces.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, Vec};
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::{
     AstKind,
     ast::{Argument, CallExpression, NewExpression, RegExpLiteral},
@@ -104,7 +104,7 @@ impl NoRegexSpaces {
         find_consecutive_spaces(pattern)
     }
 
-    fn find_expr_to_report(args: &Vec<'_, Argument<'_>>, ctx: &LintContext) -> Option<Span> {
+    fn find_expr_to_report(args: &ArenaVec<'_, Argument<'_>>, ctx: &LintContext) -> Option<Span> {
         if let Some(expr) = args.get(1).and_then(Argument::as_expression)
             && !expr.is_string_literal()
         {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_return.rs
@@ -268,7 +268,7 @@ impl NoUselessReturn {
     /// Check if a span is contained in the last statement of a statement list
     #[inline]
     fn is_span_in_last_statement(
-        statements: &ArenaVec<oxc_ast::ast::Statement>,
+        statements: &ArenaVec<'_, oxc_ast::ast::Statement<'_>>,
         span: Span,
     ) -> bool {
         statements.last().is_some_and(|last| last.span().contains_inclusive(span))

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 
-use oxc_allocator::Box;
+use oxc_allocator::ArenaBox;
 use oxc_ast::AstKind;
 use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKind};
 use oxc_diagnostics::OxcDiagnostic;
@@ -325,7 +325,10 @@ fn get_char_span_after(expr: &Expression, ctx: &LintContext) -> Option<Span> {
     None
 }
 
-fn get_delete_span_of_left(obj_expr: &Box<'_, ObjectExpression<'_>>, ctx: &LintContext) -> Span {
+fn get_delete_span_of_left(
+    obj_expr: &ArenaBox<'_, ObjectExpression<'_>>,
+    ctx: &LintContext,
+) -> Span {
     let mut span_end = obj_expr.span.start;
     for (i, c) in ctx.source_range(obj_expr.span).char_indices() {
         if i != 0 && !c.is_whitespace() {
@@ -340,7 +343,7 @@ fn get_delete_span_of_left(obj_expr: &Box<'_, ObjectExpression<'_>>, ctx: &LintC
 }
 
 fn get_delete_span_start_of_right(
-    obj_expr: &Box<'_, ObjectExpression<'_>>,
+    obj_expr: &ArenaBox<'_, ObjectExpression<'_>>,
     ctx: &LintContext,
 ) -> u32 {
     let obj_expr_last_char_span = Span::new(obj_expr.span.end - 1, obj_expr.span.end);

--- a/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/require_unicode_regexp.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::{
     AstKind,
     ast::{Argument, Expression, IdentifierReference, RegExpFlags, TemplateLiteral},
@@ -220,7 +220,7 @@ impl RequireUnicodeRegexp {
 }
 
 fn extract_regex_flags<'a>(
-    args: &'a Vec<'a, Argument<'a>>,
+    args: &'a ArenaVec<'a, Argument<'a>>,
     ctx: &LintContext<'a>,
 ) -> Option<RegExpFlags> {
     if args.iter().any(oxc_ast::ast::Argument::is_spread) {

--- a/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
+++ b/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, str::FromStr};
 
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, ArenaVec, CloneIn};
 use oxc_ast::{
     AstBuilder, AstKind,
     ast::{ImportDeclaration, ImportDeclarationSpecifier, ImportOrExportKind},
@@ -218,7 +218,7 @@ fn gen_value_import_declaration<'c, 'a: 'c>(
     let specifiers: Vec<_> = specifiers.iter().map(|it| it.clone_in(&alloc)).collect();
     let import_declaration = ast_builder.alloc_import_declaration(
         SPAN,
-        Some(oxc_allocator::Vec::from_iter_in(specifiers, &alloc)),
+        Some(ArenaVec::from_iter_in(specifiers, &alloc)),
         import_decl.source.clone_in(&alloc),
         None,
         import_decl.with_clause.clone_in(&alloc),
@@ -255,7 +255,7 @@ fn gen_type_import_declaration<'c, 'a: 'c>(
         .collect();
     let import_declaration = ast_builder.alloc_import_declaration(
         SPAN,
-        Some(oxc_allocator::Vec::from_iter_in(specifiers, &alloc)),
+        Some(ArenaVec::from_iter_in(specifiers, &alloc)),
         import_decl.source.clone_in(&alloc),
         None,
         import_decl.with_clause.clone_in(&alloc),

--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -341,7 +341,7 @@ impl Rule for NoMapSpread {
         // Look for return statements that contain an object or array spread.
         let visitor = SpreadInReturnVisitor::<'a, '_>::iter_spreads(ctx, mapper, |spread| {
             // SAFETY: references to arena-allocated objects are valid for the
-            // lifetime of the arena. Unfortunately, `AsRef` on `Box<'a, T>`
+            // lifetime of the arena. Unfortunately, `AsRef` on `ArenaBox<'a, T>`
             // returns a reference with a lifetime of 'self instead of 'a.
             spreads.push(unsafe { std::mem::transmute::<Spread<'a, '_>, Spread<'a, 'a>>(spread) });
         });

--- a/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
+++ b/crates/oxc_linter/src/rules/promise/no_return_in_finally.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box as OBox;
+use oxc_allocator::ArenaBox;
 use oxc_ast::{
     AstKind,
     ast::{Expression, FunctionBody, Statement},
@@ -82,7 +82,7 @@ impl Rule for NoReturnInFinally {
     }
 }
 
-fn find_return_statement<'a>(func_body: &OBox<'_, FunctionBody<'a>>, ctx: &LintContext<'a>) {
+fn find_return_statement<'a>(func_body: &ArenaBox<'_, FunctionBody<'a>>, ctx: &LintContext<'a>) {
     let Some(return_stmt) =
         func_body.statements.iter().find(|stmt| matches!(stmt, Statement::ReturnStatement(_)))
     else {

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -1603,7 +1603,7 @@ fn is_inside_effect_cleanup(stack: &[AstType]) -> bool {
 
 mod fix {
     use super::Name;
-    use oxc_allocator::{Allocator, CloneIn};
+    use oxc_allocator::{Allocator, ArenaVec, CloneIn};
     use oxc_ast::{
         AstBuilder,
         ast::{ArrayExpression, Expression},
@@ -1656,10 +1656,9 @@ mod fix {
             .filter(|el| (*el).span() != dependency.span)
             .map(|el| el.clone_in(&alloc));
 
-        codegen.print_expression(&Expression::ArrayExpression(ast_builder.alloc_array_expression(
-            deps.span,
-            oxc_allocator::Vec::from_iter_in(new_deps, &alloc),
-        )));
+        codegen.print_expression(&Expression::ArrayExpression(
+            ast_builder.alloc_array_expression(deps.span, ArenaVec::from_iter_in(new_deps, &alloc)),
+        ));
         fixer.replace(deps.span, codegen.into_source_text())
     }
 }

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -4,7 +4,7 @@ use crate::{
     rule::{DefaultRuleConfig, Rule},
 };
 use lazy_regex::{Lazy, Regex, lazy_regex};
-use oxc_allocator::{Allocator, Vec};
+use oxc_allocator::{Allocator, ArenaVec};
 
 use oxc_ast::{
     AstBuilder, AstKind,
@@ -373,7 +373,7 @@ impl JsxCurlyBracePresence {
     fn check_jsx_child<'a>(
         &self,
         ctx: &LintContext<'a>,
-        children: &Vec<'a, JSXChild<'a>>,
+        children: &ArenaVec<'a, JSXChild<'a>>,
         node: &AstNode<'a>,
     ) {
         for child in children {

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -240,7 +240,7 @@ fn trim_like_react(text: &str) -> &str {
     &text[start..end]
 }
 
-fn can_fix(node: &AstNode, children: &ArenaVec<JSXChild<'_>>, ctx: &LintContext) -> bool {
+fn can_fix(node: &AstNode, children: &ArenaVec<'_, JSXChild<'_>>, ctx: &LintContext) -> bool {
     let parent = ctx.nodes().parent_kind(node.id());
 
     if !matches!(parent, AstKind::JSXElement(_) | AstKind::JSXFragment(_)) {
@@ -293,7 +293,7 @@ fn jsx_elem_has_key_attr(elem: &JSXElement) -> bool {
     })
 }
 
-fn is_fragment_with_single_expression(children: &oxc_allocator::Vec<'_, JSXChild<'_>>) -> bool {
+fn is_fragment_with_single_expression(children: &ArenaVec<'_, JSXChild<'_>>) -> bool {
     let mut non_padding_children = children.iter().filter(|child| is_padding_spaces(child));
 
     matches!(non_padding_children.next(), Some(JSXChild::ExpressionContainer(_)))
@@ -326,7 +326,7 @@ fn is_html_element(elem_name: &JSXElementName) -> bool {
     ident.name.starts_with(char::is_lowercase)
 }
 
-fn has_less_than_two_children(children: &oxc_allocator::Vec<'_, JSXChild<'_>>) -> bool {
+fn has_less_than_two_children(children: &ArenaVec<'_, JSXChild<'_>>) -> bool {
     let mut non_padding_child_count = 0;
     let mut has_call_expression_child = false;
 
@@ -348,7 +348,7 @@ fn has_less_than_two_children(children: &oxc_allocator::Vec<'_, JSXChild<'_>>) -
 
 fn is_fragment_with_only_text_and_is_not_child<'a>(
     id: NodeId,
-    node: &oxc_allocator::Vec<'a, JSXChild<'a>>,
+    node: &ArenaVec<'a, JSXChild<'a>>,
     ctx: &LintContext,
 ) -> bool {
     if node.len() != 1 {

--- a/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger_with_children.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::ArenaVec;
 use oxc_ast::{
     AstKind,
     ast::{Argument, Expression, JSXAttributeItem, JSXAttributeName, JSXChild, ObjectPropertyKind},
@@ -336,7 +337,7 @@ fn find_var_in_scope<'c>(
 
 /// Returns whether a given object has a property with the given name.
 fn is_object_with_prop_name(
-    obj_props: &oxc_allocator::Vec<'_, ObjectPropertyKind<'_>>,
+    obj_props: &ArenaVec<'_, ObjectPropertyKind<'_>>,
     prop_name: &str,
 ) -> bool {
     obj_props.iter().any(|prop| {

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_test_return_statement.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_test_return_statement.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box as OBox;
+use oxc_allocator::ArenaBox;
 use oxc_ast::{
     AstKind,
     ast::{CallExpression, Expression, FunctionBody, Statement},
@@ -94,7 +94,10 @@ fn check_call_expression<'a>(
     }
 }
 
-fn check_test_return_statement<'a>(func_body: &OBox<'_, FunctionBody<'a>>, ctx: &LintContext<'a>) {
+fn check_test_return_statement<'a>(
+    func_body: &ArenaBox<'_, FunctionBody<'a>>,
+    ctx: &LintContext<'a>,
+) {
     let Some(return_stmt) =
         func_body.statements.iter().find(|stmt| matches!(stmt, Statement::ReturnStatement(_)))
     else {

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/require_hook.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec as OxcVec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::{
     AstKind,
     ast::{Argument, Expression, Statement, VariableDeclarationKind},
@@ -185,7 +185,7 @@ impl RequireHookConfig {
 
     fn check_block_body<'a>(
         &self,
-        statements: &'a OxcVec<'a, Statement<'_>>,
+        statements: &'a ArenaVec<'a, Statement<'_>>,
         ctx: &LintContext<'a>,
     ) {
         for stmt in statements {

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect_in_promise.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/valid_expect_in_promise.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::ArenaVec;
 use oxc_ast::{
     AstKind,
     ast::{
@@ -127,7 +128,7 @@ pub fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<
 }
 
 fn process_statements<'a>(
-    statements: &'a oxc_allocator::Vec<'a, Statement<'a>>,
+    statements: &'a ArenaVec<'a, Statement<'a>>,
     pending_promises: &mut FxHashMap<CompactStr, Span>,
     return_found: &mut bool,
     ctx: &LintContext<'a>,
@@ -229,7 +230,7 @@ fn ident_name_of<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
 /// the arguments of the innermost `expect(...)` call.
 fn find_expect_args<'a>(
     call_expr: &'a CallExpression<'a>,
-) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
+) -> Option<&'a ArenaVec<'a, Argument<'a>>> {
     if let Expression::Identifier(ident) = &call_expr.callee
         && ident.name == "expect"
     {
@@ -238,9 +239,7 @@ fn find_expect_args<'a>(
     find_inner_expect(&call_expr.callee)
 }
 
-fn find_inner_expect<'a>(
-    expr: &'a Expression<'a>,
-) -> Option<&'a oxc_allocator::Vec<'a, Argument<'a>>> {
+fn find_inner_expect<'a>(expr: &'a Expression<'a>) -> Option<&'a ArenaVec<'a, Argument<'a>>> {
     match expr {
         Expression::CallExpression(call) => find_expect_args(call),
         _ => find_inner_expect(expr.as_member_expression()?.object()),

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::ArenaBox;
 use oxc_ast::{
     AstKind,
     ast::{
@@ -121,7 +122,7 @@ impl ConsistentGenericConstructors {
     fn check<'a>(
         &self,
         node: &AstNode<'a>,
-        type_annotation: Option<&oxc_allocator::Box<'a, TSTypeAnnotation<'a>>>,
+        type_annotation: Option<&ArenaBox<'a, TSTypeAnnotation<'a>>>,
         init: Option<&Expression<'a>>,
         ctx: &LintContext<'a>,
     ) {

--- a/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_module_boundary_types.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, ops::Deref};
 
-use oxc_allocator::{Address, UnstableAddress};
+use oxc_allocator::{Address, ArenaVec, UnstableAddress};
 use oxc_ast::{AstKind, ast::*};
 use oxc_ast_visit::{
     Visit,
@@ -612,7 +612,7 @@ impl<'a> Visit<'a> for ExplicitTypesChecker<'a, '_> {
         }
     }
 
-    fn visit_statements(&mut self, it: &oxc_allocator::Vec<'a, Statement<'a>>) {
+    fn visit_statements(&mut self, it: &ArenaVec<'a, Statement<'a>>) {
         for stmt in it {
             match stmt {
                 Statement::ReturnStatement(_) => {

--- a/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::ArenaVec;
 use oxc_ast::{
     AstKind,
     ast::{
@@ -148,7 +149,7 @@ impl Rule for NoInferrableTypes {
 impl NoInferrableTypes {
     fn check_formal_parameters<'a>(
         &self,
-        params: &oxc_allocator::Vec<'a, FormalParameter<'a>>,
+        params: &ArenaVec<'a, FormalParameter<'a>>,
         ctx: &LintContext<'a>,
     ) {
         if self.ignore_parameters {

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -290,7 +290,7 @@ impl Rule for PreferFunctionType {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSInterfaceDeclaration(decl) => {
-                let body: &oxc_allocator::Vec<'_, TSSignature<'_>> = &decl.body.body;
+                let body = &decl.body.body;
 
                 if !has_one_super_type(decl) && body.len() == 1 {
                     check_member(&body[0], node, ctx);

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::{LintContext, ast_util::is_new_expression, rule::Rule};
 use cow_utils::CowUtils;
-use oxc_allocator::Box;
+use oxc_allocator::ArenaBox;
 use oxc_ast::{
     AstKind,
     ast::{
@@ -93,7 +93,7 @@ impl Rule for NoInvalidFetchOptions {
 const UNKNOWN_METHOD_NAME: Cow<'static, str> = Cow::Borrowed("UNKNOWN");
 
 fn is_invalid_fetch_options<'a>(
-    obj_expr: &'a Box<'_, ObjectExpression<'_>>,
+    obj_expr: &'a ArenaBox<'_, ObjectExpression<'_>>,
     ctx: &'a LintContext<'_>,
 ) -> Option<(Cow<'a, str>, Span)> {
     // fetch and Request method defaults to "GET"

--- a/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_unreadable_array_destructuring.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -50,7 +50,10 @@ declare_oxc_lint!(
     short_description = "Disallows destructuring values from an array in ways that are difficult to read.",
 );
 
-fn is_unreadable_array_destructuring<T, U>(elements: &Vec<Option<T>>, rest: Option<&U>) -> bool {
+fn is_unreadable_array_destructuring<T, U>(
+    elements: &ArenaVec<'_, Option<T>>,
+    rest: Option<&U>,
+) -> bool {
     if elements.len() >= 3 && elements.windows(2).any(|window| window.iter().all(Option::is_none)) {
         return true;
     }

--- a/crates/oxc_linter/src/rules/unicorn/require_module_attributes.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_module_attributes.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::ArenaVec;
 use oxc_ast::{
     AstKind,
     ast::{Expression, ObjectProperty, PropertyKind, WithClause},
@@ -177,7 +178,7 @@ fn check_with_clause(
 fn fix_empty_with_property(
     fixer: RuleFixer<'_, '_>,
     empty_with_prop: &ObjectProperty<'_>,
-    properties: &oxc_allocator::Vec<'_, oxc_ast::ast::ObjectPropertyKind<'_>>,
+    properties: &ArenaVec<'_, oxc_ast::ast::ObjectPropertyKind<'_>>,
 ) -> RuleFix {
     // Find the position of the empty_with_prop in properties
     let prop_index = properties

--- a/crates/oxc_linter/src/rules/vitest/prefer_called_exactly_once_with.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_called_exactly_once_with.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use oxc_allocator::Vec as OxcVec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::{
     AstKind,
     ast::{CallExpression, Expression, FunctionBody, MemberExpression, Statement},
@@ -211,7 +211,7 @@ const MOCK_RESET_METHODS: [&str; 3] = ["mockClear", "mockReset", "mockRestore"];
 
 impl PreferCalledExactlyOnceWith {
     fn check_block_body<'a>(
-        statements: &'a OxcVec<'a, Statement<'_>>,
+        statements: &'a ArenaVec<'a, Statement<'_>>,
         node: &AstNode<'a>,
         ctx: &LintContext<'a>,
     ) {
@@ -353,7 +353,7 @@ impl PreferCalledExactlyOnceWith {
 }
 
 enum TestCallExpression<'a> {
-    TestBlock(&'a oxc_allocator::Vec<'a, Statement<'a>>),
+    TestBlock(&'a ArenaVec<'a, Statement<'a>>),
     MockReset,
     ExpectFnCall(ParsedExpectFnCall<'a>),
 }

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -1,6 +1,8 @@
 use std::{borrow::Cow, cmp::Ordering};
 
 use cow_utils::CowUtils;
+
+use oxc_allocator::ArenaVec;
 use oxc_ast::{
     AstKind,
     ast::{
@@ -402,7 +404,7 @@ pub struct ParsedExpectFnCall<'a> {
     /// this args changed bases on condition
     /// In `expect(fn).toBeCalledTimes(2)`, it will be `[2]`
     /// In `expect(fn)`, it will be `fn`
-    pub args: &'a oxc_allocator::Vec<'a, Argument<'a>>,
+    pub args: &'a ArenaVec<'a, Argument<'a>>,
     // In `expect(1).not.resolved.toBe()`, "not", "resolved" will be modifier
     // it save a group of modifier index from members
     pub modifier_indices: Vec<usize>,
@@ -413,11 +415,11 @@ pub struct ParsedExpectFnCall<'a> {
 
     /// the arguments passed to the expect function
     /// In `expect(1).toBe(2)`, it will be `[1]`
-    pub expect_arguments: Option<&'a oxc_allocator::Vec<'a, Argument<'a>>>,
+    pub expect_arguments: Option<&'a ArenaVec<'a, Argument<'a>>>,
     /// the arguments passed to the matcher function
     /// In `expect(1).toBe(2)`, it will be `[2]
     /// In `expect(1)`, it will be `None`
-    pub matcher_arguments: Option<&'a oxc_allocator::Vec<'a, Argument<'a>>>,
+    pub matcher_arguments: Option<&'a ArenaVec<'a, Argument<'a>>>,
 }
 
 impl<'a> ParsedExpectFnCall<'a> {

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -7,7 +7,7 @@ use oxc_syntax::class::ClassId;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use base54::base54;
-use oxc_allocator::{Allocator, BitSet, HashSet, Vec};
+use oxc_allocator::{Allocator, ArenaHashSet, ArenaVec, BitSet};
 use oxc_ast::ast::{Declaration, Program, Statement};
 use oxc_data_structures::inline_string::InlineString;
 use oxc_semantic::{AstNodes, Reference, Scoping, Semantic, SemanticBuilder, Stats, SymbolId};
@@ -456,12 +456,12 @@ fn is_special_name(name: &str) -> bool {
 struct SlotFrequency<'a> {
     pub slot: Slot,
     pub frequency: usize,
-    pub symbol_ids: Vec<'a, SymbolId>,
+    pub symbol_ids: ArenaVec<'a, SymbolId>,
 }
 
 impl<'t> SlotFrequency<'t> {
     fn new(temp_allocator: &'t Allocator) -> Self {
-        Self { slot: 0, frequency: 0, symbol_ids: Vec::new_in(temp_allocator) }
+        Self { slot: 0, frequency: 0, symbol_ids: ArenaVec::new_in(temp_allocator) }
     }
 }
 
@@ -477,7 +477,7 @@ struct Constraints<'a, 's> {
     /// Whether top-level (module / CommonJS) bindings may be mangled at all.
     top_level: bool,
     /// Names of top-level exports — kept when `top_level` so importers still resolve.
-    exported_names: HashSet<'a, Str<'a>>,
+    exported_names: ArenaHashSet<'a, Str<'a>>,
     exported_symbols: Option<BitSet<'a>>,
     /// Names preserved by the `keep_names` option (function / class names).
     keep_name_names: FxHashSet<&'s str>,
@@ -487,7 +487,7 @@ struct Constraints<'a, 's> {
 /// Phase 2 output — each symbol's slot, plus the names a direct `eval` can see.
 struct SlotAssignment<'a, 's> {
     /// `slots[symbol] == slot`, or `SLOT_UNASSIGNED` for symbols that keep their name.
-    slots: Vec<'a, Slot>,
+    slots: ArenaVec<'a, Slot>,
     total_slots: usize,
     /// Names of bindings in direct-`eval` scopes — they keep their names, nothing may shadow them.
     eval_reserved_names: FxHashSet<&'s str>,
@@ -495,12 +495,12 @@ struct SlotAssignment<'a, 's> {
 
 /// Phase 3 output — slots ranked by reference count, hottest first.
 struct SlotRanking<'a> {
-    frequencies: Vec<'a, SlotFrequency<'a>>,
+    frequencies: ArenaVec<'a, SlotFrequency<'a>>,
 }
 
 /// Phase 4 output — the short names to hand out, shortest first.
 struct NameTable<'a, const CAPACITY: usize> {
-    names: Vec<'a, InlineString<CAPACITY, u8>>,
+    names: ArenaVec<'a, InlineString<CAPACITY, u8>>,
 }
 
 impl<'a, 's> Constraints<'a, 's> {
@@ -516,7 +516,7 @@ impl<'a, 's> Constraints<'a, 's> {
         let (exported_names, exported_symbols) = if top_level && program.source_type.is_module() {
             collect_exported_symbols(program, allocator, scoping.symbols_len())
         } else {
-            (HashSet::new_in(allocator), None)
+            (ArenaHashSet::new_in(allocator), None)
         };
         let (keep_name_names, keep_name_symbols) =
             collect_keep_name_symbols(options.keep_names, allocator, scoping, ast_nodes);
@@ -545,14 +545,16 @@ impl<'a, 's> SlotAssignment<'a, 's> {
         let mut eval_reserved_names: FxHashSet<&'s str> = FxHashSet::default();
 
         // All symbols with their assigned slots. Keyed by symbol id.
-        let mut slots =
-            Vec::from_iter_in(iter::repeat_n(SLOT_UNASSIGNED, scoping.symbols_len()), allocator);
+        let mut slots = ArenaVec::from_iter_in(
+            iter::repeat_n(SLOT_UNASSIGNED, scoping.symbols_len()),
+            allocator,
+        );
         // Stores the lived scope ids for each slot. Keyed by slot number. Symbol count is the
         // upper bound on slots.
-        let mut slot_liveness: Vec<BitSet> =
-            Vec::with_capacity_in(scoping.symbols_len(), allocator);
-        let mut tmp_bindings = Vec::with_capacity_in(100, allocator);
-        let mut reusable_slots = Vec::new_in(allocator);
+        let mut slot_liveness =
+            ArenaVec::<BitSet>::with_capacity_in(scoping.symbols_len(), allocator);
+        let mut tmp_bindings = ArenaVec::with_capacity_in(100, allocator);
+        let mut reusable_slots = ArenaVec::new_in(allocator);
         // Pre-computed BitSet for ancestor membership tests - reused across iterations
         let mut ancestor_set = BitSet::new_in(scoping.scopes_len(), allocator);
 
@@ -701,7 +703,7 @@ impl<'a> SlotRanking<'a> {
         let exported_symbols = constraints.exported_symbols.as_ref();
         let keep_name_symbols = constraints.keep_name_symbols.as_ref();
         let root_scope_id = scoping.root_scope_id();
-        let mut frequencies = Vec::from_iter_in(
+        let mut frequencies = ArenaVec::from_iter_in(
             repeat_with(|| SlotFrequency::new(allocator)).take(slots.total_slots),
             allocator,
         );
@@ -769,7 +771,7 @@ impl<'a, const CAPACITY: usize> NameTable<'a, CAPACITY> {
         };
 
         let count = ranking.frequencies.len();
-        let mut names = Vec::with_capacity_in(count, allocator);
+        let mut names = ArenaVec::with_capacity_in(count, allocator);
         let mut candidate = 0;
         for _ in 0..count {
             let name = loop {
@@ -794,8 +796,8 @@ impl<'a, const CAPACITY: usize> NameTable<'a, CAPACITY> {
         // Yields slots hottest-first as we consume each length bucket.
         let mut freq_iter = ranking.frequencies.iter();
         // Scratch buffers in the temp arena (reused/reset across files via `new_with_temp_allocator`).
-        let mut symbols_renamed_in_this_batch = Vec::with_capacity_in(100, allocator);
-        let mut slice_of_same_len_strings = Vec::with_capacity_in(100, allocator);
+        let mut symbols_renamed_in_this_batch = ArenaVec::with_capacity_in(100, allocator);
+        let mut slice_of_same_len_strings = ArenaVec::with_capacity_in(100, allocator);
         // Names are generated shortest-first, so each `chunk_by(len)` group is one name length.
         for (_, group) in &self.names.into_iter().chunk_by(InlineString::len) {
             // Take the N hottest remaining slots to receive the N names of this length...
@@ -834,9 +836,9 @@ fn collect_exported_symbols<'a>(
     program: &Program<'a>,
     allocator: &'a Allocator,
     symbols_len: usize,
-) -> (HashSet<'a, Str<'a>>, Option<BitSet<'a>>) {
+) -> (ArenaHashSet<'a, Str<'a>>, Option<BitSet<'a>>) {
     let mut exported_symbols = BitSet::new_in(symbols_len, allocator);
-    let mut exported_names = HashSet::new_in(allocator);
+    let mut exported_names = ArenaHashSet::new_in(allocator);
     for statement in &program.body {
         let Statement::ExportNamedDeclaration(v) = statement else { continue };
         let Some(decl) = &v.declaration else { continue };

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1,7 +1,7 @@
 use std::{iter, ops::ControlFlow};
 
 use crate::generated::ancestor::Ancestor;
-use oxc_allocator::{Box, TakeIn, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ecmascript::{
@@ -47,7 +47,7 @@ impl<'a> PeepholeOptimizations {
     ///
     /// ## MinimizeExitPoints:
     /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/MinimizeExitPoints.java>
-    pub fn minimize_statements(stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
+    pub fn minimize_statements(stmts: &mut ArenaVec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
         let mut old_stmts = stmts.take_in(ctx);
         let mut is_control_flow_dead = false;
         let mut keep_var = KeepVar::new(ctx.ast);
@@ -359,8 +359,8 @@ impl<'a> PeepholeOptimizations {
     fn minimize_statement(
         stmt: Statement<'a>,
         i: usize,
-        stmts: &mut Vec<'a, Statement<'a>>,
-        result: &mut Vec<'a, Statement<'a>>,
+        stmts: &mut ArenaVec<'a, Statement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
         is_control_flow_dead: &mut bool,
 
         ctx: &mut TraverseCtx<'a>,
@@ -447,8 +447,8 @@ impl<'a> PeepholeOptimizations {
     /// * remove the variable declarator if it is unused
     /// * keep the initializer if it has side effects
     fn handle_variable_declaration(
-        mut var_decl: Box<'a, VariableDeclaration<'a>>,
-        result: &mut Vec<'a, Statement<'a>>,
+        mut var_decl: ArenaBox<'a, VariableDeclaration<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
 
         ctx: &mut TraverseCtx<'a>,
     ) {
@@ -521,8 +521,8 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn handle_expression_statement(
-        mut expr_stmt: Box<'a, ExpressionStatement<'a>>,
-        result: &mut Vec<'a, Statement<'a>>,
+        mut expr_stmt: ArenaBox<'a, ExpressionStatement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
 
         ctx: &mut TraverseCtx<'a>,
     ) {
@@ -618,7 +618,7 @@ impl<'a> PeepholeOptimizations {
 
     fn merge_assignment_to_declaration(
         assign_expr: &mut AssignmentExpression<'a>,
-        result: &mut Vec<'a, Statement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
         ctx: &TraverseCtx<'a>,
     ) -> bool {
         if assign_expr.operator != AssignmentOperator::Assign {
@@ -669,8 +669,8 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn handle_switch_statement(
-        mut switch_stmt: Box<'a, SwitchStatement<'a>>,
-        result: &mut Vec<'a, Statement<'a>>,
+        mut switch_stmt: ArenaBox<'a, SwitchStatement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
 
         ctx: &mut TraverseCtx<'a>,
     ) {
@@ -726,9 +726,9 @@ impl<'a> PeepholeOptimizations {
 
     fn handle_if_statement(
         i: usize,
-        stmts: &mut Vec<'a, Statement<'a>>,
-        mut if_stmt: Box<'a, IfStatement<'a>>,
-        result: &mut Vec<'a, Statement<'a>>,
+        stmts: &mut ArenaVec<'a, Statement<'a>>,
+        mut if_stmt: ArenaBox<'a, IfStatement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
 
         ctx: &mut TraverseCtx<'a>,
     ) -> ControlFlow<()> {
@@ -873,8 +873,8 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn handle_return_statement(
-        mut ret_stmt: Box<'a, ReturnStatement<'a>>,
-        result: &mut Vec<'a, Statement<'a>>,
+        mut ret_stmt: ArenaBox<'a, ReturnStatement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
         is_control_flow_dead: &mut bool,
 
         ctx: &mut TraverseCtx<'a>,
@@ -923,8 +923,8 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn handle_throw_statement(
-        mut throw_stmt: Box<'a, ThrowStatement<'a>>,
-        result: &mut Vec<'a, Statement<'a>>,
+        mut throw_stmt: ArenaBox<'a, ThrowStatement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
         is_control_flow_dead: &mut bool,
 
         ctx: &mut TraverseCtx<'a>,
@@ -951,8 +951,8 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn handle_for_statement(
-        mut for_stmt: Box<'a, ForStatement<'a>>,
-        result: &mut Vec<'a, Statement<'a>>,
+        mut for_stmt: ArenaBox<'a, ForStatement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
 
         ctx: &mut TraverseCtx<'a>,
     ) {
@@ -1051,8 +1051,8 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn handle_for_in_statement(
-        mut for_in_stmt: Box<'a, ForInStatement<'a>>,
-        result: &mut Vec<'a, Statement<'a>>,
+        mut for_in_stmt: ArenaBox<'a, ForInStatement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
 
         ctx: &mut TraverseCtx<'a>,
     ) {
@@ -1142,8 +1142,8 @@ impl<'a> PeepholeOptimizations {
     }
 
     fn handle_for_of_statement(
-        mut for_of_stmt: Box<'a, ForOfStatement<'a>>,
-        result: &mut Vec<'a, Statement<'a>>,
+        mut for_of_stmt: ArenaBox<'a, ForOfStatement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) {
         let is_block_scoped_decl = matches!(&for_of_stmt.left, ForStatementLeft::VariableDeclaration(var_decl) if !var_decl.kind.is_var());
@@ -1184,8 +1184,8 @@ impl<'a> PeepholeOptimizations {
 
     /// `appendIfOrLabelBodyPreservingScope`: <https://github.com/evanw/esbuild/blob/v0.24.2/internal/js_ast/js_parser.go#L9852>
     fn handle_block(
-        result: &mut Vec<'a, Statement<'a>>,
-        block_stmt: Box<'a, BlockStatement<'a>>,
+        result: &mut ArenaVec<'a, Statement<'a>>,
+        block_stmt: ArenaBox<'a, BlockStatement<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) {
         let keep_block = block_stmt.body.iter().any(Self::statement_cares_about_scope);
@@ -1237,7 +1237,7 @@ impl<'a> PeepholeOptimizations {
     /// `substituteSingleUseSymbolInStmt`: <https://github.com/evanw/esbuild/blob/v0.25.9/internal/js_parser/js_parser.go#L9583>
     fn substitute_single_use_symbol_in_statement(
         expr_in_stmt: &mut Expression<'a>,
-        stmts: &mut Vec<'a, Statement<'a>>,
+        stmts: &mut ArenaVec<'a, Statement<'a>>,
         ctx: &mut TraverseCtx<'a>,
         non_scoped_literal_only: bool,
     ) -> bool {
@@ -1282,7 +1282,7 @@ impl<'a> PeepholeOptimizations {
 
     fn substitute_single_use_symbol_within_declaration(
         kind: VariableDeclarationKind,
-        declarations: &mut Vec<'a, VariableDeclarator<'a>>,
+        declarations: &mut ArenaVec<'a, VariableDeclarator<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> bool {
         if Self::keep_top_level_var_in_script_mode(ctx)

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -25,7 +25,7 @@ use oxc_syntax::{
 };
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::{BitSet, Vec};
+use oxc_allocator::{ArenaVec, BitSet};
 use oxc_ast::ast::*;
 
 use crate::{
@@ -467,7 +467,11 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         debug_assert!(ctx.state.dce || ctx.state.class_symbols_stack.is_exhausted());
     }
 
-    fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
+    fn exit_statements(
+        &mut self,
+        stmts: &mut ArenaVec<'a, Statement<'a>>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
         Self::minimize_statements(stmts, ctx);
     }
 

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -1,5 +1,5 @@
 use crate::generated::ancestor::Ancestor;
-use oxc_allocator::{TakeIn, Vec};
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 use oxc_ecmascript::{
     constant_evaluation::{DetermineValueType, ValueType},
@@ -54,7 +54,11 @@ impl<'a> Traverse<'a> for Normalize {
         }
     }
 
-    fn exit_statements(&mut self, stmts: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
+    fn exit_statements(
+        &mut self,
+        stmts: &mut ArenaVec<'a, Statement<'a>>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
         // No console handling here: `exit_expression` has already rewritten
         // every console call (statement position included) to `void 0`.
         stmts.retain(|stmt| match stmt {

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -1,5 +1,5 @@
 use crate::generated::ancestor::Ancestor;
-use oxc_allocator::{TakeIn, Vec};
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_ecmascript::{
@@ -587,7 +587,7 @@ impl<'a> PeepholeOptimizations {
         body.body.retain(|e| !matches!(e, ClassElement::StaticBlock(s) if s.body.is_empty()));
     }
 
-    pub fn remove_empty_spread_arguments(args: &mut Vec<'a, Argument<'a>>) {
+    pub fn remove_empty_spread_arguments(args: &mut ArenaVec<'a, Argument<'a>>) {
         if args.len() != 1 {
             return;
         }

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use crate::{CompressOptionsUnused, TraverseCtx, generated::ancestor::Ancestor};
-use oxc_allocator::{TakeIn, Vec};
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 use oxc_compat::ESFeature;
 use oxc_ecmascript::{
@@ -660,14 +660,14 @@ impl<'a> PeepholeOptimizations {
     }
 
     pub fn fold_arguments_into_needed_expressions(
-        args: &mut Vec<'a, Argument<'a>>,
+        args: &mut ArenaVec<'a, Argument<'a>>,
         ctx: &mut TraverseCtx<'a>,
-    ) -> Vec<'a, Expression<'a>> {
+    ) -> ArenaVec<'a, Expression<'a>> {
         // `args.drain(..)` would silently move owned `Argument`s out and the
         // filter would drop any whose inner expression `remove_unused_expression`
         // collapsed to nothing — leaking references in the dropped subtree.
         // Use a manual loop so we can `drop_expression` before discarding.
-        let mut out: Vec<'a, Expression<'a>> = ctx.ast.vec_with_capacity(args.len());
+        let mut out: ArenaVec<'a, Expression<'a>> = ctx.ast.vec_with_capacity(args.len());
         for arg in args.drain(..) {
             let mut expr = match arg {
                 Argument::SpreadElement(e) => ctx.ast.expression_array(
@@ -859,7 +859,7 @@ impl<'a> PeepholeOptimizations {
     pub fn remove_unused_class(
         c: &mut Class<'a>,
         ctx: &mut TraverseCtx<'a>,
-    ) -> Option<Vec<'a, Expression<'a>>> {
+    ) -> Option<ArenaVec<'a, Expression<'a>>> {
         // TypeError `class C extends (() => {}) {}`
         if c.super_class
             .as_ref()

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -2,8 +2,7 @@ use std::borrow::Cow;
 
 use cow_utils::CowUtils;
 
-use crate::generated::ancestor::Ancestor;
-use oxc_allocator::{Box, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_compat::ESFeature;
 use oxc_ecmascript::{
@@ -16,11 +15,11 @@ use oxc_regular_expression::{
 };
 use oxc_span::SPAN;
 
-use crate::TraverseCtx;
+use crate::{TraverseCtx, generated::ancestor::Ancestor};
 
 use super::PeepholeOptimizations;
 
-type Arguments<'a> = oxc_allocator::Vec<'a, Argument<'a>>;
+type Arguments<'a> = ArenaVec<'a, Argument<'a>>;
 
 /// Minimize With Known Methods
 /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/PeepholeReplaceKnownMethods.java>
@@ -453,7 +452,8 @@ impl<'a> PeepholeOptimizations {
                     if regex.regex.pattern.pattern.is_none()
                         && let Ok(pattern) = regex.parse_pattern(ctx.ast.allocator)
                     {
-                        regex.regex.pattern.pattern = Some(Box::new_in(pattern, ctx.ast.allocator));
+                        regex.regex.pattern.pattern =
+                            Some(ArenaBox::new_in(pattern, ctx.ast.allocator));
                     }
                     if let Some(pattern) = &regex.regex.pattern.pattern
                         // for now, only replace regexes that are supported by ES2015 to preserve the syntax error

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1,7 +1,7 @@
 use std::iter::repeat_with;
 
 use crate::generated::ancestor::Ancestor;
-use oxc_allocator::{CloneIn, TakeIn, Vec};
+use oxc_allocator::{ArenaVec, CloneIn, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_compat::ESFeature;
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
@@ -1403,7 +1403,7 @@ impl<'a> PeepholeOptimizations {
 
     // `foo(...[1,2,3])` -> `foo(1,2,3)`
     // `new Foo(...[1,2,3])` -> `new Foo(1,2,3)`
-    fn try_flatten_arguments(args: &mut Vec<'a, Argument<'a>>, ctx: &mut TraverseCtx<'a>) {
+    fn try_flatten_arguments(args: &mut ArenaVec<'a, Argument<'a>>, ctx: &mut TraverseCtx<'a>) {
         let (new_size, should_fold) =
             args.iter().fold((0, false), |(mut new_size, mut should_fold), arg| {
                 new_size += if let Argument::SpreadElement(spread_el) = arg {

--- a/crates/oxc_minifier/src/traverse_context/mod.rs
+++ b/crates/oxc_minifier/src/traverse_context/mod.rs
@@ -319,7 +319,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     /// This is a shortcut for `ctx.scoping.insert_scope_below_statements`.
     pub fn insert_scope_below_statements(
         &mut self,
-        stmts: &ArenaVec<Statement>,
+        stmts: &ArenaVec<'a, Statement<'a>>,
         flags: ScopeFlags,
     ) -> ScopeId {
         self.scoping.insert_scope_below_statements(stmts, flags)

--- a/crates/oxc_minifier/src/traverse_context/scoping.rs
+++ b/crates/oxc_minifier/src/traverse_context/scoping.rs
@@ -143,7 +143,7 @@ impl<'a> TraverseScoping<'a> {
     /// `flags` provided are amended to inherit from parent scope's flags.
     pub fn insert_scope_below_statements(
         &mut self,
-        stmts: &ArenaVec<Statement>,
+        stmts: &ArenaVec<'a, Statement<'a>>,
         flags: ScopeFlags,
     ) -> ScopeId {
         let mut collector = ChildScopeCollector::new();

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -1,6 +1,6 @@
 //! Code related to navigating `Token`s from the lexer
 
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::ast::{BindingRestElement, RegExpFlags};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
@@ -384,7 +384,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         open: Kind,
         close: Kind,
         mut f: F,
-    ) -> Vec<'a, T>
+    ) -> ArenaVec<'a, T>
     where
         F: FnMut(&mut Self) -> T,
     {
@@ -410,7 +410,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         open: Kind,
         close: Kind,
         f: F,
-    ) -> Vec<'a, T>
+    ) -> ArenaVec<'a, T>
     where
         F: Fn(&mut Self) -> Option<T>,
     {
@@ -437,7 +437,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         separator: Kind,
         opening_span: Span,
         mut f: F,
-    ) -> (Vec<'a, T>, Option<u32>)
+    ) -> (ArenaVec<'a, T>, Option<u32>)
     where
         F: FnMut(&mut Self) -> T,
     {
@@ -480,7 +480,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_delimited_list_into<F, T>(
         &mut self,
-        list: &mut Vec<'a, T>,
+        list: &mut ArenaVec<'a, T>,
         close: Kind,
         separator: Kind,
         opening_span: Span,
@@ -532,14 +532,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         parse_element: E,
         parse_rest: R,
         rest_last_diagnostic: D,
-    ) -> (Vec<'a, A>, Option<Box<'a, BindingRestElement<'a>>>)
+    ) -> (ArenaVec<'a, A>, Option<ArenaBox<'a, BindingRestElement<'a>>>)
     where
         E: Fn(&mut Self) -> A,
-        R: Fn(&mut Self) -> Box<'a, BindingRestElement<'a>>,
+        R: Fn(&mut Self) -> ArenaBox<'a, BindingRestElement<'a>>,
         D: Fn(Span) -> OxcDiagnostic,
     {
         let mut list = self.ast.vec();
-        let mut rest: Option<Box<'a, BindingRestElement<'a>>> = None;
+        let mut rest: Option<ArenaBox<'a, BindingRestElement<'a>>> = None;
         let mut first = true;
         loop {
             let kind = self.cur_kind();

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box;
+use oxc_allocator::ArenaBox;
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{FileExtension, GetSpan};
 use oxc_syntax::precedence::Precedence;
@@ -7,9 +7,9 @@ use super::{FunctionKind, Tristate};
 use crate::{Context, ParserConfig as Config, ParserImpl, diagnostics, lexer::Kind};
 
 struct ArrowFunctionHead<'a> {
-    type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
-    params: Box<'a, FormalParameters<'a>>,
-    return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
+    type_parameters: Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>,
+    params: ArenaBox<'a, FormalParameters<'a>>,
+    return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
     r#async: bool,
     span: u32,
 }

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box;
+use oxc_allocator::ArenaBox;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 
@@ -20,7 +20,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(super) fn parse_binding_pattern_with_type_annotation(
         &mut self,
-    ) -> (BindingPattern<'a>, Option<Box<'a, TSTypeAnnotation<'a>>>) {
+    ) -> (BindingPattern<'a>, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>) {
         let pattern = self.parse_binding_pattern_kind();
         let type_annotation = self.parse_ts_type_annotation();
         (pattern, type_annotation)
@@ -87,7 +87,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// Section 14.3.3 Binding Rest Property
-    pub(crate) fn parse_rest_element(&mut self) -> Box<'a, BindingRestElement<'a>> {
+    pub(crate) fn parse_rest_element(&mut self) -> ArenaBox<'a, BindingRestElement<'a>> {
         let span = self.start_span();
         self.bump_any(); // advance `...`
         let init_span = self.start_span();

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_ecmascript::PropName;
 use oxc_span::{GetSpan, Span};
@@ -11,7 +11,7 @@ use crate::{
 
 use super::FunctionKind;
 
-type ImplementsWithKeywordSpan<'a> = (Span, Vec<'a, TSClassImplements<'a>>);
+type ImplementsWithKeywordSpan<'a> = (Span, ArenaVec<'a, TSClassImplements<'a>>);
 
 /// Section 15.7 Class Definitions
 impl<'a, C: Config> ParserImpl<'a, C> {
@@ -21,7 +21,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         start_span: u32,
         stmt_ctx: StatementContext,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> Statement<'a> {
         let decl = self.parse_class_declaration(start_span, modifiers, decorators);
         if stmt_ctx.is_single_statement() {
@@ -38,8 +38,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         start_span: u32,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
-    ) -> Box<'a, Class<'a>> {
+        decorators: ArenaVec<'a, Decorator<'a>>,
+    ) -> ArenaBox<'a, Class<'a>> {
         self.parse_class(start_span, ClassType::ClassDeclaration, modifiers, decorators)
     }
 
@@ -50,7 +50,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         span: u32,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> Expression<'a> {
         let class = self.parse_class(span, ClassType::ClassExpression, modifiers, decorators);
         Expression::ClassExpression(class)
@@ -61,8 +61,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         start_span: u32,
         r#type: ClassType,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
-    ) -> Box<'a, Class<'a>> {
+        decorators: ArenaVec<'a, Decorator<'a>>,
+    ) -> ArenaBox<'a, Class<'a>> {
         self.bump_any(); // advance `class`
 
         // Move span start to decorator position if this is a class expression.
@@ -130,9 +130,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_heritage_clause(
         &mut self,
-    ) -> (Option<Vec<'a, TSInterfaceHeritage<'a>>>, Option<ImplementsWithKeywordSpan<'a>>) {
+    ) -> (Option<ArenaVec<'a, TSInterfaceHeritage<'a>>>, Option<ImplementsWithKeywordSpan<'a>>)
+    {
         let mut extends = None;
-        let mut implements: Option<(Span, Vec<'a, TSClassImplements<'a>>)> = None;
+        let mut implements: Option<(Span, ArenaVec<'a, TSClassImplements<'a>>)> = None;
 
         loop {
             match self.cur_kind() {
@@ -175,7 +176,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// `ClassHeritage`
     /// extends `LeftHandSideExpression`[?Yield, ?Await]
-    fn parse_extends_clause(&mut self) -> Vec<'a, TSInterfaceHeritage<'a>> {
+    fn parse_extends_clause(&mut self) -> ArenaVec<'a, TSInterfaceHeritage<'a>> {
         self.bump_any(); // bump `extends`
 
         let mut extends = self.ast.vec_with_capacity(1);
@@ -208,7 +209,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         extends
     }
 
-    fn parse_class_body(&mut self) -> Box<'a, ClassBody<'a>> {
+    fn parse_class_body(&mut self) -> ArenaBox<'a, ClassBody<'a>> {
         let span = self.start_span();
         let class_elements = self.parse_normal_list_breakable(Kind::LCurly, Kind::RCurly, |p| {
             // Skip empty class element `;`
@@ -395,7 +396,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         computed: bool,
         definite: Option<u32>,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
         let type_annotation = if self.is_ts { self.parse_ts_type_annotation() } else { None };
         // `new.target` is allowed in a class accessor field initializer.
@@ -452,7 +453,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         r#type: MethodDefinitionType,
         kind: MethodDefinitionKind,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
         let (name, computed) = self.parse_class_element_name(modifiers);
         let value = self.parse_method(
@@ -489,7 +490,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         r#type: MethodDefinitionType,
         name: PropertyKey<'a>,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
         if let Some(modifier) = modifiers.get(ModifierKind::Declare) {
             self.error(diagnostics::declare_constructor(modifier.span()));
@@ -537,7 +538,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         r#type: MethodDefinitionType,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
         let generator = self.eat(Kind::Star);
         let (name, computed) = self.parse_class_element_name(modifiers);
@@ -625,7 +626,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         computed: bool,
         optional: bool,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
         let value = self.parse_method(
             modifiers.contains(ModifierKind::Async),
@@ -657,7 +658,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         optional_span: Option<Span>,
         definite: Option<u32>,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ClassElement<'a> {
         let type_annotation = if self.is_ts { self.parse_ts_type_annotation() } else { None };
         // Initializer[+In, ?Yield, ?Await]opt

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box;
+use oxc_allocator::ArenaBox;
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 
@@ -82,7 +82,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         kind: VariableDeclarationKind,
         decl_parent: VariableDeclarationParent,
         declare: bool,
-    ) -> Box<'a, VariableDeclaration<'a>> {
+    ) -> ArenaBox<'a, VariableDeclaration<'a>> {
         let mut declarations = self.ast.vec();
         loop {
             let declaration = self.parse_variable_declarator(decl_parent, kind);
@@ -182,7 +182,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_using_declaration(
         &mut self,
         statement_ctx: StatementContext,
-    ) -> Box<'a, VariableDeclaration<'a>> {
+    ) -> ArenaBox<'a, VariableDeclaration<'a>> {
         let span = self.start_span();
 
         let is_await = self.eat(Kind::Await);

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1,5 +1,5 @@
 use cow_utils::CowUtils;
-use oxc_allocator::{Box, TakeIn, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 #[cfg(feature = "regular_expression")]
 use oxc_regular_expression::ast::Pattern;
@@ -331,7 +331,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
     }
 
-    pub(crate) fn parse_literal_boolean(&mut self) -> Box<'a, BooleanLiteral> {
+    pub(crate) fn parse_literal_boolean(&mut self) -> ArenaBox<'a, BooleanLiteral> {
         let span = self.start_span();
         let value = match self.cur_kind() {
             Kind::True => true,
@@ -342,13 +342,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ast.alloc_boolean_literal(self.end_span(span), value)
     }
 
-    pub(crate) fn parse_literal_null(&mut self) -> Box<'a, NullLiteral> {
+    pub(crate) fn parse_literal_null(&mut self) -> ArenaBox<'a, NullLiteral> {
         let span = self.cur_token().span();
         self.bump_any(); // bump `null`
         self.ast.alloc_null_literal(span)
     }
 
-    pub(crate) fn parse_literal_number(&mut self) -> Box<'a, NumericLiteral<'a>> {
+    pub(crate) fn parse_literal_number(&mut self) -> ArenaBox<'a, NumericLiteral<'a>> {
         let token = self.cur_token();
         let span = token.span();
         let kind = token.kind();
@@ -386,7 +386,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ast.alloc_numeric_literal(span, value, Some(Str::from(src)), base)
     }
 
-    pub(crate) fn parse_literal_bigint(&mut self) -> Box<'a, BigIntLiteral<'a>> {
+    pub(crate) fn parse_literal_bigint(&mut self) -> ArenaBox<'a, BigIntLiteral<'a>> {
         let token = self.cur_token();
         let kind = token.kind();
         let has_separator = token.has_separator();
@@ -406,7 +406,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ast.alloc_big_int_literal(span, value, Some(Str::from(raw)), base)
     }
 
-    pub(crate) fn parse_literal_regexp(&mut self) -> Box<'a, RegExpLiteral<'a>> {
+    pub(crate) fn parse_literal_regexp(&mut self) -> ArenaBox<'a, RegExpLiteral<'a>> {
         let (pattern_end, flags, flags_error) = self.read_regex();
         if !self.lexer.errors.is_empty() {
             return self.unexpected();
@@ -448,7 +448,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         pattern: &'a str,
         flags_span_offset: u32,
         flags: &'a str,
-    ) -> Option<Box<'a, Pattern<'a>>> {
+    ) -> Option<ArenaBox<'a, Pattern<'a>>> {
         use oxc_regular_expression::{LiteralParser, Options};
         match LiteralParser::new(
             self.ast.allocator,
@@ -576,7 +576,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         lhs: Expression<'a>,
         in_optional_chain: bool,
-        type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+        type_arguments: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
     ) -> Expression<'a> {
         let quasi = self.parse_template_literal(true);
         let span = self.end_span(span);
@@ -1104,7 +1104,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         lhs_span: u32,
         lhs: Expression<'a>,
         optional: bool,
-        type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+        type_parameters: Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
     ) -> Expression<'a> {
         // ArgumentList[Yield, Await] :
         //   AssignmentExpression[+In, ?Yield, ?Await]
@@ -1688,7 +1688,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
     }
 
-    pub(crate) fn parse_decorators(&mut self) -> Vec<'a, Decorator<'a>> {
+    pub(crate) fn parse_decorators(&mut self) -> ArenaVec<'a, Decorator<'a>> {
         if self.at(Kind::At) {
             let mut decorators = self.ast.vec_with_capacity(1);
             while self.at(Kind::At) {

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 
@@ -28,7 +28,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             }
     }
 
-    pub(crate) fn parse_function_body(&mut self) -> Box<'a, FunctionBody<'a>> {
+    pub(crate) fn parse_function_body(&mut self) -> ArenaBox<'a, FunctionBody<'a>> {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
@@ -46,7 +46,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         func_kind: FunctionKind,
         params_kind: FormalParameterKind,
-    ) -> (Option<TSThisParameter<'a>>, Box<'a, FormalParameters<'a>>) {
+    ) -> (Option<TSThisParameter<'a>>, ArenaBox<'a, FormalParameters<'a>>) {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LParen);
@@ -69,10 +69,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         func_kind: FunctionKind,
         opening_span: Span,
-    ) -> (oxc_allocator::Vec<'a, FormalParameter<'a>>, Option<Box<'a, FormalParameterRest<'a>>>)
-    {
+    ) -> (ArenaVec<'a, FormalParameter<'a>>, Option<ArenaBox<'a, FormalParameterRest<'a>>>) {
         let mut list = self.ast.vec();
-        let mut rest: Option<Box<'a, FormalParameterRest<'a>>> = None;
+        let mut rest: Option<ArenaBox<'a, FormalParameterRest<'a>>> = None;
         let mut first = true;
 
         loop {
@@ -154,7 +153,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         func_kind: FunctionKind,
         span: u32,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> FormalParameter<'a> {
         let modifiers = self.parse_modifiers(false, false);
         if self.is_ts {
@@ -250,7 +249,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         func_kind: FunctionKind,
         param_kind: FormalParameterKind,
         modifiers: &Modifiers,
-    ) -> Box<'a, Function<'a>> {
+    ) -> ArenaBox<'a, Function<'a>> {
         let ctx = self.ctx;
         // `new.target` is allowed in a function's parameters and body (but not arrow
         // functions, which are parsed via `parse_function_body` directly).
@@ -378,7 +377,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         r#async: bool,
         func_kind: FunctionKind,
-    ) -> Box<'a, Function<'a>> {
+    ) -> ArenaBox<'a, Function<'a>> {
         self.expect(Kind::Function);
         let generator = self.eat(Kind::Star);
         let id = self.parse_function_id(func_kind, r#async, generator);
@@ -400,7 +399,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         start_span: u32,
         func_kind: FunctionKind,
         modifiers: &Modifiers,
-    ) -> Box<'a, Function<'a>> {
+    ) -> ArenaBox<'a, Function<'a>> {
         let r#async = modifiers.contains(ModifierKind::Async);
         self.expect(Kind::Function);
         let generator = self.eat(Kind::Star);
@@ -448,7 +447,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         r#async: bool,
         generator: bool,
         func_kind: FunctionKind,
-    ) -> Box<'a, Function<'a>> {
+    ) -> ArenaBox<'a, Function<'a>> {
         let span = self.start_span();
         self.parse_function(
             span,

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::GetSpan;
 use rustc_hash::FxHashMap;
@@ -254,7 +254,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // A default specifier, if we already saw any identifier after `import`
         default_specifier: Option<BindingIdentifier<'a>>,
         import_kind: ImportOrExportKind,
-    ) -> Vec<'a, ImportDeclarationSpecifier<'a>> {
+    ) -> ArenaVec<'a, ImportDeclarationSpecifier<'a>> {
         // If there is a default specifier, create a Vec with the default specifier in it,
         // otherwise, create an empty Vec.
         let mut specifiers = if default_specifier.is_some() {
@@ -328,7 +328,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     // import { export1 , export2 as alias2 , [...] } from "module-name";
     fn parse_import_specifiers_into(
         &mut self,
-        specifiers: &mut Vec<'a, ImportDeclarationSpecifier<'a>>,
+        specifiers: &mut ArenaVec<'a, ImportDeclarationSpecifier<'a>>,
         import_kind: ImportOrExportKind,
     ) {
         let opening_span = self.cur_token().span();
@@ -399,7 +399,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_ts_export_assignment_declaration(
         &mut self,
         start_span: u32,
-    ) -> Box<'a, TSExportAssignment<'a>> {
+    ) -> ArenaBox<'a, TSExportAssignment<'a>> {
         self.expect(Kind::Eq);
         let expression = self.parse_assignment_expression_or_higher();
         self.asi();
@@ -412,7 +412,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_ts_export_namespace(
         &mut self,
         start_span: u32,
-    ) -> Box<'a, TSNamespaceExportDeclaration<'a>> {
+    ) -> ArenaBox<'a, TSNamespaceExportDeclaration<'a>> {
         self.expect(Kind::As);
         self.expect(Kind::Namespace);
         let id = self.parse_identifier_name();
@@ -427,7 +427,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_export_declaration(
         &mut self,
         span: u32,
-        mut decorators: Vec<'a, Decorator<'a>>,
+        mut decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> Statement<'a> {
         self.bump_any(); // bump `export`
         // `export` is unambiguously module syntax (ECMA-262 §16.2.3): commit to the
@@ -549,7 +549,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     // ExportSpecifier :
     //   ModuleExportName
     //   ModuleExportName as ModuleExportName
-    fn parse_export_named_specifiers(&mut self, span: u32) -> Box<'a, ExportNamedDeclaration<'a>> {
+    fn parse_export_named_specifiers(
+        &mut self,
+        span: u32,
+    ) -> ArenaBox<'a, ExportNamedDeclaration<'a>> {
         let export_kind = self.parse_import_or_export_kind();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
@@ -624,8 +627,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_export_named_declaration(
         &mut self,
         span: u32,
-        decorators: Vec<'a, Decorator<'a>>,
-    ) -> Box<'a, ExportNamedDeclaration<'a>> {
+        decorators: ArenaVec<'a, Decorator<'a>>,
+    ) -> ArenaBox<'a, ExportNamedDeclaration<'a>> {
         let decl_span = self.start_span();
         let reserved_ctx = self.ctx;
         let modifiers =
@@ -659,8 +662,8 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_export_default_declaration(
         &mut self,
         span: u32,
-        decorators: Vec<'a, Decorator<'a>>,
-    ) -> Box<'a, ExportDefaultDeclaration<'a>> {
+        decorators: ArenaVec<'a, Decorator<'a>>,
+    ) -> ArenaBox<'a, ExportDefaultDeclaration<'a>> {
         let default_keyword_span = self.cur_token().span();
         self.advance(Kind::Default);
         let declaration = self.parse_export_default_declaration_kind(decorators);
@@ -675,7 +678,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     fn parse_export_default_declaration_kind(
         &mut self,
-        mut decorators: Vec<'a, Decorator<'a>>,
+        mut decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> ExportDefaultDeclarationKind<'a> {
         let decl_span = self.start_span();
 
@@ -791,7 +794,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     //   *
     //   * as ModuleExportName
     //   NamedExports
-    fn parse_export_all_declaration(&mut self, span: u32) -> Box<'a, ExportAllDeclaration<'a>> {
+    fn parse_export_all_declaration(
+        &mut self,
+        span: u32,
+    ) -> ArenaBox<'a, ExportAllDeclaration<'a>> {
         let export_kind = self.parse_import_or_export_kind();
         self.bump_any(); // bump `star`
         let exported = self.eat(Kind::As).then(|| self.parse_module_export_name());
@@ -1037,7 +1043,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
 #[cfg(test)]
 mod test {
-    use oxc_allocator::Allocator;
+    use oxc_allocator::{Allocator, ArenaBox};
     use oxc_ast::ast::{ImportDeclarationSpecifier, ImportOrExportKind, ImportPhase, Statement};
     use oxc_span::SourceType;
 
@@ -1385,7 +1391,7 @@ mod test {
     fn parse_and_assert_import_declarations(
         src: &'static str,
         // takes a function which accepts the list of statements
-        f: fn(Vec<&oxc_allocator::Box<'_, oxc_ast::ast::ImportDeclaration<'_>>>) -> (),
+        f: fn(Vec<&ArenaBox<'_, oxc_ast::ast::ImportDeclaration<'_>>>) -> (),
     ) {
         let source_type = SourceType::default().with_typescript(true);
         let allocator = Allocator::default();

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box;
+use oxc_allocator::ArenaBox;
 use oxc_ast::ast::*;
 use oxc_syntax::operator::AssignmentOperator;
 
@@ -16,7 +16,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ///     { }
     ///     { `PropertyDefinitionList`[?Yield, ?Await] }
     ///     { `PropertyDefinitionList`[?Yield, ?Await] , }
-    pub(crate) fn parse_object_expression(&mut self) -> Box<'a, ObjectExpression<'a>> {
+    pub(crate) fn parse_object_expression(&mut self) -> ArenaBox<'a, ObjectExpression<'a>> {
         let span = self.start_span();
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
@@ -43,7 +43,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// `PropertyDefinition`[Yield, Await]
-    fn parse_object_literal_element(&mut self) -> Box<'a, ObjectProperty<'a>> {
+    fn parse_object_literal_element(&mut self) -> ArenaBox<'a, ObjectProperty<'a>> {
         let span = self.start_span();
 
         let modifiers = self.parse_modifiers(
@@ -135,7 +135,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// `PropertyDefinition`[Yield, Await] :
     ///   ... `AssignmentExpression`[+In, ?Yield, ?Await]
-    pub(crate) fn parse_spread_element(&mut self) -> Box<'a, SpreadElement<'a>> {
+    pub(crate) fn parse_spread_element(&mut self) -> ArenaBox<'a, SpreadElement<'a>> {
         let span = self.start_span();
         self.bump_any(); // advance `...`
         let argument = self.parse_assignment_expression_or_higher();
@@ -149,7 +149,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         key: PropertyKey<'a>,
         computed: bool,
-    ) -> Box<'a, ObjectProperty<'a>> {
+    ) -> ArenaBox<'a, ObjectProperty<'a>> {
         self.expect(Kind::Colon);
         let value = self.parse_assignment_expression_or_higher();
         self.ast.alloc_object_property(
@@ -210,7 +210,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         kind: PropertyKind,
         modifiers: &Modifiers,
-    ) -> Box<'a, ObjectProperty<'a>> {
+    ) -> ArenaBox<'a, ObjectProperty<'a>> {
         let (key, computed) = self.parse_property_name();
         let function = self.parse_method(false, false, FunctionKind::ObjectMethod);
         match kind {

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 use oxc_str::Str;
@@ -33,7 +33,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     pub(crate) fn parse_directives_and_statements(
         &mut self,
         in_ts_namespace_body: bool,
-    ) -> (Vec<'a, Directive<'a>>, Vec<'a, Statement<'a>>) {
+    ) -> (ArenaVec<'a, Directive<'a>>, ArenaVec<'a, Statement<'a>>) {
         let mut directives = self.ast.vec();
         let mut statements = self.ast.vec();
 
@@ -256,7 +256,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     }
 
     /// Section 14.2 Block Statement
-    pub(crate) fn parse_block(&mut self) -> Box<'a, BlockStatement<'a>> {
+    pub(crate) fn parse_block(&mut self) -> ArenaBox<'a, BlockStatement<'a>> {
         let span = self.start_span();
         let body = self.parse_normal_list(Kind::LCurly, Kind::RCurly, |p| {
             p.parse_statement_list_item(StatementContext::StatementList)
@@ -542,7 +542,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         span: u32,
         parenthesis_opening_span: Span,
-        init_declaration: Box<'a, VariableDeclaration<'a>>,
+        init_declaration: ArenaBox<'a, VariableDeclaration<'a>>,
         r#await: bool,
     ) -> Statement<'a> {
         match self.cur_kind() {
@@ -789,7 +789,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ast.statement_try(self.end_span(span), block, handler, finalizer)
     }
 
-    fn parse_catch_clause(&mut self) -> Box<'a, CatchClause<'a>> {
+    fn parse_catch_clause(&mut self) -> ArenaBox<'a, CatchClause<'a>> {
         let span = self.start_span();
         self.bump_any(); // advance `catch`
         let pattern = if self.eat(Kind::LParen) {

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -1,6 +1,6 @@
 //! [JSX](https://facebook.github.io/jsx)
 
-use oxc_allocator::{Allocator, Box, Dummy, Vec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 use oxc_str::Str;
@@ -10,7 +10,7 @@ use crate::{ParserConfig as Config, ParserImpl, diagnostics, lexer::Kind};
 /// Represents either a closing JSX element or fragment.
 enum JSXClosing<'a> {
     /// [`JSXClosingElement`]
-    Element(Box<'a, JSXClosingElement<'a>>),
+    Element(ArenaBox<'a, JSXClosingElement<'a>>),
     /// [`JSXClosingFragment`]
     Fragment(JSXClosingFragment),
 }
@@ -46,7 +46,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// `JSXFragment` :
     ///   < > `JSXChildren_opt` < / >
-    fn parse_jsx_fragment(&mut self, span: u32, in_jsx_child: bool) -> Box<'a, JSXFragment<'a>> {
+    fn parse_jsx_fragment(
+        &mut self,
+        span: u32,
+        in_jsx_child: bool,
+    ) -> ArenaBox<'a, JSXFragment<'a>> {
         self.expect_jsx_child(Kind::RAngle);
         let opening_fragment = self.ast.jsx_opening_fragment(self.end_span(span));
         let (children, closing) = self.parse_jsx_children_and_closing(in_jsx_child);
@@ -75,7 +79,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// `in_jsx_child`:
     ///     used for telling `JSXClosingElement` to parse the next jsx child or not
     ///     true when inside jsx element, false when at top level expression
-    fn parse_jsx_element(&mut self, span: u32, in_jsx_child: bool) -> Box<'a, JSXElement<'a>> {
+    fn parse_jsx_element(&mut self, span: u32, in_jsx_child: bool) -> ArenaBox<'a, JSXElement<'a>> {
         let (opening_element, self_closing) = self.parse_jsx_opening_element(span, in_jsx_child);
         let (children, closing_element) = if self_closing {
             (self.ast.vec(), None)
@@ -113,7 +117,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         in_jsx_child: bool,
     ) -> (
-        Box<'a, JSXOpeningElement<'a>>,
+        ArenaBox<'a, JSXOpeningElement<'a>>,
         bool, // `true` if self-closing
     ) {
         let name = self.parse_jsx_element_name();
@@ -198,7 +202,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         span: u32,
         object: &JSXIdentifier<'a>,
-    ) -> Box<'a, JSXMemberExpression<'a>> {
+    ) -> ArenaBox<'a, JSXMemberExpression<'a>> {
         let mut object = if object.name == "this" {
             self.ast.jsx_member_expression_object_this_expression(object.span)
         } else {
@@ -244,7 +248,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     fn parse_jsx_children_and_closing(
         &mut self,
         in_jsx_child: bool,
-    ) -> (Vec<'a, JSXChild<'a>>, JSXClosing<'a>) {
+    ) -> (ArenaVec<'a, JSXChild<'a>>, JSXClosing<'a>) {
         let mut children = self.ast.vec();
         loop {
             if self.fatal_error.is_some() {
@@ -342,7 +346,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         span_start: u32,
         in_jsx_child: bool,
-    ) -> Box<'a, JSXExpressionContainer<'a>> {
+    ) -> ArenaBox<'a, JSXExpressionContainer<'a>> {
         let expr = if self.at(Kind::RCurly) {
             if in_jsx_child {
                 self.expect_jsx_child(Kind::RCurly);
@@ -381,7 +385,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// `JSXChildExpression` :
     ///   { ... `AssignmentExpression` }
-    fn parse_jsx_spread_child(&mut self, span_start: u32) -> Box<'a, JSXSpreadChild<'a>> {
+    fn parse_jsx_spread_child(&mut self, span_start: u32) -> ArenaBox<'a, JSXSpreadChild<'a>> {
         let expr = self.parse_expr();
         self.expect_jsx_child(Kind::RCurly);
         self.ast.alloc_jsx_spread_child(self.end_span(span_start), expr)
@@ -390,7 +394,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// `JSXAttributes` :
     ///   `JSXSpreadAttribute` `JSXAttributes_opt`
     ///   `JSXAttribute` `JSXAttributes_opt`
-    fn parse_jsx_attributes(&mut self) -> Vec<'a, JSXAttributeItem<'a>> {
+    fn parse_jsx_attributes(&mut self) -> ArenaVec<'a, JSXAttributeItem<'a>> {
         let mut attributes = self.ast.vec();
         loop {
             let kind = self.cur_kind();
@@ -412,7 +416,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// `JSXAttribute` :
     ///   `JSXAttributeName` `JSXAttributeInitializer_opt`
-    fn parse_jsx_attribute(&mut self) -> Box<'a, JSXAttribute<'a>> {
+    fn parse_jsx_attribute(&mut self) -> ArenaBox<'a, JSXAttribute<'a>> {
         let span = self.start_span();
         let name = self.parse_jsx_attribute_name();
         let value = if self.at(Kind::Eq) {
@@ -426,7 +430,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// `JSXSpreadAttribute` :
     ///   { ... `AssignmentExpression` }
-    fn parse_jsx_spread_attribute(&mut self) -> Box<'a, JSXSpreadAttribute<'a>> {
+    fn parse_jsx_spread_attribute(&mut self) -> ArenaBox<'a, JSXSpreadAttribute<'a>> {
         let span = self.start_span();
         self.bump_any(); // bump `{`
         self.expect(Kind::Dot3);
@@ -501,7 +505,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         (identifier, contains_dash)
     }
 
-    fn parse_jsx_text(&mut self) -> Box<'a, JSXText<'a>> {
+    fn parse_jsx_text(&mut self) -> ArenaBox<'a, JSXText<'a>> {
         let span = self.cur_token().span();
         let raw = Str::from(self.cur_src());
         let value = Str::from(self.cur_string());

--- a/crates/oxc_parser/src/lexer/identifier.rs
+++ b/crates/oxc_parser/src/lexer/identifier.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 
-use oxc_allocator::StringBuilder;
+use oxc_allocator::ArenaStringBuilder;
 use oxc_span::Span;
 use oxc_syntax::identifier::{
     is_identifier_part, is_identifier_part_unicode, is_identifier_start_unicode,
@@ -136,7 +136,7 @@ impl<'a, C: Config> Lexer<'a, C> {
     pub fn identifier_backslash_handler(&mut self) -> Kind {
         // Create arena string to hold unescaped identifier.
         // We don't know how long identifier will end up being, so guess.
-        let str = StringBuilder::with_capacity_in(MIN_ESCAPED_STR_LEN, self.allocator);
+        let str = ArenaStringBuilder::with_capacity_in(MIN_ESCAPED_STR_LEN, self.allocator);
 
         // Process escape and get rest of identifier
         let id = self.identifier_on_backslash(str, true);
@@ -153,7 +153,7 @@ impl<'a, C: Config> Lexer<'a, C> {
         // will be double what we've seen so far, or `MIN_ESCAPED_STR_LEN` minimum.
         let so_far = self.source.str_from_pos_to_current(start_pos);
         let capacity = max(so_far.len() * 2, MIN_ESCAPED_STR_LEN);
-        let mut str = StringBuilder::with_capacity_in(capacity, self.allocator);
+        let mut str = ArenaStringBuilder::with_capacity_in(capacity, self.allocator);
 
         // Push identifier up this point into `str`
         str.push_str(so_far);
@@ -169,7 +169,7 @@ impl<'a, C: Config> Lexer<'a, C> {
     /// `is_start` should be `true` if this is first char in the identifier, `false` otherwise.
     fn identifier_on_backslash(
         &mut self,
-        mut str: StringBuilder<'a>,
+        mut str: ArenaStringBuilder<'a>,
         mut is_start: bool,
     ) -> &'a str {
         'outer: loop {

--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 
-use oxc_allocator::StringBuilder;
+use oxc_allocator::ArenaStringBuilder;
 
 use crate::{config::LexerConfig as Config, diagnostics};
 
@@ -109,7 +109,7 @@ macro_rules! handle_string_literal_escape {
         // will be double what we've seen so far, or `MIN_ESCAPED_STR_LEN` minimum.
         let so_far = $lexer.source.str_from_pos_to_current($after_opening_quote);
         let capacity = max(so_far.len() * 2, MIN_ESCAPED_STR_LEN);
-        let mut str = StringBuilder::with_capacity_in(capacity, $lexer.allocator);
+        let mut str = ArenaStringBuilder::with_capacity_in(capacity, $lexer.allocator);
 
         // Push chunk before `\` into `str`.
         str.push_str(so_far);

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, str};
 
-use oxc_allocator::StringBuilder;
+use oxc_allocator::ArenaStringBuilder;
 
 use crate::{config::LexerConfig as Config, diagnostics};
 
@@ -195,14 +195,17 @@ impl<'a, C: Config> Lexer<'a, C> {
     ///
     /// # SAFETY
     /// `pos` must not be before `self.source.position()`
-    unsafe fn template_literal_create_string(&self, pos: SourcePosition<'a>) -> StringBuilder<'a> {
+    unsafe fn template_literal_create_string(
+        &self,
+        pos: SourcePosition<'a>,
+    ) -> ArenaStringBuilder<'a> {
         // Create arena string to hold modified template literal.
         // We don't know how long template literal will end up being. Take a guess that total length
         // will be double what we've seen so far, or `MIN_ESCAPED_TEMPLATE_LIT_LEN` minimum.
         // SAFETY: Caller guarantees `pos` is not before `self.source.position()`.
         let so_far = unsafe { self.source.str_from_current_to_pos_unchecked(pos) };
         let capacity = max(so_far.len() * 2, MIN_ESCAPED_TEMPLATE_LIT_LEN);
-        let mut str = StringBuilder::with_capacity_in(capacity, self.allocator);
+        let mut str = ArenaStringBuilder::with_capacity_in(capacity, self.allocator);
         str.push_str(so_far);
         str
     }
@@ -213,7 +216,7 @@ impl<'a, C: Config> Lexer<'a, C> {
     /// `chunk_start` must not be after `pos`.
     unsafe fn template_literal_escaped(
         &mut self,
-        mut str: StringBuilder<'a>,
+        mut str: ArenaStringBuilder<'a>,
         pos: SourcePosition<'a>,
         mut chunk_start: SourcePosition<'a>,
         mut is_valid_escape_sequence: bool,

--- a/crates/oxc_parser/src/lexer/unicode.rs
+++ b/crates/oxc_parser/src/lexer/unicode.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, fmt::Write};
 use cow_utils::CowUtils;
 
 use crate::{config::LexerConfig as Config, diagnostics};
-use oxc_allocator::StringBuilder;
+use oxc_allocator::ArenaStringBuilder;
 use oxc_syntax::{
     identifier::{
         FF, TAB, VT, is_identifier_part, is_identifier_start, is_identifier_start_unicode,
@@ -83,7 +83,7 @@ impl<'a, C: Config> Lexer<'a, C> {
     ///   \u{ `CodePoint` }
     pub(super) fn identifier_unicode_escape_sequence(
         &mut self,
-        str: &mut StringBuilder<'a>,
+        str: &mut ArenaStringBuilder<'a>,
         check_identifier_start: bool,
     ) {
         let start = self.offset();
@@ -137,7 +137,7 @@ impl<'a, C: Config> Lexer<'a, C> {
     ///   \u{ `CodePoint` }
     fn string_unicode_escape_sequence(
         &mut self,
-        text: &mut StringBuilder<'a>,
+        text: &mut ArenaStringBuilder<'a>,
         is_valid_escape_sequence: &mut bool,
     ) {
         let value = match self.peek_byte() {
@@ -175,7 +175,7 @@ impl<'a, C: Config> Lexer<'a, C> {
     }
 
     /// Lone surrogate found in string.
-    fn string_lone_surrogate(&mut self, code_point: u32, text: &mut StringBuilder<'a>) {
+    fn string_lone_surrogate(&mut self, code_point: u32, text: &mut ArenaStringBuilder<'a>) {
         debug_assert!(code_point <= 0xFFFF);
 
         if !self.token.lone_surrogates() {
@@ -189,7 +189,7 @@ impl<'a, C: Config> Lexer<'a, C> {
             // But strings containing both lone surrogates and lossy replacement characters
             // should be vanishingly rare, so don't bother.
             if let Cow::Owned(replaced) = text.cow_replace("\u{FFFD}", "\u{FFFD}fffd") {
-                *text = StringBuilder::from_str_in(&replaced, self.allocator);
+                *text = ArenaStringBuilder::from_str_in(&replaced, self.allocator);
             }
         }
 
@@ -329,7 +329,7 @@ impl<'a, C: Config> Lexer<'a, C> {
     // EscapeSequence ::
     pub(super) fn read_string_escape_sequence(
         &mut self,
-        text: &mut StringBuilder<'a>,
+        text: &mut ArenaStringBuilder<'a>,
         in_template: bool,
         is_valid_escape_sequence: &mut bool,
     ) {

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -90,7 +90,7 @@ pub mod lexer;
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy, GetAllocator};
 use oxc_ast::{
     AstBuilder,
-    ast::{Expression, Program},
+    ast::{Expression, Program, Statement},
 };
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::{SourceType, Span};
@@ -176,7 +176,7 @@ pub struct ParserReturn<'a> {
     /// Lexed tokens in source order.
     ///
     /// Tokens are only collected when tokens are enabled in [`ParserConfig`].
-    pub tokens: oxc_allocator::Vec<'a, Token>,
+    pub tokens: ArenaVec<'a, Token>,
 
     /// Whether the parser panicked and terminated early.
     ///
@@ -805,10 +805,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
     /// In unambiguous mode, statements like `await /x/u` are initially parsed as
     /// `await / x / u` (identifier with divisions). If ESM syntax is detected,
     /// we need to reparse them with the await context enabled.
-    fn reparse_potential_top_level_awaits(
-        &mut self,
-        statements: &mut oxc_allocator::Vec<'a, oxc_ast::ast::Statement<'a>>,
-    ) {
+    fn reparse_potential_top_level_awaits(&mut self, statements: &mut ArenaVec<'a, Statement<'a>>) {
         // Token stream is already complete from the first parse.
         // Reparsing here is only to patch AST nodes, so keep the original token stream.
         let original_tokens =

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, Vec};
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::BoundNames;
@@ -11,8 +11,8 @@ pub struct ModuleRecordBuilder<'a> {
     allocator: &'a Allocator,
     source_type: SourceType,
     module_record: ModuleRecord<'a>,
-    export_entries: Vec<'a, ExportEntry<'a>>,
-    exported_bindings_duplicated: Vec<'a, NameSpan<'a>>,
+    export_entries: ArenaVec<'a, ExportEntry<'a>>,
+    exported_bindings_duplicated: ArenaVec<'a, NameSpan<'a>>,
 }
 
 impl<'a> ModuleRecordBuilder<'a> {
@@ -21,8 +21,8 @@ impl<'a> ModuleRecordBuilder<'a> {
             allocator,
             source_type,
             module_record: ModuleRecord::new(allocator),
-            export_entries: Vec::new_in(allocator),
-            exported_bindings_duplicated: Vec::new_in(allocator),
+            export_entries: ArenaVec::new_in(allocator),
+            exported_bindings_duplicated: ArenaVec::new_in(allocator),
         }
     }
 
@@ -81,7 +81,7 @@ impl<'a> ModuleRecordBuilder<'a> {
         self.module_record
             .requested_modules
             .entry(name)
-            .or_insert_with(|| oxc_allocator::Vec::new_in(self.allocator))
+            .or_insert_with(|| ArenaVec::new_in(self.allocator))
             .push(requested_module);
     }
 
@@ -116,7 +116,7 @@ impl<'a> ModuleRecordBuilder<'a> {
     fn resolve_export_entries(&mut self) {
         // let export_entries = self.export_entries.drain(..).collect::<Vec<_>>();
         let export_entries =
-            std::mem::replace(&mut self.export_entries, Vec::new_in(self.allocator));
+            std::mem::replace(&mut self.export_entries, ArenaVec::new_in(self.allocator));
         // 10. For each ExportEntry Record ee of exportEntries, do
         for ee in export_entries {
             // a. If ee.[[ModuleRequest]] is null, then

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_span::{FileExtension, GetSpan};
 
@@ -109,7 +109,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /* ------------------- Annotation ----------------- */
 
-    pub(crate) fn parse_ts_type_annotation(&mut self) -> Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub(crate) fn parse_ts_type_annotation(
+        &mut self,
+    ) -> Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         if !self.is_ts {
             return None;
         }
@@ -254,7 +256,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         )
     }
 
-    fn parse_ts_interface_body(&mut self) -> Box<'a, TSInterfaceBody<'a>> {
+    fn parse_ts_interface_body(&mut self) -> ArenaBox<'a, TSInterfaceBody<'a>> {
         let span = self.start_span();
         let body_list =
             self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature);
@@ -345,7 +347,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         span: u32,
         modifiers: &Modifiers,
-    ) -> Box<'a, TSModuleDeclaration<'a>> {
+    ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
         let kind = if self.eat(Kind::Namespace) {
             TSModuleDeclarationKind::Namespace
         } else {
@@ -362,7 +364,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         span: u32,
         modifiers: &Modifiers,
-    ) -> Box<'a, TSModuleDeclaration<'a>> {
+    ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
         let id = TSModuleDeclarationName::StringLiteral(self.parse_literal_string());
         let body = if self.at(Kind::LCurly) {
             // External module body (`declare module "x" {}`); `import`/`export` are allowed here.
@@ -428,7 +430,10 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
     }
 
-    fn parse_ts_module_block(&mut self, in_ts_namespace_body: bool) -> Box<'a, TSModuleBlock<'a>> {
+    fn parse_ts_module_block(
+        &mut self,
+        in_ts_namespace_body: bool,
+    ) -> ArenaBox<'a, TSModuleBlock<'a>> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
         // Remove TopLevel context for module block
@@ -444,7 +449,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         span: u32,
         kind: TSModuleDeclarationKind,
         modifiers: &Modifiers,
-    ) -> Box<'a, TSModuleDeclaration<'a>> {
+    ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
         let id = TSModuleDeclarationName::Identifier(self.parse_binding_identifier());
         let body = if self.eat(Kind::Dot) {
             let span = self.start_span();
@@ -475,7 +480,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         span: u32,
         modifiers: &Modifiers,
-    ) -> Box<'a, TSGlobalDeclaration<'a>> {
+    ) -> ArenaBox<'a, TSGlobalDeclaration<'a>> {
         let keyword_span_start = self.start_span();
         self.expect(Kind::Global);
         let keyword_span = self.end_span(keyword_span_start);
@@ -531,7 +536,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         start_span: u32,
         modifiers: &Modifiers,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
     ) -> Declaration<'a> {
         let kind = self.cur_kind();
         if kind != Kind::Class {
@@ -634,7 +639,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         start_span: u32,
         modifiers: &Modifiers,
-    ) -> Box<'a, Function<'a>> {
+    ) -> ArenaBox<'a, Function<'a>> {
         let r#async = modifiers.contains(ModifierKind::Async);
         self.expect(Kind::Function);
         let generator = self.eat(Kind::Star);

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::GetSpan;
 use oxc_syntax::operator::UnaryOperator;
@@ -150,13 +150,13 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_ts_type_parameters(
         &mut self,
-    ) -> Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    ) -> Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         self.parse_ts_type_parameters_impl(false).0
     }
 
     pub(crate) fn parse_ts_type_parameters_with_variance(
         &mut self,
-    ) -> Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    ) -> Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         self.parse_ts_type_parameters_impl(true).0
     }
 
@@ -164,14 +164,14 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// Used for arrow functions to check for TS7060 (JSX-like type parameters in .mts/.cts).
     pub(crate) fn parse_ts_type_parameters_with_trailing_comma(
         &mut self,
-    ) -> (Option<Box<'a, TSTypeParameterDeclaration<'a>>>, bool) {
+    ) -> (Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>, bool) {
         self.parse_ts_type_parameters_impl(false)
     }
 
     fn parse_ts_type_parameters_impl(
         &mut self,
         allow_variance: bool,
-    ) -> (Option<Box<'a, TSTypeParameterDeclaration<'a>>>, bool) {
+    ) -> (Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>, bool) {
         if !self.is_ts {
             return (None, false);
         }
@@ -193,7 +193,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         (Some(self.ast.alloc_ts_type_parameter_declaration(span, params)), trailing_comma.is_some())
     }
 
-    pub(crate) fn parse_ts_implements_clause(&mut self) -> Vec<'a, TSClassImplements<'a>> {
+    pub(crate) fn parse_ts_implements_clause(&mut self) -> ArenaVec<'a, TSClassImplements<'a>> {
         self.expect(Kind::Implements);
         let first = self.parse_ts_implement_name();
         let mut implements = self.ast.vec1(first);
@@ -318,7 +318,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ast.ts_type_infer_type(self.end_span(span), type_parameter)
     }
 
-    fn parse_type_parameter_of_infer_type(&mut self) -> Box<'a, TSTypeParameter<'a>> {
+    fn parse_type_parameter_of_infer_type(&mut self) -> ArenaBox<'a, TSTypeParameter<'a>> {
         let span = self.start_span();
         let name = self.parse_binding_identifier();
         self.check_reserved_type_name(&name, "Type parameter");
@@ -721,7 +721,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ast.ts_type_type_query(self.end_span(span), entity_name, type_arguments)
     }
 
-    fn parse_this_type_predicate(&mut self, span: u32, this_ty: Box<'a, TSThisType>) -> TSType<'a> {
+    fn parse_this_type_predicate(
+        &mut self,
+        span: u32,
+        this_ty: ArenaBox<'a, TSThisType>,
+    ) -> TSType<'a> {
         self.bump_any(); // bump `is`
         let ty = self.parse_ts_type();
         let type_annotation = Some(self.ast.ts_type_annotation(ty.span(), ty));
@@ -733,7 +737,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         )
     }
 
-    fn parse_this_type_node(&mut self) -> Box<'a, TSThisType> {
+    fn parse_this_type_node(&mut self) -> ArenaBox<'a, TSThisType> {
         let span = self.start_span();
         self.bump_any(); // bump `this`
         self.ast.alloc_ts_this_type(self.end_span(span))
@@ -854,7 +858,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn try_parse_type_arguments(
         &mut self,
-    ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    ) -> Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         if self.re_lex_ts_l_angle() {
             let span = self.start_span();
             let opening_span = self.cur_token().span();
@@ -877,7 +881,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_type_arguments_of_type_reference(
         &mut self,
-    ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    ) -> Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         if !self.cur_token().is_on_new_line() && self.re_lex_ts_l_angle() {
             let span = self.start_span();
             let opening_span = self.cur_token().span();
@@ -904,7 +908,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// valid type-argument list.
     pub(crate) fn parse_type_arguments_in_expression(
         &mut self,
-    ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    ) -> Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         // A type-argument list can only open with `<`, or `<<` for nested generics like
         // `f<<T>() => U>()`. This mirrors TypeScript's `reScanLessThanToken`, which re-scans only
         // `<`/`<<`. `<=`/`<<=` can never open one — splitting off the leading `<` leaves a `=`, and
@@ -1124,7 +1128,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         self.ast.ts_type_literal_type(span, literal)
     }
 
-    fn parse_ts_import_type(&mut self) -> Box<'a, TSImportType<'a>> {
+    fn parse_ts_import_type(&mut self) -> ArenaBox<'a, TSImportType<'a>> {
         let span = self.start_span();
         self.expect(Kind::Import);
         self.expect(Kind::LParen);
@@ -1177,7 +1181,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     /// The options must have a property with key `with` or `assert` (as identifier, not string).
     /// If the value is an object literal, it must have only static key-value pairs
     /// (no computed keys, no spread elements).
-    fn parse_ts_import_type_options(&mut self) -> Box<'a, ObjectExpression<'a>> {
+    fn parse_ts_import_type_options(&mut self) -> ArenaBox<'a, ObjectExpression<'a>> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
 
@@ -1227,7 +1231,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     /// Parse TypeScript import type attributes object: `{ type: "json" }`
     /// Only allows static key-value pairs (no computed keys, no spread elements).
-    fn parse_ts_import_type_attributes(&mut self) -> Box<'a, ObjectExpression<'a>> {
+    fn parse_ts_import_type_attributes(&mut self) -> ArenaBox<'a, ObjectExpression<'a>> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
 
@@ -1313,7 +1317,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
 
     pub(crate) fn parse_ts_return_type_annotation(
         &mut self,
-    ) -> Option<Box<'a, TSTypeAnnotation<'a>>> {
+    ) -> Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         if !self.at(Kind::Colon) {
             return None;
         }
@@ -1511,7 +1515,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         &mut self,
         span: u32,
         modifiers: &Modifiers,
-    ) -> Box<'a, TSIndexSignature<'a>> {
+    ) -> ArenaBox<'a, TSIndexSignature<'a>> {
         let opening_span = self.cur_token().span();
         self.expect(Kind::LBrack);
         let (params, comma_span) = self.parse_delimited_list(

--- a/crates/oxc_react_compiler/src/convert_ast_reverse.rs
+++ b/crates/oxc_react_compiler/src/convert_ast_reverse.rs
@@ -9,7 +9,7 @@
 //! (which represents the compiler's Babel-compatible output) and produces OXC AST
 //! nodes allocated in an OXC arena, suitable for code generation via `oxc_codegen`.
 
-use oxc_allocator::{Allocator, ArenaBox};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec};
 use oxc_ast::ast as oxc;
 use oxc_ast_visit::VisitMut;
 use oxc_span::SPAN;
@@ -177,7 +177,7 @@ impl<'a> ReverseCtx<'a> {
     }
 
     fn copy_source_text_to_allocator(&self, text: &str) -> &'a str {
-        oxc_allocator::StringBuilder::from_str_in(text, self.allocator).into_str()
+        oxc_allocator::ArenaStringBuilder::from_str_in(text, self.allocator).into_str()
     }
 
     fn extract_source_class_expression(
@@ -945,7 +945,7 @@ impl<'a> ReverseCtx<'a> {
     /// The returned `&'a str` converts into both `Ident` and `Str` (identifier
     /// and string-literal name types), so it feeds every `AstBuilder` method.
     fn atom(&self, s: &str) -> &'a str {
-        oxc_allocator::StringBuilder::from_str_in(s, self.allocator).into_str()
+        oxc_allocator::ArenaStringBuilder::from_str_in(s, self.allocator).into_str()
     }
 
     /// Convert a BaseNode's start/end into an OXC Span.
@@ -982,10 +982,7 @@ impl<'a> ReverseCtx<'a> {
 
     // ===== Directives =====
 
-    fn convert_directives(
-        &self,
-        directives: &[Directive],
-    ) -> oxc_allocator::Vec<'a, oxc::Directive<'a>> {
+    fn convert_directives(&self, directives: &[Directive]) -> ArenaVec<'a, oxc::Directive<'a>> {
         self.builder.vec_from_iter(directives.iter().map(|d| self.convert_directive(d)))
     }
 
@@ -1002,7 +999,7 @@ impl<'a> ReverseCtx<'a> {
     fn convert_statements_with_spans(
         &self,
         stmts: &[Statement],
-    ) -> oxc_allocator::Vec<'a, oxc::Statement<'a>> {
+    ) -> ArenaVec<'a, oxc::Statement<'a>> {
         self.builder.vec_from_iter(stmts.iter().map(|s| {
             let span = self.get_statement_span(s);
             let mut oxc_stmt = self.convert_statement(s);
@@ -1239,10 +1236,7 @@ impl<'a> ReverseCtx<'a> {
         }
     }
 
-    fn convert_statement_vec(
-        &self,
-        stmts: &[Statement],
-    ) -> oxc_allocator::Vec<'a, oxc::Statement<'a>> {
+    fn convert_statement_vec(&self, stmts: &[Statement]) -> ArenaVec<'a, oxc::Statement<'a>> {
         self.builder.vec_from_iter(stmts.iter().map(|s| self.convert_statement(s)))
     }
 
@@ -1734,7 +1728,7 @@ impl<'a> ReverseCtx<'a> {
         &self,
         args: &[Expression],
         source_args: Option<Vec<oxc::Argument<'a>>>,
-    ) -> oxc_allocator::Vec<'a, oxc::Argument<'a>> {
+    ) -> ArenaVec<'a, oxc::Argument<'a>> {
         let mut source_args = source_args.map(Vec::into_iter);
         self.builder.vec_from_iter(args.iter().map(|arg| {
             let source_arg = source_args.as_mut().and_then(Iterator::next);
@@ -1918,10 +1912,10 @@ impl<'a> ReverseCtx<'a> {
             f.generator,
             f.is_async,
             f.declare.unwrap_or(false),
-            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
-            None::<oxc_allocator::Box<'a, oxc::TSThisParameter<'a>>>,
+            None::<ArenaBox<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            None::<ArenaBox<'a, oxc::TSThisParameter<'a>>>,
             params,
-            None::<oxc_allocator::Box<'a, oxc::TSTypeAnnotation<'a>>>,
+            None::<ArenaBox<'a, oxc::TSTypeAnnotation<'a>>>,
             Some(body),
         );
         if !self.block_initializes_react_cache(&f.body)
@@ -1945,9 +1939,9 @@ impl<'a> ReverseCtx<'a> {
             oxc::ClassType::ClassDeclaration,
             self.builder.vec(), // decorators
             id,
-            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            None::<ArenaBox<'a, oxc::TSTypeParameterDeclaration<'a>>>,
             super_class,
-            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterInstantiation<'a>>>,
+            None::<ArenaBox<'a, oxc::TSTypeParameterInstantiation<'a>>>,
             self.builder.vec(), // implements
             body,
             c.is_abstract.unwrap_or(false),
@@ -1968,9 +1962,9 @@ impl<'a> ReverseCtx<'a> {
             class_type,
             self.builder.vec(), // decorators
             id,
-            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            None::<ArenaBox<'a, oxc::TSTypeParameterDeclaration<'a>>>,
             super_class,
-            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterInstantiation<'a>>>,
+            None::<ArenaBox<'a, oxc::TSTypeParameterInstantiation<'a>>>,
             self.builder.vec(), // implements
             body,
             false, // is_abstract
@@ -1997,8 +1991,8 @@ impl<'a> ReverseCtx<'a> {
             f.generator,
             f.is_async,
             false,
-            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
-            None::<oxc_allocator::Box<'a, oxc::TSThisParameter<'a>>>,
+            None::<ArenaBox<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            None::<ArenaBox<'a, oxc::TSThisParameter<'a>>>,
             params,
             return_type,
             Some(body),
@@ -2029,8 +2023,8 @@ impl<'a> ReverseCtx<'a> {
             m.generator,
             m.is_async,
             false,
-            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
-            None::<oxc_allocator::Box<'a, oxc::TSThisParameter<'a>>>,
+            None::<ArenaBox<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            None::<ArenaBox<'a, oxc::TSThisParameter<'a>>>,
             params,
             return_type,
             Some(body),
@@ -2065,7 +2059,7 @@ impl<'a> ReverseCtx<'a> {
             SPAN,
             is_expression,
             arrow.is_async,
-            None::<oxc_allocator::Box<'a, oxc::TSTypeParameterDeclaration<'a>>>,
+            None::<ArenaBox<'a, oxc::TSTypeParameterDeclaration<'a>>>,
             params,
             if arrow_initializes_react_cache {
                 None
@@ -2118,7 +2112,7 @@ impl<'a> ReverseCtx<'a> {
                     // invalid in FormalParameter position).
                     let left = self.convert_pattern_to_binding_pattern(&ap.left);
                     let right = self.convert_expression(&ap.right);
-                    let initializer = Some(oxc_allocator::Box::new_in(right, self.allocator));
+                    let initializer = Some(ArenaBox::new_in(right, self.allocator));
                     let type_annotation = self
                         .pattern_type_annotation(param)
                         .or_else(|| self.pattern_type_annotation(&ap.left));
@@ -2145,7 +2139,7 @@ impl<'a> ReverseCtx<'a> {
                         self.builder.vec(), // decorators
                         pattern,
                         type_annotation,
-                        None::<oxc_allocator::Box<'a, oxc::Expression<'a>>>,
+                        None::<ArenaBox<'a, oxc::Expression<'a>>>,
                         optional,
                         None,  // accessibility
                         false, // readonly
@@ -2778,7 +2772,7 @@ impl<'a> ReverseCtx<'a> {
     fn convert_with_clause(
         &self,
         attributes: Option<&[ImportAttribute]>,
-    ) -> Option<oxc_allocator::Box<'a, oxc::WithClause<'a>>> {
+    ) -> Option<ArenaBox<'a, oxc::WithClause<'a>>> {
         attributes.map(|attributes| {
             let with_entries = self
                 .builder

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -1,3 +1,5 @@
+use oxc_allocator::ArenaVec;
+
 pub mod convert_ast;
 pub mod convert_ast_reverse;
 pub mod convert_scope;
@@ -137,7 +139,7 @@ fn preserve_comments<'a>(
     }
 
     // Copy only comments attached to top-level statements.
-    let mut comments = oxc_allocator::Vec::with_capacity_in(source.comments.len(), allocator);
+    let mut comments = ArenaVec::with_capacity_in(source.comments.len(), allocator);
     for comment in &source.comments {
         if top_level_starts.contains(&comment.attached_to) {
             comments.push(*comment);

--- a/crates/oxc_regular_expression/src/ast.rs
+++ b/crates/oxc_regular_expression/src/ast.rs
@@ -1,6 +1,6 @@
 use bitflags::bitflags;
 
-use oxc_allocator::{Box, CloneIn, GetAddress, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec, CloneIn, GetAddress};
 use oxc_ast_macros::ast;
 use oxc_span::{ContentEq, Span};
 use oxc_str::Str;
@@ -20,7 +20,7 @@ pub struct Pattern<'a> {
 #[generate_derive(CloneIn, ContentEq)]
 pub struct Disjunction<'a> {
     pub span: Span,
-    pub body: Vec<'a, Alternative<'a>>,
+    pub body: ArenaVec<'a, Alternative<'a>>,
 }
 
 /// Single unit of `|` separated alternatives.
@@ -29,7 +29,7 @@ pub struct Disjunction<'a> {
 #[generate_derive(CloneIn, ContentEq)]
 pub struct Alternative<'a> {
     pub span: Span,
-    pub body: Vec<'a, Term<'a>>,
+    pub body: ArenaVec<'a, Term<'a>>,
 }
 
 /// Single unit of [`Alternative`], containing various kinds.
@@ -38,20 +38,20 @@ pub struct Alternative<'a> {
 #[generate_derive(CloneIn, ContentEq)]
 pub enum Term<'a> {
     // Assertion, QuantifiableAssertion
-    BoundaryAssertion(Box<'a, BoundaryAssertion>) = 0,
-    LookAroundAssertion(Box<'a, LookAroundAssertion<'a>>) = 1,
+    BoundaryAssertion(ArenaBox<'a, BoundaryAssertion>) = 0,
+    LookAroundAssertion(ArenaBox<'a, LookAroundAssertion<'a>>) = 1,
     // Quantifier
-    Quantifier(Box<'a, Quantifier<'a>>) = 2,
+    Quantifier(ArenaBox<'a, Quantifier<'a>>) = 2,
     // Atom, ExtendedAtom
-    Character(Box<'a, Character>) = 3,
+    Character(ArenaBox<'a, Character>) = 3,
     Dot(Dot) = 4,
-    CharacterClassEscape(Box<'a, CharacterClassEscape>) = 5,
-    UnicodePropertyEscape(Box<'a, UnicodePropertyEscape<'a>>) = 6,
-    CharacterClass(Box<'a, CharacterClass<'a>>) = 7,
-    CapturingGroup(Box<'a, CapturingGroup<'a>>) = 8,
-    IgnoreGroup(Box<'a, IgnoreGroup<'a>>) = 9,
-    IndexedReference(Box<'a, IndexedReference>) = 10,
-    NamedReference(Box<'a, NamedReference<'a>>) = 11,
+    CharacterClassEscape(ArenaBox<'a, CharacterClassEscape>) = 5,
+    UnicodePropertyEscape(ArenaBox<'a, UnicodePropertyEscape<'a>>) = 6,
+    CharacterClass(ArenaBox<'a, CharacterClass<'a>>) = 7,
+    CapturingGroup(ArenaBox<'a, CapturingGroup<'a>>) = 8,
+    IgnoreGroup(ArenaBox<'a, IgnoreGroup<'a>>) = 9,
+    IndexedReference(ArenaBox<'a, IndexedReference>) = 10,
+    NamedReference(ArenaBox<'a, NamedReference<'a>>) = 11,
 }
 
 /// Simple form of assertion.
@@ -195,7 +195,7 @@ pub struct CharacterClass<'a> {
     /// - and matches each logic depends on `kind`
     pub strings: bool,
     pub kind: CharacterClassContentsKind,
-    pub body: Vec<'a, CharacterClassContents<'a>>,
+    pub body: ArenaVec<'a, CharacterClassContents<'a>>,
 }
 
 #[ast]
@@ -213,14 +213,14 @@ pub enum CharacterClassContentsKind {
 #[derive(Debug)]
 #[generate_derive(CloneIn, ContentEq, GetAddress)]
 pub enum CharacterClassContents<'a> {
-    CharacterClassRange(Box<'a, CharacterClassRange>) = 0,
-    CharacterClassEscape(Box<'a, CharacterClassEscape>) = 1,
-    UnicodePropertyEscape(Box<'a, UnicodePropertyEscape<'a>>) = 2,
-    Character(Box<'a, Character>) = 3,
+    CharacterClassRange(ArenaBox<'a, CharacterClassRange>) = 0,
+    CharacterClassEscape(ArenaBox<'a, CharacterClassEscape>) = 1,
+    UnicodePropertyEscape(ArenaBox<'a, UnicodePropertyEscape<'a>>) = 2,
+    Character(ArenaBox<'a, Character>) = 3,
     /// `UnicodeSetsMode` only
-    NestedCharacterClass(Box<'a, CharacterClass<'a>>) = 4,
+    NestedCharacterClass(ArenaBox<'a, CharacterClass<'a>>) = 4,
     /// `UnicodeSetsMode` only
-    ClassStringDisjunction(Box<'a, ClassStringDisjunction<'a>>) = 5,
+    ClassStringDisjunction(ArenaBox<'a, ClassStringDisjunction<'a>>) = 5,
 }
 
 /// `-` separated range of characters.
@@ -242,7 +242,7 @@ pub struct ClassStringDisjunction<'a> {
     pub span: Span,
     /// `true` if body is empty or contains [`ClassString`] which `strings` is `true`.
     pub strings: bool,
-    pub body: Vec<'a, ClassString<'a>>,
+    pub body: ArenaVec<'a, ClassString<'a>>,
 }
 
 /// Single unit of [`ClassStringDisjunction`].
@@ -253,7 +253,7 @@ pub struct ClassString<'a> {
     pub span: Span,
     /// `true` if body is empty or contain 2 more characters.
     pub strings: bool,
-    pub body: Vec<'a, Character>,
+    pub body: ArenaVec<'a, Character>,
 }
 
 /// Named or unnamed capturing group.

--- a/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, Box, Vec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec};
 use oxc_diagnostics::Result;
 use oxc_str::Str;
 
@@ -100,7 +100,7 @@ impl<'a> PatternParser<'a> {
     fn parse_disjunction(&mut self) -> Result<ast::Disjunction<'a>> {
         let span_start = self.reader.offset();
 
-        let mut body = Vec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self.allocator);
         loop {
             body.push(self.parse_alternative()?);
 
@@ -123,7 +123,7 @@ impl<'a> PatternParser<'a> {
     fn parse_alternative(&mut self) -> Result<ast::Alternative<'a>> {
         let span_start = self.reader.offset();
 
-        let mut body = Vec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self.allocator);
         while let Some(term) = self.parse_term()? {
             body.push(term);
         }
@@ -157,7 +157,7 @@ impl<'a> PatternParser<'a> {
             let span_start = self.reader.offset();
             return match (self.parse_atom()?, self.consume_quantifier()?) {
                 (Some(atom), Some(((min, max), greedy))) => {
-                    Ok(Some(ast::Term::Quantifier(Box::new_in(
+                    Ok(Some(ast::Term::Quantifier(ArenaBox::new_in(
                         ast::Quantifier {
                             span: self.span_factory.create(span_start, self.reader.offset()),
                             greedy,
@@ -192,7 +192,7 @@ impl<'a> PatternParser<'a> {
                 )
                 && let Some(((min, max), greedy)) = self.consume_quantifier()?
             {
-                return Ok(Some(ast::Term::Quantifier(Box::new_in(
+                return Ok(Some(ast::Term::Quantifier(ArenaBox::new_in(
                     ast::Quantifier {
                         span: self.span_factory.create(span_start, self.reader.offset()),
                         greedy,
@@ -209,7 +209,7 @@ impl<'a> PatternParser<'a> {
 
         match (self.parse_extended_atom()?, self.consume_quantifier()?) {
             (Some(extended_atom), Some(((min, max), greedy))) => {
-                Ok(Some(ast::Term::Quantifier(Box::new_in(
+                Ok(Some(ast::Term::Quantifier(ArenaBox::new_in(
                     ast::Quantifier {
                         span: self.span_factory.create(span_start, self.reader.offset()),
                         min,
@@ -262,7 +262,7 @@ impl<'a> PatternParser<'a> {
         };
 
         if let Some(kind) = kind {
-            return Ok(Some(ast::Term::BoundaryAssertion(Box::new_in(
+            return Ok(Some(ast::Term::BoundaryAssertion(ArenaBox::new_in(
                 ast::BoundaryAssertion {
                     span: self.span_factory.create(span_start, self.reader.offset()),
                     kind,
@@ -293,7 +293,7 @@ impl<'a> PatternParser<'a> {
                 ));
             }
 
-            return Ok(Some(ast::Term::LookAroundAssertion(Box::new_in(
+            return Ok(Some(ast::Term::LookAroundAssertion(ArenaBox::new_in(
                 ast::LookAroundAssertion {
                     span: self.span_factory.create(span_start, self.reader.offset()),
                     kind,
@@ -324,7 +324,7 @@ impl<'a> PatternParser<'a> {
             let kind = Self::escape_kind_to_character_kind(self.reader.peek_escape_kind());
             self.reader.advance();
 
-            return Ok(Some(ast::Term::Character(Box::new_in(
+            return Ok(Some(ast::Term::Character(ArenaBox::new_in(
                 ast::Character {
                     span: self.span_factory.create(span_start, self.reader.offset()),
                     kind,
@@ -350,7 +350,7 @@ impl<'a> PatternParser<'a> {
 
         // CharacterClass[?UnicodeMode, ?UnicodeSetsMode]
         if let Some(character_class) = self.parse_character_class()? {
-            return Ok(Some(ast::Term::CharacterClass(Box::new_in(
+            return Ok(Some(ast::Term::CharacterClass(ArenaBox::new_in(
                 character_class,
                 self.allocator,
             ))));
@@ -359,7 +359,7 @@ impl<'a> PatternParser<'a> {
         // ( GroupSpecifier[?UnicodeMode][opt] Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] )
         // ( Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] )
         if let Some(capturing_group) = self.parse_capturing_group()? {
-            return Ok(Some(ast::Term::CapturingGroup(Box::new_in(
+            return Ok(Some(ast::Term::CapturingGroup(ArenaBox::new_in(
                 capturing_group,
                 self.allocator,
             ))));
@@ -369,7 +369,10 @@ impl<'a> PatternParser<'a> {
         // (? RegularExpressionModifiers : Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] )
         // (? RegularExpressionModifiers - RegularExpressionModifiers : Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] )
         if let Some(ignore_group) = self.parse_ignore_group()? {
-            return Ok(Some(ast::Term::IgnoreGroup(Box::new_in(ignore_group, self.allocator))));
+            return Ok(Some(ast::Term::IgnoreGroup(ArenaBox::new_in(
+                ignore_group,
+                self.allocator,
+            ))));
         }
 
         Ok(None)
@@ -405,7 +408,7 @@ impl<'a> PatternParser<'a> {
 
             // \ [lookahead = c]
             if self.reader.peek().as_ref().is_some_and(|&cp| cp == 'c' as u32) {
-                return Ok(Some(ast::Term::Character(Box::new_in(
+                return Ok(Some(ast::Term::Character(ArenaBox::new_in(
                     ast::Character {
                         span: self.span_factory.create(span_start, self.reader.offset()),
                         kind: ast::CharacterKind::Symbol,
@@ -422,7 +425,7 @@ impl<'a> PatternParser<'a> {
 
         // CharacterClass[~UnicodeMode, ~UnicodeSetsMode]
         if let Some(character_class) = self.parse_character_class()? {
-            return Ok(Some(ast::Term::CharacterClass(Box::new_in(
+            return Ok(Some(ast::Term::CharacterClass(ArenaBox::new_in(
                 character_class,
                 self.allocator,
             ))));
@@ -431,7 +434,7 @@ impl<'a> PatternParser<'a> {
         // ( GroupSpecifier[?UnicodeMode][opt] Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] )
         // ( Disjunction[?UnicodeMode, ?UnicodeSetsMode, ?NamedCaptureGroups] )
         if let Some(capturing_group) = self.parse_capturing_group()? {
-            return Ok(Some(ast::Term::CapturingGroup(Box::new_in(
+            return Ok(Some(ast::Term::CapturingGroup(ArenaBox::new_in(
                 capturing_group,
                 self.allocator,
             ))));
@@ -441,7 +444,10 @@ impl<'a> PatternParser<'a> {
         // (? RegularExpressionModifiers : Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] )
         // (? RegularExpressionModifiers - RegularExpressionModifiers : Disjunction[~UnicodeMode, ~UnicodeSetsMode, ?NamedCaptureGroups] )
         if let Some(ignore_group) = self.parse_ignore_group()? {
-            return Ok(Some(ast::Term::IgnoreGroup(Box::new_in(ignore_group, self.allocator))));
+            return Ok(Some(ast::Term::IgnoreGroup(ArenaBox::new_in(
+                ignore_group,
+                self.allocator,
+            ))));
         }
 
         // InvalidBracedQuantifier
@@ -458,7 +464,7 @@ impl<'a> PatternParser<'a> {
         // ExtendedPatternCharacter
         let escape_kind = self.reader.peek_escape_kind();
         if let Some(cp) = self.consume_extended_pattern_character() {
-            return Ok(Some(ast::Term::Character(Box::new_in(
+            return Ok(Some(ast::Term::Character(ArenaBox::new_in(
                 ast::Character {
                     span: self.span_factory.create(span_start, self.reader.offset()),
                     kind: Self::escape_kind_to_character_kind(escape_kind),
@@ -495,7 +501,7 @@ impl<'a> PatternParser<'a> {
                     ));
                 }
 
-                return Ok(Some(ast::Term::IndexedReference(Box::new_in(
+                return Ok(Some(ast::Term::IndexedReference(ArenaBox::new_in(
                     ast::IndexedReference {
                         span: self.span_factory.create(span_start, self.reader.offset()),
                         index,
@@ -505,7 +511,7 @@ impl<'a> PatternParser<'a> {
             }
 
             if index <= self.state.num_of_capturing_groups {
-                return Ok(Some(ast::Term::IndexedReference(Box::new_in(
+                return Ok(Some(ast::Term::IndexedReference(ArenaBox::new_in(
                     ast::IndexedReference {
                         span: self.span_factory.create(span_start, self.reader.offset()),
                         index,
@@ -519,7 +525,7 @@ impl<'a> PatternParser<'a> {
 
         // CharacterClassEscape: \d, \p{...}
         if let Some(character_class_escape) = self.parse_character_class_escape(span_start) {
-            return Ok(Some(ast::Term::CharacterClassEscape(Box::new_in(
+            return Ok(Some(ast::Term::CharacterClassEscape(ArenaBox::new_in(
                 character_class_escape,
                 self.allocator,
             ))));
@@ -527,7 +533,7 @@ impl<'a> PatternParser<'a> {
         if let Some(unicode_property_escape) =
             self.parse_character_class_escape_unicode(span_start)?
         {
-            return Ok(Some(ast::Term::UnicodePropertyEscape(Box::new_in(
+            return Ok(Some(ast::Term::UnicodePropertyEscape(ArenaBox::new_in(
                 unicode_property_escape,
                 self.allocator,
             ))));
@@ -535,7 +541,10 @@ impl<'a> PatternParser<'a> {
 
         // CharacterEscape: \n, \cM, \0, etc...
         if let Some(character_escape) = self.parse_character_escape(span_start)? {
-            return Ok(Some(ast::Term::Character(Box::new_in(character_escape, self.allocator))));
+            return Ok(Some(ast::Term::Character(ArenaBox::new_in(
+                character_escape,
+                self.allocator,
+            ))));
         }
 
         // k GroupName: \k<name> means named reference
@@ -552,7 +561,7 @@ impl<'a> PatternParser<'a> {
                     ));
                 }
 
-                return Ok(Some(ast::Term::NamedReference(Box::new_in(
+                return Ok(Some(ast::Term::NamedReference(ArenaBox::new_in(
                     ast::NamedReference {
                         span: self.span_factory.create(span_start, self.reader.offset()),
                         name,
@@ -810,13 +819,14 @@ impl<'a> PatternParser<'a> {
     // ```
     fn parse_class_contents(
         &mut self,
-    ) -> Result<(ast::CharacterClassContentsKind, Vec<'a, ast::CharacterClassContents<'a>>)> {
+    ) -> Result<(ast::CharacterClassContentsKind, ArenaVec<'a, ast::CharacterClassContents<'a>>)>
+    {
         // [empty]
         if self.reader.peek().as_ref().is_some_and(|&cp| cp == ']' as u32)
             // Unterminated
             || self.reader.peek().is_none()
         {
-            return Ok((ast::CharacterClassContentsKind::Union, Vec::new_in(self.allocator)));
+            return Ok((ast::CharacterClassContentsKind::Union, ArenaVec::new_in(self.allocator)));
         }
 
         // [+UnicodeSetsMode] ClassSetExpression
@@ -841,8 +851,9 @@ impl<'a> PatternParser<'a> {
     // ```
     fn parse_nonempty_class_ranges(
         &mut self,
-    ) -> Result<(ast::CharacterClassContentsKind, Vec<'a, ast::CharacterClassContents<'a>>)> {
-        let mut body = Vec::new_in(self.allocator);
+    ) -> Result<(ast::CharacterClassContentsKind, ArenaVec<'a, ast::CharacterClassContents<'a>>)>
+    {
+        let mut body = ArenaVec::new_in(self.allocator);
 
         loop {
             let range_span_start = self.reader.offset();
@@ -858,7 +869,7 @@ impl<'a> PatternParser<'a> {
                 continue;
             }
 
-            let dash = ast::CharacterClassContents::Character(Box::new_in(
+            let dash = ast::CharacterClassContents::Character(ArenaBox::new_in(
                 ast::Character {
                     span: self.span_factory.create(span_start, self.reader.offset()),
                     kind: ast::CharacterKind::Symbol,
@@ -898,7 +909,7 @@ impl<'a> PatternParser<'a> {
                     ));
                 }
 
-                body.push(ast::CharacterClassContents::CharacterClassRange(Box::new_in(
+                body.push(ast::CharacterClassContents::CharacterClassRange(ArenaBox::new_in(
                     ast::CharacterClassRange {
                         span: from.span.merge(to.span),
                         min: **from,
@@ -941,7 +952,7 @@ impl<'a> PatternParser<'a> {
         let span_start = self.reader.offset();
 
         if self.reader.eat('-') {
-            return Ok(Some(ast::CharacterClassContents::Character(Box::new_in(
+            return Ok(Some(ast::CharacterClassContents::Character(ArenaBox::new_in(
                 ast::Character {
                     span: self.span_factory.create(span_start, self.reader.offset()),
                     kind: ast::CharacterKind::Symbol,
@@ -972,7 +983,7 @@ impl<'a> PatternParser<'a> {
             let kind = Self::escape_kind_to_character_kind(self.reader.peek_escape_kind());
             self.reader.advance();
 
-            return Ok(Some(ast::CharacterClassContents::Character(Box::new_in(
+            return Ok(Some(ast::CharacterClassContents::Character(ArenaBox::new_in(
                 ast::Character {
                     span: self.span_factory.create(span_start, self.reader.offset()),
                     kind,
@@ -984,7 +995,7 @@ impl<'a> PatternParser<'a> {
 
         if self.reader.eat('\\') {
             if self.reader.peek().as_ref().is_some_and(|&cp| cp == 'c' as u32) {
-                return Ok(Some(ast::CharacterClassContents::Character(Box::new_in(
+                return Ok(Some(ast::CharacterClassContents::Character(ArenaBox::new_in(
                     ast::Character {
                         span: self.span_factory.create(span_start, self.reader.offset()),
                         kind: ast::CharacterKind::Symbol,
@@ -1025,7 +1036,7 @@ impl<'a> PatternParser<'a> {
     ) -> Result<Option<ast::CharacterClassContents<'a>>> {
         // b
         if self.reader.eat('b') {
-            return Ok(Some(ast::CharacterClassContents::Character(Box::new_in(
+            return Ok(Some(ast::CharacterClassContents::Character(ArenaBox::new_in(
                 ast::Character {
                     span: self.span_factory.create(span_start, self.reader.offset()),
                     kind: ast::CharacterKind::SingleEscape,
@@ -1037,7 +1048,7 @@ impl<'a> PatternParser<'a> {
 
         // [+UnicodeMode] -
         if self.state.unicode_mode && self.reader.eat('-') {
-            return Ok(Some(ast::CharacterClassContents::Character(Box::new_in(
+            return Ok(Some(ast::CharacterClassContents::Character(ArenaBox::new_in(
                 ast::Character {
                     span: self.span_factory.create(span_start, self.reader.offset()),
                     kind: ast::CharacterKind::SingleEscape,
@@ -1059,7 +1070,7 @@ impl<'a> PatternParser<'a> {
                 {
                     self.reader.advance();
 
-                    return Ok(Some(ast::CharacterClassContents::Character(Box::new_in(
+                    return Ok(Some(ast::CharacterClassContents::Character(ArenaBox::new_in(
                         ast::Character {
                             span: self.span_factory.create(span_start, self.reader.offset()),
                             kind: ast::CharacterKind::ControlLetter,
@@ -1075,7 +1086,7 @@ impl<'a> PatternParser<'a> {
 
         // CharacterClassEscape[?UnicodeMode]
         if let Some(character_class_escape) = self.parse_character_class_escape(span_start) {
-            return Ok(Some(ast::CharacterClassContents::CharacterClassEscape(Box::new_in(
+            return Ok(Some(ast::CharacterClassContents::CharacterClassEscape(ArenaBox::new_in(
                 character_class_escape,
                 self.allocator,
             ))));
@@ -1083,7 +1094,7 @@ impl<'a> PatternParser<'a> {
         if let Some(unicode_property_escape) =
             self.parse_character_class_escape_unicode(span_start)?
         {
-            return Ok(Some(ast::CharacterClassContents::UnicodePropertyEscape(Box::new_in(
+            return Ok(Some(ast::CharacterClassContents::UnicodePropertyEscape(ArenaBox::new_in(
                 unicode_property_escape,
                 self.allocator,
             ))));
@@ -1091,7 +1102,7 @@ impl<'a> PatternParser<'a> {
 
         // CharacterEscape[?UnicodeMode, ?NamedCaptureGroups]
         if let Some(character_escape) = self.parse_character_escape(span_start)? {
-            return Ok(Some(ast::CharacterClassContents::Character(Box::new_in(
+            return Ok(Some(ast::CharacterClassContents::Character(ArenaBox::new_in(
                 character_escape,
                 self.allocator,
             ))));
@@ -1108,7 +1119,8 @@ impl<'a> PatternParser<'a> {
     // ```
     fn parse_class_set_expression(
         &mut self,
-    ) -> Result<(ast::CharacterClassContentsKind, Vec<'a, ast::CharacterClassContents<'a>>)> {
+    ) -> Result<(ast::CharacterClassContentsKind, ArenaVec<'a, ast::CharacterClassContents<'a>>)>
+    {
         // ClassUnion :: ClassSetRange ClassUnion[opt]
         if let Some(class_set_range) = self.parse_class_set_range()? {
             return self.parse_class_set_union(class_set_range);
@@ -1146,8 +1158,9 @@ impl<'a> PatternParser<'a> {
     fn parse_class_set_union(
         &mut self,
         class_set_range_or_class_set_operand: ast::CharacterClassContents<'a>,
-    ) -> Result<(ast::CharacterClassContentsKind, Vec<'a, ast::CharacterClassContents<'a>>)> {
-        let mut body = Vec::new_in(self.allocator);
+    ) -> Result<(ast::CharacterClassContentsKind, ArenaVec<'a, ast::CharacterClassContents<'a>>)>
+    {
+        let mut body = ArenaVec::new_in(self.allocator);
         body.push(class_set_range_or_class_set_operand);
 
         loop {
@@ -1174,8 +1187,9 @@ impl<'a> PatternParser<'a> {
     fn parse_class_set_intersection(
         &mut self,
         class_set_operand: ast::CharacterClassContents<'a>,
-    ) -> Result<(ast::CharacterClassContentsKind, Vec<'a, ast::CharacterClassContents<'a>>)> {
-        let mut body = Vec::new_in(self.allocator);
+    ) -> Result<(ast::CharacterClassContentsKind, ArenaVec<'a, ast::CharacterClassContents<'a>>)>
+    {
+        let mut body = ArenaVec::new_in(self.allocator);
         body.push(class_set_operand);
 
         loop {
@@ -1215,8 +1229,9 @@ impl<'a> PatternParser<'a> {
     fn parse_class_set_subtraction(
         &mut self,
         class_set_operand: ast::CharacterClassContents<'a>,
-    ) -> Result<(ast::CharacterClassContentsKind, Vec<'a, ast::CharacterClassContents<'a>>)> {
-        let mut body = Vec::new_in(self.allocator);
+    ) -> Result<(ast::CharacterClassContentsKind, ArenaVec<'a, ast::CharacterClassContents<'a>>)>
+    {
+        let mut body = ArenaVec::new_in(self.allocator);
         body.push(class_set_operand);
 
         loop {
@@ -1261,7 +1276,7 @@ impl<'a> PatternParser<'a> {
                 ));
             }
 
-            return Ok(Some(ast::CharacterClassContents::CharacterClassRange(Box::new_in(
+            return Ok(Some(ast::CharacterClassContents::CharacterClassRange(ArenaBox::new_in(
                 ast::CharacterClassRange {
                     span: class_set_character.span.merge(class_set_character_to.span),
                     min: class_set_character,
@@ -1295,14 +1310,16 @@ impl<'a> PatternParser<'a> {
                 self.parse_class_string_disjunction_contents()?;
 
             if self.reader.eat('}') {
-                return Ok(Some(ast::CharacterClassContents::ClassStringDisjunction(Box::new_in(
-                    ast::ClassStringDisjunction {
-                        span: self.span_factory.create(span_start, self.reader.offset()),
-                        strings,
-                        body: class_string_disjunction_contents,
-                    },
-                    self.allocator,
-                ))));
+                return Ok(Some(ast::CharacterClassContents::ClassStringDisjunction(
+                    ArenaBox::new_in(
+                        ast::ClassStringDisjunction {
+                            span: self.span_factory.create(span_start, self.reader.offset()),
+                            strings,
+                            body: class_string_disjunction_contents,
+                        },
+                        self.allocator,
+                    ),
+                )));
             }
 
             return Err(diagnostics::unterminated_pattern(
@@ -1312,7 +1329,7 @@ impl<'a> PatternParser<'a> {
         }
 
         if let Some(class_set_character) = self.parse_class_set_character()? {
-            return Ok(Some(ast::CharacterClassContents::Character(Box::new_in(
+            return Ok(Some(ast::CharacterClassContents::Character(ArenaBox::new_in(
                 class_set_character,
                 self.allocator,
             ))));
@@ -1347,16 +1364,18 @@ impl<'a> PatternParser<'a> {
                     ));
                 }
 
-                return Ok(Some(ast::CharacterClassContents::NestedCharacterClass(Box::new_in(
-                    ast::CharacterClass {
-                        span: self.span_factory.create(span_start, self.reader.offset()),
-                        negative,
-                        kind,
-                        strings,
-                        body,
-                    },
-                    self.allocator,
-                ))));
+                return Ok(Some(ast::CharacterClassContents::NestedCharacterClass(
+                    ArenaBox::new_in(
+                        ast::CharacterClass {
+                            span: self.span_factory.create(span_start, self.reader.offset()),
+                            negative,
+                            kind,
+                            strings,
+                            body,
+                        },
+                        self.allocator,
+                    ),
+                )));
             }
 
             return Err(diagnostics::unterminated_pattern(
@@ -1370,18 +1389,16 @@ impl<'a> PatternParser<'a> {
         let checkpoint = self.reader.checkpoint();
         if self.reader.eat('\\') {
             if let Some(character_class_escape) = self.parse_character_class_escape(span_start) {
-                return Ok(Some(ast::CharacterClassContents::CharacterClassEscape(Box::new_in(
-                    character_class_escape,
-                    self.allocator,
-                ))));
+                return Ok(Some(ast::CharacterClassContents::CharacterClassEscape(
+                    ArenaBox::new_in(character_class_escape, self.allocator),
+                )));
             }
             if let Some(unicode_property_escape) =
                 self.parse_character_class_escape_unicode(span_start)?
             {
-                return Ok(Some(ast::CharacterClassContents::UnicodePropertyEscape(Box::new_in(
-                    unicode_property_escape,
-                    self.allocator,
-                ))));
+                return Ok(Some(ast::CharacterClassContents::UnicodePropertyEscape(
+                    ArenaBox::new_in(unicode_property_escape, self.allocator),
+                )));
             }
 
             self.reader.rewind(checkpoint);
@@ -1398,8 +1415,8 @@ impl<'a> PatternParser<'a> {
     // Returns: (ClassStringDisjunctionContents, contain_strings)
     fn parse_class_string_disjunction_contents(
         &mut self,
-    ) -> Result<(Vec<'a, ast::ClassString<'a>>, bool)> {
-        let mut body = Vec::new_in(self.allocator);
+    ) -> Result<(ArenaVec<'a, ast::ClassString<'a>>, bool)> {
+        let mut body = ArenaVec::new_in(self.allocator);
         let mut strings = false;
 
         loop {
@@ -1435,7 +1452,7 @@ impl<'a> PatternParser<'a> {
     fn parse_class_string(&mut self) -> Result<ast::ClassString<'a>> {
         let span_start = self.reader.offset();
 
-        let mut body = Vec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self.allocator);
         while let Some(class_set_character) = self.parse_class_set_character()? {
             body.push(class_set_character);
         }
@@ -2335,7 +2352,7 @@ impl<'a> PatternParser<'a> {
 
     fn may_contain_strings_in_class_contents(
         kind: ast::CharacterClassContentsKind,
-        body: &Vec<'a, ast::CharacterClassContents<'a>>,
+        body: &ArenaVec<'a, ast::CharacterClassContents<'a>>,
     ) -> bool {
         let may_contain_strings = |item: &ast::CharacterClassContents<'a>| match item {
             // MayContainStrings is true

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -7,7 +7,7 @@ use std::{
 
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::Address;
+use oxc_allocator::{Address, ArenaVec};
 use oxc_ast::{AstKind, ast::*};
 use oxc_ast_visit::Visit;
 #[cfg(feature = "cfg")]
@@ -747,7 +747,7 @@ impl<'a> SemanticBuilder<'a> {
         );
     }
 
-    fn visit_parameter_decorators(&mut self, decorators: &oxc_allocator::Vec<'a, Decorator<'a>>) {
+    fn visit_parameter_decorators(&mut self, decorators: &ArenaVec<'a, Decorator<'a>>) {
         if decorators.is_empty() {
             return;
         }

--- a/crates/oxc_span/src/cmp.rs
+++ b/crates/oxc_span/src/cmp.rs
@@ -1,5 +1,7 @@
 //! Specialized comparison traits
 
+use oxc_allocator::{ArenaBox, ArenaVec};
+
 /// This trait works similarly to [PartialEq] but it gives the liberty of checking the equality of the
 /// content loosely.
 ///
@@ -94,21 +96,21 @@ impl<T: ContentEq> ContentEq for Option<T> {
     }
 }
 
-/// Blanket implementation for [oxc_allocator::Box] types
-impl<T: ContentEq> ContentEq for oxc_allocator::Box<'_, T> {
+/// Blanket implementation for [`Box`](ArenaBox) types
+impl<T: ContentEq> ContentEq for ArenaBox<'_, T> {
     #[inline]
     fn content_eq(&self, other: &Self) -> bool {
         self.as_ref().content_eq(other.as_ref())
     }
 }
 
-/// Blanket implementation for [oxc_allocator::Vec] types
+/// Blanket implementation for [`Vec`](ArenaVec) types.
 ///
 /// # Warning
 /// This implementation is slow compared to [PartialEq] for native types which are [Copy] (e.g. `u32`).
 /// Prefer comparing the 2 vectors using `==` if they contain such native types (e.g. `Vec<u32>`).
 /// <https://godbolt.org/z/54on5sMWc>
-impl<T: ContentEq> ContentEq for oxc_allocator::Vec<'_, T> {
+impl<T: ContentEq> ContentEq for ArenaVec<'_, T> {
     #[inline]
     fn content_eq(&self, other: &Self) -> bool {
         if self.len() == other.len() {

--- a/crates/oxc_str/src/ident.rs
+++ b/crates/oxc_str/src/ident.rs
@@ -485,7 +485,7 @@ pub type IdentHashMap<'a, V> = hashbrown::HashMap<Ident<'a>, V, IdentBuildHasher
 
 /// Arena-allocated hash map keyed by [`Ident`], using precomputed ident hash.
 pub type ArenaIdentHashMap<'alloc, V> =
-    oxc_allocator::HashMap<'alloc, Ident<'alloc>, V, IdentBuildHasher>;
+    oxc_allocator::ArenaHashMap<'alloc, Ident<'alloc>, V, IdentBuildHasher>;
 
 /// Hash set of [`Ident`], using precomputed ident hash.
 pub type IdentHashSet<'a> = hashbrown::HashSet<Ident<'a>, IdentBuildHasher>;

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -1,6 +1,6 @@
 //! [ECMAScript Module Record](https://tc39.es/ecma262/#sec-abstract-module-records)
 
-use oxc_allocator::{Allocator, HashMap, Vec};
+use oxc_allocator::{Allocator, ArenaHashMap, ArenaVec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_span::Span;
@@ -28,41 +28,41 @@ pub struct ModuleRecord<'a> {
     ///   export ExportFromClause FromClause
     ///
     /// Keyed by ModuleSpecifier, valued by all node occurrences
-    pub requested_modules: HashMap<'a, Str<'a>, Vec<'a, RequestedModule>>,
+    pub requested_modules: ArenaHashMap<'a, Str<'a>, ArenaVec<'a, RequestedModule>>,
 
     /// `[[ImportEntries]]`
     ///
     /// A List of ImportEntry records derived from the code of this module
-    pub import_entries: Vec<'a, ImportEntry<'a>>,
+    pub import_entries: ArenaVec<'a, ImportEntry<'a>>,
 
     /// `[[LocalExportEntries]]`
     ///
     /// A List of [`ExportEntry`] records derived from the code of this module
     /// that correspond to declarations that occur within the module
-    pub local_export_entries: Vec<'a, ExportEntry<'a>>,
+    pub local_export_entries: ArenaVec<'a, ExportEntry<'a>>,
 
     /// `[[IndirectExportEntries]]`
     ///
     /// A List of [`ExportEntry`] records derived from the code of this module
     /// that correspond to reexported imports that occur within the module
     /// or exports from `export * as namespace` declarations.
-    pub indirect_export_entries: Vec<'a, ExportEntry<'a>>,
+    pub indirect_export_entries: ArenaVec<'a, ExportEntry<'a>>,
 
     /// `[[StarExportEntries]]`
     ///
     /// A List of [`ExportEntry`] records derived from the code of this module
     /// that correspond to `export *` declarations that occur within the module,
     /// not including `export * as namespace` declarations.
-    pub star_export_entries: Vec<'a, ExportEntry<'a>>,
+    pub star_export_entries: ArenaVec<'a, ExportEntry<'a>>,
 
     /// Local exported bindings
-    pub exported_bindings: HashMap<'a, Str<'a>, Span>,
+    pub exported_bindings: ArenaHashMap<'a, Str<'a>, Span>,
 
     /// Dynamic import expressions `import(specifier)`.
-    pub dynamic_imports: Vec<'a, DynamicImport>,
+    pub dynamic_imports: ArenaVec<'a, DynamicImport>,
 
     /// Span position of `import.meta`.
-    pub import_metas: Vec<'a, Span>,
+    pub import_metas: ArenaVec<'a, Span>,
 }
 
 impl<'a> ModuleRecord<'a> {
@@ -70,14 +70,14 @@ impl<'a> ModuleRecord<'a> {
     pub fn new(allocator: &'a Allocator) -> Self {
         Self {
             has_module_syntax: false,
-            requested_modules: HashMap::new_in(allocator),
-            import_entries: Vec::new_in(allocator),
-            local_export_entries: Vec::new_in(allocator),
-            indirect_export_entries: Vec::new_in(allocator),
-            star_export_entries: Vec::new_in(allocator),
-            exported_bindings: HashMap::new_in(allocator),
-            dynamic_imports: Vec::new_in(allocator),
-            import_metas: Vec::new_in(allocator),
+            requested_modules: ArenaHashMap::new_in(allocator),
+            import_entries: ArenaVec::new_in(allocator),
+            local_export_entries: ArenaVec::new_in(allocator),
+            indirect_export_entries: ArenaVec::new_in(allocator),
+            star_export_entries: ArenaVec::new_in(allocator),
+            exported_bindings: ArenaHashMap::new_in(allocator),
+            dynamic_imports: ArenaVec::new_in(allocator),
+            import_metas: ArenaVec::new_in(allocator),
         }
     }
 }

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -584,7 +584,7 @@ impl<'a> JsxImpl<'a> {
         &mut self,
         span: Span,
         opening_element: Option<ArenaBox<'a, JSXOpeningElement<'a>>>,
-        children: ArenaVec<JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let has_key_after_props_spread =

--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, sync::Arc};
 
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::{Address, Allocator, GetAddress, TakeIn, UnstableAddress};
+use oxc_allocator::{Address, Allocator, ArenaBox, GetAddress, TakeIn, UnstableAddress};
 use oxc_ast::ast::*;
 use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
@@ -397,7 +397,7 @@ impl<'a> ReplaceGlobalDefines<'a> {
 
     fn replace_identifier_define_impl(
         &mut self,
-        ident: &oxc_allocator::Box<'_, IdentifierReference<'_>>,
+        ident: &ArenaBox<'_, IdentifierReference<'_>>,
     ) -> Option<Expression<'a>> {
         if !Self::is_global_or_ambient_reference(self.scoping(), ident) {
             return None;

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -311,7 +311,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     /// This is a shortcut for `ctx.scoping.insert_scope_below_statements`.
     pub fn insert_scope_below_statements(
         &mut self,
-        stmts: &ArenaVec<Statement>,
+        stmts: &ArenaVec<'a, Statement<'a>>,
         flags: ScopeFlags,
     ) -> ScopeId {
         self.scoping.insert_scope_below_statements(stmts, flags)

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -143,7 +143,7 @@ impl<'a> TraverseScoping<'a> {
     /// `flags` provided are amended to inherit from parent scope's flags.
     pub fn insert_scope_below_statements(
         &mut self,
-        stmts: &ArenaVec<Statement>,
+        stmts: &ArenaVec<'a, Statement<'a>>,
         flags: ScopeFlags,
     ) -> ScopeId {
         let mut collector = ChildScopeCollector::new();

--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use rustc_hash::FxHashMap;
 
 use oxc::{
-    allocator::{Allocator, FromIn, Vec},
+    allocator::{Allocator, ArenaVec, FromIn},
     ast::ast::{Comment, Program},
     diagnostics::{LabeledSpan, NamedSource, OxcDiagnostic, Severity},
     span::Span,
@@ -21,9 +21,9 @@ use oxc_str::{Str, format_str};
 #[estree(no_type, no_ts_def)]
 pub struct RawTransferData<'a> {
     pub program: Program<'a>,
-    pub comments: Vec<'a, Comment>,
+    pub comments: ArenaVec<'a, Comment>,
     pub module: EcmaScriptModule<'a>,
-    pub errors: Vec<'a, Error<'a>>,
+    pub errors: ArenaVec<'a, Error<'a>>,
 }
 
 /// Metadata written to end of buffer.
@@ -65,7 +65,7 @@ impl RawTransferMetadata {
 pub struct Error<'a> {
     pub severity: ErrorSeverity,
     pub message: Str<'a>,
-    pub labels: Vec<'a, ErrorLabel<'a>>,
+    pub labels: ArenaVec<'a, ErrorLabel<'a>>,
     pub help_message: Option<Str<'a>>,
     pub codeframe: Str<'a>,
 }
@@ -76,10 +76,10 @@ impl<'a> Error<'a> {
         source_text: &str,
         filename: &str,
         allocator: &'a Allocator,
-    ) -> Vec<'a, Self> {
+    ) -> ArenaVec<'a, Self> {
         let named_source = Arc::new(NamedSource::new(filename, source_text.to_string()));
 
-        Vec::from_iter_in(
+        ArenaVec::from_iter_in(
             diagnostics
                 .into_iter()
                 .map(|diagnostic| Self::from_diagnostic_in(diagnostic, &named_source, allocator)),
@@ -92,7 +92,7 @@ impl<'a> Error<'a> {
         named_source: &Arc<NamedSource<String>>,
         allocator: &'a Allocator,
     ) -> Self {
-        let labels = Vec::from_iter_in(
+        let labels = ArenaVec::from_iter_in(
             diagnostic.labels.iter().map(|label| ErrorLabel::from_in(label, allocator)),
             allocator,
         );
@@ -164,13 +164,13 @@ pub struct EcmaScriptModule<'a> {
     /// Dynamic imports `import('foo')` are ignored since they can be used in non-ESM files.
     pub has_module_syntax: bool,
     /// Import statements.
-    pub static_imports: Vec<'a, StaticImport<'a>>,
+    pub static_imports: ArenaVec<'a, StaticImport<'a>>,
     /// Export statements.
-    pub static_exports: Vec<'a, StaticExport<'a>>,
+    pub static_exports: ArenaVec<'a, StaticExport<'a>>,
     /// Dynamic import expressions.
-    pub dynamic_imports: Vec<'a, DynamicImport>,
+    pub dynamic_imports: ArenaVec<'a, DynamicImport>,
     /// Span positions` of `import.meta`
-    pub import_metas: Vec<'a, Span>,
+    pub import_metas: ArenaVec<'a, Span>,
 }
 
 #[ast]
@@ -189,7 +189,7 @@ pub struct StaticImport<'a> {
     /// Import specifiers.
     ///
     /// Empty for `import "mod"`.
-    pub entries: Vec<'a, ImportEntry<'a>>,
+    pub entries: ArenaVec<'a, ImportEntry<'a>>,
 }
 
 #[ast]
@@ -197,7 +197,7 @@ pub struct StaticImport<'a> {
 #[estree(no_type, no_ts_def)]
 pub struct StaticExport<'a> {
     pub span: Span,
-    pub entries: Vec<'a, ExportEntry<'a>>,
+    pub entries: ArenaVec<'a, ExportEntry<'a>>,
 }
 
 impl<'a> FromIn<'a, ModuleRecord<'a>> for EcmaScriptModule<'a> {
@@ -210,7 +210,7 @@ impl<'a> FromIn<'a, ModuleRecord<'a>> for EcmaScriptModule<'a> {
                         .iter()
                         .filter(|e| e.statement_span == m.statement_span)
                         .cloned();
-                    let entries = Vec::from_iter_in(entries, allocator);
+                    let entries = ArenaVec::from_iter_in(entries, allocator);
 
                     StaticImport {
                         span: m.statement_span,
@@ -219,7 +219,7 @@ impl<'a> FromIn<'a, ModuleRecord<'a>> for EcmaScriptModule<'a> {
                     }
                 })
             });
-        let mut static_imports = Vec::from_iter_in(static_imports, allocator);
+        let mut static_imports = ArenaVec::from_iter_in(static_imports, allocator);
         static_imports.sort_unstable_by_key(|e| e.span.start);
 
         let static_exports = record
@@ -227,15 +227,15 @@ impl<'a> FromIn<'a, ModuleRecord<'a>> for EcmaScriptModule<'a> {
             .iter()
             .chain(&record.indirect_export_entries)
             .chain(&record.star_export_entries)
-            .fold(FxHashMap::<Span, Vec<'a, ExportEntry>>::default(), |mut acc, e| {
+            .fold(FxHashMap::<Span, ArenaVec<'a, ExportEntry>>::default(), |mut acc, e| {
                 acc.entry(e.statement_span)
-                    .or_insert_with(|| Vec::new_in(allocator))
+                    .or_insert_with(|| ArenaVec::new_in(allocator))
                     .push(e.clone());
                 acc
             })
             .into_iter()
             .map(|(span, entries)| StaticExport { span, entries });
-        let mut static_exports = Vec::from_iter_in(static_exports, allocator);
+        let mut static_exports = ArenaVec::from_iter_in(static_exports, allocator);
         static_exports.sort_unstable_by_key(|e| e.span.start);
 
         Self {

--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -576,14 +576,14 @@ impl<'c> Parser<'c> {
                 self.options.insert(inner_type_id, type_id);
                 type_id
             }),
-            "Box" => self.boxes.get(&inner_type_id).copied().unwrap_or_else(|| {
+            "Box" | "ArenaBox" => self.boxes.get(&inner_type_id).copied().unwrap_or_else(|| {
                 let name = format!("Box<{}>", self.type_name(inner_type_id));
                 let type_def = TypeDef::Box(BoxDef::new(name, inner_type_id));
                 let type_id = self.create_new_type(type_def);
                 self.boxes.insert(inner_type_id, type_id);
                 type_id
             }),
-            "Vec" => self.vecs.get(&inner_type_id).copied().unwrap_or_else(|| {
+            "Vec" | "ArenaVec" => self.vecs.get(&inner_type_id).copied().unwrap_or_else(|| {
                 let name = format!("Vec<{}>", self.type_name(inner_type_id));
                 let type_def = TypeDef::Vec(VecDef::new(name, inner_type_id));
                 let type_id = self.create_new_type(type_def);

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -9,7 +9,10 @@ use std::{
 
 use convert_case::{Case, Casing};
 use lazy_regex::regex;
-use oxc_allocator::Allocator;
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde::Serialize;
+
+use oxc_allocator::{Allocator, ArenaVec};
 use oxc_ast::ast::{
     Argument, ArrayExpression, ArrayExpressionElement, AssignmentTarget, CallExpression,
     Expression, ExpressionStatement, IdentifierName, ObjectExpression, ObjectProperty,
@@ -20,8 +23,6 @@ use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType, Span};
 use oxc_tasks_common::project_root;
-use rustc_hash::{FxHashMap, FxHashSet};
-use serde::Serialize;
 
 mod json;
 mod template;
@@ -648,7 +649,7 @@ impl<'a> Visit<'a> for State<'a> {
 
 fn find_parser_arguments<'a, 'b>(
     mut expr: &'b Expression<'a>,
-) -> Option<&'b oxc_allocator::Vec<'a, Argument<'a>>> {
+) -> Option<&'b ArenaVec<'a, Argument<'a>>> {
     loop {
         let Expression::CallExpression(call_expr) = expr else { return None };
         let Expression::StaticMemberExpression(static_member_expr) = &call_expr.callee else {


### PR DESCRIPTION
Pure refactor.

Use `ArenaBox` and `ArenaVec` everywhere for the arena-allocated types from `oxc_allocator`, instead of plain `Box` and `Vec`.

This disambiguates when `Vec` is `oxc_allocator::Vec` and when it's `std::vec::Vec`, making code clearer to follow.

Previously it was easy to confuse the two, and such confusion led to UB in `Traverse` (fixed in #23745).

Ditto other arena types - `ArenaHashMap`, `ArenaHashSet`, `ArenaStringBuilder`.

The only exceptions are:

1. Inside `oxc_allocator` crate itself.
2. AST type definitions.
3. Generated code (migrated separately in #23749).