### PR TITLE
fix(linter/react/rules-of-hooks): flag `useEffectEvent` escapes

### DIFF
--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -4,12 +4,12 @@ use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use oxc_ast::{
     AstKind,
-    ast::{ArrowFunctionExpression, Function},
+    ast::{ArrowFunctionExpression, CallExpression, Function},
 };
 use oxc_ast_visit::{Visit, walk};
 use oxc_cfg::{ControlFlowGraph, EdgeType, ErrorEdgeKind, InstructionKind, graph::visit::EdgeRef};
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{AstNodes, NodeId};
+use oxc_semantic::{AstNodes, NodeId, SymbolId};
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{AssignmentOperator, LogicalOperator};
 
@@ -161,6 +161,33 @@ mod diagnostics {
         .with_label(span.label("This Hook call is inside a nested callback."))
         .with_error_code_scope(SCOPE)
     }
+
+    pub(super) fn use_effect_event_reference(
+        span: Span,
+        name: &str,
+        called: bool,
+    ) -> OxcDiagnostic {
+        let mut message = format!(
+            "`{name}` is a function created with React Hook \"useEffectEvent\", and can only be called from \
+            Effects and Effect Events in the same component."
+        );
+
+        if !called {
+            message.push_str(" It cannot be assigned to a variable or passed down.");
+        }
+
+        OxcDiagnostic::warn(message)
+            .with_label(span.label("Effect Event escapes its component or custom Hook."))
+            .with_error_code_scope(SCOPE)
+    }
+
+    pub(super) fn use_effect_event_inline_escape(span: Span) -> OxcDiagnostic {
+        OxcDiagnostic::warn(
+            "React Hook \"useEffectEvent\" can only be called at the top level of your component. It cannot be passed down.",
+        )
+        .with_label(span.label("Effect Event is passed directly instead of being assigned locally."))
+        .with_error_code_scope(SCOPE)
+    }
 }
 
 #[derive(Debug, Default, Clone)]
@@ -259,6 +286,10 @@ impl Rule for RulesOfHooks {
         let Some(parent_func) = parent_func(nodes, node) else {
             return ctx.diagnostic(diagnostics::top_level_hook(span, hook_name));
         };
+
+        if is_react_function_call(call, "useEffectEvent") {
+            check_use_effect_event_usage(node, call, ctx);
+        }
 
         // Check if our parent function is part of a class.
         if matches!(
@@ -744,6 +775,59 @@ fn is_inside_try_catch(
         .ancestors(hook_node_id)
         .take_while(|node| node.id() != function_node_id)
         .any(|node| matches!(node.kind(), AstKind::TryStatement(_) | AstKind::CatchClause(_)))
+}
+
+fn check_use_effect_event_usage(
+    node: &AstNode<'_>,
+    call: &CallExpression<'_>,
+    ctx: &LintContext<'_>,
+) {
+    match ctx.nodes().parent_kind(node.id()) {
+        AstKind::VariableDeclarator(decl) => {
+            if let Some(ident) = decl.id.get_binding_identifier() {
+                report_invalid_use_effect_event_references(ident.symbol_id(), ctx);
+            }
+        }
+        // As with other Hooks, a top-level expression statement is permitted.
+        AstKind::ExpressionStatement(_) => {}
+        _ => ctx.diagnostic(diagnostics::use_effect_event_inline_escape(call.span)),
+    }
+}
+
+fn report_invalid_use_effect_event_references(symbol_id: SymbolId, ctx: &LintContext<'_>) {
+    for reference in ctx.semantic().symbol_references(symbol_id) {
+        if is_inside_effect_or_effect_event_call(ctx.nodes(), reference.node_id()) {
+            continue;
+        }
+
+        let span = ctx.semantic().reference_span(reference);
+        ctx.diagnostic(diagnostics::use_effect_event_reference(
+            span,
+            ctx.semantic().reference_name(reference),
+            is_reference_call_callee(ctx.nodes(), reference.node_id(), span),
+        ));
+    }
+}
+
+fn is_inside_effect_or_effect_event_call(nodes: &AstNodes<'_>, node_id: NodeId) -> bool {
+    nodes.ancestors(node_id).any(|ancestor| match ancestor.kind() {
+        AstKind::CallExpression(call) => is_effect_or_effect_event_call(call),
+        _ => false,
+    })
+}
+
+fn is_effect_or_effect_event_call(call: &CallExpression<'_>) -> bool {
+    is_react_function_call(call, "useEffect")
+        || is_react_function_call(call, "useLayoutEffect")
+        || is_react_function_call(call, "useInsertionEffect")
+        || is_react_function_call(call, "useEffectEvent")
+}
+
+fn is_reference_call_callee(nodes: &AstNodes<'_>, node_id: NodeId, span: Span) -> bool {
+    nodes.ancestors(node_id).any(|ancestor| match ancestor.kind() {
+        AstKind::CallExpression(call) => call.callee.span() == span,
+        _ => false,
+    })
 }
 
 /// Checks if the `node_id` is a callback argument (including JSX render props),
@@ -1479,6 +1563,33 @@ fn test() {
             const value = 1;
             useState(value);
           } catch {}
+        }
+    ",
+    "
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => {
+            showNotification(theme);
+          });
+          useEffect(() => {
+            onClick();
+          });
+          React.useLayoutEffect(() => {
+            setTimeout(onClick, 100);
+          });
+        }
+    ",
+    "
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => {
+            showNotification(theme);
+          });
+          const onClick2 = useEffectEvent(() => {
+            debounce(onClick);
+            debounce(() => onClick());
+          });
+          useInsertionEffect(() => {
+            onClick2();
+          });
         }
     "
     ];
@@ -2238,6 +2349,36 @@ fn test() {
             }
         ",
         r"const Foo3 = hoc(function NamedComp(props) { if (props.cond) { const [_a, _b] = useState(false); } });",
+        r#"
+            function MyComponent({ theme }) {
+                const onClick = useEffectEvent(() => {
+                    showNotification(theme);
+                });
+                return <Child onClick={onClick} />;
+            }
+        "#,
+        r"
+            function useCustomHook() {
+                const onEvent = useEffectEvent(() => {});
+                return { onEvent };
+            }
+        ",
+        r#"
+            function MyComponent({ theme }) {
+                return <Child onClick={useEffectEvent(() => {
+                    showNotification(theme);
+                })} />;
+            }
+        "#,
+        r"
+            function MyComponent({ theme }) {
+                const onClick = useEffectEvent(() => {
+                    showNotification(theme);
+                });
+                const handler = () => onClick();
+                return <Child onClick={handler} />;
+            }
+        ",
     ];
 
     Tester::new(RulesOfHooks::NAME, RulesOfHooks::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use lazy_regex::Regex;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use oxc_ast::{
@@ -784,7 +785,12 @@ fn check_use_effect_event_usage(
     match ctx.nodes().parent_kind(node.id()) {
         AstKind::VariableDeclarator(decl) => {
             if let Some(ident) = decl.id.get_binding_identifier() {
-                report_invalid_use_effect_event_references(ident.symbol_id(), ctx);
+                let additional_effect_hooks = additional_effect_hooks(ctx);
+                report_invalid_use_effect_event_references(
+                    ident.symbol_id(),
+                    additional_effect_hooks.as_ref(),
+                    ctx,
+                );
             }
         }
         // As with other Hooks, a top-level expression statement is permitted.
@@ -793,9 +799,23 @@ fn check_use_effect_event_usage(
     }
 }
 
-fn report_invalid_use_effect_event_references(symbol_id: SymbolId, ctx: &LintContext<'_>) {
+fn additional_effect_hooks(ctx: &LintContext<'_>) -> Option<Regex> {
+    let pattern =
+        ctx.settings().json.as_ref()?.get("react-hooks")?.get("additionalEffectHooks")?.as_str()?;
+    Regex::new(pattern).ok()
+}
+
+fn report_invalid_use_effect_event_references(
+    symbol_id: SymbolId,
+    additional_effect_hooks: Option<&Regex>,
+    ctx: &LintContext<'_>,
+) {
     for reference in ctx.semantic().symbol_references(symbol_id) {
-        if is_inside_effect_or_effect_event_call(ctx.nodes(), reference.node_id()) {
+        if is_inside_effect_or_effect_event_call(
+            ctx.nodes(),
+            reference.node_id(),
+            additional_effect_hooks,
+        ) {
             continue;
         }
 
@@ -808,18 +828,31 @@ fn report_invalid_use_effect_event_references(symbol_id: SymbolId, ctx: &LintCon
     }
 }
 
-fn is_inside_effect_or_effect_event_call(nodes: &AstNodes<'_>, node_id: NodeId) -> bool {
+fn is_inside_effect_or_effect_event_call(
+    nodes: &AstNodes<'_>,
+    node_id: NodeId,
+    additional_effect_hooks: Option<&Regex>,
+) -> bool {
     nodes.ancestors(node_id).any(|ancestor| match ancestor.kind() {
-        AstKind::CallExpression(call) => is_effect_or_effect_event_call(call),
+        AstKind::CallExpression(call) => {
+            is_effect_or_effect_event_call(call, additional_effect_hooks)
+        }
         _ => false,
     })
 }
 
-fn is_effect_or_effect_event_call(call: &CallExpression<'_>) -> bool {
+fn is_effect_or_effect_event_call(
+    call: &CallExpression<'_>,
+    additional_effect_hooks: Option<&Regex>,
+) -> bool {
     is_react_function_call(call, "useEffect")
         || is_react_function_call(call, "useLayoutEffect")
         || is_react_function_call(call, "useInsertionEffect")
         || is_react_function_call(call, "useEffectEvent")
+        || additional_effect_hooks.is_some_and(|regex| {
+            call.callee_name()
+                .is_some_and(|name| is_react_function_call(call, name) && regex.is_match(name))
+        })
 }
 
 fn is_reference_call_callee(nodes: &AstNodes<'_>, node_id: NodeId, span: Span) -> bool {
@@ -1564,34 +1597,145 @@ fn test() {
           } catch {}
         }
     ",
-    "
-        function MyComponent({ theme }) {
-          const onClick = useEffectEvent(() => {
-            showNotification(theme);
-          });
-          useEffect(() => {
-            onClick();
-          });
-          React.useLayoutEffect(() => {
-            setTimeout(onClick, 100);
-          });
-        }
-    ",
-    "
-        function MyComponent({ theme }) {
-          const onClick = useEffectEvent(() => {
-            showNotification(theme);
-          });
-          const onClick2 = useEffectEvent(() => {
-            debounce(onClick);
-            debounce(() => onClick());
-          });
-          useInsertionEffect(() => {
-            onClick2();
-          });
-        }
-    "
+        r"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              useEffect(() => {
+                onClick();
+              });
+              React.useEffect(() => {
+                onClick();
+              });
+            }
+        ",
+        r"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              const onClick2 = useEffectEvent(() => {
+                debounce(onClick);
+                debounce(() => onClick());
+                debounce(() => { onClick() });
+                deboucne(() => debounce(onClick));
+              });
+              useEffect(() => {
+                let id = setInterval(() => onClick(), 100);
+                return () => clearInterval(onClick);
+              }, []);
+              React.useEffect(() => {
+                let id = setInterval(() => onClick(), 100);
+                return () => clearInterval(onClick);
+              }, []);
+              return null;
+            }
+        ",
+        r"
+            function MyComponent({ theme }) {
+              useEffect(() => {
+                onClick();
+              });
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+            }
+        ",
+        r"
+            function MyComponent({ theme }) {
+              const onEvent = useEffectEvent((text) => {
+                console.log(text);
+              });
+              useEffect(() => {
+                onEvent('Hello world');
+              });
+              React.useEffect(() => {
+                onEvent('Hello world');
+              });
+            }
+        ",
+        r"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              useLayoutEffect(() => {
+                onClick();
+              });
+              React.useLayoutEffect(() => {
+                onClick();
+              });
+            }
+        ",
+        r"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              useInsertionEffect(() => {
+                onClick();
+              });
+              React.useInsertionEffect(() => {
+                onClick();
+              });
+            }
+        ",
+        r"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              const onClick2 = useEffectEvent(() => {
+                debounce(onClick);
+                debounce(() => onClick());
+                debounce(() => { onClick() });
+                deboucne(() => debounce(onClick));
+              });
+              useLayoutEffect(() => {
+                let id = setInterval(() => onClick(), 100);
+                return () => clearInterval(onClick);
+              }, []);
+              React.useLayoutEffect(() => {
+                let id = setInterval(() => onClick(), 100);
+                return () => clearInterval(onClick);
+              }, []);
+              useInsertionEffect(() => {
+                let id = setInterval(() => onClick(), 100);
+                return () => clearInterval(onClick);
+              }, []);
+              React.useInsertionEffect(() => {
+                let id = setInterval(() => onClick(), 100);
+                return () => clearInterval(onClick);
+              }, []);
+              return null;
+            }
+        ",
     ];
+
+    let pass_additional_effect_hooks = vec![(
+        r"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              useMyEffect(() => {
+                onClick();
+              });
+              useServerEffect(() => {
+                onClick();
+              });
+            }
+        ",
+        None,
+        Some(serde_json::json!({
+            "settings": {
+                "react-hooks": {
+                    "additionalEffectHooks": "(useMyEffect|useServerEffect)"
+                }
+            }
+        })),
+    )];
 
     let fail = vec![
         // Invalid because it's dangerous and might not warn otherwise.
@@ -2348,20 +2492,24 @@ fn test() {
             }
         ",
         r"const Foo3 = hoc(function NamedComp(props) { if (props.cond) { const [_a, _b] = useState(false); } });",
+        r"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              useCustomHook(() => {
+                onClick();
+              });
+            }
+        ",
         r#"
             function MyComponent({ theme }) {
                 const onClick = useEffectEvent(() => {
                     showNotification(theme);
                 });
-                return <Child onClick={onClick} />;
+                return <Child onClick={onClick}></Child>;
             }
         "#,
-        r"
-            function useCustomHook() {
-                const onEvent = useEffectEvent(() => {});
-                return { onEvent };
-            }
-        ",
         r#"
             function MyComponent({ theme }) {
                 return <Child onClick={useEffectEvent(() => {
@@ -2370,15 +2518,114 @@ fn test() {
             }
         "#,
         r"
-            function MyComponent({ theme }) {
+            function MyComponent({theme}) {
                 const onClick = useEffectEvent(() => {
-                    showNotification(theme);
+                    showNotification(theme)
                 });
-                const handler = () => onClick();
-                return <Child onClick={handler} />;
+                return <Child onClick={onClick} />
+            }
+
+            function MyOtherComponent({theme}) {
+                const onClick = useEffectEvent(() => {
+                    showNotification(theme)
+                });
+                return <Child onClick={() => onClick()} />
+            }
+
+            function MyLastComponent({theme}) {
+                const onClick = useEffectEvent(() => {
+                    showNotification(theme)
+                });
+                useEffect(() => {
+                    onClick();
+                    onClick;
+                })
+                return <Child />
+            }
+        ",
+        r#"
+            const MyComponent = ({ theme }) => {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              return <Child onClick={onClick}></Child>;
+            }
+        "#,
+        r#"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              let foo = onClick;
+              return <Bar onClick={foo} />
+            }
+        "#,
+        r#"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              useEffect(() => {
+                setTimeout(onClick, 100);
+              });
+              return <Child onClick={onClick} />
+            }
+        "#,
+        r#"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              const onClick2 = () => { onClick() };
+              const onClick3 = useCallback(() => onClick(), []);
+              const onClick4 = onClick;
+              return <>
+                <Child onClick={onClick}></Child>
+                <Child onClick={onClick2}></Child>
+                <Child onClick={onClick3}></Child>
+              </>;
+            }
+        "#,
+        r"
+            function useCustomHook() {
+                const onEvent = useEffectEvent(() => {});
+                return { onEvent };
             }
         ",
     ];
 
-    Tester::new(RulesOfHooks::NAME, RulesOfHooks::PLUGIN, pass, fail).test_and_snapshot();
+    let fail_additional_effect_hooks = vec![(
+        r"
+            function MyComponent({ theme }) {
+              const onClick = useEffectEvent(() => {
+                showNotification(theme);
+              });
+              useWrongHook(() => {
+                onClick();
+              });
+            }
+        ",
+        None,
+        Some(serde_json::json!({
+            "settings": {
+                "react-hooks": {
+                    "additionalEffectHooks": "useMyEffect"
+                }
+            }
+        })),
+    )];
+
+    Tester::new(
+        RulesOfHooks::NAME,
+        RulesOfHooks::PLUGIN,
+        pass.iter()
+            .map(|&code| (code, None, None))
+            .chain(pass_additional_effect_hooks)
+            .collect::<Vec<_>>(),
+        fail.iter()
+            .map(|&code| (code, None, None))
+            .chain(fail_additional_effect_hooks)
+            .collect::<Vec<_>>(),
+    )
+    .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -2505,21 +2505,21 @@ fn test() {
               });
             }
         ",
-        r#"
+        r"
             function MyComponent({ theme }) {
                 const onClick = useEffectEvent(() => {
                     showNotification(theme);
                 });
                 return <Child onClick={onClick}></Child>;
             }
-        "#,
-        r#"
+        ",
+        r"
             function MyComponent({ theme }) {
                 return <Child onClick={useEffectEvent(() => {
                     showNotification(theme);
                 })} />;
             }
-        "#,
+        ",
         r"
             function MyComponent({theme}) {
                 const onClick = useEffectEvent(() => {
@@ -2546,15 +2546,15 @@ fn test() {
                 return <Child />
             }
         ",
-        r#"
+        r"
             const MyComponent = ({ theme }) => {
               const onClick = useEffectEvent(() => {
                 showNotification(theme);
               });
               return <Child onClick={onClick}></Child>;
             }
-        "#,
-        r#"
+        ",
+        r"
             function MyComponent({ theme }) {
               const onClick = useEffectEvent(() => {
                 showNotification(theme);
@@ -2562,8 +2562,8 @@ fn test() {
               let foo = onClick;
               return <Bar onClick={foo} />
             }
-        "#,
-        r#"
+        ",
+        r"
             function MyComponent({ theme }) {
               const onClick = useEffectEvent(() => {
                 showNotification(theme);
@@ -2573,8 +2573,8 @@ fn test() {
               });
               return <Child onClick={onClick} />
             }
-        "#,
-        r#"
+        ",
+        r"
             function MyComponent({ theme }) {
               const onClick = useEffectEvent(() => {
                 showNotification(theme);
@@ -2588,7 +2588,7 @@ fn test() {
                 <Child onClick={onClick3}></Child>
               </>;
             }
-        "#,
+        ",
         r"
             function useCustomHook() {
                 const onEvent = useEffectEvent(() => {});

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -168,8 +168,7 @@ mod diagnostics {
         called: bool,
     ) -> OxcDiagnostic {
         let mut message = format!(
-            "`{name}` is a function created with React Hook \"useEffectEvent\", and can only be called from \
-            Effects and Effect Events in the same component."
+            r#"`{name}` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component."#
         );
 
         if !called {
@@ -183,7 +182,7 @@ mod diagnostics {
 
     pub(super) fn use_effect_event_inline_escape(span: Span) -> OxcDiagnostic {
         OxcDiagnostic::warn(
-            "React Hook \"useEffectEvent\" can only be called at the top level of your component. It cannot be passed down.",
+            r#"React Hook "useEffectEvent" can only be called at the top level of your component. It cannot be passed down."#,
         )
         .with_label(span.label("Effect Event is passed directly instead of being assigned locally."))
         .with_error_code_scope(SCOPE)

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -784,6 +784,9 @@ fn check_use_effect_event_usage(
 ) {
     match ctx.nodes().parent_kind(node.id()) {
         AstKind::VariableDeclarator(decl) => {
+            if !is_somewhere_inside_component_or_hook(ctx.nodes(), node.id()) {
+                return;
+            }
             if let Some(ident) = decl.id.get_binding_identifier() {
                 let additional_effect_hooks = additional_effect_hooks(ctx);
                 report_invalid_use_effect_event_references(
@@ -2592,6 +2595,10 @@ fn test() {
                 return { onEvent };
             }
         ",
+        r"function notAComponent() {
+  const onEvent = useEffectEvent(() => {});
+  return onEvent;
+}",
     ];
 
     let fail_additional_effect_hooks = vec![(

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -1171,3 +1171,40 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                       ╰── When this condition is false, this Hook is skipped.
    ╰────
   help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
+   ╭─[rules_of_hooks.tsx:6:40]
+ 5 │                 });
+ 6 │                 return <Child onClick={onClick} />;
+   ·                                        ───┬───
+   ·                                           ╰── Effect Event escapes its component or custom Hook.
+ 7 │             }
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onEvent` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
+   ╭─[rules_of_hooks.tsx:4:26]
+ 3 │                 const onEvent = useEffectEvent(() => {});
+ 4 │                 return { onEvent };
+   ·                          ───┬───
+   ·                             ╰── Effect Event escapes its component or custom Hook.
+ 5 │             }
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): React Hook "useEffectEvent" can only be called at the top level of your component. It cannot be passed down.
+   ╭─[rules_of_hooks.tsx:3:40]
+ 2 │                 function MyComponent({ theme }) {
+ 3 │ ╭─▶                 return <Child onClick={useEffectEvent(() => {
+ 4 │ │                       showNotification(theme);
+ 5 │ ├─▶                 })} />;
+   · ╰──── Effect Event is passed directly instead of being assigned locally.
+ 6 │                 }
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component.
+   ╭─[rules_of_hooks.tsx:6:39]
+ 5 │                 });
+ 6 │                 const handler = () => onClick();
+   ·                                       ───┬───
+   ·                                          ╰── Effect Event escapes its component or custom Hook.
+ 7 │                 return <Child onClick={handler} />;
+   ╰────

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -1172,22 +1172,22 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Move the Hook call before the condition, or call it unconditionally and branch inside the Hook/effect instead.
 
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component.
+   ╭─[rules_of_hooks.tsx:7:17]
+ 6 │               useCustomHook(() => {
+ 7 │                 onClick();
+   ·                 ───┬───
+   ·                    ╰── Effect Event escapes its component or custom Hook.
+ 8 │               });
+   ╰────
+
   ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
    ╭─[rules_of_hooks.tsx:6:40]
  5 │                 });
- 6 │                 return <Child onClick={onClick} />;
+ 6 │                 return <Child onClick={onClick}></Child>;
    ·                                        ───┬───
    ·                                           ╰── Effect Event escapes its component or custom Hook.
  7 │             }
-   ╰────
-
-  ⚠ react-hooks(rules-of-hooks): `onEvent` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
-   ╭─[rules_of_hooks.tsx:4:26]
- 3 │                 const onEvent = useEffectEvent(() => {});
- 4 │                 return { onEvent };
-   ·                          ───┬───
-   ·                             ╰── Effect Event escapes its component or custom Hook.
- 5 │             }
    ╰────
 
   ⚠ react-hooks(rules-of-hooks): React Hook "useEffectEvent" can only be called at the top level of your component. It cannot be passed down.
@@ -1200,11 +1200,101 @@ source: crates/oxc_linter/src/tester.rs
  6 │                 }
    ╰────
 
-  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component.
-   ╭─[rules_of_hooks.tsx:6:39]
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
+   ╭─[rules_of_hooks.tsx:6:40]
  5 │                 });
- 6 │                 const handler = () => onClick();
-   ·                                       ───┬───
-   ·                                          ╰── Effect Event escapes its component or custom Hook.
- 7 │                 return <Child onClick={handler} />;
+ 6 │                 return <Child onClick={onClick} />
+   ·                                        ───┬───
+   ·                                           ╰── Effect Event escapes its component or custom Hook.
+ 7 │             }
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component.
+    ╭─[rules_of_hooks.tsx:13:46]
+ 12 │                 });
+ 13 │                 return <Child onClick={() => onClick()} />
+    ·                                              ───┬───
+    ·                                                 ╰── Effect Event escapes its component or custom Hook.
+ 14 │             }
+    ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
+   ╭─[rules_of_hooks.tsx:6:38]
+ 5 │               });
+ 6 │               return <Child onClick={onClick}></Child>;
+   ·                                      ───┬───
+   ·                                         ╰── Effect Event escapes its component or custom Hook.
+ 7 │             }
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
+   ╭─[rules_of_hooks.tsx:6:25]
+ 5 │               });
+ 6 │               let foo = onClick;
+   ·                         ───┬───
+   ·                            ╰── Effect Event escapes its component or custom Hook.
+ 7 │               return <Bar onClick={foo} />
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
+    ╭─[rules_of_hooks.tsx:9:38]
+  8 │               });
+  9 │               return <Child onClick={onClick} />
+    ·                                      ───┬───
+    ·                                         ╰── Effect Event escapes its component or custom Hook.
+ 10 │             }
+    ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component.
+   ╭─[rules_of_hooks.tsx:6:40]
+ 5 │               });
+ 6 │               const onClick2 = () => { onClick() };
+   ·                                        ───┬───
+   ·                                           ╰── Effect Event escapes its component or custom Hook.
+ 7 │               const onClick3 = useCallback(() => onClick(), []);
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component.
+   ╭─[rules_of_hooks.tsx:7:50]
+ 6 │               const onClick2 = () => { onClick() };
+ 7 │               const onClick3 = useCallback(() => onClick(), []);
+   ·                                                  ───┬───
+   ·                                                     ╰── Effect Event escapes its component or custom Hook.
+ 8 │               const onClick4 = onClick;
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
+   ╭─[rules_of_hooks.tsx:8:32]
+ 7 │               const onClick3 = useCallback(() => onClick(), []);
+ 8 │               const onClick4 = onClick;
+   ·                                ───┬───
+   ·                                   ╰── Effect Event escapes its component or custom Hook.
+ 9 │               return <>
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
+    ╭─[rules_of_hooks.tsx:10:33]
+  9 │               return <>
+ 10 │                 <Child onClick={onClick}></Child>
+    ·                                 ───┬───
+    ·                                    ╰── Effect Event escapes its component or custom Hook.
+ 11 │                 <Child onClick={onClick2}></Child>
+    ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onEvent` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.
+   ╭─[rules_of_hooks.tsx:4:26]
+ 3 │                 const onEvent = useEffectEvent(() => {});
+ 4 │                 return { onEvent };
+   ·                          ───┬───
+   ·                             ╰── Effect Event escapes its component or custom Hook.
+ 5 │             }
+   ╰────
+
+  ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component.
+   ╭─[rules_of_hooks.tsx:7:17]
+ 6 │               useWrongHook(() => {
+ 7 │                 onClick();
+   ·                 ───┬───
+   ·                    ╰── Effect Event escapes its component or custom Hook.
+ 8 │               });
    ╰────

--- a/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/react_rules_of_hooks.snap
@@ -1290,6 +1290,17 @@ source: crates/oxc_linter/src/tester.rs
  5 │             }
    ╰────
 
+  ⚠ react-hooks(rules-of-hooks): React Hook "useEffectEvent" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".
+   ╭─[rules_of_hooks.tsx:2:19]
+ 1 │ function notAComponent() {
+   ·          ──────┬──────
+   ·                ╰── Outer function
+ 2 │   const onEvent = useEffectEvent(() => {});
+   ·                   ───────┬──────
+   ·                          ╰── Hook is called here
+ 3 │   return onEvent;
+   ╰────
+
   ⚠ react-hooks(rules-of-hooks): `onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component.
    ╭─[rules_of_hooks.tsx:7:17]
  6 │               useWrongHook(() => {


### PR DESCRIPTION
Fixes #23744

## Summary

- Track local variables initialized from `useEffectEvent` in `react/rules-of-hooks`
- Report references that escape the component/custom hook instead of being called from an effect or another effect event
- Cover JSX prop, returned object, inline prop, and nested callback escape cases in the rule snapshot

## Test plan

- `cargo test -p oxc_linter rules_of_hooks -- --nocapture`
- `cargo fmt --check --package oxc_linter`
- `git diff --check`

AI assistance was used to prepare this change; I reviewed and validated the implementation and tests.
