### PR TITLE
feat(linter): Add `react/react-compiler` sub-rule disable-diagnostics

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -5117,12 +5117,96 @@ export interface PreferFunctionComponent {
 }
 export interface ReactCompilerConfig {
   /**
+   * Capitalized functions are reserved for components and must be invoked as
+   * JSX (`validate_no_capitalized_calls`).
+   */
+  capitalizedCalls?: boolean;
+  /**
+   * Effects may not recompute values that could be derived during render
+   * (emitted as the `EffectDerivationsOfState` category;
+   * `validate_no_derived_computations_in_effects`).
+   */
+  derivedComputationsInEffect?: boolean;
+  /**
+   * JSX may not be constructed inside `try`/`catch`
+   * (`validate_no_jsx_in_try_statements`).
+   */
+  errorBoundaries?: boolean;
+  /**
+   * Hooks must be called unconditionally and in a consistent order
+   * (`validate_hooks_usage`).
+   */
+  hooks?: boolean;
+  /**
+   * Values that are known to be mutable (props, state) may not be mutated —
+   * the `Immutability` category. Emitted by the core mutation/aliasing
+   * inference pass and by `validate_locals_not_reassigned_after_render`,
+   * neither of which the compiler exposes a flag for.
+   */
+  immutability?: boolean;
+  /**
+   * Memoization dependency arrays (`useMemo`/`useCallback`/`useEffect`) must
+   * be exhaustive — the `MemoDependencies` category, equivalent to ESLint's
+   * `react-hooks/exhaustive-deps` (`validate_exhaustive_memoization_dependencies`).
+   */
+  memoDependencies?: boolean;
+  /**
+   * Manual `useMemo`/`useCallback` memoization must be preservable by the
+   * compiler — the `PreserveManualMemo` category. `eslint-plugin-react-compiler`
+   * ships this off by default; set to `false` to match
+   * (`enable_preserve_existing_memoization_guarantees` +
+   * `validate_preserve_existing_memoization_guarantees`).
+   *
+   * NOTE: the memoization validations are coupled. Disabling this alone
+   * *reclassifies* rather than removes — the compiler still bails on those
+   * sites and re-reports them under `MemoDependencies` (and a few under
+   * `Purity`). To silence the family, also set `memoDependencies: false`
+   * (and `purity: false` if those remain).
+   */
+  preserveManualMemo?: boolean;
+  /**
+   * Known-impure functions (e.g. `Math.random`, `Date.now`) may not be
+   * called during render (`validate_no_impure_functions_in_render`).
+   */
+  purity?: boolean;
+  /**
+   * Refs may not be read or written during render
+   * (`validate_ref_access_during_render`).
+   */
+  refs?: boolean;
+  /**
    * Also report compiler bail-outs — places where React Compiler skipped a
    * component or hook (for example because of unsupported syntax) without
    * finding a rule violation. These do not indicate incorrect code, only
    * code that the compiler declined to optimize.
    */
   reportAllBailouts?: boolean;
+  /**
+   * `setState` may not be called unconditionally inside an effect
+   * (`validate_no_set_state_in_effects`).
+   */
+  setStateInEffect?: boolean;
+  /**
+   * `setState` may not be called during render
+   * (`validate_no_set_state_in_render`).
+   */
+  setStateInRender?: boolean;
+  /**
+   * Components must be statically defined (`validate_static_components`).
+   */
+  staticComponents?: boolean;
+  /**
+   * `useMemo`/`useCallback` callbacks must be well-formed — the `UseMemo`
+   * category (callbacks taking parameters, being async/generator, or
+   * reassigning outer variables). Distinct from `voidUseMemo`, which covers
+   * callbacks that return nothing. Emitted by `drop_manual_memoization` and
+   * the non-void part of `validate_use_memo`, neither gated by a flag.
+   */
+  useMemo?: boolean;
+  /**
+   * `useMemo` callbacks must return a value (`validate_no_void_use_memo`).
+   */
+  voidUseMemo?: boolean;
 }
 export interface SelfClosingComp {
   /**

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -278,8 +278,21 @@ impl<'a> LintContext<'a> {
 
     /// Add a diagnostic message to the list of diagnostics. Outputs a diagnostic with the current rule
     /// name, severity, and a link to the rule's documentation URL.
-    fn add_diagnostic(&self, mut message: Message) {
-        if self.parent.disable_directives().contains(self.current_rule_name, message.span) {
+    fn add_diagnostic(&self, message: Message) {
+        self.add_diagnostic_impl(message, None);
+    }
+
+    /// [`Self::add_diagnostic`], for a diagnostic tagged with a sub-rule.
+    fn add_diagnostic_impl(&self, mut message: Message, sub_rule: Option<&str>) {
+        let disable_directives = self.parent.disable_directives();
+        // A directive naming the bare rule suppresses every diagnostic it emits.
+        if disable_directives.contains(self.current_rule_name, message.span) {
+            return;
+        }
+        // A directive naming `{rule}/{sub_rule}` suppresses only that category.
+        if let Some(sub_rule) = sub_rule
+            && disable_directives.contains_sub_rule(self.current_rule_name, sub_rule, message.span)
+        {
             return;
         }
         message.error = message
@@ -302,6 +315,17 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn diagnostic(&self, diagnostic: OxcDiagnostic) {
         self.add_diagnostic(Message::new(diagnostic, PossibleFixes::None));
+    }
+
+    /// Report a lint rule violation, tagging it with a sub-rule.
+    ///
+    /// Used by "umbrella" rules that emit several diagnostic categories under one
+    /// rule name: the sub-rule lets a `{rule}/{sub_rule}` disable directive
+    /// suppress just this category. A directive naming the bare rule still
+    /// suppresses every category.
+    #[inline]
+    pub fn diagnostic_with_sub_rule(&self, sub_rule: &str, diagnostic: OxcDiagnostic) {
+        self.add_diagnostic_impl(Message::new(diagnostic, PossibleFixes::None), Some(sub_rule));
     }
 
     /// Report a lint rule violation and provide an automatic fix.

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -304,6 +304,21 @@ impl DisableDirectives {
     }
 
     pub fn contains(&self, rule_name: &str, span: Span) -> bool {
+        self.contains_impl(rule_name, None, span)
+    }
+
+    /// Like [`Self::contains`], but for a diagnostic tagged with a sub-rule by an
+    /// "umbrella" rule (see [`LintContext::diagnostic_with_sub_rule`]). Matches a
+    /// directive naming `{rule_name}/{sub_rule}`, with the same optional plugin
+    /// prefix as [`Self::contains`] — so both `react-compiler/refs` and
+    /// `react/react-compiler/refs` match.
+    ///
+    /// [`LintContext::diagnostic_with_sub_rule`]: crate::context::LintContext::diagnostic_with_sub_rule
+    pub fn contains_sub_rule(&self, rule_name: &str, sub_rule: &str, span: Span) -> bool {
+        self.contains_impl(rule_name, Some(sub_rule), span)
+    }
+
+    fn contains_impl(&self, rule_name: &str, sub_rule: Option<&str>, span: Span) -> bool {
         // For `eslint-disable-next-line` and `eslint-disable-line` directives, we only check
         // if the diagnostic's starting position falls within the disabled interval.
         // This prevents suppressing diagnostics for larger constructs (like functions) that
@@ -329,13 +344,22 @@ impl DisableDirectives {
                 // rather than doing a substring match. Otherwise unrelated rules like
                 // `canonical/no-re-export` would accidentally match oxlint's `export`
                 // rule because `"no-re-export".contains("export")` is true.
-                DisabledRule::Single { rule_name: name, .. } => {
-                    if rule_name.contains('/') {
-                        name == rule_name
-                    } else {
-                        name.rsplit_once('/').map_or(name.as_str(), |(_, rule)| rule) == rule_name
+                DisabledRule::Single { rule_name: name, .. } => match sub_rule {
+                    // Split the sub-rule off the end first, then match what remains
+                    // against `rule_name` exactly as an un-tagged diagnostic would.
+                    Some(sub_rule) => name.rsplit_once('/').is_some_and(|(name, last)| {
+                        last == sub_rule
+                            && name.rsplit_once('/').map_or(name, |(_, rule)| rule) == rule_name
+                    }),
+                    None => {
+                        if rule_name.contains('/') {
+                            name == rule_name
+                        } else {
+                            name.rsplit_once('/').map_or(name.as_str(), |(_, rule)| rule)
+                                == rule_name
+                        }
                     }
-                }
+                },
             };
 
             if !rule_matches {

--- a/crates/oxc_linter/src/rules/react/react_compiler.rs
+++ b/crates/oxc_linter/src/rules/react/react_compiler.rs
@@ -12,27 +12,45 @@ use crate::{
 };
 
 /// The compiler options `eslint-plugin-react-compiler` lints with — `lint`
-/// output mode plus validations that are off by default in the compiler.
+/// output mode plus the validations that are off by default in the compiler.
 /// Mirrors `COMPILER_OPTIONS` in the plugin's `src/shared/RunReactCompiler.ts`.
-fn react_compiler_options() -> PluginOptions {
+///
+/// Each validation is gated on the matching [`ReactCompilerConfig`] toggle, so
+/// turning a sub-rule off in the config stops the compiler from emitting its
+/// diagnostics at all (rather than reporting and then filtering them).
+fn react_compiler_options(config: &ReactCompilerConfig) -> PluginOptions {
     PluginOptions {
         output_mode: Some(CompilerOutputMode::Lint),
         // Don't emit errors on Flow suppressions — Flow already gave a signal.
         // Suppressed lines are filtered in `run_once` instead (like the eslint
         // plugin), so other diagnostics in the same function still surface.
         flow_suppressions: false,
+        // The `Suppression` category reports pre-existing `eslint-disable react-*`
+        // comments. The compiler only scans for them when `hooks` or
+        // `memoDependencies` is off (see `program.rs`: `validate_exhaustive &&
+        // validate_hooks`), so without gating, an unrelated toggle would surface
+        // a user's existing ESLint suppressions as new errors. Treat it as a
+        // bail-out: an empty rule list silences the scan unless the user opts in
+        // via `reportAllBailouts` (`None` lets the compiler use its defaults).
+        eslint_suppression_rules: if config.report_all_bailouts { None } else { Some(vec![]) },
         environment: EnvironmentConfig {
-            validate_ref_access_during_render: true,
-            validate_no_set_state_in_render: true,
-            validate_no_set_state_in_effects: true,
-            validate_no_jsx_in_try_statements: true,
-            validate_no_impure_functions_in_render: true,
-            validate_static_components: true,
-            validate_no_freezing_known_mutable_functions: true,
-            validate_no_void_use_memo: true,
-            validate_no_capitalized_calls: Some(vec![]),
-            validate_hooks_usage: true,
-            validate_no_derived_computations_in_effects: true,
+            validate_ref_access_during_render: config.refs,
+            validate_no_set_state_in_render: config.set_state_in_render,
+            validate_no_set_state_in_effects: config.set_state_in_effect,
+            validate_no_jsx_in_try_statements: config.error_boundaries,
+            validate_no_impure_functions_in_render: config.purity,
+            validate_static_components: config.static_components,
+            validate_no_void_use_memo: config.void_use_memo,
+            // `Some(vec![])` enables the check with the default allowlist; `None`
+            // disables it entirely.
+            validate_no_capitalized_calls: config.capitalized_calls.then(Vec::new),
+            validate_hooks_usage: config.hooks,
+            validate_no_derived_computations_in_effects: config.derived_computations_in_effect,
+            validate_exhaustive_memoization_dependencies: config.memo_dependencies,
+            // `PreserveManualMemo` fires when *either* flag is on, so both must be
+            // cleared to silence it.
+            enable_preserve_existing_memoization_guarantees: config.preserve_manual_memo,
+            validate_preserve_existing_memoization_guarantees: config.preserve_manual_memo,
             ..EnvironmentConfig::default()
         },
         ..PluginOptions::default()
@@ -50,7 +68,7 @@ impl std::ops::Deref for ReactCompiler {
     }
 }
 
-#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(default, rename_all = "camelCase", deny_unknown_fields)]
 pub struct ReactCompilerConfig {
     /// Also report compiler bail-outs — places where React Compiler skipped a
@@ -58,6 +76,102 @@ pub struct ReactCompilerConfig {
     /// finding a rule violation. These do not indicate incorrect code, only
     /// code that the compiler declined to optimize.
     report_all_bailouts: bool,
+
+    // ---- Sub-rule toggles ----
+    //
+    // Each flag enables one React Compiler validation. They default to `true`
+    // (see the `Default` impl below); set one to `false` to disable that
+    // category of diagnostic globally, e.g.:
+    //
+    // ```json
+    // "react/react-compiler": ["error", { "refs": false }]
+    // ```
+    /// Hooks must be called unconditionally and in a consistent order
+    /// (`validate_hooks_usage`).
+    hooks: bool,
+    /// Refs may not be read or written during render
+    /// (`validate_ref_access_during_render`).
+    refs: bool,
+    /// `setState` may not be called during render
+    /// (`validate_no_set_state_in_render`).
+    set_state_in_render: bool,
+    /// `setState` may not be called unconditionally inside an effect
+    /// (`validate_no_set_state_in_effects`).
+    set_state_in_effect: bool,
+    /// JSX may not be constructed inside `try`/`catch`
+    /// (`validate_no_jsx_in_try_statements`).
+    error_boundaries: bool,
+    /// Known-impure functions (e.g. `Math.random`, `Date.now`) may not be
+    /// called during render (`validate_no_impure_functions_in_render`).
+    purity: bool,
+    /// Components must be statically defined (`validate_static_components`).
+    static_components: bool,
+    /// `useMemo` callbacks must return a value (`validate_no_void_use_memo`).
+    void_use_memo: bool,
+    /// Capitalized functions are reserved for components and must be invoked as
+    /// JSX (`validate_no_capitalized_calls`).
+    capitalized_calls: bool,
+    /// Effects may not recompute values that could be derived during render
+    /// (emitted as the `EffectDerivationsOfState` category;
+    /// `validate_no_derived_computations_in_effects`).
+    derived_computations_in_effect: bool,
+    /// Memoization dependency arrays (`useMemo`/`useCallback`/`useEffect`) must
+    /// be exhaustive — the `MemoDependencies` category, equivalent to ESLint's
+    /// `react-hooks/exhaustive-deps` (`validate_exhaustive_memoization_dependencies`).
+    memo_dependencies: bool,
+    /// Manual `useMemo`/`useCallback` memoization must be preservable by the
+    /// compiler — the `PreserveManualMemo` category. `eslint-plugin-react-compiler`
+    /// ships this off by default; set to `false` to match
+    /// (`enable_preserve_existing_memoization_guarantees` +
+    /// `validate_preserve_existing_memoization_guarantees`).
+    ///
+    /// NOTE: the memoization validations are coupled. Disabling this alone
+    /// *reclassifies* rather than removes — the compiler still bails on those
+    /// sites and re-reports them under `MemoDependencies` (and a few under
+    /// `Purity`). To silence the family, also set `memoDependencies: false`
+    /// (and `purity: false` if those remain).
+    preserve_manual_memo: bool,
+
+    // ---- Rule-layer toggles ----
+    //
+    // These categories have no usable compiler flag, so the toggle is enforced
+    // by dropping the diagnostic in the rule rather than in the compiler. They
+    // still default to `true`.
+    /// Values that are known to be mutable (props, state) may not be mutated —
+    /// the `Immutability` category. Emitted by the core mutation/aliasing
+    /// inference pass and by `validate_locals_not_reassigned_after_render`,
+    /// neither of which the compiler exposes a flag for.
+    immutability: bool,
+    /// `useMemo`/`useCallback` callbacks must be well-formed — the `UseMemo`
+    /// category (callbacks taking parameters, being async/generator, or
+    /// reassigning outer variables). Distinct from `voidUseMemo`, which covers
+    /// callbacks that return nothing. Emitted by `drop_manual_memoization` and
+    /// the non-void part of `validate_use_memo`, neither gated by a flag.
+    use_memo: bool,
+}
+
+impl Default for ReactCompilerConfig {
+    fn default() -> Self {
+        // Every validation is on by default — this mirrors the set of checks the
+        // rule has always run. Only `report_all_bailouts` is opt-in.
+        Self {
+            report_all_bailouts: false,
+            hooks: true,
+            refs: true,
+            set_state_in_render: true,
+            set_state_in_effect: true,
+            error_boundaries: true,
+            purity: true,
+            static_components: true,
+            void_use_memo: true,
+            capitalized_calls: true,
+            derived_computations_in_effect: true,
+            memo_dependencies: true,
+            preserve_manual_memo: true,
+            immutability: true,
+            use_memo: true,
+        }
+    }
 }
 
 declare_oxc_lint!(
@@ -121,22 +235,36 @@ impl Rule for ReactCompiler {
 
     fn run_once(&self, ctx: &LintContext) {
         let program = ctx.nodes().program();
-        let options = react_compiler_options();
+        let options =
+            react_compiler_options(self);
 
         let result = oxc_react_compiler::lint(program, ctx.semantic(), ctx.allocator(), options);
 
-        let diagnostics = result.diagnostics.into_vec();
-        let diagnostics = if self.report_all_bailouts {
-            diagnostics
-        } else {
-            diagnostics
-                .into_iter()
-                .filter(|diagnostic| diagnostic.severity == Severity::Error)
-                .collect::<Vec<_>>()
-        };
-
         let suppressed_lines = flow_suppression_lines(ctx);
-        for mut diagnostic in diagnostics {
+        for mut diagnostic in result.diagnostics.into_vec() {
+            // Bail-outs surface as non-error severities; hide them unless asked.
+            if !self.report_all_bailouts && diagnostic.severity != Severity::Error {
+                continue;
+            }
+
+            let category = react_compiler_category(&diagnostic.message);
+
+            // `Immutability` and `UseMemo` have no compiler flag, so the
+            // sub-rules are enforced here by dropping their diagnostics when the
+            // toggle is off.
+            if !self.immutability && category == Some("Immutability") {
+                continue;
+            }
+            if !self.use_memo && category == Some("UseMemo") {
+                continue;
+            }
+
+            // Internal compiler errors are not Rules of React violations; hide
+            // them unless the user opts into the full firehose.
+            if !self.report_all_bailouts && category.is_some_and(is_internal_noise) {
+                continue;
+            }
+
             // If Flow already caught this error, we don't need to report it again.
             if is_flow_suppressed(&diagnostic, &suppressed_lines, ctx.source_text()) {
                 continue;
@@ -148,6 +276,23 @@ impl Rule for ReactCompiler {
             ctx.diagnostic(diagnostic);
         }
     }
+}
+
+/// The leading category token of a React Compiler message — e.g. `Immutability`
+/// from `"[ReactCompiler] Immutability: Cannot reassign ..."`. Returns `None`
+/// when the message carries no category, as some fatal-error paths do. Reliable
+/// because the rule runs with `panicThreshold: "none"`, so categorized
+/// diagnostics always render with the `"{category}: {reason}"` shape.
+fn react_compiler_category(message: &str) -> Option<&str> {
+    message.strip_prefix("[ReactCompiler] ").and_then(|rest| rest.split_once(": ")).map(|(c, _)| c)
+}
+
+/// Categories that are internal compiler errors rather than Rules of React
+/// violations. `Invariant` is a compiler-internal assertion; `Unexpected error`
+/// and `Pipeline error` are thrown failures. They are hidden unless
+/// `reportAllBailouts` is set.
+fn is_internal_noise(category: &str) -> bool {
+    matches!(category, "Invariant" | "Unexpected error" | "Pipeline error")
 }
 
 /// Flow suppression codes that silence a React Compiler diagnostic on the next
@@ -307,6 +452,44 @@ function Component(props) {
                 return <fbt desc='label'>Hello</fbt>;
             }",
             None,
+        ),
+        // A sub-rule toggled off in the config does not report: this would
+        // otherwise be a `Refs` violation (see the matching `fail` case).
+        (
+            "
+function Component(props) {
+  const ref = useRef(null);
+  const value = ref.current;
+  return value;
+}
+",
+            Some(json!([{ "refs": false }])),
+        ),
+        // `immutability` is filtered in the rule (the compiler has no flag for
+        // it): turning it off silences the `Immutability` diagnostic that the
+        // matching `fail` case (mutating a `useState` value) otherwise reports.
+        (
+            "
+import { useState } from 'react';
+function Component(props) {
+  const [state, setState] = useState({a: 0});
+  state.a = 1;
+  return <div>{props.foo}</div>;
+}
+",
+            Some(json!([{ "immutability": false }])),
+        ),
+        // `useMemo` is also rule-layer filtered: turning it off silences the
+        // `UseMemo` diagnostic for a malformed (async) `useMemo` callback.
+        (
+            "
+import { useMemo } from 'react';
+function Component(props) {
+  const x = useMemo(async () => props.a + 1, [props.a]);
+  return <div>{x}</div>;
+}
+",
+            Some(json!([{ "useMemo": false }])),
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/react/react_compiler.rs
+++ b/crates/oxc_linter/src/rules/react/react_compiler.rs
@@ -265,6 +265,12 @@ impl Rule for ReactCompiler {
                 continue;
             }
 
+            // The sub-rule id (a `&'static str`) lets a disable directive like
+            // `react/react-compiler/refs` suppress just this category. Resolve it
+            // now so the borrow of `diagnostic.message` ends before the message
+            // is rewritten below.
+            let sub_rule = category.and_then(category_sub_rule);
+
             // If Flow already caught this error, we don't need to report it again.
             if is_flow_suppressed(&diagnostic, &suppressed_lines, ctx.source_text()) {
                 continue;
@@ -273,9 +279,37 @@ impl Rule for ReactCompiler {
             if let Some(message) = diagnostic.message.strip_prefix("[ReactCompiler] ") {
                 diagnostic.message = Cow::Owned(message.to_string());
             }
-            ctx.diagnostic(diagnostic);
+            match sub_rule {
+                Some(sub_rule) => ctx.diagnostic_with_sub_rule(sub_rule, diagnostic),
+                None => ctx.diagnostic(diagnostic),
+            }
         }
     }
+}
+
+/// Maps a React Compiler diagnostic category to the rule's sub-rule id. The id
+/// matches the config toggle name, so the same identifier works in both places:
+/// `"react/react-compiler": { "refs": false }` and
+/// `// oxlint-disable-next-line react/react-compiler/refs`. Categories without a
+/// dedicated toggle return `None` and can only be suppressed via the bare rule.
+fn category_sub_rule(category: &str) -> Option<&'static str> {
+    Some(match category {
+        "Hooks" => "hooks",
+        "Refs" => "refs",
+        "RenderSetState" => "setStateInRender",
+        "EffectSetState" => "setStateInEffect",
+        "ErrorBoundaries" => "errorBoundaries",
+        "Purity" => "purity",
+        "StaticComponents" => "staticComponents",
+        "VoidUseMemo" => "voidUseMemo",
+        "CapitalizedCalls" => "capitalizedCalls",
+        "EffectDerivationsOfState" => "derivedComputationsInEffect",
+        "MemoDependencies" => "memoDependencies",
+        "PreserveManualMemo" => "preserveManualMemo",
+        "Immutability" => "immutability",
+        "UseMemo" => "useMemo",
+        _ => return None,
+    })
 }
 
 /// The leading category token of a React Compiler message — e.g. `Immutability`
@@ -491,6 +525,30 @@ function Component(props) {
 ",
             Some(json!([{ "useMemo": false }])),
         ),
+        // A `{rule}/{sub-rule}` disable directive suppresses just that category.
+        (
+            "
+// oxlint-disable react/react-compiler/refs
+function Component(props) {
+  const ref = useRef(null);
+  const value = ref.current;
+  return value;
+}
+",
+            None,
+        ),
+        // A directive naming the bare rule still suppresses every category.
+        (
+            "
+// oxlint-disable react/react-compiler
+function Component(props) {
+  const ref = useRef(null);
+  const value = ref.current;
+  return value;
+}
+",
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -702,6 +760,19 @@ function useConditional2(props) {
                 return <fbt desc='label'>Hello</fbt>;
             }",
             Some(json!([{ "reportAllBailouts": true }])),
+        ),
+        // A disable directive for a *different* sub-rule does not suppress: this
+        // `Refs` violation still surfaces despite the `.../hooks` directive.
+        (
+            "
+// oxlint-disable react/react-compiler/hooks
+function Component(props) {
+  const ref = useRef(null);
+  const value = ref.current;
+  return value;
+}
+",
+            None,
         ),
     ];
 

--- a/crates/oxc_linter/src/rules/react/react_compiler.rs
+++ b/crates/oxc_linter/src/rules/react/react_compiler.rs
@@ -2,7 +2,9 @@ use std::borrow::Cow;
 
 use oxc_diagnostics::Severity;
 use oxc_macros::declare_oxc_lint;
-use oxc_react_compiler::{CompilerOutputMode, EnvironmentConfig, PluginOptions};
+use oxc_react_compiler::{
+    CompilerOutputMode, EnvironmentConfig, ErrorCategory, PluginOptions, ReactCompilerDiagnostic,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -235,41 +237,32 @@ impl Rule for ReactCompiler {
 
     fn run_once(&self, ctx: &LintContext) {
         let program = ctx.nodes().program();
-        let options =
-            react_compiler_options(self);
+        let options = react_compiler_options(self);
 
         let result = oxc_react_compiler::lint(program, ctx.semantic(), ctx.allocator(), options);
 
         let suppressed_lines = flow_suppression_lines(ctx);
-        for mut diagnostic in result.diagnostics.into_vec() {
+        for ReactCompilerDiagnostic { mut diagnostic, category } in result.diagnostics {
             // Bail-outs surface as non-error severities; hide them unless asked.
             if !self.report_all_bailouts && diagnostic.severity != Severity::Error {
                 continue;
             }
 
-            let category = react_compiler_category(&diagnostic.message);
-
             // `Immutability` and `UseMemo` have no compiler flag, so the
             // sub-rules are enforced here by dropping their diagnostics when the
             // toggle is off.
-            if !self.immutability && category == Some("Immutability") {
+            if !self.immutability && category == Some(ErrorCategory::Immutability) {
                 continue;
             }
-            if !self.use_memo && category == Some("UseMemo") {
+            if !self.use_memo && category == Some(ErrorCategory::UseMemo) {
                 continue;
             }
 
             // Internal compiler errors are not Rules of React violations; hide
             // them unless the user opts into the full firehose.
-            if !self.report_all_bailouts && category.is_some_and(is_internal_noise) {
+            if !self.report_all_bailouts && is_internal_noise(category) {
                 continue;
             }
-
-            // The sub-rule id (a `&'static str`) lets a disable directive like
-            // `react/react-compiler/refs` suppress just this category. Resolve it
-            // now so the borrow of `diagnostic.message` ends before the message
-            // is rewritten below.
-            let sub_rule = category.and_then(category_sub_rule);
 
             // If Flow already caught this error, we don't need to report it again.
             if is_flow_suppressed(&diagnostic, &suppressed_lines, ctx.source_text()) {
@@ -279,7 +272,9 @@ impl Rule for ReactCompiler {
             if let Some(message) = diagnostic.message.strip_prefix("[ReactCompiler] ") {
                 diagnostic.message = Cow::Owned(message.to_string());
             }
-            match sub_rule {
+            // A sub-rule id lets a disable directive like
+            // `react/react-compiler/refs` suppress just this category.
+            match category_sub_rule(category) {
                 Some(sub_rule) => ctx.diagnostic_with_sub_rule(sub_rule, diagnostic),
                 None => ctx.diagnostic(diagnostic),
             }
@@ -292,41 +287,46 @@ impl Rule for ReactCompiler {
 /// `"react/react-compiler": { "refs": false }` and
 /// `// oxlint-disable-next-line react/react-compiler/refs`. Categories without a
 /// dedicated toggle return `None` and can only be suppressed via the bare rule.
-fn category_sub_rule(category: &str) -> Option<&'static str> {
-    Some(match category {
-        "Hooks" => "hooks",
-        "Refs" => "refs",
-        "RenderSetState" => "setStateInRender",
-        "EffectSetState" => "setStateInEffect",
-        "ErrorBoundaries" => "errorBoundaries",
-        "Purity" => "purity",
-        "StaticComponents" => "staticComponents",
-        "VoidUseMemo" => "voidUseMemo",
-        "CapitalizedCalls" => "capitalizedCalls",
-        "EffectDerivationsOfState" => "derivedComputationsInEffect",
-        "MemoDependencies" => "memoDependencies",
-        "PreserveManualMemo" => "preserveManualMemo",
-        "Immutability" => "immutability",
-        "UseMemo" => "useMemo",
-        _ => return None,
+///
+/// The match is exhaustive so that a category added to the compiler has to be
+/// classified here rather than silently losing its sub-rule.
+fn category_sub_rule(category: Option<ErrorCategory>) -> Option<&'static str> {
+    Some(match category? {
+        ErrorCategory::Hooks => "hooks",
+        ErrorCategory::Refs => "refs",
+        ErrorCategory::RenderSetState => "setStateInRender",
+        ErrorCategory::EffectSetState => "setStateInEffect",
+        ErrorCategory::ErrorBoundaries => "errorBoundaries",
+        ErrorCategory::Purity => "purity",
+        ErrorCategory::StaticComponents => "staticComponents",
+        ErrorCategory::VoidUseMemo => "voidUseMemo",
+        ErrorCategory::CapitalizedCalls => "capitalizedCalls",
+        ErrorCategory::EffectDerivationsOfState => "derivedComputationsInEffect",
+        ErrorCategory::MemoDependencies => "memoDependencies",
+        ErrorCategory::PreserveManualMemo => "preserveManualMemo",
+        ErrorCategory::Immutability => "immutability",
+        ErrorCategory::UseMemo => "useMemo",
+        // Compiler-internal errors (see `is_internal_noise`), plus categories the
+        // rule exposes no toggle for. Suppressible only via the bare rule.
+        ErrorCategory::Invariant
+        | ErrorCategory::EffectExhaustiveDependencies
+        | ErrorCategory::IncompatibleLibrary
+        | ErrorCategory::Globals
+        | ErrorCategory::Todo
+        | ErrorCategory::Syntax
+        | ErrorCategory::UnsupportedSyntax
+        | ErrorCategory::Config
+        | ErrorCategory::Gating
+        | ErrorCategory::Suppression => return None,
     })
 }
 
-/// The leading category token of a React Compiler message — e.g. `Immutability`
-/// from `"[ReactCompiler] Immutability: Cannot reassign ..."`. Returns `None`
-/// when the message carries no category, as some fatal-error paths do. Reliable
-/// because the rule runs with `panicThreshold: "none"`, so categorized
-/// diagnostics always render with the `"{category}: {reason}"` shape.
-fn react_compiler_category(message: &str) -> Option<&str> {
-    message.strip_prefix("[ReactCompiler] ").and_then(|rest| rest.split_once(": ")).map(|(c, _)| c)
-}
-
-/// Categories that are internal compiler errors rather than Rules of React
-/// violations. `Invariant` is a compiler-internal assertion; `Unexpected error`
-/// and `Pipeline error` are thrown failures. They are hidden unless
-/// `reportAllBailouts` is set.
-fn is_internal_noise(category: &str) -> bool {
-    matches!(category, "Invariant" | "Unexpected error" | "Pipeline error")
+/// Whether a diagnostic is an internal compiler error rather than a Rules of
+/// React violation. `Invariant` is a compiler-internal assertion; a `None`
+/// category is the compiler's synthetic pipeline error for a thrown failure. Both
+/// are hidden unless `reportAllBailouts` is set.
+fn is_internal_noise(category: Option<ErrorCategory>) -> bool {
+    matches!(category, None | Some(ErrorCategory::Invariant))
 }
 
 /// Flow suppression codes that silence a React Compiler diagnostic on the next
@@ -529,6 +529,18 @@ function Component(props) {
         (
             "
 // oxlint-disable react/react-compiler/refs
+function Component(props) {
+  const ref = useRef(null);
+  const value = ref.current;
+  return value;
+}
+",
+            None,
+        ),
+        // A sub-rule directive may omit the plugin prefix, like a bare rule one.
+        (
+            "
+// oxlint-disable react-compiler/refs
 function Component(props) {
   const ref = useRef(null);
   const value = ref.current;

--- a/crates/oxc_linter/src/snapshots/react_react_compiler.snap
+++ b/crates/oxc_linter/src/snapshots/react_react_compiler.snap
@@ -239,3 +239,13 @@ source: crates/oxc_linter/src/tester.rs
  3 │                 return <fbt desc='label'>Hello</fbt>;
    ╰────
   help: Local variables named `fbt` may conflict with the fbt plugin and are not yet supported
+
+  ⚠ react(react-compiler): Refs: Cannot access refs during render
+   ╭─[react_compiler.tsx:5:17]
+ 4 │   const ref = useRef(null);
+ 5 │   const value = ref.current;
+   ·                 ─────┬─────
+   ·                      ╰── Cannot access ref value during render
+ 6 │   return value;
+   ╰────
+  help: React refs are values that are not needed for rendering. Refs should only be accessed outside of render, such as in event handlers or effects. Accessing a ref value (the `current` property) during render can cause your component not to update as expected (https://react.dev/reference/react/useRef)

--- a/crates/oxc_react_compiler/src/diagnostics.rs
+++ b/crates/oxc_react_compiler/src/diagnostics.rs
@@ -20,6 +20,10 @@ use oxc_span::Span;
 
 use crate::options::PanicThreshold;
 
+/// The category segment of the compiler's synthetic pipeline error (built in
+/// `program.rs::log_error`), which is deliberately not an [`ErrorCategory`].
+const PIPELINE_ERROR: &str = "Pipeline error";
+
 /// Error categories matching the TS `ErrorCategory` enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ErrorCategory {
@@ -79,6 +83,38 @@ impl ErrorCategory {
         }
     }
 
+    /// The inverse of [`Self::as_str`]. `None` for any name this enum does not
+    /// model — see [`Self::of`].
+    fn from_str(name: &str) -> Option<Self> {
+        Some(match name {
+            "Hooks" => Self::Hooks,
+            "CapitalizedCalls" => Self::CapitalizedCalls,
+            "StaticComponents" => Self::StaticComponents,
+            "UseMemo" => Self::UseMemo,
+            "VoidUseMemo" => Self::VoidUseMemo,
+            "PreserveManualMemo" => Self::PreserveManualMemo,
+            "MemoDependencies" => Self::MemoDependencies,
+            "IncompatibleLibrary" => Self::IncompatibleLibrary,
+            "Immutability" => Self::Immutability,
+            "Globals" => Self::Globals,
+            "Refs" => Self::Refs,
+            "EffectExhaustiveDependencies" => Self::EffectExhaustiveDependencies,
+            "EffectSetState" => Self::EffectSetState,
+            "EffectDerivationsOfState" => Self::EffectDerivationsOfState,
+            "ErrorBoundaries" => Self::ErrorBoundaries,
+            "Purity" => Self::Purity,
+            "RenderSetState" => Self::RenderSetState,
+            "Invariant" => Self::Invariant,
+            "Todo" => Self::Todo,
+            "Syntax" => Self::Syntax,
+            "UnsupportedSyntax" => Self::UnsupportedSyntax,
+            "Config" => Self::Config,
+            "Gating" => Self::Gating,
+            "Suppression" => Self::Suppression,
+            _ => return None,
+        })
+    }
+
     /// Displayed severity, matching the TS compiler's `getRuleForCategory()`.
     /// `PreserveManualMemo` displays as an error but does not count towards
     /// `panicThreshold: critical_errors` (see [`has_critical_errors`]).
@@ -103,11 +139,32 @@ impl ErrorCategory {
     /// Whether `diagnostic` was built for this category via [`Self::diagnostic`],
     /// recovered from the deterministic message prefix.
     pub fn matches(self, diagnostic: &OxcDiagnostic) -> bool {
-        Self::of(diagnostic) == Some(self.as_str())
+        Self::name_of(diagnostic) == Some(self.as_str())
+    }
+
+    /// The category `diagnostic` was built for by [`Self::diagnostic`], recovered
+    /// from the deterministic message prefix. Lets consumers branch on the
+    /// category (e.g. per-category lint suppression) without parsing messages
+    /// themselves.
+    ///
+    /// `None` for a diagnostic that carries no category: the only one the
+    /// compiler produces is the synthetic `[ReactCompiler] Pipeline error: …`
+    /// raised for an exception that is not a compiler error (see
+    /// `program.rs::log_error`).
+    pub fn of(diagnostic: &OxcDiagnostic) -> Option<Self> {
+        let name = Self::name_of(diagnostic)?;
+        let category = Self::from_str(name);
+        // A category [`Self::from_str`] does not know is indistinguishable from an
+        // uncategorized diagnostic, so a new variant must be added there too.
+        debug_assert!(
+            category.is_some() || name == PIPELINE_ERROR,
+            "`ErrorCategory::from_str` is missing `{name}`"
+        );
+        category
     }
 
     /// The category segment of a message built by [`Self::diagnostic`].
-    fn of(diagnostic: &OxcDiagnostic) -> Option<&str> {
+    fn name_of(diagnostic: &OxcDiagnostic) -> Option<&str> {
         let rest = diagnostic.message.strip_prefix("[ReactCompiler] ")?;
         rest.split_once(": ").map(|(category, _)| category)
     }

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -23,6 +23,7 @@ use crate::react_compiler::entrypoint::program::compile_program;
 pub use crate::react_compiler::entrypoint::compile_result::CompileResult;
 pub use crate::react_compiler::entrypoint::program::CompileOutput;
 
+pub use crate::diagnostics::ErrorCategory;
 // Re-exported so integrations needn't depend on the upstream `react_compiler` crates.
 pub use crate::options::{
     CompilationMode, CompilerOutputMode, CompilerTarget, DynamicGatingConfig, GatingConfig,
@@ -40,14 +41,24 @@ pub use crate::react_compiler_hir::type_config::{
 pub use crate::react_compiler_utils::FxIndexMap;
 
 use oxc_ast::ast::Program;
-use oxc_diagnostics::Diagnostics;
+use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_semantic::Semantic;
 
 pub struct LintResult {
-    /// Errors and warnings produced by the compile.
-    pub diagnostics: Diagnostics,
+    /// Errors and warnings produced by the compile, each paired with its
+    /// [`ErrorCategory`] so consumers can filter or suppress by category (e.g.
+    /// per-sub-rule disable directives) without re-parsing the message.
+    pub diagnostics: Vec<ReactCompilerDiagnostic>,
     /// Whether compilation was aborted according to `panic_threshold`.
     pub fatal: bool,
+}
+
+/// A diagnostic from [`lint`], paired with the [`ErrorCategory`] it was built for.
+#[derive(Debug)]
+pub struct ReactCompilerDiagnostic {
+    pub diagnostic: OxcDiagnostic,
+    /// `None` for a diagnostic that carries no category — see [`ErrorCategory::of`].
+    pub category: Option<ErrorCategory>,
 }
 
 /// Run the React Compiler on a pre-parsed program.
@@ -115,8 +126,20 @@ pub fn lint<'a>(
     let mut options = options;
     options.no_emit = true;
 
-    match compile(program, semantic, allocator, options) {
-        CompileResult::Success { diagnostics, .. } => LintResult { diagnostics, fatal: false },
-        CompileResult::Fatal { diagnostics } => LintResult { diagnostics, fatal: true },
-    }
+    let (diagnostics, fatal) = match compile(program, semantic, allocator, options) {
+        CompileResult::Success { diagnostics, .. } => (diagnostics, false),
+        CompileResult::Fatal { diagnostics } => (diagnostics, true),
+    };
+    // The compiler flattens the category into the message when it builds each
+    // diagnostic (`ErrorCategory::diagnostic`). Recover it here so consumers match
+    // on the enum instead of re-parsing the message themselves.
+    let diagnostics = diagnostics
+        .into_vec()
+        .into_iter()
+        .map(|diagnostic| ReactCompilerDiagnostic {
+            category: ErrorCategory::of(&diagnostic),
+            diagnostic,
+        })
+        .collect();
+    LintResult { diagnostics, fatal }
 }

--- a/crates/oxc_react_compiler/tests/snapshot.rs
+++ b/crates/oxc_react_compiler/tests/snapshot.rs
@@ -116,7 +116,12 @@ fn run_fixture(source: &str) -> String {
     // emitting. Surface any divergence in the snapshot so it stays reviewed rather than
     // drifting silently.
     let transform_body = diagnostics_body(diagnostics.as_slice());
-    let lint_body = diagnostics_body(lint_result.diagnostics.as_slice());
+    // `lint` pairs each diagnostic with its category; compare and render the inner
+    // `OxcDiagnostic` so this cross-check tracks the diagnostics themselves rather
+    // than reporting a spurious divergence from the category wrapper's `Debug`.
+    let lint_oxc_diagnostics: Vec<_> =
+        lint_result.diagnostics.iter().map(|d| &d.diagnostic).collect();
+    let lint_body = diagnostics_body(&lint_oxc_diagnostics);
     if lint_body != transform_body {
         out.push_str("\n\nLint-mode diagnostics (differ from transform):\n\n");
         out.push_str(if lint_body.is_empty() { "(none)\n" } else { &lint_body });

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -18227,11 +18227,95 @@
     "ReactCompilerConfig": {
       "type": "object",
       "properties": {
+        "capitalizedCalls": {
+          "description": "Capitalized functions are reserved for components and must be invoked as\nJSX (`validate_no_capitalized_calls`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "Capitalized functions are reserved for components and must be invoked as\nJSX (`validate_no_capitalized_calls`)."
+        },
+        "derivedComputationsInEffect": {
+          "description": "Effects may not recompute values that could be derived during render\n(emitted as the `EffectDerivationsOfState` category;\n`validate_no_derived_computations_in_effects`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "Effects may not recompute values that could be derived during render\n(emitted as the `EffectDerivationsOfState` category;\n`validate_no_derived_computations_in_effects`)."
+        },
+        "errorBoundaries": {
+          "description": "JSX may not be constructed inside `try`/`catch`\n(`validate_no_jsx_in_try_statements`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "JSX may not be constructed inside `try`/`catch`\n(`validate_no_jsx_in_try_statements`)."
+        },
+        "hooks": {
+          "description": "Hooks must be called unconditionally and in a consistent order\n(`validate_hooks_usage`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "Hooks must be called unconditionally and in a consistent order\n(`validate_hooks_usage`)."
+        },
+        "immutability": {
+          "description": "Values that are known to be mutable (props, state) may not be mutated —\nthe `Immutability` category. Emitted by the core mutation/aliasing\ninference pass and by `validate_locals_not_reassigned_after_render`,\nneither of which the compiler exposes a flag for.",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "Values that are known to be mutable (props, state) may not be mutated —\nthe `Immutability` category. Emitted by the core mutation/aliasing\ninference pass and by `validate_locals_not_reassigned_after_render`,\nneither of which the compiler exposes a flag for."
+        },
+        "memoDependencies": {
+          "description": "Memoization dependency arrays (`useMemo`/`useCallback`/`useEffect`) must\nbe exhaustive — the `MemoDependencies` category, equivalent to ESLint's\n`react-hooks/exhaustive-deps` (`validate_exhaustive_memoization_dependencies`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "Memoization dependency arrays (`useMemo`/`useCallback`/`useEffect`) must\nbe exhaustive — the `MemoDependencies` category, equivalent to ESLint's\n`react-hooks/exhaustive-deps` (`validate_exhaustive_memoization_dependencies`)."
+        },
+        "preserveManualMemo": {
+          "description": "Manual `useMemo`/`useCallback` memoization must be preservable by the\ncompiler — the `PreserveManualMemo` category. `eslint-plugin-react-compiler`\nships this off by default; set to `false` to match\n(`enable_preserve_existing_memoization_guarantees` +\n`validate_preserve_existing_memoization_guarantees`).\n\nNOTE: the memoization validations are coupled. Disabling this alone\n*reclassifies* rather than removes — the compiler still bails on those\nsites and re-reports them under `MemoDependencies` (and a few under\n`Purity`). To silence the family, also set `memoDependencies: false`\n(and `purity: false` if those remain).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "Manual `useMemo`/`useCallback` memoization must be preservable by the\ncompiler — the `PreserveManualMemo` category. `eslint-plugin-react-compiler`\nships this off by default; set to `false` to match\n(`enable_preserve_existing_memoization_guarantees` +\n`validate_preserve_existing_memoization_guarantees`).\n\nNOTE: the memoization validations are coupled. Disabling this alone\n*reclassifies* rather than removes — the compiler still bails on those\nsites and re-reports them under `MemoDependencies` (and a few under\n`Purity`). To silence the family, also set `memoDependencies: false`\n(and `purity: false` if those remain)."
+        },
+        "purity": {
+          "description": "Known-impure functions (e.g. `Math.random`, `Date.now`) may not be\ncalled during render (`validate_no_impure_functions_in_render`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "Known-impure functions (e.g. `Math.random`, `Date.now`) may not be\ncalled during render (`validate_no_impure_functions_in_render`)."
+        },
+        "refs": {
+          "description": "Refs may not be read or written during render\n(`validate_ref_access_during_render`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "Refs may not be read or written during render\n(`validate_ref_access_during_render`)."
+        },
         "reportAllBailouts": {
           "description": "Also report compiler bail-outs — places where React Compiler skipped a\ncomponent or hook (for example because of unsupported syntax) without\nfinding a rule violation. These do not indicate incorrect code, only\ncode that the compiler declined to optimize.",
           "default": false,
           "type": "boolean",
           "markdownDescription": "Also report compiler bail-outs — places where React Compiler skipped a\ncomponent or hook (for example because of unsupported syntax) without\nfinding a rule violation. These do not indicate incorrect code, only\ncode that the compiler declined to optimize."
+        },
+        "setStateInEffect": {
+          "description": "`setState` may not be called unconditionally inside an effect\n(`validate_no_set_state_in_effects`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "`setState` may not be called unconditionally inside an effect\n(`validate_no_set_state_in_effects`)."
+        },
+        "setStateInRender": {
+          "description": "`setState` may not be called during render\n(`validate_no_set_state_in_render`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "`setState` may not be called during render\n(`validate_no_set_state_in_render`)."
+        },
+        "staticComponents": {
+          "description": "Components must be statically defined (`validate_static_components`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "Components must be statically defined (`validate_static_components`)."
+        },
+        "useMemo": {
+          "description": "`useMemo`/`useCallback` callbacks must be well-formed — the `UseMemo`\ncategory (callbacks taking parameters, being async/generator, or\nreassigning outer variables). Distinct from `voidUseMemo`, which covers\ncallbacks that return nothing. Emitted by `drop_manual_memoization` and\nthe non-void part of `validate_use_memo`, neither gated by a flag.",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "`useMemo`/`useCallback` callbacks must be well-formed — the `UseMemo`\ncategory (callbacks taking parameters, being async/generator, or\nreassigning outer variables). Distinct from `voidUseMemo`, which covers\ncallbacks that return nothing. Emitted by `drop_manual_memoization` and\nthe non-void part of `validate_use_memo`, neither gated by a flag."
+        },
+        "voidUseMemo": {
+          "description": "`useMemo` callbacks must return a value (`validate_no_void_use_memo`).",
+          "default": true,
+          "type": "boolean",
+          "markdownDescription": "`useMemo` callbacks must return a value (`validate_no_void_use_memo`)."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Follows on from #23757 and implements support for sub-rule inline disable-diagnostics.

This is required for migrating a complex typescript/react project from eslint to oxlint. We are opting out of eslint react rules via eslint config and inline disable-directives. The oxlint catch-all `react/react-compiler` directive is too limited, so this PR adds support for sub-rules (matching the new config options in #23757).

Behavior, verified by tests:
- `oxlint-disable react/react-compiler/refs` → suppresses only Refs.
- `oxlint-disable react-compiler/refs` → the same, with the plugin prefix omitted (as is already allowed for a bare rule name).
- `oxlint-disable react/react-compiler` → suppresses everything (unchanged).
- `oxlint-disable react/react-compiler/hooks` over a Refs violation → still reports
- No regression: sub-rule lookup is a separate entry point, so the existing rule-name matching path is untouched.

## Linter Core

- Add support for sub-rule disable directives. The sub-rule is passed as an argument (`LintContext::diagnostic_with_sub_rule` → `DisableDirectives::contains_sub_rule`) rather than stored, so `Message` is unchanged.

## React Compiler

- `lint()` now pairs each diagnostic with the `ErrorCategory` it was built for, so the rule can filter and tag sub-rules by category instead of matching on message text.
- Add react-compiler sub-rule disable directives.

## Notes

- The compiler flattens the category into the message as it builds each diagnostic (`ErrorCategory::diagnostic`), so `lint()` recovers it via `ErrorCategory::of` — the inverse of that prefix, added next to `as_str` in `diagnostics.rs`. A `debug_assert!` catches a category missing from the inverse, which would otherwise read as uncategorized.
- `category` is an `Option<ErrorCategory>`. `None` is the synthetic `Pipeline error` (`program.rs::log_error`), the only uncategorized diagnostic the compiler emits.
- The category → sub-rule mapping is exhaustive, so a category added to the compiler has to be classified rather than silently losing its sub-rule.
- The code and tests have been implemented by an agent. I have reviewed the changes and verified the sub-rule directives on a large existing project.

## Testing

- `cargo test -p oxc_react_compiler -p oxc_linter`
- Each commit builds on its own (`git rebase --exec cargo check --all-targets`).
- The `refs`/`immutability`/`useMemo` suppression tests cover both the compiler-flag and rule-layer paths, along with the qualified and unqualified directive forms.
