### PR TITLE
refactor(all): use `ArenaBox` and `ArenaVec` in generated code

### DIFF
--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -8,7 +8,7 @@
 
 use std::cell::Cell;
 
-use oxc_allocator::{Allocator, Box, IntoIn, Vec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, IntoIn};
 use oxc_str::{Ident, Str};
 use oxc_syntax::{reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
@@ -31,10 +31,10 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         source_type: SourceType,
         source_text: &'a str,
-        comments: Vec<'a, Comment>,
+        comments: ArenaVec<'a, Comment>,
         hashbang: Option<Hashbang<'a>>,
-        directives: Vec<'a, Directive<'a>>,
-        body: Vec<'a, Statement<'a>>,
+        directives: ArenaVec<'a, Directive<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
     ) -> Program<'a> {
         Program {
             node_id: Default::default(),
@@ -66,10 +66,10 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         source_type: SourceType,
         source_text: &'a str,
-        comments: Vec<'a, Comment>,
+        comments: ArenaVec<'a, Comment>,
         hashbang: Option<Hashbang<'a>>,
-        directives: Vec<'a, Directive<'a>>,
-        body: Vec<'a, Statement<'a>>,
+        directives: ArenaVec<'a, Directive<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
     ) -> Program<'a> {
         Program {
@@ -230,8 +230,8 @@ impl<'a> AstBuilder<'a> {
     pub fn expression_template_literal(
         self,
         span: Span,
-        quasis: Vec<'a, TemplateElement<'a>>,
-        expressions: Vec<'a, Expression<'a>>,
+        quasis: ArenaVec<'a, TemplateElement<'a>>,
+        expressions: ArenaVec<'a, Expression<'a>>,
     ) -> Expression<'a> {
         Expression::TemplateLiteral(self.alloc_template_literal(span, quasis, expressions))
     }
@@ -316,7 +316,7 @@ impl<'a> AstBuilder<'a> {
     pub fn expression_array(
         self,
         span: Span,
-        elements: Vec<'a, ArrayExpressionElement<'a>>,
+        elements: ArenaVec<'a, ArrayExpressionElement<'a>>,
     ) -> Expression<'a> {
         Expression::ArrayExpression(self.alloc_array_expression(span, elements))
     }
@@ -345,10 +345,10 @@ impl<'a> AstBuilder<'a> {
         body: T4,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
     {
         Expression::ArrowFunctionExpression(self.alloc_arrow_function_expression(
             span,
@@ -391,10 +391,10 @@ impl<'a> AstBuilder<'a> {
         pife: bool,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
     {
         Expression::ArrowFunctionExpression(
             self.alloc_arrow_function_expression_with_scope_id_and_pure_and_pife(
@@ -482,11 +482,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         optional: bool,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Expression::CallExpression(self.alloc_call_expression(
             span,
@@ -514,12 +514,12 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         optional: bool,
         pure: bool,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Expression::CallExpression(self.alloc_call_expression_with_pure(
             span,
@@ -564,20 +564,20 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: ClassType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
         super_type_arguments: T2,
-        implements: Vec<'a, TSClassImplements<'a>>,
+        implements: ArenaVec<'a, TSClassImplements<'a>>,
         body: T3,
         r#abstract: bool,
         declare: bool,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-        T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
     {
         Expression::ClassExpression(self.alloc_class(
             span,
@@ -616,21 +616,21 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: ClassType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
         super_type_arguments: T2,
-        implements: Vec<'a, TSClassImplements<'a>>,
+        implements: ArenaVec<'a, TSClassImplements<'a>>,
         body: T3,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-        T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
     {
         Expression::ClassExpression(self.alloc_class_with_scope_id(
             span,
@@ -702,11 +702,11 @@ impl<'a> AstBuilder<'a> {
         body: T5,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
         Expression::FunctionExpression(self.alloc_function(
             span,
@@ -761,11 +761,11 @@ impl<'a> AstBuilder<'a> {
         pife: bool,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
         Expression::FunctionExpression(self.alloc_function_with_scope_id_and_pure_and_pife(
             span,
@@ -840,10 +840,10 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Expression::NewExpression(self.alloc_new_expression(
             span,
@@ -869,11 +869,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         pure: bool,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Expression::NewExpression(self.alloc_new_expression_with_pure(
             span,
@@ -895,7 +895,7 @@ impl<'a> AstBuilder<'a> {
     pub fn expression_object(
         self,
         span: Span,
-        properties: Vec<'a, ObjectPropertyKind<'a>>,
+        properties: ArenaVec<'a, ObjectPropertyKind<'a>>,
     ) -> Expression<'a> {
         Expression::ObjectExpression(self.alloc_object_expression(span, properties))
     }
@@ -927,7 +927,7 @@ impl<'a> AstBuilder<'a> {
     pub fn expression_sequence(
         self,
         span: Span,
-        expressions: Vec<'a, Expression<'a>>,
+        expressions: ArenaVec<'a, Expression<'a>>,
     ) -> Expression<'a> {
         Expression::SequenceExpression(self.alloc_sequence_expression(span, expressions))
     }
@@ -950,7 +950,7 @@ impl<'a> AstBuilder<'a> {
         quasi: TemplateLiteral<'a>,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Expression::TaggedTemplateExpression(self.alloc_tagged_template_expression(
             span,
@@ -1059,12 +1059,12 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         opening_element: T1,
-        children: Vec<'a, JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         closing_element: T2,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
     {
         Expression::JSXElement(self.alloc_jsx_element(
             span,
@@ -1088,7 +1088,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
-        children: Vec<'a, JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         closing_fragment: JSXClosingFragment,
     ) -> Expression<'a> {
         Expression::JSXFragment(self.alloc_jsx_fragment(
@@ -1185,7 +1185,7 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T1,
     ) -> Expression<'a>
     where
-        T1: IntoIn<'a, Box<'a, TSTypeParameterInstantiation<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
     {
         Expression::TSInstantiationExpression(self.alloc_ts_instantiation_expression(
             span,
@@ -1207,7 +1207,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         name: IdentifierName<'a>,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
     ) -> Expression<'a> {
         Expression::V8IntrinsicExpression(self.alloc_v8_intrinsic_expression(span, name, arguments))
     }
@@ -1230,18 +1230,18 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IdentifierName`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::identifier_name`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn alloc_identifier_name<S1>(self, span: Span, name: S1) -> Box<'a, IdentifierName<'a>>
+    pub fn alloc_identifier_name<S1>(self, span: Span, name: S1) -> ArenaBox<'a, IdentifierName<'a>>
     where
         S1: Into<Ident<'a>>,
     {
-        Box::new_in(self.identifier_name(span, name), self.allocator)
+        ArenaBox::new_in(self.identifier_name(span, name), self.allocator)
     }
 
     /// Build an [`IdentifierReference`].
@@ -1267,7 +1267,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IdentifierReference`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::identifier_reference`] instead.
     ///
     /// ## Parameters
@@ -1278,11 +1278,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         name: S1,
-    ) -> Box<'a, IdentifierReference<'a>>
+    ) -> ArenaBox<'a, IdentifierReference<'a>>
     where
         S1: Into<Ident<'a>>,
     {
-        Box::new_in(self.identifier_reference(span, name), self.allocator)
+        ArenaBox::new_in(self.identifier_reference(span, name), self.allocator)
     }
 
     /// Build an [`IdentifierReference`] with `reference_id`.
@@ -1314,7 +1314,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IdentifierReference`] with `reference_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::identifier_reference_with_reference_id`] instead.
     ///
     /// ## Parameters
@@ -1327,11 +1327,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         name: S1,
         reference_id: ReferenceId,
-    ) -> Box<'a, IdentifierReference<'a>>
+    ) -> ArenaBox<'a, IdentifierReference<'a>>
     where
         S1: Into<Ident<'a>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.identifier_reference_with_reference_id(span, name, reference_id),
             self.allocator,
         )
@@ -1360,7 +1360,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingIdentifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::binding_identifier`] instead.
     ///
     /// ## Parameters
@@ -1371,11 +1371,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         name: S1,
-    ) -> Box<'a, BindingIdentifier<'a>>
+    ) -> ArenaBox<'a, BindingIdentifier<'a>>
     where
         S1: Into<Ident<'a>>,
     {
-        Box::new_in(self.binding_identifier(span, name), self.allocator)
+        ArenaBox::new_in(self.binding_identifier(span, name), self.allocator)
     }
 
     /// Build a [`BindingIdentifier`] with `symbol_id`.
@@ -1407,7 +1407,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingIdentifier`] with `symbol_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::binding_identifier_with_symbol_id`] instead.
     ///
     /// ## Parameters
@@ -1420,11 +1420,14 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         name: S1,
         symbol_id: SymbolId,
-    ) -> Box<'a, BindingIdentifier<'a>>
+    ) -> ArenaBox<'a, BindingIdentifier<'a>>
     where
         S1: Into<Ident<'a>>,
     {
-        Box::new_in(self.binding_identifier_with_symbol_id(span, name, symbol_id), self.allocator)
+        ArenaBox::new_in(
+            self.binding_identifier_with_symbol_id(span, name, symbol_id),
+            self.allocator,
+        )
     }
 
     /// Build a [`LabelIdentifier`].
@@ -1454,14 +1457,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ThisExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::this_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_this_expression(self, span: Span) -> Box<'a, ThisExpression> {
-        Box::new_in(self.this_expression(span), self.allocator)
+    pub fn alloc_this_expression(self, span: Span) -> ArenaBox<'a, ThisExpression> {
+        ArenaBox::new_in(self.this_expression(span), self.allocator)
     }
 
     /// Build an [`ArrayExpression`].
@@ -1476,14 +1479,14 @@ impl<'a> AstBuilder<'a> {
     pub fn array_expression(
         self,
         span: Span,
-        elements: Vec<'a, ArrayExpressionElement<'a>>,
+        elements: ArenaVec<'a, ArrayExpressionElement<'a>>,
     ) -> ArrayExpression<'a> {
         ArrayExpression { node_id: Default::default(), span, elements }
     }
 
     /// Build an [`ArrayExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::array_expression`] instead.
     ///
     /// ## Parameters
@@ -1493,9 +1496,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_array_expression(
         self,
         span: Span,
-        elements: Vec<'a, ArrayExpressionElement<'a>>,
-    ) -> Box<'a, ArrayExpression<'a>> {
-        Box::new_in(self.array_expression(span, elements), self.allocator)
+        elements: ArenaVec<'a, ArrayExpressionElement<'a>>,
+    ) -> ArenaBox<'a, ArrayExpression<'a>> {
+        ArenaBox::new_in(self.array_expression(span, elements), self.allocator)
     }
 
     /// Build an [`ArrayExpressionElement::SpreadElement`].
@@ -1539,14 +1542,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`Elision`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::elision`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_elision(self, span: Span) -> Box<'a, Elision> {
-        Box::new_in(self.elision(span), self.allocator)
+    pub fn alloc_elision(self, span: Span) -> ArenaBox<'a, Elision> {
+        ArenaBox::new_in(self.elision(span), self.allocator)
     }
 
     /// Build an [`ObjectExpression`].
@@ -1561,14 +1564,14 @@ impl<'a> AstBuilder<'a> {
     pub fn object_expression(
         self,
         span: Span,
-        properties: Vec<'a, ObjectPropertyKind<'a>>,
+        properties: ArenaVec<'a, ObjectPropertyKind<'a>>,
     ) -> ObjectExpression<'a> {
         ObjectExpression { node_id: Default::default(), span, properties }
     }
 
     /// Build an [`ObjectExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::object_expression`] instead.
     ///
     /// ## Parameters
@@ -1578,9 +1581,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_object_expression(
         self,
         span: Span,
-        properties: Vec<'a, ObjectPropertyKind<'a>>,
-    ) -> Box<'a, ObjectExpression<'a>> {
-        Box::new_in(self.object_expression(span, properties), self.allocator)
+        properties: ArenaVec<'a, ObjectPropertyKind<'a>>,
+    ) -> ArenaBox<'a, ObjectExpression<'a>> {
+        ArenaBox::new_in(self.object_expression(span, properties), self.allocator)
     }
 
     /// Build an [`ObjectPropertyKind::ObjectProperty`].
@@ -1665,7 +1668,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectProperty`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::object_property`] instead.
     ///
     /// ## Parameters
@@ -1686,8 +1689,8 @@ impl<'a> AstBuilder<'a> {
         method: bool,
         shorthand: bool,
         computed: bool,
-    ) -> Box<'a, ObjectProperty<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, ObjectProperty<'a>> {
+        ArenaBox::new_in(
             self.object_property(span, kind, key, value, method, shorthand, computed),
             self.allocator,
         )
@@ -1736,15 +1739,15 @@ impl<'a> AstBuilder<'a> {
     pub fn template_literal(
         self,
         span: Span,
-        quasis: Vec<'a, TemplateElement<'a>>,
-        expressions: Vec<'a, Expression<'a>>,
+        quasis: ArenaVec<'a, TemplateElement<'a>>,
+        expressions: ArenaVec<'a, Expression<'a>>,
     ) -> TemplateLiteral<'a> {
         TemplateLiteral { node_id: Default::default(), span, quasis, expressions }
     }
 
     /// Build a [`TemplateLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::template_literal`] instead.
     ///
     /// ## Parameters
@@ -1755,10 +1758,10 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_template_literal(
         self,
         span: Span,
-        quasis: Vec<'a, TemplateElement<'a>>,
-        expressions: Vec<'a, Expression<'a>>,
-    ) -> Box<'a, TemplateLiteral<'a>> {
-        Box::new_in(self.template_literal(span, quasis, expressions), self.allocator)
+        quasis: ArenaVec<'a, TemplateElement<'a>>,
+        expressions: ArenaVec<'a, Expression<'a>>,
+    ) -> ArenaBox<'a, TemplateLiteral<'a>> {
+        ArenaBox::new_in(self.template_literal(span, quasis, expressions), self.allocator)
     }
 
     /// Build a [`TaggedTemplateExpression`].
@@ -1780,7 +1783,7 @@ impl<'a> AstBuilder<'a> {
         quasi: TemplateLiteral<'a>,
     ) -> TaggedTemplateExpression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TaggedTemplateExpression {
             node_id: Default::default(),
@@ -1793,7 +1796,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TaggedTemplateExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::tagged_template_expression`] instead.
     ///
     /// ## Parameters
@@ -1808,11 +1811,11 @@ impl<'a> AstBuilder<'a> {
         tag: Expression<'a>,
         type_arguments: T1,
         quasi: TemplateLiteral<'a>,
-    ) -> Box<'a, TaggedTemplateExpression<'a>>
+    ) -> ArenaBox<'a, TaggedTemplateExpression<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.tagged_template_expression(span, tag, type_arguments, quasi),
             self.allocator,
         )
@@ -1947,7 +1950,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ComputedMemberExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::computed_member_expression`] instead.
     ///
     /// ## Parameters
@@ -1962,8 +1965,8 @@ impl<'a> AstBuilder<'a> {
         object: Expression<'a>,
         expression: Expression<'a>,
         optional: bool,
-    ) -> Box<'a, ComputedMemberExpression<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, ComputedMemberExpression<'a>> {
+        ArenaBox::new_in(
             self.computed_member_expression(span, object, expression, optional),
             self.allocator,
         )
@@ -1992,7 +1995,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StaticMemberExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::static_member_expression`] instead.
     ///
     /// ## Parameters
@@ -2007,8 +2010,11 @@ impl<'a> AstBuilder<'a> {
         object: Expression<'a>,
         property: IdentifierName<'a>,
         optional: bool,
-    ) -> Box<'a, StaticMemberExpression<'a>> {
-        Box::new_in(self.static_member_expression(span, object, property, optional), self.allocator)
+    ) -> ArenaBox<'a, StaticMemberExpression<'a>> {
+        ArenaBox::new_in(
+            self.static_member_expression(span, object, property, optional),
+            self.allocator,
+        )
     }
 
     /// Build a [`PrivateFieldExpression`].
@@ -2034,7 +2040,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PrivateFieldExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::private_field_expression`] instead.
     ///
     /// ## Parameters
@@ -2049,8 +2055,11 @@ impl<'a> AstBuilder<'a> {
         object: Expression<'a>,
         field: PrivateIdentifier<'a>,
         optional: bool,
-    ) -> Box<'a, PrivateFieldExpression<'a>> {
-        Box::new_in(self.private_field_expression(span, object, field, optional), self.allocator)
+    ) -> ArenaBox<'a, PrivateFieldExpression<'a>> {
+        ArenaBox::new_in(
+            self.private_field_expression(span, object, field, optional),
+            self.allocator,
+        )
     }
 
     /// Build a [`CallExpression`].
@@ -2070,11 +2079,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         optional: bool,
     ) -> CallExpression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         CallExpression {
             node_id: Default::default(),
@@ -2089,7 +2098,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CallExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::call_expression`] instead.
     ///
     /// ## Parameters
@@ -2104,13 +2113,13 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         optional: bool,
-    ) -> Box<'a, CallExpression<'a>>
+    ) -> ArenaBox<'a, CallExpression<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.call_expression(span, callee, type_arguments, arguments, optional),
             self.allocator,
         )
@@ -2134,12 +2143,12 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         optional: bool,
         pure: bool,
     ) -> CallExpression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         CallExpression {
             node_id: Default::default(),
@@ -2154,7 +2163,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CallExpression`] with `pure`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::call_expression_with_pure`] instead.
     ///
     /// ## Parameters
@@ -2170,14 +2179,14 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         optional: bool,
         pure: bool,
-    ) -> Box<'a, CallExpression<'a>>
+    ) -> ArenaBox<'a, CallExpression<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.call_expression_with_pure(span, callee, type_arguments, arguments, optional, pure),
             self.allocator,
         )
@@ -2199,10 +2208,10 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
     ) -> NewExpression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         NewExpression {
             node_id: Default::default(),
@@ -2216,7 +2225,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NewExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::new_expression`] instead.
     ///
     /// ## Parameters
@@ -2230,12 +2239,15 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
-    ) -> Box<'a, NewExpression<'a>>
+        arguments: ArenaVec<'a, Argument<'a>>,
+    ) -> ArenaBox<'a, NewExpression<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(self.new_expression(span, callee, type_arguments, arguments), self.allocator)
+        ArenaBox::new_in(
+            self.new_expression(span, callee, type_arguments, arguments),
+            self.allocator,
+        )
     }
 
     /// Build a [`NewExpression`] with `pure`.
@@ -2255,11 +2267,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         pure: bool,
     ) -> NewExpression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         NewExpression {
             node_id: Default::default(),
@@ -2273,7 +2285,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NewExpression`] with `pure`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::new_expression_with_pure`] instead.
     ///
     /// ## Parameters
@@ -2288,13 +2300,13 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         pure: bool,
-    ) -> Box<'a, NewExpression<'a>>
+    ) -> ArenaBox<'a, NewExpression<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.new_expression_with_pure(span, callee, type_arguments, arguments, pure),
             self.allocator,
         )
@@ -2321,7 +2333,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`MetaProperty`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::meta_property`] instead.
     ///
     /// ## Parameters
@@ -2334,8 +2346,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         meta: IdentifierName<'a>,
         property: IdentifierName<'a>,
-    ) -> Box<'a, MetaProperty<'a>> {
-        Box::new_in(self.meta_property(span, meta, property), self.allocator)
+    ) -> ArenaBox<'a, MetaProperty<'a>> {
+        ArenaBox::new_in(self.meta_property(span, meta, property), self.allocator)
     }
 
     /// Build a [`SpreadElement`].
@@ -2353,7 +2365,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SpreadElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::spread_element`] instead.
     ///
     /// ## Parameters
@@ -2364,8 +2376,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         argument: Expression<'a>,
-    ) -> Box<'a, SpreadElement<'a>> {
-        Box::new_in(self.spread_element(span, argument), self.allocator)
+    ) -> ArenaBox<'a, SpreadElement<'a>> {
+        ArenaBox::new_in(self.spread_element(span, argument), self.allocator)
     }
 
     /// Build an [`Argument::SpreadElement`].
@@ -2403,7 +2415,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`UpdateExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::update_expression`] instead.
     ///
     /// ## Parameters
@@ -2418,8 +2430,8 @@ impl<'a> AstBuilder<'a> {
         operator: UpdateOperator,
         prefix: bool,
         argument: SimpleAssignmentTarget<'a>,
-    ) -> Box<'a, UpdateExpression<'a>> {
-        Box::new_in(self.update_expression(span, operator, prefix, argument), self.allocator)
+    ) -> ArenaBox<'a, UpdateExpression<'a>> {
+        ArenaBox::new_in(self.update_expression(span, operator, prefix, argument), self.allocator)
     }
 
     /// Build an [`UnaryExpression`].
@@ -2443,7 +2455,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`UnaryExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::unary_expression`] instead.
     ///
     /// ## Parameters
@@ -2456,8 +2468,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         operator: UnaryOperator,
         argument: Expression<'a>,
-    ) -> Box<'a, UnaryExpression<'a>> {
-        Box::new_in(self.unary_expression(span, operator, argument), self.allocator)
+    ) -> ArenaBox<'a, UnaryExpression<'a>> {
+        ArenaBox::new_in(self.unary_expression(span, operator, argument), self.allocator)
     }
 
     /// Build a [`BinaryExpression`].
@@ -2483,7 +2495,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BinaryExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::binary_expression`] instead.
     ///
     /// ## Parameters
@@ -2498,8 +2510,8 @@ impl<'a> AstBuilder<'a> {
         left: Expression<'a>,
         operator: BinaryOperator,
         right: Expression<'a>,
-    ) -> Box<'a, BinaryExpression<'a>> {
-        Box::new_in(self.binary_expression(span, left, operator, right), self.allocator)
+    ) -> ArenaBox<'a, BinaryExpression<'a>> {
+        ArenaBox::new_in(self.binary_expression(span, left, operator, right), self.allocator)
     }
 
     /// Build a [`PrivateInExpression`].
@@ -2523,7 +2535,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PrivateInExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::private_in_expression`] instead.
     ///
     /// ## Parameters
@@ -2536,8 +2548,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         left: PrivateIdentifier<'a>,
         right: Expression<'a>,
-    ) -> Box<'a, PrivateInExpression<'a>> {
-        Box::new_in(self.private_in_expression(span, left, right), self.allocator)
+    ) -> ArenaBox<'a, PrivateInExpression<'a>> {
+        ArenaBox::new_in(self.private_in_expression(span, left, right), self.allocator)
     }
 
     /// Build a [`LogicalExpression`].
@@ -2563,7 +2575,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`LogicalExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::logical_expression`] instead.
     ///
     /// ## Parameters
@@ -2578,8 +2590,8 @@ impl<'a> AstBuilder<'a> {
         left: Expression<'a>,
         operator: LogicalOperator,
         right: Expression<'a>,
-    ) -> Box<'a, LogicalExpression<'a>> {
-        Box::new_in(self.logical_expression(span, left, operator, right), self.allocator)
+    ) -> ArenaBox<'a, LogicalExpression<'a>> {
+        ArenaBox::new_in(self.logical_expression(span, left, operator, right), self.allocator)
     }
 
     /// Build a [`ConditionalExpression`].
@@ -2605,7 +2617,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ConditionalExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::conditional_expression`] instead.
     ///
     /// ## Parameters
@@ -2620,8 +2632,11 @@ impl<'a> AstBuilder<'a> {
         test: Expression<'a>,
         consequent: Expression<'a>,
         alternate: Expression<'a>,
-    ) -> Box<'a, ConditionalExpression<'a>> {
-        Box::new_in(self.conditional_expression(span, test, consequent, alternate), self.allocator)
+    ) -> ArenaBox<'a, ConditionalExpression<'a>> {
+        ArenaBox::new_in(
+            self.conditional_expression(span, test, consequent, alternate),
+            self.allocator,
+        )
     }
 
     /// Build an [`AssignmentExpression`].
@@ -2647,7 +2662,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::assignment_expression`] instead.
     ///
     /// ## Parameters
@@ -2662,8 +2677,8 @@ impl<'a> AstBuilder<'a> {
         operator: AssignmentOperator,
         left: AssignmentTarget<'a>,
         right: Expression<'a>,
-    ) -> Box<'a, AssignmentExpression<'a>> {
-        Box::new_in(self.assignment_expression(span, operator, left, right), self.allocator)
+    ) -> ArenaBox<'a, AssignmentExpression<'a>> {
+        ArenaBox::new_in(self.assignment_expression(span, operator, left, right), self.allocator)
     }
 
     /// Build a [`SimpleAssignmentTarget::AssignmentTargetIdentifier`].
@@ -2806,11 +2821,11 @@ impl<'a> AstBuilder<'a> {
     pub fn assignment_target_pattern_array_assignment_target<T1>(
         self,
         span: Span,
-        elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
+        elements: ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: T1,
     ) -> AssignmentTargetPattern<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, AssignmentTargetRest<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         AssignmentTargetPattern::ArrayAssignmentTarget(
             self.alloc_array_assignment_target(span, elements, rest),
@@ -2829,11 +2844,11 @@ impl<'a> AstBuilder<'a> {
     pub fn assignment_target_pattern_object_assignment_target<T1>(
         self,
         span: Span,
-        properties: Vec<'a, AssignmentTargetProperty<'a>>,
+        properties: ArenaVec<'a, AssignmentTargetProperty<'a>>,
         rest: T1,
     ) -> AssignmentTargetPattern<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, AssignmentTargetRest<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         AssignmentTargetPattern::ObjectAssignmentTarget(
             self.alloc_object_assignment_target(span, properties, rest),
@@ -2853,11 +2868,11 @@ impl<'a> AstBuilder<'a> {
     pub fn array_assignment_target<T1>(
         self,
         span: Span,
-        elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
+        elements: ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: T1,
     ) -> ArrayAssignmentTarget<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, AssignmentTargetRest<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         ArrayAssignmentTarget {
             node_id: Default::default(),
@@ -2869,7 +2884,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrayAssignmentTarget`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::array_assignment_target`] instead.
     ///
     /// ## Parameters
@@ -2880,13 +2895,13 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_array_assignment_target<T1>(
         self,
         span: Span,
-        elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
+        elements: ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: T1,
-    ) -> Box<'a, ArrayAssignmentTarget<'a>>
+    ) -> ArenaBox<'a, ArrayAssignmentTarget<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, AssignmentTargetRest<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
-        Box::new_in(self.array_assignment_target(span, elements, rest), self.allocator)
+        ArenaBox::new_in(self.array_assignment_target(span, elements, rest), self.allocator)
     }
 
     /// Build an [`ObjectAssignmentTarget`].
@@ -2902,11 +2917,11 @@ impl<'a> AstBuilder<'a> {
     pub fn object_assignment_target<T1>(
         self,
         span: Span,
-        properties: Vec<'a, AssignmentTargetProperty<'a>>,
+        properties: ArenaVec<'a, AssignmentTargetProperty<'a>>,
         rest: T1,
     ) -> ObjectAssignmentTarget<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, AssignmentTargetRest<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
         ObjectAssignmentTarget {
             node_id: Default::default(),
@@ -2918,7 +2933,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectAssignmentTarget`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::object_assignment_target`] instead.
     ///
     /// ## Parameters
@@ -2929,13 +2944,13 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_object_assignment_target<T1>(
         self,
         span: Span,
-        properties: Vec<'a, AssignmentTargetProperty<'a>>,
+        properties: ArenaVec<'a, AssignmentTargetProperty<'a>>,
         rest: T1,
-    ) -> Box<'a, ObjectAssignmentTarget<'a>>
+    ) -> ArenaBox<'a, ObjectAssignmentTarget<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, AssignmentTargetRest<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
-        Box::new_in(self.object_assignment_target(span, properties, rest), self.allocator)
+        ArenaBox::new_in(self.object_assignment_target(span, properties, rest), self.allocator)
     }
 
     /// Build an [`AssignmentTargetRest`].
@@ -2957,7 +2972,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetRest`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::assignment_target_rest`] instead.
     ///
     /// ## Parameters
@@ -2968,8 +2983,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         target: AssignmentTarget<'a>,
-    ) -> Box<'a, AssignmentTargetRest<'a>> {
-        Box::new_in(self.assignment_target_rest(span, target), self.allocator)
+    ) -> ArenaBox<'a, AssignmentTargetRest<'a>> {
+        ArenaBox::new_in(self.assignment_target_rest(span, target), self.allocator)
     }
 
     /// Build an [`AssignmentTargetMaybeDefault::AssignmentTargetWithDefault`].
@@ -3013,7 +3028,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetWithDefault`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::assignment_target_with_default`] instead.
     ///
     /// ## Parameters
@@ -3026,8 +3041,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         binding: AssignmentTarget<'a>,
         init: Expression<'a>,
-    ) -> Box<'a, AssignmentTargetWithDefault<'a>> {
-        Box::new_in(self.assignment_target_with_default(span, binding, init), self.allocator)
+    ) -> ArenaBox<'a, AssignmentTargetWithDefault<'a>> {
+        ArenaBox::new_in(self.assignment_target_with_default(span, binding, init), self.allocator)
     }
 
     /// Build an [`AssignmentTargetProperty::AssignmentTargetPropertyIdentifier`].
@@ -3093,7 +3108,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetPropertyIdentifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::assignment_target_property_identifier`] instead.
     ///
     /// ## Parameters
@@ -3106,8 +3121,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         binding: IdentifierReference<'a>,
         init: Option<Expression<'a>>,
-    ) -> Box<'a, AssignmentTargetPropertyIdentifier<'a>> {
-        Box::new_in(self.assignment_target_property_identifier(span, binding, init), self.allocator)
+    ) -> ArenaBox<'a, AssignmentTargetPropertyIdentifier<'a>> {
+        ArenaBox::new_in(
+            self.assignment_target_property_identifier(span, binding, init),
+            self.allocator,
+        )
     }
 
     /// Build an [`AssignmentTargetPropertyProperty`].
@@ -3139,7 +3157,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetPropertyProperty`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::assignment_target_property_property`] instead.
     ///
     /// ## Parameters
@@ -3154,8 +3172,8 @@ impl<'a> AstBuilder<'a> {
         name: PropertyKey<'a>,
         binding: AssignmentTargetMaybeDefault<'a>,
         computed: bool,
-    ) -> Box<'a, AssignmentTargetPropertyProperty<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, AssignmentTargetPropertyProperty<'a>> {
+        ArenaBox::new_in(
             self.assignment_target_property_property(span, name, binding, computed),
             self.allocator,
         )
@@ -3173,14 +3191,14 @@ impl<'a> AstBuilder<'a> {
     pub fn sequence_expression(
         self,
         span: Span,
-        expressions: Vec<'a, Expression<'a>>,
+        expressions: ArenaVec<'a, Expression<'a>>,
     ) -> SequenceExpression<'a> {
         SequenceExpression { node_id: Default::default(), span, expressions }
     }
 
     /// Build a [`SequenceExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::sequence_expression`] instead.
     ///
     /// ## Parameters
@@ -3190,9 +3208,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_sequence_expression(
         self,
         span: Span,
-        expressions: Vec<'a, Expression<'a>>,
-    ) -> Box<'a, SequenceExpression<'a>> {
-        Box::new_in(self.sequence_expression(span, expressions), self.allocator)
+        expressions: ArenaVec<'a, Expression<'a>>,
+    ) -> ArenaBox<'a, SequenceExpression<'a>> {
+        ArenaBox::new_in(self.sequence_expression(span, expressions), self.allocator)
     }
 
     /// Build a [`Super`].
@@ -3209,14 +3227,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Super`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::super_`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_super(self, span: Span) -> Box<'a, Super> {
-        Box::new_in(self.super_(span), self.allocator)
+    pub fn alloc_super(self, span: Span) -> ArenaBox<'a, Super> {
+        ArenaBox::new_in(self.super_(span), self.allocator)
     }
 
     /// Build an [`AwaitExpression`].
@@ -3234,7 +3252,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AwaitExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::await_expression`] instead.
     ///
     /// ## Parameters
@@ -3245,8 +3263,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         argument: Expression<'a>,
-    ) -> Box<'a, AwaitExpression<'a>> {
-        Box::new_in(self.await_expression(span, argument), self.allocator)
+    ) -> ArenaBox<'a, AwaitExpression<'a>> {
+        ArenaBox::new_in(self.await_expression(span, argument), self.allocator)
     }
 
     /// Build a [`ChainExpression`].
@@ -3264,7 +3282,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ChainExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::chain_expression`] instead.
     ///
     /// ## Parameters
@@ -3275,8 +3293,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         expression: ChainElement<'a>,
-    ) -> Box<'a, ChainExpression<'a>> {
-        Box::new_in(self.chain_expression(span, expression), self.allocator)
+    ) -> ArenaBox<'a, ChainExpression<'a>> {
+        ArenaBox::new_in(self.chain_expression(span, expression), self.allocator)
     }
 
     /// Build a [`ChainElement::CallExpression`].
@@ -3295,11 +3313,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         optional: bool,
     ) -> ChainElement<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         ChainElement::CallExpression(self.alloc_call_expression(
             span,
@@ -3327,12 +3345,12 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
         optional: bool,
         pure: bool,
     ) -> ChainElement<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         ChainElement::CallExpression(self.alloc_call_expression_with_pure(
             span,
@@ -3379,7 +3397,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ParenthesizedExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::parenthesized_expression`] instead.
     ///
     /// ## Parameters
@@ -3390,8 +3408,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         expression: Expression<'a>,
-    ) -> Box<'a, ParenthesizedExpression<'a>> {
-        Box::new_in(self.parenthesized_expression(span, expression), self.allocator)
+    ) -> ArenaBox<'a, ParenthesizedExpression<'a>> {
+        ArenaBox::new_in(self.parenthesized_expression(span, expression), self.allocator)
     }
 
     /// Build a [`Statement::BlockStatement`].
@@ -3402,7 +3420,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn statement_block(self, span: Span, body: Vec<'a, Statement<'a>>) -> Statement<'a> {
+    pub fn statement_block(self, span: Span, body: ArenaVec<'a, Statement<'a>>) -> Statement<'a> {
         Statement::BlockStatement(self.alloc_block_statement(span, body))
     }
 
@@ -3418,7 +3436,7 @@ impl<'a> AstBuilder<'a> {
     pub fn statement_block_with_scope_id(
         self,
         span: Span,
-        body: Vec<'a, Statement<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
     ) -> Statement<'a> {
         Statement::BlockStatement(self.alloc_block_statement_with_scope_id(span, body, scope_id))
@@ -3707,7 +3725,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         discriminant: Expression<'a>,
-        cases: Vec<'a, SwitchCase<'a>>,
+        cases: ArenaVec<'a, SwitchCase<'a>>,
     ) -> Statement<'a> {
         Statement::SwitchStatement(self.alloc_switch_statement(span, discriminant, cases))
     }
@@ -3726,7 +3744,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         discriminant: Expression<'a>,
-        cases: Vec<'a, SwitchCase<'a>>,
+        cases: ArenaVec<'a, SwitchCase<'a>>,
         scope_id: ScopeId,
     ) -> Statement<'a> {
         Statement::SwitchStatement(self.alloc_switch_statement_with_scope_id(
@@ -3767,9 +3785,9 @@ impl<'a> AstBuilder<'a> {
         finalizer: T3,
     ) -> Statement<'a>
     where
-        T1: IntoIn<'a, Box<'a, BlockStatement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, CatchClause<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, BlockStatement<'a>>>>,
+        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, CatchClause<'a>>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, BlockStatement<'a>>>>,
     {
         Statement::TryStatement(self.alloc_try_statement(span, block, handler, finalizer))
     }
@@ -3873,13 +3891,17 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn block_statement(self, span: Span, body: Vec<'a, Statement<'a>>) -> BlockStatement<'a> {
+    pub fn block_statement(
+        self,
+        span: Span,
+        body: ArenaVec<'a, Statement<'a>>,
+    ) -> BlockStatement<'a> {
         BlockStatement { node_id: Default::default(), span, body, scope_id: Default::default() }
     }
 
     /// Build a [`BlockStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::block_statement`] instead.
     ///
     /// ## Parameters
@@ -3889,9 +3911,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_block_statement(
         self,
         span: Span,
-        body: Vec<'a, Statement<'a>>,
-    ) -> Box<'a, BlockStatement<'a>> {
-        Box::new_in(self.block_statement(span, body), self.allocator)
+        body: ArenaVec<'a, Statement<'a>>,
+    ) -> ArenaBox<'a, BlockStatement<'a>> {
+        ArenaBox::new_in(self.block_statement(span, body), self.allocator)
     }
 
     /// Build a [`BlockStatement`] with `scope_id`.
@@ -3907,7 +3929,7 @@ impl<'a> AstBuilder<'a> {
     pub fn block_statement_with_scope_id(
         self,
         span: Span,
-        body: Vec<'a, Statement<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
     ) -> BlockStatement<'a> {
         BlockStatement {
@@ -3920,7 +3942,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BlockStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::block_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -3931,10 +3953,10 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_block_statement_with_scope_id(
         self,
         span: Span,
-        body: Vec<'a, Statement<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
-    ) -> Box<'a, BlockStatement<'a>> {
-        Box::new_in(self.block_statement_with_scope_id(span, body, scope_id), self.allocator)
+    ) -> ArenaBox<'a, BlockStatement<'a>> {
+        ArenaBox::new_in(self.block_statement_with_scope_id(span, body, scope_id), self.allocator)
     }
 
     /// Build a [`Declaration::VariableDeclaration`].
@@ -3951,7 +3973,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         kind: VariableDeclarationKind,
-        declarations: Vec<'a, VariableDeclarator<'a>>,
+        declarations: ArenaVec<'a, VariableDeclarator<'a>>,
         declare: bool,
     ) -> Declaration<'a> {
         Declaration::VariableDeclaration(self.alloc_variable_declaration(
@@ -3994,11 +4016,11 @@ impl<'a> AstBuilder<'a> {
         body: T5,
     ) -> Declaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
         Declaration::FunctionDeclaration(self.alloc_function(
             span,
@@ -4053,11 +4075,11 @@ impl<'a> AstBuilder<'a> {
         pife: bool,
     ) -> Declaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
         Declaration::FunctionDeclaration(self.alloc_function_with_scope_id_and_pure_and_pife(
             span,
@@ -4098,20 +4120,20 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: ClassType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
         super_type_arguments: T2,
-        implements: Vec<'a, TSClassImplements<'a>>,
+        implements: ArenaVec<'a, TSClassImplements<'a>>,
         body: T3,
         r#abstract: bool,
         declare: bool,
     ) -> Declaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-        T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
     {
         Declaration::ClassDeclaration(self.alloc_class(
             span,
@@ -4150,21 +4172,21 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: ClassType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
         super_type_arguments: T2,
-        implements: Vec<'a, TSClassImplements<'a>>,
+        implements: ArenaVec<'a, TSClassImplements<'a>>,
         body: T3,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
     ) -> Declaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-        T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
     {
         Declaration::ClassDeclaration(self.alloc_class_with_scope_id(
             span,
@@ -4202,7 +4224,7 @@ impl<'a> AstBuilder<'a> {
         declare: bool,
     ) -> Declaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         Declaration::TSTypeAliasDeclaration(self.alloc_ts_type_alias_declaration(
             span,
@@ -4235,7 +4257,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> Declaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         Declaration::TSTypeAliasDeclaration(self.alloc_ts_type_alias_declaration_with_scope_id(
             span,
@@ -4264,13 +4286,13 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
+        extends: ArenaVec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
     ) -> Declaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
     {
         Declaration::TSInterfaceDeclaration(self.alloc_ts_interface_declaration(
             span,
@@ -4300,14 +4322,14 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
+        extends: ArenaVec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
         scope_id: ScopeId,
     ) -> Declaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
     {
         Declaration::TSInterfaceDeclaration(self.alloc_ts_interface_declaration_with_scope_id(
             span,
@@ -4487,7 +4509,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         kind: VariableDeclarationKind,
-        declarations: Vec<'a, VariableDeclarator<'a>>,
+        declarations: ArenaVec<'a, VariableDeclarator<'a>>,
         declare: bool,
     ) -> VariableDeclaration<'a> {
         VariableDeclaration { node_id: Default::default(), span, kind, declarations, declare }
@@ -4495,7 +4517,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`VariableDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::variable_declaration`] instead.
     ///
     /// ## Parameters
@@ -4508,10 +4530,13 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         kind: VariableDeclarationKind,
-        declarations: Vec<'a, VariableDeclarator<'a>>,
+        declarations: ArenaVec<'a, VariableDeclarator<'a>>,
         declare: bool,
-    ) -> Box<'a, VariableDeclaration<'a>> {
-        Box::new_in(self.variable_declaration(span, kind, declarations, declare), self.allocator)
+    ) -> ArenaBox<'a, VariableDeclaration<'a>> {
+        ArenaBox::new_in(
+            self.variable_declaration(span, kind, declarations, declare),
+            self.allocator,
+        )
     }
 
     /// Build a [`VariableDeclarator`].
@@ -4534,7 +4559,7 @@ impl<'a> AstBuilder<'a> {
         definite: bool,
     ) -> VariableDeclarator<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         VariableDeclarator {
             node_id: Default::default(),
@@ -4561,14 +4586,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`EmptyStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::empty_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_empty_statement(self, span: Span) -> Box<'a, EmptyStatement> {
-        Box::new_in(self.empty_statement(span), self.allocator)
+    pub fn alloc_empty_statement(self, span: Span) -> ArenaBox<'a, EmptyStatement> {
+        ArenaBox::new_in(self.empty_statement(span), self.allocator)
     }
 
     /// Build an [`ExpressionStatement`].
@@ -4590,7 +4615,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExpressionStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::expression_statement`] instead.
     ///
     /// ## Parameters
@@ -4601,8 +4626,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         expression: Expression<'a>,
-    ) -> Box<'a, ExpressionStatement<'a>> {
-        Box::new_in(self.expression_statement(span, expression), self.allocator)
+    ) -> ArenaBox<'a, ExpressionStatement<'a>> {
+        ArenaBox::new_in(self.expression_statement(span, expression), self.allocator)
     }
 
     /// Build an [`IfStatement`].
@@ -4628,7 +4653,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IfStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::if_statement`] instead.
     ///
     /// ## Parameters
@@ -4643,8 +4668,8 @@ impl<'a> AstBuilder<'a> {
         test: Expression<'a>,
         consequent: Statement<'a>,
         alternate: Option<Statement<'a>>,
-    ) -> Box<'a, IfStatement<'a>> {
-        Box::new_in(self.if_statement(span, test, consequent, alternate), self.allocator)
+    ) -> ArenaBox<'a, IfStatement<'a>> {
+        ArenaBox::new_in(self.if_statement(span, test, consequent, alternate), self.allocator)
     }
 
     /// Build a [`DoWhileStatement`].
@@ -4668,7 +4693,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`DoWhileStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::do_while_statement`] instead.
     ///
     /// ## Parameters
@@ -4681,8 +4706,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         body: Statement<'a>,
         test: Expression<'a>,
-    ) -> Box<'a, DoWhileStatement<'a>> {
-        Box::new_in(self.do_while_statement(span, body, test), self.allocator)
+    ) -> ArenaBox<'a, DoWhileStatement<'a>> {
+        ArenaBox::new_in(self.do_while_statement(span, body, test), self.allocator)
     }
 
     /// Build a [`WhileStatement`].
@@ -4706,7 +4731,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`WhileStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::while_statement`] instead.
     ///
     /// ## Parameters
@@ -4719,8 +4744,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         test: Expression<'a>,
         body: Statement<'a>,
-    ) -> Box<'a, WhileStatement<'a>> {
-        Box::new_in(self.while_statement(span, test, body), self.allocator)
+    ) -> ArenaBox<'a, WhileStatement<'a>> {
+        ArenaBox::new_in(self.while_statement(span, test, body), self.allocator)
     }
 
     /// Build a [`ForStatement`].
@@ -4756,7 +4781,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::for_statement`] instead.
     ///
     /// ## Parameters
@@ -4773,8 +4798,8 @@ impl<'a> AstBuilder<'a> {
         test: Option<Expression<'a>>,
         update: Option<Expression<'a>>,
         body: Statement<'a>,
-    ) -> Box<'a, ForStatement<'a>> {
-        Box::new_in(self.for_statement(span, init, test, update, body), self.allocator)
+    ) -> ArenaBox<'a, ForStatement<'a>> {
+        ArenaBox::new_in(self.for_statement(span, init, test, update, body), self.allocator)
     }
 
     /// Build a [`ForStatement`] with `scope_id`.
@@ -4812,7 +4837,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::for_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -4831,8 +4856,8 @@ impl<'a> AstBuilder<'a> {
         update: Option<Expression<'a>>,
         body: Statement<'a>,
         scope_id: ScopeId,
-    ) -> Box<'a, ForStatement<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, ForStatement<'a>> {
+        ArenaBox::new_in(
             self.for_statement_with_scope_id(span, init, test, update, body, scope_id),
             self.allocator,
         )
@@ -4852,7 +4877,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         kind: VariableDeclarationKind,
-        declarations: Vec<'a, VariableDeclarator<'a>>,
+        declarations: ArenaVec<'a, VariableDeclarator<'a>>,
         declare: bool,
     ) -> ForStatementInit<'a> {
         ForStatementInit::VariableDeclaration(self.alloc_variable_declaration(
@@ -4893,7 +4918,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForInStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::for_in_statement`] instead.
     ///
     /// ## Parameters
@@ -4908,8 +4933,8 @@ impl<'a> AstBuilder<'a> {
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
         body: Statement<'a>,
-    ) -> Box<'a, ForInStatement<'a>> {
-        Box::new_in(self.for_in_statement(span, left, right, body), self.allocator)
+    ) -> ArenaBox<'a, ForInStatement<'a>> {
+        ArenaBox::new_in(self.for_in_statement(span, left, right, body), self.allocator)
     }
 
     /// Build a [`ForInStatement`] with `scope_id`.
@@ -4944,7 +4969,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForInStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::for_in_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -4961,8 +4986,8 @@ impl<'a> AstBuilder<'a> {
         right: Expression<'a>,
         body: Statement<'a>,
         scope_id: ScopeId,
-    ) -> Box<'a, ForInStatement<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, ForInStatement<'a>> {
+        ArenaBox::new_in(
             self.for_in_statement_with_scope_id(span, left, right, body, scope_id),
             self.allocator,
         )
@@ -4982,7 +5007,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         kind: VariableDeclarationKind,
-        declarations: Vec<'a, VariableDeclarator<'a>>,
+        declarations: ArenaVec<'a, VariableDeclarator<'a>>,
         declare: bool,
     ) -> ForStatementLeft<'a> {
         ForStatementLeft::VariableDeclaration(self.alloc_variable_declaration(
@@ -5026,7 +5051,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForOfStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::for_of_statement`] instead.
     ///
     /// ## Parameters
@@ -5043,8 +5068,8 @@ impl<'a> AstBuilder<'a> {
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
         body: Statement<'a>,
-    ) -> Box<'a, ForOfStatement<'a>> {
-        Box::new_in(self.for_of_statement(span, r#await, left, right, body), self.allocator)
+    ) -> ArenaBox<'a, ForOfStatement<'a>> {
+        ArenaBox::new_in(self.for_of_statement(span, r#await, left, right, body), self.allocator)
     }
 
     /// Build a [`ForOfStatement`] with `scope_id`.
@@ -5082,7 +5107,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForOfStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::for_of_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -5101,8 +5126,8 @@ impl<'a> AstBuilder<'a> {
         right: Expression<'a>,
         body: Statement<'a>,
         scope_id: ScopeId,
-    ) -> Box<'a, ForOfStatement<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, ForOfStatement<'a>> {
+        ArenaBox::new_in(
             self.for_of_statement_with_scope_id(span, r#await, left, right, body, scope_id),
             self.allocator,
         )
@@ -5127,7 +5152,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ContinueStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::continue_statement`] instead.
     ///
     /// ## Parameters
@@ -5138,8 +5163,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
-    ) -> Box<'a, ContinueStatement<'a>> {
-        Box::new_in(self.continue_statement(span, label), self.allocator)
+    ) -> ArenaBox<'a, ContinueStatement<'a>> {
+        ArenaBox::new_in(self.continue_statement(span, label), self.allocator)
     }
 
     /// Build a [`BreakStatement`].
@@ -5161,7 +5186,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BreakStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::break_statement`] instead.
     ///
     /// ## Parameters
@@ -5172,8 +5197,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
-    ) -> Box<'a, BreakStatement<'a>> {
-        Box::new_in(self.break_statement(span, label), self.allocator)
+    ) -> ArenaBox<'a, BreakStatement<'a>> {
+        ArenaBox::new_in(self.break_statement(span, label), self.allocator)
     }
 
     /// Build a [`ReturnStatement`].
@@ -5195,7 +5220,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ReturnStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::return_statement`] instead.
     ///
     /// ## Parameters
@@ -5206,8 +5231,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         argument: Option<Expression<'a>>,
-    ) -> Box<'a, ReturnStatement<'a>> {
-        Box::new_in(self.return_statement(span, argument), self.allocator)
+    ) -> ArenaBox<'a, ReturnStatement<'a>> {
+        ArenaBox::new_in(self.return_statement(span, argument), self.allocator)
     }
 
     /// Build a [`WithStatement`].
@@ -5237,7 +5262,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`WithStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::with_statement`] instead.
     ///
     /// ## Parameters
@@ -5250,8 +5275,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         object: Expression<'a>,
         body: Statement<'a>,
-    ) -> Box<'a, WithStatement<'a>> {
-        Box::new_in(self.with_statement(span, object, body), self.allocator)
+    ) -> ArenaBox<'a, WithStatement<'a>> {
+        ArenaBox::new_in(self.with_statement(span, object, body), self.allocator)
     }
 
     /// Build a [`WithStatement`] with `scope_id`.
@@ -5283,7 +5308,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`WithStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::with_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -5298,8 +5323,11 @@ impl<'a> AstBuilder<'a> {
         object: Expression<'a>,
         body: Statement<'a>,
         scope_id: ScopeId,
-    ) -> Box<'a, WithStatement<'a>> {
-        Box::new_in(self.with_statement_with_scope_id(span, object, body, scope_id), self.allocator)
+    ) -> ArenaBox<'a, WithStatement<'a>> {
+        ArenaBox::new_in(
+            self.with_statement_with_scope_id(span, object, body, scope_id),
+            self.allocator,
+        )
     }
 
     /// Build a [`SwitchStatement`].
@@ -5316,7 +5344,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         discriminant: Expression<'a>,
-        cases: Vec<'a, SwitchCase<'a>>,
+        cases: ArenaVec<'a, SwitchCase<'a>>,
     ) -> SwitchStatement<'a> {
         SwitchStatement {
             node_id: Default::default(),
@@ -5329,7 +5357,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SwitchStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::switch_statement`] instead.
     ///
     /// ## Parameters
@@ -5341,9 +5369,9 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         discriminant: Expression<'a>,
-        cases: Vec<'a, SwitchCase<'a>>,
-    ) -> Box<'a, SwitchStatement<'a>> {
-        Box::new_in(self.switch_statement(span, discriminant, cases), self.allocator)
+        cases: ArenaVec<'a, SwitchCase<'a>>,
+    ) -> ArenaBox<'a, SwitchStatement<'a>> {
+        ArenaBox::new_in(self.switch_statement(span, discriminant, cases), self.allocator)
     }
 
     /// Build a [`SwitchStatement`] with `scope_id`.
@@ -5361,7 +5389,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         discriminant: Expression<'a>,
-        cases: Vec<'a, SwitchCase<'a>>,
+        cases: ArenaVec<'a, SwitchCase<'a>>,
         scope_id: ScopeId,
     ) -> SwitchStatement<'a> {
         SwitchStatement {
@@ -5375,7 +5403,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SwitchStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::switch_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -5388,10 +5416,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         discriminant: Expression<'a>,
-        cases: Vec<'a, SwitchCase<'a>>,
+        cases: ArenaVec<'a, SwitchCase<'a>>,
         scope_id: ScopeId,
-    ) -> Box<'a, SwitchStatement<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, SwitchStatement<'a>> {
+        ArenaBox::new_in(
             self.switch_statement_with_scope_id(span, discriminant, cases, scope_id),
             self.allocator,
         )
@@ -5408,7 +5436,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         test: Option<Expression<'a>>,
-        consequent: Vec<'a, Statement<'a>>,
+        consequent: ArenaVec<'a, Statement<'a>>,
     ) -> SwitchCase<'a> {
         SwitchCase { node_id: Default::default(), span, test, consequent }
     }
@@ -5434,7 +5462,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`LabeledStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::labeled_statement`] instead.
     ///
     /// ## Parameters
@@ -5447,8 +5475,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         label: LabelIdentifier<'a>,
         body: Statement<'a>,
-    ) -> Box<'a, LabeledStatement<'a>> {
-        Box::new_in(self.labeled_statement(span, label, body), self.allocator)
+    ) -> ArenaBox<'a, LabeledStatement<'a>> {
+        ArenaBox::new_in(self.labeled_statement(span, label, body), self.allocator)
     }
 
     /// Build a [`ThrowStatement`].
@@ -5466,7 +5494,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ThrowStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::throw_statement`] instead.
     ///
     /// ## Parameters
@@ -5477,8 +5505,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         argument: Expression<'a>,
-    ) -> Box<'a, ThrowStatement<'a>> {
-        Box::new_in(self.throw_statement(span, argument), self.allocator)
+    ) -> ArenaBox<'a, ThrowStatement<'a>> {
+        ArenaBox::new_in(self.throw_statement(span, argument), self.allocator)
     }
 
     /// Build a [`TryStatement`].
@@ -5500,9 +5528,9 @@ impl<'a> AstBuilder<'a> {
         finalizer: T3,
     ) -> TryStatement<'a>
     where
-        T1: IntoIn<'a, Box<'a, BlockStatement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, CatchClause<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, BlockStatement<'a>>>>,
+        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, CatchClause<'a>>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, BlockStatement<'a>>>>,
     {
         TryStatement {
             node_id: Default::default(),
@@ -5515,7 +5543,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TryStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::try_statement`] instead.
     ///
     /// ## Parameters
@@ -5530,13 +5558,13 @@ impl<'a> AstBuilder<'a> {
         block: T1,
         handler: T2,
         finalizer: T3,
-    ) -> Box<'a, TryStatement<'a>>
+    ) -> ArenaBox<'a, TryStatement<'a>>
     where
-        T1: IntoIn<'a, Box<'a, BlockStatement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, CatchClause<'a>>>>,
-        T3: IntoIn<'a, Option<Box<'a, BlockStatement<'a>>>>,
+        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, CatchClause<'a>>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, BlockStatement<'a>>>>,
     {
-        Box::new_in(self.try_statement(span, block, handler, finalizer), self.allocator)
+        ArenaBox::new_in(self.try_statement(span, block, handler, finalizer), self.allocator)
     }
 
     /// Build a [`CatchClause`].
@@ -5556,7 +5584,7 @@ impl<'a> AstBuilder<'a> {
         body: T1,
     ) -> CatchClause<'a>
     where
-        T1: IntoIn<'a, Box<'a, BlockStatement<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
     {
         CatchClause {
             node_id: Default::default(),
@@ -5569,7 +5597,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CatchClause`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::catch_clause`] instead.
     ///
     /// ## Parameters
@@ -5582,11 +5610,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         param: Option<CatchParameter<'a>>,
         body: T1,
-    ) -> Box<'a, CatchClause<'a>>
+    ) -> ArenaBox<'a, CatchClause<'a>>
     where
-        T1: IntoIn<'a, Box<'a, BlockStatement<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
     {
-        Box::new_in(self.catch_clause(span, param, body), self.allocator)
+        ArenaBox::new_in(self.catch_clause(span, param, body), self.allocator)
     }
 
     /// Build a [`CatchClause`] with `scope_id`.
@@ -5608,7 +5636,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> CatchClause<'a>
     where
-        T1: IntoIn<'a, Box<'a, BlockStatement<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
     {
         CatchClause {
             node_id: Default::default(),
@@ -5621,7 +5649,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CatchClause`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::catch_clause_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -5636,11 +5664,14 @@ impl<'a> AstBuilder<'a> {
         param: Option<CatchParameter<'a>>,
         body: T1,
         scope_id: ScopeId,
-    ) -> Box<'a, CatchClause<'a>>
+    ) -> ArenaBox<'a, CatchClause<'a>>
     where
-        T1: IntoIn<'a, Box<'a, BlockStatement<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
     {
-        Box::new_in(self.catch_clause_with_scope_id(span, param, body, scope_id), self.allocator)
+        ArenaBox::new_in(
+            self.catch_clause_with_scope_id(span, param, body, scope_id),
+            self.allocator,
+        )
     }
 
     /// Build a [`CatchParameter`].
@@ -5657,7 +5688,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: T1,
     ) -> CatchParameter<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         CatchParameter {
             node_id: Default::default(),
@@ -5681,14 +5712,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`DebuggerStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::debugger_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_debugger_statement(self, span: Span) -> Box<'a, DebuggerStatement> {
-        Box::new_in(self.debugger_statement(span), self.allocator)
+    pub fn alloc_debugger_statement(self, span: Span) -> ArenaBox<'a, DebuggerStatement> {
+        ArenaBox::new_in(self.debugger_statement(span), self.allocator)
     }
 
     /// Build a [`BindingPattern::BindingIdentifier`].
@@ -5741,11 +5772,11 @@ impl<'a> AstBuilder<'a> {
     pub fn binding_pattern_object_pattern<T1>(
         self,
         span: Span,
-        properties: Vec<'a, BindingProperty<'a>>,
+        properties: ArenaVec<'a, BindingProperty<'a>>,
         rest: T1,
     ) -> BindingPattern<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
         BindingPattern::ObjectPattern(self.alloc_object_pattern(span, properties, rest))
     }
@@ -5762,11 +5793,11 @@ impl<'a> AstBuilder<'a> {
     pub fn binding_pattern_array_pattern<T1>(
         self,
         span: Span,
-        elements: Vec<'a, Option<BindingPattern<'a>>>,
+        elements: ArenaVec<'a, Option<BindingPattern<'a>>>,
         rest: T1,
     ) -> BindingPattern<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
         BindingPattern::ArrayPattern(self.alloc_array_pattern(span, elements, rest))
     }
@@ -5810,7 +5841,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentPattern`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::assignment_pattern`] instead.
     ///
     /// ## Parameters
@@ -5823,8 +5854,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         left: BindingPattern<'a>,
         right: Expression<'a>,
-    ) -> Box<'a, AssignmentPattern<'a>> {
-        Box::new_in(self.assignment_pattern(span, left, right), self.allocator)
+    ) -> ArenaBox<'a, AssignmentPattern<'a>> {
+        ArenaBox::new_in(self.assignment_pattern(span, left, right), self.allocator)
     }
 
     /// Build an [`ObjectPattern`].
@@ -5840,11 +5871,11 @@ impl<'a> AstBuilder<'a> {
     pub fn object_pattern<T1>(
         self,
         span: Span,
-        properties: Vec<'a, BindingProperty<'a>>,
+        properties: ArenaVec<'a, BindingProperty<'a>>,
         rest: T1,
     ) -> ObjectPattern<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
         ObjectPattern {
             node_id: Default::default(),
@@ -5856,7 +5887,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectPattern`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::object_pattern`] instead.
     ///
     /// ## Parameters
@@ -5867,13 +5898,13 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_object_pattern<T1>(
         self,
         span: Span,
-        properties: Vec<'a, BindingProperty<'a>>,
+        properties: ArenaVec<'a, BindingProperty<'a>>,
         rest: T1,
-    ) -> Box<'a, ObjectPattern<'a>>
+    ) -> ArenaBox<'a, ObjectPattern<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
-        Box::new_in(self.object_pattern(span, properties, rest), self.allocator)
+        ArenaBox::new_in(self.object_pattern(span, properties, rest), self.allocator)
     }
 
     /// Build a [`BindingProperty`].
@@ -5909,11 +5940,11 @@ impl<'a> AstBuilder<'a> {
     pub fn array_pattern<T1>(
         self,
         span: Span,
-        elements: Vec<'a, Option<BindingPattern<'a>>>,
+        elements: ArenaVec<'a, Option<BindingPattern<'a>>>,
         rest: T1,
     ) -> ArrayPattern<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
         ArrayPattern {
             node_id: Default::default(),
@@ -5925,7 +5956,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrayPattern`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::array_pattern`] instead.
     ///
     /// ## Parameters
@@ -5936,13 +5967,13 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_array_pattern<T1>(
         self,
         span: Span,
-        elements: Vec<'a, Option<BindingPattern<'a>>>,
+        elements: ArenaVec<'a, Option<BindingPattern<'a>>>,
         rest: T1,
-    ) -> Box<'a, ArrayPattern<'a>>
+    ) -> ArenaBox<'a, ArrayPattern<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, BindingRestElement<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
-        Box::new_in(self.array_pattern(span, elements, rest), self.allocator)
+        ArenaBox::new_in(self.array_pattern(span, elements, rest), self.allocator)
     }
 
     /// Build a [`BindingRestElement`].
@@ -5964,7 +5995,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingRestElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::binding_rest_element`] instead.
     ///
     /// ## Parameters
@@ -5975,8 +6006,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         argument: BindingPattern<'a>,
-    ) -> Box<'a, BindingRestElement<'a>> {
-        Box::new_in(self.binding_rest_element(span, argument), self.allocator)
+    ) -> ArenaBox<'a, BindingRestElement<'a>> {
+        ArenaBox::new_in(self.binding_rest_element(span, argument), self.allocator)
     }
 
     /// Build a [`Function`].
@@ -6012,11 +6043,11 @@ impl<'a> AstBuilder<'a> {
         body: T5,
     ) -> Function<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
         Function {
             node_id: Default::default(),
@@ -6039,7 +6070,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Function`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::function`] instead.
     ///
     /// ## Parameters
@@ -6068,15 +6099,15 @@ impl<'a> AstBuilder<'a> {
         params: T3,
         return_type: T4,
         body: T5,
-    ) -> Box<'a, Function<'a>>
+    ) -> ArenaBox<'a, Function<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.function(
                 span,
                 r#type,
@@ -6133,11 +6164,11 @@ impl<'a> AstBuilder<'a> {
         pife: bool,
     ) -> Function<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
         Function {
             node_id: Default::default(),
@@ -6160,7 +6191,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Function`] with `scope_id` and `pure` and `pife`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::function_with_scope_id_and_pure_and_pife`] instead.
     ///
     /// ## Parameters
@@ -6195,15 +6226,15 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
-    ) -> Box<'a, Function<'a>>
+    ) -> ArenaBox<'a, Function<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.function_with_scope_id_and_pure_and_pife(
                 span,
                 r#type,
@@ -6239,11 +6270,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         kind: FormalParameterKind,
-        items: Vec<'a, FormalParameter<'a>>,
+        items: ArenaVec<'a, FormalParameter<'a>>,
         rest: T1,
     ) -> FormalParameters<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, FormalParameterRest<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, FormalParameterRest<'a>>>>,
     {
         FormalParameters {
             node_id: Default::default(),
@@ -6256,7 +6287,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`FormalParameters`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::formal_parameters`] instead.
     ///
     /// ## Parameters
@@ -6269,13 +6300,13 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         kind: FormalParameterKind,
-        items: Vec<'a, FormalParameter<'a>>,
+        items: ArenaVec<'a, FormalParameter<'a>>,
         rest: T1,
-    ) -> Box<'a, FormalParameters<'a>>
+    ) -> ArenaBox<'a, FormalParameters<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, FormalParameterRest<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, FormalParameterRest<'a>>>>,
     {
-        Box::new_in(self.formal_parameters(span, kind, items, rest), self.allocator)
+        ArenaBox::new_in(self.formal_parameters(span, kind, items, rest), self.allocator)
     }
 
     /// Build a [`FormalParameter`].
@@ -6294,7 +6325,7 @@ impl<'a> AstBuilder<'a> {
     pub fn formal_parameter<T1, T2>(
         self,
         span: Span,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         pattern: BindingPattern<'a>,
         type_annotation: T1,
         initializer: T2,
@@ -6304,8 +6335,8 @@ impl<'a> AstBuilder<'a> {
         r#override: bool,
     ) -> FormalParameter<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, Expression<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, Expression<'a>>>>,
     {
         FormalParameter {
             node_id: Default::default(),
@@ -6335,12 +6366,12 @@ impl<'a> AstBuilder<'a> {
     pub fn formal_parameter_rest<T1>(
         self,
         span: Span,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         rest: BindingRestElement<'a>,
         type_annotation: T1,
     ) -> FormalParameterRest<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         FormalParameterRest {
             node_id: Default::default(),
@@ -6353,7 +6384,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`FormalParameterRest`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::formal_parameter_rest`] instead.
     ///
     /// ## Parameters
@@ -6365,14 +6396,14 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_formal_parameter_rest<T1>(
         self,
         span: Span,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         rest: BindingRestElement<'a>,
         type_annotation: T1,
-    ) -> Box<'a, FormalParameterRest<'a>>
+    ) -> ArenaBox<'a, FormalParameterRest<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.formal_parameter_rest(span, decorators, rest, type_annotation),
             self.allocator,
         )
@@ -6391,15 +6422,15 @@ impl<'a> AstBuilder<'a> {
     pub fn function_body(
         self,
         span: Span,
-        directives: Vec<'a, Directive<'a>>,
-        statements: Vec<'a, Statement<'a>>,
+        directives: ArenaVec<'a, Directive<'a>>,
+        statements: ArenaVec<'a, Statement<'a>>,
     ) -> FunctionBody<'a> {
         FunctionBody { node_id: Default::default(), span, directives, statements }
     }
 
     /// Build a [`FunctionBody`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::function_body`] instead.
     ///
     /// ## Parameters
@@ -6410,10 +6441,10 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_function_body(
         self,
         span: Span,
-        directives: Vec<'a, Directive<'a>>,
-        statements: Vec<'a, Statement<'a>>,
-    ) -> Box<'a, FunctionBody<'a>> {
-        Box::new_in(self.function_body(span, directives, statements), self.allocator)
+        directives: ArenaVec<'a, Directive<'a>>,
+        statements: ArenaVec<'a, Statement<'a>>,
+    ) -> ArenaBox<'a, FunctionBody<'a>> {
+        ArenaBox::new_in(self.function_body(span, directives, statements), self.allocator)
     }
 
     /// Build an [`ArrowFunctionExpression`].
@@ -6441,10 +6472,10 @@ impl<'a> AstBuilder<'a> {
         body: T4,
     ) -> ArrowFunctionExpression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
     {
         ArrowFunctionExpression {
             node_id: Default::default(),
@@ -6463,7 +6494,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrowFunctionExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::arrow_function_expression`] instead.
     ///
     /// ## Parameters
@@ -6484,14 +6515,14 @@ impl<'a> AstBuilder<'a> {
         params: T2,
         return_type: T3,
         body: T4,
-    ) -> Box<'a, ArrowFunctionExpression<'a>>
+    ) -> ArenaBox<'a, ArrowFunctionExpression<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.arrow_function_expression(
                 span,
                 expression,
@@ -6536,10 +6567,10 @@ impl<'a> AstBuilder<'a> {
         pife: bool,
     ) -> ArrowFunctionExpression<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
     {
         ArrowFunctionExpression {
             node_id: Default::default(),
@@ -6558,7 +6589,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrowFunctionExpression`] with `scope_id` and `pure` and `pife`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::arrow_function_expression_with_scope_id_and_pure_and_pife`] instead.
     ///
     /// ## Parameters
@@ -6585,14 +6616,14 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
         pure: bool,
         pife: bool,
-    ) -> Box<'a, ArrowFunctionExpression<'a>>
+    ) -> ArenaBox<'a, ArrowFunctionExpression<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T4: IntoIn<'a, Box<'a, FunctionBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T4: IntoIn<'a, ArenaBox<'a, FunctionBody<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.arrow_function_expression_with_scope_id_and_pure_and_pife(
                 span,
                 expression,
@@ -6630,7 +6661,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`YieldExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::yield_expression`] instead.
     ///
     /// ## Parameters
@@ -6643,8 +6674,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         delegate: bool,
         argument: Option<Expression<'a>>,
-    ) -> Box<'a, YieldExpression<'a>> {
-        Box::new_in(self.yield_expression(span, delegate, argument), self.allocator)
+    ) -> ArenaBox<'a, YieldExpression<'a>> {
+        ArenaBox::new_in(self.yield_expression(span, delegate, argument), self.allocator)
     }
 
     /// Build a [`Class`].
@@ -6669,20 +6700,20 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: ClassType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
         super_type_arguments: T2,
-        implements: Vec<'a, TSClassImplements<'a>>,
+        implements: ArenaVec<'a, TSClassImplements<'a>>,
         body: T3,
         r#abstract: bool,
         declare: bool,
     ) -> Class<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-        T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
     {
         Class {
             node_id: Default::default(),
@@ -6703,7 +6734,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Class`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::class`] instead.
     ///
     /// ## Parameters
@@ -6723,22 +6754,22 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: ClassType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
         super_type_arguments: T2,
-        implements: Vec<'a, TSClassImplements<'a>>,
+        implements: ArenaVec<'a, TSClassImplements<'a>>,
         body: T3,
         r#abstract: bool,
         declare: bool,
-    ) -> Box<'a, Class<'a>>
+    ) -> ArenaBox<'a, Class<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-        T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.class(
                 span,
                 r#type,
@@ -6779,21 +6810,21 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: ClassType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
         super_type_arguments: T2,
-        implements: Vec<'a, TSClassImplements<'a>>,
+        implements: ArenaVec<'a, TSClassImplements<'a>>,
         body: T3,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
     ) -> Class<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-        T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
     {
         Class {
             node_id: Default::default(),
@@ -6814,7 +6845,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Class`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::class_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -6835,23 +6866,23 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: ClassType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
         super_type_arguments: T2,
-        implements: Vec<'a, TSClassImplements<'a>>,
+        implements: ArenaVec<'a, TSClassImplements<'a>>,
         body: T3,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
-    ) -> Box<'a, Class<'a>>
+    ) -> ArenaBox<'a, Class<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-        T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.class_with_scope_id(
                 span,
                 r#type,
@@ -6879,13 +6910,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn class_body(self, span: Span, body: Vec<'a, ClassElement<'a>>) -> ClassBody<'a> {
+    pub fn class_body(self, span: Span, body: ArenaVec<'a, ClassElement<'a>>) -> ClassBody<'a> {
         ClassBody { node_id: Default::default(), span, body }
     }
 
     /// Build a [`ClassBody`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::class_body`] instead.
     ///
     /// ## Parameters
@@ -6895,9 +6926,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_class_body(
         self,
         span: Span,
-        body: Vec<'a, ClassElement<'a>>,
-    ) -> Box<'a, ClassBody<'a>> {
-        Box::new_in(self.class_body(span, body), self.allocator)
+        body: ArenaVec<'a, ClassElement<'a>>,
+    ) -> ArenaBox<'a, ClassBody<'a>> {
+        ArenaBox::new_in(self.class_body(span, body), self.allocator)
     }
 
     /// Build a [`ClassElement::StaticBlock`].
@@ -6911,7 +6942,7 @@ impl<'a> AstBuilder<'a> {
     pub fn class_element_static_block(
         self,
         span: Span,
-        body: Vec<'a, Statement<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
     ) -> ClassElement<'a> {
         ClassElement::StaticBlock(self.alloc_static_block(span, body))
     }
@@ -6928,7 +6959,7 @@ impl<'a> AstBuilder<'a> {
     pub fn class_element_static_block_with_scope_id(
         self,
         span: Span,
-        body: Vec<'a, Statement<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
     ) -> ClassElement<'a> {
         ClassElement::StaticBlock(self.alloc_static_block_with_scope_id(span, body, scope_id))
@@ -6955,7 +6986,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: MethodDefinitionType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: T1,
         kind: MethodDefinitionKind,
@@ -6966,7 +6997,7 @@ impl<'a> AstBuilder<'a> {
         accessibility: Option<TSAccessibility>,
     ) -> ClassElement<'a>
     where
-        T1: IntoIn<'a, Box<'a, Function<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, Function<'a>>>,
     {
         ClassElement::MethodDefinition(self.alloc_method_definition(
             span,
@@ -7007,7 +7038,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: PropertyDefinitionType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         type_annotation: T1,
         value: Option<Expression<'a>>,
@@ -7021,7 +7052,7 @@ impl<'a> AstBuilder<'a> {
         accessibility: Option<TSAccessibility>,
     ) -> ClassElement<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         ClassElement::PropertyDefinition(self.alloc_property_definition(
             span,
@@ -7062,7 +7093,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: AccessorPropertyType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         type_annotation: T1,
         value: Option<Expression<'a>>,
@@ -7073,7 +7104,7 @@ impl<'a> AstBuilder<'a> {
         accessibility: Option<TSAccessibility>,
     ) -> ClassElement<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         ClassElement::AccessorProperty(self.alloc_accessor_property(
             span,
@@ -7104,13 +7135,13 @@ impl<'a> AstBuilder<'a> {
     pub fn class_element_ts_index_signature<T1>(
         self,
         span: Span,
-        parameters: Vec<'a, TSIndexSignatureName<'a>>,
+        parameters: ArenaVec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
         readonly: bool,
         r#static: bool,
     ) -> ClassElement<'a>
     where
-        T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         ClassElement::TSIndexSignature(self.alloc_ts_index_signature(
             span,
@@ -7143,7 +7174,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: MethodDefinitionType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: T1,
         kind: MethodDefinitionKind,
@@ -7154,7 +7185,7 @@ impl<'a> AstBuilder<'a> {
         accessibility: Option<TSAccessibility>,
     ) -> MethodDefinition<'a>
     where
-        T1: IntoIn<'a, Box<'a, Function<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, Function<'a>>>,
     {
         MethodDefinition {
             node_id: Default::default(),
@@ -7174,7 +7205,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`MethodDefinition`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::method_definition`] instead.
     ///
     /// ## Parameters
@@ -7194,7 +7225,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: MethodDefinitionType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         value: T1,
         kind: MethodDefinitionKind,
@@ -7203,11 +7234,11 @@ impl<'a> AstBuilder<'a> {
         r#override: bool,
         optional: bool,
         accessibility: Option<TSAccessibility>,
-    ) -> Box<'a, MethodDefinition<'a>>
+    ) -> ArenaBox<'a, MethodDefinition<'a>>
     where
-        T1: IntoIn<'a, Box<'a, Function<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, Function<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.method_definition(
                 span,
                 r#type,
@@ -7250,7 +7281,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: PropertyDefinitionType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         type_annotation: T1,
         value: Option<Expression<'a>>,
@@ -7264,7 +7295,7 @@ impl<'a> AstBuilder<'a> {
         accessibility: Option<TSAccessibility>,
     ) -> PropertyDefinition<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         PropertyDefinition {
             node_id: Default::default(),
@@ -7287,7 +7318,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PropertyDefinition`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::property_definition`] instead.
     ///
     /// ## Parameters
@@ -7310,7 +7341,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: PropertyDefinitionType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         type_annotation: T1,
         value: Option<Expression<'a>>,
@@ -7322,11 +7353,11 @@ impl<'a> AstBuilder<'a> {
         definite: bool,
         readonly: bool,
         accessibility: Option<TSAccessibility>,
-    ) -> Box<'a, PropertyDefinition<'a>>
+    ) -> ArenaBox<'a, PropertyDefinition<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.property_definition(
                 span,
                 r#type,
@@ -7365,7 +7396,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PrivateIdentifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::private_identifier`] instead.
     ///
     /// ## Parameters
@@ -7376,11 +7407,11 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         name: S1,
-    ) -> Box<'a, PrivateIdentifier<'a>>
+    ) -> ArenaBox<'a, PrivateIdentifier<'a>>
     where
         S1: Into<Ident<'a>>,
     {
-        Box::new_in(self.private_identifier(span, name), self.allocator)
+        ArenaBox::new_in(self.private_identifier(span, name), self.allocator)
     }
 
     /// Build a [`StaticBlock`].
@@ -7392,13 +7423,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn static_block(self, span: Span, body: Vec<'a, Statement<'a>>) -> StaticBlock<'a> {
+    pub fn static_block(self, span: Span, body: ArenaVec<'a, Statement<'a>>) -> StaticBlock<'a> {
         StaticBlock { node_id: Default::default(), span, body, scope_id: Default::default() }
     }
 
     /// Build a [`StaticBlock`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::static_block`] instead.
     ///
     /// ## Parameters
@@ -7408,9 +7439,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_static_block(
         self,
         span: Span,
-        body: Vec<'a, Statement<'a>>,
-    ) -> Box<'a, StaticBlock<'a>> {
-        Box::new_in(self.static_block(span, body), self.allocator)
+        body: ArenaVec<'a, Statement<'a>>,
+    ) -> ArenaBox<'a, StaticBlock<'a>> {
+        ArenaBox::new_in(self.static_block(span, body), self.allocator)
     }
 
     /// Build a [`StaticBlock`] with `scope_id`.
@@ -7426,7 +7457,7 @@ impl<'a> AstBuilder<'a> {
     pub fn static_block_with_scope_id(
         self,
         span: Span,
-        body: Vec<'a, Statement<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
     ) -> StaticBlock<'a> {
         StaticBlock { node_id: Default::default(), span, body, scope_id: Cell::new(Some(scope_id)) }
@@ -7434,7 +7465,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StaticBlock`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::static_block_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -7445,10 +7476,10 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_static_block_with_scope_id(
         self,
         span: Span,
-        body: Vec<'a, Statement<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
-    ) -> Box<'a, StaticBlock<'a>> {
-        Box::new_in(self.static_block_with_scope_id(span, body, scope_id), self.allocator)
+    ) -> ArenaBox<'a, StaticBlock<'a>> {
+        ArenaBox::new_in(self.static_block_with_scope_id(span, body, scope_id), self.allocator)
     }
 
     /// Build a [`ModuleDeclaration::ImportDeclaration`].
@@ -7466,14 +7497,14 @@ impl<'a> AstBuilder<'a> {
     pub fn module_declaration_import_declaration<T1>(
         self,
         span: Span,
-        specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
+        specifiers: Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
         phase: Option<ImportPhase>,
         with_clause: T1,
         import_kind: ImportOrExportKind,
     ) -> ModuleDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
         ModuleDeclaration::ImportDeclaration(self.alloc_import_declaration(
             span,
@@ -7505,7 +7536,7 @@ impl<'a> AstBuilder<'a> {
         export_kind: ImportOrExportKind,
     ) -> ModuleDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
         ModuleDeclaration::ExportAllDeclaration(self.alloc_export_all_declaration(
             span,
@@ -7550,13 +7581,13 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         declaration: Option<Declaration<'a>>,
-        specifiers: Vec<'a, ExportSpecifier<'a>>,
+        specifiers: ArenaVec<'a, ExportSpecifier<'a>>,
         source: Option<StringLiteral<'a>>,
         export_kind: ImportOrExportKind,
         with_clause: T1,
     ) -> ModuleDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
         ModuleDeclaration::ExportNamedDeclaration(self.alloc_export_named_declaration(
             span,
@@ -7624,7 +7655,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: AccessorPropertyType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         type_annotation: T1,
         value: Option<Expression<'a>>,
@@ -7635,7 +7666,7 @@ impl<'a> AstBuilder<'a> {
         accessibility: Option<TSAccessibility>,
     ) -> AccessorProperty<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         AccessorProperty {
             node_id: Default::default(),
@@ -7655,7 +7686,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AccessorProperty`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::accessor_property`] instead.
     ///
     /// ## Parameters
@@ -7675,7 +7706,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: AccessorPropertyType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         key: PropertyKey<'a>,
         type_annotation: T1,
         value: Option<Expression<'a>>,
@@ -7684,11 +7715,11 @@ impl<'a> AstBuilder<'a> {
         r#override: bool,
         definite: bool,
         accessibility: Option<TSAccessibility>,
-    ) -> Box<'a, AccessorProperty<'a>>
+    ) -> ArenaBox<'a, AccessorProperty<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.accessor_property(
                 span,
                 r#type,
@@ -7729,7 +7760,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::import_expression`] instead.
     ///
     /// ## Parameters
@@ -7744,8 +7775,8 @@ impl<'a> AstBuilder<'a> {
         source: Expression<'a>,
         options: Option<Expression<'a>>,
         phase: Option<ImportPhase>,
-    ) -> Box<'a, ImportExpression<'a>> {
-        Box::new_in(self.import_expression(span, source, options, phase), self.allocator)
+    ) -> ArenaBox<'a, ImportExpression<'a>> {
+        ArenaBox::new_in(self.import_expression(span, source, options, phase), self.allocator)
     }
 
     /// Build an [`ImportDeclaration`].
@@ -7764,14 +7795,14 @@ impl<'a> AstBuilder<'a> {
     pub fn import_declaration<T1>(
         self,
         span: Span,
-        specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
+        specifiers: Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
         phase: Option<ImportPhase>,
         with_clause: T1,
         import_kind: ImportOrExportKind,
     ) -> ImportDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
         ImportDeclaration {
             node_id: Default::default(),
@@ -7786,7 +7817,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::import_declaration`] instead.
     ///
     /// ## Parameters
@@ -7800,16 +7831,16 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_import_declaration<T1>(
         self,
         span: Span,
-        specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
+        specifiers: Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
         phase: Option<ImportPhase>,
         with_clause: T1,
         import_kind: ImportOrExportKind,
-    ) -> Box<'a, ImportDeclaration<'a>>
+    ) -> ArenaBox<'a, ImportDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.import_declaration(span, specifiers, source, phase, with_clause, import_kind),
             self.allocator,
         )
@@ -7899,7 +7930,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportSpecifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::import_specifier`] instead.
     ///
     /// ## Parameters
@@ -7914,8 +7945,8 @@ impl<'a> AstBuilder<'a> {
         imported: ModuleExportName<'a>,
         local: BindingIdentifier<'a>,
         import_kind: ImportOrExportKind,
-    ) -> Box<'a, ImportSpecifier<'a>> {
-        Box::new_in(self.import_specifier(span, imported, local, import_kind), self.allocator)
+    ) -> ArenaBox<'a, ImportSpecifier<'a>> {
+        ArenaBox::new_in(self.import_specifier(span, imported, local, import_kind), self.allocator)
     }
 
     /// Build an [`ImportDefaultSpecifier`].
@@ -7937,7 +7968,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportDefaultSpecifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::import_default_specifier`] instead.
     ///
     /// ## Parameters
@@ -7948,8 +7979,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         local: BindingIdentifier<'a>,
-    ) -> Box<'a, ImportDefaultSpecifier<'a>> {
-        Box::new_in(self.import_default_specifier(span, local), self.allocator)
+    ) -> ArenaBox<'a, ImportDefaultSpecifier<'a>> {
+        ArenaBox::new_in(self.import_default_specifier(span, local), self.allocator)
     }
 
     /// Build an [`ImportNamespaceSpecifier`].
@@ -7971,7 +8002,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportNamespaceSpecifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::import_namespace_specifier`] instead.
     ///
     /// ## Parameters
@@ -7982,8 +8013,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         local: BindingIdentifier<'a>,
-    ) -> Box<'a, ImportNamespaceSpecifier<'a>> {
-        Box::new_in(self.import_namespace_specifier(span, local), self.allocator)
+    ) -> ArenaBox<'a, ImportNamespaceSpecifier<'a>> {
+        ArenaBox::new_in(self.import_namespace_specifier(span, local), self.allocator)
     }
 
     /// Build a [`WithClause`].
@@ -8000,14 +8031,14 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         keyword: WithClauseKeyword,
-        with_entries: Vec<'a, ImportAttribute<'a>>,
+        with_entries: ArenaVec<'a, ImportAttribute<'a>>,
     ) -> WithClause<'a> {
         WithClause { node_id: Default::default(), span, keyword, with_entries }
     }
 
     /// Build a [`WithClause`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::with_clause`] instead.
     ///
     /// ## Parameters
@@ -8019,9 +8050,9 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         keyword: WithClauseKeyword,
-        with_entries: Vec<'a, ImportAttribute<'a>>,
-    ) -> Box<'a, WithClause<'a>> {
-        Box::new_in(self.with_clause(span, keyword, with_entries), self.allocator)
+        with_entries: ArenaVec<'a, ImportAttribute<'a>>,
+    ) -> ArenaBox<'a, WithClause<'a>> {
+        ArenaBox::new_in(self.with_clause(span, keyword, with_entries), self.allocator)
     }
 
     /// Build an [`ImportAttribute`].
@@ -8115,13 +8146,13 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         declaration: Option<Declaration<'a>>,
-        specifiers: Vec<'a, ExportSpecifier<'a>>,
+        specifiers: ArenaVec<'a, ExportSpecifier<'a>>,
         source: Option<StringLiteral<'a>>,
         export_kind: ImportOrExportKind,
         with_clause: T1,
     ) -> ExportNamedDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
         ExportNamedDeclaration {
             node_id: Default::default(),
@@ -8136,7 +8167,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportNamedDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::export_named_declaration`] instead.
     ///
     /// ## Parameters
@@ -8151,15 +8182,15 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         declaration: Option<Declaration<'a>>,
-        specifiers: Vec<'a, ExportSpecifier<'a>>,
+        specifiers: ArenaVec<'a, ExportSpecifier<'a>>,
         source: Option<StringLiteral<'a>>,
         export_kind: ImportOrExportKind,
         with_clause: T1,
-    ) -> Box<'a, ExportNamedDeclaration<'a>>
+    ) -> ArenaBox<'a, ExportNamedDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.export_named_declaration(
                 span,
                 declaration,
@@ -8191,7 +8222,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportDefaultDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::export_default_declaration`] instead.
     ///
     /// ## Parameters
@@ -8202,8 +8233,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         declaration: ExportDefaultDeclarationKind<'a>,
-    ) -> Box<'a, ExportDefaultDeclaration<'a>> {
-        Box::new_in(self.export_default_declaration(span, declaration), self.allocator)
+    ) -> ArenaBox<'a, ExportDefaultDeclaration<'a>> {
+        ArenaBox::new_in(self.export_default_declaration(span, declaration), self.allocator)
     }
 
     /// Build an [`ExportAllDeclaration`].
@@ -8227,7 +8258,7 @@ impl<'a> AstBuilder<'a> {
         export_kind: ImportOrExportKind,
     ) -> ExportAllDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
         ExportAllDeclaration {
             node_id: Default::default(),
@@ -8241,7 +8272,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportAllDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::export_all_declaration`] instead.
     ///
     /// ## Parameters
@@ -8258,11 +8289,11 @@ impl<'a> AstBuilder<'a> {
         source: StringLiteral<'a>,
         with_clause: T1,
         export_kind: ImportOrExportKind,
-    ) -> Box<'a, ExportAllDeclaration<'a>>
+    ) -> ArenaBox<'a, ExportAllDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, WithClause<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, WithClause<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.export_all_declaration(span, exported, source, with_clause, export_kind),
             self.allocator,
         )
@@ -8318,11 +8349,11 @@ impl<'a> AstBuilder<'a> {
         body: T5,
     ) -> ExportDefaultDeclarationKind<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
         ExportDefaultDeclarationKind::FunctionDeclaration(self.alloc_function(
             span,
@@ -8383,11 +8414,11 @@ impl<'a> AstBuilder<'a> {
         pife: bool,
     ) -> ExportDefaultDeclarationKind<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
-        T5: IntoIn<'a, Option<Box<'a, FunctionBody<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
+        T5: IntoIn<'a, Option<ArenaBox<'a, FunctionBody<'a>>>>,
     {
         ExportDefaultDeclarationKind::FunctionDeclaration(
             self.alloc_function_with_scope_id_and_pure_and_pife(
@@ -8430,20 +8461,20 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: ClassType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
         super_type_arguments: T2,
-        implements: Vec<'a, TSClassImplements<'a>>,
+        implements: ArenaVec<'a, TSClassImplements<'a>>,
         body: T3,
         r#abstract: bool,
         declare: bool,
     ) -> ExportDefaultDeclarationKind<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-        T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
     {
         ExportDefaultDeclarationKind::ClassDeclaration(self.alloc_class(
             span,
@@ -8482,21 +8513,21 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         r#type: ClassType,
-        decorators: Vec<'a, Decorator<'a>>,
+        decorators: ArenaVec<'a, Decorator<'a>>,
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
         super_type_arguments: T2,
-        implements: Vec<'a, TSClassImplements<'a>>,
+        implements: ArenaVec<'a, TSClassImplements<'a>>,
         body: T3,
         r#abstract: bool,
         declare: bool,
         scope_id: ScopeId,
     ) -> ExportDefaultDeclarationKind<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-        T3: IntoIn<'a, Box<'a, ClassBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, ClassBody<'a>>>,
     {
         ExportDefaultDeclarationKind::ClassDeclaration(self.alloc_class_with_scope_id(
             span,
@@ -8531,13 +8562,13 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
+        extends: ArenaVec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
     ) -> ExportDefaultDeclarationKind<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
     {
         ExportDefaultDeclarationKind::TSInterfaceDeclaration(self.alloc_ts_interface_declaration(
             span,
@@ -8567,14 +8598,14 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
+        extends: ArenaVec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
         scope_id: ScopeId,
     ) -> ExportDefaultDeclarationKind<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
     {
         ExportDefaultDeclarationKind::TSInterfaceDeclaration(
             self.alloc_ts_interface_declaration_with_scope_id(
@@ -8705,14 +8736,14 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         name: IdentifierName<'a>,
-        arguments: Vec<'a, Argument<'a>>,
+        arguments: ArenaVec<'a, Argument<'a>>,
     ) -> V8IntrinsicExpression<'a> {
         V8IntrinsicExpression { node_id: Default::default(), span, name, arguments }
     }
 
     /// Build a [`V8IntrinsicExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::v8_intrinsic_expression`] instead.
     ///
     /// ## Parameters
@@ -8724,9 +8755,9 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         name: IdentifierName<'a>,
-        arguments: Vec<'a, Argument<'a>>,
-    ) -> Box<'a, V8IntrinsicExpression<'a>> {
-        Box::new_in(self.v8_intrinsic_expression(span, name, arguments), self.allocator)
+        arguments: ArenaVec<'a, Argument<'a>>,
+    ) -> ArenaBox<'a, V8IntrinsicExpression<'a>> {
+        ArenaBox::new_in(self.v8_intrinsic_expression(span, name, arguments), self.allocator)
     }
 
     /// Build a [`BooleanLiteral`].
@@ -8744,15 +8775,15 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BooleanLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::boolean_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `value`: The boolean value itself
     #[inline]
-    pub fn alloc_boolean_literal(self, span: Span, value: bool) -> Box<'a, BooleanLiteral> {
-        Box::new_in(self.boolean_literal(span, value), self.allocator)
+    pub fn alloc_boolean_literal(self, span: Span, value: bool) -> ArenaBox<'a, BooleanLiteral> {
+        ArenaBox::new_in(self.boolean_literal(span, value), self.allocator)
     }
 
     /// Build a [`NullLiteral`].
@@ -8769,14 +8800,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NullLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::null_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
     #[inline]
-    pub fn alloc_null_literal(self, span: Span) -> Box<'a, NullLiteral> {
-        Box::new_in(self.null_literal(span), self.allocator)
+    pub fn alloc_null_literal(self, span: Span) -> ArenaBox<'a, NullLiteral> {
+        ArenaBox::new_in(self.null_literal(span), self.allocator)
     }
 
     /// Build a [`NumericLiteral`].
@@ -8802,7 +8833,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NumericLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::numeric_literal`] instead.
     ///
     /// ## Parameters
@@ -8817,8 +8848,8 @@ impl<'a> AstBuilder<'a> {
         value: f64,
         raw: Option<Str<'a>>,
         base: NumberBase,
-    ) -> Box<'a, NumericLiteral<'a>> {
-        Box::new_in(self.numeric_literal(span, value, raw, base), self.allocator)
+    ) -> ArenaBox<'a, NumericLiteral<'a>> {
+        ArenaBox::new_in(self.numeric_literal(span, value, raw, base), self.allocator)
     }
 
     /// Build a [`StringLiteral`].
@@ -8851,7 +8882,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StringLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::string_literal`] instead.
     ///
     /// ## Parameters
@@ -8864,11 +8895,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
-    ) -> Box<'a, StringLiteral<'a>>
+    ) -> ArenaBox<'a, StringLiteral<'a>>
     where
         S1: Into<Str<'a>>,
     {
-        Box::new_in(self.string_literal(span, value, raw), self.allocator)
+        ArenaBox::new_in(self.string_literal(span, value, raw), self.allocator)
     }
 
     /// Build a [`StringLiteral`] with `lone_surrogates`.
@@ -8903,7 +8934,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StringLiteral`] with `lone_surrogates`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::string_literal_with_lone_surrogates`] instead.
     ///
     /// ## Parameters
@@ -8918,11 +8949,11 @@ impl<'a> AstBuilder<'a> {
         value: S1,
         raw: Option<Str<'a>>,
         lone_surrogates: bool,
-    ) -> Box<'a, StringLiteral<'a>>
+    ) -> ArenaBox<'a, StringLiteral<'a>>
     where
         S1: Into<Str<'a>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.string_literal_with_lone_surrogates(span, value, raw, lone_surrogates),
             self.allocator,
         )
@@ -8954,7 +8985,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BigIntLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::big_int_literal`] instead.
     ///
     /// ## Parameters
@@ -8969,11 +9000,11 @@ impl<'a> AstBuilder<'a> {
         value: S1,
         raw: Option<Str<'a>>,
         base: BigintBase,
-    ) -> Box<'a, BigIntLiteral<'a>>
+    ) -> ArenaBox<'a, BigIntLiteral<'a>>
     where
         S1: Into<Str<'a>>,
     {
-        Box::new_in(self.big_int_literal(span, value, raw, base), self.allocator)
+        ArenaBox::new_in(self.big_int_literal(span, value, raw, base), self.allocator)
     }
 
     /// Build a [`RegExpLiteral`].
@@ -8997,7 +9028,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`RegExpLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::reg_exp_literal`] instead.
     ///
     /// ## Parameters
@@ -9010,8 +9041,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         regex: RegExp<'a>,
         raw: Option<Str<'a>>,
-    ) -> Box<'a, RegExpLiteral<'a>> {
-        Box::new_in(self.reg_exp_literal(span, regex, raw), self.allocator)
+    ) -> ArenaBox<'a, RegExpLiteral<'a>> {
+        ArenaBox::new_in(self.reg_exp_literal(span, regex, raw), self.allocator)
     }
 
     /// Build a [`JSXElement`].
@@ -9029,12 +9060,12 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         opening_element: T1,
-        children: Vec<'a, JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         closing_element: T2,
     ) -> JSXElement<'a>
     where
-        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
     {
         JSXElement {
             node_id: Default::default(),
@@ -9047,7 +9078,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_element`] instead.
     ///
     /// ## Parameters
@@ -9060,14 +9091,14 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         opening_element: T1,
-        children: Vec<'a, JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         closing_element: T2,
-    ) -> Box<'a, JSXElement<'a>>
+    ) -> ArenaBox<'a, JSXElement<'a>>
     where
-        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.jsx_element(span, opening_element, children, closing_element),
             self.allocator,
         )
@@ -9089,10 +9120,10 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         name: JSXElementName<'a>,
         type_arguments: T1,
-        attributes: Vec<'a, JSXAttributeItem<'a>>,
+        attributes: ArenaVec<'a, JSXAttributeItem<'a>>,
     ) -> JSXOpeningElement<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         JSXOpeningElement {
             node_id: Default::default(),
@@ -9105,7 +9136,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXOpeningElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_opening_element`] instead.
     ///
     /// ## Parameters
@@ -9119,12 +9150,12 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         name: JSXElementName<'a>,
         type_arguments: T1,
-        attributes: Vec<'a, JSXAttributeItem<'a>>,
-    ) -> Box<'a, JSXOpeningElement<'a>>
+        attributes: ArenaVec<'a, JSXAttributeItem<'a>>,
+    ) -> ArenaBox<'a, JSXOpeningElement<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.jsx_opening_element(span, name, type_arguments, attributes),
             self.allocator,
         )
@@ -9149,7 +9180,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXClosingElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_closing_element`] instead.
     ///
     /// ## Parameters
@@ -9160,8 +9191,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         name: JSXElementName<'a>,
-    ) -> Box<'a, JSXClosingElement<'a>> {
-        Box::new_in(self.jsx_closing_element(span, name), self.allocator)
+    ) -> ArenaBox<'a, JSXClosingElement<'a>> {
+        ArenaBox::new_in(self.jsx_closing_element(span, name), self.allocator)
     }
 
     /// Build a [`JSXFragment`].
@@ -9179,7 +9210,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
-        children: Vec<'a, JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         closing_fragment: JSXClosingFragment,
     ) -> JSXFragment<'a> {
         JSXFragment {
@@ -9193,7 +9224,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXFragment`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_fragment`] instead.
     ///
     /// ## Parameters
@@ -9206,10 +9237,10 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
-        children: Vec<'a, JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         closing_fragment: JSXClosingFragment,
-    ) -> Box<'a, JSXFragment<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, JSXFragment<'a>> {
+        ArenaBox::new_in(
             self.jsx_fragment(span, opening_fragment, children, closing_fragment),
             self.allocator,
         )
@@ -9360,7 +9391,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXNamespacedName`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_namespaced_name`] instead.
     ///
     /// ## Parameters
@@ -9373,8 +9404,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         namespace: JSXIdentifier<'a>,
         name: JSXIdentifier<'a>,
-    ) -> Box<'a, JSXNamespacedName<'a>> {
-        Box::new_in(self.jsx_namespaced_name(span, namespace, name), self.allocator)
+    ) -> ArenaBox<'a, JSXNamespacedName<'a>> {
+        ArenaBox::new_in(self.jsx_namespaced_name(span, namespace, name), self.allocator)
     }
 
     /// Build a [`JSXMemberExpression`].
@@ -9398,7 +9429,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXMemberExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_member_expression`] instead.
     ///
     /// ## Parameters
@@ -9411,8 +9442,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
-    ) -> Box<'a, JSXMemberExpression<'a>> {
-        Box::new_in(self.jsx_member_expression(span, object, property), self.allocator)
+    ) -> ArenaBox<'a, JSXMemberExpression<'a>> {
+        ArenaBox::new_in(self.jsx_member_expression(span, object, property), self.allocator)
     }
 
     /// Build a [`JSXMemberExpressionObject::IdentifierReference`].
@@ -9510,7 +9541,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXExpressionContainer`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_expression_container`] instead.
     ///
     /// ## Parameters
@@ -9521,8 +9552,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         expression: JSXExpression<'a>,
-    ) -> Box<'a, JSXExpressionContainer<'a>> {
-        Box::new_in(self.jsx_expression_container(span, expression), self.allocator)
+    ) -> ArenaBox<'a, JSXExpressionContainer<'a>> {
+        ArenaBox::new_in(self.jsx_expression_container(span, expression), self.allocator)
     }
 
     /// Build a [`JSXExpression::EmptyExpression`].
@@ -9550,14 +9581,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXEmptyExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_empty_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
     #[inline]
-    pub fn alloc_jsx_empty_expression(self, span: Span) -> Box<'a, JSXEmptyExpression> {
-        Box::new_in(self.jsx_empty_expression(span), self.allocator)
+    pub fn alloc_jsx_empty_expression(self, span: Span) -> ArenaBox<'a, JSXEmptyExpression> {
+        ArenaBox::new_in(self.jsx_empty_expression(span), self.allocator)
     }
 
     /// Build a [`JSXAttributeItem::Attribute`].
@@ -9615,7 +9646,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXAttribute`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_attribute`] instead.
     ///
     /// ## Parameters
@@ -9628,8 +9659,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         name: JSXAttributeName<'a>,
         value: Option<JSXAttributeValue<'a>>,
-    ) -> Box<'a, JSXAttribute<'a>> {
-        Box::new_in(self.jsx_attribute(span, name, value), self.allocator)
+    ) -> ArenaBox<'a, JSXAttribute<'a>> {
+        ArenaBox::new_in(self.jsx_attribute(span, name, value), self.allocator)
     }
 
     /// Build a [`JSXSpreadAttribute`].
@@ -9651,7 +9682,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXSpreadAttribute`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_spread_attribute`] instead.
     ///
     /// ## Parameters
@@ -9662,8 +9693,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         argument: Expression<'a>,
-    ) -> Box<'a, JSXSpreadAttribute<'a>> {
-        Box::new_in(self.jsx_spread_attribute(span, argument), self.allocator)
+    ) -> ArenaBox<'a, JSXSpreadAttribute<'a>> {
+        ArenaBox::new_in(self.jsx_spread_attribute(span, argument), self.allocator)
     }
 
     /// Build a [`JSXAttributeName::Identifier`].
@@ -9780,12 +9811,12 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         opening_element: T1,
-        children: Vec<'a, JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         closing_element: T2,
     ) -> JSXAttributeValue<'a>
     where
-        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
     {
         JSXAttributeValue::Element(self.alloc_jsx_element(
             span,
@@ -9809,7 +9840,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
-        children: Vec<'a, JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         closing_fragment: JSXClosingFragment,
     ) -> JSXAttributeValue<'a> {
         JSXAttributeValue::Fragment(self.alloc_jsx_fragment(
@@ -9838,18 +9869,18 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXIdentifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn alloc_jsx_identifier<S1>(self, span: Span, name: S1) -> Box<'a, JSXIdentifier<'a>>
+    pub fn alloc_jsx_identifier<S1>(self, span: Span, name: S1) -> ArenaBox<'a, JSXIdentifier<'a>>
     where
         S1: Into<Str<'a>>,
     {
-        Box::new_in(self.jsx_identifier(span, name), self.allocator)
+        ArenaBox::new_in(self.jsx_identifier(span, name), self.allocator)
     }
 
     /// Build a [`JSXChild::Text`].
@@ -9882,12 +9913,12 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         opening_element: T1,
-        children: Vec<'a, JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         closing_element: T2,
     ) -> JSXChild<'a>
     where
-        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
+        T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
     {
         JSXChild::Element(self.alloc_jsx_element(span, opening_element, children, closing_element))
     }
@@ -9906,7 +9937,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
-        children: Vec<'a, JSXChild<'a>>,
+        children: ArenaVec<'a, JSXChild<'a>>,
         closing_fragment: JSXClosingFragment,
     ) -> JSXChild<'a> {
         JSXChild::Fragment(self.alloc_jsx_fragment(
@@ -9960,7 +9991,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXSpreadChild`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_spread_child`] instead.
     ///
     /// ## Parameters
@@ -9971,8 +10002,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         expression: Expression<'a>,
-    ) -> Box<'a, JSXSpreadChild<'a>> {
-        Box::new_in(self.jsx_spread_child(span, expression), self.allocator)
+    ) -> ArenaBox<'a, JSXSpreadChild<'a>> {
+        ArenaBox::new_in(self.jsx_spread_child(span, expression), self.allocator)
     }
 
     /// Build a [`JSXText`].
@@ -9994,7 +10025,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXText`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::jsx_text`] instead.
     ///
     /// ## Parameters
@@ -10007,11 +10038,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
-    ) -> Box<'a, JSXText<'a>>
+    ) -> ArenaBox<'a, JSXText<'a>>
     where
         S1: Into<Str<'a>>,
     {
-        Box::new_in(self.jsx_text(span, value, raw), self.allocator)
+        ArenaBox::new_in(self.jsx_text(span, value, raw), self.allocator)
     }
 
     /// Build a [`TSThisParameter`].
@@ -10031,7 +10062,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: T1,
     ) -> TSThisParameter<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSThisParameter {
             node_id: Default::default(),
@@ -10043,7 +10074,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSThisParameter`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_this_parameter`] instead.
     ///
     /// ## Parameters
@@ -10056,11 +10087,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         this_span: Span,
         type_annotation: T1,
-    ) -> Box<'a, TSThisParameter<'a>>
+    ) -> ArenaBox<'a, TSThisParameter<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(self.ts_this_parameter(span, this_span, type_annotation), self.allocator)
+        ArenaBox::new_in(self.ts_this_parameter(span, this_span, type_annotation), self.allocator)
     }
 
     /// Build a [`TSEnumDeclaration`].
@@ -10088,7 +10119,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSEnumDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_enum_declaration`] instead.
     ///
     /// ## Parameters
@@ -10105,8 +10136,8 @@ impl<'a> AstBuilder<'a> {
         body: TSEnumBody<'a>,
         r#const: bool,
         declare: bool,
-    ) -> Box<'a, TSEnumDeclaration<'a>> {
-        Box::new_in(self.ts_enum_declaration(span, id, body, r#const, declare), self.allocator)
+    ) -> ArenaBox<'a, TSEnumDeclaration<'a>> {
+        ArenaBox::new_in(self.ts_enum_declaration(span, id, body, r#const, declare), self.allocator)
     }
 
     /// Build a [`TSEnumBody`].
@@ -10115,7 +10146,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `members`
     #[inline]
-    pub fn ts_enum_body(self, span: Span, members: Vec<'a, TSEnumMember<'a>>) -> TSEnumBody<'a> {
+    pub fn ts_enum_body(
+        self,
+        span: Span,
+        members: ArenaVec<'a, TSEnumMember<'a>>,
+    ) -> TSEnumBody<'a> {
         TSEnumBody { node_id: Default::default(), span, members, scope_id: Default::default() }
     }
 
@@ -10129,7 +10164,7 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_enum_body_with_scope_id(
         self,
         span: Span,
-        members: Vec<'a, TSEnumMember<'a>>,
+        members: ArenaVec<'a, TSEnumMember<'a>>,
         scope_id: ScopeId,
     ) -> TSEnumBody<'a> {
         TSEnumBody {
@@ -10281,8 +10316,8 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_enum_member_name_computed_template_string(
         self,
         span: Span,
-        quasis: Vec<'a, TemplateElement<'a>>,
-        expressions: Vec<'a, Expression<'a>>,
+        quasis: ArenaVec<'a, TemplateElement<'a>>,
+        expressions: ArenaVec<'a, Expression<'a>>,
     ) -> TSEnumMemberName<'a> {
         TSEnumMemberName::ComputedTemplateString(self.alloc_template_literal(
             span,
@@ -10310,7 +10345,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAnnotation`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_annotation`] instead.
     ///
     /// ## Parameters
@@ -10321,8 +10356,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         type_annotation: TSType<'a>,
-    ) -> Box<'a, TSTypeAnnotation<'a>> {
-        Box::new_in(self.ts_type_annotation(span, type_annotation), self.allocator)
+    ) -> ArenaBox<'a, TSTypeAnnotation<'a>> {
+        ArenaBox::new_in(self.ts_type_annotation(span, type_annotation), self.allocator)
     }
 
     /// Build a [`TSLiteralType`].
@@ -10340,7 +10375,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSLiteralType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_literal_type`] instead.
     ///
     /// ## Parameters
@@ -10351,8 +10386,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         literal: TSLiteral<'a>,
-    ) -> Box<'a, TSLiteralType<'a>> {
-        Box::new_in(self.ts_literal_type(span, literal), self.allocator)
+    ) -> ArenaBox<'a, TSLiteralType<'a>> {
+        ArenaBox::new_in(self.ts_literal_type(span, literal), self.allocator)
     }
 
     /// Build a [`TSLiteral::BooleanLiteral`].
@@ -10471,8 +10506,8 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_literal_template_literal(
         self,
         span: Span,
-        quasis: Vec<'a, TemplateElement<'a>>,
-        expressions: Vec<'a, Expression<'a>>,
+        quasis: ArenaVec<'a, TemplateElement<'a>>,
+        expressions: ArenaVec<'a, Expression<'a>>,
     ) -> TSLiteral<'a> {
         TSLiteral::TemplateLiteral(self.alloc_template_literal(span, quasis, expressions))
     }
@@ -10729,9 +10764,9 @@ impl<'a> AstBuilder<'a> {
         return_type: T3,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSType::TSConstructorType(self.alloc_ts_constructor_type(
             span,
@@ -10764,9 +10799,9 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSType::TSConstructorType(self.alloc_ts_constructor_type_with_scope_id(
             span,
@@ -10798,10 +10833,10 @@ impl<'a> AstBuilder<'a> {
         return_type: T4,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSType::TSFunctionType(self.alloc_ts_function_type(
             span,
@@ -10834,10 +10869,10 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSType::TSFunctionType(self.alloc_ts_function_type_with_scope_id(
             span,
@@ -10869,8 +10904,8 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T2,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, ObjectExpression<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, ObjectExpression<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSType::TSImportType(self.alloc_ts_import_type(
             span,
@@ -10913,7 +10948,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn ts_type_infer_type<T1>(self, span: Span, type_parameter: T1) -> TSType<'a>
     where
-        T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameter<'a>>>,
     {
         TSType::TSInferType(self.alloc_ts_infer_type(span, type_parameter))
     }
@@ -10926,7 +10961,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `types`
     #[inline]
-    pub fn ts_type_intersection_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSType<'a> {
+    pub fn ts_type_intersection_type(
+        self,
+        span: Span,
+        types: ArenaVec<'a, TSType<'a>>,
+    ) -> TSType<'a> {
         TSType::TSIntersectionType(self.alloc_ts_intersection_type(span, types))
     }
 
@@ -11050,8 +11089,8 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_type_template_literal_type(
         self,
         span: Span,
-        quasis: Vec<'a, TemplateElement<'a>>,
-        types: Vec<'a, TSType<'a>>,
+        quasis: ArenaVec<'a, TemplateElement<'a>>,
+        types: ArenaVec<'a, TSType<'a>>,
     ) -> TSType<'a> {
         TSType::TSTemplateLiteralType(self.alloc_ts_template_literal_type(span, quasis, types))
     }
@@ -11078,7 +11117,7 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_type_tuple_type(
         self,
         span: Span,
-        element_types: Vec<'a, TSTupleElement<'a>>,
+        element_types: ArenaVec<'a, TSTupleElement<'a>>,
     ) -> TSType<'a> {
         TSType::TSTupleType(self.alloc_ts_tuple_type(span, element_types))
     }
@@ -11091,7 +11130,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `members`
     #[inline]
-    pub fn ts_type_type_literal(self, span: Span, members: Vec<'a, TSSignature<'a>>) -> TSType<'a> {
+    pub fn ts_type_type_literal(
+        self,
+        span: Span,
+        members: ArenaVec<'a, TSSignature<'a>>,
+    ) -> TSType<'a> {
         TSType::TSTypeLiteral(self.alloc_ts_type_literal(span, members))
     }
 
@@ -11131,7 +11174,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: T1,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSType::TSTypePredicate(self.alloc_ts_type_predicate(
             span,
@@ -11157,7 +11200,7 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T1,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSType::TSTypeQuery(self.alloc_ts_type_query(span, expr_name, type_arguments))
     }
@@ -11178,7 +11221,7 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T1,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSType::TSTypeReference(self.alloc_ts_type_reference(span, type_name, type_arguments))
     }
@@ -11191,7 +11234,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `types`: The types in the union.
     #[inline]
-    pub fn ts_type_union_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSType<'a> {
+    pub fn ts_type_union_type(self, span: Span, types: ArenaVec<'a, TSType<'a>>) -> TSType<'a> {
         TSType::TSUnionType(self.alloc_ts_union_type(span, types))
     }
 
@@ -11291,7 +11334,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConditionalType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_conditional_type`] instead.
     ///
     /// ## Parameters
@@ -11308,8 +11351,8 @@ impl<'a> AstBuilder<'a> {
         extends_type: TSType<'a>,
         true_type: TSType<'a>,
         false_type: TSType<'a>,
-    ) -> Box<'a, TSConditionalType<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, TSConditionalType<'a>> {
+        ArenaBox::new_in(
             self.ts_conditional_type(span, check_type, extends_type, true_type, false_type),
             self.allocator,
         )
@@ -11350,7 +11393,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConditionalType`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_conditional_type_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -11369,8 +11412,8 @@ impl<'a> AstBuilder<'a> {
         true_type: TSType<'a>,
         false_type: TSType<'a>,
         scope_id: ScopeId,
-    ) -> Box<'a, TSConditionalType<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, TSConditionalType<'a>> {
+        ArenaBox::new_in(
             self.ts_conditional_type_with_scope_id(
                 span,
                 check_type,
@@ -11392,13 +11435,13 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `types`: The types in the union.
     #[inline]
-    pub fn ts_union_type(self, span: Span, types: Vec<'a, TSType<'a>>) -> TSUnionType<'a> {
+    pub fn ts_union_type(self, span: Span, types: ArenaVec<'a, TSType<'a>>) -> TSUnionType<'a> {
         TSUnionType { node_id: Default::default(), span, types }
     }
 
     /// Build a [`TSUnionType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_union_type`] instead.
     ///
     /// ## Parameters
@@ -11408,9 +11451,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_union_type(
         self,
         span: Span,
-        types: Vec<'a, TSType<'a>>,
-    ) -> Box<'a, TSUnionType<'a>> {
-        Box::new_in(self.ts_union_type(span, types), self.allocator)
+        types: ArenaVec<'a, TSType<'a>>,
+    ) -> ArenaBox<'a, TSUnionType<'a>> {
+        ArenaBox::new_in(self.ts_union_type(span, types), self.allocator)
     }
 
     /// Build a [`TSIntersectionType`].
@@ -11425,14 +11468,14 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_intersection_type(
         self,
         span: Span,
-        types: Vec<'a, TSType<'a>>,
+        types: ArenaVec<'a, TSType<'a>>,
     ) -> TSIntersectionType<'a> {
         TSIntersectionType { node_id: Default::default(), span, types }
     }
 
     /// Build a [`TSIntersectionType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_intersection_type`] instead.
     ///
     /// ## Parameters
@@ -11442,9 +11485,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_intersection_type(
         self,
         span: Span,
-        types: Vec<'a, TSType<'a>>,
-    ) -> Box<'a, TSIntersectionType<'a>> {
-        Box::new_in(self.ts_intersection_type(span, types), self.allocator)
+        types: ArenaVec<'a, TSType<'a>>,
+    ) -> ArenaBox<'a, TSIntersectionType<'a>> {
+        ArenaBox::new_in(self.ts_intersection_type(span, types), self.allocator)
     }
 
     /// Build a [`TSParenthesizedType`].
@@ -11466,7 +11509,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSParenthesizedType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_parenthesized_type`] instead.
     ///
     /// ## Parameters
@@ -11477,8 +11520,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         type_annotation: TSType<'a>,
-    ) -> Box<'a, TSParenthesizedType<'a>> {
-        Box::new_in(self.ts_parenthesized_type(span, type_annotation), self.allocator)
+    ) -> ArenaBox<'a, TSParenthesizedType<'a>> {
+        ArenaBox::new_in(self.ts_parenthesized_type(span, type_annotation), self.allocator)
     }
 
     /// Build a [`TSTypeOperator`].
@@ -11502,7 +11545,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeOperator`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_operator`] instead.
     ///
     /// ## Parameters
@@ -11515,8 +11558,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         operator: TSTypeOperatorOperator,
         type_annotation: TSType<'a>,
-    ) -> Box<'a, TSTypeOperator<'a>> {
-        Box::new_in(self.ts_type_operator(span, operator, type_annotation), self.allocator)
+    ) -> ArenaBox<'a, TSTypeOperator<'a>> {
+        ArenaBox::new_in(self.ts_type_operator(span, operator, type_annotation), self.allocator)
     }
 
     /// Build a [`TSArrayType`].
@@ -11534,7 +11577,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSArrayType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_array_type`] instead.
     ///
     /// ## Parameters
@@ -11545,8 +11588,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         element_type: TSType<'a>,
-    ) -> Box<'a, TSArrayType<'a>> {
-        Box::new_in(self.ts_array_type(span, element_type), self.allocator)
+    ) -> ArenaBox<'a, TSArrayType<'a>> {
+        ArenaBox::new_in(self.ts_array_type(span, element_type), self.allocator)
     }
 
     /// Build a [`TSIndexedAccessType`].
@@ -11570,7 +11613,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIndexedAccessType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_indexed_access_type`] instead.
     ///
     /// ## Parameters
@@ -11583,8 +11626,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         object_type: TSType<'a>,
         index_type: TSType<'a>,
-    ) -> Box<'a, TSIndexedAccessType<'a>> {
-        Box::new_in(self.ts_indexed_access_type(span, object_type, index_type), self.allocator)
+    ) -> ArenaBox<'a, TSIndexedAccessType<'a>> {
+        ArenaBox::new_in(self.ts_indexed_access_type(span, object_type, index_type), self.allocator)
     }
 
     /// Build a [`TSTupleType`].
@@ -11599,14 +11642,14 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_tuple_type(
         self,
         span: Span,
-        element_types: Vec<'a, TSTupleElement<'a>>,
+        element_types: ArenaVec<'a, TSTupleElement<'a>>,
     ) -> TSTupleType<'a> {
         TSTupleType { node_id: Default::default(), span, element_types }
     }
 
     /// Build a [`TSTupleType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_tuple_type`] instead.
     ///
     /// ## Parameters
@@ -11616,9 +11659,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_tuple_type(
         self,
         span: Span,
-        element_types: Vec<'a, TSTupleElement<'a>>,
-    ) -> Box<'a, TSTupleType<'a>> {
-        Box::new_in(self.ts_tuple_type(span, element_types), self.allocator)
+        element_types: ArenaVec<'a, TSTupleElement<'a>>,
+    ) -> ArenaBox<'a, TSTupleType<'a>> {
+        ArenaBox::new_in(self.ts_tuple_type(span, element_types), self.allocator)
     }
 
     /// Build a [`TSNamedTupleMember`].
@@ -11644,7 +11687,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNamedTupleMember`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_named_tuple_member`] instead.
     ///
     /// ## Parameters
@@ -11659,8 +11702,11 @@ impl<'a> AstBuilder<'a> {
         label: IdentifierName<'a>,
         element_type: TSTupleElement<'a>,
         optional: bool,
-    ) -> Box<'a, TSNamedTupleMember<'a>> {
-        Box::new_in(self.ts_named_tuple_member(span, label, element_type, optional), self.allocator)
+    ) -> ArenaBox<'a, TSNamedTupleMember<'a>> {
+        ArenaBox::new_in(
+            self.ts_named_tuple_member(span, label, element_type, optional),
+            self.allocator,
+        )
     }
 
     /// Build a [`TSOptionalType`].
@@ -11678,7 +11724,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSOptionalType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_optional_type`] instead.
     ///
     /// ## Parameters
@@ -11689,8 +11735,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         type_annotation: TSType<'a>,
-    ) -> Box<'a, TSOptionalType<'a>> {
-        Box::new_in(self.ts_optional_type(span, type_annotation), self.allocator)
+    ) -> ArenaBox<'a, TSOptionalType<'a>> {
+        ArenaBox::new_in(self.ts_optional_type(span, type_annotation), self.allocator)
     }
 
     /// Build a [`TSRestType`].
@@ -11708,7 +11754,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSRestType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_rest_type`] instead.
     ///
     /// ## Parameters
@@ -11719,8 +11765,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         type_annotation: TSType<'a>,
-    ) -> Box<'a, TSRestType<'a>> {
-        Box::new_in(self.ts_rest_type(span, type_annotation), self.allocator)
+    ) -> ArenaBox<'a, TSRestType<'a>> {
+        ArenaBox::new_in(self.ts_rest_type(span, type_annotation), self.allocator)
     }
 
     /// Build a [`TSTupleElement::TSOptionalType`].
@@ -11769,14 +11815,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSAnyKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_any_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_any_keyword(self, span: Span) -> Box<'a, TSAnyKeyword> {
-        Box::new_in(self.ts_any_keyword(span), self.allocator)
+    pub fn alloc_ts_any_keyword(self, span: Span) -> ArenaBox<'a, TSAnyKeyword> {
+        ArenaBox::new_in(self.ts_any_keyword(span), self.allocator)
     }
 
     /// Build a [`TSStringKeyword`].
@@ -11793,14 +11839,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSStringKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_string_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_string_keyword(self, span: Span) -> Box<'a, TSStringKeyword> {
-        Box::new_in(self.ts_string_keyword(span), self.allocator)
+    pub fn alloc_ts_string_keyword(self, span: Span) -> ArenaBox<'a, TSStringKeyword> {
+        ArenaBox::new_in(self.ts_string_keyword(span), self.allocator)
     }
 
     /// Build a [`TSBooleanKeyword`].
@@ -11817,14 +11863,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSBooleanKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_boolean_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_boolean_keyword(self, span: Span) -> Box<'a, TSBooleanKeyword> {
-        Box::new_in(self.ts_boolean_keyword(span), self.allocator)
+    pub fn alloc_ts_boolean_keyword(self, span: Span) -> ArenaBox<'a, TSBooleanKeyword> {
+        ArenaBox::new_in(self.ts_boolean_keyword(span), self.allocator)
     }
 
     /// Build a [`TSNumberKeyword`].
@@ -11841,14 +11887,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNumberKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_number_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_number_keyword(self, span: Span) -> Box<'a, TSNumberKeyword> {
-        Box::new_in(self.ts_number_keyword(span), self.allocator)
+    pub fn alloc_ts_number_keyword(self, span: Span) -> ArenaBox<'a, TSNumberKeyword> {
+        ArenaBox::new_in(self.ts_number_keyword(span), self.allocator)
     }
 
     /// Build a [`TSNeverKeyword`].
@@ -11865,14 +11911,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNeverKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_never_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_never_keyword(self, span: Span) -> Box<'a, TSNeverKeyword> {
-        Box::new_in(self.ts_never_keyword(span), self.allocator)
+    pub fn alloc_ts_never_keyword(self, span: Span) -> ArenaBox<'a, TSNeverKeyword> {
+        ArenaBox::new_in(self.ts_never_keyword(span), self.allocator)
     }
 
     /// Build a [`TSIntrinsicKeyword`].
@@ -11889,14 +11935,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIntrinsicKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_intrinsic_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_intrinsic_keyword(self, span: Span) -> Box<'a, TSIntrinsicKeyword> {
-        Box::new_in(self.ts_intrinsic_keyword(span), self.allocator)
+    pub fn alloc_ts_intrinsic_keyword(self, span: Span) -> ArenaBox<'a, TSIntrinsicKeyword> {
+        ArenaBox::new_in(self.ts_intrinsic_keyword(span), self.allocator)
     }
 
     /// Build a [`TSUnknownKeyword`].
@@ -11913,14 +11959,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSUnknownKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_unknown_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_unknown_keyword(self, span: Span) -> Box<'a, TSUnknownKeyword> {
-        Box::new_in(self.ts_unknown_keyword(span), self.allocator)
+    pub fn alloc_ts_unknown_keyword(self, span: Span) -> ArenaBox<'a, TSUnknownKeyword> {
+        ArenaBox::new_in(self.ts_unknown_keyword(span), self.allocator)
     }
 
     /// Build a [`TSNullKeyword`].
@@ -11937,14 +11983,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNullKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_null_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_null_keyword(self, span: Span) -> Box<'a, TSNullKeyword> {
-        Box::new_in(self.ts_null_keyword(span), self.allocator)
+    pub fn alloc_ts_null_keyword(self, span: Span) -> ArenaBox<'a, TSNullKeyword> {
+        ArenaBox::new_in(self.ts_null_keyword(span), self.allocator)
     }
 
     /// Build a [`TSUndefinedKeyword`].
@@ -11961,14 +12007,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSUndefinedKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_undefined_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_undefined_keyword(self, span: Span) -> Box<'a, TSUndefinedKeyword> {
-        Box::new_in(self.ts_undefined_keyword(span), self.allocator)
+    pub fn alloc_ts_undefined_keyword(self, span: Span) -> ArenaBox<'a, TSUndefinedKeyword> {
+        ArenaBox::new_in(self.ts_undefined_keyword(span), self.allocator)
     }
 
     /// Build a [`TSVoidKeyword`].
@@ -11985,14 +12031,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSVoidKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_void_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_void_keyword(self, span: Span) -> Box<'a, TSVoidKeyword> {
-        Box::new_in(self.ts_void_keyword(span), self.allocator)
+    pub fn alloc_ts_void_keyword(self, span: Span) -> ArenaBox<'a, TSVoidKeyword> {
+        ArenaBox::new_in(self.ts_void_keyword(span), self.allocator)
     }
 
     /// Build a [`TSSymbolKeyword`].
@@ -12009,14 +12055,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSSymbolKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_symbol_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_symbol_keyword(self, span: Span) -> Box<'a, TSSymbolKeyword> {
-        Box::new_in(self.ts_symbol_keyword(span), self.allocator)
+    pub fn alloc_ts_symbol_keyword(self, span: Span) -> ArenaBox<'a, TSSymbolKeyword> {
+        ArenaBox::new_in(self.ts_symbol_keyword(span), self.allocator)
     }
 
     /// Build a [`TSThisType`].
@@ -12033,14 +12079,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSThisType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_this_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_this_type(self, span: Span) -> Box<'a, TSThisType> {
-        Box::new_in(self.ts_this_type(span), self.allocator)
+    pub fn alloc_ts_this_type(self, span: Span) -> ArenaBox<'a, TSThisType> {
+        ArenaBox::new_in(self.ts_this_type(span), self.allocator)
     }
 
     /// Build a [`TSObjectKeyword`].
@@ -12057,14 +12103,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSObjectKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_object_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_object_keyword(self, span: Span) -> Box<'a, TSObjectKeyword> {
-        Box::new_in(self.ts_object_keyword(span), self.allocator)
+    pub fn alloc_ts_object_keyword(self, span: Span) -> ArenaBox<'a, TSObjectKeyword> {
+        ArenaBox::new_in(self.ts_object_keyword(span), self.allocator)
     }
 
     /// Build a [`TSBigIntKeyword`].
@@ -12081,14 +12127,14 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSBigIntKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_big_int_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_big_int_keyword(self, span: Span) -> Box<'a, TSBigIntKeyword> {
-        Box::new_in(self.ts_big_int_keyword(span), self.allocator)
+    pub fn alloc_ts_big_int_keyword(self, span: Span) -> ArenaBox<'a, TSBigIntKeyword> {
+        ArenaBox::new_in(self.ts_big_int_keyword(span), self.allocator)
     }
 
     /// Build a [`TSTypeReference`].
@@ -12108,7 +12154,7 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T1,
     ) -> TSTypeReference<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSTypeReference {
             node_id: Default::default(),
@@ -12120,7 +12166,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeReference`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_reference`] instead.
     ///
     /// ## Parameters
@@ -12133,11 +12179,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         type_name: TSTypeName<'a>,
         type_arguments: T1,
-    ) -> Box<'a, TSTypeReference<'a>>
+    ) -> ArenaBox<'a, TSTypeReference<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(self.ts_type_reference(span, type_name, type_arguments), self.allocator)
+        ArenaBox::new_in(self.ts_type_reference(span, type_name, type_arguments), self.allocator)
     }
 
     /// Build a [`TSTypeName::IdentifierReference`].
@@ -12230,7 +12276,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSQualifiedName`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_qualified_name`] instead.
     ///
     /// ## Parameters
@@ -12243,8 +12289,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         left: TSTypeName<'a>,
         right: IdentifierName<'a>,
-    ) -> Box<'a, TSQualifiedName<'a>> {
-        Box::new_in(self.ts_qualified_name(span, left, right), self.allocator)
+    ) -> ArenaBox<'a, TSQualifiedName<'a>> {
+        ArenaBox::new_in(self.ts_qualified_name(span, left, right), self.allocator)
     }
 
     /// Build a [`TSTypeParameterInstantiation`].
@@ -12259,14 +12305,14 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_type_parameter_instantiation(
         self,
         span: Span,
-        params: Vec<'a, TSType<'a>>,
+        params: ArenaVec<'a, TSType<'a>>,
     ) -> TSTypeParameterInstantiation<'a> {
         TSTypeParameterInstantiation { node_id: Default::default(), span, params }
     }
 
     /// Build a [`TSTypeParameterInstantiation`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter_instantiation`] instead.
     ///
     /// ## Parameters
@@ -12276,9 +12322,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_type_parameter_instantiation(
         self,
         span: Span,
-        params: Vec<'a, TSType<'a>>,
-    ) -> Box<'a, TSTypeParameterInstantiation<'a>> {
-        Box::new_in(self.ts_type_parameter_instantiation(span, params), self.allocator)
+        params: ArenaVec<'a, TSType<'a>>,
+    ) -> ArenaBox<'a, TSTypeParameterInstantiation<'a>> {
+        ArenaBox::new_in(self.ts_type_parameter_instantiation(span, params), self.allocator)
     }
 
     /// Build a [`TSTypeParameter`].
@@ -12319,7 +12365,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeParameter`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter`] instead.
     ///
     /// ## Parameters
@@ -12340,8 +12386,8 @@ impl<'a> AstBuilder<'a> {
         r#in: bool,
         out: bool,
         r#const: bool,
-    ) -> Box<'a, TSTypeParameter<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, TSTypeParameter<'a>> {
+        ArenaBox::new_in(
             self.ts_type_parameter(span, name, constraint, default, r#in, out, r#const),
             self.allocator,
         )
@@ -12359,14 +12405,14 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_type_parameter_declaration(
         self,
         span: Span,
-        params: Vec<'a, TSTypeParameter<'a>>,
+        params: ArenaVec<'a, TSTypeParameter<'a>>,
     ) -> TSTypeParameterDeclaration<'a> {
         TSTypeParameterDeclaration { node_id: Default::default(), span, params }
     }
 
     /// Build a [`TSTypeParameterDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter_declaration`] instead.
     ///
     /// ## Parameters
@@ -12376,9 +12422,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_type_parameter_declaration(
         self,
         span: Span,
-        params: Vec<'a, TSTypeParameter<'a>>,
-    ) -> Box<'a, TSTypeParameterDeclaration<'a>> {
-        Box::new_in(self.ts_type_parameter_declaration(span, params), self.allocator)
+        params: ArenaVec<'a, TSTypeParameter<'a>>,
+    ) -> ArenaBox<'a, TSTypeParameterDeclaration<'a>> {
+        ArenaBox::new_in(self.ts_type_parameter_declaration(span, params), self.allocator)
     }
 
     /// Build a [`TSTypeAliasDeclaration`].
@@ -12402,7 +12448,7 @@ impl<'a> AstBuilder<'a> {
         declare: bool,
     ) -> TSTypeAliasDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSTypeAliasDeclaration {
             node_id: Default::default(),
@@ -12417,7 +12463,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAliasDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_alias_declaration`] instead.
     ///
     /// ## Parameters
@@ -12434,11 +12480,11 @@ impl<'a> AstBuilder<'a> {
         type_parameters: T1,
         type_annotation: TSType<'a>,
         declare: bool,
-    ) -> Box<'a, TSTypeAliasDeclaration<'a>>
+    ) -> ArenaBox<'a, TSTypeAliasDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_type_alias_declaration(span, id, type_parameters, type_annotation, declare),
             self.allocator,
         )
@@ -12467,7 +12513,7 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSTypeAliasDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
     {
         TSTypeAliasDeclaration {
             node_id: Default::default(),
@@ -12482,7 +12528,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAliasDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_alias_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -12501,11 +12547,11 @@ impl<'a> AstBuilder<'a> {
         type_annotation: TSType<'a>,
         declare: bool,
         scope_id: ScopeId,
-    ) -> Box<'a, TSTypeAliasDeclaration<'a>>
+    ) -> ArenaBox<'a, TSTypeAliasDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_type_alias_declaration_with_scope_id(
                 span,
                 id,
@@ -12532,7 +12578,7 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T1,
     ) -> TSClassImplements<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSClassImplements {
             node_id: Default::default(),
@@ -12560,13 +12606,13 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
+        extends: ArenaVec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
     ) -> TSInterfaceDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
     {
         TSInterfaceDeclaration {
             node_id: Default::default(),
@@ -12582,7 +12628,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInterfaceDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_interface_declaration`] instead.
     ///
     /// ## Parameters
@@ -12598,15 +12644,15 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
+        extends: ArenaVec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
-    ) -> Box<'a, TSInterfaceDeclaration<'a>>
+    ) -> ArenaBox<'a, TSInterfaceDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_interface_declaration(span, id, type_parameters, extends, body, declare),
             self.allocator,
         )
@@ -12631,14 +12677,14 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
+        extends: ArenaVec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
         scope_id: ScopeId,
     ) -> TSInterfaceDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
     {
         TSInterfaceDeclaration {
             node_id: Default::default(),
@@ -12654,7 +12700,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInterfaceDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_interface_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -12671,16 +12717,16 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
+        extends: ArenaVec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
         scope_id: ScopeId,
-    ) -> Box<'a, TSInterfaceDeclaration<'a>>
+    ) -> ArenaBox<'a, TSInterfaceDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, TSInterfaceBody<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_interface_declaration_with_scope_id(
                 span,
                 id,
@@ -12706,14 +12752,14 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_interface_body(
         self,
         span: Span,
-        body: Vec<'a, TSSignature<'a>>,
+        body: ArenaVec<'a, TSSignature<'a>>,
     ) -> TSInterfaceBody<'a> {
         TSInterfaceBody { node_id: Default::default(), span, body }
     }
 
     /// Build a [`TSInterfaceBody`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_interface_body`] instead.
     ///
     /// ## Parameters
@@ -12723,9 +12769,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_interface_body(
         self,
         span: Span,
-        body: Vec<'a, TSSignature<'a>>,
-    ) -> Box<'a, TSInterfaceBody<'a>> {
-        Box::new_in(self.ts_interface_body(span, body), self.allocator)
+        body: ArenaVec<'a, TSSignature<'a>>,
+    ) -> ArenaBox<'a, TSInterfaceBody<'a>> {
+        ArenaBox::new_in(self.ts_interface_body(span, body), self.allocator)
     }
 
     /// Build a [`TSPropertySignature`].
@@ -12751,7 +12797,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: T1,
     ) -> TSPropertySignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSPropertySignature {
             node_id: Default::default(),
@@ -12766,7 +12812,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSPropertySignature`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_property_signature`] instead.
     ///
     /// ## Parameters
@@ -12785,11 +12831,11 @@ impl<'a> AstBuilder<'a> {
         readonly: bool,
         key: PropertyKey<'a>,
         type_annotation: T1,
-    ) -> Box<'a, TSPropertySignature<'a>>
+    ) -> ArenaBox<'a, TSPropertySignature<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_property_signature(span, computed, optional, readonly, key, type_annotation),
             self.allocator,
         )
@@ -12809,13 +12855,13 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_signature_index_signature<T1>(
         self,
         span: Span,
-        parameters: Vec<'a, TSIndexSignatureName<'a>>,
+        parameters: ArenaVec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
         readonly: bool,
         r#static: bool,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSSignature::TSIndexSignature(self.alloc_ts_index_signature(
             span,
@@ -12848,7 +12894,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: T1,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSPropertySignature(self.alloc_ts_property_signature(
             span,
@@ -12880,10 +12926,10 @@ impl<'a> AstBuilder<'a> {
         return_type: T4,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSCallSignatureDeclaration(self.alloc_ts_call_signature_declaration(
             span,
@@ -12916,10 +12962,10 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSCallSignatureDeclaration(
             self.alloc_ts_call_signature_declaration_with_scope_id(
@@ -12951,9 +12997,9 @@ impl<'a> AstBuilder<'a> {
         return_type: T3,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSConstructSignatureDeclaration(self.alloc_ts_construct_signature_declaration(
             span,
@@ -12983,9 +13029,9 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSConstructSignatureDeclaration(
             self.alloc_ts_construct_signature_declaration_with_scope_id(
@@ -13026,10 +13072,10 @@ impl<'a> AstBuilder<'a> {
         return_type: T4,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSMethodSignature(self.alloc_ts_method_signature(
             span,
@@ -13074,10 +13120,10 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSMethodSignature(self.alloc_ts_method_signature_with_scope_id(
             span,
@@ -13108,13 +13154,13 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_index_signature<T1>(
         self,
         span: Span,
-        parameters: Vec<'a, TSIndexSignatureName<'a>>,
+        parameters: ArenaVec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
         readonly: bool,
         r#static: bool,
     ) -> TSIndexSignature<'a>
     where
-        T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSIndexSignature {
             node_id: Default::default(),
@@ -13128,7 +13174,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIndexSignature`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_index_signature`] instead.
     ///
     /// ## Parameters
@@ -13141,15 +13187,15 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_index_signature<T1>(
         self,
         span: Span,
-        parameters: Vec<'a, TSIndexSignatureName<'a>>,
+        parameters: ArenaVec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
         readonly: bool,
         r#static: bool,
-    ) -> Box<'a, TSIndexSignature<'a>>
+    ) -> ArenaBox<'a, TSIndexSignature<'a>>
     where
-        T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_index_signature(span, parameters, type_annotation, readonly, r#static),
             self.allocator,
         )
@@ -13176,10 +13222,10 @@ impl<'a> AstBuilder<'a> {
         return_type: T4,
     ) -> TSCallSignatureDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSCallSignatureDeclaration {
             node_id: Default::default(),
@@ -13194,7 +13240,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSCallSignatureDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_call_signature_declaration`] instead.
     ///
     /// ## Parameters
@@ -13211,14 +13257,14 @@ impl<'a> AstBuilder<'a> {
         this_param: T2,
         params: T3,
         return_type: T4,
-    ) -> Box<'a, TSCallSignatureDeclaration<'a>>
+    ) -> ArenaBox<'a, TSCallSignatureDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_call_signature_declaration(
                 span,
                 type_parameters,
@@ -13253,10 +13299,10 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSCallSignatureDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSCallSignatureDeclaration {
             node_id: Default::default(),
@@ -13271,7 +13317,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSCallSignatureDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_call_signature_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -13290,14 +13336,14 @@ impl<'a> AstBuilder<'a> {
         params: T3,
         return_type: T4,
         scope_id: ScopeId,
-    ) -> Box<'a, TSCallSignatureDeclaration<'a>>
+    ) -> ArenaBox<'a, TSCallSignatureDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_call_signature_declaration_with_scope_id(
                 span,
                 type_parameters,
@@ -13339,10 +13385,10 @@ impl<'a> AstBuilder<'a> {
         return_type: T4,
     ) -> TSMethodSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSMethodSignature {
             node_id: Default::default(),
@@ -13361,7 +13407,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMethodSignature`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_method_signature`] instead.
     ///
     /// ## Parameters
@@ -13386,14 +13432,14 @@ impl<'a> AstBuilder<'a> {
         this_param: T2,
         params: T3,
         return_type: T4,
-    ) -> Box<'a, TSMethodSignature<'a>>
+    ) -> ArenaBox<'a, TSMethodSignature<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_method_signature(
                 span,
                 key,
@@ -13440,10 +13486,10 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSMethodSignature<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSMethodSignature {
             node_id: Default::default(),
@@ -13462,7 +13508,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMethodSignature`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_method_signature_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -13489,14 +13535,14 @@ impl<'a> AstBuilder<'a> {
         params: T3,
         return_type: T4,
         scope_id: ScopeId,
-    ) -> Box<'a, TSMethodSignature<'a>>
+    ) -> ArenaBox<'a, TSMethodSignature<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_method_signature_with_scope_id(
                 span,
                 key,
@@ -13532,9 +13578,9 @@ impl<'a> AstBuilder<'a> {
         return_type: T3,
     ) -> TSConstructSignatureDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSConstructSignatureDeclaration {
             node_id: Default::default(),
@@ -13548,7 +13594,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConstructSignatureDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_construct_signature_declaration`] instead.
     ///
     /// ## Parameters
@@ -13563,13 +13609,13 @@ impl<'a> AstBuilder<'a> {
         type_parameters: T1,
         params: T2,
         return_type: T3,
-    ) -> Box<'a, TSConstructSignatureDeclaration<'a>>
+    ) -> ArenaBox<'a, TSConstructSignatureDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_construct_signature_declaration(span, type_parameters, params, return_type),
             self.allocator,
         )
@@ -13596,9 +13642,9 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSConstructSignatureDeclaration<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSConstructSignatureDeclaration {
             node_id: Default::default(),
@@ -13612,7 +13658,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConstructSignatureDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_construct_signature_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -13629,13 +13675,13 @@ impl<'a> AstBuilder<'a> {
         params: T2,
         return_type: T3,
         scope_id: ScopeId,
-    ) -> Box<'a, TSConstructSignatureDeclaration<'a>>
+    ) -> ArenaBox<'a, TSConstructSignatureDeclaration<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_construct_signature_declaration_with_scope_id(
                 span,
                 type_parameters,
@@ -13662,7 +13708,7 @@ impl<'a> AstBuilder<'a> {
     ) -> TSIndexSignatureName<'a>
     where
         S1: Into<Str<'a>>,
-        T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSIndexSignatureName {
             node_id: Default::default(),
@@ -13686,7 +13732,7 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T1,
     ) -> TSInterfaceHeritage<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSInterfaceHeritage {
             node_id: Default::default(),
@@ -13715,7 +13761,7 @@ impl<'a> AstBuilder<'a> {
         type_annotation: T1,
     ) -> TSTypePredicate<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
         TSTypePredicate {
             node_id: Default::default(),
@@ -13728,7 +13774,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypePredicate`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_predicate`] instead.
     ///
     /// ## Parameters
@@ -13743,11 +13789,11 @@ impl<'a> AstBuilder<'a> {
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
         type_annotation: T1,
-    ) -> Box<'a, TSTypePredicate<'a>>
+    ) -> ArenaBox<'a, TSTypePredicate<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_type_predicate(span, parameter_name, asserts, type_annotation),
             self.allocator,
         )
@@ -13816,7 +13862,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSModuleDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_module_declaration`] instead.
     ///
     /// ## Parameters
@@ -13833,8 +13879,8 @@ impl<'a> AstBuilder<'a> {
         body: Option<TSModuleDeclarationBody<'a>>,
         kind: TSModuleDeclarationKind,
         declare: bool,
-    ) -> Box<'a, TSModuleDeclaration<'a>> {
-        Box::new_in(self.ts_module_declaration(span, id, body, kind, declare), self.allocator)
+    ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
+        ArenaBox::new_in(self.ts_module_declaration(span, id, body, kind, declare), self.allocator)
     }
 
     /// Build a [`TSModuleDeclaration`] with `scope_id`.
@@ -13872,7 +13918,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSModuleDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_module_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -13891,8 +13937,8 @@ impl<'a> AstBuilder<'a> {
         kind: TSModuleDeclarationKind,
         declare: bool,
         scope_id: ScopeId,
-    ) -> Box<'a, TSModuleDeclaration<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
+        ArenaBox::new_in(
             self.ts_module_declaration_with_scope_id(span, id, body, kind, declare, scope_id),
             self.allocator,
         )
@@ -14043,8 +14089,8 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_module_declaration_body_module_block(
         self,
         span: Span,
-        directives: Vec<'a, Directive<'a>>,
-        body: Vec<'a, Statement<'a>>,
+        directives: ArenaVec<'a, Directive<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
     ) -> TSModuleDeclarationBody<'a> {
         TSModuleDeclarationBody::TSModuleBlock(self.alloc_ts_module_block(span, directives, body))
     }
@@ -14079,7 +14125,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSGlobalDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_global_declaration`] instead.
     ///
     /// ## Parameters
@@ -14094,8 +14140,11 @@ impl<'a> AstBuilder<'a> {
         global_span: Span,
         body: TSModuleBlock<'a>,
         declare: bool,
-    ) -> Box<'a, TSGlobalDeclaration<'a>> {
-        Box::new_in(self.ts_global_declaration(span, global_span, body, declare), self.allocator)
+    ) -> ArenaBox<'a, TSGlobalDeclaration<'a>> {
+        ArenaBox::new_in(
+            self.ts_global_declaration(span, global_span, body, declare),
+            self.allocator,
+        )
     }
 
     /// Build a [`TSGlobalDeclaration`] with `scope_id`.
@@ -14130,7 +14179,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSGlobalDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_global_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -14147,8 +14196,8 @@ impl<'a> AstBuilder<'a> {
         body: TSModuleBlock<'a>,
         declare: bool,
         scope_id: ScopeId,
-    ) -> Box<'a, TSGlobalDeclaration<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, TSGlobalDeclaration<'a>> {
+        ArenaBox::new_in(
             self.ts_global_declaration_with_scope_id(span, global_span, body, declare, scope_id),
             self.allocator,
         )
@@ -14167,15 +14216,15 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_module_block(
         self,
         span: Span,
-        directives: Vec<'a, Directive<'a>>,
-        body: Vec<'a, Statement<'a>>,
+        directives: ArenaVec<'a, Directive<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
     ) -> TSModuleBlock<'a> {
         TSModuleBlock { node_id: Default::default(), span, directives, body }
     }
 
     /// Build a [`TSModuleBlock`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_module_block`] instead.
     ///
     /// ## Parameters
@@ -14186,10 +14235,10 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_module_block(
         self,
         span: Span,
-        directives: Vec<'a, Directive<'a>>,
-        body: Vec<'a, Statement<'a>>,
-    ) -> Box<'a, TSModuleBlock<'a>> {
-        Box::new_in(self.ts_module_block(span, directives, body), self.allocator)
+        directives: ArenaVec<'a, Directive<'a>>,
+        body: ArenaVec<'a, Statement<'a>>,
+    ) -> ArenaBox<'a, TSModuleBlock<'a>> {
+        ArenaBox::new_in(self.ts_module_block(span, directives, body), self.allocator)
     }
 
     /// Build a [`TSTypeLiteral`].
@@ -14204,14 +14253,14 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_type_literal(
         self,
         span: Span,
-        members: Vec<'a, TSSignature<'a>>,
+        members: ArenaVec<'a, TSSignature<'a>>,
     ) -> TSTypeLiteral<'a> {
         TSTypeLiteral { node_id: Default::default(), span, members }
     }
 
     /// Build a [`TSTypeLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_literal`] instead.
     ///
     /// ## Parameters
@@ -14221,9 +14270,9 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_type_literal(
         self,
         span: Span,
-        members: Vec<'a, TSSignature<'a>>,
-    ) -> Box<'a, TSTypeLiteral<'a>> {
-        Box::new_in(self.ts_type_literal(span, members), self.allocator)
+        members: ArenaVec<'a, TSSignature<'a>>,
+    ) -> ArenaBox<'a, TSTypeLiteral<'a>> {
+        ArenaBox::new_in(self.ts_type_literal(span, members), self.allocator)
     }
 
     /// Build a [`TSInferType`].
@@ -14237,7 +14286,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn ts_infer_type<T1>(self, span: Span, type_parameter: T1) -> TSInferType<'a>
     where
-        T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameter<'a>>>,
     {
         TSInferType {
             node_id: Default::default(),
@@ -14248,18 +14297,22 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInferType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_infer_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
     #[inline]
-    pub fn alloc_ts_infer_type<T1>(self, span: Span, type_parameter: T1) -> Box<'a, TSInferType<'a>>
+    pub fn alloc_ts_infer_type<T1>(
+        self,
+        span: Span,
+        type_parameter: T1,
+    ) -> ArenaBox<'a, TSInferType<'a>>
     where
-        T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameter<'a>>>,
     {
-        Box::new_in(self.ts_infer_type(span, type_parameter), self.allocator)
+        ArenaBox::new_in(self.ts_infer_type(span, type_parameter), self.allocator)
     }
 
     /// Build a [`TSTypeQuery`].
@@ -14279,7 +14332,7 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T1,
     ) -> TSTypeQuery<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSTypeQuery {
             node_id: Default::default(),
@@ -14291,7 +14344,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeQuery`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_query`] instead.
     ///
     /// ## Parameters
@@ -14304,11 +14357,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
         type_arguments: T1,
-    ) -> Box<'a, TSTypeQuery<'a>>
+    ) -> ArenaBox<'a, TSTypeQuery<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(self.ts_type_query(span, expr_name, type_arguments), self.allocator)
+        ArenaBox::new_in(self.ts_type_query(span, expr_name, type_arguments), self.allocator)
     }
 
     /// Build a [`TSTypeQueryExprName::TSImportType`].
@@ -14331,8 +14384,8 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T2,
     ) -> TSTypeQueryExprName<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, ObjectExpression<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, ObjectExpression<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSTypeQueryExprName::TSImportType(self.alloc_ts_import_type(
             span,
@@ -14364,8 +14417,8 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T2,
     ) -> TSImportType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, ObjectExpression<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, ObjectExpression<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSImportType {
             node_id: Default::default(),
@@ -14379,7 +14432,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSImportType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_import_type`] instead.
     ///
     /// ## Parameters
@@ -14396,12 +14449,12 @@ impl<'a> AstBuilder<'a> {
         options: T1,
         qualifier: Option<TSImportTypeQualifier<'a>>,
         type_arguments: T2,
-    ) -> Box<'a, TSImportType<'a>>
+    ) -> ArenaBox<'a, TSImportType<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, ObjectExpression<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, ObjectExpression<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_import_type(span, source, options, qualifier, type_arguments),
             self.allocator,
         )
@@ -14467,7 +14520,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSImportTypeQualifiedName`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_import_type_qualified_name`] instead.
     ///
     /// ## Parameters
@@ -14480,8 +14533,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         left: TSImportTypeQualifier<'a>,
         right: IdentifierName<'a>,
-    ) -> Box<'a, TSImportTypeQualifiedName<'a>> {
-        Box::new_in(self.ts_import_type_qualified_name(span, left, right), self.allocator)
+    ) -> ArenaBox<'a, TSImportTypeQualifiedName<'a>> {
+        ArenaBox::new_in(self.ts_import_type_qualified_name(span, left, right), self.allocator)
     }
 
     /// Build a [`TSFunctionType`].
@@ -14505,10 +14558,10 @@ impl<'a> AstBuilder<'a> {
         return_type: T4,
     ) -> TSFunctionType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSFunctionType {
             node_id: Default::default(),
@@ -14523,7 +14576,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSFunctionType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_function_type`] instead.
     ///
     /// ## Parameters
@@ -14540,14 +14593,14 @@ impl<'a> AstBuilder<'a> {
         this_param: T2,
         params: T3,
         return_type: T4,
-    ) -> Box<'a, TSFunctionType<'a>>
+    ) -> ArenaBox<'a, TSFunctionType<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_function_type(span, type_parameters, this_param, params, return_type),
             self.allocator,
         )
@@ -14576,10 +14629,10 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSFunctionType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSFunctionType {
             node_id: Default::default(),
@@ -14594,7 +14647,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSFunctionType`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_function_type_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -14613,14 +14666,14 @@ impl<'a> AstBuilder<'a> {
         params: T3,
         return_type: T4,
         scope_id: ScopeId,
-    ) -> Box<'a, TSFunctionType<'a>>
+    ) -> ArenaBox<'a, TSFunctionType<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
-        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T4: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, Option<ArenaBox<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_function_type_with_scope_id(
                 span,
                 type_parameters,
@@ -14654,9 +14707,9 @@ impl<'a> AstBuilder<'a> {
         return_type: T3,
     ) -> TSConstructorType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSConstructorType {
             node_id: Default::default(),
@@ -14671,7 +14724,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConstructorType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_constructor_type`] instead.
     ///
     /// ## Parameters
@@ -14688,13 +14741,13 @@ impl<'a> AstBuilder<'a> {
         type_parameters: T1,
         params: T2,
         return_type: T3,
-    ) -> Box<'a, TSConstructorType<'a>>
+    ) -> ArenaBox<'a, TSConstructorType<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_constructor_type(span, r#abstract, type_parameters, params, return_type),
             self.allocator,
         )
@@ -14723,9 +14776,9 @@ impl<'a> AstBuilder<'a> {
         scope_id: ScopeId,
     ) -> TSConstructorType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
         TSConstructorType {
             node_id: Default::default(),
@@ -14740,7 +14793,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConstructorType`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_constructor_type_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -14759,13 +14812,13 @@ impl<'a> AstBuilder<'a> {
         params: T2,
         return_type: T3,
         scope_id: ScopeId,
-    ) -> Box<'a, TSConstructorType<'a>>
+    ) -> ArenaBox<'a, TSConstructorType<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>,
+        T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>>,
+        T2: IntoIn<'a, ArenaBox<'a, FormalParameters<'a>>>,
+        T3: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_constructor_type_with_scope_id(
                 span,
                 r#abstract,
@@ -14817,7 +14870,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMappedType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_mapped_type`] instead.
     ///
     /// ## Parameters
@@ -14838,8 +14891,8 @@ impl<'a> AstBuilder<'a> {
         type_annotation: Option<TSType<'a>>,
         optional: Option<TSMappedTypeModifierOperator>,
         readonly: Option<TSMappedTypeModifierOperator>,
-    ) -> Box<'a, TSMappedType<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, TSMappedType<'a>> {
+        ArenaBox::new_in(
             self.ts_mapped_type(
                 span,
                 key,
@@ -14894,7 +14947,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMappedType`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_mapped_type_with_scope_id`] instead.
     ///
     /// ## Parameters
@@ -14917,8 +14970,8 @@ impl<'a> AstBuilder<'a> {
         optional: Option<TSMappedTypeModifierOperator>,
         readonly: Option<TSMappedTypeModifierOperator>,
         scope_id: ScopeId,
-    ) -> Box<'a, TSMappedType<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, TSMappedType<'a>> {
+        ArenaBox::new_in(
             self.ts_mapped_type_with_scope_id(
                 span,
                 key,
@@ -14946,15 +14999,15 @@ impl<'a> AstBuilder<'a> {
     pub fn ts_template_literal_type(
         self,
         span: Span,
-        quasis: Vec<'a, TemplateElement<'a>>,
-        types: Vec<'a, TSType<'a>>,
+        quasis: ArenaVec<'a, TemplateElement<'a>>,
+        types: ArenaVec<'a, TSType<'a>>,
     ) -> TSTemplateLiteralType<'a> {
         TSTemplateLiteralType { node_id: Default::default(), span, quasis, types }
     }
 
     /// Build a [`TSTemplateLiteralType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_template_literal_type`] instead.
     ///
     /// ## Parameters
@@ -14965,10 +15018,10 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_ts_template_literal_type(
         self,
         span: Span,
-        quasis: Vec<'a, TemplateElement<'a>>,
-        types: Vec<'a, TSType<'a>>,
-    ) -> Box<'a, TSTemplateLiteralType<'a>> {
-        Box::new_in(self.ts_template_literal_type(span, quasis, types), self.allocator)
+        quasis: ArenaVec<'a, TemplateElement<'a>>,
+        types: ArenaVec<'a, TSType<'a>>,
+    ) -> ArenaBox<'a, TSTemplateLiteralType<'a>> {
+        ArenaBox::new_in(self.ts_template_literal_type(span, quasis, types), self.allocator)
     }
 
     /// Build a [`TSAsExpression`].
@@ -14992,7 +15045,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSAsExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_as_expression`] instead.
     ///
     /// ## Parameters
@@ -15005,8 +15058,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
-    ) -> Box<'a, TSAsExpression<'a>> {
-        Box::new_in(self.ts_as_expression(span, expression, type_annotation), self.allocator)
+    ) -> ArenaBox<'a, TSAsExpression<'a>> {
+        ArenaBox::new_in(self.ts_as_expression(span, expression, type_annotation), self.allocator)
     }
 
     /// Build a [`TSSatisfiesExpression`].
@@ -15030,7 +15083,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSSatisfiesExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_satisfies_expression`] instead.
     ///
     /// ## Parameters
@@ -15043,8 +15096,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
-    ) -> Box<'a, TSSatisfiesExpression<'a>> {
-        Box::new_in(self.ts_satisfies_expression(span, expression, type_annotation), self.allocator)
+    ) -> ArenaBox<'a, TSSatisfiesExpression<'a>> {
+        ArenaBox::new_in(
+            self.ts_satisfies_expression(span, expression, type_annotation),
+            self.allocator,
+        )
     }
 
     /// Build a [`TSTypeAssertion`].
@@ -15068,7 +15124,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAssertion`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_type_assertion`] instead.
     ///
     /// ## Parameters
@@ -15081,8 +15137,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         type_annotation: TSType<'a>,
         expression: Expression<'a>,
-    ) -> Box<'a, TSTypeAssertion<'a>> {
-        Box::new_in(self.ts_type_assertion(span, type_annotation, expression), self.allocator)
+    ) -> ArenaBox<'a, TSTypeAssertion<'a>> {
+        ArenaBox::new_in(self.ts_type_assertion(span, type_annotation, expression), self.allocator)
     }
 
     /// Build a [`TSImportEqualsDeclaration`].
@@ -15114,7 +15170,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSImportEqualsDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_import_equals_declaration`] instead.
     ///
     /// ## Parameters
@@ -15129,8 +15185,8 @@ impl<'a> AstBuilder<'a> {
         id: BindingIdentifier<'a>,
         module_reference: TSModuleReference<'a>,
         import_kind: ImportOrExportKind,
-    ) -> Box<'a, TSImportEqualsDeclaration<'a>> {
-        Box::new_in(
+    ) -> ArenaBox<'a, TSImportEqualsDeclaration<'a>> {
+        ArenaBox::new_in(
             self.ts_import_equals_declaration(span, id, module_reference, import_kind),
             self.allocator,
         )
@@ -15235,7 +15291,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSExternalModuleReference`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_external_module_reference`] instead.
     ///
     /// ## Parameters
@@ -15246,8 +15302,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         expression: StringLiteral<'a>,
-    ) -> Box<'a, TSExternalModuleReference<'a>> {
-        Box::new_in(self.ts_external_module_reference(span, expression), self.allocator)
+    ) -> ArenaBox<'a, TSExternalModuleReference<'a>> {
+        ArenaBox::new_in(self.ts_external_module_reference(span, expression), self.allocator)
     }
 
     /// Build a [`TSNonNullExpression`].
@@ -15269,7 +15325,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNonNullExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_non_null_expression`] instead.
     ///
     /// ## Parameters
@@ -15280,8 +15336,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         expression: Expression<'a>,
-    ) -> Box<'a, TSNonNullExpression<'a>> {
-        Box::new_in(self.ts_non_null_expression(span, expression), self.allocator)
+    ) -> ArenaBox<'a, TSNonNullExpression<'a>> {
+        ArenaBox::new_in(self.ts_non_null_expression(span, expression), self.allocator)
     }
 
     /// Build a [`Decorator`].
@@ -15313,7 +15369,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSExportAssignment`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_export_assignment`] instead.
     ///
     /// ## Parameters
@@ -15324,8 +15380,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         expression: Expression<'a>,
-    ) -> Box<'a, TSExportAssignment<'a>> {
-        Box::new_in(self.ts_export_assignment(span, expression), self.allocator)
+    ) -> ArenaBox<'a, TSExportAssignment<'a>> {
+        ArenaBox::new_in(self.ts_export_assignment(span, expression), self.allocator)
     }
 
     /// Build a [`TSNamespaceExportDeclaration`].
@@ -15347,7 +15403,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNamespaceExportDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_namespace_export_declaration`] instead.
     ///
     /// ## Parameters
@@ -15358,8 +15414,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         id: IdentifierName<'a>,
-    ) -> Box<'a, TSNamespaceExportDeclaration<'a>> {
-        Box::new_in(self.ts_namespace_export_declaration(span, id), self.allocator)
+    ) -> ArenaBox<'a, TSNamespaceExportDeclaration<'a>> {
+        ArenaBox::new_in(self.ts_namespace_export_declaration(span, id), self.allocator)
     }
 
     /// Build a [`TSInstantiationExpression`].
@@ -15379,7 +15435,7 @@ impl<'a> AstBuilder<'a> {
         type_arguments: T1,
     ) -> TSInstantiationExpression<'a>
     where
-        T1: IntoIn<'a, Box<'a, TSTypeParameterInstantiation<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
     {
         TSInstantiationExpression {
             node_id: Default::default(),
@@ -15391,7 +15447,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInstantiationExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::ts_instantiation_expression`] instead.
     ///
     /// ## Parameters
@@ -15404,11 +15460,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         expression: Expression<'a>,
         type_arguments: T1,
-    ) -> Box<'a, TSInstantiationExpression<'a>>
+    ) -> ArenaBox<'a, TSInstantiationExpression<'a>>
     where
-        T1: IntoIn<'a, Box<'a, TSTypeParameterInstantiation<'a>>>,
+        T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
     {
-        Box::new_in(
+        ArenaBox::new_in(
             self.ts_instantiation_expression(span, expression, type_arguments),
             self.allocator,
         )
@@ -15435,7 +15491,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSDocNullableType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::js_doc_nullable_type`] instead.
     ///
     /// ## Parameters
@@ -15448,8 +15504,8 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
-    ) -> Box<'a, JSDocNullableType<'a>> {
-        Box::new_in(self.js_doc_nullable_type(span, type_annotation, postfix), self.allocator)
+    ) -> ArenaBox<'a, JSDocNullableType<'a>> {
+        ArenaBox::new_in(self.js_doc_nullable_type(span, type_annotation, postfix), self.allocator)
     }
 
     /// Build a [`JSDocNonNullableType`].
@@ -15473,7 +15529,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSDocNonNullableType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::js_doc_non_nullable_type`] instead.
     ///
     /// ## Parameters
@@ -15486,8 +15542,11 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
-    ) -> Box<'a, JSDocNonNullableType<'a>> {
-        Box::new_in(self.js_doc_non_nullable_type(span, type_annotation, postfix), self.allocator)
+    ) -> ArenaBox<'a, JSDocNonNullableType<'a>> {
+        ArenaBox::new_in(
+            self.js_doc_non_nullable_type(span, type_annotation, postfix),
+            self.allocator,
+        )
     }
 
     /// Build a [`JSDocUnknownType`].
@@ -15504,13 +15563,13 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSDocUnknownType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node.
+    /// Returns a [`Box`](ArenaBox) containing the newly-allocated node.
     /// If you want a stack-allocated node, use [`AstBuilder::js_doc_unknown_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_js_doc_unknown_type(self, span: Span) -> Box<'a, JSDocUnknownType> {
-        Box::new_in(self.js_doc_unknown_type(span), self.allocator)
+    pub fn alloc_js_doc_unknown_type(self, span: Span) -> ArenaBox<'a, JSDocUnknownType> {
+        ArenaBox::new_in(self.js_doc_unknown_type(span), self.allocator)
     }
 }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -12,7 +12,7 @@
 
 use std::cell::Cell;
 
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
 use oxc_ast::ast::*;
@@ -1205,145 +1205,148 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_directives(&mut self, it: &Vec<'a, Directive<'a>>) {
+    fn visit_directives(&mut self, it: &ArenaVec<'a, Directive<'a>>) {
         walk_directives(self, it);
     }
 
     #[inline]
-    fn visit_statements(&mut self, it: &Vec<'a, Statement<'a>>) {
+    fn visit_statements(&mut self, it: &ArenaVec<'a, Statement<'a>>) {
         walk_statements(self, it);
     }
 
     #[inline]
-    fn visit_array_expression_elements(&mut self, it: &Vec<'a, ArrayExpressionElement<'a>>) {
+    fn visit_array_expression_elements(&mut self, it: &ArenaVec<'a, ArrayExpressionElement<'a>>) {
         walk_array_expression_elements(self, it);
     }
 
     #[inline]
-    fn visit_object_property_kinds(&mut self, it: &Vec<'a, ObjectPropertyKind<'a>>) {
+    fn visit_object_property_kinds(&mut self, it: &ArenaVec<'a, ObjectPropertyKind<'a>>) {
         walk_object_property_kinds(self, it);
     }
 
     #[inline]
-    fn visit_template_elements(&mut self, it: &Vec<'a, TemplateElement<'a>>) {
+    fn visit_template_elements(&mut self, it: &ArenaVec<'a, TemplateElement<'a>>) {
         walk_template_elements(self, it);
     }
 
     #[inline]
-    fn visit_expressions(&mut self, it: &Vec<'a, Expression<'a>>) {
+    fn visit_expressions(&mut self, it: &ArenaVec<'a, Expression<'a>>) {
         walk_expressions(self, it);
     }
 
     #[inline]
-    fn visit_arguments(&mut self, it: &Vec<'a, Argument<'a>>) {
+    fn visit_arguments(&mut self, it: &ArenaVec<'a, Argument<'a>>) {
         walk_arguments(self, it);
     }
 
     #[inline]
-    fn visit_assignment_target_properties(&mut self, it: &Vec<'a, AssignmentTargetProperty<'a>>) {
+    fn visit_assignment_target_properties(
+        &mut self,
+        it: &ArenaVec<'a, AssignmentTargetProperty<'a>>,
+    ) {
         walk_assignment_target_properties(self, it);
     }
 
     #[inline]
-    fn visit_variable_declarators(&mut self, it: &Vec<'a, VariableDeclarator<'a>>) {
+    fn visit_variable_declarators(&mut self, it: &ArenaVec<'a, VariableDeclarator<'a>>) {
         walk_variable_declarators(self, it);
     }
 
     #[inline]
-    fn visit_switch_cases(&mut self, it: &Vec<'a, SwitchCase<'a>>) {
+    fn visit_switch_cases(&mut self, it: &ArenaVec<'a, SwitchCase<'a>>) {
         walk_switch_cases(self, it);
     }
 
     #[inline]
-    fn visit_binding_properties(&mut self, it: &Vec<'a, BindingProperty<'a>>) {
+    fn visit_binding_properties(&mut self, it: &ArenaVec<'a, BindingProperty<'a>>) {
         walk_binding_properties(self, it);
     }
 
     #[inline]
-    fn visit_formal_parameter_list(&mut self, it: &Vec<'a, FormalParameter<'a>>) {
+    fn visit_formal_parameter_list(&mut self, it: &ArenaVec<'a, FormalParameter<'a>>) {
         walk_formal_parameter_list(self, it);
     }
 
     #[inline]
-    fn visit_decorators(&mut self, it: &Vec<'a, Decorator<'a>>) {
+    fn visit_decorators(&mut self, it: &ArenaVec<'a, Decorator<'a>>) {
         walk_decorators(self, it);
     }
 
     #[inline]
-    fn visit_ts_class_implements_list(&mut self, it: &Vec<'a, TSClassImplements<'a>>) {
+    fn visit_ts_class_implements_list(&mut self, it: &ArenaVec<'a, TSClassImplements<'a>>) {
         walk_ts_class_implements_list(self, it);
     }
 
     #[inline]
-    fn visit_class_elements(&mut self, it: &Vec<'a, ClassElement<'a>>) {
+    fn visit_class_elements(&mut self, it: &ArenaVec<'a, ClassElement<'a>>) {
         walk_class_elements(self, it);
     }
 
     #[inline]
     fn visit_import_declaration_specifiers(
         &mut self,
-        it: &Vec<'a, ImportDeclarationSpecifier<'a>>,
+        it: &ArenaVec<'a, ImportDeclarationSpecifier<'a>>,
     ) {
         walk_import_declaration_specifiers(self, it);
     }
 
     #[inline]
-    fn visit_import_attributes(&mut self, it: &Vec<'a, ImportAttribute<'a>>) {
+    fn visit_import_attributes(&mut self, it: &ArenaVec<'a, ImportAttribute<'a>>) {
         walk_import_attributes(self, it);
     }
 
     #[inline]
-    fn visit_export_specifiers(&mut self, it: &Vec<'a, ExportSpecifier<'a>>) {
+    fn visit_export_specifiers(&mut self, it: &ArenaVec<'a, ExportSpecifier<'a>>) {
         walk_export_specifiers(self, it);
     }
 
     #[inline]
-    fn visit_jsx_children(&mut self, it: &Vec<'a, JSXChild<'a>>) {
+    fn visit_jsx_children(&mut self, it: &ArenaVec<'a, JSXChild<'a>>) {
         walk_jsx_children(self, it);
     }
 
     #[inline]
-    fn visit_jsx_attribute_items(&mut self, it: &Vec<'a, JSXAttributeItem<'a>>) {
+    fn visit_jsx_attribute_items(&mut self, it: &ArenaVec<'a, JSXAttributeItem<'a>>) {
         walk_jsx_attribute_items(self, it);
     }
 
     #[inline]
-    fn visit_ts_enum_members(&mut self, it: &Vec<'a, TSEnumMember<'a>>) {
+    fn visit_ts_enum_members(&mut self, it: &ArenaVec<'a, TSEnumMember<'a>>) {
         walk_ts_enum_members(self, it);
     }
 
     #[inline]
-    fn visit_ts_types(&mut self, it: &Vec<'a, TSType<'a>>) {
+    fn visit_ts_types(&mut self, it: &ArenaVec<'a, TSType<'a>>) {
         walk_ts_types(self, it);
     }
 
     #[inline]
-    fn visit_ts_tuple_elements(&mut self, it: &Vec<'a, TSTupleElement<'a>>) {
+    fn visit_ts_tuple_elements(&mut self, it: &ArenaVec<'a, TSTupleElement<'a>>) {
         walk_ts_tuple_elements(self, it);
     }
 
     #[inline]
-    fn visit_ts_type_parameters(&mut self, it: &Vec<'a, TSTypeParameter<'a>>) {
+    fn visit_ts_type_parameters(&mut self, it: &ArenaVec<'a, TSTypeParameter<'a>>) {
         walk_ts_type_parameters(self, it);
     }
 
     #[inline]
-    fn visit_ts_interface_heritages(&mut self, it: &Vec<'a, TSInterfaceHeritage<'a>>) {
+    fn visit_ts_interface_heritages(&mut self, it: &ArenaVec<'a, TSInterfaceHeritage<'a>>) {
         walk_ts_interface_heritages(self, it);
     }
 
     #[inline]
-    fn visit_ts_signatures(&mut self, it: &Vec<'a, TSSignature<'a>>) {
+    fn visit_ts_signatures(&mut self, it: &ArenaVec<'a, TSSignature<'a>>) {
         walk_ts_signatures(self, it);
     }
 
     #[inline]
-    fn visit_ts_index_signature_names(&mut self, it: &Vec<'a, TSIndexSignatureName<'a>>) {
+    fn visit_ts_index_signature_names(&mut self, it: &ArenaVec<'a, TSIndexSignatureName<'a>>) {
         walk_ts_index_signature_names(self, it);
     }
 
     #[inline]
-    fn visit_spans(&mut self, it: &Vec<'a, Span>) {
+    fn visit_spans(&mut self, it: &ArenaVec<'a, Span>) {
         walk_spans(self, it);
     }
 }
@@ -4241,14 +4244,14 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_directives<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Directive<'a>>) {
+    pub fn walk_directives<'a, V: Visit<'a>>(visitor: &mut V, it: &ArenaVec<'a, Directive<'a>>) {
         for el in it {
             visitor.visit_directive(el);
         }
     }
 
     #[inline]
-    pub fn walk_statements<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Statement<'a>>) {
+    pub fn walk_statements<'a, V: Visit<'a>>(visitor: &mut V, it: &ArenaVec<'a, Statement<'a>>) {
         for el in it {
             visitor.visit_statement(el);
         }
@@ -4257,7 +4260,7 @@ pub mod walk {
     #[inline]
     pub fn walk_array_expression_elements<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, ArrayExpressionElement<'a>>,
+        it: &ArenaVec<'a, ArrayExpressionElement<'a>>,
     ) {
         for el in it {
             visitor.visit_array_expression_element(el);
@@ -4267,7 +4270,7 @@ pub mod walk {
     #[inline]
     pub fn walk_object_property_kinds<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, ObjectPropertyKind<'a>>,
+        it: &ArenaVec<'a, ObjectPropertyKind<'a>>,
     ) {
         for el in it {
             visitor.visit_object_property_kind(el);
@@ -4277,7 +4280,7 @@ pub mod walk {
     #[inline]
     pub fn walk_template_elements<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, TemplateElement<'a>>,
+        it: &ArenaVec<'a, TemplateElement<'a>>,
     ) {
         for el in it {
             visitor.visit_template_element(el);
@@ -4285,14 +4288,14 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_expressions<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Expression<'a>>) {
+    pub fn walk_expressions<'a, V: Visit<'a>>(visitor: &mut V, it: &ArenaVec<'a, Expression<'a>>) {
         for el in it {
             visitor.visit_expression(el);
         }
     }
 
     #[inline]
-    pub fn walk_arguments<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Argument<'a>>) {
+    pub fn walk_arguments<'a, V: Visit<'a>>(visitor: &mut V, it: &ArenaVec<'a, Argument<'a>>) {
         for el in it {
             match el {
                 oxc_ast::ast::Argument::SpreadElement(spread) => {
@@ -4308,7 +4311,7 @@ pub mod walk {
     #[inline]
     pub fn walk_assignment_target_properties<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, AssignmentTargetProperty<'a>>,
+        it: &ArenaVec<'a, AssignmentTargetProperty<'a>>,
     ) {
         for el in it {
             visitor.visit_assignment_target_property(el);
@@ -4318,7 +4321,7 @@ pub mod walk {
     #[inline]
     pub fn walk_variable_declarators<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, VariableDeclarator<'a>>,
+        it: &ArenaVec<'a, VariableDeclarator<'a>>,
     ) {
         for el in it {
             visitor.visit_variable_declarator(el);
@@ -4326,7 +4329,7 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_switch_cases<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, SwitchCase<'a>>) {
+    pub fn walk_switch_cases<'a, V: Visit<'a>>(visitor: &mut V, it: &ArenaVec<'a, SwitchCase<'a>>) {
         for el in it {
             visitor.visit_switch_case(el);
         }
@@ -4335,7 +4338,7 @@ pub mod walk {
     #[inline]
     pub fn walk_binding_properties<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, BindingProperty<'a>>,
+        it: &ArenaVec<'a, BindingProperty<'a>>,
     ) {
         for el in it {
             visitor.visit_binding_property(el);
@@ -4345,7 +4348,7 @@ pub mod walk {
     #[inline]
     pub fn walk_formal_parameter_list<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, FormalParameter<'a>>,
+        it: &ArenaVec<'a, FormalParameter<'a>>,
     ) {
         for el in it {
             visitor.visit_formal_parameter(el);
@@ -4353,7 +4356,7 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_decorators<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Decorator<'a>>) {
+    pub fn walk_decorators<'a, V: Visit<'a>>(visitor: &mut V, it: &ArenaVec<'a, Decorator<'a>>) {
         for el in it {
             visitor.visit_decorator(el);
         }
@@ -4362,7 +4365,7 @@ pub mod walk {
     #[inline]
     pub fn walk_ts_class_implements_list<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, TSClassImplements<'a>>,
+        it: &ArenaVec<'a, TSClassImplements<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_class_implements(el);
@@ -4370,7 +4373,10 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_class_elements<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, ClassElement<'a>>) {
+    pub fn walk_class_elements<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ArenaVec<'a, ClassElement<'a>>,
+    ) {
         for el in it {
             visitor.visit_class_element(el);
         }
@@ -4379,7 +4385,7 @@ pub mod walk {
     #[inline]
     pub fn walk_import_declaration_specifiers<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, ImportDeclarationSpecifier<'a>>,
+        it: &ArenaVec<'a, ImportDeclarationSpecifier<'a>>,
     ) {
         for el in it {
             visitor.visit_import_declaration_specifier(el);
@@ -4389,7 +4395,7 @@ pub mod walk {
     #[inline]
     pub fn walk_import_attributes<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, ImportAttribute<'a>>,
+        it: &ArenaVec<'a, ImportAttribute<'a>>,
     ) {
         for el in it {
             visitor.visit_import_attribute(el);
@@ -4399,7 +4405,7 @@ pub mod walk {
     #[inline]
     pub fn walk_export_specifiers<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, ExportSpecifier<'a>>,
+        it: &ArenaVec<'a, ExportSpecifier<'a>>,
     ) {
         for el in it {
             visitor.visit_export_specifier(el);
@@ -4407,7 +4413,7 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_jsx_children<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, JSXChild<'a>>) {
+    pub fn walk_jsx_children<'a, V: Visit<'a>>(visitor: &mut V, it: &ArenaVec<'a, JSXChild<'a>>) {
         for el in it {
             visitor.visit_jsx_child(el);
         }
@@ -4416,7 +4422,7 @@ pub mod walk {
     #[inline]
     pub fn walk_jsx_attribute_items<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, JSXAttributeItem<'a>>,
+        it: &ArenaVec<'a, JSXAttributeItem<'a>>,
     ) {
         for el in it {
             visitor.visit_jsx_attribute_item(el);
@@ -4424,14 +4430,17 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_ts_enum_members<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSEnumMember<'a>>) {
+    pub fn walk_ts_enum_members<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ArenaVec<'a, TSEnumMember<'a>>,
+    ) {
         for el in it {
             visitor.visit_ts_enum_member(el);
         }
     }
 
     #[inline]
-    pub fn walk_ts_types<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSType<'a>>) {
+    pub fn walk_ts_types<'a, V: Visit<'a>>(visitor: &mut V, it: &ArenaVec<'a, TSType<'a>>) {
         for el in it {
             visitor.visit_ts_type(el);
         }
@@ -4440,7 +4449,7 @@ pub mod walk {
     #[inline]
     pub fn walk_ts_tuple_elements<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, TSTupleElement<'a>>,
+        it: &ArenaVec<'a, TSTupleElement<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_tuple_element(el);
@@ -4450,7 +4459,7 @@ pub mod walk {
     #[inline]
     pub fn walk_ts_type_parameters<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, TSTypeParameter<'a>>,
+        it: &ArenaVec<'a, TSTypeParameter<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_type_parameter(el);
@@ -4460,7 +4469,7 @@ pub mod walk {
     #[inline]
     pub fn walk_ts_interface_heritages<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, TSInterfaceHeritage<'a>>,
+        it: &ArenaVec<'a, TSInterfaceHeritage<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_interface_heritage(el);
@@ -4468,7 +4477,10 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_ts_signatures<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSSignature<'a>>) {
+    pub fn walk_ts_signatures<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ArenaVec<'a, TSSignature<'a>>,
+    ) {
         for el in it {
             visitor.visit_ts_signature(el);
         }
@@ -4477,7 +4489,7 @@ pub mod walk {
     #[inline]
     pub fn walk_ts_index_signature_names<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, TSIndexSignatureName<'a>>,
+        it: &ArenaVec<'a, TSIndexSignatureName<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_index_signature_name(el);
@@ -4485,7 +4497,7 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_spans<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Span>) {
+    pub fn walk_spans<'a, V: Visit<'a>>(visitor: &mut V, it: &ArenaVec<'a, Span>) {
         for el in it {
             visitor.visit_span(el);
         }

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -12,7 +12,7 @@
 
 use std::cell::Cell;
 
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
 use oxc_ast::ast::*;
@@ -1197,148 +1197,151 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_directives(&mut self, it: &mut Vec<'a, Directive<'a>>) {
+    fn visit_directives(&mut self, it: &mut ArenaVec<'a, Directive<'a>>) {
         walk_directives(self, it);
     }
 
     #[inline]
-    fn visit_statements(&mut self, it: &mut Vec<'a, Statement<'a>>) {
+    fn visit_statements(&mut self, it: &mut ArenaVec<'a, Statement<'a>>) {
         walk_statements(self, it);
     }
 
     #[inline]
-    fn visit_array_expression_elements(&mut self, it: &mut Vec<'a, ArrayExpressionElement<'a>>) {
+    fn visit_array_expression_elements(
+        &mut self,
+        it: &mut ArenaVec<'a, ArrayExpressionElement<'a>>,
+    ) {
         walk_array_expression_elements(self, it);
     }
 
     #[inline]
-    fn visit_object_property_kinds(&mut self, it: &mut Vec<'a, ObjectPropertyKind<'a>>) {
+    fn visit_object_property_kinds(&mut self, it: &mut ArenaVec<'a, ObjectPropertyKind<'a>>) {
         walk_object_property_kinds(self, it);
     }
 
     #[inline]
-    fn visit_template_elements(&mut self, it: &mut Vec<'a, TemplateElement<'a>>) {
+    fn visit_template_elements(&mut self, it: &mut ArenaVec<'a, TemplateElement<'a>>) {
         walk_template_elements(self, it);
     }
 
     #[inline]
-    fn visit_expressions(&mut self, it: &mut Vec<'a, Expression<'a>>) {
+    fn visit_expressions(&mut self, it: &mut ArenaVec<'a, Expression<'a>>) {
         walk_expressions(self, it);
     }
 
     #[inline]
-    fn visit_arguments(&mut self, it: &mut Vec<'a, Argument<'a>>) {
+    fn visit_arguments(&mut self, it: &mut ArenaVec<'a, Argument<'a>>) {
         walk_arguments(self, it);
     }
 
     #[inline]
     fn visit_assignment_target_properties(
         &mut self,
-        it: &mut Vec<'a, AssignmentTargetProperty<'a>>,
+        it: &mut ArenaVec<'a, AssignmentTargetProperty<'a>>,
     ) {
         walk_assignment_target_properties(self, it);
     }
 
     #[inline]
-    fn visit_variable_declarators(&mut self, it: &mut Vec<'a, VariableDeclarator<'a>>) {
+    fn visit_variable_declarators(&mut self, it: &mut ArenaVec<'a, VariableDeclarator<'a>>) {
         walk_variable_declarators(self, it);
     }
 
     #[inline]
-    fn visit_switch_cases(&mut self, it: &mut Vec<'a, SwitchCase<'a>>) {
+    fn visit_switch_cases(&mut self, it: &mut ArenaVec<'a, SwitchCase<'a>>) {
         walk_switch_cases(self, it);
     }
 
     #[inline]
-    fn visit_binding_properties(&mut self, it: &mut Vec<'a, BindingProperty<'a>>) {
+    fn visit_binding_properties(&mut self, it: &mut ArenaVec<'a, BindingProperty<'a>>) {
         walk_binding_properties(self, it);
     }
 
     #[inline]
-    fn visit_formal_parameter_list(&mut self, it: &mut Vec<'a, FormalParameter<'a>>) {
+    fn visit_formal_parameter_list(&mut self, it: &mut ArenaVec<'a, FormalParameter<'a>>) {
         walk_formal_parameter_list(self, it);
     }
 
     #[inline]
-    fn visit_decorators(&mut self, it: &mut Vec<'a, Decorator<'a>>) {
+    fn visit_decorators(&mut self, it: &mut ArenaVec<'a, Decorator<'a>>) {
         walk_decorators(self, it);
     }
 
     #[inline]
-    fn visit_ts_class_implements_list(&mut self, it: &mut Vec<'a, TSClassImplements<'a>>) {
+    fn visit_ts_class_implements_list(&mut self, it: &mut ArenaVec<'a, TSClassImplements<'a>>) {
         walk_ts_class_implements_list(self, it);
     }
 
     #[inline]
-    fn visit_class_elements(&mut self, it: &mut Vec<'a, ClassElement<'a>>) {
+    fn visit_class_elements(&mut self, it: &mut ArenaVec<'a, ClassElement<'a>>) {
         walk_class_elements(self, it);
     }
 
     #[inline]
     fn visit_import_declaration_specifiers(
         &mut self,
-        it: &mut Vec<'a, ImportDeclarationSpecifier<'a>>,
+        it: &mut ArenaVec<'a, ImportDeclarationSpecifier<'a>>,
     ) {
         walk_import_declaration_specifiers(self, it);
     }
 
     #[inline]
-    fn visit_import_attributes(&mut self, it: &mut Vec<'a, ImportAttribute<'a>>) {
+    fn visit_import_attributes(&mut self, it: &mut ArenaVec<'a, ImportAttribute<'a>>) {
         walk_import_attributes(self, it);
     }
 
     #[inline]
-    fn visit_export_specifiers(&mut self, it: &mut Vec<'a, ExportSpecifier<'a>>) {
+    fn visit_export_specifiers(&mut self, it: &mut ArenaVec<'a, ExportSpecifier<'a>>) {
         walk_export_specifiers(self, it);
     }
 
     #[inline]
-    fn visit_jsx_children(&mut self, it: &mut Vec<'a, JSXChild<'a>>) {
+    fn visit_jsx_children(&mut self, it: &mut ArenaVec<'a, JSXChild<'a>>) {
         walk_jsx_children(self, it);
     }
 
     #[inline]
-    fn visit_jsx_attribute_items(&mut self, it: &mut Vec<'a, JSXAttributeItem<'a>>) {
+    fn visit_jsx_attribute_items(&mut self, it: &mut ArenaVec<'a, JSXAttributeItem<'a>>) {
         walk_jsx_attribute_items(self, it);
     }
 
     #[inline]
-    fn visit_ts_enum_members(&mut self, it: &mut Vec<'a, TSEnumMember<'a>>) {
+    fn visit_ts_enum_members(&mut self, it: &mut ArenaVec<'a, TSEnumMember<'a>>) {
         walk_ts_enum_members(self, it);
     }
 
     #[inline]
-    fn visit_ts_types(&mut self, it: &mut Vec<'a, TSType<'a>>) {
+    fn visit_ts_types(&mut self, it: &mut ArenaVec<'a, TSType<'a>>) {
         walk_ts_types(self, it);
     }
 
     #[inline]
-    fn visit_ts_tuple_elements(&mut self, it: &mut Vec<'a, TSTupleElement<'a>>) {
+    fn visit_ts_tuple_elements(&mut self, it: &mut ArenaVec<'a, TSTupleElement<'a>>) {
         walk_ts_tuple_elements(self, it);
     }
 
     #[inline]
-    fn visit_ts_type_parameters(&mut self, it: &mut Vec<'a, TSTypeParameter<'a>>) {
+    fn visit_ts_type_parameters(&mut self, it: &mut ArenaVec<'a, TSTypeParameter<'a>>) {
         walk_ts_type_parameters(self, it);
     }
 
     #[inline]
-    fn visit_ts_interface_heritages(&mut self, it: &mut Vec<'a, TSInterfaceHeritage<'a>>) {
+    fn visit_ts_interface_heritages(&mut self, it: &mut ArenaVec<'a, TSInterfaceHeritage<'a>>) {
         walk_ts_interface_heritages(self, it);
     }
 
     #[inline]
-    fn visit_ts_signatures(&mut self, it: &mut Vec<'a, TSSignature<'a>>) {
+    fn visit_ts_signatures(&mut self, it: &mut ArenaVec<'a, TSSignature<'a>>) {
         walk_ts_signatures(self, it);
     }
 
     #[inline]
-    fn visit_ts_index_signature_names(&mut self, it: &mut Vec<'a, TSIndexSignatureName<'a>>) {
+    fn visit_ts_index_signature_names(&mut self, it: &mut ArenaVec<'a, TSIndexSignatureName<'a>>) {
         walk_ts_index_signature_names(self, it);
     }
 
     #[inline]
-    fn visit_spans(&mut self, it: &mut Vec<'a, Span>) {
+    fn visit_spans(&mut self, it: &mut ArenaVec<'a, Span>) {
         walk_spans(self, it);
     }
 }
@@ -4468,14 +4471,20 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_directives<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Directive<'a>>) {
+    pub fn walk_directives<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ArenaVec<'a, Directive<'a>>,
+    ) {
         for el in it {
             visitor.visit_directive(el);
         }
     }
 
     #[inline]
-    pub fn walk_statements<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Statement<'a>>) {
+    pub fn walk_statements<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ArenaVec<'a, Statement<'a>>,
+    ) {
         for el in it {
             visitor.visit_statement(el);
         }
@@ -4484,7 +4493,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_array_expression_elements<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, ArrayExpressionElement<'a>>,
+        it: &mut ArenaVec<'a, ArrayExpressionElement<'a>>,
     ) {
         for el in it {
             visitor.visit_array_expression_element(el);
@@ -4494,7 +4503,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_object_property_kinds<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, ObjectPropertyKind<'a>>,
+        it: &mut ArenaVec<'a, ObjectPropertyKind<'a>>,
     ) {
         for el in it {
             visitor.visit_object_property_kind(el);
@@ -4504,7 +4513,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_template_elements<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, TemplateElement<'a>>,
+        it: &mut ArenaVec<'a, TemplateElement<'a>>,
     ) {
         for el in it {
             visitor.visit_template_element(el);
@@ -4514,7 +4523,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_expressions<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, Expression<'a>>,
+        it: &mut ArenaVec<'a, Expression<'a>>,
     ) {
         for el in it {
             visitor.visit_expression(el);
@@ -4522,7 +4531,10 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_arguments<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Argument<'a>>) {
+    pub fn walk_arguments<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ArenaVec<'a, Argument<'a>>,
+    ) {
         for el in it {
             match el {
                 oxc_ast::ast::Argument::SpreadElement(spread) => {
@@ -4538,7 +4550,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_assignment_target_properties<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, AssignmentTargetProperty<'a>>,
+        it: &mut ArenaVec<'a, AssignmentTargetProperty<'a>>,
     ) {
         for el in it {
             visitor.visit_assignment_target_property(el);
@@ -4548,7 +4560,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_variable_declarators<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, VariableDeclarator<'a>>,
+        it: &mut ArenaVec<'a, VariableDeclarator<'a>>,
     ) {
         for el in it {
             visitor.visit_variable_declarator(el);
@@ -4558,7 +4570,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_switch_cases<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, SwitchCase<'a>>,
+        it: &mut ArenaVec<'a, SwitchCase<'a>>,
     ) {
         for el in it {
             visitor.visit_switch_case(el);
@@ -4568,7 +4580,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_binding_properties<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, BindingProperty<'a>>,
+        it: &mut ArenaVec<'a, BindingProperty<'a>>,
     ) {
         for el in it {
             visitor.visit_binding_property(el);
@@ -4578,7 +4590,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_formal_parameter_list<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, FormalParameter<'a>>,
+        it: &mut ArenaVec<'a, FormalParameter<'a>>,
     ) {
         for el in it {
             visitor.visit_formal_parameter(el);
@@ -4586,7 +4598,10 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_decorators<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Decorator<'a>>) {
+    pub fn walk_decorators<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ArenaVec<'a, Decorator<'a>>,
+    ) {
         for el in it {
             visitor.visit_decorator(el);
         }
@@ -4595,7 +4610,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_ts_class_implements_list<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, TSClassImplements<'a>>,
+        it: &mut ArenaVec<'a, TSClassImplements<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_class_implements(el);
@@ -4605,7 +4620,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_class_elements<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, ClassElement<'a>>,
+        it: &mut ArenaVec<'a, ClassElement<'a>>,
     ) {
         for el in it {
             visitor.visit_class_element(el);
@@ -4615,7 +4630,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_import_declaration_specifiers<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, ImportDeclarationSpecifier<'a>>,
+        it: &mut ArenaVec<'a, ImportDeclarationSpecifier<'a>>,
     ) {
         for el in it {
             visitor.visit_import_declaration_specifier(el);
@@ -4625,7 +4640,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_import_attributes<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, ImportAttribute<'a>>,
+        it: &mut ArenaVec<'a, ImportAttribute<'a>>,
     ) {
         for el in it {
             visitor.visit_import_attribute(el);
@@ -4635,7 +4650,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_export_specifiers<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, ExportSpecifier<'a>>,
+        it: &mut ArenaVec<'a, ExportSpecifier<'a>>,
     ) {
         for el in it {
             visitor.visit_export_specifier(el);
@@ -4643,7 +4658,10 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_jsx_children<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, JSXChild<'a>>) {
+    pub fn walk_jsx_children<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ArenaVec<'a, JSXChild<'a>>,
+    ) {
         for el in it {
             visitor.visit_jsx_child(el);
         }
@@ -4652,7 +4670,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_jsx_attribute_items<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, JSXAttributeItem<'a>>,
+        it: &mut ArenaVec<'a, JSXAttributeItem<'a>>,
     ) {
         for el in it {
             visitor.visit_jsx_attribute_item(el);
@@ -4662,7 +4680,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_ts_enum_members<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, TSEnumMember<'a>>,
+        it: &mut ArenaVec<'a, TSEnumMember<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_enum_member(el);
@@ -4670,7 +4688,7 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_ts_types<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, TSType<'a>>) {
+    pub fn walk_ts_types<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ArenaVec<'a, TSType<'a>>) {
         for el in it {
             visitor.visit_ts_type(el);
         }
@@ -4679,7 +4697,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_ts_tuple_elements<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, TSTupleElement<'a>>,
+        it: &mut ArenaVec<'a, TSTupleElement<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_tuple_element(el);
@@ -4689,7 +4707,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_ts_type_parameters<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, TSTypeParameter<'a>>,
+        it: &mut ArenaVec<'a, TSTypeParameter<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_type_parameter(el);
@@ -4699,7 +4717,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_ts_interface_heritages<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, TSInterfaceHeritage<'a>>,
+        it: &mut ArenaVec<'a, TSInterfaceHeritage<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_interface_heritage(el);
@@ -4709,7 +4727,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_ts_signatures<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, TSSignature<'a>>,
+        it: &mut ArenaVec<'a, TSSignature<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_signature(el);
@@ -4719,7 +4737,7 @@ pub mod walk_mut {
     #[inline]
     pub fn walk_ts_index_signature_names<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, TSIndexSignatureName<'a>>,
+        it: &mut ArenaVec<'a, TSIndexSignatureName<'a>>,
     ) {
         for el in it {
             visitor.visit_ts_index_signature_name(el);
@@ -4727,7 +4745,7 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_spans<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Span>) {
+    pub fn walk_spans<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ArenaVec<'a, Span>) {
         for el in it {
             visitor.visit_span(el);
         }

--- a/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
+++ b/crates/oxc_formatter/src/ast_nodes/generated/ast_nodes.rs
@@ -3,7 +3,7 @@
 
 use std::mem::transmute;
 
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 use oxc_span::GetSpan;
 use oxc_str::Ident;
@@ -827,7 +827,7 @@ impl<'a> AstNode<'a, Program<'a>> {
     }
 
     #[inline]
-    pub fn comments(&self) -> &Vec<'a, Comment> {
+    pub fn comments(&self) -> &ArenaVec<'a, Comment> {
         &self.inner.comments
     }
 
@@ -852,7 +852,7 @@ impl<'a> AstNode<'a, Program<'a>> {
     }
 
     #[inline]
-    pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
+    pub fn directives(&self) -> &AstNode<'a, ArenaVec<'a, Directive<'a>>> {
         let following_span_start = self
             .inner
             .body
@@ -869,7 +869,7 @@ impl<'a> AstNode<'a, Program<'a>> {
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn body(&self) -> &AstNode<'a, ArenaVec<'a, Statement<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
@@ -1325,7 +1325,7 @@ impl<'a> AstNode<'a, ArrayExpression<'a>> {
     }
 
     #[inline]
-    pub fn elements(&self) -> &AstNode<'a, Vec<'a, ArrayExpressionElement<'a>>> {
+    pub fn elements(&self) -> &AstNode<'a, ArenaVec<'a, ArrayExpressionElement<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
@@ -1405,7 +1405,7 @@ impl<'a> AstNode<'a, ObjectExpression<'a>> {
     }
 
     #[inline]
-    pub fn properties(&self) -> &AstNode<'a, Vec<'a, ObjectPropertyKind<'a>>> {
+    pub fn properties(&self) -> &AstNode<'a, ArenaVec<'a, ObjectPropertyKind<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
@@ -1553,7 +1553,7 @@ impl<'a> AstNode<'a, TemplateLiteral<'a>> {
     }
 
     #[inline]
-    pub fn quasis(&self) -> &AstNode<'a, Vec<'a, TemplateElement<'a>>> {
+    pub fn quasis(&self) -> &AstNode<'a, ArenaVec<'a, TemplateElement<'a>>> {
         let following_span_start = self
             .inner
             .expressions
@@ -1570,7 +1570,7 @@ impl<'a> AstNode<'a, TemplateLiteral<'a>> {
     }
 
     #[inline]
-    pub fn expressions(&self) -> &AstNode<'a, Vec<'a, Expression<'a>>> {
+    pub fn expressions(&self) -> &AstNode<'a, ArenaVec<'a, Expression<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expressions,
@@ -1885,7 +1885,7 @@ impl<'a> AstNode<'a, CallExpression<'a>> {
     }
 
     #[inline]
-    pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
+    pub fn arguments(&self) -> &AstNode<'a, ArenaVec<'a, Argument<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.arguments,
@@ -1959,7 +1959,7 @@ impl<'a> AstNode<'a, NewExpression<'a>> {
     }
 
     #[inline]
-    pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
+    pub fn arguments(&self) -> &AstNode<'a, ArenaVec<'a, Argument<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.arguments,
@@ -2487,7 +2487,7 @@ impl<'a> AstNode<'a, ArrayAssignmentTarget<'a>> {
     }
 
     #[inline]
-    pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>> {
+    pub fn elements(&self) -> &AstNode<'a, ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>> {
         let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
@@ -2527,7 +2527,7 @@ impl<'a> AstNode<'a, ObjectAssignmentTarget<'a>> {
     }
 
     #[inline]
-    pub fn properties(&self) -> &AstNode<'a, Vec<'a, AssignmentTargetProperty<'a>>> {
+    pub fn properties(&self) -> &AstNode<'a, ArenaVec<'a, AssignmentTargetProperty<'a>>> {
         let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
@@ -2776,7 +2776,7 @@ impl<'a> AstNode<'a, SequenceExpression<'a>> {
     }
 
     #[inline]
-    pub fn expressions(&self) -> &AstNode<'a, Vec<'a, Expression<'a>>> {
+    pub fn expressions(&self) -> &AstNode<'a, ArenaVec<'a, Expression<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.expressions,
@@ -3158,7 +3158,7 @@ impl<'a> AstNode<'a, BlockStatement<'a>> {
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn body(&self) -> &AstNode<'a, ArenaVec<'a, Statement<'a>>> {
         let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
@@ -3270,7 +3270,7 @@ impl<'a> AstNode<'a, VariableDeclaration<'a>> {
     }
 
     #[inline]
-    pub fn declarations(&self) -> &AstNode<'a, Vec<'a, VariableDeclarator<'a>>> {
+    pub fn declarations(&self) -> &AstNode<'a, ArenaVec<'a, VariableDeclarator<'a>>> {
         let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.declarations,
@@ -3924,7 +3924,7 @@ impl<'a> AstNode<'a, SwitchStatement<'a>> {
     }
 
     #[inline]
-    pub fn cases(&self) -> &AstNode<'a, Vec<'a, SwitchCase<'a>>> {
+    pub fn cases(&self) -> &AstNode<'a, ArenaVec<'a, SwitchCase<'a>>> {
         let following_span_start = 0;
         self.allocator.alloc(AstNode {
             inner: &self.inner.cases,
@@ -3970,7 +3970,7 @@ impl<'a> AstNode<'a, SwitchCase<'a>> {
     }
 
     #[inline]
-    pub fn consequent(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn consequent(&self) -> &AstNode<'a, ArenaVec<'a, Statement<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.consequent,
@@ -4303,7 +4303,7 @@ impl<'a> AstNode<'a, ObjectPattern<'a>> {
     }
 
     #[inline]
-    pub fn properties(&self) -> &AstNode<'a, Vec<'a, BindingProperty<'a>>> {
+    pub fn properties(&self) -> &AstNode<'a, ArenaVec<'a, BindingProperty<'a>>> {
         let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.properties,
@@ -4391,7 +4391,7 @@ impl<'a> AstNode<'a, ArrayPattern<'a>> {
     }
 
     #[inline]
-    pub fn elements(&self) -> &AstNode<'a, Vec<'a, Option<BindingPattern<'a>>>> {
+    pub fn elements(&self) -> &AstNode<'a, ArenaVec<'a, Option<BindingPattern<'a>>>> {
         let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.elements,
@@ -4611,7 +4611,7 @@ impl<'a> AstNode<'a, FormalParameters<'a>> {
     }
 
     #[inline]
-    pub fn items(&self) -> &AstNode<'a, Vec<'a, FormalParameter<'a>>> {
+    pub fn items(&self) -> &AstNode<'a, ArenaVec<'a, FormalParameter<'a>>> {
         let following_span_start = self.inner.rest.as_deref().map_or(0, |n| n.span().start);
         self.allocator.alloc(AstNode {
             inner: &self.inner.items,
@@ -4651,7 +4651,7 @@ impl<'a> AstNode<'a, FormalParameter<'a>> {
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators(&self) -> &AstNode<'a, ArenaVec<'a, Decorator<'a>>> {
         let following_span_start = self.inner.pattern.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
@@ -4748,7 +4748,7 @@ impl<'a> AstNode<'a, FormalParameterRest<'a>> {
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators(&self) -> &AstNode<'a, ArenaVec<'a, Decorator<'a>>> {
         let following_span_start = self.inner.rest.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
@@ -4805,7 +4805,7 @@ impl<'a> AstNode<'a, FunctionBody<'a>> {
     }
 
     #[inline]
-    pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
+    pub fn directives(&self) -> &AstNode<'a, ArenaVec<'a, Directive<'a>>> {
         let following_span_start = self
             .inner
             .statements
@@ -4822,7 +4822,7 @@ impl<'a> AstNode<'a, FunctionBody<'a>> {
     }
 
     #[inline]
-    pub fn statements(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn statements(&self) -> &AstNode<'a, ArenaVec<'a, Statement<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.statements,
@@ -4978,7 +4978,7 @@ impl<'a> AstNode<'a, Class<'a>> {
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators(&self) -> &AstNode<'a, ArenaVec<'a, Decorator<'a>>> {
         let following_span_start = self
             .inner
             .id
@@ -5081,7 +5081,7 @@ impl<'a> AstNode<'a, Class<'a>> {
     }
 
     #[inline]
-    pub fn implements(&self) -> &AstNode<'a, Vec<'a, TSClassImplements<'a>>> {
+    pub fn implements(&self) -> &AstNode<'a, ArenaVec<'a, TSClassImplements<'a>>> {
         let following_span_start = self.inner.body.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.implements,
@@ -5129,7 +5129,7 @@ impl<'a> AstNode<'a, ClassBody<'a>> {
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, ClassElement<'a>>> {
+    pub fn body(&self) -> &AstNode<'a, ArenaVec<'a, ClassElement<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
@@ -5209,7 +5209,7 @@ impl<'a> AstNode<'a, MethodDefinition<'a>> {
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators(&self) -> &AstNode<'a, ArenaVec<'a, Decorator<'a>>> {
         let following_span_start = self.inner.key.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
@@ -5293,7 +5293,7 @@ impl<'a> AstNode<'a, PropertyDefinition<'a>> {
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators(&self) -> &AstNode<'a, ArenaVec<'a, Decorator<'a>>> {
         let following_span_start = self.inner.key.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
@@ -5431,7 +5431,7 @@ impl<'a> AstNode<'a, StaticBlock<'a>> {
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn body(&self) -> &AstNode<'a, ArenaVec<'a, Statement<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
@@ -5521,7 +5521,7 @@ impl<'a> AstNode<'a, AccessorProperty<'a>> {
     }
 
     #[inline]
-    pub fn decorators(&self) -> &AstNode<'a, Vec<'a, Decorator<'a>>> {
+    pub fn decorators(&self) -> &AstNode<'a, ArenaVec<'a, Decorator<'a>>> {
         let following_span_start = self.inner.key.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.decorators,
@@ -5674,7 +5674,7 @@ impl<'a> AstNode<'a, ImportDeclaration<'a>> {
     }
 
     #[inline]
-    pub fn specifiers(&self) -> Option<&AstNode<'a, Vec<'a, ImportDeclarationSpecifier<'a>>>> {
+    pub fn specifiers(&self) -> Option<&AstNode<'a, ArenaVec<'a, ImportDeclarationSpecifier<'a>>>> {
         let following_span_start = self.inner.source.span().start;
         self.allocator
             .alloc(self.inner.specifiers.as_ref().map(|inner| AstNode {
@@ -5873,7 +5873,7 @@ impl<'a> AstNode<'a, WithClause<'a>> {
     }
 
     #[inline]
-    pub fn with_entries(&self) -> &AstNode<'a, Vec<'a, ImportAttribute<'a>>> {
+    pub fn with_entries(&self) -> &AstNode<'a, ArenaVec<'a, ImportAttribute<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.with_entries,
@@ -5984,7 +5984,7 @@ impl<'a> AstNode<'a, ExportNamedDeclaration<'a>> {
     }
 
     #[inline]
-    pub fn specifiers(&self) -> &AstNode<'a, Vec<'a, ExportSpecifier<'a>>> {
+    pub fn specifiers(&self) -> &AstNode<'a, ArenaVec<'a, ExportSpecifier<'a>>> {
         let following_span_start = self
             .inner
             .source
@@ -6272,7 +6272,7 @@ impl<'a> AstNode<'a, V8IntrinsicExpression<'a>> {
     }
 
     #[inline]
-    pub fn arguments(&self) -> &AstNode<'a, Vec<'a, Argument<'a>>> {
+    pub fn arguments(&self) -> &AstNode<'a, ArenaVec<'a, Argument<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.arguments,
@@ -6473,7 +6473,7 @@ impl<'a> AstNode<'a, JSXElement<'a>> {
     }
 
     #[inline]
-    pub fn children(&self) -> &AstNode<'a, Vec<'a, JSXChild<'a>>> {
+    pub fn children(&self) -> &AstNode<'a, ArenaVec<'a, JSXChild<'a>>> {
         let following_span_start = self
             .inner
             .closing_element
@@ -6556,7 +6556,7 @@ impl<'a> AstNode<'a, JSXOpeningElement<'a>> {
     }
 
     #[inline]
-    pub fn attributes(&self) -> &AstNode<'a, Vec<'a, JSXAttributeItem<'a>>> {
+    pub fn attributes(&self) -> &AstNode<'a, ArenaVec<'a, JSXAttributeItem<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.attributes,
@@ -6627,7 +6627,7 @@ impl<'a> AstNode<'a, JSXFragment<'a>> {
     }
 
     #[inline]
-    pub fn children(&self) -> &AstNode<'a, Vec<'a, JSXChild<'a>>> {
+    pub fn children(&self) -> &AstNode<'a, ArenaVec<'a, JSXChild<'a>>> {
         let following_span_start = self.inner.closing_fragment.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.children,
@@ -7292,7 +7292,7 @@ impl<'a> AstNode<'a, TSEnumBody<'a>> {
     }
 
     #[inline]
-    pub fn members(&self) -> &AstNode<'a, Vec<'a, TSEnumMember<'a>>> {
+    pub fn members(&self) -> &AstNode<'a, ArenaVec<'a, TSEnumMember<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.members,
@@ -7849,7 +7849,7 @@ impl<'a> AstNode<'a, TSUnionType<'a>> {
     }
 
     #[inline]
-    pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
+    pub fn types(&self) -> &AstNode<'a, ArenaVec<'a, TSType<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.types,
@@ -7876,7 +7876,7 @@ impl<'a> AstNode<'a, TSIntersectionType<'a>> {
     }
 
     #[inline]
-    pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
+    pub fn types(&self) -> &AstNode<'a, ArenaVec<'a, TSType<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.types,
@@ -8027,7 +8027,7 @@ impl<'a> AstNode<'a, TSTupleType<'a>> {
     }
 
     #[inline]
-    pub fn element_types(&self) -> &AstNode<'a, Vec<'a, TSTupleElement<'a>>> {
+    pub fn element_types(&self) -> &AstNode<'a, ArenaVec<'a, TSTupleElement<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.element_types,
@@ -8528,7 +8528,7 @@ impl<'a> AstNode<'a, TSTypeParameterInstantiation<'a>> {
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
+    pub fn params(&self) -> &AstNode<'a, ArenaVec<'a, TSType<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.params,
@@ -8636,7 +8636,7 @@ impl<'a> AstNode<'a, TSTypeParameterDeclaration<'a>> {
     }
 
     #[inline]
-    pub fn params(&self) -> &AstNode<'a, Vec<'a, TSTypeParameter<'a>>> {
+    pub fn params(&self) -> &AstNode<'a, ArenaVec<'a, TSTypeParameter<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.params,
@@ -8808,7 +8808,7 @@ impl<'a> AstNode<'a, TSInterfaceDeclaration<'a>> {
     }
 
     #[inline]
-    pub fn extends(&self) -> &AstNode<'a, Vec<'a, TSInterfaceHeritage<'a>>> {
+    pub fn extends(&self) -> &AstNode<'a, ArenaVec<'a, TSInterfaceHeritage<'a>>> {
         let following_span_start = self.inner.body.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.extends,
@@ -8851,7 +8851,7 @@ impl<'a> AstNode<'a, TSInterfaceBody<'a>> {
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, TSSignature<'a>>> {
+    pub fn body(&self) -> &AstNode<'a, ArenaVec<'a, TSSignature<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
@@ -8989,7 +8989,7 @@ impl<'a> AstNode<'a, TSIndexSignature<'a>> {
     }
 
     #[inline]
-    pub fn parameters(&self) -> &AstNode<'a, Vec<'a, TSIndexSignatureName<'a>>> {
+    pub fn parameters(&self) -> &AstNode<'a, ArenaVec<'a, TSIndexSignatureName<'a>>> {
         let following_span_start = self.inner.type_annotation.span().start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.parameters,
@@ -9577,7 +9577,7 @@ impl<'a> AstNode<'a, TSModuleBlock<'a>> {
     }
 
     #[inline]
-    pub fn directives(&self) -> &AstNode<'a, Vec<'a, Directive<'a>>> {
+    pub fn directives(&self) -> &AstNode<'a, ArenaVec<'a, Directive<'a>>> {
         let following_span_start = self
             .inner
             .body
@@ -9594,7 +9594,7 @@ impl<'a> AstNode<'a, TSModuleBlock<'a>> {
     }
 
     #[inline]
-    pub fn body(&self) -> &AstNode<'a, Vec<'a, Statement<'a>>> {
+    pub fn body(&self) -> &AstNode<'a, ArenaVec<'a, Statement<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.body,
@@ -9621,7 +9621,7 @@ impl<'a> AstNode<'a, TSTypeLiteral<'a>> {
     }
 
     #[inline]
-    pub fn members(&self) -> &AstNode<'a, Vec<'a, TSSignature<'a>>> {
+    pub fn members(&self) -> &AstNode<'a, ArenaVec<'a, TSSignature<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.members,
@@ -10114,7 +10114,7 @@ impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
     }
 
     #[inline]
-    pub fn quasis(&self) -> &AstNode<'a, Vec<'a, TemplateElement<'a>>> {
+    pub fn quasis(&self) -> &AstNode<'a, ArenaVec<'a, TemplateElement<'a>>> {
         let following_span_start = self
             .inner
             .types
@@ -10131,7 +10131,7 @@ impl<'a> AstNode<'a, TSTemplateLiteralType<'a>> {
     }
 
     #[inline]
-    pub fn types(&self) -> &AstNode<'a, Vec<'a, TSType<'a>>> {
+    pub fn types(&self) -> &AstNode<'a, ArenaVec<'a, TSType<'a>>> {
         let following_span_start = self.following_span_start;
         self.allocator.alloc(AstNode {
             inner: &self.inner.types,

--- a/crates/oxc_minifier/src/generated/ancestor.rs
+++ b/crates/oxc_minifier/src/generated/ancestor.rs
@@ -12,7 +12,7 @@
 
 use std::{cell::Cell, marker::PhantomData, mem::offset_of};
 
-use oxc_allocator::{Address, Box, GetAddress, Vec};
+use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress};
 use oxc_ast::ast::*;
 use oxc_syntax::{node::NodeId, scope::ScopeId};
 
@@ -2602,22 +2602,24 @@ impl<'a, 't> ProgramWithoutHashbang<'a, 't> {
     }
 
     #[inline]
-    pub fn comments(self) -> &'t Vec<'a, Comment> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const Vec<'a, Comment>) }
-    }
-
-    #[inline]
-    pub fn directives(self) -> &'t Vec<'a, Directive<'a>> {
+    pub fn comments(self) -> &'t ArenaVec<'a, Comment> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_PROGRAM_DIRECTIVES)
-                as *const Vec<'a, Directive<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const ArenaVec<'a, Comment>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Vec<'a, Statement<'a>> {
+    pub fn directives(self) -> &'t ArenaVec<'a, Directive<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_PROGRAM_BODY) as *const Vec<'a, Statement<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_DIRECTIVES)
+                as *const ArenaVec<'a, Directive<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn body(self) -> &'t ArenaVec<'a, Statement<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_BODY) as *const ArenaVec<'a, Statement<'a>>)
         }
     }
 
@@ -2665,8 +2667,10 @@ impl<'a, 't> ProgramWithoutDirectives<'a, 't> {
     }
 
     #[inline]
-    pub fn comments(self) -> &'t Vec<'a, Comment> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const Vec<'a, Comment>) }
+    pub fn comments(self) -> &'t ArenaVec<'a, Comment> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const ArenaVec<'a, Comment>)
+        }
     }
 
     #[inline]
@@ -2677,9 +2681,9 @@ impl<'a, 't> ProgramWithoutDirectives<'a, 't> {
     }
 
     #[inline]
-    pub fn body(self) -> &'t Vec<'a, Statement<'a>> {
+    pub fn body(self) -> &'t ArenaVec<'a, Statement<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_PROGRAM_BODY) as *const Vec<'a, Statement<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_BODY) as *const ArenaVec<'a, Statement<'a>>)
         }
     }
 
@@ -2727,8 +2731,10 @@ impl<'a, 't> ProgramWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn comments(self) -> &'t Vec<'a, Comment> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const Vec<'a, Comment>) }
+    pub fn comments(self) -> &'t ArenaVec<'a, Comment> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const ArenaVec<'a, Comment>)
+        }
     }
 
     #[inline]
@@ -2739,10 +2745,10 @@ impl<'a, 't> ProgramWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn directives(self) -> &'t Vec<'a, Directive<'a>> {
+    pub fn directives(self) -> &'t ArenaVec<'a, Directive<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_DIRECTIVES)
-                as *const Vec<'a, Directive<'a>>)
+                as *const ArenaVec<'a, Directive<'a>>)
         }
     }
 
@@ -2972,10 +2978,10 @@ impl<'a, 't> TemplateLiteralWithoutQuasis<'a, 't> {
     }
 
     #[inline]
-    pub fn expressions(self) -> &'t Vec<'a, Expression<'a>> {
+    pub fn expressions(self) -> &'t ArenaVec<'a, Expression<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TEMPLATE_LITERAL_EXPRESSIONS)
-                as *const Vec<'a, Expression<'a>>)
+                as *const ArenaVec<'a, Expression<'a>>)
         }
     }
 }
@@ -3008,10 +3014,10 @@ impl<'a, 't> TemplateLiteralWithoutExpressions<'a, 't> {
     }
 
     #[inline]
-    pub fn quasis(self) -> &'t Vec<'a, TemplateElement<'a>> {
+    pub fn quasis(self) -> &'t ArenaVec<'a, TemplateElement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TEMPLATE_LITERAL_QUASIS)
-                as *const Vec<'a, TemplateElement<'a>>)
+                as *const ArenaVec<'a, TemplateElement<'a>>)
         }
     }
 }
@@ -3058,10 +3064,10 @@ impl<'a, 't> TaggedTemplateExpressionWithoutTag<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
@@ -3160,10 +3166,10 @@ impl<'a, 't> TaggedTemplateExpressionWithoutQuasi<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -3514,18 +3520,18 @@ impl<'a, 't> CallExpressionWithoutCallee<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+    pub fn arguments(self) -> &'t ArenaVec<'a, Argument<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
+                as *const ArenaVec<'a, Argument<'a>>)
         }
     }
 
@@ -3575,10 +3581,10 @@ impl<'a, 't> CallExpressionWithoutTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+    pub fn arguments(self) -> &'t ArenaVec<'a, Argument<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
+                as *const ArenaVec<'a, Argument<'a>>)
         }
     }
 
@@ -3628,10 +3634,10 @@ impl<'a, 't> CallExpressionWithoutArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
@@ -3682,18 +3688,18 @@ impl<'a, 't> NewExpressionWithoutCallee<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+    pub fn arguments(self) -> &'t ArenaVec<'a, Argument<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
+                as *const ArenaVec<'a, Argument<'a>>)
         }
     }
 
@@ -3738,10 +3744,10 @@ impl<'a, 't> NewExpressionWithoutTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+    pub fn arguments(self) -> &'t ArenaVec<'a, Argument<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
+                as *const ArenaVec<'a, Argument<'a>>)
         }
     }
 
@@ -3786,10 +3792,10 @@ impl<'a, 't> NewExpressionWithoutArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
@@ -4542,10 +4548,10 @@ impl<'a, 't> ArrayAssignmentTargetWithoutElements<'a, 't> {
     }
 
     #[inline]
-    pub fn rest(self) -> &'t Option<Box<'a, AssignmentTargetRest<'a>>> {
+    pub fn rest(self) -> &'t Option<ArenaBox<'a, AssignmentTargetRest<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_ASSIGNMENT_TARGET_REST)
-                as *const Option<Box<'a, AssignmentTargetRest<'a>>>)
+                as *const Option<ArenaBox<'a, AssignmentTargetRest<'a>>>)
         }
     }
 }
@@ -4579,10 +4585,10 @@ impl<'a, 't> ArrayAssignmentTargetWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn elements(self) -> &'t Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>> {
+    pub fn elements(self) -> &'t ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_ASSIGNMENT_TARGET_ELEMENTS)
-                as *const Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>)
+                as *const ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>)
         }
     }
 }
@@ -4627,10 +4633,10 @@ impl<'a, 't> ObjectAssignmentTargetWithoutProperties<'a, 't> {
     }
 
     #[inline]
-    pub fn rest(self) -> &'t Option<Box<'a, AssignmentTargetRest<'a>>> {
+    pub fn rest(self) -> &'t Option<ArenaBox<'a, AssignmentTargetRest<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_OBJECT_ASSIGNMENT_TARGET_REST)
-                as *const Option<Box<'a, AssignmentTargetRest<'a>>>)
+                as *const Option<ArenaBox<'a, AssignmentTargetRest<'a>>>)
         }
     }
 }
@@ -4666,10 +4672,10 @@ impl<'a, 't> ObjectAssignmentTargetWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn properties(self) -> &'t Vec<'a, AssignmentTargetProperty<'a>> {
+    pub fn properties(self) -> &'t ArenaVec<'a, AssignmentTargetProperty<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_OBJECT_ASSIGNMENT_TARGET_PROPERTIES)
-                as *const Vec<'a, AssignmentTargetProperty<'a>>)
+                as *const ArenaVec<'a, AssignmentTargetProperty<'a>>)
         }
     }
 }
@@ -5304,10 +5310,10 @@ impl<'a, 't> VariableDeclaratorWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_VARIABLE_DECLARATOR_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -5426,10 +5432,10 @@ impl<'a, 't> VariableDeclaratorWithoutInit<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_VARIABLE_DECLARATOR_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -6542,10 +6548,10 @@ impl<'a, 't> SwitchStatementWithoutDiscriminant<'a, 't> {
     }
 
     #[inline]
-    pub fn cases(self) -> &'t Vec<'a, SwitchCase<'a>> {
+    pub fn cases(self) -> &'t ArenaVec<'a, SwitchCase<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_SWITCH_STATEMENT_CASES)
-                as *const Vec<'a, SwitchCase<'a>>)
+                as *const ArenaVec<'a, SwitchCase<'a>>)
         }
     }
 
@@ -6633,10 +6639,10 @@ impl<'a, 't> SwitchCaseWithoutTest<'a, 't> {
     }
 
     #[inline]
-    pub fn consequent(self) -> &'t Vec<'a, Statement<'a>> {
+    pub fn consequent(self) -> &'t ArenaVec<'a, Statement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_SWITCH_CASE_CONSEQUENT)
-                as *const Vec<'a, Statement<'a>>)
+                as *const ArenaVec<'a, Statement<'a>>)
         }
     }
 }
@@ -6816,18 +6822,18 @@ impl<'a, 't> TryStatementWithoutBlock<'a, 't> {
     }
 
     #[inline]
-    pub fn handler(self) -> &'t Option<Box<'a, CatchClause<'a>>> {
+    pub fn handler(self) -> &'t Option<ArenaBox<'a, CatchClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_HANDLER)
-                as *const Option<Box<'a, CatchClause<'a>>>)
+                as *const Option<ArenaBox<'a, CatchClause<'a>>>)
         }
     }
 
     #[inline]
-    pub fn finalizer(self) -> &'t Option<Box<'a, BlockStatement<'a>>> {
+    pub fn finalizer(self) -> &'t Option<ArenaBox<'a, BlockStatement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_FINALIZER)
-                as *const Option<Box<'a, BlockStatement<'a>>>)
+                as *const Option<ArenaBox<'a, BlockStatement<'a>>>)
         }
     }
 }
@@ -6860,18 +6866,18 @@ impl<'a, 't> TryStatementWithoutHandler<'a, 't> {
     }
 
     #[inline]
-    pub fn block(self) -> &'t Box<'a, BlockStatement<'a>> {
+    pub fn block(self) -> &'t ArenaBox<'a, BlockStatement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_BLOCK)
-                as *const Box<'a, BlockStatement<'a>>)
+                as *const ArenaBox<'a, BlockStatement<'a>>)
         }
     }
 
     #[inline]
-    pub fn finalizer(self) -> &'t Option<Box<'a, BlockStatement<'a>>> {
+    pub fn finalizer(self) -> &'t Option<ArenaBox<'a, BlockStatement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_FINALIZER)
-                as *const Option<Box<'a, BlockStatement<'a>>>)
+                as *const Option<ArenaBox<'a, BlockStatement<'a>>>)
         }
     }
 }
@@ -6904,18 +6910,18 @@ impl<'a, 't> TryStatementWithoutFinalizer<'a, 't> {
     }
 
     #[inline]
-    pub fn block(self) -> &'t Box<'a, BlockStatement<'a>> {
+    pub fn block(self) -> &'t ArenaBox<'a, BlockStatement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_BLOCK)
-                as *const Box<'a, BlockStatement<'a>>)
+                as *const ArenaBox<'a, BlockStatement<'a>>)
         }
     }
 
     #[inline]
-    pub fn handler(self) -> &'t Option<Box<'a, CatchClause<'a>>> {
+    pub fn handler(self) -> &'t Option<ArenaBox<'a, CatchClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_HANDLER)
-                as *const Option<Box<'a, CatchClause<'a>>>)
+                as *const Option<ArenaBox<'a, CatchClause<'a>>>)
         }
     }
 }
@@ -6952,10 +6958,10 @@ impl<'a, 't> CatchClauseWithoutParam<'a, 't> {
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, BlockStatement<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, BlockStatement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CATCH_CLAUSE_BODY)
-                as *const Box<'a, BlockStatement<'a>>)
+                as *const ArenaBox<'a, BlockStatement<'a>>)
         }
     }
 
@@ -7044,10 +7050,10 @@ impl<'a, 't> CatchParameterWithoutPattern<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CATCH_PARAMETER_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 }
@@ -7197,10 +7203,10 @@ impl<'a, 't> ObjectPatternWithoutProperties<'a, 't> {
     }
 
     #[inline]
-    pub fn rest(self) -> &'t Option<Box<'a, BindingRestElement<'a>>> {
+    pub fn rest(self) -> &'t Option<ArenaBox<'a, BindingRestElement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_OBJECT_PATTERN_REST)
-                as *const Option<Box<'a, BindingRestElement<'a>>>)
+                as *const Option<ArenaBox<'a, BindingRestElement<'a>>>)
         }
     }
 }
@@ -7233,10 +7239,10 @@ impl<'a, 't> ObjectPatternWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn properties(self) -> &'t Vec<'a, BindingProperty<'a>> {
+    pub fn properties(self) -> &'t ArenaVec<'a, BindingProperty<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_OBJECT_PATTERN_PROPERTIES)
-                as *const Vec<'a, BindingProperty<'a>>)
+                as *const ArenaVec<'a, BindingProperty<'a>>)
         }
     }
 }
@@ -7372,10 +7378,10 @@ impl<'a, 't> ArrayPatternWithoutElements<'a, 't> {
     }
 
     #[inline]
-    pub fn rest(self) -> &'t Option<Box<'a, BindingRestElement<'a>>> {
+    pub fn rest(self) -> &'t Option<ArenaBox<'a, BindingRestElement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_PATTERN_REST)
-                as *const Option<Box<'a, BindingRestElement<'a>>>)
+                as *const Option<ArenaBox<'a, BindingRestElement<'a>>>)
         }
     }
 }
@@ -7408,10 +7414,10 @@ impl<'a, 't> ArrayPatternWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn elements(self) -> &'t Vec<'a, Option<BindingPattern<'a>>> {
+    pub fn elements(self) -> &'t ArenaVec<'a, Option<BindingPattern<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_PATTERN_ELEMENTS)
-                as *const Vec<'a, Option<BindingPattern<'a>>>)
+                as *const ArenaVec<'a, Option<BindingPattern<'a>>>)
         }
     }
 }
@@ -7513,42 +7519,42 @@ impl<'a, 't> FunctionWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Option<Box<'a, FunctionBody<'a>>> {
+    pub fn body(self) -> &'t Option<ArenaBox<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
+                as *const Option<ArenaBox<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -7624,34 +7630,34 @@ impl<'a, 't> FunctionWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Option<Box<'a, FunctionBody<'a>>> {
+    pub fn body(self) -> &'t Option<ArenaBox<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
+                as *const Option<ArenaBox<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -7727,34 +7733,34 @@ impl<'a, 't> FunctionWithoutThisParam<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Option<Box<'a, FunctionBody<'a>>> {
+    pub fn body(self) -> &'t Option<ArenaBox<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
+                as *const Option<ArenaBox<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -7830,34 +7836,34 @@ impl<'a, 't> FunctionWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Option<Box<'a, FunctionBody<'a>>> {
+    pub fn body(self) -> &'t Option<ArenaBox<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
+                as *const Option<ArenaBox<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -7933,34 +7939,34 @@ impl<'a, 't> FunctionWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Option<Box<'a, FunctionBody<'a>>> {
+    pub fn body(self) -> &'t Option<ArenaBox<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
+                as *const Option<ArenaBox<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -8036,34 +8042,34 @@ impl<'a, 't> FunctionWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -8127,10 +8133,10 @@ impl<'a, 't> FormalParametersWithoutItems<'a, 't> {
     }
 
     #[inline]
-    pub fn rest(self) -> &'t Option<Box<'a, FormalParameterRest<'a>>> {
+    pub fn rest(self) -> &'t Option<ArenaBox<'a, FormalParameterRest<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETERS_REST)
-                as *const Option<Box<'a, FormalParameterRest<'a>>>)
+                as *const Option<ArenaBox<'a, FormalParameterRest<'a>>>)
         }
     }
 }
@@ -8171,10 +8177,10 @@ impl<'a, 't> FormalParametersWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn items(self) -> &'t Vec<'a, FormalParameter<'a>> {
+    pub fn items(self) -> &'t ArenaVec<'a, FormalParameter<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETERS_ITEMS)
-                as *const Vec<'a, FormalParameter<'a>>)
+                as *const ArenaVec<'a, FormalParameter<'a>>)
         }
     }
 }
@@ -8230,18 +8236,18 @@ impl<'a, 't> FormalParameterWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn initializer(self) -> &'t Option<Box<'a, Expression<'a>>> {
+    pub fn initializer(self) -> &'t Option<ArenaBox<'a, Expression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_INITIALIZER)
-                as *const Option<Box<'a, Expression<'a>>>)
+                as *const Option<ArenaBox<'a, Expression<'a>>>)
         }
     }
 
@@ -8297,26 +8303,26 @@ impl<'a, 't> FormalParameterWithoutPattern<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn initializer(self) -> &'t Option<Box<'a, Expression<'a>>> {
+    pub fn initializer(self) -> &'t Option<ArenaBox<'a, Expression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_INITIALIZER)
-                as *const Option<Box<'a, Expression<'a>>>)
+                as *const Option<ArenaBox<'a, Expression<'a>>>)
         }
     }
 
@@ -8372,10 +8378,10 @@ impl<'a, 't> FormalParameterWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -8388,10 +8394,10 @@ impl<'a, 't> FormalParameterWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn initializer(self) -> &'t Option<Box<'a, Expression<'a>>> {
+    pub fn initializer(self) -> &'t Option<ArenaBox<'a, Expression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_INITIALIZER)
-                as *const Option<Box<'a, Expression<'a>>>)
+                as *const Option<ArenaBox<'a, Expression<'a>>>)
         }
     }
 
@@ -8447,10 +8453,10 @@ impl<'a, 't> FormalParameterWithoutInitializer<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -8463,10 +8469,10 @@ impl<'a, 't> FormalParameterWithoutInitializer<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -8540,10 +8546,10 @@ impl<'a, 't> FormalParameterRestWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_REST_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 }
@@ -8577,18 +8583,18 @@ impl<'a, 't> FormalParameterRestWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_REST_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_REST_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 }
@@ -8622,10 +8628,10 @@ impl<'a, 't> FormalParameterRestWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_REST_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -8671,10 +8677,10 @@ impl<'a, 't> FunctionBodyWithoutDirectives<'a, 't> {
     }
 
     #[inline]
-    pub fn statements(self) -> &'t Vec<'a, Statement<'a>> {
+    pub fn statements(self) -> &'t ArenaVec<'a, Statement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY_STATEMENTS)
-                as *const Vec<'a, Statement<'a>>)
+                as *const ArenaVec<'a, Statement<'a>>)
         }
     }
 }
@@ -8707,10 +8713,10 @@ impl<'a, 't> FunctionBodyWithoutStatements<'a, 't> {
     }
 
     #[inline]
-    pub fn directives(self) -> &'t Vec<'a, Directive<'a>> {
+    pub fn directives(self) -> &'t ArenaVec<'a, Directive<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY_DIRECTIVES)
-                as *const Vec<'a, Directive<'a>>)
+                as *const ArenaVec<'a, Directive<'a>>)
         }
     }
 }
@@ -8784,26 +8790,26 @@ impl<'a, 't> ArrowFunctionExpressionWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, FunctionBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, FunctionBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-                as *const Box<'a, FunctionBody<'a>>)
+                as *const ArenaBox<'a, FunctionBody<'a>>)
         }
     }
 
@@ -8876,26 +8882,26 @@ impl<'a, 't> ArrowFunctionExpressionWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, FunctionBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, FunctionBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-                as *const Box<'a, FunctionBody<'a>>)
+                as *const ArenaBox<'a, FunctionBody<'a>>)
         }
     }
 
@@ -8968,26 +8974,26 @@ impl<'a, 't> ArrowFunctionExpressionWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, FunctionBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, FunctionBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-                as *const Box<'a, FunctionBody<'a>>)
+                as *const ArenaBox<'a, FunctionBody<'a>>)
         }
     }
 
@@ -9060,26 +9066,26 @@ impl<'a, 't> ArrowFunctionExpressionWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -9196,10 +9202,10 @@ impl<'a, 't> ClassWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -9211,24 +9217,28 @@ impl<'a, 't> ClassWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9277,17 +9287,18 @@ impl<'a, 't> ClassWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -9299,24 +9310,28 @@ impl<'a, 't> ClassWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9368,9 +9383,10 @@ impl<'a, 't> ClassWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -9389,24 +9405,28 @@ impl<'a, 't> ClassWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9458,9 +9478,10 @@ impl<'a, 't> ClassWithoutSuperClass<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -9472,32 +9493,36 @@ impl<'a, 't> ClassWithoutSuperClass<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9549,9 +9574,10 @@ impl<'a, 't> ClassWithoutSuperTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -9563,10 +9589,10 @@ impl<'a, 't> ClassWithoutSuperTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -9578,16 +9604,18 @@ impl<'a, 't> ClassWithoutSuperTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9639,9 +9667,10 @@ impl<'a, 't> ClassWithoutImplements<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -9653,10 +9682,10 @@ impl<'a, 't> ClassWithoutImplements<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -9668,16 +9697,20 @@ impl<'a, 't> ClassWithoutImplements<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9726,9 +9759,10 @@ impl<'a, 't> ClassWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -9740,10 +9774,10 @@ impl<'a, 't> ClassWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -9755,18 +9789,20 @@ impl<'a, 't> ClassWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
@@ -9877,10 +9913,10 @@ impl<'a, 't> MethodDefinitionWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn value(self) -> &'t Box<'a, Function<'a>> {
+    pub fn value(self) -> &'t ArenaBox<'a, Function<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_VALUE)
-                as *const Box<'a, Function<'a>>)
+                as *const ArenaBox<'a, Function<'a>>)
         }
     }
 
@@ -9957,18 +9993,18 @@ impl<'a, 't> MethodDefinitionWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn value(self) -> &'t Box<'a, Function<'a>> {
+    pub fn value(self) -> &'t ArenaBox<'a, Function<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_VALUE)
-                as *const Box<'a, Function<'a>>)
+                as *const ArenaBox<'a, Function<'a>>)
         }
     }
 
@@ -10045,10 +10081,10 @@ impl<'a, 't> MethodDefinitionWithoutValue<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -10166,10 +10202,10 @@ impl<'a, 't> PropertyDefinitionWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -10261,18 +10297,18 @@ impl<'a, 't> PropertyDefinitionWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -10364,10 +10400,10 @@ impl<'a, 't> PropertyDefinitionWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -10466,10 +10502,10 @@ impl<'a, 't> PropertyDefinitionWithoutValue<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -10481,10 +10517,10 @@ impl<'a, 't> PropertyDefinitionWithoutValue<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -10631,10 +10667,10 @@ impl<'a, 't> AccessorPropertyWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -10711,18 +10747,18 @@ impl<'a, 't> AccessorPropertyWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -10799,10 +10835,10 @@ impl<'a, 't> AccessorPropertyWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -10886,10 +10922,10 @@ impl<'a, 't> AccessorPropertyWithoutValue<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -10901,10 +10937,10 @@ impl<'a, 't> AccessorPropertyWithoutValue<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -11085,10 +11121,10 @@ impl<'a, 't> ImportDeclarationWithoutSpecifiers<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 
@@ -11129,10 +11165,10 @@ impl<'a, 't> ImportDeclarationWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn specifiers(self) -> &'t Option<Vec<'a, ImportDeclarationSpecifier<'a>>> {
+    pub fn specifiers(self) -> &'t Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_DECLARATION_SPECIFIERS)
-                as *const Option<Vec<'a, ImportDeclarationSpecifier<'a>>>)
+                as *const Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>)
         }
     }
 
@@ -11145,10 +11181,10 @@ impl<'a, 't> ImportDeclarationWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 
@@ -11189,10 +11225,10 @@ impl<'a, 't> ImportDeclarationWithoutWithClause<'a, 't> {
     }
 
     #[inline]
-    pub fn specifiers(self) -> &'t Option<Vec<'a, ImportDeclarationSpecifier<'a>>> {
+    pub fn specifiers(self) -> &'t Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_DECLARATION_SPECIFIERS)
-                as *const Option<Vec<'a, ImportDeclarationSpecifier<'a>>>)
+                as *const Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>)
         }
     }
 
@@ -11552,10 +11588,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutDeclaration<'a, 't> {
     }
 
     #[inline]
-    pub fn specifiers(self) -> &'t Vec<'a, ExportSpecifier<'a>> {
+    pub fn specifiers(self) -> &'t ArenaVec<'a, ExportSpecifier<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
-                as *const Vec<'a, ExportSpecifier<'a>>)
+                as *const ArenaVec<'a, ExportSpecifier<'a>>)
         }
     }
 
@@ -11576,10 +11612,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutDeclaration<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 }
@@ -11639,10 +11675,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutSpecifiers<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 }
@@ -11686,10 +11722,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn specifiers(self) -> &'t Vec<'a, ExportSpecifier<'a>> {
+    pub fn specifiers(self) -> &'t ArenaVec<'a, ExportSpecifier<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
-                as *const Vec<'a, ExportSpecifier<'a>>)
+                as *const ArenaVec<'a, ExportSpecifier<'a>>)
         }
     }
 
@@ -11702,10 +11738,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 }
@@ -11749,10 +11785,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutWithClause<'a, 't> {
     }
 
     #[inline]
-    pub fn specifiers(self) -> &'t Vec<'a, ExportSpecifier<'a>> {
+    pub fn specifiers(self) -> &'t ArenaVec<'a, ExportSpecifier<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
-                as *const Vec<'a, ExportSpecifier<'a>>)
+                as *const ArenaVec<'a, ExportSpecifier<'a>>)
         }
     }
 
@@ -11860,10 +11896,10 @@ impl<'a, 't> ExportAllDeclarationWithoutExported<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_ALL_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 
@@ -11913,10 +11949,10 @@ impl<'a, 't> ExportAllDeclarationWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_ALL_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 
@@ -12115,10 +12151,10 @@ impl<'a, 't> V8IntrinsicExpressionWithoutName<'a, 't> {
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+    pub fn arguments(self) -> &'t ArenaVec<'a, Argument<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_V8_INTRINSIC_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
+                as *const ArenaVec<'a, Argument<'a>>)
         }
     }
 }
@@ -12194,18 +12230,18 @@ impl<'a, 't> JSXElementWithoutOpeningElement<'a, 't> {
     }
 
     #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+    pub fn children(self) -> &'t ArenaVec<'a, JSXChild<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
+                as *const ArenaVec<'a, JSXChild<'a>>)
         }
     }
 
     #[inline]
-    pub fn closing_element(self) -> &'t Option<Box<'a, JSXClosingElement<'a>>> {
+    pub fn closing_element(self) -> &'t Option<ArenaBox<'a, JSXClosingElement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
-                as *const Option<Box<'a, JSXClosingElement<'a>>>)
+                as *const Option<ArenaBox<'a, JSXClosingElement<'a>>>)
         }
     }
 }
@@ -12236,18 +12272,18 @@ impl<'a, 't> JSXElementWithoutChildren<'a, 't> {
     }
 
     #[inline]
-    pub fn opening_element(self) -> &'t Box<'a, JSXOpeningElement<'a>> {
+    pub fn opening_element(self) -> &'t ArenaBox<'a, JSXOpeningElement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
-                as *const Box<'a, JSXOpeningElement<'a>>)
+                as *const ArenaBox<'a, JSXOpeningElement<'a>>)
         }
     }
 
     #[inline]
-    pub fn closing_element(self) -> &'t Option<Box<'a, JSXClosingElement<'a>>> {
+    pub fn closing_element(self) -> &'t Option<ArenaBox<'a, JSXClosingElement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
-                as *const Option<Box<'a, JSXClosingElement<'a>>>)
+                as *const Option<ArenaBox<'a, JSXClosingElement<'a>>>)
         }
     }
 }
@@ -12278,18 +12314,18 @@ impl<'a, 't> JSXElementWithoutClosingElement<'a, 't> {
     }
 
     #[inline]
-    pub fn opening_element(self) -> &'t Box<'a, JSXOpeningElement<'a>> {
+    pub fn opening_element(self) -> &'t ArenaBox<'a, JSXOpeningElement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
-                as *const Box<'a, JSXOpeningElement<'a>>)
+                as *const ArenaBox<'a, JSXOpeningElement<'a>>)
         }
     }
 
     #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+    pub fn children(self) -> &'t ArenaVec<'a, JSXChild<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
+                as *const ArenaVec<'a, JSXChild<'a>>)
         }
     }
 }
@@ -12330,18 +12366,18 @@ impl<'a, 't> JSXOpeningElementWithoutName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn attributes(self) -> &'t Vec<'a, JSXAttributeItem<'a>> {
+    pub fn attributes(self) -> &'t ArenaVec<'a, JSXAttributeItem<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
-                as *const Vec<'a, JSXAttributeItem<'a>>)
+                as *const ArenaVec<'a, JSXAttributeItem<'a>>)
         }
     }
 }
@@ -12382,10 +12418,10 @@ impl<'a, 't> JSXOpeningElementWithoutTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn attributes(self) -> &'t Vec<'a, JSXAttributeItem<'a>> {
+    pub fn attributes(self) -> &'t ArenaVec<'a, JSXAttributeItem<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
-                as *const Vec<'a, JSXAttributeItem<'a>>)
+                as *const ArenaVec<'a, JSXAttributeItem<'a>>)
         }
     }
 }
@@ -12426,10 +12462,10 @@ impl<'a, 't> JSXOpeningElementWithoutAttributes<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -12500,10 +12536,10 @@ impl<'a, 't> JSXFragmentWithoutOpeningFragment<'a, 't> {
     }
 
     #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+    pub fn children(self) -> &'t ArenaVec<'a, JSXChild<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
+                as *const ArenaVec<'a, JSXChild<'a>>)
         }
     }
 
@@ -12592,10 +12628,10 @@ impl<'a, 't> JSXFragmentWithoutClosingFragment<'a, 't> {
     }
 
     #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+    pub fn children(self) -> &'t ArenaVec<'a, JSXChild<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
+                as *const ArenaVec<'a, JSXChild<'a>>)
         }
     }
 }
@@ -13992,10 +14028,10 @@ impl<'a, 't> TSTypeReferenceWithoutTypeName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_REFERENCE_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -14422,10 +14458,10 @@ impl<'a, 't> TSTypeAliasDeclarationWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -14554,10 +14590,10 @@ impl<'a, 't> TSTypeAliasDeclarationWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -14612,10 +14648,10 @@ impl<'a, 't> TSClassImplementsWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CLASS_IMPLEMENTS_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -14703,26 +14739,26 @@ impl<'a, 't> TSInterfaceDeclarationWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn extends(self) -> &'t Vec<'a, TSInterfaceHeritage<'a>> {
+    pub fn extends(self) -> &'t ArenaVec<'a, TSInterfaceHeritage<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-                as *const Vec<'a, TSInterfaceHeritage<'a>>)
+                as *const ArenaVec<'a, TSInterfaceHeritage<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, TSInterfaceBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, TSInterfaceBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_BODY)
-                as *const Box<'a, TSInterfaceBody<'a>>)
+                as *const ArenaBox<'a, TSInterfaceBody<'a>>)
         }
     }
 
@@ -14781,18 +14817,18 @@ impl<'a, 't> TSInterfaceDeclarationWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn extends(self) -> &'t Vec<'a, TSInterfaceHeritage<'a>> {
+    pub fn extends(self) -> &'t ArenaVec<'a, TSInterfaceHeritage<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-                as *const Vec<'a, TSInterfaceHeritage<'a>>)
+                as *const ArenaVec<'a, TSInterfaceHeritage<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, TSInterfaceBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, TSInterfaceBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_BODY)
-                as *const Box<'a, TSInterfaceBody<'a>>)
+                as *const ArenaBox<'a, TSInterfaceBody<'a>>)
         }
     }
 
@@ -14851,18 +14887,18 @@ impl<'a, 't> TSInterfaceDeclarationWithoutExtends<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, TSInterfaceBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, TSInterfaceBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_BODY)
-                as *const Box<'a, TSInterfaceBody<'a>>)
+                as *const ArenaBox<'a, TSInterfaceBody<'a>>)
         }
     }
 
@@ -14921,18 +14957,18 @@ impl<'a, 't> TSInterfaceDeclarationWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn extends(self) -> &'t Vec<'a, TSInterfaceHeritage<'a>> {
+    pub fn extends(self) -> &'t ArenaVec<'a, TSInterfaceHeritage<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-                as *const Vec<'a, TSInterfaceHeritage<'a>>)
+                as *const ArenaVec<'a, TSInterfaceHeritage<'a>>)
         }
     }
 
@@ -15047,10 +15083,10 @@ impl<'a, 't> TSPropertySignatureWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_PROPERTY_SIGNATURE_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 }
@@ -15150,10 +15186,10 @@ impl<'a, 't> TSIndexSignatureWithoutParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn type_annotation(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_TYPE_ANNOTATION)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -15196,10 +15232,10 @@ impl<'a, 't> TSIndexSignatureWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn parameters(self) -> &'t Vec<'a, TSIndexSignatureName<'a>> {
+    pub fn parameters(self) -> &'t ArenaVec<'a, TSIndexSignatureName<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_PARAMETERS)
-                as *const Vec<'a, TSIndexSignatureName<'a>>)
+                as *const ArenaVec<'a, TSIndexSignatureName<'a>>)
         }
     }
 
@@ -15260,26 +15296,26 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15323,26 +15359,26 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutThisParam<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15386,26 +15422,26 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15449,26 +15485,26 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
@@ -15545,34 +15581,34 @@ impl<'a, 't> TSMethodSignatureWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15638,26 +15674,26 @@ impl<'a, 't> TSMethodSignatureWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15723,26 +15759,26 @@ impl<'a, 't> TSMethodSignatureWithoutThisParam<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15808,26 +15844,26 @@ impl<'a, 't> TSMethodSignatureWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15893,26 +15929,26 @@ impl<'a, 't> TSMethodSignatureWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
@@ -15970,18 +16006,18 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -16026,18 +16062,18 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -16082,18 +16118,18 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
@@ -16188,10 +16224,10 @@ impl<'a, 't> TSInterfaceHeritageWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_HERITAGE_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -16274,10 +16310,10 @@ impl<'a, 't> TSTypePredicateWithoutParameterName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_PREDICATE_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 }
@@ -16549,10 +16585,10 @@ impl<'a, 't> TSModuleBlockWithoutDirectives<'a, 't> {
     }
 
     #[inline]
-    pub fn body(self) -> &'t Vec<'a, Statement<'a>> {
+    pub fn body(self) -> &'t ArenaVec<'a, Statement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_MODULE_BLOCK_BODY)
-                as *const Vec<'a, Statement<'a>>)
+                as *const ArenaVec<'a, Statement<'a>>)
         }
     }
 }
@@ -16585,10 +16621,10 @@ impl<'a, 't> TSModuleBlockWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn directives(self) -> &'t Vec<'a, Directive<'a>> {
+    pub fn directives(self) -> &'t ArenaVec<'a, Directive<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_MODULE_BLOCK_DIRECTIVES)
-                as *const Vec<'a, Directive<'a>>)
+                as *const ArenaVec<'a, Directive<'a>>)
         }
     }
 }
@@ -16692,10 +16728,10 @@ impl<'a, 't> TSTypeQueryWithoutExprName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_QUERY_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -16772,10 +16808,10 @@ impl<'a, 't> TSImportTypeWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn options(self) -> &'t Option<Box<'a, ObjectExpression<'a>>> {
+    pub fn options(self) -> &'t Option<ArenaBox<'a, ObjectExpression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_OPTIONS)
-                as *const Option<Box<'a, ObjectExpression<'a>>>)
+                as *const Option<ArenaBox<'a, ObjectExpression<'a>>>)
         }
     }
 
@@ -16788,10 +16824,10 @@ impl<'a, 't> TSImportTypeWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -16839,10 +16875,10 @@ impl<'a, 't> TSImportTypeWithoutOptions<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -16882,18 +16918,18 @@ impl<'a, 't> TSImportTypeWithoutQualifier<'a, 't> {
     }
 
     #[inline]
-    pub fn options(self) -> &'t Option<Box<'a, ObjectExpression<'a>>> {
+    pub fn options(self) -> &'t Option<ArenaBox<'a, ObjectExpression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_OPTIONS)
-                as *const Option<Box<'a, ObjectExpression<'a>>>)
+                as *const Option<ArenaBox<'a, ObjectExpression<'a>>>)
         }
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -16933,10 +16969,10 @@ impl<'a, 't> TSImportTypeWithoutTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn options(self) -> &'t Option<Box<'a, ObjectExpression<'a>>> {
+    pub fn options(self) -> &'t Option<ArenaBox<'a, ObjectExpression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_OPTIONS)
-                as *const Option<Box<'a, ObjectExpression<'a>>>)
+                as *const Option<ArenaBox<'a, ObjectExpression<'a>>>)
         }
     }
 
@@ -17074,26 +17110,26 @@ impl<'a, 't> TSFunctionTypeWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -17134,26 +17170,26 @@ impl<'a, 't> TSFunctionTypeWithoutThisParam<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -17194,26 +17230,26 @@ impl<'a, 't> TSFunctionTypeWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -17254,26 +17290,26 @@ impl<'a, 't> TSFunctionTypeWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
@@ -17331,18 +17367,18 @@ impl<'a, 't> TSConstructorTypeWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -17388,18 +17424,18 @@ impl<'a, 't> TSConstructorTypeWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -17445,18 +17481,18 @@ impl<'a, 't> TSConstructorTypeWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
@@ -17818,10 +17854,10 @@ impl<'a, 't> TSTemplateLiteralTypeWithoutQuasis<'a, 't> {
     }
 
     #[inline]
-    pub fn types(self) -> &'t Vec<'a, TSType<'a>> {
+    pub fn types(self) -> &'t ArenaVec<'a, TSType<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TEMPLATE_LITERAL_TYPE_TYPES)
-                as *const Vec<'a, TSType<'a>>)
+                as *const ArenaVec<'a, TSType<'a>>)
         }
     }
 }
@@ -17857,10 +17893,10 @@ impl<'a, 't> TSTemplateLiteralTypeWithoutTypes<'a, 't> {
     }
 
     #[inline]
-    pub fn quasis(self) -> &'t Vec<'a, TemplateElement<'a>> {
+    pub fn quasis(self) -> &'t ArenaVec<'a, TemplateElement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TEMPLATE_LITERAL_TYPE_QUASIS)
-                as *const Vec<'a, TemplateElement<'a>>)
+                as *const ArenaVec<'a, TemplateElement<'a>>)
         }
     }
 }
@@ -18427,10 +18463,10 @@ impl<'a, 't> TSInstantiationExpressionWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Box<'a, TSTypeParameterInstantiation<'a>> {
+    pub fn type_arguments(self) -> &'t ArenaBox<'a, TSTypeParameterInstantiation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Box<'a, TSTypeParameterInstantiation<'a>>)
+                as *const ArenaBox<'a, TSTypeParameterInstantiation<'a>>)
         }
     }
 }

--- a/crates/oxc_minifier/src/generated/traverse.rs
+++ b/crates/oxc_minifier/src/generated/traverse.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/minifier_traverse/mod.rs`.
 
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 
 use crate::TraverseCtx;
@@ -2482,7 +2482,17 @@ pub trait Traverse<'a> {
     }
 
     #[inline]
-    fn enter_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {}
+    fn enter_statements(
+        &mut self,
+        node: &mut ArenaVec<'a, Statement<'a>>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
     #[inline]
-    fn exit_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {}
+    fn exit_statements(
+        &mut self,
+        node: &mut ArenaVec<'a, Statement<'a>>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
 }

--- a/crates/oxc_minifier/src/generated/walk.rs
+++ b/crates/oxc_minifier/src/generated/walk.rs
@@ -13,7 +13,7 @@
 
 use std::{cell::Cell, marker::PhantomData};
 
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_syntax::scope::ScopeId;
 
@@ -61,15 +61,15 @@ unsafe fn walk_program<'a, Tr: Traverse<'a>>(
         walk_hashbang(traverser, field as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ProgramDirectives);
-    for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_PROGRAM_DIRECTIVES) as *mut Vec<Directive>)
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_PROGRAM_DIRECTIVES)
+        as *mut ArenaVec<Directive>)
     {
         walk_directive(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ProgramBody);
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_PROGRAM_BODY) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_PROGRAM_BODY) as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -260,7 +260,7 @@ unsafe fn walk_array_expression<'a, Tr: Traverse<'a>>(
         ancestor::ArrayExpressionWithoutElements(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_EXPRESSION_ELEMENTS)
-        as *mut Vec<ArrayExpressionElement>)
+        as *mut ArenaVec<ArrayExpressionElement>)
     {
         walk_array_expression_element(traverser, item as *mut _, ctx);
     }
@@ -349,7 +349,7 @@ unsafe fn walk_object_expression<'a, Tr: Traverse<'a>>(
         ancestor::ObjectExpressionWithoutProperties(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_EXPRESSION_PROPERTIES)
-        as *mut Vec<ObjectPropertyKind>)
+        as *mut ArenaVec<ObjectPropertyKind>)
     {
         walk_object_property_kind(traverser, item as *mut _, ctx);
     }
@@ -468,13 +468,13 @@ unsafe fn walk_template_literal<'a, Tr: Traverse<'a>>(
         ancestor::TemplateLiteralWithoutQuasis(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TEMPLATE_LITERAL_QUASIS)
-        as *mut Vec<TemplateElement>)
+        as *mut ArenaVec<TemplateElement>)
     {
         walk_template_element(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TemplateLiteralExpressions);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TEMPLATE_LITERAL_EXPRESSIONS)
-        as *mut Vec<Expression>)
+        as *mut ArenaVec<Expression>)
     {
         walk_expression(traverser, item as *mut _, ctx);
     }
@@ -498,7 +498,7 @@ unsafe fn walk_tagged_template_expression<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TaggedTemplateExpressionTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -635,14 +635,14 @@ unsafe fn walk_call_expression<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::CallExpressionTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::CallExpressionArguments);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_CALL_EXPRESSION_ARGUMENTS)
-        as *mut Vec<Argument>)
+        as *mut ArenaVec<Argument>)
     {
         walk_argument(traverser, item as *mut _, ctx);
     }
@@ -666,14 +666,14 @@ unsafe fn walk_new_expression<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::NewExpressionTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::NewExpressionArguments);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_NEW_EXPRESSION_ARGUMENTS)
-        as *mut Vec<Argument>)
+        as *mut ArenaVec<Argument>)
     {
         walk_argument(traverser, item as *mut _, ctx);
     }
@@ -1029,14 +1029,14 @@ unsafe fn walk_array_assignment_target<'a, Tr: Traverse<'a>>(
         ancestor::ArrayAssignmentTargetWithoutElements(node, PhantomData),
     ));
     for item in (*((node as *mut u8).add(ancestor::OFFSET_ARRAY_ASSIGNMENT_TARGET_ELEMENTS)
-        as *mut Vec<Option<AssignmentTargetMaybeDefault>>))
+        as *mut ArenaVec<Option<AssignmentTargetMaybeDefault>>))
         .iter_mut()
         .flatten()
     {
         walk_assignment_target_maybe_default(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_ASSIGNMENT_TARGET_REST)
-        as *mut Option<Box<AssignmentTargetRest>>)
+        as *mut Option<ArenaBox<AssignmentTargetRest>>)
     {
         ctx.retag_stack(AncestorType::ArrayAssignmentTargetRest);
         walk_assignment_target_rest(traverser, (&mut **field) as *mut _, ctx);
@@ -1055,13 +1055,13 @@ unsafe fn walk_object_assignment_target<'a, Tr: Traverse<'a>>(
         ancestor::ObjectAssignmentTargetWithoutProperties(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_ASSIGNMENT_TARGET_PROPERTIES)
-        as *mut Vec<AssignmentTargetProperty>)
+        as *mut ArenaVec<AssignmentTargetProperty>)
     {
         walk_assignment_target_property(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_OBJECT_ASSIGNMENT_TARGET_REST)
-        as *mut Option<Box<AssignmentTargetRest>>)
+        as *mut Option<ArenaBox<AssignmentTargetRest>>)
     {
         ctx.retag_stack(AncestorType::ObjectAssignmentTargetRest);
         walk_assignment_target_rest(traverser, (&mut **field) as *mut _, ctx);
@@ -1220,7 +1220,7 @@ unsafe fn walk_sequence_expression<'a, Tr: Traverse<'a>>(
         ancestor::SequenceExpressionWithoutExpressions(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_SEQUENCE_EXPRESSION_EXPRESSIONS)
-        as *mut Vec<Expression>)
+        as *mut ArenaVec<Expression>)
     {
         walk_expression(traverser, item as *mut _, ctx);
     }
@@ -1442,7 +1442,7 @@ unsafe fn walk_block_statement<'a, Tr: Traverse<'a>>(
     ));
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_BLOCK_STATEMENT_BODY) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_BLOCK_STATEMENT_BODY) as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1497,7 +1497,7 @@ unsafe fn walk_variable_declaration<'a, Tr: Traverse<'a>>(
         ancestor::VariableDeclarationWithoutDeclarations(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_VARIABLE_DECLARATION_DECLARATIONS)
-        as *mut Vec<VariableDeclarator>)
+        as *mut ArenaVec<VariableDeclarator>)
     {
         walk_variable_declarator(traverser, item as *mut _, ctx);
     }
@@ -1521,7 +1521,7 @@ unsafe fn walk_variable_declarator<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_VARIABLE_DECLARATOR_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::VariableDeclaratorTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -1950,7 +1950,7 @@ unsafe fn walk_switch_statement<'a, Tr: Traverse<'a>>(
     ctx.set_current_scope_id(current_scope_id);
     ctx.retag_stack(AncestorType::SwitchStatementCases);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_CASES)
-        as *mut Vec<SwitchCase>)
+        as *mut ArenaVec<SwitchCase>)
     {
         walk_switch_case(traverser, item as *mut _, ctx);
     }
@@ -1975,7 +1975,7 @@ unsafe fn walk_switch_case<'a, Tr: Traverse<'a>>(
     ctx.retag_stack(AncestorType::SwitchCaseConsequent);
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_SWITCH_CASE_CONSEQUENT) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_SWITCH_CASE_CONSEQUENT) as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2036,17 +2036,17 @@ unsafe fn walk_try_statement<'a, Tr: Traverse<'a>>(
     walk_block_statement(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_BLOCK)
-            as *mut Box<BlockStatement>)) as *mut _,
+            as *mut ArenaBox<BlockStatement>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_HANDLER)
-        as *mut Option<Box<CatchClause>>)
+        as *mut Option<ArenaBox<CatchClause>>)
     {
         ctx.retag_stack(AncestorType::TryStatementHandler);
         walk_catch_clause(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_FINALIZER)
-        as *mut Option<Box<BlockStatement>>)
+        as *mut Option<ArenaBox<BlockStatement>>)
     {
         ctx.retag_stack(AncestorType::TryStatementFinalizer);
         walk_block_statement(traverser, (&mut **field) as *mut _, ctx);
@@ -2080,7 +2080,7 @@ unsafe fn walk_catch_clause<'a, Tr: Traverse<'a>>(
     walk_block_statement(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_BODY)
-            as *mut Box<BlockStatement>)) as *mut _,
+            as *mut ArenaBox<BlockStatement>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2104,7 +2104,7 @@ unsafe fn walk_catch_parameter<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_CATCH_PARAMETER_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::CatchParameterTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -2179,12 +2179,12 @@ unsafe fn walk_object_pattern<'a, Tr: Traverse<'a>>(
         ancestor::ObjectPatternWithoutProperties(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_PATTERN_PROPERTIES)
-        as *mut Vec<BindingProperty>)
+        as *mut ArenaVec<BindingProperty>)
     {
         walk_binding_property(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_PATTERN_REST)
-        as *mut Option<Box<BindingRestElement>>)
+        as *mut Option<ArenaBox<BindingRestElement>>)
     {
         ctx.retag_stack(AncestorType::ObjectPatternRest);
         walk_binding_rest_element(traverser, (&mut **field) as *mut _, ctx);
@@ -2227,14 +2227,14 @@ unsafe fn walk_array_pattern<'a, Tr: Traverse<'a>>(
         ancestor::ArrayPatternWithoutElements(node, PhantomData),
     ));
     for item in (*((node as *mut u8).add(ancestor::OFFSET_ARRAY_PATTERN_ELEMENTS)
-        as *mut Vec<Option<BindingPattern>>))
+        as *mut ArenaVec<Option<BindingPattern>>))
         .iter_mut()
         .flatten()
     {
         walk_binding_pattern(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_PATTERN_REST)
-        as *mut Option<Box<BindingRestElement>>)
+        as *mut Option<ArenaBox<BindingRestElement>>)
     {
         ctx.retag_stack(AncestorType::ArrayPatternRest);
         walk_binding_rest_element(traverser, (&mut **field) as *mut _, ctx);
@@ -2286,13 +2286,13 @@ unsafe fn walk_function<'a, Tr: Traverse<'a>>(
         walk_binding_identifier(traverser, field as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::FunctionTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_THIS_PARAM)
-        as *mut Option<Box<TSThisParameter>>)
+        as *mut Option<ArenaBox<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::FunctionThisParam);
         walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
@@ -2301,17 +2301,17 @@ unsafe fn walk_function<'a, Tr: Traverse<'a>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_FUNCTION_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_RETURN_TYPE)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::FunctionReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY)
-        as *mut Option<Box<FunctionBody>>)
+        as *mut Option<ArenaBox<FunctionBody>>)
     {
         ctx.retag_stack(AncestorType::FunctionBody);
         walk_function_body(traverser, (&mut **field) as *mut _, ctx);
@@ -2333,12 +2333,12 @@ unsafe fn walk_formal_parameters<'a, Tr: Traverse<'a>>(
         ancestor::FormalParametersWithoutItems(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETERS_ITEMS)
-        as *mut Vec<FormalParameter>)
+        as *mut ArenaVec<FormalParameter>)
     {
         walk_formal_parameter(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETERS_REST)
-        as *mut Option<Box<FormalParameterRest>>)
+        as *mut Option<ArenaBox<FormalParameterRest>>)
     {
         ctx.retag_stack(AncestorType::FormalParametersRest);
         walk_formal_parameter_rest(traverser, (&mut **field) as *mut _, ctx);
@@ -2357,7 +2357,7 @@ unsafe fn walk_formal_parameter<'a, Tr: Traverse<'a>>(
         ancestor::FormalParameterWithoutDecorators(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_DECORATORS)
-        as *mut Vec<Decorator>)
+        as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2369,13 +2369,13 @@ unsafe fn walk_formal_parameter<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_FORMAL_PARAMETER_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::FormalParameterTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_INITIALIZER)
-        as *mut Option<Box<Expression>>)
+        as *mut Option<ArenaBox<Expression>>)
     {
         ctx.retag_stack(AncestorType::FormalParameterInitializer);
         walk_expression(traverser, (&mut **field) as *mut _, ctx);
@@ -2394,7 +2394,7 @@ unsafe fn walk_formal_parameter_rest<'a, Tr: Traverse<'a>>(
         ancestor::FormalParameterRestWithoutDecorators(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_REST_DECORATORS)
-        as *mut Vec<Decorator>)
+        as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2407,7 +2407,7 @@ unsafe fn walk_formal_parameter_rest<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_FORMAL_PARAMETER_REST_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::FormalParameterRestTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -2426,14 +2426,15 @@ unsafe fn walk_function_body<'a, Tr: Traverse<'a>>(
         ancestor::FunctionBodyWithoutDirectives(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_DIRECTIVES)
-        as *mut Vec<Directive>)
+        as *mut ArenaVec<Directive>)
     {
         walk_directive(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::FunctionBodyStatements);
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_STATEMENTS) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_STATEMENTS)
+            as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2462,7 +2463,7 @@ unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
@@ -2470,12 +2471,12 @@ unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::ArrowFunctionExpressionReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -2484,7 +2485,7 @@ unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
     walk_function_body(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-            as *mut Box<FunctionBody>)) as *mut _,
+            as *mut ArenaBox<FunctionBody>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2521,7 +2522,7 @@ unsafe fn walk_class<'a, Tr: Traverse<'a>>(
     let pop_token = ctx
         .push_stack(Ancestor::ClassDecorators(ancestor::ClassWithoutDecorators(node, PhantomData)));
     for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_DECORATORS) as *mut Vec<Decorator>)
+        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_DECORATORS) as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2538,7 +2539,7 @@ unsafe fn walk_class<'a, Tr: Traverse<'a>>(
         .unwrap();
     ctx.set_current_scope_id(current_scope_id);
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::ClassTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
@@ -2550,21 +2551,21 @@ unsafe fn walk_class<'a, Tr: Traverse<'a>>(
         walk_expression(traverser, field as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::ClassSuperTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ClassImplements);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_IMPLEMENTS)
-        as *mut Vec<TSClassImplements>)
+        as *mut ArenaVec<TSClassImplements>)
     {
         walk_ts_class_implements(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ClassBody);
     walk_class_body(
         traverser,
-        (&mut **((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY) as *mut Box<ClassBody>))
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY) as *mut ArenaBox<ClassBody>))
             as *mut _,
         ctx,
     );
@@ -2581,8 +2582,8 @@ unsafe fn walk_class_body<'a, Tr: Traverse<'a>>(
     traverser.enter_class_body(&mut *node, ctx);
     let pop_token =
         ctx.push_stack(Ancestor::ClassBodyBody(ancestor::ClassBodyWithoutBody(node, PhantomData)));
-    for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY_BODY) as *mut Vec<ClassElement>)
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY_BODY)
+        as *mut ArenaVec<ClassElement>)
     {
         walk_class_element(traverser, item as *mut _, ctx);
     }
@@ -2626,7 +2627,7 @@ unsafe fn walk_method_definition<'a, Tr: Traverse<'a>>(
         ancestor::MethodDefinitionWithoutDecorators(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_DECORATORS)
-        as *mut Vec<Decorator>)
+        as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2640,7 +2641,7 @@ unsafe fn walk_method_definition<'a, Tr: Traverse<'a>>(
     walk_function(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_VALUE)
-            as *mut Box<Function>)) as *mut _,
+            as *mut ArenaBox<Function>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2657,7 +2658,7 @@ unsafe fn walk_property_definition<'a, Tr: Traverse<'a>>(
         ancestor::PropertyDefinitionWithoutDecorators(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_PROPERTY_DEFINITION_DECORATORS)
-        as *mut Vec<Decorator>)
+        as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2669,7 +2670,7 @@ unsafe fn walk_property_definition<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_PROPERTY_DEFINITION_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::PropertyDefinitionTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -2713,7 +2714,7 @@ unsafe fn walk_static_block<'a, Tr: Traverse<'a>>(
         .push_stack(Ancestor::StaticBlockBody(ancestor::StaticBlockWithoutBody(node, PhantomData)));
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_STATIC_BLOCK_BODY) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_STATIC_BLOCK_BODY) as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2762,7 +2763,7 @@ unsafe fn walk_accessor_property<'a, Tr: Traverse<'a>>(
         ancestor::AccessorPropertyWithoutDecorators(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_ACCESSOR_PROPERTY_DECORATORS)
-        as *mut Vec<Decorator>)
+        as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2774,7 +2775,7 @@ unsafe fn walk_accessor_property<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ACCESSOR_PROPERTY_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::AccessorPropertyTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -2824,7 +2825,7 @@ unsafe fn walk_import_declaration<'a, Tr: Traverse<'a>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_IMPORT_DECLARATION_SPECIFIERS)
-        as *mut Option<Vec<ImportDeclarationSpecifier>>)
+        as *mut Option<ArenaVec<ImportDeclarationSpecifier>>)
     {
         for item in field.iter_mut() {
             walk_import_declaration_specifier(traverser, item as *mut _, ctx);
@@ -2838,7 +2839,7 @@ unsafe fn walk_import_declaration<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_IMPORT_DECLARATION_WITH_CLAUSE)
-        as *mut Option<Box<WithClause>>)
+        as *mut Option<ArenaBox<WithClause>>)
     {
         ctx.retag_stack(AncestorType::ImportDeclarationWithClause);
         walk_with_clause(traverser, (&mut **field) as *mut _, ctx);
@@ -2939,7 +2940,7 @@ unsafe fn walk_with_clause<'a, Tr: Traverse<'a>>(
         ancestor::WithClauseWithoutWithEntries(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_WITH_CLAUSE_WITH_ENTRIES)
-        as *mut Vec<ImportAttribute>)
+        as *mut ArenaVec<ImportAttribute>)
     {
         walk_import_attribute(traverser, item as *mut _, ctx);
     }
@@ -3005,7 +3006,7 @@ unsafe fn walk_export_named_declaration<'a, Tr: Traverse<'a>>(
     }
     ctx.retag_stack(AncestorType::ExportNamedDeclarationSpecifiers);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
-        as *mut Vec<ExportSpecifier>)
+        as *mut ArenaVec<ExportSpecifier>)
     {
         walk_export_specifier(traverser, item as *mut _, ctx);
     }
@@ -3018,7 +3019,7 @@ unsafe fn walk_export_named_declaration<'a, Tr: Traverse<'a>>(
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
-        as *mut Option<Box<WithClause>>)
+        as *mut Option<ArenaBox<WithClause>>)
     {
         ctx.retag_stack(AncestorType::ExportNamedDeclarationWithClause);
         walk_with_clause(traverser, (&mut **field) as *mut _, ctx);
@@ -3069,7 +3070,7 @@ unsafe fn walk_export_all_declaration<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_EXPORT_ALL_DECLARATION_WITH_CLAUSE)
-        as *mut Option<Box<WithClause>>)
+        as *mut Option<ArenaBox<WithClause>>)
     {
         ctx.retag_stack(AncestorType::ExportAllDeclarationWithClause);
         walk_with_clause(traverser, (&mut **field) as *mut _, ctx);
@@ -3203,7 +3204,7 @@ unsafe fn walk_v8_intrinsic_expression<'a, Tr: Traverse<'a>>(
     );
     ctx.retag_stack(AncestorType::V8IntrinsicExpressionArguments);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_V8_INTRINSIC_EXPRESSION_ARGUMENTS)
-        as *mut Vec<Argument>)
+        as *mut ArenaVec<Argument>)
     {
         walk_argument(traverser, item as *mut _, ctx);
     }
@@ -3277,17 +3278,17 @@ unsafe fn walk_jsx_element<'a, Tr: Traverse<'a>>(
     walk_jsx_opening_element(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
-            as *mut Box<JSXOpeningElement>)) as *mut _,
+            as *mut ArenaBox<JSXOpeningElement>)) as *mut _,
         ctx,
     );
     ctx.retag_stack(AncestorType::JSXElementChildren);
-    for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CHILDREN) as *mut Vec<JSXChild>)
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CHILDREN)
+        as *mut ArenaVec<JSXChild>)
     {
         walk_jsx_child(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
-        as *mut Option<Box<JSXClosingElement>>)
+        as *mut Option<ArenaBox<JSXClosingElement>>)
     {
         ctx.retag_stack(AncestorType::JSXElementClosingElement);
         walk_jsx_closing_element(traverser, (&mut **field) as *mut _, ctx);
@@ -3312,14 +3313,14 @@ unsafe fn walk_jsx_opening_element<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::JSXOpeningElementTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::JSXOpeningElementAttributes);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
-        as *mut Vec<JSXAttributeItem>)
+        as *mut ArenaVec<JSXAttributeItem>)
     {
         walk_jsx_attribute_item(traverser, item as *mut _, ctx);
     }
@@ -3361,8 +3362,8 @@ unsafe fn walk_jsx_fragment<'a, Tr: Traverse<'a>>(
         ctx,
     );
     ctx.retag_stack(AncestorType::JSXFragmentChildren);
-    for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CHILDREN) as *mut Vec<JSXChild>)
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CHILDREN)
+        as *mut ArenaVec<JSXChild>)
     {
         walk_jsx_child(traverser, item as *mut _, ctx);
     }
@@ -3743,7 +3744,7 @@ unsafe fn walk_ts_this_parameter<'a, Tr: Traverse<'a>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_THIS_PARAMETER_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
@@ -3791,7 +3792,7 @@ unsafe fn walk_ts_enum_body<'a, Tr: Traverse<'a>>(
         ancestor::TSEnumBodyWithoutMembers(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_ENUM_BODY_MEMBERS)
-        as *mut Vec<TSEnumMember>)
+        as *mut ArenaVec<TSEnumMember>)
     {
         walk_ts_enum_member(traverser, item as *mut _, ctx);
     }
@@ -4069,7 +4070,7 @@ unsafe fn walk_ts_union_type<'a, Tr: Traverse<'a>>(
         PhantomData,
     )));
     for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_TS_UNION_TYPE_TYPES) as *mut Vec<TSType>)
+        &mut *((node as *mut u8).add(ancestor::OFFSET_TS_UNION_TYPE_TYPES) as *mut ArenaVec<TSType>)
     {
         walk_ts_type(traverser, item as *mut _, ctx);
     }
@@ -4087,7 +4088,7 @@ unsafe fn walk_ts_intersection_type<'a, Tr: Traverse<'a>>(
         ancestor::TSIntersectionTypeWithoutTypes(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERSECTION_TYPE_TYPES)
-        as *mut Vec<TSType>)
+        as *mut ArenaVec<TSType>)
     {
         walk_ts_type(traverser, item as *mut _, ctx);
     }
@@ -4184,7 +4185,7 @@ unsafe fn walk_ts_tuple_type<'a, Tr: Traverse<'a>>(
         ancestor::TSTupleTypeWithoutElementTypes(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TUPLE_TYPE_ELEMENT_TYPES)
-        as *mut Vec<TSTupleElement>)
+        as *mut ArenaVec<TSTupleElement>)
     {
         walk_ts_tuple_element(traverser, item as *mut _, ctx);
     }
@@ -4449,7 +4450,7 @@ unsafe fn walk_ts_type_reference<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_REFERENCE_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSTypeReferenceTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -4513,7 +4514,7 @@ unsafe fn walk_ts_type_parameter_instantiation<'a, Tr: Traverse<'a>>(
     ));
     for item in &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_PARAMETER_INSTANTIATION_PARAMS)
-        as *mut Vec<TSType>)
+        as *mut ArenaVec<TSType>)
     {
         walk_ts_type(traverser, item as *mut _, ctx);
     }
@@ -4561,7 +4562,7 @@ unsafe fn walk_ts_type_parameter_declaration<'a, Tr: Traverse<'a>>(
         ancestor::TSTypeParameterDeclarationWithoutParams(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_DECLARATION_PARAMS)
-        as *mut Vec<TSTypeParameter>)
+        as *mut ArenaVec<TSTypeParameter>)
     {
         walk_ts_type_parameter(traverser, item as *mut _, ctx);
     }
@@ -4593,7 +4594,7 @@ unsafe fn walk_ts_type_alias_declaration<'a, Tr: Traverse<'a>>(
     ctx.set_current_scope_id(current_scope_id);
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSTypeAliasDeclarationTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
@@ -4626,7 +4627,7 @@ unsafe fn walk_ts_class_implements<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CLASS_IMPLEMENTS_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSClassImplementsTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -4659,14 +4660,14 @@ unsafe fn walk_ts_interface_declaration<'a, Tr: Traverse<'a>>(
     ctx.set_current_scope_id(current_scope_id);
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSInterfaceDeclarationTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSInterfaceDeclarationExtends);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-        as *mut Vec<TSInterfaceHeritage>)
+        as *mut ArenaVec<TSInterfaceHeritage>)
     {
         walk_ts_interface_heritage(traverser, item as *mut _, ctx);
     }
@@ -4674,7 +4675,7 @@ unsafe fn walk_ts_interface_declaration<'a, Tr: Traverse<'a>>(
     walk_ts_interface_body(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_BODY)
-            as *mut Box<TSInterfaceBody>)) as *mut _,
+            as *mut ArenaBox<TSInterfaceBody>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4692,7 +4693,7 @@ unsafe fn walk_ts_interface_body<'a, Tr: Traverse<'a>>(
         ancestor::TSInterfaceBodyWithoutBody(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_BODY_BODY)
-        as *mut Vec<TSSignature>)
+        as *mut ArenaVec<TSSignature>)
     {
         walk_ts_signature(traverser, item as *mut _, ctx);
     }
@@ -4716,7 +4717,7 @@ unsafe fn walk_ts_property_signature<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_PROPERTY_SIGNATURE_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSPropertySignatureTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -4761,7 +4762,7 @@ unsafe fn walk_ts_index_signature<'a, Tr: Traverse<'a>>(
         ancestor::TSIndexSignatureWithoutParameters(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_PARAMETERS)
-        as *mut Vec<TSIndexSignatureName>)
+        as *mut ArenaVec<TSIndexSignatureName>)
     {
         walk_ts_index_signature_name(traverser, item as *mut _, ctx);
     }
@@ -4769,7 +4770,7 @@ unsafe fn walk_ts_index_signature<'a, Tr: Traverse<'a>>(
     walk_ts_type_annotation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_TYPE_ANNOTATION)
-            as *mut Box<TSTypeAnnotation>)) as *mut _,
+            as *mut ArenaBox<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4794,13 +4795,13 @@ unsafe fn walk_ts_call_signature_declaration<'a, Tr: Traverse<'a>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-        as *mut Option<Box<TSThisParameter>>)
+        as *mut Option<ArenaBox<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::TSCallSignatureDeclarationThisParam);
         walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
@@ -4809,12 +4810,12 @@ unsafe fn walk_ts_call_signature_declaration<'a, Tr: Traverse<'a>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSCallSignatureDeclarationReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -4846,14 +4847,14 @@ unsafe fn walk_ts_method_signature<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSMethodSignatureTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-        as *mut Option<Box<TSThisParameter>>)
+        as *mut Option<ArenaBox<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::TSMethodSignatureThisParam);
         walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
@@ -4862,12 +4863,12 @@ unsafe fn walk_ts_method_signature<'a, Tr: Traverse<'a>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSMethodSignatureReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -4895,7 +4896,7 @@ unsafe fn walk_ts_construct_signature_declaration<'a, Tr: Traverse<'a>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
@@ -4903,12 +4904,12 @@ unsafe fn walk_ts_construct_signature_declaration<'a, Tr: Traverse<'a>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSConstructSignatureDeclarationReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -4930,7 +4931,7 @@ unsafe fn walk_ts_index_signature_name<'a, Tr: Traverse<'a>>(
     walk_ts_type_annotation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION)
-            as *mut Box<TSTypeAnnotation>)) as *mut _,
+            as *mut ArenaBox<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4953,7 +4954,7 @@ unsafe fn walk_ts_interface_heritage<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_INTERFACE_HERITAGE_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSInterfaceHeritageTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -4979,7 +4980,7 @@ unsafe fn walk_ts_type_predicate<'a, Tr: Traverse<'a>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_PREDICATE_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSTypePredicateTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -5120,14 +5121,14 @@ unsafe fn walk_ts_module_block<'a, Tr: Traverse<'a>>(
         ancestor::TSModuleBlockWithoutDirectives(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_DIRECTIVES)
-        as *mut Vec<Directive>)
+        as *mut ArenaVec<Directive>)
     {
         walk_directive(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSModuleBlockBody);
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_BODY) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_BODY) as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5144,7 +5145,7 @@ unsafe fn walk_ts_type_literal<'a, Tr: Traverse<'a>>(
         ancestor::TSTypeLiteralWithoutMembers(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_LITERAL_MEMBERS)
-        as *mut Vec<TSSignature>)
+        as *mut ArenaVec<TSSignature>)
     {
         walk_ts_signature(traverser, item as *mut _, ctx);
     }
@@ -5164,7 +5165,7 @@ unsafe fn walk_ts_infer_type<'a, Tr: Traverse<'a>>(
     walk_ts_type_parameter(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INFER_TYPE_TYPE_PARAMETER)
-            as *mut Box<TSTypeParameter>)) as *mut _,
+            as *mut ArenaBox<TSTypeParameter>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5186,7 +5187,7 @@ unsafe fn walk_ts_type_query<'a, Tr: Traverse<'a>>(
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_QUERY_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSTypeQueryTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -5229,7 +5230,7 @@ unsafe fn walk_ts_import_type<'a, Tr: Traverse<'a>>(
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_OPTIONS)
-        as *mut Option<Box<ObjectExpression>>)
+        as *mut Option<ArenaBox<ObjectExpression>>)
     {
         ctx.retag_stack(AncestorType::TSImportTypeOptions);
         walk_object_expression(traverser, (&mut **field) as *mut _, ctx);
@@ -5242,7 +5243,7 @@ unsafe fn walk_ts_import_type<'a, Tr: Traverse<'a>>(
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSImportTypeTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -5311,12 +5312,12 @@ unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-        as *mut Option<Box<TSThisParameter>>)
+        as *mut Option<ArenaBox<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::TSFunctionTypeThisParam);
         walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
@@ -5325,14 +5326,14 @@ unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSFunctionTypeReturnType);
     walk_ts_type_annotation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-            as *mut Box<TSTypeAnnotation>)) as *mut _,
+            as *mut ArenaBox<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5357,7 +5358,7 @@ unsafe fn walk_ts_constructor_type<'a, Tr: Traverse<'a>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
@@ -5365,14 +5366,14 @@ unsafe fn walk_ts_constructor_type<'a, Tr: Traverse<'a>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSConstructorTypeReturnType);
     walk_ts_type_annotation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
-            as *mut Box<TSTypeAnnotation>)) as *mut _,
+            as *mut ArenaBox<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5433,13 +5434,13 @@ unsafe fn walk_ts_template_literal_type<'a, Tr: Traverse<'a>>(
         ancestor::TSTemplateLiteralTypeWithoutQuasis(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TEMPLATE_LITERAL_TYPE_QUASIS)
-        as *mut Vec<TemplateElement>)
+        as *mut ArenaVec<TemplateElement>)
     {
         walk_template_element(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSTemplateLiteralTypeTypes);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TEMPLATE_LITERAL_TYPE_TYPES)
-        as *mut Vec<TSType>)
+        as *mut ArenaVec<TSType>)
     {
         walk_ts_type(traverser, item as *mut _, ctx);
     }
@@ -5679,7 +5680,7 @@ unsafe fn walk_ts_instantiation_expression<'a, Tr: Traverse<'a>>(
     walk_ts_type_parameter_instantiation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_ARGUMENTS)
-            as *mut Box<TSTypeParameterInstantiation>)) as *mut _,
+            as *mut ArenaBox<TSTypeParameterInstantiation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5734,7 +5735,7 @@ unsafe fn walk_js_doc_unknown_type<'a, Tr: Traverse<'a>>(
 
 unsafe fn walk_statements<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
-    stmts: *mut Vec<'a, Statement<'a>>,
+    stmts: *mut ArenaVec<'a, Statement<'a>>,
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_statements(&mut *stmts, ctx);

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -12,7 +12,7 @@
 
 use std::{cell::Cell, marker::PhantomData, mem::offset_of};
 
-use oxc_allocator::{Address, Box, GetAddress, Vec};
+use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress};
 use oxc_ast::ast::*;
 use oxc_syntax::{node::NodeId, scope::ScopeId};
 
@@ -2602,22 +2602,24 @@ impl<'a, 't> ProgramWithoutHashbang<'a, 't> {
     }
 
     #[inline]
-    pub fn comments(self) -> &'t Vec<'a, Comment> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const Vec<'a, Comment>) }
-    }
-
-    #[inline]
-    pub fn directives(self) -> &'t Vec<'a, Directive<'a>> {
+    pub fn comments(self) -> &'t ArenaVec<'a, Comment> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_PROGRAM_DIRECTIVES)
-                as *const Vec<'a, Directive<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const ArenaVec<'a, Comment>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Vec<'a, Statement<'a>> {
+    pub fn directives(self) -> &'t ArenaVec<'a, Directive<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_PROGRAM_BODY) as *const Vec<'a, Statement<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_DIRECTIVES)
+                as *const ArenaVec<'a, Directive<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn body(self) -> &'t ArenaVec<'a, Statement<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_BODY) as *const ArenaVec<'a, Statement<'a>>)
         }
     }
 
@@ -2665,8 +2667,10 @@ impl<'a, 't> ProgramWithoutDirectives<'a, 't> {
     }
 
     #[inline]
-    pub fn comments(self) -> &'t Vec<'a, Comment> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const Vec<'a, Comment>) }
+    pub fn comments(self) -> &'t ArenaVec<'a, Comment> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const ArenaVec<'a, Comment>)
+        }
     }
 
     #[inline]
@@ -2677,9 +2681,9 @@ impl<'a, 't> ProgramWithoutDirectives<'a, 't> {
     }
 
     #[inline]
-    pub fn body(self) -> &'t Vec<'a, Statement<'a>> {
+    pub fn body(self) -> &'t ArenaVec<'a, Statement<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_PROGRAM_BODY) as *const Vec<'a, Statement<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_BODY) as *const ArenaVec<'a, Statement<'a>>)
         }
     }
 
@@ -2727,8 +2731,10 @@ impl<'a, 't> ProgramWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn comments(self) -> &'t Vec<'a, Comment> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const Vec<'a, Comment>) }
+    pub fn comments(self) -> &'t ArenaVec<'a, Comment> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_PROGRAM_COMMENTS) as *const ArenaVec<'a, Comment>)
+        }
     }
 
     #[inline]
@@ -2739,10 +2745,10 @@ impl<'a, 't> ProgramWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn directives(self) -> &'t Vec<'a, Directive<'a>> {
+    pub fn directives(self) -> &'t ArenaVec<'a, Directive<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROGRAM_DIRECTIVES)
-                as *const Vec<'a, Directive<'a>>)
+                as *const ArenaVec<'a, Directive<'a>>)
         }
     }
 
@@ -2972,10 +2978,10 @@ impl<'a, 't> TemplateLiteralWithoutQuasis<'a, 't> {
     }
 
     #[inline]
-    pub fn expressions(self) -> &'t Vec<'a, Expression<'a>> {
+    pub fn expressions(self) -> &'t ArenaVec<'a, Expression<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TEMPLATE_LITERAL_EXPRESSIONS)
-                as *const Vec<'a, Expression<'a>>)
+                as *const ArenaVec<'a, Expression<'a>>)
         }
     }
 }
@@ -3008,10 +3014,10 @@ impl<'a, 't> TemplateLiteralWithoutExpressions<'a, 't> {
     }
 
     #[inline]
-    pub fn quasis(self) -> &'t Vec<'a, TemplateElement<'a>> {
+    pub fn quasis(self) -> &'t ArenaVec<'a, TemplateElement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TEMPLATE_LITERAL_QUASIS)
-                as *const Vec<'a, TemplateElement<'a>>)
+                as *const ArenaVec<'a, TemplateElement<'a>>)
         }
     }
 }
@@ -3058,10 +3064,10 @@ impl<'a, 't> TaggedTemplateExpressionWithoutTag<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
@@ -3160,10 +3166,10 @@ impl<'a, 't> TaggedTemplateExpressionWithoutQuasi<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -3514,18 +3520,18 @@ impl<'a, 't> CallExpressionWithoutCallee<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+    pub fn arguments(self) -> &'t ArenaVec<'a, Argument<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
+                as *const ArenaVec<'a, Argument<'a>>)
         }
     }
 
@@ -3575,10 +3581,10 @@ impl<'a, 't> CallExpressionWithoutTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+    pub fn arguments(self) -> &'t ArenaVec<'a, Argument<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
+                as *const ArenaVec<'a, Argument<'a>>)
         }
     }
 
@@ -3628,10 +3634,10 @@ impl<'a, 't> CallExpressionWithoutArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
@@ -3682,18 +3688,18 @@ impl<'a, 't> NewExpressionWithoutCallee<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+    pub fn arguments(self) -> &'t ArenaVec<'a, Argument<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
+                as *const ArenaVec<'a, Argument<'a>>)
         }
     }
 
@@ -3738,10 +3744,10 @@ impl<'a, 't> NewExpressionWithoutTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+    pub fn arguments(self) -> &'t ArenaVec<'a, Argument<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
+                as *const ArenaVec<'a, Argument<'a>>)
         }
     }
 
@@ -3786,10 +3792,10 @@ impl<'a, 't> NewExpressionWithoutArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
@@ -4542,10 +4548,10 @@ impl<'a, 't> ArrayAssignmentTargetWithoutElements<'a, 't> {
     }
 
     #[inline]
-    pub fn rest(self) -> &'t Option<Box<'a, AssignmentTargetRest<'a>>> {
+    pub fn rest(self) -> &'t Option<ArenaBox<'a, AssignmentTargetRest<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_ASSIGNMENT_TARGET_REST)
-                as *const Option<Box<'a, AssignmentTargetRest<'a>>>)
+                as *const Option<ArenaBox<'a, AssignmentTargetRest<'a>>>)
         }
     }
 }
@@ -4579,10 +4585,10 @@ impl<'a, 't> ArrayAssignmentTargetWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn elements(self) -> &'t Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>> {
+    pub fn elements(self) -> &'t ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_ASSIGNMENT_TARGET_ELEMENTS)
-                as *const Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>)
+                as *const ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>)
         }
     }
 }
@@ -4627,10 +4633,10 @@ impl<'a, 't> ObjectAssignmentTargetWithoutProperties<'a, 't> {
     }
 
     #[inline]
-    pub fn rest(self) -> &'t Option<Box<'a, AssignmentTargetRest<'a>>> {
+    pub fn rest(self) -> &'t Option<ArenaBox<'a, AssignmentTargetRest<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_OBJECT_ASSIGNMENT_TARGET_REST)
-                as *const Option<Box<'a, AssignmentTargetRest<'a>>>)
+                as *const Option<ArenaBox<'a, AssignmentTargetRest<'a>>>)
         }
     }
 }
@@ -4666,10 +4672,10 @@ impl<'a, 't> ObjectAssignmentTargetWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn properties(self) -> &'t Vec<'a, AssignmentTargetProperty<'a>> {
+    pub fn properties(self) -> &'t ArenaVec<'a, AssignmentTargetProperty<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_OBJECT_ASSIGNMENT_TARGET_PROPERTIES)
-                as *const Vec<'a, AssignmentTargetProperty<'a>>)
+                as *const ArenaVec<'a, AssignmentTargetProperty<'a>>)
         }
     }
 }
@@ -5304,10 +5310,10 @@ impl<'a, 't> VariableDeclaratorWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_VARIABLE_DECLARATOR_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -5426,10 +5432,10 @@ impl<'a, 't> VariableDeclaratorWithoutInit<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_VARIABLE_DECLARATOR_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -6542,10 +6548,10 @@ impl<'a, 't> SwitchStatementWithoutDiscriminant<'a, 't> {
     }
 
     #[inline]
-    pub fn cases(self) -> &'t Vec<'a, SwitchCase<'a>> {
+    pub fn cases(self) -> &'t ArenaVec<'a, SwitchCase<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_SWITCH_STATEMENT_CASES)
-                as *const Vec<'a, SwitchCase<'a>>)
+                as *const ArenaVec<'a, SwitchCase<'a>>)
         }
     }
 
@@ -6633,10 +6639,10 @@ impl<'a, 't> SwitchCaseWithoutTest<'a, 't> {
     }
 
     #[inline]
-    pub fn consequent(self) -> &'t Vec<'a, Statement<'a>> {
+    pub fn consequent(self) -> &'t ArenaVec<'a, Statement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_SWITCH_CASE_CONSEQUENT)
-                as *const Vec<'a, Statement<'a>>)
+                as *const ArenaVec<'a, Statement<'a>>)
         }
     }
 }
@@ -6816,18 +6822,18 @@ impl<'a, 't> TryStatementWithoutBlock<'a, 't> {
     }
 
     #[inline]
-    pub fn handler(self) -> &'t Option<Box<'a, CatchClause<'a>>> {
+    pub fn handler(self) -> &'t Option<ArenaBox<'a, CatchClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_HANDLER)
-                as *const Option<Box<'a, CatchClause<'a>>>)
+                as *const Option<ArenaBox<'a, CatchClause<'a>>>)
         }
     }
 
     #[inline]
-    pub fn finalizer(self) -> &'t Option<Box<'a, BlockStatement<'a>>> {
+    pub fn finalizer(self) -> &'t Option<ArenaBox<'a, BlockStatement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_FINALIZER)
-                as *const Option<Box<'a, BlockStatement<'a>>>)
+                as *const Option<ArenaBox<'a, BlockStatement<'a>>>)
         }
     }
 }
@@ -6860,18 +6866,18 @@ impl<'a, 't> TryStatementWithoutHandler<'a, 't> {
     }
 
     #[inline]
-    pub fn block(self) -> &'t Box<'a, BlockStatement<'a>> {
+    pub fn block(self) -> &'t ArenaBox<'a, BlockStatement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_BLOCK)
-                as *const Box<'a, BlockStatement<'a>>)
+                as *const ArenaBox<'a, BlockStatement<'a>>)
         }
     }
 
     #[inline]
-    pub fn finalizer(self) -> &'t Option<Box<'a, BlockStatement<'a>>> {
+    pub fn finalizer(self) -> &'t Option<ArenaBox<'a, BlockStatement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_FINALIZER)
-                as *const Option<Box<'a, BlockStatement<'a>>>)
+                as *const Option<ArenaBox<'a, BlockStatement<'a>>>)
         }
     }
 }
@@ -6904,18 +6910,18 @@ impl<'a, 't> TryStatementWithoutFinalizer<'a, 't> {
     }
 
     #[inline]
-    pub fn block(self) -> &'t Box<'a, BlockStatement<'a>> {
+    pub fn block(self) -> &'t ArenaBox<'a, BlockStatement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_BLOCK)
-                as *const Box<'a, BlockStatement<'a>>)
+                as *const ArenaBox<'a, BlockStatement<'a>>)
         }
     }
 
     #[inline]
-    pub fn handler(self) -> &'t Option<Box<'a, CatchClause<'a>>> {
+    pub fn handler(self) -> &'t Option<ArenaBox<'a, CatchClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TRY_STATEMENT_HANDLER)
-                as *const Option<Box<'a, CatchClause<'a>>>)
+                as *const Option<ArenaBox<'a, CatchClause<'a>>>)
         }
     }
 }
@@ -6952,10 +6958,10 @@ impl<'a, 't> CatchClauseWithoutParam<'a, 't> {
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, BlockStatement<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, BlockStatement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CATCH_CLAUSE_BODY)
-                as *const Box<'a, BlockStatement<'a>>)
+                as *const ArenaBox<'a, BlockStatement<'a>>)
         }
     }
 
@@ -7044,10 +7050,10 @@ impl<'a, 't> CatchParameterWithoutPattern<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CATCH_PARAMETER_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 }
@@ -7197,10 +7203,10 @@ impl<'a, 't> ObjectPatternWithoutProperties<'a, 't> {
     }
 
     #[inline]
-    pub fn rest(self) -> &'t Option<Box<'a, BindingRestElement<'a>>> {
+    pub fn rest(self) -> &'t Option<ArenaBox<'a, BindingRestElement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_OBJECT_PATTERN_REST)
-                as *const Option<Box<'a, BindingRestElement<'a>>>)
+                as *const Option<ArenaBox<'a, BindingRestElement<'a>>>)
         }
     }
 }
@@ -7233,10 +7239,10 @@ impl<'a, 't> ObjectPatternWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn properties(self) -> &'t Vec<'a, BindingProperty<'a>> {
+    pub fn properties(self) -> &'t ArenaVec<'a, BindingProperty<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_OBJECT_PATTERN_PROPERTIES)
-                as *const Vec<'a, BindingProperty<'a>>)
+                as *const ArenaVec<'a, BindingProperty<'a>>)
         }
     }
 }
@@ -7372,10 +7378,10 @@ impl<'a, 't> ArrayPatternWithoutElements<'a, 't> {
     }
 
     #[inline]
-    pub fn rest(self) -> &'t Option<Box<'a, BindingRestElement<'a>>> {
+    pub fn rest(self) -> &'t Option<ArenaBox<'a, BindingRestElement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_PATTERN_REST)
-                as *const Option<Box<'a, BindingRestElement<'a>>>)
+                as *const Option<ArenaBox<'a, BindingRestElement<'a>>>)
         }
     }
 }
@@ -7408,10 +7414,10 @@ impl<'a, 't> ArrayPatternWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn elements(self) -> &'t Vec<'a, Option<BindingPattern<'a>>> {
+    pub fn elements(self) -> &'t ArenaVec<'a, Option<BindingPattern<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_PATTERN_ELEMENTS)
-                as *const Vec<'a, Option<BindingPattern<'a>>>)
+                as *const ArenaVec<'a, Option<BindingPattern<'a>>>)
         }
     }
 }
@@ -7513,42 +7519,42 @@ impl<'a, 't> FunctionWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Option<Box<'a, FunctionBody<'a>>> {
+    pub fn body(self) -> &'t Option<ArenaBox<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
+                as *const Option<ArenaBox<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -7624,34 +7630,34 @@ impl<'a, 't> FunctionWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Option<Box<'a, FunctionBody<'a>>> {
+    pub fn body(self) -> &'t Option<ArenaBox<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
+                as *const Option<ArenaBox<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -7727,34 +7733,34 @@ impl<'a, 't> FunctionWithoutThisParam<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Option<Box<'a, FunctionBody<'a>>> {
+    pub fn body(self) -> &'t Option<ArenaBox<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
+                as *const Option<ArenaBox<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -7830,34 +7836,34 @@ impl<'a, 't> FunctionWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Option<Box<'a, FunctionBody<'a>>> {
+    pub fn body(self) -> &'t Option<ArenaBox<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
+                as *const Option<ArenaBox<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -7933,34 +7939,34 @@ impl<'a, 't> FunctionWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Option<Box<'a, FunctionBody<'a>>> {
+    pub fn body(self) -> &'t Option<ArenaBox<'a, FunctionBody<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY)
-                as *const Option<Box<'a, FunctionBody<'a>>>)
+                as *const Option<ArenaBox<'a, FunctionBody<'a>>>)
         }
     }
 
@@ -8036,34 +8042,34 @@ impl<'a, 't> FunctionWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -8127,10 +8133,10 @@ impl<'a, 't> FormalParametersWithoutItems<'a, 't> {
     }
 
     #[inline]
-    pub fn rest(self) -> &'t Option<Box<'a, FormalParameterRest<'a>>> {
+    pub fn rest(self) -> &'t Option<ArenaBox<'a, FormalParameterRest<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETERS_REST)
-                as *const Option<Box<'a, FormalParameterRest<'a>>>)
+                as *const Option<ArenaBox<'a, FormalParameterRest<'a>>>)
         }
     }
 }
@@ -8171,10 +8177,10 @@ impl<'a, 't> FormalParametersWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn items(self) -> &'t Vec<'a, FormalParameter<'a>> {
+    pub fn items(self) -> &'t ArenaVec<'a, FormalParameter<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETERS_ITEMS)
-                as *const Vec<'a, FormalParameter<'a>>)
+                as *const ArenaVec<'a, FormalParameter<'a>>)
         }
     }
 }
@@ -8230,18 +8236,18 @@ impl<'a, 't> FormalParameterWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn initializer(self) -> &'t Option<Box<'a, Expression<'a>>> {
+    pub fn initializer(self) -> &'t Option<ArenaBox<'a, Expression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_INITIALIZER)
-                as *const Option<Box<'a, Expression<'a>>>)
+                as *const Option<ArenaBox<'a, Expression<'a>>>)
         }
     }
 
@@ -8297,26 +8303,26 @@ impl<'a, 't> FormalParameterWithoutPattern<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn initializer(self) -> &'t Option<Box<'a, Expression<'a>>> {
+    pub fn initializer(self) -> &'t Option<ArenaBox<'a, Expression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_INITIALIZER)
-                as *const Option<Box<'a, Expression<'a>>>)
+                as *const Option<ArenaBox<'a, Expression<'a>>>)
         }
     }
 
@@ -8372,10 +8378,10 @@ impl<'a, 't> FormalParameterWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -8388,10 +8394,10 @@ impl<'a, 't> FormalParameterWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn initializer(self) -> &'t Option<Box<'a, Expression<'a>>> {
+    pub fn initializer(self) -> &'t Option<ArenaBox<'a, Expression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_INITIALIZER)
-                as *const Option<Box<'a, Expression<'a>>>)
+                as *const Option<ArenaBox<'a, Expression<'a>>>)
         }
     }
 
@@ -8447,10 +8453,10 @@ impl<'a, 't> FormalParameterWithoutInitializer<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -8463,10 +8469,10 @@ impl<'a, 't> FormalParameterWithoutInitializer<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -8540,10 +8546,10 @@ impl<'a, 't> FormalParameterRestWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_REST_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 }
@@ -8577,18 +8583,18 @@ impl<'a, 't> FormalParameterRestWithoutRest<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_REST_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_REST_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 }
@@ -8622,10 +8628,10 @@ impl<'a, 't> FormalParameterRestWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FORMAL_PARAMETER_REST_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -8671,10 +8677,10 @@ impl<'a, 't> FunctionBodyWithoutDirectives<'a, 't> {
     }
 
     #[inline]
-    pub fn statements(self) -> &'t Vec<'a, Statement<'a>> {
+    pub fn statements(self) -> &'t ArenaVec<'a, Statement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY_STATEMENTS)
-                as *const Vec<'a, Statement<'a>>)
+                as *const ArenaVec<'a, Statement<'a>>)
         }
     }
 }
@@ -8707,10 +8713,10 @@ impl<'a, 't> FunctionBodyWithoutStatements<'a, 't> {
     }
 
     #[inline]
-    pub fn directives(self) -> &'t Vec<'a, Directive<'a>> {
+    pub fn directives(self) -> &'t ArenaVec<'a, Directive<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_FUNCTION_BODY_DIRECTIVES)
-                as *const Vec<'a, Directive<'a>>)
+                as *const ArenaVec<'a, Directive<'a>>)
         }
     }
 }
@@ -8784,26 +8790,26 @@ impl<'a, 't> ArrowFunctionExpressionWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, FunctionBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, FunctionBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-                as *const Box<'a, FunctionBody<'a>>)
+                as *const ArenaBox<'a, FunctionBody<'a>>)
         }
     }
 
@@ -8876,26 +8882,26 @@ impl<'a, 't> ArrowFunctionExpressionWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, FunctionBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, FunctionBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-                as *const Box<'a, FunctionBody<'a>>)
+                as *const ArenaBox<'a, FunctionBody<'a>>)
         }
     }
 
@@ -8968,26 +8974,26 @@ impl<'a, 't> ArrowFunctionExpressionWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, FunctionBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, FunctionBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-                as *const Box<'a, FunctionBody<'a>>)
+                as *const ArenaBox<'a, FunctionBody<'a>>)
         }
     }
 
@@ -9060,26 +9066,26 @@ impl<'a, 't> ArrowFunctionExpressionWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -9196,10 +9202,10 @@ impl<'a, 't> ClassWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -9211,24 +9217,28 @@ impl<'a, 't> ClassWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9277,17 +9287,18 @@ impl<'a, 't> ClassWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -9299,24 +9310,28 @@ impl<'a, 't> ClassWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9368,9 +9383,10 @@ impl<'a, 't> ClassWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -9389,24 +9405,28 @@ impl<'a, 't> ClassWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9458,9 +9478,10 @@ impl<'a, 't> ClassWithoutSuperClass<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -9472,32 +9493,36 @@ impl<'a, 't> ClassWithoutSuperClass<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9549,9 +9574,10 @@ impl<'a, 't> ClassWithoutSuperTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -9563,10 +9589,10 @@ impl<'a, 't> ClassWithoutSuperTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -9578,16 +9604,18 @@ impl<'a, 't> ClassWithoutSuperTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9639,9 +9667,10 @@ impl<'a, 't> ClassWithoutImplements<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -9653,10 +9682,10 @@ impl<'a, 't> ClassWithoutImplements<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -9668,16 +9697,20 @@ impl<'a, 't> ClassWithoutImplements<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, ClassBody<'a>> {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const Box<'a, ClassBody<'a>>) }
+    pub fn body(self) -> &'t ArenaBox<'a, ClassBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_CLASS_BODY) as *const ArenaBox<'a, ClassBody<'a>>)
+        }
     }
 
     #[inline]
@@ -9726,9 +9759,10 @@ impl<'a, 't> ClassWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS) as *const Vec<'a, Decorator<'a>>)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_DECORATORS)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -9740,10 +9774,10 @@ impl<'a, 't> ClassWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -9755,18 +9789,20 @@ impl<'a, 't> ClassWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(
+        self,
+    ) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn implements(self) -> &'t Vec<'a, TSClassImplements<'a>> {
+    pub fn implements(self) -> &'t ArenaVec<'a, TSClassImplements<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_CLASS_IMPLEMENTS)
-                as *const Vec<'a, TSClassImplements<'a>>)
+                as *const ArenaVec<'a, TSClassImplements<'a>>)
         }
     }
 
@@ -9877,10 +9913,10 @@ impl<'a, 't> MethodDefinitionWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn value(self) -> &'t Box<'a, Function<'a>> {
+    pub fn value(self) -> &'t ArenaBox<'a, Function<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_VALUE)
-                as *const Box<'a, Function<'a>>)
+                as *const ArenaBox<'a, Function<'a>>)
         }
     }
 
@@ -9957,18 +9993,18 @@ impl<'a, 't> MethodDefinitionWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn value(self) -> &'t Box<'a, Function<'a>> {
+    pub fn value(self) -> &'t ArenaBox<'a, Function<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_VALUE)
-                as *const Box<'a, Function<'a>>)
+                as *const ArenaBox<'a, Function<'a>>)
         }
     }
 
@@ -10045,10 +10081,10 @@ impl<'a, 't> MethodDefinitionWithoutValue<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_METHOD_DEFINITION_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -10166,10 +10202,10 @@ impl<'a, 't> PropertyDefinitionWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -10261,18 +10297,18 @@ impl<'a, 't> PropertyDefinitionWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -10364,10 +10400,10 @@ impl<'a, 't> PropertyDefinitionWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -10466,10 +10502,10 @@ impl<'a, 't> PropertyDefinitionWithoutValue<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -10481,10 +10517,10 @@ impl<'a, 't> PropertyDefinitionWithoutValue<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PROPERTY_DEFINITION_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -10631,10 +10667,10 @@ impl<'a, 't> AccessorPropertyWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -10711,18 +10747,18 @@ impl<'a, 't> AccessorPropertyWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -10799,10 +10835,10 @@ impl<'a, 't> AccessorPropertyWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -10886,10 +10922,10 @@ impl<'a, 't> AccessorPropertyWithoutValue<'a, 't> {
     }
 
     #[inline]
-    pub fn decorators(self) -> &'t Vec<'a, Decorator<'a>> {
+    pub fn decorators(self) -> &'t ArenaVec<'a, Decorator<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_DECORATORS)
-                as *const Vec<'a, Decorator<'a>>)
+                as *const ArenaVec<'a, Decorator<'a>>)
         }
     }
 
@@ -10901,10 +10937,10 @@ impl<'a, 't> AccessorPropertyWithoutValue<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ACCESSOR_PROPERTY_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -11085,10 +11121,10 @@ impl<'a, 't> ImportDeclarationWithoutSpecifiers<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 
@@ -11129,10 +11165,10 @@ impl<'a, 't> ImportDeclarationWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn specifiers(self) -> &'t Option<Vec<'a, ImportDeclarationSpecifier<'a>>> {
+    pub fn specifiers(self) -> &'t Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_DECLARATION_SPECIFIERS)
-                as *const Option<Vec<'a, ImportDeclarationSpecifier<'a>>>)
+                as *const Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>)
         }
     }
 
@@ -11145,10 +11181,10 @@ impl<'a, 't> ImportDeclarationWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 
@@ -11189,10 +11225,10 @@ impl<'a, 't> ImportDeclarationWithoutWithClause<'a, 't> {
     }
 
     #[inline]
-    pub fn specifiers(self) -> &'t Option<Vec<'a, ImportDeclarationSpecifier<'a>>> {
+    pub fn specifiers(self) -> &'t Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_IMPORT_DECLARATION_SPECIFIERS)
-                as *const Option<Vec<'a, ImportDeclarationSpecifier<'a>>>)
+                as *const Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>)
         }
     }
 
@@ -11552,10 +11588,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutDeclaration<'a, 't> {
     }
 
     #[inline]
-    pub fn specifiers(self) -> &'t Vec<'a, ExportSpecifier<'a>> {
+    pub fn specifiers(self) -> &'t ArenaVec<'a, ExportSpecifier<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
-                as *const Vec<'a, ExportSpecifier<'a>>)
+                as *const ArenaVec<'a, ExportSpecifier<'a>>)
         }
     }
 
@@ -11576,10 +11612,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutDeclaration<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 }
@@ -11639,10 +11675,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutSpecifiers<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 }
@@ -11686,10 +11722,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn specifiers(self) -> &'t Vec<'a, ExportSpecifier<'a>> {
+    pub fn specifiers(self) -> &'t ArenaVec<'a, ExportSpecifier<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
-                as *const Vec<'a, ExportSpecifier<'a>>)
+                as *const ArenaVec<'a, ExportSpecifier<'a>>)
         }
     }
 
@@ -11702,10 +11738,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 }
@@ -11749,10 +11785,10 @@ impl<'a, 't> ExportNamedDeclarationWithoutWithClause<'a, 't> {
     }
 
     #[inline]
-    pub fn specifiers(self) -> &'t Vec<'a, ExportSpecifier<'a>> {
+    pub fn specifiers(self) -> &'t ArenaVec<'a, ExportSpecifier<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
-                as *const Vec<'a, ExportSpecifier<'a>>)
+                as *const ArenaVec<'a, ExportSpecifier<'a>>)
         }
     }
 
@@ -11860,10 +11896,10 @@ impl<'a, 't> ExportAllDeclarationWithoutExported<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_ALL_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 
@@ -11913,10 +11949,10 @@ impl<'a, 't> ExportAllDeclarationWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn with_clause(self) -> &'t Option<Box<'a, WithClause<'a>>> {
+    pub fn with_clause(self) -> &'t Option<ArenaBox<'a, WithClause<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_EXPORT_ALL_DECLARATION_WITH_CLAUSE)
-                as *const Option<Box<'a, WithClause<'a>>>)
+                as *const Option<ArenaBox<'a, WithClause<'a>>>)
         }
     }
 
@@ -12115,10 +12151,10 @@ impl<'a, 't> V8IntrinsicExpressionWithoutName<'a, 't> {
     }
 
     #[inline]
-    pub fn arguments(self) -> &'t Vec<'a, Argument<'a>> {
+    pub fn arguments(self) -> &'t ArenaVec<'a, Argument<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_V8_INTRINSIC_EXPRESSION_ARGUMENTS)
-                as *const Vec<'a, Argument<'a>>)
+                as *const ArenaVec<'a, Argument<'a>>)
         }
     }
 }
@@ -12194,18 +12230,18 @@ impl<'a, 't> JSXElementWithoutOpeningElement<'a, 't> {
     }
 
     #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+    pub fn children(self) -> &'t ArenaVec<'a, JSXChild<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
+                as *const ArenaVec<'a, JSXChild<'a>>)
         }
     }
 
     #[inline]
-    pub fn closing_element(self) -> &'t Option<Box<'a, JSXClosingElement<'a>>> {
+    pub fn closing_element(self) -> &'t Option<ArenaBox<'a, JSXClosingElement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
-                as *const Option<Box<'a, JSXClosingElement<'a>>>)
+                as *const Option<ArenaBox<'a, JSXClosingElement<'a>>>)
         }
     }
 }
@@ -12236,18 +12272,18 @@ impl<'a, 't> JSXElementWithoutChildren<'a, 't> {
     }
 
     #[inline]
-    pub fn opening_element(self) -> &'t Box<'a, JSXOpeningElement<'a>> {
+    pub fn opening_element(self) -> &'t ArenaBox<'a, JSXOpeningElement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
-                as *const Box<'a, JSXOpeningElement<'a>>)
+                as *const ArenaBox<'a, JSXOpeningElement<'a>>)
         }
     }
 
     #[inline]
-    pub fn closing_element(self) -> &'t Option<Box<'a, JSXClosingElement<'a>>> {
+    pub fn closing_element(self) -> &'t Option<ArenaBox<'a, JSXClosingElement<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
-                as *const Option<Box<'a, JSXClosingElement<'a>>>)
+                as *const Option<ArenaBox<'a, JSXClosingElement<'a>>>)
         }
     }
 }
@@ -12278,18 +12314,18 @@ impl<'a, 't> JSXElementWithoutClosingElement<'a, 't> {
     }
 
     #[inline]
-    pub fn opening_element(self) -> &'t Box<'a, JSXOpeningElement<'a>> {
+    pub fn opening_element(self) -> &'t ArenaBox<'a, JSXOpeningElement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
-                as *const Box<'a, JSXOpeningElement<'a>>)
+                as *const ArenaBox<'a, JSXOpeningElement<'a>>)
         }
     }
 
     #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+    pub fn children(self) -> &'t ArenaVec<'a, JSXChild<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_ELEMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
+                as *const ArenaVec<'a, JSXChild<'a>>)
         }
     }
 }
@@ -12330,18 +12366,18 @@ impl<'a, 't> JSXOpeningElementWithoutName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 
     #[inline]
-    pub fn attributes(self) -> &'t Vec<'a, JSXAttributeItem<'a>> {
+    pub fn attributes(self) -> &'t ArenaVec<'a, JSXAttributeItem<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
-                as *const Vec<'a, JSXAttributeItem<'a>>)
+                as *const ArenaVec<'a, JSXAttributeItem<'a>>)
         }
     }
 }
@@ -12382,10 +12418,10 @@ impl<'a, 't> JSXOpeningElementWithoutTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn attributes(self) -> &'t Vec<'a, JSXAttributeItem<'a>> {
+    pub fn attributes(self) -> &'t ArenaVec<'a, JSXAttributeItem<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
-                as *const Vec<'a, JSXAttributeItem<'a>>)
+                as *const ArenaVec<'a, JSXAttributeItem<'a>>)
         }
     }
 }
@@ -12426,10 +12462,10 @@ impl<'a, 't> JSXOpeningElementWithoutAttributes<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -12500,10 +12536,10 @@ impl<'a, 't> JSXFragmentWithoutOpeningFragment<'a, 't> {
     }
 
     #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+    pub fn children(self) -> &'t ArenaVec<'a, JSXChild<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
+                as *const ArenaVec<'a, JSXChild<'a>>)
         }
     }
 
@@ -12592,10 +12628,10 @@ impl<'a, 't> JSXFragmentWithoutClosingFragment<'a, 't> {
     }
 
     #[inline]
-    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+    pub fn children(self) -> &'t ArenaVec<'a, JSXChild<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CHILDREN)
-                as *const Vec<'a, JSXChild<'a>>)
+                as *const ArenaVec<'a, JSXChild<'a>>)
         }
     }
 }
@@ -13992,10 +14028,10 @@ impl<'a, 't> TSTypeReferenceWithoutTypeName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_REFERENCE_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -14422,10 +14458,10 @@ impl<'a, 't> TSTypeAliasDeclarationWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -14554,10 +14590,10 @@ impl<'a, 't> TSTypeAliasDeclarationWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
@@ -14612,10 +14648,10 @@ impl<'a, 't> TSClassImplementsWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CLASS_IMPLEMENTS_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -14703,26 +14739,26 @@ impl<'a, 't> TSInterfaceDeclarationWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn extends(self) -> &'t Vec<'a, TSInterfaceHeritage<'a>> {
+    pub fn extends(self) -> &'t ArenaVec<'a, TSInterfaceHeritage<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-                as *const Vec<'a, TSInterfaceHeritage<'a>>)
+                as *const ArenaVec<'a, TSInterfaceHeritage<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, TSInterfaceBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, TSInterfaceBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_BODY)
-                as *const Box<'a, TSInterfaceBody<'a>>)
+                as *const ArenaBox<'a, TSInterfaceBody<'a>>)
         }
     }
 
@@ -14781,18 +14817,18 @@ impl<'a, 't> TSInterfaceDeclarationWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn extends(self) -> &'t Vec<'a, TSInterfaceHeritage<'a>> {
+    pub fn extends(self) -> &'t ArenaVec<'a, TSInterfaceHeritage<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-                as *const Vec<'a, TSInterfaceHeritage<'a>>)
+                as *const ArenaVec<'a, TSInterfaceHeritage<'a>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, TSInterfaceBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, TSInterfaceBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_BODY)
-                as *const Box<'a, TSInterfaceBody<'a>>)
+                as *const ArenaBox<'a, TSInterfaceBody<'a>>)
         }
     }
 
@@ -14851,18 +14887,18 @@ impl<'a, 't> TSInterfaceDeclarationWithoutExtends<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn body(self) -> &'t Box<'a, TSInterfaceBody<'a>> {
+    pub fn body(self) -> &'t ArenaBox<'a, TSInterfaceBody<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_BODY)
-                as *const Box<'a, TSInterfaceBody<'a>>)
+                as *const ArenaBox<'a, TSInterfaceBody<'a>>)
         }
     }
 
@@ -14921,18 +14957,18 @@ impl<'a, 't> TSInterfaceDeclarationWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn extends(self) -> &'t Vec<'a, TSInterfaceHeritage<'a>> {
+    pub fn extends(self) -> &'t ArenaVec<'a, TSInterfaceHeritage<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-                as *const Vec<'a, TSInterfaceHeritage<'a>>)
+                as *const ArenaVec<'a, TSInterfaceHeritage<'a>>)
         }
     }
 
@@ -15047,10 +15083,10 @@ impl<'a, 't> TSPropertySignatureWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_PROPERTY_SIGNATURE_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 }
@@ -15150,10 +15186,10 @@ impl<'a, 't> TSIndexSignatureWithoutParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn type_annotation(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_TYPE_ANNOTATION)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -15196,10 +15232,10 @@ impl<'a, 't> TSIndexSignatureWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn parameters(self) -> &'t Vec<'a, TSIndexSignatureName<'a>> {
+    pub fn parameters(self) -> &'t ArenaVec<'a, TSIndexSignatureName<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INDEX_SIGNATURE_PARAMETERS)
-                as *const Vec<'a, TSIndexSignatureName<'a>>)
+                as *const ArenaVec<'a, TSIndexSignatureName<'a>>)
         }
     }
 
@@ -15260,26 +15296,26 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15323,26 +15359,26 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutThisParam<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15386,26 +15422,26 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15449,26 +15485,26 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
@@ -15545,34 +15581,34 @@ impl<'a, 't> TSMethodSignatureWithoutKey<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15638,26 +15674,26 @@ impl<'a, 't> TSMethodSignatureWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15723,26 +15759,26 @@ impl<'a, 't> TSMethodSignatureWithoutThisParam<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15808,26 +15844,26 @@ impl<'a, 't> TSMethodSignatureWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -15893,26 +15929,26 @@ impl<'a, 't> TSMethodSignatureWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
@@ -15970,18 +16006,18 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -16026,18 +16062,18 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn return_type(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 
@@ -16082,18 +16118,18 @@ impl<'a, 't> TSConstructSignatureDeclarationWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
@@ -16188,10 +16224,10 @@ impl<'a, 't> TSInterfaceHeritageWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_HERITAGE_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -16274,10 +16310,10 @@ impl<'a, 't> TSTypePredicateWithoutParameterName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_annotation(self) -> &'t Option<Box<'a, TSTypeAnnotation<'a>>> {
+    pub fn type_annotation(self) -> &'t Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_PREDICATE_TYPE_ANNOTATION)
-                as *const Option<Box<'a, TSTypeAnnotation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeAnnotation<'a>>>)
         }
     }
 }
@@ -16549,10 +16585,10 @@ impl<'a, 't> TSModuleBlockWithoutDirectives<'a, 't> {
     }
 
     #[inline]
-    pub fn body(self) -> &'t Vec<'a, Statement<'a>> {
+    pub fn body(self) -> &'t ArenaVec<'a, Statement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_MODULE_BLOCK_BODY)
-                as *const Vec<'a, Statement<'a>>)
+                as *const ArenaVec<'a, Statement<'a>>)
         }
     }
 }
@@ -16585,10 +16621,10 @@ impl<'a, 't> TSModuleBlockWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn directives(self) -> &'t Vec<'a, Directive<'a>> {
+    pub fn directives(self) -> &'t ArenaVec<'a, Directive<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_MODULE_BLOCK_DIRECTIVES)
-                as *const Vec<'a, Directive<'a>>)
+                as *const ArenaVec<'a, Directive<'a>>)
         }
     }
 }
@@ -16692,10 +16728,10 @@ impl<'a, 't> TSTypeQueryWithoutExprName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TYPE_QUERY_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -16772,10 +16808,10 @@ impl<'a, 't> TSImportTypeWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn options(self) -> &'t Option<Box<'a, ObjectExpression<'a>>> {
+    pub fn options(self) -> &'t Option<ArenaBox<'a, ObjectExpression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_OPTIONS)
-                as *const Option<Box<'a, ObjectExpression<'a>>>)
+                as *const Option<ArenaBox<'a, ObjectExpression<'a>>>)
         }
     }
 
@@ -16788,10 +16824,10 @@ impl<'a, 't> TSImportTypeWithoutSource<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -16839,10 +16875,10 @@ impl<'a, 't> TSImportTypeWithoutOptions<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -16882,18 +16918,18 @@ impl<'a, 't> TSImportTypeWithoutQualifier<'a, 't> {
     }
 
     #[inline]
-    pub fn options(self) -> &'t Option<Box<'a, ObjectExpression<'a>>> {
+    pub fn options(self) -> &'t Option<ArenaBox<'a, ObjectExpression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_OPTIONS)
-                as *const Option<Box<'a, ObjectExpression<'a>>>)
+                as *const Option<ArenaBox<'a, ObjectExpression<'a>>>)
         }
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS)
-                as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
 }
@@ -16933,10 +16969,10 @@ impl<'a, 't> TSImportTypeWithoutTypeArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn options(self) -> &'t Option<Box<'a, ObjectExpression<'a>>> {
+    pub fn options(self) -> &'t Option<ArenaBox<'a, ObjectExpression<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_OPTIONS)
-                as *const Option<Box<'a, ObjectExpression<'a>>>)
+                as *const Option<ArenaBox<'a, ObjectExpression<'a>>>)
         }
     }
 
@@ -17074,26 +17110,26 @@ impl<'a, 't> TSFunctionTypeWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -17134,26 +17170,26 @@ impl<'a, 't> TSFunctionTypeWithoutThisParam<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -17194,26 +17230,26 @@ impl<'a, 't> TSFunctionTypeWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -17254,26 +17290,26 @@ impl<'a, 't> TSFunctionTypeWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
+    pub fn this_param(self) -> &'t Option<ArenaBox<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-                as *const Option<Box<'a, TSThisParameter<'a>>>)
+                as *const Option<ArenaBox<'a, TSThisParameter<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_FUNCTION_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
@@ -17331,18 +17367,18 @@ impl<'a, 't> TSConstructorTypeWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -17388,18 +17424,18 @@ impl<'a, 't> TSConstructorTypeWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn return_type(self) -> &'t Box<'a, TSTypeAnnotation<'a>> {
+    pub fn return_type(self) -> &'t ArenaBox<'a, TSTypeAnnotation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
-                as *const Box<'a, TSTypeAnnotation<'a>>)
+                as *const ArenaBox<'a, TSTypeAnnotation<'a>>)
         }
     }
 
@@ -17445,18 +17481,18 @@ impl<'a, 't> TSConstructorTypeWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+    pub fn type_parameters(self) -> &'t Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+                as *const Option<ArenaBox<'a, TSTypeParameterDeclaration<'a>>>)
         }
     }
 
     #[inline]
-    pub fn params(self) -> &'t Box<'a, FormalParameters<'a>> {
+    pub fn params(self) -> &'t ArenaBox<'a, FormalParameters<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
-                as *const Box<'a, FormalParameters<'a>>)
+                as *const ArenaBox<'a, FormalParameters<'a>>)
         }
     }
 
@@ -17818,10 +17854,10 @@ impl<'a, 't> TSTemplateLiteralTypeWithoutQuasis<'a, 't> {
     }
 
     #[inline]
-    pub fn types(self) -> &'t Vec<'a, TSType<'a>> {
+    pub fn types(self) -> &'t ArenaVec<'a, TSType<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TEMPLATE_LITERAL_TYPE_TYPES)
-                as *const Vec<'a, TSType<'a>>)
+                as *const ArenaVec<'a, TSType<'a>>)
         }
     }
 }
@@ -17857,10 +17893,10 @@ impl<'a, 't> TSTemplateLiteralTypeWithoutTypes<'a, 't> {
     }
 
     #[inline]
-    pub fn quasis(self) -> &'t Vec<'a, TemplateElement<'a>> {
+    pub fn quasis(self) -> &'t ArenaVec<'a, TemplateElement<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_TEMPLATE_LITERAL_TYPE_QUASIS)
-                as *const Vec<'a, TemplateElement<'a>>)
+                as *const ArenaVec<'a, TemplateElement<'a>>)
         }
     }
 }
@@ -18427,10 +18463,10 @@ impl<'a, 't> TSInstantiationExpressionWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn type_arguments(self) -> &'t Box<'a, TSTypeParameterInstantiation<'a>> {
+    pub fn type_arguments(self) -> &'t ArenaBox<'a, TSTypeParameterInstantiation<'a>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_ARGUMENTS)
-                as *const Box<'a, TSTypeParameterInstantiation<'a>>)
+                as *const ArenaBox<'a, TSTypeParameterInstantiation<'a>>)
         }
     }
 }

--- a/crates/oxc_traverse/src/generated/traverse.rs
+++ b/crates/oxc_traverse/src/generated/traverse.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/traverse/mod.rs`.
 
-use oxc_allocator::Vec;
+use oxc_allocator::ArenaVec;
 use oxc_ast::ast::*;
 
 use crate::TraverseCtx;
@@ -3119,14 +3119,14 @@ pub trait Traverse<'a, State> {
     #[inline]
     fn enter_statements(
         &mut self,
-        node: &mut Vec<'a, Statement<'a>>,
+        node: &mut ArenaVec<'a, Statement<'a>>,
         ctx: &mut TraverseCtx<'a, State>,
     ) {
     }
     #[inline]
     fn exit_statements(
         &mut self,
-        node: &mut Vec<'a, Statement<'a>>,
+        node: &mut ArenaVec<'a, Statement<'a>>,
         ctx: &mut TraverseCtx<'a, State>,
     ) {
     }

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -13,7 +13,7 @@
 
 use std::{cell::Cell, marker::PhantomData};
 
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_syntax::scope::ScopeId;
 
@@ -61,15 +61,15 @@ unsafe fn walk_program<'a, State, Tr: Traverse<'a, State>>(
         walk_hashbang(traverser, field as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ProgramDirectives);
-    for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_PROGRAM_DIRECTIVES) as *mut Vec<Directive>)
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_PROGRAM_DIRECTIVES)
+        as *mut ArenaVec<Directive>)
     {
         walk_directive(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ProgramBody);
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_PROGRAM_BODY) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_PROGRAM_BODY) as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -260,7 +260,7 @@ unsafe fn walk_array_expression<'a, State, Tr: Traverse<'a, State>>(
         ancestor::ArrayExpressionWithoutElements(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_EXPRESSION_ELEMENTS)
-        as *mut Vec<ArrayExpressionElement>)
+        as *mut ArenaVec<ArrayExpressionElement>)
     {
         walk_array_expression_element(traverser, item as *mut _, ctx);
     }
@@ -349,7 +349,7 @@ unsafe fn walk_object_expression<'a, State, Tr: Traverse<'a, State>>(
         ancestor::ObjectExpressionWithoutProperties(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_EXPRESSION_PROPERTIES)
-        as *mut Vec<ObjectPropertyKind>)
+        as *mut ArenaVec<ObjectPropertyKind>)
     {
         walk_object_property_kind(traverser, item as *mut _, ctx);
     }
@@ -468,13 +468,13 @@ unsafe fn walk_template_literal<'a, State, Tr: Traverse<'a, State>>(
         ancestor::TemplateLiteralWithoutQuasis(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TEMPLATE_LITERAL_QUASIS)
-        as *mut Vec<TemplateElement>)
+        as *mut ArenaVec<TemplateElement>)
     {
         walk_template_element(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TemplateLiteralExpressions);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TEMPLATE_LITERAL_EXPRESSIONS)
-        as *mut Vec<Expression>)
+        as *mut ArenaVec<Expression>)
     {
         walk_expression(traverser, item as *mut _, ctx);
     }
@@ -498,7 +498,7 @@ unsafe fn walk_tagged_template_expression<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TaggedTemplateExpressionTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -635,14 +635,14 @@ unsafe fn walk_call_expression<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::CallExpressionTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::CallExpressionArguments);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_CALL_EXPRESSION_ARGUMENTS)
-        as *mut Vec<Argument>)
+        as *mut ArenaVec<Argument>)
     {
         walk_argument(traverser, item as *mut _, ctx);
     }
@@ -666,14 +666,14 @@ unsafe fn walk_new_expression<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::NewExpressionTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::NewExpressionArguments);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_NEW_EXPRESSION_ARGUMENTS)
-        as *mut Vec<Argument>)
+        as *mut ArenaVec<Argument>)
     {
         walk_argument(traverser, item as *mut _, ctx);
     }
@@ -1029,14 +1029,14 @@ unsafe fn walk_array_assignment_target<'a, State, Tr: Traverse<'a, State>>(
         ancestor::ArrayAssignmentTargetWithoutElements(node, PhantomData),
     ));
     for item in (*((node as *mut u8).add(ancestor::OFFSET_ARRAY_ASSIGNMENT_TARGET_ELEMENTS)
-        as *mut Vec<Option<AssignmentTargetMaybeDefault>>))
+        as *mut ArenaVec<Option<AssignmentTargetMaybeDefault>>))
         .iter_mut()
         .flatten()
     {
         walk_assignment_target_maybe_default(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_ASSIGNMENT_TARGET_REST)
-        as *mut Option<Box<AssignmentTargetRest>>)
+        as *mut Option<ArenaBox<AssignmentTargetRest>>)
     {
         ctx.retag_stack(AncestorType::ArrayAssignmentTargetRest);
         walk_assignment_target_rest(traverser, (&mut **field) as *mut _, ctx);
@@ -1055,13 +1055,13 @@ unsafe fn walk_object_assignment_target<'a, State, Tr: Traverse<'a, State>>(
         ancestor::ObjectAssignmentTargetWithoutProperties(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_ASSIGNMENT_TARGET_PROPERTIES)
-        as *mut Vec<AssignmentTargetProperty>)
+        as *mut ArenaVec<AssignmentTargetProperty>)
     {
         walk_assignment_target_property(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_OBJECT_ASSIGNMENT_TARGET_REST)
-        as *mut Option<Box<AssignmentTargetRest>>)
+        as *mut Option<ArenaBox<AssignmentTargetRest>>)
     {
         ctx.retag_stack(AncestorType::ObjectAssignmentTargetRest);
         walk_assignment_target_rest(traverser, (&mut **field) as *mut _, ctx);
@@ -1220,7 +1220,7 @@ unsafe fn walk_sequence_expression<'a, State, Tr: Traverse<'a, State>>(
         ancestor::SequenceExpressionWithoutExpressions(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_SEQUENCE_EXPRESSION_EXPRESSIONS)
-        as *mut Vec<Expression>)
+        as *mut ArenaVec<Expression>)
     {
         walk_expression(traverser, item as *mut _, ctx);
     }
@@ -1442,7 +1442,7 @@ unsafe fn walk_block_statement<'a, State, Tr: Traverse<'a, State>>(
     ));
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_BLOCK_STATEMENT_BODY) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_BLOCK_STATEMENT_BODY) as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -1497,7 +1497,7 @@ unsafe fn walk_variable_declaration<'a, State, Tr: Traverse<'a, State>>(
         ancestor::VariableDeclarationWithoutDeclarations(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_VARIABLE_DECLARATION_DECLARATIONS)
-        as *mut Vec<VariableDeclarator>)
+        as *mut ArenaVec<VariableDeclarator>)
     {
         walk_variable_declarator(traverser, item as *mut _, ctx);
     }
@@ -1521,7 +1521,7 @@ unsafe fn walk_variable_declarator<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_VARIABLE_DECLARATOR_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::VariableDeclaratorTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -1950,7 +1950,7 @@ unsafe fn walk_switch_statement<'a, State, Tr: Traverse<'a, State>>(
     ctx.set_current_scope_id(current_scope_id);
     ctx.retag_stack(AncestorType::SwitchStatementCases);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_SWITCH_STATEMENT_CASES)
-        as *mut Vec<SwitchCase>)
+        as *mut ArenaVec<SwitchCase>)
     {
         walk_switch_case(traverser, item as *mut _, ctx);
     }
@@ -1975,7 +1975,7 @@ unsafe fn walk_switch_case<'a, State, Tr: Traverse<'a, State>>(
     ctx.retag_stack(AncestorType::SwitchCaseConsequent);
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_SWITCH_CASE_CONSEQUENT) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_SWITCH_CASE_CONSEQUENT) as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2036,17 +2036,17 @@ unsafe fn walk_try_statement<'a, State, Tr: Traverse<'a, State>>(
     walk_block_statement(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_BLOCK)
-            as *mut Box<BlockStatement>)) as *mut _,
+            as *mut ArenaBox<BlockStatement>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_HANDLER)
-        as *mut Option<Box<CatchClause>>)
+        as *mut Option<ArenaBox<CatchClause>>)
     {
         ctx.retag_stack(AncestorType::TryStatementHandler);
         walk_catch_clause(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TRY_STATEMENT_FINALIZER)
-        as *mut Option<Box<BlockStatement>>)
+        as *mut Option<ArenaBox<BlockStatement>>)
     {
         ctx.retag_stack(AncestorType::TryStatementFinalizer);
         walk_block_statement(traverser, (&mut **field) as *mut _, ctx);
@@ -2080,7 +2080,7 @@ unsafe fn walk_catch_clause<'a, State, Tr: Traverse<'a, State>>(
     walk_block_statement(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_CATCH_CLAUSE_BODY)
-            as *mut Box<BlockStatement>)) as *mut _,
+            as *mut ArenaBox<BlockStatement>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2104,7 +2104,7 @@ unsafe fn walk_catch_parameter<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_CATCH_PARAMETER_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::CatchParameterTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -2179,12 +2179,12 @@ unsafe fn walk_object_pattern<'a, State, Tr: Traverse<'a, State>>(
         ancestor::ObjectPatternWithoutProperties(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_PATTERN_PROPERTIES)
-        as *mut Vec<BindingProperty>)
+        as *mut ArenaVec<BindingProperty>)
     {
         walk_binding_property(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_OBJECT_PATTERN_REST)
-        as *mut Option<Box<BindingRestElement>>)
+        as *mut Option<ArenaBox<BindingRestElement>>)
     {
         ctx.retag_stack(AncestorType::ObjectPatternRest);
         walk_binding_rest_element(traverser, (&mut **field) as *mut _, ctx);
@@ -2227,14 +2227,14 @@ unsafe fn walk_array_pattern<'a, State, Tr: Traverse<'a, State>>(
         ancestor::ArrayPatternWithoutElements(node, PhantomData),
     ));
     for item in (*((node as *mut u8).add(ancestor::OFFSET_ARRAY_PATTERN_ELEMENTS)
-        as *mut Vec<Option<BindingPattern>>))
+        as *mut ArenaVec<Option<BindingPattern>>))
         .iter_mut()
         .flatten()
     {
         walk_binding_pattern(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_ARRAY_PATTERN_REST)
-        as *mut Option<Box<BindingRestElement>>)
+        as *mut Option<ArenaBox<BindingRestElement>>)
     {
         ctx.retag_stack(AncestorType::ArrayPatternRest);
         walk_binding_rest_element(traverser, (&mut **field) as *mut _, ctx);
@@ -2286,13 +2286,13 @@ unsafe fn walk_function<'a, State, Tr: Traverse<'a, State>>(
         walk_binding_identifier(traverser, field as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::FunctionTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_THIS_PARAM)
-        as *mut Option<Box<TSThisParameter>>)
+        as *mut Option<ArenaBox<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::FunctionThisParam);
         walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
@@ -2301,17 +2301,17 @@ unsafe fn walk_function<'a, State, Tr: Traverse<'a, State>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_FUNCTION_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_RETURN_TYPE)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::FunctionReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY)
-        as *mut Option<Box<FunctionBody>>)
+        as *mut Option<ArenaBox<FunctionBody>>)
     {
         ctx.retag_stack(AncestorType::FunctionBody);
         walk_function_body(traverser, (&mut **field) as *mut _, ctx);
@@ -2333,12 +2333,12 @@ unsafe fn walk_formal_parameters<'a, State, Tr: Traverse<'a, State>>(
         ancestor::FormalParametersWithoutItems(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETERS_ITEMS)
-        as *mut Vec<FormalParameter>)
+        as *mut ArenaVec<FormalParameter>)
     {
         walk_formal_parameter(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETERS_REST)
-        as *mut Option<Box<FormalParameterRest>>)
+        as *mut Option<ArenaBox<FormalParameterRest>>)
     {
         ctx.retag_stack(AncestorType::FormalParametersRest);
         walk_formal_parameter_rest(traverser, (&mut **field) as *mut _, ctx);
@@ -2357,7 +2357,7 @@ unsafe fn walk_formal_parameter<'a, State, Tr: Traverse<'a, State>>(
         ancestor::FormalParameterWithoutDecorators(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_DECORATORS)
-        as *mut Vec<Decorator>)
+        as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2369,13 +2369,13 @@ unsafe fn walk_formal_parameter<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_FORMAL_PARAMETER_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::FormalParameterTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_INITIALIZER)
-        as *mut Option<Box<Expression>>)
+        as *mut Option<ArenaBox<Expression>>)
     {
         ctx.retag_stack(AncestorType::FormalParameterInitializer);
         walk_expression(traverser, (&mut **field) as *mut _, ctx);
@@ -2394,7 +2394,7 @@ unsafe fn walk_formal_parameter_rest<'a, State, Tr: Traverse<'a, State>>(
         ancestor::FormalParameterRestWithoutDecorators(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FORMAL_PARAMETER_REST_DECORATORS)
-        as *mut Vec<Decorator>)
+        as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2407,7 +2407,7 @@ unsafe fn walk_formal_parameter_rest<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_FORMAL_PARAMETER_REST_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::FormalParameterRestTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -2426,14 +2426,15 @@ unsafe fn walk_function_body<'a, State, Tr: Traverse<'a, State>>(
         ancestor::FunctionBodyWithoutDirectives(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_DIRECTIVES)
-        as *mut Vec<Directive>)
+        as *mut ArenaVec<Directive>)
     {
         walk_directive(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::FunctionBodyStatements);
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_STATEMENTS) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_FUNCTION_BODY_STATEMENTS)
+            as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2462,7 +2463,7 @@ unsafe fn walk_arrow_function_expression<'a, State, Tr: Traverse<'a, State>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
@@ -2470,12 +2471,12 @@ unsafe fn walk_arrow_function_expression<'a, State, Tr: Traverse<'a, State>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_RETURN_TYPE)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::ArrowFunctionExpressionReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -2484,7 +2485,7 @@ unsafe fn walk_arrow_function_expression<'a, State, Tr: Traverse<'a, State>>(
     walk_function_body(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_ARROW_FUNCTION_EXPRESSION_BODY)
-            as *mut Box<FunctionBody>)) as *mut _,
+            as *mut ArenaBox<FunctionBody>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2521,7 +2522,7 @@ unsafe fn walk_class<'a, State, Tr: Traverse<'a, State>>(
     let pop_token = ctx
         .push_stack(Ancestor::ClassDecorators(ancestor::ClassWithoutDecorators(node, PhantomData)));
     for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_DECORATORS) as *mut Vec<Decorator>)
+        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_DECORATORS) as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2538,7 +2539,7 @@ unsafe fn walk_class<'a, State, Tr: Traverse<'a, State>>(
         .unwrap();
     ctx.set_current_scope_id(current_scope_id);
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::ClassTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
@@ -2550,21 +2551,21 @@ unsafe fn walk_class<'a, State, Tr: Traverse<'a, State>>(
         walk_expression(traverser, field as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::ClassSuperTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ClassImplements);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_IMPLEMENTS)
-        as *mut Vec<TSClassImplements>)
+        as *mut ArenaVec<TSClassImplements>)
     {
         walk_ts_class_implements(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::ClassBody);
     walk_class_body(
         traverser,
-        (&mut **((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY) as *mut Box<ClassBody>))
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY) as *mut ArenaBox<ClassBody>))
             as *mut _,
         ctx,
     );
@@ -2581,8 +2582,8 @@ unsafe fn walk_class_body<'a, State, Tr: Traverse<'a, State>>(
     traverser.enter_class_body(&mut *node, ctx);
     let pop_token =
         ctx.push_stack(Ancestor::ClassBodyBody(ancestor::ClassBodyWithoutBody(node, PhantomData)));
-    for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY_BODY) as *mut Vec<ClassElement>)
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_BODY_BODY)
+        as *mut ArenaVec<ClassElement>)
     {
         walk_class_element(traverser, item as *mut _, ctx);
     }
@@ -2626,7 +2627,7 @@ unsafe fn walk_method_definition<'a, State, Tr: Traverse<'a, State>>(
         ancestor::MethodDefinitionWithoutDecorators(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_DECORATORS)
-        as *mut Vec<Decorator>)
+        as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2640,7 +2641,7 @@ unsafe fn walk_method_definition<'a, State, Tr: Traverse<'a, State>>(
     walk_function(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_METHOD_DEFINITION_VALUE)
-            as *mut Box<Function>)) as *mut _,
+            as *mut ArenaBox<Function>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2657,7 +2658,7 @@ unsafe fn walk_property_definition<'a, State, Tr: Traverse<'a, State>>(
         ancestor::PropertyDefinitionWithoutDecorators(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_PROPERTY_DEFINITION_DECORATORS)
-        as *mut Vec<Decorator>)
+        as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2669,7 +2670,7 @@ unsafe fn walk_property_definition<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_PROPERTY_DEFINITION_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::PropertyDefinitionTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -2713,7 +2714,7 @@ unsafe fn walk_static_block<'a, State, Tr: Traverse<'a, State>>(
         .push_stack(Ancestor::StaticBlockBody(ancestor::StaticBlockWithoutBody(node, PhantomData)));
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_STATIC_BLOCK_BODY) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_STATIC_BLOCK_BODY) as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -2762,7 +2763,7 @@ unsafe fn walk_accessor_property<'a, State, Tr: Traverse<'a, State>>(
         ancestor::AccessorPropertyWithoutDecorators(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_ACCESSOR_PROPERTY_DECORATORS)
-        as *mut Vec<Decorator>)
+        as *mut ArenaVec<Decorator>)
     {
         walk_decorator(traverser, item as *mut _, ctx);
     }
@@ -2774,7 +2775,7 @@ unsafe fn walk_accessor_property<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_ACCESSOR_PROPERTY_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::AccessorPropertyTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -2824,7 +2825,7 @@ unsafe fn walk_import_declaration<'a, State, Tr: Traverse<'a, State>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_IMPORT_DECLARATION_SPECIFIERS)
-        as *mut Option<Vec<ImportDeclarationSpecifier>>)
+        as *mut Option<ArenaVec<ImportDeclarationSpecifier>>)
     {
         for item in field.iter_mut() {
             walk_import_declaration_specifier(traverser, item as *mut _, ctx);
@@ -2838,7 +2839,7 @@ unsafe fn walk_import_declaration<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_IMPORT_DECLARATION_WITH_CLAUSE)
-        as *mut Option<Box<WithClause>>)
+        as *mut Option<ArenaBox<WithClause>>)
     {
         ctx.retag_stack(AncestorType::ImportDeclarationWithClause);
         walk_with_clause(traverser, (&mut **field) as *mut _, ctx);
@@ -2939,7 +2940,7 @@ unsafe fn walk_with_clause<'a, State, Tr: Traverse<'a, State>>(
         ancestor::WithClauseWithoutWithEntries(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_WITH_CLAUSE_WITH_ENTRIES)
-        as *mut Vec<ImportAttribute>)
+        as *mut ArenaVec<ImportAttribute>)
     {
         walk_import_attribute(traverser, item as *mut _, ctx);
     }
@@ -3005,7 +3006,7 @@ unsafe fn walk_export_named_declaration<'a, State, Tr: Traverse<'a, State>>(
     }
     ctx.retag_stack(AncestorType::ExportNamedDeclarationSpecifiers);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_SPECIFIERS)
-        as *mut Vec<ExportSpecifier>)
+        as *mut ArenaVec<ExportSpecifier>)
     {
         walk_export_specifier(traverser, item as *mut _, ctx);
     }
@@ -3018,7 +3019,7 @@ unsafe fn walk_export_named_declaration<'a, State, Tr: Traverse<'a, State>>(
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_EXPORT_NAMED_DECLARATION_WITH_CLAUSE)
-        as *mut Option<Box<WithClause>>)
+        as *mut Option<ArenaBox<WithClause>>)
     {
         ctx.retag_stack(AncestorType::ExportNamedDeclarationWithClause);
         walk_with_clause(traverser, (&mut **field) as *mut _, ctx);
@@ -3069,7 +3070,7 @@ unsafe fn walk_export_all_declaration<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_EXPORT_ALL_DECLARATION_WITH_CLAUSE)
-        as *mut Option<Box<WithClause>>)
+        as *mut Option<ArenaBox<WithClause>>)
     {
         ctx.retag_stack(AncestorType::ExportAllDeclarationWithClause);
         walk_with_clause(traverser, (&mut **field) as *mut _, ctx);
@@ -3203,7 +3204,7 @@ unsafe fn walk_v8_intrinsic_expression<'a, State, Tr: Traverse<'a, State>>(
     );
     ctx.retag_stack(AncestorType::V8IntrinsicExpressionArguments);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_V8_INTRINSIC_EXPRESSION_ARGUMENTS)
-        as *mut Vec<Argument>)
+        as *mut ArenaVec<Argument>)
     {
         walk_argument(traverser, item as *mut _, ctx);
     }
@@ -3277,17 +3278,17 @@ unsafe fn walk_jsx_element<'a, State, Tr: Traverse<'a, State>>(
     walk_jsx_opening_element(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_OPENING_ELEMENT)
-            as *mut Box<JSXOpeningElement>)) as *mut _,
+            as *mut ArenaBox<JSXOpeningElement>)) as *mut _,
         ctx,
     );
     ctx.retag_stack(AncestorType::JSXElementChildren);
-    for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CHILDREN) as *mut Vec<JSXChild>)
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CHILDREN)
+        as *mut ArenaVec<JSXChild>)
     {
         walk_jsx_child(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_ELEMENT_CLOSING_ELEMENT)
-        as *mut Option<Box<JSXClosingElement>>)
+        as *mut Option<ArenaBox<JSXClosingElement>>)
     {
         ctx.retag_stack(AncestorType::JSXElementClosingElement);
         walk_jsx_closing_element(traverser, (&mut **field) as *mut _, ctx);
@@ -3312,14 +3313,14 @@ unsafe fn walk_jsx_opening_element<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::JSXOpeningElementTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::JSXOpeningElementAttributes);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES)
-        as *mut Vec<JSXAttributeItem>)
+        as *mut ArenaVec<JSXAttributeItem>)
     {
         walk_jsx_attribute_item(traverser, item as *mut _, ctx);
     }
@@ -3361,8 +3362,8 @@ unsafe fn walk_jsx_fragment<'a, State, Tr: Traverse<'a, State>>(
         ctx,
     );
     ctx.retag_stack(AncestorType::JSXFragmentChildren);
-    for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CHILDREN) as *mut Vec<JSXChild>)
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CHILDREN)
+        as *mut ArenaVec<JSXChild>)
     {
         walk_jsx_child(traverser, item as *mut _, ctx);
     }
@@ -3743,7 +3744,7 @@ unsafe fn walk_ts_this_parameter<'a, State, Tr: Traverse<'a, State>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_THIS_PARAMETER_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
     }
@@ -3791,7 +3792,7 @@ unsafe fn walk_ts_enum_body<'a, State, Tr: Traverse<'a, State>>(
         ancestor::TSEnumBodyWithoutMembers(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_ENUM_BODY_MEMBERS)
-        as *mut Vec<TSEnumMember>)
+        as *mut ArenaVec<TSEnumMember>)
     {
         walk_ts_enum_member(traverser, item as *mut _, ctx);
     }
@@ -4069,7 +4070,7 @@ unsafe fn walk_ts_union_type<'a, State, Tr: Traverse<'a, State>>(
         PhantomData,
     )));
     for item in
-        &mut *((node as *mut u8).add(ancestor::OFFSET_TS_UNION_TYPE_TYPES) as *mut Vec<TSType>)
+        &mut *((node as *mut u8).add(ancestor::OFFSET_TS_UNION_TYPE_TYPES) as *mut ArenaVec<TSType>)
     {
         walk_ts_type(traverser, item as *mut _, ctx);
     }
@@ -4087,7 +4088,7 @@ unsafe fn walk_ts_intersection_type<'a, State, Tr: Traverse<'a, State>>(
         ancestor::TSIntersectionTypeWithoutTypes(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERSECTION_TYPE_TYPES)
-        as *mut Vec<TSType>)
+        as *mut ArenaVec<TSType>)
     {
         walk_ts_type(traverser, item as *mut _, ctx);
     }
@@ -4184,7 +4185,7 @@ unsafe fn walk_ts_tuple_type<'a, State, Tr: Traverse<'a, State>>(
         ancestor::TSTupleTypeWithoutElementTypes(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TUPLE_TYPE_ELEMENT_TYPES)
-        as *mut Vec<TSTupleElement>)
+        as *mut ArenaVec<TSTupleElement>)
     {
         walk_ts_tuple_element(traverser, item as *mut _, ctx);
     }
@@ -4449,7 +4450,7 @@ unsafe fn walk_ts_type_reference<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_REFERENCE_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSTypeReferenceTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -4513,7 +4514,7 @@ unsafe fn walk_ts_type_parameter_instantiation<'a, State, Tr: Traverse<'a, State
     ));
     for item in &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_PARAMETER_INSTANTIATION_PARAMS)
-        as *mut Vec<TSType>)
+        as *mut ArenaVec<TSType>)
     {
         walk_ts_type(traverser, item as *mut _, ctx);
     }
@@ -4561,7 +4562,7 @@ unsafe fn walk_ts_type_parameter_declaration<'a, State, Tr: Traverse<'a, State>>
         ancestor::TSTypeParameterDeclarationWithoutParams(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_PARAMETER_DECLARATION_PARAMS)
-        as *mut Vec<TSTypeParameter>)
+        as *mut ArenaVec<TSTypeParameter>)
     {
         walk_ts_type_parameter(traverser, item as *mut _, ctx);
     }
@@ -4593,7 +4594,7 @@ unsafe fn walk_ts_type_alias_declaration<'a, State, Tr: Traverse<'a, State>>(
     ctx.set_current_scope_id(current_scope_id);
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_ALIAS_DECLARATION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSTypeAliasDeclarationTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
@@ -4626,7 +4627,7 @@ unsafe fn walk_ts_class_implements<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CLASS_IMPLEMENTS_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSClassImplementsTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -4659,14 +4660,14 @@ unsafe fn walk_ts_interface_declaration<'a, State, Tr: Traverse<'a, State>>(
     ctx.set_current_scope_id(current_scope_id);
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSInterfaceDeclarationTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSInterfaceDeclarationExtends);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-        as *mut Vec<TSInterfaceHeritage>)
+        as *mut ArenaVec<TSInterfaceHeritage>)
     {
         walk_ts_interface_heritage(traverser, item as *mut _, ctx);
     }
@@ -4674,7 +4675,7 @@ unsafe fn walk_ts_interface_declaration<'a, State, Tr: Traverse<'a, State>>(
     walk_ts_interface_body(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_BODY)
-            as *mut Box<TSInterfaceBody>)) as *mut _,
+            as *mut ArenaBox<TSInterfaceBody>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4692,7 +4693,7 @@ unsafe fn walk_ts_interface_body<'a, State, Tr: Traverse<'a, State>>(
         ancestor::TSInterfaceBodyWithoutBody(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_BODY_BODY)
-        as *mut Vec<TSSignature>)
+        as *mut ArenaVec<TSSignature>)
     {
         walk_ts_signature(traverser, item as *mut _, ctx);
     }
@@ -4716,7 +4717,7 @@ unsafe fn walk_ts_property_signature<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_PROPERTY_SIGNATURE_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSPropertySignatureTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -4761,7 +4762,7 @@ unsafe fn walk_ts_index_signature<'a, State, Tr: Traverse<'a, State>>(
         ancestor::TSIndexSignatureWithoutParameters(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_PARAMETERS)
-        as *mut Vec<TSIndexSignatureName>)
+        as *mut ArenaVec<TSIndexSignatureName>)
     {
         walk_ts_index_signature_name(traverser, item as *mut _, ctx);
     }
@@ -4769,7 +4770,7 @@ unsafe fn walk_ts_index_signature<'a, State, Tr: Traverse<'a, State>>(
     walk_ts_type_annotation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_TYPE_ANNOTATION)
-            as *mut Box<TSTypeAnnotation>)) as *mut _,
+            as *mut ArenaBox<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4794,13 +4795,13 @@ unsafe fn walk_ts_call_signature_declaration<'a, State, Tr: Traverse<'a, State>>
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-        as *mut Option<Box<TSThisParameter>>)
+        as *mut Option<ArenaBox<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::TSCallSignatureDeclarationThisParam);
         walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
@@ -4809,12 +4810,12 @@ unsafe fn walk_ts_call_signature_declaration<'a, State, Tr: Traverse<'a, State>>
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_RETURN_TYPE)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSCallSignatureDeclarationReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -4846,14 +4847,14 @@ unsafe fn walk_ts_method_signature<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSMethodSignatureTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_THIS_PARAM)
-        as *mut Option<Box<TSThisParameter>>)
+        as *mut Option<ArenaBox<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::TSMethodSignatureThisParam);
         walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
@@ -4862,12 +4863,12 @@ unsafe fn walk_ts_method_signature<'a, State, Tr: Traverse<'a, State>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_METHOD_SIGNATURE_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_METHOD_SIGNATURE_RETURN_TYPE)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSMethodSignatureReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -4895,7 +4896,7 @@ unsafe fn walk_ts_construct_signature_declaration<'a, State, Tr: Traverse<'a, St
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
@@ -4903,12 +4904,12 @@ unsafe fn walk_ts_construct_signature_declaration<'a, State, Tr: Traverse<'a, St
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CONSTRUCT_SIGNATURE_DECLARATION_RETURN_TYPE)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSConstructSignatureDeclarationReturnType);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -4930,7 +4931,7 @@ unsafe fn walk_ts_index_signature_name<'a, State, Tr: Traverse<'a, State>>(
     walk_ts_type_annotation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INDEX_SIGNATURE_NAME_TYPE_ANNOTATION)
-            as *mut Box<TSTypeAnnotation>)) as *mut _,
+            as *mut ArenaBox<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -4953,7 +4954,7 @@ unsafe fn walk_ts_interface_heritage<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_INTERFACE_HERITAGE_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSInterfaceHeritageTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -4979,7 +4980,7 @@ unsafe fn walk_ts_type_predicate<'a, State, Tr: Traverse<'a, State>>(
     );
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_TYPE_PREDICATE_TYPE_ANNOTATION)
-        as *mut Option<Box<TSTypeAnnotation>>)
+        as *mut Option<ArenaBox<TSTypeAnnotation>>)
     {
         ctx.retag_stack(AncestorType::TSTypePredicateTypeAnnotation);
         walk_ts_type_annotation(traverser, (&mut **field) as *mut _, ctx);
@@ -5120,14 +5121,14 @@ unsafe fn walk_ts_module_block<'a, State, Tr: Traverse<'a, State>>(
         ancestor::TSModuleBlockWithoutDirectives(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_DIRECTIVES)
-        as *mut Vec<Directive>)
+        as *mut ArenaVec<Directive>)
     {
         walk_directive(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSModuleBlockBody);
     walk_statements(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_BODY) as *mut Vec<Statement>,
+        (node as *mut u8).add(ancestor::OFFSET_TS_MODULE_BLOCK_BODY) as *mut ArenaVec<Statement>,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5144,7 +5145,7 @@ unsafe fn walk_ts_type_literal<'a, State, Tr: Traverse<'a, State>>(
         ancestor::TSTypeLiteralWithoutMembers(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_LITERAL_MEMBERS)
-        as *mut Vec<TSSignature>)
+        as *mut ArenaVec<TSSignature>)
     {
         walk_ts_signature(traverser, item as *mut _, ctx);
     }
@@ -5164,7 +5165,7 @@ unsafe fn walk_ts_infer_type<'a, State, Tr: Traverse<'a, State>>(
     walk_ts_type_parameter(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INFER_TYPE_TYPE_PARAMETER)
-            as *mut Box<TSTypeParameter>)) as *mut _,
+            as *mut ArenaBox<TSTypeParameter>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5186,7 +5187,7 @@ unsafe fn walk_ts_type_query<'a, State, Tr: Traverse<'a, State>>(
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_QUERY_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSTypeQueryTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -5229,7 +5230,7 @@ unsafe fn walk_ts_import_type<'a, State, Tr: Traverse<'a, State>>(
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_OPTIONS)
-        as *mut Option<Box<ObjectExpression>>)
+        as *mut Option<ArenaBox<ObjectExpression>>)
     {
         ctx.retag_stack(AncestorType::TSImportTypeOptions);
         walk_object_expression(traverser, (&mut **field) as *mut _, ctx);
@@ -5242,7 +5243,7 @@ unsafe fn walk_ts_import_type<'a, State, Tr: Traverse<'a, State>>(
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_IMPORT_TYPE_TYPE_ARGUMENTS)
-        as *mut Option<Box<TSTypeParameterInstantiation>>)
+        as *mut Option<ArenaBox<TSTypeParameterInstantiation>>)
     {
         ctx.retag_stack(AncestorType::TSImportTypeTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
@@ -5311,12 +5312,12 @@ unsafe fn walk_ts_function_type<'a, State, Tr: Traverse<'a, State>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_FUNCTION_TYPE_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_THIS_PARAM)
-        as *mut Option<Box<TSThisParameter>>)
+        as *mut Option<ArenaBox<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::TSFunctionTypeThisParam);
         walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
@@ -5325,14 +5326,14 @@ unsafe fn walk_ts_function_type<'a, State, Tr: Traverse<'a, State>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSFunctionTypeReturnType);
     walk_ts_type_annotation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_FUNCTION_TYPE_RETURN_TYPE)
-            as *mut Box<TSTypeAnnotation>)) as *mut _,
+            as *mut ArenaBox<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5357,7 +5358,7 @@ unsafe fn walk_ts_constructor_type<'a, State, Tr: Traverse<'a, State>>(
     ));
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_TYPE_PARAMETERS)
-        as *mut Option<Box<TSTypeParameterDeclaration>>)
+        as *mut Option<ArenaBox<TSTypeParameterDeclaration>>)
     {
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
     }
@@ -5365,14 +5366,14 @@ unsafe fn walk_ts_constructor_type<'a, State, Tr: Traverse<'a, State>>(
     walk_formal_parameters(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_PARAMS)
-            as *mut Box<FormalParameters>)) as *mut _,
+            as *mut ArenaBox<FormalParameters>)) as *mut _,
         ctx,
     );
     ctx.retag_stack(AncestorType::TSConstructorTypeReturnType);
     walk_ts_type_annotation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_CONSTRUCTOR_TYPE_RETURN_TYPE)
-            as *mut Box<TSTypeAnnotation>)) as *mut _,
+            as *mut ArenaBox<TSTypeAnnotation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5433,13 +5434,13 @@ unsafe fn walk_ts_template_literal_type<'a, State, Tr: Traverse<'a, State>>(
         ancestor::TSTemplateLiteralTypeWithoutQuasis(node, PhantomData),
     ));
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TEMPLATE_LITERAL_TYPE_QUASIS)
-        as *mut Vec<TemplateElement>)
+        as *mut ArenaVec<TemplateElement>)
     {
         walk_template_element(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSTemplateLiteralTypeTypes);
     for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TEMPLATE_LITERAL_TYPE_TYPES)
-        as *mut Vec<TSType>)
+        as *mut ArenaVec<TSType>)
     {
         walk_ts_type(traverser, item as *mut _, ctx);
     }
@@ -5679,7 +5680,7 @@ unsafe fn walk_ts_instantiation_expression<'a, State, Tr: Traverse<'a, State>>(
     walk_ts_type_parameter_instantiation(
         traverser,
         (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_ARGUMENTS)
-            as *mut Box<TSTypeParameterInstantiation>)) as *mut _,
+            as *mut ArenaBox<TSTypeParameterInstantiation>)) as *mut _,
         ctx,
     );
     ctx.pop_stack(pop_token);
@@ -5734,7 +5735,7 @@ unsafe fn walk_js_doc_unknown_type<'a, State, Tr: Traverse<'a, State>>(
 
 unsafe fn walk_statements<'a, State, Tr: Traverse<'a, State>>(
     traverser: &mut Tr,
-    stmts: *mut Vec<'a, Statement<'a>>,
+    stmts: *mut ArenaVec<'a, Statement<'a>>,
     ctx: &mut TraverseCtx<'a, State>,
 ) {
     traverser.enter_statements(&mut *stmts, ctx);

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -84,7 +84,7 @@ impl Generator for AstBuilderGenerator {
             use std::cell::Cell;
 
             ///@@line_break
-            use oxc_allocator::{Allocator, Box, IntoIn, Vec};
+            use oxc_allocator::{Allocator, ArenaBox, ArenaVec, IntoIn};
             use oxc_str::{Ident, Str};
             use oxc_syntax::{scope::ScopeId, symbol::SymbolId, reference::ReferenceId};
 
@@ -120,7 +120,7 @@ struct Param<'d> {
     /// * `Some(GenericType::Into)` if is generic and uses `Into`
     ///   e.g. `name: S1 where S1: Into<Str<'a>>`.
     /// * `Some(GenericType::IntoIn)` if is generic and uses `IntoIn`
-    ///   e.g. `type_annotation: T1 where T1: IntoIn<'a, Box<'a, TSTypeAnnotation<'a>>>`.
+    ///   e.g. `type_annotation: T1 where T1: IntoIn<'a, ArenaBox<'a, TSTypeAnnotation<'a>>>`.
     generic_type: Option<GenericType>,
 }
 
@@ -285,12 +285,12 @@ fn generate_builder_methods_for_struct_impl(
         ///@@line_break
         #[doc = #alloc_doc1]
         #[doc = ""]
-        #[doc = " Returns a [`Box`] containing the newly-allocated node."]
+        #[doc = " Returns a [`Box`](ArenaBox) containing the newly-allocated node."]
         #[doc = #alloc_doc2]
         #params_docs
         #[inline]
-        pub fn #alloc_fn_name #generic_params (self, #fn_params) -> Box<'a, #struct_ty> #where_clause {
-            Box::new_in(self.#fn_name(#(#args),*), self.allocator)
+        pub fn #alloc_fn_name #generic_params (self, #fn_params) -> ArenaBox<'a, #struct_ty> #where_clause {
+            ArenaBox::new_in(self.#fn_name(#(#args),*), self.allocator)
         }
     }
 }
@@ -302,8 +302,8 @@ fn generate_builder_methods_for_struct_impl(
 /// ```
 /// //        ↓↓↓↓ generic params
 /// pub fn foo<T1>(self, span: Span, type_parameters: T1) -> Foo<'a>
-///     where T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>> {}
-/// //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ where clause
+///     where T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>> {}
+/// //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ where clause
 /// ```
 fn get_struct_params<'s>(
     struct_def: &'s StructDef,

--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -104,7 +104,7 @@ impl Generator for FormatterAstNodesGenerator {
         let output = quote! {
             use std::mem::transmute;
             ///@@line_break
-            use oxc_allocator::Vec;
+            use oxc_allocator::ArenaVec;
             use oxc_ast::ast::*;
             use oxc_span::GetSpan;
             use oxc_str::Ident;

--- a/tasks/ast_tools/src/generators/traverse/ancestor.rs
+++ b/tasks/ast_tools/src/generators/traverse/ancestor.rs
@@ -213,7 +213,7 @@ pub fn generate_ancestor(schema: &Schema) -> TokenStream {
         use std::{cell::Cell, marker::PhantomData, mem::offset_of};
 
         ///@@line_break
-        use oxc_allocator::{Address, Box, GetAddress, Vec};
+        use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress};
         use oxc_ast::ast::*;
         use oxc_syntax::{node::NodeId, scope::ScopeId};
 

--- a/tasks/ast_tools/src/generators/traverse/mod.rs
+++ b/tasks/ast_tools/src/generators/traverse/mod.rs
@@ -118,17 +118,17 @@ pub(super) fn generate_traverse_trait(
         });
     }
 
-    // Special "Statements" type: Vec<'a, Statement<'a>>
+    // Special "Statements" type: ArenaVec<'a, Statement<'a>>
     methods.extend(quote! {
         ///@@line_break
         #[inline]
-        fn enter_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &mut #ctx_ty) {}
+        fn enter_statements(&mut self, node: &mut ArenaVec<'a, Statement<'a>>, ctx: &mut #ctx_ty) {}
         #[inline]
-        fn exit_statements(&mut self, node: &mut Vec<'a, Statement<'a>>, ctx: &mut #ctx_ty) {}
+        fn exit_statements(&mut self, node: &mut ArenaVec<'a, Statement<'a>>, ctx: &mut #ctx_ty) {}
     });
 
     quote! {
-        use oxc_allocator::Vec;
+        use oxc_allocator::ArenaVec;
         use oxc_ast::ast::*;
 
         ///@@line_break

--- a/tasks/ast_tools/src/generators/traverse/walk.rs
+++ b/tasks/ast_tools/src/generators/traverse/walk.rs
@@ -89,7 +89,7 @@ pub(super) fn generate_walk(schema: &Schema, config: &WalkConfig) -> TokenStream
         use std::{cell::Cell, marker::PhantomData};
 
         ///@@line_break
-        use oxc_allocator::{Box, Vec};
+        use oxc_allocator::{ArenaBox, ArenaVec};
         use oxc_ast::ast::*;
         use oxc_syntax::scope::ScopeId;
 
@@ -117,7 +117,7 @@ pub(super) fn generate_walk(schema: &Schema, config: &WalkConfig) -> TokenStream
         ///@@line_break
         unsafe fn walk_statements<#walk_generics>(
             traverser: &mut Tr,
-            stmts: *mut Vec<'a, Statement<'a>>,
+            stmts: *mut ArenaVec<'a, Statement<'a>>,
             ctx: &mut #ctx_ty,
         ) {
             traverser.enter_statements(&mut *stmts, ctx);
@@ -627,9 +627,9 @@ fn collect_inherited_patterns(
 /// Generate a type signature without lifetimes.
 ///
 /// Matches the JS behavior: `rawTypeName.replace(/<'a>/g, "").replace(/<'a, ?/g, "<")`
-/// e.g. `Box<'a, TSTypeAnnotation<'a>>` -> `Box<TSTypeAnnotation>`
-/// e.g. `Vec<'a, Statement<'a>>` -> `Vec<Statement>`
-/// e.g. `Option<Box<'a, FunctionBody<'a>>>` -> `Option<Box<FunctionBody>>`
+/// e.g. `ArenaBox<'a, TSTypeAnnotation<'a>>` -> `ArenaBox<TSTypeAnnotation>`
+/// e.g. `ArenaVec<'a, Statement<'a>>` -> `ArenaVec<Statement>`
+/// e.g. `Option<ArenaBox<'a, FunctionBody<'a>>>` -> `Option<ArenaBox<FunctionBody>>`
 fn ty_no_lifetime(type_def: &TypeDef, schema: &Schema) -> TokenStream {
     match type_def {
         TypeDef::Struct(s) => {
@@ -646,11 +646,11 @@ fn ty_no_lifetime(type_def: &TypeDef, schema: &Schema) -> TokenStream {
         }
         TypeDef::Box(b) => {
             let inner = ty_no_lifetime(b.inner_type(schema), schema);
-            quote!(Box<#inner>)
+            quote!(ArenaBox<#inner>)
         }
         TypeDef::Vec(v) => {
             let inner = ty_no_lifetime(v.inner_type(schema), schema);
-            quote!(Vec<#inner>)
+            quote!(ArenaVec<#inner>)
         }
         TypeDef::Cell(c) => {
             let inner = ty_no_lifetime(&schema.types[c.inner_type_id], schema);

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -254,7 +254,7 @@ fn generate_output(
         use std::cell::Cell;
 
         ///@@line_break
-        use oxc_allocator::Vec;
+        use oxc_allocator::ArenaVec;
         use oxc_syntax::scope::{ScopeFlags, ScopeId};
 
         ///@@line_break

--- a/tasks/ast_tools/src/schema/defs/box.rs
+++ b/tasks/ast_tools/src/schema/defs/box.rs
@@ -65,7 +65,7 @@ impl Def for BoxDef {
     fn ty_with_lifetime(&self, schema: &Schema, anon: bool) -> TokenStream {
         let inner_ty = self.inner_type(schema).ty_with_lifetime(schema, anon);
         let lifetime = if anon { quote!( '_ ) } else { quote!( 'a ) };
-        quote!( Box<#lifetime, #inner_ty> )
+        quote!( ArenaBox<#lifetime, #inner_ty> )
     }
 
     /// Get inner type, if type has one.

--- a/tasks/ast_tools/src/schema/defs/vec.rs
+++ b/tasks/ast_tools/src/schema/defs/vec.rs
@@ -70,7 +70,7 @@ impl Def for VecDef {
     fn ty_with_lifetime(&self, schema: &Schema, anon: bool) -> TokenStream {
         let inner_ty = self.inner_type(schema).ty_with_lifetime(schema, anon);
         let lifetime = if anon { quote!( '_ ) } else { quote!( 'a ) };
-        quote!( Vec<#lifetime, #inner_ty> )
+        quote!( ArenaVec<#lifetime, #inner_ty> )
     }
 
     /// Get inner type, if type has one.


### PR DESCRIPTION
Pure refactor.

#23747 changed all usage of `Vec` and `Box` to `ArenaVec` / `ArenaBox` in hand-written code. Do the same for generated code.