### PR TITLE
perf(lsp): avoid blocking on diagnostic requests

### DIFF
--- a/apps/oxfmt/src/lsp/server_formatter.rs
+++ b/apps/oxfmt/src/lsp/server_formatter.rs
@@ -234,7 +234,7 @@ impl Tool for ServerFormatter {
                 .ok_or_else(|| "In-memory formatting requires content".to_string())?;
 
             let Some(result) =
-                self.format_in_memory(document.uri, source_text, &document.language_id)
+                self.format_in_memory(&document.uri, source_text, &document.language_id)
             else {
                 return Ok(vec![]); // currently not supported
             };

--- a/apps/oxlint/src/lsp/server_linter.rs
+++ b/apps/oxlint/src/lsp/server_linter.rs
@@ -643,7 +643,7 @@ impl Tool for ServerLinter {
     /// Lint a file with the current linter
     /// - If the file is not lintable or ignored, an empty vector is returned
     fn run_diagnostic(&self, document: &TextDocument) -> DiagnosticResult {
-        Ok(vec![(document.uri.clone(), self.run_file(document.uri, document.text.as_deref())?)])
+        Ok(vec![(document.uri.clone(), self.run_file(&document.uri, document.text.as_deref())?)])
     }
 
     /// Lint a file with the current linter

--- a/apps/oxlint/src/lsp/tester.rs
+++ b/apps/oxlint/src/lsp/tester.rs
@@ -226,7 +226,7 @@ impl Tester<'_> {
             let range = Range::new(Position::new(0, 0), Position::new(u32::MAX, u32::MAX));
             let reports = FileResult {
                 diagnostic: linter.run_diagnostic(&TextDocument::new(
-                    &uri,
+                    uri.clone(),
                     oxc_language_server::LanguageId::default(),
                     None,
                 )),

--- a/crates/oxc_language_server/src/backend.rs
+++ b/crates/oxc_language_server/src/backend.rs
@@ -25,7 +25,6 @@ use crate::{
     capabilities::{Capabilities, DiagnosticMode, server_capabilities},
     file_system::LSPFileSystem,
     options::WorkspaceOption,
-    worker::WorkspaceWorker,
     worker_manager::WorkerManager,
 };
 
@@ -74,7 +73,7 @@ pub struct Backend {
 impl LanguageServer for Backend {
     /// Initialize the language server with the given parameters.
     /// This method sets up workspace workers, capabilities, and starts the
-    /// [WorkspaceWorker]s if the client sent the configuration with initialization options.
+    /// [crate::worker::WorkspaceWorker]s if the client sent the configuration with initialization options.
     ///
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize>
     #[expect(deprecated)] // `params.root_uri` is deprecated, we are only falling back to it if no workspace folder is provided
@@ -184,9 +183,9 @@ impl LanguageServer for Backend {
     }
 
     /// It registers dynamic capabilities like file watchers and formatting if the client supports it.
-    /// It also starts the [WorkspaceWorker]s if they did not start during initialization.
+    /// It also starts the [crate::worker::WorkspaceWorker]s if they did not start during initialization.
     /// If the client supports `workspace/configuration` request, it will request the configuration for each workspace folder
-    /// and start the [WorkspaceWorker]s with the received configuration.
+    /// and start the [crate::worker::WorkspaceWorker]s with the received configuration.
     ///
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialized>
     async fn initialized(&self, _params: InitializedParams) {
@@ -236,7 +235,7 @@ impl LanguageServer for Backend {
                     let Some(worker) = self.worker_manager.get_worker_for_uri(uri).await else {
                         continue;
                     };
-                    let document = self.file_system.get_document(uri);
+                    let document = self.file_system.get_document(uri.clone());
                     let diagnostics = worker.run_diagnostic(&document).await;
                     match diagnostics {
                         Err(err) => {
@@ -315,7 +314,7 @@ impl LanguageServer for Backend {
         Ok(())
     }
 
-    /// This method updates the configuration of each [WorkspaceWorker] and restarts them if necessary.
+    /// This method updates the configuration of each [crate::worker::WorkspaceWorker] and restarts them if necessary.
     /// It also manages dynamic registrations for file watchers and formatting based on the new configuration.
     /// It will remove/add dynamic registrations if the client supports it.
     /// As an example, if a workspace changes the configuration file path, the file watcher will be updated.
@@ -359,7 +358,7 @@ impl LanguageServer for Backend {
         {
             let configs = self
                 .request_workspace_configuration(
-                    workers.iter().map(WorkspaceWorker::get_root_uri).collect(),
+                    workers.iter().map(|worker| worker.get_root_uri()).collect(),
                 )
                 .await;
 
@@ -495,8 +494,8 @@ impl LanguageServer for Backend {
         }
     }
 
-    /// The server will start new [WorkspaceWorker]s for added workspace folders
-    /// and stop and remove [WorkspaceWorker]s for removed workspace folders including:
+    /// The server will start new [crate::worker::WorkspaceWorker]s for added workspace folders
+    /// and stop and remove [crate::worker::WorkspaceWorker]s for removed workspace folders including:
     /// - clearing diagnostics
     /// - unregistering file watchers
     ///
@@ -584,10 +583,21 @@ impl LanguageServer for Backend {
             let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
                 return;
             };
-            let document = self.file_system.get_document(&uri);
-            match worker.run_diagnostic_on_save(&document).await {
+            let document = self.file_system.get_document(uri);
+            let document_uri = document.uri.clone();
+            let handle = tokio::runtime::Handle::current();
+            // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
+            let diagnostics = tokio::task::spawn_blocking(move || {
+                handle.block_on(async move { worker.run_diagnostic_on_save(&document).await })
+            })
+            .await
+            // unwrap because we want to panic if the task panics,
+            // because it should not happen and we want to know about it.
+            .unwrap();
+
+            match diagnostics {
                 Err(err) => {
-                    error!("running diagnostics for {} failed: {err}", uri.as_str());
+                    error!("running diagnostics for {} failed: {err}", document_uri.as_str());
                     if self.capabilities.get().is_some_and(|cap| cap.show_message) {
                         self.client.show_message(MessageType::ERROR, err).await;
                     }
@@ -615,9 +625,6 @@ impl LanguageServer for Backend {
         {
             self.file_system.set(uri.clone(), content);
         }
-
-        let document = self.file_system.get_document(&uri);
-
         let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
             return;
         };
@@ -628,10 +635,23 @@ impl LanguageServer for Backend {
         // Sadly, some editors/extensions have bugs, so we need to make sure the cache is cleared on change.
         worker.remove_uri_cache(&uri).await;
 
+        let document = self.file_system.get_document(uri);
+
         if self.capabilities.get().is_some_and(|cap| cap.diagnostic_mode == DiagnosticMode::Push) {
-            match worker.run_diagnostic_on_change(&document).await {
+            let document_uri = document.uri.clone();
+            let handle = tokio::runtime::Handle::current();
+            // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
+            let diagnostics = tokio::task::spawn_blocking(move || {
+                handle.block_on(async move { worker.run_diagnostic_on_change(&document).await })
+            })
+            .await
+            // unwrap because we want to panic if the task panics,
+            // because it should not happen and we want to know about it.
+            .unwrap();
+
+            match diagnostics {
                 Err(err) => {
-                    error!("running diagnostics for {} failed: {err}", uri.as_str());
+                    error!("running diagnostics for {} failed: {err}", document_uri.as_str());
                     if self.capabilities.get().is_some_and(|cap| cap.show_message) {
                         self.client.show_message(MessageType::ERROR, err).await;
                     }
@@ -639,7 +659,7 @@ impl LanguageServer for Backend {
                 Ok(diagnostics) => {
                     if !diagnostics.is_empty() {
                         let version_map = ConcurrentHashMap::default();
-                        version_map.pin().insert(uri.clone(), params.text_document.version);
+                        version_map.pin().insert(document_uri, params.text_document.version);
                         self.publish_all_diagnostics(diagnostics, version_map).await;
                     }
                 }
@@ -651,7 +671,7 @@ impl LanguageServer for Backend {
     /// It will lint the file and send diagnostics, if necessary.
     ///
     /// In single file mode (no workspace was configured during initialize), a new
-    /// [WorkspaceWorker] is created dynamically using the file's parent directory as
+    /// [crate::worker::WorkspaceWorker] is created dynamically using the file's parent directory as
     /// the workspace root if no existing worker covers the URI.
     ///
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didOpen>
@@ -687,11 +707,22 @@ impl LanguageServer for Backend {
                 return;
             };
 
-            let document = self.file_system.get_document(&uri);
+            let document = self.file_system.get_document(uri);
 
-            match worker.run_diagnostic(&document).await {
+            let document_uri = document.uri.clone();
+            let handle = tokio::runtime::Handle::current();
+            // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
+            let diagnostics = tokio::task::spawn_blocking(move || {
+                handle.block_on(async move { worker.run_diagnostic(&document).await })
+            })
+            .await
+            // unwrap because we want to panic if the task panics,
+            // because it should not happen and we want to know about it.
+            .unwrap();
+
+            match diagnostics {
                 Err(err) => {
-                    error!("running diagnostics for {} failed: {err}", uri.as_str());
+                    error!("running diagnostics for {} failed: {err}", document_uri.as_str());
                     if self.capabilities.get().is_some_and(|cap| cap.show_message) {
                         self.client.show_message(MessageType::ERROR, err).await;
                     }
@@ -699,7 +730,7 @@ impl LanguageServer for Backend {
                 Ok(diagnostics) => {
                     if !diagnostics.is_empty() {
                         let version_map = ConcurrentHashMap::default();
-                        version_map.pin().insert(uri, params.text_document.version);
+                        version_map.pin().insert(document_uri, params.text_document.version);
                         self.publish_all_diagnostics(diagnostics, version_map).await;
                     }
                 }
@@ -837,15 +868,23 @@ impl LanguageServer for Backend {
         &self,
         params: DocumentDiagnosticParams,
     ) -> Result<DocumentDiagnosticReportResult> {
-        let uri = &params.text_document.uri;
-        let Some(worker) = self.worker_manager.get_worker_for_uri(uri).await else {
+        let uri = params.text_document.uri;
+        let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
             return Ok(DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(
                 RelatedFullDocumentDiagnosticReport::default(),
             )));
         };
+        let document = self.file_system.get_document(uri.clone());
 
-        let document = self.file_system.get_document(uri);
-        let diagnostics = worker.run_diagnostic(&document).await;
+        let handle = tokio::runtime::Handle::current();
+        // use `spawn_blocking` because this is a very CPU intensive task and we do not want to block the async runtime.
+        let diagnostics = tokio::task::spawn_blocking(move || {
+            handle.block_on(async move { worker.run_diagnostic(&document).await })
+        })
+        .await
+        // unwrap because we want to panic if the task panics,
+        // because it should not happen and we want to know about it.
+        .unwrap();
 
         let diagnostics = match diagnostics {
             Err(err) => {
@@ -861,12 +900,12 @@ impl LanguageServer for Backend {
 
         let uri_diagnostics = diagnostics
             .iter()
-            .filter(|(diag_uri, _)| diag_uri == uri)
+            .filter(|(diag_uri, _)| *diag_uri == uri)
             .flat_map(|(_, diags)| diags.clone())
             .collect::<Vec<_>>();
 
         let related_diagnostics =
-            diagnostics.into_iter().filter(|(diag_uri, _)| diag_uri != uri).collect::<Vec<_>>();
+            diagnostics.into_iter().filter(|(diag_uri, _)| *diag_uri != uri).collect::<Vec<_>>();
 
         Ok(DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(
             RelatedFullDocumentDiagnosticReport {
@@ -902,8 +941,8 @@ impl LanguageServer for Backend {
     ///
     /// See: <https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting>
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {
-        let uri = &params.text_document.uri;
-        let Some(worker) = self.worker_manager.get_worker_for_uri(uri).await else {
+        let uri = params.text_document.uri;
+        let Some(worker) = self.worker_manager.get_worker_for_uri(&uri).await else {
             return Ok(None);
         };
 
@@ -924,7 +963,7 @@ impl LanguageServer for Backend {
 
 impl Backend {
     /// Create a new Backend with the given client.
-    /// The Backend will manage multiple [WorkspaceWorker]s and their configurations.
+    /// The Backend will manage multiple [crate::worker::WorkspaceWorker]s and their configurations.
     /// It also holds the capabilities of the language server and an in-memory file system.
     /// The client is used to communicate with the LSP client.
     pub fn new(client: Client, server_info: ServerInfo, worker_manager: WorkerManager) -> Self {

--- a/crates/oxc_language_server/src/file_system.rs
+++ b/crates/oxc_language_server/src/file_system.rs
@@ -92,15 +92,12 @@ impl LSPFileSystem {
         self.files.pin().get(uri).map(|(lang, _)| lang.clone())
     }
 
-    pub fn get_document<'a>(&self, uri: &'a Uri) -> TextDocument<'a> {
-        self.files.pin().get(uri).map_or_else(
-            || TextDocument { uri, language_id: LanguageId::default(), text: None },
-            |(language_id, content)| TextDocument {
-                uri,
-                language_id: language_id.clone(),
-                text: Some(Arc::clone(content)),
-            },
-        )
+    pub fn get_document(&self, uri: Uri) -> TextDocument {
+        let binding = self.files.pin();
+        let Some((language_id, content)) = binding.get(&uri) else {
+            return TextDocument { uri, language_id: LanguageId::default(), text: None };
+        };
+        TextDocument { uri, language_id: language_id.clone(), text: Some(Arc::clone(content)) }
     }
 
     pub fn remove(&self, uri: &Uri) {

--- a/crates/oxc_language_server/src/lib.rs
+++ b/crates/oxc_language_server/src/lib.rs
@@ -26,14 +26,14 @@ pub use crate::worker_manager::WorkerManager;
 pub type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 
 #[derive(Debug)]
-pub struct TextDocument<'a> {
-    pub uri: &'a Uri,
+pub struct TextDocument {
+    pub uri: Uri,
     pub language_id: LanguageId,
     pub text: Option<Arc<str>>,
 }
 
-impl<'a> TextDocument<'a> {
-    pub fn new(uri: &'a Uri, language_id: LanguageId, text: Option<Arc<str>>) -> Self {
+impl TextDocument {
+    pub fn new(uri: Uri, language_id: LanguageId, text: Option<Arc<str>>) -> Self {
         Self { uri, language_id, text }
     }
 }

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -2235,8 +2235,8 @@ mod test_suite {
         use crate::tests::{FakeToolDelays, create_dynamic_workspace_manager};
 
         use super::*;
+
         #[tokio::test]
-        #[ignore = "This needs to be fixed"]
         async fn test_request_locks() {
             let delay = 100;
             let mut server = TestServer::new_initialized(

--- a/crates/oxc_language_server/src/tests.rs
+++ b/crates/oxc_language_server/src/tests.rs
@@ -20,21 +20,31 @@ use crate::{
 pub struct FakeToolBuilder {
     diagnostic_mode: DiagnosticMode,
     cache_uris: Option<Arc<Mutex<Vec<Uri>>>>,
+    delays: FakeToolDelays,
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct FakeToolDelays {
+    run_diagnostic: u64,
 }
 
 impl FakeToolBuilder {
     pub fn new(diagnostic_mode: DiagnosticMode) -> Self {
-        Self { diagnostic_mode, cache_uris: None }
+        Self { diagnostic_mode, cache_uris: None, delays: FakeToolDelays::default() }
     }
 
     pub fn with_cache_tracking(self, cache_uris: Arc<Mutex<Vec<Uri>>>) -> Self {
         Self { cache_uris: Some(cache_uris), ..self }
     }
+
+    pub fn with_delays(self, delays: FakeToolDelays) -> Self {
+        Self { delays, ..self }
+    }
 }
 
 impl ToolBuilder for FakeToolBuilder {
     fn build_boxed(&self, _root_uri: &Uri, _options: serde_json::Value) -> Box<dyn Tool> {
-        Box::new(FakeTool { cache_uris: self.cache_uris.clone() })
+        Box::new(FakeTool { cache_uris: self.cache_uris.clone(), delays: self.delays })
     }
 
     fn server_capabilities(
@@ -56,6 +66,7 @@ impl ToolBuilder for FakeToolBuilder {
 
 pub struct FakeTool {
     cache_uris: Option<Arc<Mutex<Vec<Uri>>>>,
+    delays: FakeToolDelays,
 }
 
 pub const FAKE_COMMAND: &str = "fake.command";
@@ -155,6 +166,9 @@ impl Tool for FakeTool {
     }
 
     fn run_diagnostic(&self, document: &TextDocument) -> DiagnosticResult {
+        if self.delays.run_diagnostic > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(self.delays.run_diagnostic));
+        }
         if let Some(cache_uris) = &self.cache_uris {
             cache_uris.lock().unwrap().push(document.uri.clone());
         }
@@ -2212,6 +2226,71 @@ mod test_suite {
             server.send_ack(&Id::Number(0)).await;
 
             server.shutdown(2).await;
+        }
+    }
+
+    mod request_locks {
+        use std::time::Instant;
+
+        use crate::tests::{FakeToolDelays, create_dynamic_workspace_manager};
+
+        use super::*;
+        #[tokio::test]
+        #[ignore = "This needs to be fixed"]
+        async fn test_request_locks() {
+            let delay = 100;
+            let mut server = TestServer::new_initialized(
+                |client| {
+                    Backend::new(
+                        client,
+                        server_info(),
+                        create_dynamic_workspace_manager(
+                            FakeToolBuilder::new(DiagnosticMode::Pull)
+                                .with_delays(FakeToolDelays { run_diagnostic: delay }),
+                        ),
+                    )
+                },
+                initialize_request(InitializeRequestOptions::default()),
+            )
+            .await;
+
+            let file = format!("{WORKSPACE}/diagnostics.config");
+            server.send_request(did_open(&file, "content")).await;
+
+            let now = Instant::now();
+
+            // Send multiple diagnostic requests
+            for i in 0..5 {
+                server.send_request(diagnostic(1 + i, &file)).await;
+            }
+            server.send_request(code_action(6, &file)).await;
+
+            let mut diagnostic_responses = 0;
+            loop {
+                let response = server.recv_response().await;
+                if response.id() == &Id::Number(6) {
+                    break;
+                }
+                diagnostic_responses += 1;
+            }
+
+            let elapsed = now.elapsed().as_millis();
+
+            while diagnostic_responses < 5 {
+                let response = server.recv_response().await;
+                assert_ne!(response.id(), &Id::Number(6));
+                diagnostic_responses += 1;
+            }
+
+            server.shutdown(7).await;
+
+            // The diagnostic request should not block the code action request,
+            // so the total elapsed time should be less than delay * number of diagnostic requests.
+            assert!(
+                elapsed < u128::from(delay * 5),
+                "Diagnostic requests are blocking the code action request, elapsed time: {elapsed}ms, expected under {}ms",
+                delay * 5
+            );
         }
     }
 }

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -102,7 +102,7 @@ impl WorkspaceWorker {
     /// Common aggregator for tool-provided diagnostics.
     async fn collect_diagnostics_with<F>(
         &self,
-        document: &TextDocument<'_>,
+        document: &TextDocument,
         run: F,
     ) -> Result<Vec<(Uri, Vec<Diagnostic>)>, String>
     where
@@ -149,7 +149,7 @@ impl WorkspaceWorker {
     /// When calling `Tool::run_diagnostic` results into an error.
     pub async fn run_diagnostic(
         &self,
-        document: &TextDocument<'_>,
+        document: &TextDocument,
     ) -> Result<Vec<(Uri, Vec<Diagnostic>)>, String> {
         self.collect_diagnostics_with(document, |tool, document| tool.run_diagnostic(document))
             .await
@@ -161,7 +161,7 @@ impl WorkspaceWorker {
     /// When calling `Tool::run_diagnostic_on_change` results into an error.
     pub async fn run_diagnostic_on_change(
         &self,
-        document: &TextDocument<'_>,
+        document: &TextDocument,
     ) -> Result<Vec<(Uri, Vec<Diagnostic>)>, String> {
         self.collect_diagnostics_with(document, |tool, document| {
             tool.run_diagnostic_on_change(document)
@@ -175,7 +175,7 @@ impl WorkspaceWorker {
     /// When calling `Tool::run_diagnostic_on_save` results into an error.
     pub async fn run_diagnostic_on_save(
         &self,
-        document: &TextDocument<'_>,
+        document: &TextDocument,
     ) -> Result<Vec<(Uri, Vec<Diagnostic>)>, String> {
         self.collect_diagnostics_with(document, |tool, document| {
             tool.run_diagnostic_on_save(document)
@@ -190,7 +190,7 @@ impl WorkspaceWorker {
     ///
     /// # Errors
     /// When calling `Tool::run_format` results into an error.
-    pub async fn format_file(&self, document: &TextDocument<'_>) -> Result<Vec<TextEdit>, String> {
+    pub async fn format_file(&self, document: &TextDocument) -> Result<Vec<TextEdit>, String> {
         let tool_guard = self.tool.read().await;
         let Some(tool) = tool_guard.as_ref() else {
             return Ok(Vec::new());
@@ -348,7 +348,7 @@ impl WorkspaceWorker {
             };
 
             for uri in file_system.keys() {
-                let document = file_system.get_document(&uri);
+                let document = file_system.get_document(uri);
                 let Ok(mut reports) = tool.run_diagnostic(&document) else {
                     // If diagnostics could not be run, skip this URI, but continue with others
                     // TODO: Should we aggregate errors instead? One by one, or all together?
@@ -735,7 +735,7 @@ mod tests {
         worker.start_worker(serde_json::Value::Null).await;
 
         let diagnostics_no_content = worker
-            .run_diagnostic(&TextDocument::new(&uri, LanguageId::default(), None))
+            .run_diagnostic(&TextDocument::new(uri.clone(), LanguageId::default(), None))
             .await
             .unwrap();
 
@@ -749,7 +749,7 @@ mod tests {
 
         let diagnostics_with_content = worker
             .run_diagnostic(&TextDocument::new(
-                &uri,
+                uri.clone(),
                 LanguageId::default(),
                 Some(Arc::from("helloworld")),
             ))
@@ -766,7 +766,7 @@ mod tests {
 
         let no_diagnostics = worker
             .run_diagnostic(&TextDocument::new(
-                &Uri::from_str("file:///root/unknown.file").unwrap(),
+                Uri::from_str("file:///root/unknown.file").unwrap(),
                 LanguageId::default(),
                 None,
             ))
@@ -777,7 +777,7 @@ mod tests {
 
         let error = worker
             .run_diagnostic(&TextDocument::new(
-                &Uri::from_str("file:///root/error.config").unwrap(),
+                Uri::from_str("file:///root/error.config").unwrap(),
                 LanguageId::default(),
                 None,
             ))
@@ -799,7 +799,7 @@ mod tests {
         worker.start_worker(serde_json::Value::Null).await;
 
         let diagnostics_no_content = worker
-            .run_diagnostic_on_change(&TextDocument::new(&uri, LanguageId::default(), None))
+            .run_diagnostic_on_change(&TextDocument::new(uri.clone(), LanguageId::default(), None))
             .await
             .unwrap();
 
@@ -813,7 +813,7 @@ mod tests {
 
         let diagnostics_with_content = worker
             .run_diagnostic_on_change(&TextDocument::new(
-                &uri,
+                uri.clone(),
                 LanguageId::default(),
                 Some(Arc::from("helloworld")),
             ))
@@ -830,7 +830,7 @@ mod tests {
 
         let no_diagnostics = worker
             .run_diagnostic_on_change(&TextDocument::new(
-                &Uri::from_str("file:///root/unknown.file").unwrap(),
+                Uri::from_str("file:///root/unknown.file").unwrap(),
                 LanguageId::default(),
                 None,
             ))
@@ -841,7 +841,7 @@ mod tests {
 
         let error = worker
             .run_diagnostic_on_change(&TextDocument::new(
-                &Uri::from_str("file:///root/error.config").unwrap(),
+                Uri::from_str("file:///root/error.config").unwrap(),
                 LanguageId::default(),
                 None,
             ))
@@ -862,7 +862,7 @@ mod tests {
         worker.start_worker(serde_json::Value::Null).await;
 
         let diagnostics_no_content = worker
-            .run_diagnostic_on_save(&TextDocument::new(&uri, LanguageId::default(), None))
+            .run_diagnostic_on_save(&TextDocument::new(uri.clone(), LanguageId::default(), None))
             .await
             .unwrap();
 
@@ -876,7 +876,7 @@ mod tests {
 
         let diagnostics_with_content = worker
             .run_diagnostic_on_save(&TextDocument::new(
-                &uri,
+                uri.clone(),
                 LanguageId::default(),
                 Some(Arc::from("helloworld")),
             ))
@@ -893,7 +893,7 @@ mod tests {
 
         let no_diagnostics = worker
             .run_diagnostic_on_save(&TextDocument::new(
-                &Uri::from_str("file:///root/unknown.file").unwrap(),
+                Uri::from_str("file:///root/unknown.file").unwrap(),
                 LanguageId::default(),
                 None,
             ))
@@ -904,7 +904,7 @@ mod tests {
 
         let error = worker
             .run_diagnostic_on_save(&TextDocument::new(
-                &Uri::from_str("file:///root/error.config").unwrap(),
+                Uri::from_str("file:///root/error.config").unwrap(),
                 LanguageId::default(),
                 None,
             ))

--- a/crates/oxc_language_server/src/worker_manager.rs
+++ b/crates/oxc_language_server/src/worker_manager.rs
@@ -16,32 +16,6 @@ use crate::{
     worker::WorkspaceWorker,
 };
 
-enum WorkerGuardInner<'a> {
-    Vec(RwLockReadGuard<'a, Vec<WorkspaceWorker>>),
-    Single(&'a WorkspaceWorker),
-}
-
-/// A RAII guard that holds a shared read lock over the workers list and exposes
-/// a reference to a single [`WorkspaceWorker`] inside it.
-///
-/// Obtained from [`WorkerManager::get_worker_for_uri`].
-/// The read lock is held for as long as this guard is alive.
-pub struct WorkerGuard<'a> {
-    guard: WorkerGuardInner<'a>,
-    index: usize,
-}
-
-impl std::ops::Deref for WorkerGuard<'_> {
-    type Target = WorkspaceWorker;
-
-    fn deref(&self) -> &Self::Target {
-        match &self.guard {
-            WorkerGuardInner::Vec(vec_guard) => &vec_guard[self.index],
-            WorkerGuardInner::Single(single_guard) => single_guard,
-        }
-    }
-}
-
 /// The mode that the [`WorkerManager`] is operating in, which determines how it manages workers and delegates the task to the tool.
 pub enum ManagerMode {
     // the manager works in 2 modes, when no workspaces are configured, it creates workers dynamically for file URIs.
@@ -53,7 +27,7 @@ pub enum ManagerMode {
     // The manager will create workers dynamically for file URIs. It also supports workspaces configured by the client, but does not require them.
     // This is useful for tasks on URIs that are outside of any configured workspace.
     // At first it is `None` until the diagnostic mode is known, then it is set to a worker with the root URI `file:///` and the same diagnostic mode as the other workers.
-    DynamicWithWorkspaces(Box<OnceCell<WorkspaceWorker>>),
+    DynamicWithWorkspaces(Box<OnceCell<Arc<WorkspaceWorker>>>),
 }
 
 /// Manages the lifecycle of [`WorkspaceWorker`]s for the language server.
@@ -68,10 +42,10 @@ pub enum ManagerMode {
 /// - Dynamically creating / tearing down workers in single-file mode.
 /// - Handling workspace-folder additions and removals atomically.
 ///
-/// **Workers are never cloned** – they are expensive and each root URI must
-/// have at most one live worker at any point in time.
+/// Workers are stored behind [`Arc`] so request handlers can move a cheap handle
+/// into background tasks while each root URI still has at most one live worker.
 pub struct WorkerManager {
-    workers: RwLock<Vec<WorkspaceWorker>>,
+    workers: RwLock<Vec<Arc<WorkspaceWorker>>>,
     mode: ManagerMode,
     tool_builder: Arc<dyn ToolBuilder>,
 }
@@ -104,7 +78,7 @@ impl WorkerManager {
         workers: Vec<WorkspaceWorker>,
         diagnostic_mode: DiagnosticMode,
     ) {
-        *self.workers.write().await = workers;
+        *self.workers.write().await = workers.into_iter().map(Arc::new).collect();
 
         // for dynamic workspaces we need to start them manually
         if let ManagerMode::DynamicWithWorkspaces(cell) = &self.mode {
@@ -113,11 +87,11 @@ impl WorkerManager {
                 "dynamic worker should not be set when starting the manager"
             );
 
-            let worker = WorkspaceWorker::new(
+            let worker = Arc::new(WorkspaceWorker::new(
                 "file:///".parse().unwrap(),
                 Arc::clone(&self.tool_builder),
                 diagnostic_mode,
-            );
+            ));
             worker.start_worker(serde_json::Value::Null).await;
 
             let _ = cell.set(worker);
@@ -155,14 +129,14 @@ impl WorkerManager {
 
     /// Acquire a shared read lock over the worker list.
     /// Does not include the dynamic worker in `DynamicWithWorkspaces` mode, which must be accessed by `read_dynamic_worker`.
-    pub async fn read_workspace_workers(&self) -> RwLockReadGuard<'_, Vec<WorkspaceWorker>> {
+    pub async fn read_workspace_workers(&self) -> RwLockReadGuard<'_, Vec<Arc<WorkspaceWorker>>> {
         self.workers.read().await
     }
 
     /// Return the dynamic worker from `DynamicWithWorkspaces` mode, if enabled.
-    pub fn read_dynamic_worker(&self) -> Option<&WorkspaceWorker> {
+    pub fn read_dynamic_worker(&self) -> Option<Arc<WorkspaceWorker>> {
         if let ManagerMode::DynamicWithWorkspaces(worker) = &self.mode {
-            return worker.get();
+            return worker.get().map(Arc::clone);
         }
         None
     }
@@ -188,7 +162,7 @@ impl WorkerManager {
 
     /// Append new workers to the list (used after `didChangeWorkspaceFolders`).
     pub async fn add_workers(&self, workers: Vec<WorkspaceWorker>) {
-        self.workers.write().await.extend(workers);
+        self.workers.write().await.extend(workers.into_iter().map(Arc::new));
     }
 
     /// Build a new [`WorkspaceWorker`] for the given root URI without starting
@@ -205,7 +179,7 @@ impl WorkerManager {
     /// For non-`file://` URIs the first worker (index `0`) is returned when
     /// the list is non-empty, mirroring the behaviour of rust-analyzer and
     /// typescript-language-server.
-    fn find_worker_index_for_uri(workers: &[WorkspaceWorker], uri: &Uri) -> Option<usize> {
+    fn find_worker_index_for_uri(workers: &[Arc<WorkspaceWorker>], uri: &Uri) -> Option<usize> {
         if uri.scheme().as_str() != "file" {
             return if workers.is_empty() { None } else { Some(0) };
         }
@@ -232,9 +206,9 @@ impl WorkerManager {
     // SAFETY: call this method only when you are sure, that we are not in `DynamicWithWorkspaces` mode,
     // or else it will return [`None`] for URIs that are outside of any workspace.
     fn find_worker_for_uri<'a>(
-        workers: &'a [WorkspaceWorker],
+        workers: &'a [Arc<WorkspaceWorker>],
         uri: &Uri,
-    ) -> Option<&'a WorkspaceWorker> {
+    ) -> Option<&'a Arc<WorkspaceWorker>> {
         let index = Self::find_worker_index_for_uri(workers, uri)?;
         Some(&workers[index])
     }
@@ -247,11 +221,11 @@ impl WorkerManager {
     /// For non-`file://` URIs the first worker in the list is returned,
     /// mirroring the behaviour of rust-analyzer and
     /// typescript-language-server.
-    pub async fn get_worker_for_uri(&self, uri: &Uri) -> Option<WorkerGuard<'_>> {
+    pub async fn get_worker_for_uri(&self, uri: &Uri) -> Option<Arc<WorkspaceWorker>> {
         {
             let guard = self.workers.read().await;
             if let Some(index) = Self::find_worker_index_for_uri(&guard, uri) {
-                return Some(WorkerGuard { guard: WorkerGuardInner::Vec(guard), index });
+                return Some(Arc::clone(&guard[index]));
             }
         }
 
@@ -264,7 +238,7 @@ impl WorkerManager {
                 return None;
             };
             // In DynamicWithWorkspaces mode, if no worker matches the URI, fallback to the dynamic worker.
-            return Some(WorkerGuard { guard: WorkerGuardInner::Single(worker), index: 0 });
+            return Some(Arc::clone(worker));
         }
 
         None
@@ -315,8 +289,8 @@ impl WorkerManager {
         &self,
         added: &[WorkspaceFolder],
         removed: &[WorkspaceFolder],
-    ) -> Vec<WorkspaceWorker> {
-        let mut workers_to_shutdown: Vec<WorkspaceWorker> = vec![];
+    ) -> Vec<Arc<WorkspaceWorker>> {
+        let mut workers_to_shutdown: Vec<Arc<WorkspaceWorker>> = vec![];
         let mut workers = self.workers.write().await;
 
         // Transition out of single-file mode when real workspace folders arrive.
@@ -390,9 +364,9 @@ impl WorkerManager {
             if self.is_single_file_mode() && Self::find_worker_for_uri(&workers, uri).is_none() {
                 #[expect(clippy::missing_panics_doc)]
                 // We wrapped the worker in `Some` to avoid moving it before acquiring the lock, so it should always be `Some` here.
-                workers.push(worker.take().expect(
+                workers.push(Arc::new(worker.take().expect(
                     "freshly created worker should be available when storing it in the list",
-                ));
+                )));
             }
         }
 


### PR DESCRIPTION
## Summary

- Run pull diagnostics on a spawned blocking task so slow diagnostic work does not block unrelated LSP requests.
- Make `TextDocument` own its URI, so diagnostic work can be moved into spawned tasks safely.
- Store workspace workers behind `Arc` and return cloned worker handles from `WorkerManager`.
- Update the request-lock test to verify code actions can respond before slower diagnostic requests finish.


Generated by codex 5.5 - reviewed by myself.