### PR TITLE
docs(ast): correct doc comment for `NONE`

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -7,7 +7,7 @@ use oxc_syntax::{number::NumberBase, operator::UnaryOperator, scope::ScopeId};
 
 use crate::ast::*;
 
-/// Type that can be used in any AST builder method call which requires an `IntoIn<'a, Anything<'a>>`.
+/// Type that can be used in any AST builder method call which requires an `IntoIn<'a, Option<Anything<'a>>>`.
 /// Pass `NONE` instead of `None::<Anything<'a>>`.
 #[expect(clippy::upper_case_acronyms)]
 pub struct NONE;


### PR DESCRIPTION
Just fix an inaccurate doc comment.