### PR TITLE
refactor(all): shorten redundant `std::vec::Vec`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1279,10 +1279,7 @@ impl<'a> BindingPattern<'a> {
         }
     }
 
-    fn append_binding_identifiers<'b>(
-        &'b self,
-        idents: &mut std::vec::Vec<&'b BindingIdentifier<'a>>,
-    ) {
+    fn append_binding_identifiers<'b>(&'b self, idents: &mut Vec<&'b BindingIdentifier<'a>>) {
         match self {
             Self::BindingIdentifier(ident) => idents.push(ident),
             Self::AssignmentPattern(assign) => assign.left.append_binding_identifiers(idents),
@@ -1314,13 +1311,13 @@ impl<'a> BindingPattern<'a> {
     /// - `let {} = obj` would return `[]`
     /// - `let {a, b} = obj` would return `[a, b]`
     /// - `let {a = 1, b: c} = obj` would return `[a, c]`
-    pub fn get_binding_identifiers(&self) -> std::vec::Vec<&BindingIdentifier<'a>> {
+    pub fn get_binding_identifiers(&self) -> Vec<&BindingIdentifier<'a>> {
         let mut idents = vec![];
         self.append_binding_identifiers(&mut idents);
         idents
     }
 
-    fn append_symbol_ids(&self, symbol_ids: &mut std::vec::Vec<SymbolId>) {
+    fn append_symbol_ids(&self, symbol_ids: &mut Vec<SymbolId>) {
         match self {
             Self::BindingIdentifier(ident) => {
                 symbol_ids.push(ident.symbol_id());
@@ -1346,7 +1343,7 @@ impl<'a> BindingPattern<'a> {
     }
 
     /// Returns the [`SymbolId`]s of the bound identifiers in this binding pattern.
-    pub fn get_symbol_ids(&self) -> std::vec::Vec<SymbolId> {
+    pub fn get_symbol_ids(&self) -> Vec<SymbolId> {
         let mut symbol_ids = vec![];
         self.append_symbol_ids(&mut symbol_ids);
         symbol_ids

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -496,7 +496,7 @@ fn try_fold_math_variadic<'a>(
     if !ctx.is_global_expr("Math", object) {
         return None;
     }
-    let mut numbers = std::vec::Vec::new();
+    let mut numbers = Vec::new();
     for arg in args {
         let expr = arg.as_expression()?;
         let value = expr.get_side_free_number_value(ctx)?;

--- a/crates/oxc_formatter/src/formatter/jsdoc/wrap.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/wrap.rs
@@ -81,7 +81,7 @@ pub fn format_table_block(table_lines: &[&str]) -> Vec<String> {
     }
 
     // Determine number of columns
-    let num_cols = all_cells.iter().map(std::vec::Vec::len).max().unwrap_or(0);
+    let num_cols = all_cells.iter().map(Vec::len).max().unwrap_or(0);
     if num_cols == 0 {
         return to_owned();
     }

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -680,13 +680,12 @@ fn report_missing_curly_for_text_node(ctx: &LintContext, span: Span, string_valu
         let fixer = fixer.for_multifix();
         let alloc = Allocator::default();
         let ast_builder = AstBuilder::new(&alloc);
-        let line_matches =
-            string_value.match_indices('\n').map(|(i, _)| i).collect::<std::vec::Vec<_>>();
+        let line_matches = string_value.match_indices('\n').map(|(i, _)| i).collect::<Vec<_>>();
         let fix_contexts = if line_matches.is_empty() {
             build_missing_curly_fix_context_for_part(span, string_value, 0)
                 .iter()
                 .copied()
-                .collect::<std::vec::Vec<_>>()
+                .collect::<Vec<_>>()
         } else {
             string_value
                 .split('\n')
@@ -695,7 +694,7 @@ fn report_missing_curly_for_text_node(ctx: &LintContext, span: Span, string_valu
                     let line_start = calculate_line_start(line_matches.as_slice(), index);
                     build_missing_curly_fix_context_for_line(span, line, line_start)
                 })
-                .collect::<std::vec::Vec<_>>()
+                .collect::<Vec<_>>()
         };
         if fix_contexts.is_empty() {
             return fixer.noop();
@@ -720,9 +719,8 @@ fn build_missing_curly_fix_context_for_line(
     span: Span,
     line: &str,
     line_start: u32,
-) -> std::vec::Vec<(Span, &str)> {
-    let html_entities =
-        HTML_ENTITY_REGEX.find_iter(line).map(|mat| mat.end()).collect::<std::vec::Vec<_>>();
+) -> Vec<(Span, &str)> {
+    let html_entities = HTML_ENTITY_REGEX.find_iter(line).map(|mat| mat.end()).collect::<Vec<_>>();
     HTML_ENTITY_REGEX
         .split(line)
         .enumerate()
@@ -730,7 +728,7 @@ fn build_missing_curly_fix_context_for_line(
             let part_start = calculate_part_start(html_entities.as_slice(), index);
             build_missing_curly_fix_context_for_part(span, part, line_start + part_start)
         })
-        .collect::<std::vec::Vec<_>>()
+        .collect::<Vec<_>>()
 }
 
 fn build_missing_curly_fix_context_for_part(

--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -8,7 +8,7 @@ use oxc_syntax::symbol::SymbolId;
 
 pub struct KeepVar<'a> {
     ast: AstBuilder<'a>,
-    vars: std::vec::Vec<(Str<'a>, Span, Option<SymbolId>)>,
+    vars: Vec<(Str<'a>, Span, Option<SymbolId>)>,
     all_hoisted: bool,
 }
 

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1703,7 +1703,7 @@ impl<'a> PeepholeOptimizations {
         });
         let Some(delimiter) = Self::pick_delimiter(&strings) else { return };
 
-        let concatenated_string = strings.collect::<std::vec::Vec<_>>().join(delimiter);
+        let concatenated_string = strings.collect::<Vec<_>>().join(delimiter);
 
         // "str1,str2".split(',')
         let new_value = ctx.ast.expression_call_with_pure(

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -26,7 +26,7 @@ impl<'a> ModuleRecordBuilder<'a> {
         }
     }
 
-    pub fn build(mut self) -> (ModuleRecord<'a>, std::vec::Vec<OxcDiagnostic>) {
+    pub fn build(mut self) -> (ModuleRecord<'a>, Vec<OxcDiagnostic>) {
         // The `ParseModule` algorithm requires `importedBoundNames` (import entries) to be
         // resolved before resolving export entries.
         self.resolve_export_entries();
@@ -39,7 +39,7 @@ impl<'a> ModuleRecordBuilder<'a> {
         self.module_record.has_module_syntax
     }
 
-    pub fn errors(&self) -> std::vec::Vec<OxcDiagnostic> {
+    pub fn errors(&self) -> Vec<OxcDiagnostic> {
         let mut errors = vec![];
 
         let module_record = &self.module_record;

--- a/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
@@ -553,7 +553,7 @@ impl<'a> PatternParser<'a> {
                 // [SS:EE] AtomEscape :: k GroupName
                 // It is a Syntax Error if GroupSpecifiersThatMatch(GroupName) is empty.
                 if !self.state.capturing_group_names.contains(name.as_str()) {
-                    let names: std::vec::Vec<&str> =
+                    let names: Vec<&str> =
                         self.state.capturing_group_names.iter().map(Str::as_str).collect();
                     return Err(diagnostics::invalid_named_reference(
                         self.span_factory.create(span_start, self.reader.offset()),

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -168,7 +168,7 @@ impl<'a> ModuleImportsStore<'a> {
 
     pub(crate) fn get_require(
         source: Str<'a>,
-        names: std::vec::Vec<Import<'a>>,
+        names: Vec<Import<'a>>,
         require_symbol_id: Option<SymbolId>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {


### PR DESCRIPTION
Pure refactor.

#23748 made all usages of arena-allocated `Vec` be named `ArenaVec`. This makes plain `Vec` unambiguously refer to heap-allocated `Vec` from standard library.

Shorten `std::vec::Vec` to just `Vec` in various places.