### PR TITLE
perf(react_compiler): pre-size convert_scope collections

### DIFF
--- a/crates/oxc_react_compiler/src/convert_scope.rs
+++ b/crates/oxc_react_compiler/src/convert_scope.rs
@@ -21,16 +21,30 @@ pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo 
     let scoping = semantic.scoping();
     let nodes = semantic.nodes();
 
-    let mut scopes: Vec<ScopeData> = Vec::new();
-    let mut bindings: Vec<BindingData> = Vec::new();
-    let mut node_to_scope: FxHashMap<u32, ScopeId> = FxHashMap::default();
-    let mut node_to_scope_end: FxHashMap<u32, u32> = FxHashMap::default();
+    // Pre-size the long-lived collections to their known final sizes (taken from the
+    // semantic counts) so they don't rehash/realloc while being populated. Profiling the
+    // React-compiler showed `convert_scope_info`'s maps repeatedly rehashing — the largest
+    // rehash source in oxc's own glue code. This is a capacity-only change with no behavioral
+    // difference: `node_*`/`bindings`/`scopes` get ~one entry per scope/symbol, and
+    // `ref_node_id_to_binding` one per resolved reference (`references_len` is an upper bound).
+    let symbol_count = scoping.symbols_len();
+    let scope_count = scoping.scopes_len();
+    let reference_count = scoping.references_len();
+
+    let mut scopes: Vec<ScopeData> = Vec::with_capacity(scope_count);
+    let mut bindings: Vec<BindingData> = Vec::with_capacity(symbol_count);
+    let mut node_to_scope: FxHashMap<u32, ScopeId> =
+        FxHashMap::with_capacity_and_hasher(scope_count, FxBuildHasher);
+    let mut node_to_scope_end: FxHashMap<u32, u32> =
+        FxHashMap::with_capacity_and_hasher(scope_count, FxBuildHasher);
     // In OXC, span.start is used as node_id (OXC spans are unique).
-    let mut node_id_to_scope: FxHashMap<u32, ScopeId> = FxHashMap::default();
-    let mut ref_node_id_to_binding: FxIndexMap<u32, BindingId> = FxIndexMap::default();
+    let mut node_id_to_scope: FxHashMap<u32, ScopeId> =
+        FxHashMap::with_capacity_and_hasher(scope_count, FxBuildHasher);
+    let mut ref_node_id_to_binding: FxIndexMap<u32, BindingId> =
+        FxIndexMap::with_capacity_and_hasher(reference_count, FxBuildHasher);
 
     let mut symbol_to_binding: FxHashMap<oxc_syntax::symbol::SymbolId, BindingId> =
-        FxHashMap::default();
+        FxHashMap::with_capacity_and_hasher(symbol_count, FxBuildHasher);
 
     // First pass: Create all bindings from symbols
     for symbol_id in scoping.symbol_ids() {


### PR DESCRIPTION
## What

`convert_scope_info` (oxc semantic → React Compiler scope conversion) builds seven collections — three `node → scope` maps, the `symbol → binding` map, the `ref → binding` index map, and the `scopes` / `bindings` vecs — but creates them empty and lets them grow while being populated.

## Why

Profiling the `react_compiler` benchmark (excalidraw `App.tsx`) showed `convert_scope_info`'s maps as the largest rehash source in oxc's own React-compiler glue code (~2.6% of the benchmark; the remaining rehash sits inside the external `forked_react_compiler` passes).

## How

Pre-size each collection up front from the counts already available on `Scoping` (`symbols_len`, `scopes_len`, `references_len`). They end up with the same contents — this is a capacity-only change with no behavioural difference.

## Result

Interleaved A/B on the `react_compiler` benchmark (`App.tsx`): **~3.5% faster** (~5.40 ms → ~5.21 ms, consistent across 3 rounds). All 16 crate tests pass; `cargo clippy` clean.

---

_Disclosure: developed with AI assistance (Claude Code). Benchmarks, tests and clippy were run and the change reviewed._
