### PR TITLE
fix(ast): fix name of `AstBuilder` method for `Expression::V8IntrinsicExpression`

### DIFF
--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -1203,7 +1203,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`
     /// * `arguments`
     #[inline]
-    pub fn expression_v_8_intrinsic(
+    pub fn expression_v8_intrinsic(
         self,
         span: Span,
         name: IdentifierName<'a>,

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -699,7 +699,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
             )
         });
         self.expect(Kind::RParen);
-        self.ast.expression_v_8_intrinsic(self.end_span(span), name, arguments)
+        self.ast.expression_v8_intrinsic(self.end_span(span), name, arguments)
     }
 
     fn parse_v8_intrinsic_argument(&mut self) -> Argument<'a> {

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Ident;
 
-use crate::utils::{create_ident, pluralize};
+use crate::utils::{create_ident, pluralize, snake_case};
 
 use super::{
     Containers, Def, Derives, File, FileId, Schema, TypeDef, TypeId, Visibility,
@@ -201,7 +201,7 @@ impl VariantDef {
 
     /// Get variant name in snake case.
     pub fn snake_name(&self) -> String {
-        self.name().to_case(Case::Snake)
+        snake_case(self.name())
     }
 
     /// Get variant name in camel case.

--- a/tasks/ast_tools/src/schema/defs/mod.rs
+++ b/tasks/ast_tools/src/schema/defs/mod.rs
@@ -1,4 +1,3 @@
-use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Ident;
@@ -6,7 +5,7 @@ use syn::Ident;
 use crate::{
     codegen::DeriveId,
     schema::{File, Schema},
-    utils::create_ident,
+    utils::{create_ident, snake_case},
 };
 
 use super::{Derives, FileId, TypeId, extensions};
@@ -50,11 +49,8 @@ pub trait Def {
     fn has_lifetime(&self, schema: &Schema) -> bool;
 
     /// Get type name in snake case.
-    ///
-    /// `convert_case` splits `V8` into `v` + `8`, producing `v_8_intrinsic_expression`.
-    /// We fix this to `v8_intrinsic_expression` to match the conventional naming.
     fn snake_name(&self) -> String {
-        fix_snake_case(&self.name().to_case(Case::Snake))
+        snake_case(self.name())
     }
 
     /// Get type name as an [`Ident`].
@@ -118,27 +114,6 @@ pub trait Def {
             &schema.types[self.id()]
         }
     }
-}
-
-/// Fix `convert_case`'s snake_case output which inserts underscores between letters and digits.
-///
-/// e.g. `v_8_intrinsic_expression` -> `v8_intrinsic_expression`.
-fn fix_snake_case(s: &str) -> String {
-    let bytes = s.as_bytes();
-    let mut result = String::with_capacity(s.len());
-    for (i, &byte) in bytes.iter().enumerate() {
-        // Skip underscores between a letter and a digit
-        if byte == b'_'
-            && i > 0
-            && i + 1 < bytes.len()
-            && bytes[i - 1].is_ascii_alphabetic()
-            && bytes[i + 1].is_ascii_digit()
-        {
-            continue;
-        }
-        result.push(byte as char);
-    }
-    result
 }
 
 /// IDs of container types containing a type.

--- a/tasks/ast_tools/src/utils.rs
+++ b/tasks/ast_tools/src/utils.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use convert_case::{Case, Casing};
 use indexmap::{IndexMap, IndexSet};
 use phf::{Set as PhfSet, phf_set};
 use proc_macro2::{Span, TokenStream};
@@ -102,6 +103,31 @@ pub fn upper_case_first(s: &str) -> Cow<'_, str> {
     } else {
         Cow::Owned(first_char.to_uppercase().chain(chars).collect::<String>())
     }
+}
+
+/// Convert type name to snake case.
+///
+/// e.g. `ExpressionStatement` -> `expression_statement`.
+///
+/// Fixup `convert_case`'s output which inserts underscores between letters and digits.
+/// e.g. `v_8_intrinsic_expression` -> `v8_intrinsic_expression`.
+pub fn snake_case(s: &str) -> String {
+    let s = s.to_case(Case::Snake);
+    let bytes = s.as_bytes();
+    let mut result = String::with_capacity(s.len());
+    for (i, &byte) in bytes.iter().enumerate() {
+        // Skip underscores between a letter and a digit
+        if byte == b'_'
+            && i > 0
+            && i + 1 < bytes.len()
+            && bytes[i - 1].is_ascii_alphabetic()
+            && bytes[i + 1].is_ascii_digit()
+        {
+            continue;
+        }
+        result.push(byte as char);
+    }
+    result
 }
 
 /// Macro to `format!` arguments, and wrap the formatted string in a `Cow::Owned`.


### PR DESCRIPTION
`ast_tools` codegen handles of converting types names to snake case. It ensures that `V8IntrinsicExpression` is converted to `v8_intrinsic_expression` not `v_8_intrinsic_expression`.

However, this special case was missed out when converting enum variant names.

Fix this, which results in `AstBuilder::expression_v_8_intrinsic` being corrected to `expression_v8_intrinsic`.