### PR TITLE
refactor(allocator): `Vec` construction methods take `&GetAllocator`

### DIFF
--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -552,7 +552,7 @@ impl Allocator {
     ///
     /// allocator.reset();
     ///
-    /// let mut vec = Vec::<u64>::with_capacity_in(2, &allocator);
+    /// let mut vec = Vec::<u64>::with_capacity_in(2, &&allocator);
     ///
     /// // Allocate something else, so `vec`'s allocation is not the most recent
     /// allocator.alloc(123u64);

--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -324,6 +324,7 @@ mod test {
     #[test]
     fn boxed_slice_into_arena_slice() {
         let allocator = Allocator::default();
+        let allocator = &allocator;
         let v = Vec::from_iter_in([1, 2, 3], &allocator);
         let b = v.into_boxed_slice();
         let slice = b.into_arena_slice();
@@ -333,6 +334,7 @@ mod test {
     #[test]
     fn boxed_slice_into_arena_slice_mut() {
         let allocator = Allocator::default();
+        let allocator = &allocator;
         let v = Vec::from_iter_in([10, 20, 30], &allocator);
         let b = v.into_boxed_slice();
         let slice = b.into_arena_slice_mut();

--- a/crates/oxc_allocator/src/clone_in.rs
+++ b/crates/oxc_allocator/src/clone_in.rs
@@ -173,7 +173,7 @@ where
 
         let slice = self.as_slice();
 
-        let mut vec = Vec::<C>::with_capacity_in(slice.len(), allocator);
+        let mut vec = Vec::<C>::with_capacity_in(slice.len(), &allocator);
 
         // SAFETY: We allocated capacity for `slice.len()` elements in `vec`.
         // Therefore, writing `slice.len()` elements to that memory region is safe.
@@ -194,7 +194,7 @@ where
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         let slice = self.as_slice();
 
-        let mut vec = Vec::<C>::with_capacity_in(slice.len(), allocator);
+        let mut vec = Vec::<C>::with_capacity_in(slice.len(), &allocator);
 
         // SAFETY: We allocated capacity for `slice.len()` elements in `vec`.
         // Therefore, writing `slice.len()` elements to that memory region is safe.
@@ -293,11 +293,12 @@ mod test {
     #[test]
     fn clone_in_boxed_slice() {
         let allocator = Allocator::default();
+        let allocator = &allocator;
 
         let mut original = Vec::from_iter_in([1, 2, 3], &allocator).into_boxed_slice();
 
-        let cloned = original.clone_in(&allocator);
-        let cloned2 = original.clone_in_with_semantic_ids(&allocator);
+        let cloned = original.clone_in(allocator);
+        let cloned2 = original.clone_in_with_semantic_ids(allocator);
         original[1] = 4;
 
         assert_eq!(original.as_ref(), &[1, 4, 3]);
@@ -308,12 +309,13 @@ mod test {
     #[test]
     fn clone_in_vec() {
         let allocator = Allocator::default();
+        let allocator = &allocator;
 
         let mut original = Vec::with_capacity_in(8, &allocator);
         original.extend_from_slice(&[1, 2, 3]);
 
-        let cloned = original.clone_in(&allocator);
-        let cloned2 = original.clone_in_with_semantic_ids(&allocator);
+        let cloned = original.clone_in(allocator);
+        let cloned2 = original.clone_in_with_semantic_ids(allocator);
         original[1] = 4;
 
         assert_eq!(original.as_slice(), &[1, 4, 3]);

--- a/crates/oxc_allocator/src/take_in.rs
+++ b/crates/oxc_allocator/src/take_in.rs
@@ -60,7 +60,7 @@ impl<'a, T> Dummy<'a> for Vec<'a, T> {
     /// Create a dummy [`Vec`].
     #[inline]
     fn dummy(allocator: &'a Allocator) -> Self {
-        Vec::new_in(allocator)
+        Vec::new_in(&allocator)
     }
 }
 

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -20,7 +20,7 @@ use serde::{Serialize, Serializer as SerdeSerializer};
 #[cfg(feature = "serialize")]
 use oxc_estree::{ConcatElement, ESTree, SequenceSerializer, Serializer as ESTreeSerializer};
 
-use crate::{Allocator, Box, arena::Arena, vec2::Vec as InnerVecGeneric};
+use crate::{Box, GetAllocator, arena::Arena, vec2::Vec as InnerVecGeneric};
 
 type InnerVec<'a, T> = InnerVecGeneric<'a, T, Arena>;
 
@@ -70,15 +70,16 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// use oxc_allocator::{Allocator, Vec};
     ///
     /// let allocator = Allocator::default();
+    /// let allocator = &allocator;
     ///
     /// let mut vec: Vec<i32> = Vec::new_in(&allocator);
     /// assert!(vec.is_empty());
     /// ```
     #[inline(always)]
-    pub fn new_in(allocator: &'alloc Allocator) -> Self {
+    pub fn new_in<A: GetAllocator<'alloc>>(allocator: &A) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
-        Self(InnerVec::new_in(allocator.arena()))
+        Self(InnerVec::new_in(allocator.allocator().arena()))
     }
 
     /// Constructs a new, empty `Vec<T>` with at least the specified capacity
@@ -103,6 +104,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// use oxc_allocator::{Allocator, Vec};
     ///
     /// let allocator = Allocator::default();
+    /// let allocator = &allocator;
     ///
     /// let mut vec = Vec::with_capacity_in(10, &allocator);
     ///
@@ -128,10 +130,10 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// assert_eq!(vec_units.capacity(), usize::MAX);
     /// ```
     #[inline(always)]
-    pub fn with_capacity_in(capacity: usize, allocator: &'alloc Allocator) -> Self {
+    pub fn with_capacity_in<A: GetAllocator<'alloc>>(capacity: usize, allocator: &A) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
-        Self(InnerVec::with_capacity_in(capacity, allocator.arena()))
+        Self(InnerVec::with_capacity_in(capacity, allocator.allocator().arena()))
     }
 
     /// Create a new [`Vec`] whose elements are taken from an iterator and
@@ -139,13 +141,16 @@ impl<'alloc, T> Vec<'alloc, T> {
     ///
     /// This is behaviorially identical to [`FromIterator::from_iter`].
     #[inline]
-    pub fn from_iter_in<I: IntoIterator<Item = T>>(iter: I, allocator: &'alloc Allocator) -> Self {
+    pub fn from_iter_in<I: IntoIterator<Item = T>, A: GetAllocator<'alloc>>(
+        iter: I,
+        allocator: &A,
+    ) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
         let iter = iter.into_iter();
         let hint = iter.size_hint();
         let capacity = hint.1.unwrap_or(hint.0);
-        let mut vec = InnerVec::with_capacity_in(capacity, allocator.arena());
+        let mut vec = InnerVec::with_capacity_in(capacity, allocator.allocator().arena());
         vec.extend(iter);
         Self(vec)
     }
@@ -157,17 +162,19 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// use oxc_allocator::{Allocator, Vec};
     ///
     /// let allocator = Allocator::default();
+    /// let allocator = &allocator;
     ///
     /// let value = 123u32;
     /// let vec = Vec::from_value_in(value, &allocator);
     /// assert_eq!(vec, [123]);
     /// ```
     #[inline]
-    pub fn from_value_in(value: T, allocator: &'alloc Allocator) -> Self {
+    pub fn from_value_in<A: GetAllocator<'alloc>>(value: T, allocator: &A) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
+        let allocator = allocator.allocator();
         let boxed = Box::new_in(value, allocator);
-        Self::from_box_in(boxed, allocator)
+        Self::from_box_in(boxed, &allocator)
     }
 
     /// Create a new [`Vec`] from a fixed-size array, allocated in the given `allocator`.
@@ -181,14 +188,19 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// use oxc_allocator::{Allocator, Vec};
     ///
     /// let allocator = Allocator::default();
+    /// let allocator = &allocator;
     ///
     /// let array: [u32; 4] = [1, 2, 3, 4];
     /// let vec = Vec::from_array_in(array, &allocator);
     /// ```
     #[inline]
-    pub fn from_array_in<const N: usize>(array: [T; N], allocator: &'alloc Allocator) -> Self {
+    pub fn from_array_in<const N: usize, A: GetAllocator<'alloc>>(
+        array: [T; N],
+        allocator: &A,
+    ) -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 
+        let allocator = allocator.allocator();
         let boxed = Box::new_in(array, allocator);
         let ptr = Box::into_non_null(boxed).as_ptr().cast::<T>();
         // SAFETY: `ptr` has correct alignment - it was just allocated as `[T; N]`.
@@ -211,7 +223,8 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// use oxc_allocator::{Allocator, Box, Vec};
     ///
     /// let allocator = Allocator::default();
-    /// let boxed = Box::new_in(123u32, &allocator);
+    /// let allocator = &allocator;
+    /// let boxed = Box::new_in(123u32, allocator);
     /// let vec = Vec::from_box_in(boxed, &allocator);
     /// assert_eq!(vec, [123]);
     /// ```
@@ -223,6 +236,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// use oxc_allocator::{Allocator, Box, Vec};
     ///
     /// let vec_allocator = Allocator::default();
+    /// let vec_allocator = &vec_allocator;
     /// let vec = {
     ///     let box_allocator = Allocator::default();
     ///     let boxed = Box::new_in(123u32, &box_allocator);
@@ -240,12 +254,13 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// let boxed = Box::new_in(123u32, &box_allocator);
     /// let vec = {
     ///     let vec_allocator = Allocator::default();
+    ///     let vec_allocator = &vec_allocator;
     ///     Vec::from_box_in(boxed, &vec_allocator)
     /// };
     /// assert_eq!(vec, [123]);
     /// ```
     #[inline]
-    pub fn from_box_in(boxed: Box<'alloc, T>, allocator: &'alloc Allocator) -> Self {
+    pub fn from_box_in<A: GetAllocator<'alloc>>(boxed: Box<'alloc, T>, allocator: &A) -> Self {
         let ptr = Box::into_non_null(boxed).as_ptr();
         // SAFETY: `boxed` owns its backing memory which comprises 1 valid initialized `T`.
         // A `Vec` with length 1, capacity 1 owns the same memory.
@@ -255,7 +270,7 @@ impl<'alloc, T> Vec<'alloc, T> {
         // The single element stays valid (it lives in the original allocator) for the lifetime of the returned `Vec`.
         // If the `Vec` is grown later, it reallocates in `allocator`. Both outlive the `Vec`, so either way the memory
         // is valid for the whole life of the returned `Vec`.
-        let vec = unsafe { InnerVec::from_raw_parts_in(ptr, 1, 1, allocator.arena()) };
+        let vec = unsafe { InnerVec::from_raw_parts_in(ptr, 1, 1, allocator.allocator().arena()) };
         Self(vec)
     }
 
@@ -283,6 +298,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// use oxc_allocator::{Allocator, Vec};
     ///
     /// let allocator = Allocator::default();
+    /// let allocator = &allocator;
     ///
     /// let mut vec = Vec::from_iter_in([1, 2, 3], &allocator);
     /// let slice = vec.into_arena_slice();
@@ -301,6 +317,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// use oxc_allocator::{Allocator, Vec};
     ///
     /// let allocator = Allocator::default();
+    /// let allocator = &allocator;
     ///
     /// let vec = Vec::from_iter_in([1, 2, 3], &allocator);
     /// let slice = vec.into_arena_slice_mut();
@@ -493,6 +510,7 @@ mod test {
     #[test]
     fn vec_with_capacity() {
         let allocator = Allocator::default();
+        let allocator = &allocator;
         let v: Vec<i32> = Vec::with_capacity_in(10, &allocator);
         assert!(v.is_empty());
     }
@@ -500,6 +518,7 @@ mod test {
     #[test]
     fn vec_debug() {
         let allocator = Allocator::default();
+        let allocator = &allocator;
         let mut v = Vec::new_in(&allocator);
         v.push("x");
         let v = format!("{v:?}");
@@ -509,6 +528,7 @@ mod test {
     #[test]
     fn vec_into_boxed_slice() {
         let allocator = Allocator::default();
+        let allocator = &allocator;
         let mut v = Vec::with_capacity_in(4, &allocator);
         v.push("x");
         v.push("y");
@@ -520,6 +540,7 @@ mod test {
     #[test]
     fn vec_serialize() {
         let allocator = Allocator::default();
+        let allocator = &allocator;
         let mut v = Vec::new_in(&allocator);
         v.push("x");
         let s = serde_json::to_string(&v).unwrap();
@@ -532,6 +553,7 @@ mod test {
         use oxc_estree::{CompactSerializer, ESTree};
 
         let allocator = Allocator::default();
+        let allocator = &allocator;
         let mut v = Vec::new_in(&allocator);
         v.push("x");
 
@@ -545,6 +567,7 @@ mod test {
     #[expect(clippy::op_ref)]
     fn vec_partial_eq() {
         let allocator = Allocator::default();
+        let allocator = &allocator;
 
         let v = Vec::from_array_in([1, 2, 3], &allocator);
         let same = Vec::from_array_in([1, 2, 3], &allocator);
@@ -612,6 +635,7 @@ mod test {
     #[test]
     fn vec_from_value_in() {
         let allocator = Allocator::default();
+        let allocator = &allocator;
         let mut v = Vec::from_value_in(123u32, &allocator);
         assert_eq!(v, [123]);
         assert_eq!(v.len(), 1);
@@ -625,7 +649,8 @@ mod test {
     #[test]
     fn vec_from_box_in() {
         let allocator = Allocator::default();
-        let boxed = Box::new_in(123u32, &allocator);
+        let allocator = &allocator;
+        let boxed = Box::new_in(123u32, allocator);
         let mut v = Vec::from_box_in(boxed, &allocator);
         assert_eq!(v, [123]);
         assert_eq!(v.len(), 1);
@@ -640,6 +665,7 @@ mod test {
     #[test]
     fn vec_from_box_in_different_allocator() {
         let vec_allocator = Allocator::default();
+        let vec_allocator = &vec_allocator;
         let box_allocator = Allocator::default();
         let boxed = Box::new_in(123u32, &box_allocator);
         let mut v = Vec::from_box_in(boxed, &vec_allocator);

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -50,7 +50,7 @@ impl<'a> AstBuilder<'a> {
     /// [`Vec`]: ArenaVec
     #[inline]
     pub fn vec<T>(self) -> ArenaVec<'a, T> {
-        ArenaVec::new_in(self.allocator)
+        ArenaVec::new_in(&self)
     }
 
     /// Create a new empty [`Vec`] that stores its elements in the memory arena.
@@ -60,7 +60,7 @@ impl<'a> AstBuilder<'a> {
     /// [`Vec`]: ArenaVec
     #[inline]
     pub fn vec_with_capacity<T>(self, capacity: usize) -> ArenaVec<'a, T> {
-        ArenaVec::with_capacity_in(capacity, self.allocator)
+        ArenaVec::with_capacity_in(capacity, &self)
     }
 
     /// Create a new arena-allocated [`Vec`] initialized with a single element.
@@ -68,7 +68,7 @@ impl<'a> AstBuilder<'a> {
     /// [`Vec`]: ArenaVec
     #[inline]
     pub fn vec1<T>(self, value: T) -> ArenaVec<'a, T> {
-        ArenaVec::from_value_in(value, self.allocator)
+        ArenaVec::from_value_in(value, &self)
     }
 
     /// Collect an iterator into a new arena-allocated [`Vec`].
@@ -76,7 +76,7 @@ impl<'a> AstBuilder<'a> {
     /// [`Vec`]: ArenaVec
     #[inline]
     pub fn vec_from_iter<T, I: IntoIterator<Item = T>>(self, iter: I) -> ArenaVec<'a, T> {
-        ArenaVec::from_iter_in(iter, self.allocator)
+        ArenaVec::from_iter_in(iter, &self)
     }
 
     /// Create [`Vec`] from a fixed-size array.
@@ -88,7 +88,7 @@ impl<'a> AstBuilder<'a> {
     /// [`Vec`]: ArenaVec
     #[inline]
     pub fn vec_from_array<T, const N: usize>(self, array: [T; N]) -> ArenaVec<'a, T> {
-        ArenaVec::from_array_in(array, self.allocator)
+        ArenaVec::from_array_in(array, &self)
     }
 
     /// Allocate an [`Ident`] from a string slice.

--- a/crates/oxc_formatter/src/ast_nodes/node.rs
+++ b/crates/oxc_formatter/src/ast_nodes/node.rs
@@ -161,7 +161,7 @@ impl<'a> AstNode<'a, ImportExpression<'a>> {
         // This allows us to reuse CallExpression's argument formatting logic when printing
         // import expressions, since import(source, options) has the same structure as
         // a function call with arguments.
-        let mut arguments = ArenaVec::new_in(self.allocator);
+        let mut arguments = ArenaVec::new_in(&self.allocator);
 
         // SAFETY: Argument inherits all Expression variants through the inherit_variants! macro,
         // so Expression and Argument have identical memory layout for shared variants.

--- a/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
+++ b/crates/oxc_formatter/src/ir_transform/sort_imports/mod.rs
@@ -233,7 +233,7 @@ fn transform<'a>(
 
     // Finally, sort import lines within each chunk.
     // After sorting, flatten everything back to `FormatElement`s.
-    let mut next_elements = ArenaVec::with_capacity_in(prev_elements.len(), allocator);
+    let mut next_elements = ArenaVec::with_capacity_in(prev_elements.len(), &allocator);
 
     let mut chunks_iter = chunks.into_iter().peekable();
     while let Some(chunk) = chunks_iter.next() {

--- a/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
+++ b/crates/oxc_formatter/src/print/call_like_expression/arguments.rs
@@ -867,7 +867,7 @@ fn write_grouped_arguments<'a>(
     // since we already know that it won't be fitting on a single line.
     let variants = if grouped_breaks {
         write!(f, [expand_parent()]);
-        ArenaVec::from_array_in([middle_variant, most_expanded], f.allocator())
+        ArenaVec::from_array_in([middle_variant, most_expanded], f)
     } else {
         // Write the most flat variant with the first or last argument grouped.
         let most_flat = {
@@ -898,7 +898,7 @@ fn write_grouped_arguments<'a>(
             buffer.into_vec().into_arena_slice()
         };
 
-        ArenaVec::from_array_in([most_flat, middle_variant, most_expanded], f.allocator())
+        ArenaVec::from_array_in([most_flat, middle_variant, most_expanded], f)
     };
 
     // SAFETY: Safe because variants is guaranteed to contain exactly 3 entries:

--- a/crates/oxc_formatter/src/print/jsx/child_list.rs
+++ b/crates/oxc_formatter/src/print/jsx/child_list.rs
@@ -558,7 +558,7 @@ struct MultilineBuilder<'a> {
 
 impl<'a> MultilineBuilder<'a> {
     fn new(layout: MultilineLayout, allocator: &'a Allocator) -> Self {
-        Self { layout, result: ArenaVec::new_in(allocator) }
+        Self { layout, result: ArenaVec::new_in(&allocator) }
     }
 
     /// Formats an element that does not require a separator
@@ -596,7 +596,7 @@ impl<'a> MultilineBuilder<'a> {
         separator: Option<&dyn Format<'a, JsFormatContext<'a>>>,
         f: &mut JsFormatter<'_, 'a>,
     ) {
-        let elements = std::mem::replace(&mut self.result, ArenaVec::new_in(f.allocator()));
+        let elements = std::mem::replace(&mut self.result, ArenaVec::new_in(f));
 
         self.result = {
             let mut buffer = VecBuffer::new_with_vec(f.state_mut(), elements);
@@ -701,7 +701,7 @@ struct FlatBuilder<'a> {
 
 impl<'a> FlatBuilder<'a> {
     fn new(disabled: bool, allocator: &'a Allocator) -> Self {
-        Self { result: ArenaVec::new_in(allocator), disabled }
+        Self { result: ArenaVec::new_in(&allocator), disabled }
     }
 
     fn write(
@@ -713,7 +713,7 @@ impl<'a> FlatBuilder<'a> {
             return;
         }
 
-        let result = std::mem::replace(&mut self.result, ArenaVec::new_in(f.allocator()));
+        let result = std::mem::replace(&mut self.result, ArenaVec::new_in(f));
 
         self.result = {
             let elements = result;

--- a/crates/oxc_formatter_core/src/buffer.rs
+++ b/crates/oxc_formatter_core/src/buffer.rs
@@ -90,7 +90,7 @@ pub struct VecBuffer<'buf, 'ast, C> {
 
 impl<'buf, 'ast, C> VecBuffer<'buf, 'ast, C> {
     pub fn new(state: &'buf mut FormatState<'ast, C>) -> Self {
-        Self::new_with_vec(state, ArenaVec::new_in(state.allocator()))
+        Self::new_with_vec(state, ArenaVec::new_in(state))
     }
 
     pub fn new_with_vec(
@@ -102,7 +102,7 @@ impl<'buf, 'ast, C> VecBuffer<'buf, 'ast, C> {
 
     /// Creates a buffer with the specified capacity
     pub fn with_capacity(capacity: usize, state: &'buf mut FormatState<'ast, C>) -> Self {
-        let elements = ArenaVec::with_capacity_in(capacity, state.allocator());
+        let elements = ArenaVec::with_capacity_in(capacity, state);
         Self { state, elements }
     }
 
@@ -310,7 +310,7 @@ fn clean_interned<'ast>(
             FormatElement::Line(LineMode::Soft | LineMode::SoftOrSpace)
             | FormatElement::Tag(Tag::StartConditionalContent(_) | Tag::EndConditionalContent)
             | FormatElement::BestFitting(_) => {
-                let cleaned = ArenaVec::from_iter_in(interned[..index].iter().cloned(), allocator);
+                let cleaned = ArenaVec::from_iter_in(interned[..index].iter().cloned(), &allocator);
                 Some((cleaned, &interned[index..]))
             }
             FormatElement::Interned(inner) => {
@@ -324,7 +324,7 @@ fn clean_interned<'ast>(
                 if &cleaned_inner == inner {
                     None
                 } else {
-                    let mut cleaned = ArenaVec::with_capacity_in(interned.len(), allocator);
+                    let mut cleaned = ArenaVec::with_capacity_in(interned.len(), &allocator);
                     cleaned.extend(interned[..index].iter().cloned());
                     cleaned.push(FormatElement::Interned(cleaned_inner));
                     Some((cleaned, &interned[index + 1..]))

--- a/crates/oxc_formatter_core/src/builders.rs
+++ b/crates/oxc_formatter_core/src/builders.rs
@@ -828,7 +828,7 @@ impl<'ast, C> Format<'ast, C> for BestFitting<'_, 'ast, C> {
             formatted_variants.push(buffer.take_vec().into_arena_slice());
         }
 
-        let formatted_variants = ArenaVec::from_iter_in(formatted_variants, f.allocator());
+        let formatted_variants = ArenaVec::from_iter_in(formatted_variants, f);
 
         // SAFETY: The constructor guarantees that there are always at least two variants. It's, therefore,
         // safe to call into the unsafe `from_vec_unchecked` function

--- a/crates/oxc_formatter_json/src/parse.rs
+++ b/crates/oxc_formatter_json/src/parse.rs
@@ -88,9 +88,9 @@ pub fn parse_json<'a>(
     // This is needed so neither the returned expression reference
     // nor the comments slice borrow from the local `program`.
     let comments =
-        std::mem::replace(&mut program.comments, ArenaVec::new_in(allocator)).into_arena_slice();
+        std::mem::replace(&mut program.comments, ArenaVec::new_in(&allocator)).into_arena_slice();
     let body: &'a [Statement<'a>] =
-        std::mem::replace(&mut program.body, ArenaVec::new_in(allocator)).into_arena_slice();
+        std::mem::replace(&mut program.body, ArenaVec::new_in(&allocator)).into_arena_slice();
 
     // The wrap source guarantees exactly one top-level `ExpressionStatement`
     let stmt = body.first().ok_or_else(|| OxcDiagnostic::error("Empty JSON source"))?;
@@ -148,7 +148,7 @@ fn try_parse_comments_only<'a>(
 
     let mut program = ret.program;
     let comments =
-        std::mem::replace(&mut program.comments, ArenaVec::new_in(allocator)).into_arena_slice();
+        std::mem::replace(&mut program.comments, ArenaVec::new_in(&allocator)).into_arena_slice();
 
     Some(ParsedJson { expression: None, comments, wrapped_source: bare_source, source_offset: 0 })
 }

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -608,7 +608,8 @@ impl Linter {
         original_program: &mut Program<'_>,
         js_allocator_pool: &AllocatorPool,
     ) {
-        let js_allocator = js_allocator_pool.get();
+        let js_allocator_guard = js_allocator_pool.get();
+        let js_allocator = &*js_allocator_guard;
 
         // Get the original source text from the `Program`, and replace it with an empty string.
         // This avoids cloning the original source text, which can be large.
@@ -644,7 +645,7 @@ impl Linter {
         // We need to allocate the `Program` struct ITSELF in the allocator, not just its contents.
         // `clone_in` returns a value on the stack, but we need it in the allocator for raw transfer.
         let program = {
-            let mut program = original_program.clone_in(&js_allocator);
+            let mut program = original_program.clone_in(js_allocator);
             program.source_text = new_source_text;
             js_allocator.alloc(program)
         };
@@ -663,10 +664,10 @@ impl Linter {
             ctx_host,
             program,
             tokens,
-            &js_allocator,
+            js_allocator,
         );
 
-        // The `AllocatorGuard` (`js_allocator`) is dropped here, returning the allocator to the pool.
+        // The `AllocatorGuard` (`js_allocator_guard`) is dropped here, returning the allocator to the pool.
         // This ensures that we never have too many allocators in play at once, avoiding OOM.
     }
 

--- a/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
+++ b/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
@@ -218,7 +218,7 @@ fn gen_value_import_declaration<'c, 'a: 'c>(
     let specifiers: Vec<_> = specifiers.iter().map(|it| it.clone_in(&alloc)).collect();
     let import_declaration = ast_builder.alloc_import_declaration(
         SPAN,
-        Some(ArenaVec::from_iter_in(specifiers, &alloc)),
+        Some(ArenaVec::from_iter_in(specifiers, &ast_builder)),
         import_decl.source.clone_in(&alloc),
         None,
         import_decl.with_clause.clone_in(&alloc),
@@ -255,7 +255,7 @@ fn gen_type_import_declaration<'c, 'a: 'c>(
         .collect();
     let import_declaration = ast_builder.alloc_import_declaration(
         SPAN,
-        Some(ArenaVec::from_iter_in(specifiers, &alloc)),
+        Some(ArenaVec::from_iter_in(specifiers, &ast_builder)),
         import_decl.source.clone_in(&alloc),
         None,
         import_decl.with_clause.clone_in(&alloc),

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -1657,7 +1657,8 @@ mod fix {
             .map(|el| el.clone_in(&alloc));
 
         codegen.print_expression(&Expression::ArrayExpression(
-            ast_builder.alloc_array_expression(deps.span, ArenaVec::from_iter_in(new_deps, &alloc)),
+            ast_builder
+                .alloc_array_expression(deps.span, ArenaVec::from_iter_in(new_deps, &ast_builder)),
         ));
         fixer.replace(deps.span, codegen.into_source_text())
     }

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -461,7 +461,7 @@ struct SlotFrequency<'a> {
 
 impl<'t> SlotFrequency<'t> {
     fn new(temp_allocator: &'t Allocator) -> Self {
-        Self { slot: 0, frequency: 0, symbol_ids: ArenaVec::new_in(temp_allocator) }
+        Self { slot: 0, frequency: 0, symbol_ids: ArenaVec::new_in(&temp_allocator) }
     }
 }
 
@@ -547,14 +547,14 @@ impl<'a, 's> SlotAssignment<'a, 's> {
         // All symbols with their assigned slots. Keyed by symbol id.
         let mut slots = ArenaVec::from_iter_in(
             iter::repeat_n(SLOT_UNASSIGNED, scoping.symbols_len()),
-            allocator,
+            &allocator,
         );
         // Stores the lived scope ids for each slot. Keyed by slot number. Symbol count is the
         // upper bound on slots.
         let mut slot_liveness =
-            ArenaVec::<BitSet>::with_capacity_in(scoping.symbols_len(), allocator);
-        let mut tmp_bindings = ArenaVec::with_capacity_in(100, allocator);
-        let mut reusable_slots = ArenaVec::new_in(allocator);
+            ArenaVec::<BitSet>::with_capacity_in(scoping.symbols_len(), &allocator);
+        let mut tmp_bindings = ArenaVec::with_capacity_in(100, &allocator);
+        let mut reusable_slots = ArenaVec::new_in(&allocator);
         // Pre-computed BitSet for ancestor membership tests - reused across iterations
         let mut ancestor_set = BitSet::new_in(scoping.scopes_len(), allocator);
 
@@ -705,7 +705,7 @@ impl<'a> SlotRanking<'a> {
         let root_scope_id = scoping.root_scope_id();
         let mut frequencies = ArenaVec::from_iter_in(
             repeat_with(|| SlotFrequency::new(allocator)).take(slots.total_slots),
-            allocator,
+            &allocator,
         );
 
         for (symbol_id, &slot) in slots.slots.iter().enumerate() {
@@ -771,7 +771,7 @@ impl<'a, const CAPACITY: usize> NameTable<'a, CAPACITY> {
         };
 
         let count = ranking.frequencies.len();
-        let mut names = ArenaVec::with_capacity_in(count, allocator);
+        let mut names = ArenaVec::with_capacity_in(count, &allocator);
         let mut candidate = 0;
         for _ in 0..count {
             let name = loop {
@@ -796,8 +796,8 @@ impl<'a, const CAPACITY: usize> NameTable<'a, CAPACITY> {
         // Yields slots hottest-first as we consume each length bucket.
         let mut freq_iter = ranking.frequencies.iter();
         // Scratch buffers in the temp arena (reused/reset across files via `new_with_temp_allocator`).
-        let mut symbols_renamed_in_this_batch = ArenaVec::with_capacity_in(100, allocator);
-        let mut slice_of_same_len_strings = ArenaVec::with_capacity_in(100, allocator);
+        let mut symbols_renamed_in_this_batch = ArenaVec::with_capacity_in(100, &allocator);
+        let mut slice_of_same_len_strings = ArenaVec::with_capacity_in(100, &allocator);
         // Names are generated shortest-first, so each `chunk_by(len)` group is one name length.
         for (_, group) in &self.names.into_iter().chunk_by(InlineString::len) {
             // Take the N hottest remaining slots to receive the N names of this length...

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -133,9 +133,9 @@ impl<'a, C: Config> Lexer<'a, C> {
         //
         // However, we should choose a better heuristic based on real-world observation, and bring this usage down.
         let tokens = if config.tokens() {
-            ArenaVec::with_capacity_in(source_text.len() + 1, allocator)
+            ArenaVec::with_capacity_in(source_text.len() + 1, &allocator)
         } else {
-            ArenaVec::new_in(allocator)
+            ArenaVec::new_in(&allocator)
         };
 
         // The first token is at the start of file, so is allows on a new line
@@ -355,7 +355,7 @@ impl<'a, C: Config> Lexer<'a, C> {
     }
 
     pub(crate) fn take_tokens(&mut self) -> ArenaVec<'a, Token> {
-        mem::replace(&mut self.tokens, ArenaVec::new_in(self.allocator))
+        mem::replace(&mut self.tokens, ArenaVec::new_in(&self.allocator))
     }
 
     pub(crate) fn set_tokens(&mut self, tokens: ArenaVec<'a, Token>) {
@@ -374,7 +374,7 @@ impl<'a, C: Config> Lexer<'a, C> {
         } else {
             // Tokens are disabled. Just return an empty vec.
             debug_assert!(self.tokens.is_empty());
-            ArenaVec::new_in(self.allocator)
+            ArenaVec::new_in(&self.allocator)
         }
     }
 

--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -38,7 +38,7 @@ pub struct TriviaBuilder<'a> {
 impl<'a> TriviaBuilder<'a> {
     pub fn new_in(allocator: &'a Allocator) -> Self {
         Self {
-            comments: ArenaVec::new_in(allocator),
+            comments: ArenaVec::new_in(&allocator),
             irregular_whitespaces: vec![],
             processed: 0,
             saw_newline: true,

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -730,11 +730,8 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
             }
         }
 
-        let tokens = if panicked {
-            ArenaVec::new_in(self.ast.allocator)
-        } else {
-            self.lexer.finalize_tokens()
-        };
+        let tokens =
+            if panicked { ArenaVec::new_in(&self.ast) } else { self.lexer.finalize_tokens() };
 
         program.comments = self.lexer.trivia_builder.comments;
 

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -21,8 +21,8 @@ impl<'a> ModuleRecordBuilder<'a> {
             allocator,
             source_type,
             module_record: ModuleRecord::new(allocator),
-            export_entries: ArenaVec::new_in(allocator),
-            exported_bindings_duplicated: ArenaVec::new_in(allocator),
+            export_entries: ArenaVec::new_in(&allocator),
+            exported_bindings_duplicated: ArenaVec::new_in(&allocator),
         }
     }
 
@@ -81,7 +81,7 @@ impl<'a> ModuleRecordBuilder<'a> {
         self.module_record
             .requested_modules
             .entry(name)
-            .or_insert_with(|| ArenaVec::new_in(self.allocator))
+            .or_insert_with(|| ArenaVec::new_in(&self.allocator))
             .push(requested_module);
     }
 
@@ -116,7 +116,7 @@ impl<'a> ModuleRecordBuilder<'a> {
     fn resolve_export_entries(&mut self) {
         // let export_entries = self.export_entries.drain(..).collect::<Vec<_>>();
         let export_entries =
-            std::mem::replace(&mut self.export_entries, ArenaVec::new_in(self.allocator));
+            std::mem::replace(&mut self.export_entries, ArenaVec::new_in(&self.allocator));
         // 10. For each ExportEntry Record ee of exportEntries, do
         for ee in export_entries {
             // a. If ee.[[ModuleRequest]] is null, then

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -139,7 +139,7 @@ fn preserve_comments<'a>(
     }
 
     // Copy only comments attached to top-level statements.
-    let mut comments = ArenaVec::with_capacity_in(source.comments.len(), allocator);
+    let mut comments = ArenaVec::with_capacity_in(source.comments.len(), &allocator);
     for comment in &source.comments {
         if top_level_starts.contains(&comment.attached_to) {
             comments.push(*comment);

--- a/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator};
 use oxc_diagnostics::Result;
 use oxc_str::Str;
 
@@ -100,7 +100,7 @@ impl<'a> PatternParser<'a> {
     fn parse_disjunction(&mut self) -> Result<ast::Disjunction<'a>> {
         let span_start = self.reader.offset();
 
-        let mut body = ArenaVec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self);
         loop {
             body.push(self.parse_alternative()?);
 
@@ -123,7 +123,7 @@ impl<'a> PatternParser<'a> {
     fn parse_alternative(&mut self) -> Result<ast::Alternative<'a>> {
         let span_start = self.reader.offset();
 
-        let mut body = ArenaVec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self);
         while let Some(term) = self.parse_term()? {
             body.push(term);
         }
@@ -826,7 +826,7 @@ impl<'a> PatternParser<'a> {
             // Unterminated
             || self.reader.peek().is_none()
         {
-            return Ok((ast::CharacterClassContentsKind::Union, ArenaVec::new_in(self.allocator)));
+            return Ok((ast::CharacterClassContentsKind::Union, ArenaVec::new_in(self)));
         }
 
         // [+UnicodeSetsMode] ClassSetExpression
@@ -853,7 +853,7 @@ impl<'a> PatternParser<'a> {
         &mut self,
     ) -> Result<(ast::CharacterClassContentsKind, ArenaVec<'a, ast::CharacterClassContents<'a>>)>
     {
-        let mut body = ArenaVec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self);
 
         loop {
             let range_span_start = self.reader.offset();
@@ -1160,7 +1160,7 @@ impl<'a> PatternParser<'a> {
         class_set_range_or_class_set_operand: ast::CharacterClassContents<'a>,
     ) -> Result<(ast::CharacterClassContentsKind, ArenaVec<'a, ast::CharacterClassContents<'a>>)>
     {
-        let mut body = ArenaVec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self);
         body.push(class_set_range_or_class_set_operand);
 
         loop {
@@ -1189,7 +1189,7 @@ impl<'a> PatternParser<'a> {
         class_set_operand: ast::CharacterClassContents<'a>,
     ) -> Result<(ast::CharacterClassContentsKind, ArenaVec<'a, ast::CharacterClassContents<'a>>)>
     {
-        let mut body = ArenaVec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self);
         body.push(class_set_operand);
 
         loop {
@@ -1231,7 +1231,7 @@ impl<'a> PatternParser<'a> {
         class_set_operand: ast::CharacterClassContents<'a>,
     ) -> Result<(ast::CharacterClassContentsKind, ArenaVec<'a, ast::CharacterClassContents<'a>>)>
     {
-        let mut body = ArenaVec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self);
         body.push(class_set_operand);
 
         loop {
@@ -1416,7 +1416,7 @@ impl<'a> PatternParser<'a> {
     fn parse_class_string_disjunction_contents(
         &mut self,
     ) -> Result<(ArenaVec<'a, ast::ClassString<'a>>, bool)> {
-        let mut body = ArenaVec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self);
         let mut strings = false;
 
         loop {
@@ -1452,7 +1452,7 @@ impl<'a> PatternParser<'a> {
     fn parse_class_string(&mut self) -> Result<ast::ClassString<'a>> {
         let span_start = self.reader.offset();
 
-        let mut body = ArenaVec::new_in(self.allocator);
+        let mut body = ArenaVec::new_in(self);
         while let Some(class_set_character) = self.parse_class_set_character()? {
             body.push(class_set_character);
         }
@@ -2391,5 +2391,12 @@ impl<'a> PatternParser<'a> {
                 body.iter().next().is_some_and(may_contain_strings)
             }
         }
+    }
+}
+
+impl<'a> GetAllocator<'a> for PatternParser<'a> {
+    #[inline]
+    fn allocator(&self) -> &'a Allocator {
+        self.allocator
     }
 }

--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -122,8 +122,8 @@ impl Default for Scoping {
             enum_data: EnumData::default(),
             scope_table: ScopeTable::new(),
             cell: ScopingCell::new(Allocator::default(), |allocator| ScopingInner {
-                symbol_names: ArenaVec::new_in(allocator),
-                resolved_references: ArenaVec::new_in(allocator),
+                symbol_names: ArenaVec::new_in(&allocator),
+                resolved_references: ArenaVec::new_in(&allocator),
                 symbol_redeclarations: FxHashMap::default(),
                 bindings: IndexVec::new(),
                 root_unresolved_references: UnresolvedReferences::new_in(allocator),
@@ -441,7 +441,7 @@ impl Scoping {
     ) -> SymbolId {
         self.cell.with_dependent_mut(|allocator, cell| {
             cell.symbol_names.push(name.clone_in(allocator));
-            cell.resolved_references.push(ArenaVec::new_in(allocator));
+            cell.resolved_references.push(ArenaVec::new_in(&allocator));
         });
         self.symbol_table.push(span, flags, scope_id, node_id)
     }
@@ -460,7 +460,7 @@ impl Scoping {
         self.cell.with_dependent_mut(|allocator, cell| {
             let name = name.clone_in(allocator);
             cell.symbol_names.push(name);
-            cell.resolved_references.push(ArenaVec::new_in(allocator));
+            cell.resolved_references.push(ArenaVec::new_in(&allocator));
             cell.bindings[binding_scope_id].insert(name, symbol_id);
         });
         symbol_id
@@ -496,7 +496,7 @@ impl Scoping {
                             "The above step has already been checked, and it was first declared."
                         )
                     });
-                    let v = ArenaVec::from_array_in([first_declaration, redeclaration], allocator);
+                    let v = ArenaVec::from_array_in([first_declaration, redeclaration], &allocator);
                     vacant.insert(v);
                 }
             }
@@ -805,7 +805,7 @@ impl Scoping {
             let name = name.clone_in(allocator);
             cell.root_unresolved_references
                 .entry(name)
-                .or_insert_with(|| ArenaVec::new_in(allocator))
+                .or_insert_with(|| ArenaVec::new_in(&allocator))
                 .push(reference_id);
         });
     }

--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -71,13 +71,13 @@ impl<'a> ModuleRecord<'a> {
         Self {
             has_module_syntax: false,
             requested_modules: ArenaHashMap::new_in(allocator),
-            import_entries: ArenaVec::new_in(allocator),
-            local_export_entries: ArenaVec::new_in(allocator),
-            indirect_export_entries: ArenaVec::new_in(allocator),
-            star_export_entries: ArenaVec::new_in(allocator),
+            import_entries: ArenaVec::new_in(&allocator),
+            local_export_entries: ArenaVec::new_in(&allocator),
+            indirect_export_entries: ArenaVec::new_in(&allocator),
+            star_export_entries: ArenaVec::new_in(&allocator),
             exported_bindings: ArenaHashMap::new_in(allocator),
-            dynamic_imports: ArenaVec::new_in(allocator),
-            import_metas: ArenaVec::new_in(allocator),
+            dynamic_imports: ArenaVec::new_in(&allocator),
+            import_metas: ArenaVec::new_in(&allocator),
         }
     }
 }

--- a/napi/parser/src/raw_transfer.rs
+++ b/napi/parser/src/raw_transfer.rs
@@ -222,6 +222,7 @@ unsafe fn parse_raw_impl(
     let allocator =
         unsafe { Allocator::from_raw_parts(buffer_ptr, BLOCK_SIZE, buffer_ptr, BLOCK_LAYOUT) };
     let allocator = ManuallyDrop::new(allocator);
+    let allocator = &*allocator;
 
     // Check source text is in bounds of active data region of buffer.
     // Caller guarantees it is, but as this is critical to avoid reading/writing out of bounds,
@@ -263,7 +264,7 @@ unsafe fn parse_raw_impl(
         };
 
         // Parse
-        let ret = parse_impl(&allocator, source_type, source_text, &options);
+        let ret = parse_impl(allocator, source_type, source_text, &options);
         let mut program = ret.program;
         let mut comments = mem::replace(&mut program.comments, ArenaVec::new_in(&allocator));
         let mut module_record = ret.module_record;
@@ -281,13 +282,13 @@ unsafe fn parse_raw_impl(
                     ret.diagnostics.into_iter().chain(semantic_ret.diagnostics),
                     source_text,
                     filename,
-                    &allocator,
+                    allocator,
                 )
             } else {
                 ArenaVec::new_in(&allocator)
             }
         } else if !ret.diagnostics.is_empty() {
-            Error::from_diagnostics_in(ret.diagnostics, source_text, filename, &allocator)
+            Error::from_diagnostics_in(ret.diagnostics, source_text, filename, allocator)
         } else {
             ArenaVec::new_in(&allocator)
         };
@@ -325,7 +326,7 @@ unsafe fn parse_raw_impl(
         }
 
         // Convert module record
-        let module = EcmaScriptModule::from_in(module_record, &allocator);
+        let module = EcmaScriptModule::from_in(module_record, allocator);
 
         // Write `RawTransferData` to arena, and return pointer to it
         let data = RawTransferData { program, comments, module, errors };

--- a/napi/parser/src/raw_transfer_types.rs
+++ b/napi/parser/src/raw_transfer_types.rs
@@ -83,7 +83,7 @@ impl<'a> Error<'a> {
             diagnostics
                 .into_iter()
                 .map(|diagnostic| Self::from_diagnostic_in(diagnostic, &named_source, allocator)),
-            allocator,
+            &allocator,
         )
     }
 
@@ -94,7 +94,7 @@ impl<'a> Error<'a> {
     ) -> Self {
         let labels = ArenaVec::from_iter_in(
             diagnostic.labels.iter().map(|label| ErrorLabel::from_in(label, allocator)),
-            allocator,
+            &allocator,
         );
 
         let severity = ErrorSeverity::from(diagnostic.severity);
@@ -210,7 +210,7 @@ impl<'a> FromIn<'a, ModuleRecord<'a>> for EcmaScriptModule<'a> {
                         .iter()
                         .filter(|e| e.statement_span == m.statement_span)
                         .cloned();
-                    let entries = ArenaVec::from_iter_in(entries, allocator);
+                    let entries = ArenaVec::from_iter_in(entries, &allocator);
 
                     StaticImport {
                         span: m.statement_span,
@@ -219,7 +219,7 @@ impl<'a> FromIn<'a, ModuleRecord<'a>> for EcmaScriptModule<'a> {
                     }
                 })
             });
-        let mut static_imports = ArenaVec::from_iter_in(static_imports, allocator);
+        let mut static_imports = ArenaVec::from_iter_in(static_imports, &allocator);
         static_imports.sort_unstable_by_key(|e| e.span.start);
 
         let static_exports = record
@@ -229,13 +229,13 @@ impl<'a> FromIn<'a, ModuleRecord<'a>> for EcmaScriptModule<'a> {
             .chain(&record.star_export_entries)
             .fold(FxHashMap::<Span, ArenaVec<'a, ExportEntry>>::default(), |mut acc, e| {
                 acc.entry(e.statement_span)
-                    .or_insert_with(|| ArenaVec::new_in(allocator))
+                    .or_insert_with(|| ArenaVec::new_in(&allocator))
                     .push(e.clone());
                 acc
             })
             .into_iter()
             .map(|(span, entries)| StaticExport { span, entries });
-        let mut static_exports = ArenaVec::from_iter_in(static_exports, allocator);
+        let mut static_exports = ArenaVec::from_iter_in(static_exports, &allocator);
         static_exports.sort_unstable_by_key(|e| e.span.start);
 
         Self {


### PR DESCRIPTION
Part of #23043.

`Vec::new_in`, `Vec::with_capacity_in`, `Vec::from_array_in` etc previously took an `&'a Allocator`. Instead make them take an `&A where A: GetAllocator<'a>`.

This makes them more flexible - you can pass a reference to any type which implements `GetAllocator` e.g. `ParserImpl`, `TraverseCtx` etc.

```rust
// Before (`ctx` here is `&mut TraverseCtx`)
let vec = ArenaVec::new_in(ctx.ast.allocator);
// After
let vec = ArenaVec::new_in(ctx);
```

The main motivation is to make them workable replacements for what are currently methods on `AstBuilder`, but will be removed in the new `AstBuilder`:

```rust
// Before (`ctx` here is `&mut TraverseCtx`)
let vec = ctx.ast.vec();
// After
let vec = ArenaVec::new_in(ctx);
// Instead of
let vec = ArenaVec::new_in(ctx.ast.allocator);
```

This is still longer code than the original, which is not ideal, but it's as short as can make them.

The main downside of this change is that when calling these methods with an `&Allocator`, you have to double reference:

```rust
let allocator: &'a Allocator = get_allocator_somehow();
// Passing `&&Allocator`
let vec = ArenaVec::new_in(&allocator);
```

This has no perf impact - these methods are inlined, and compiler collapses the double-reference like it wasn't there, but it's just ugly. Unfortunately, there's no way to implement `GetAllocator` so it'll accept both `&Allocator` and `&mut TraverseCtx`, and the latter is the much more common use case.