### PR TITLE
fix(linter): newline-terminate tsgolint errors

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -483,7 +483,7 @@ impl CliRunner {
         {
             Ok(runner) => runner,
             Err(err) => {
-                print_and_flush_stdout(stdout, &err);
+                print_and_flush_stdout(stdout, &format!("{err}\n"));
                 return CliRunResult::TsGoLintError;
             }
         };
@@ -507,7 +507,7 @@ impl CliRunner {
                 lint_runner.report_unused_directives(report_unused_directives, &tx_error);
             }
             Err(err) => {
-                print_and_flush_stdout(stdout, &err);
+                print_and_flush_stdout(stdout, &format!("{err}\n"));
                 return CliRunResult::TsGoLintError;
             }
         }


### PR DESCRIPTION
Fixes #23686, adds trailing `\n` to tsgolint error output, matching other CLI errors

tested locally with:
```
cargo build -p oxlint

mkdir -p /tmp/oxlint-npx-repro
cd /tmp/oxlint-npx-repro
npm init -y

echo 'export default {}' > index.ts
echo '{"rules": {}}' > oxlintrc.json

mkdir -p node_modules/.bin
ln -sf oxc/target/debug/oxlint node_modules/.bin/oxlint

npx --no-install oxlint -c oxlintrc.json --type-aware
```

Before fix:

https://github.com/user-attachments/assets/4c70115d-1c26-4c9b-9f0a-c4c33d767029

After fix:

https://github.com/user-attachments/assets/1a1fd337-cca1-4fb6-ab63-326ca16095ce

