### PR TITLE
fix(linter): honor jsx-a11y attributes href alias

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_activedescendant_has_tabindex.rs
@@ -91,7 +91,7 @@ impl Rule for AriaActivedescendantHasTabindex {
             if !is_valid_tab_index_attr(tab_index_attr) {
                 return;
             }
-        } else if is_interactive_element(&element_type, jsx_opening_el) {
+        } else if is_interactive_element(ctx, &element_type, jsx_opening_el) {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/click_events_have_key_events.rs
@@ -73,7 +73,7 @@ impl Rule for ClickEventsHaveKeyEvents {
             return;
         }
 
-        if is_interactive_element(&element_type, jsx_opening_el) {
+        if is_interactive_element(ctx, &element_type, jsx_opening_el) {
             return;
         }
 
@@ -117,6 +117,28 @@ fn test() {
         (r"<TestComponent onClick={doFoo} />", None, None),
         (r"<Button onClick={doFoo} />", None, None),
         (r"<Footer onClick={doFoo} />", None, None),
+        // `settings.jsx-a11y.attributes` maps `href` to `to`, so a component
+        // mapped to `a` via `components` is recognized as an interactive anchor.
+        (
+            r#"<Link to="/x" onClick={() => void 0}>label</Link>"#,
+            None,
+            Some(serde_json::json!({
+                "settings": { "jsx-a11y": {
+                    "components": { "Link": "a" },
+                    "attributes": { "href": ["href", "to"] }
+                } }
+            })),
+        ),
+        (
+            r#"<Link to="/x" onClick={(e) => { e.preventDefault(); }}>label</Link>"#,
+            None,
+            Some(serde_json::json!({
+                "settings": { "jsx-a11y": {
+                    "components": { "Link": "a" },
+                    "attributes": { "href": ["href", "to"] }
+                } }
+            })),
+        ),
     ];
 
     let fail = vec![
@@ -139,6 +161,29 @@ fn test() {
                     "components": {
                         "Footer": "footer",
                     }
+                } }
+            })),
+        ),
+        // Regression guard: a `<Link>` without any `href` alias prop is still a
+        // non-interactive anchor, even with the `attributes` setting.
+        (
+            r#"<Link onClick={() => void 0}>label</Link>"#,
+            None,
+            Some(serde_json::json!({
+                "settings": { "jsx-a11y": {
+                    "components": { "Link": "a" },
+                    "attributes": { "href": ["href", "to"] }
+                } }
+            })),
+        ),
+        // Without the `attributes` setting, `to` is not treated as `href`, so the
+        // default behavior is unchanged.
+        (
+            r#"<Link to="/x" onClick={() => void 0}>label</Link>"#,
+            None,
+            Some(serde_json::json!({
+                "settings": { "jsx-a11y": {
+                    "components": { "Link": "a" }
                 } }
             })),
         ),

--- a/crates/oxc_linter/src/rules/jsx_a11y/control_has_associated_label.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/control_has_associated_label.rs
@@ -176,7 +176,8 @@ impl Rule for ControlHasAssociatedLabel {
         }
 
         let is_dom_element = HTML_TAG.contains(element_type.as_ref());
-        let is_interactive_el = is_interactive_element(&element_type, &element.opening_element);
+        let is_interactive_el =
+            is_interactive_element(ctx, &element_type, &element.opening_element);
         let is_interactive_role_el = role.is_some_and(is_interactive_role);
         let is_control_component =
             self.control_components.iter().any(|c| c.as_str() == element_type.as_ref());

--- a/crates/oxc_linter/src/rules/jsx_a11y/interactive_supports_focus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/interactive_supports_focus.rs
@@ -126,7 +126,7 @@ impl Rule for InteractiveSupportsFocus {
 
         let Some(role) = role_str else { return };
         if !is_interactive_role(role)
-            || is_interactive_element(&element_type, jsx_el)
+            || is_interactive_element(ctx, &element_type, jsx_el)
             || is_non_interactive_role(role)
             || is_non_interactive_element(&element_type, jsx_el)
             || has_tab_index

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_interactive_element_to_noninteractive_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_interactive_element_to_noninteractive_role.rs
@@ -98,7 +98,7 @@ impl Rule for NoInteractiveElementToNoninteractiveRole {
         }
 
         let is_interactive =
-            element_type.as_ref() == "input" || is_interactive_element(&element_type, jsx_el);
+            element_type.as_ref() == "input" || is_interactive_element(ctx, &element_type, jsx_el);
         if !is_interactive {
             return;
         }

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_element_interactions.rs
@@ -193,7 +193,8 @@ impl Rule for NoNoninteractiveElementInteractions {
         // Oxc's `is_interactive_element` follows HTML interactive-content semantics, which are
         // broader than this rule's accessibility semantics. Some elements such as `<iframe>`,
         // `<label>`, and `<details>` are still non-interactive for this rule.
-        if is_interactive_element(element_type.as_ref(), jsx_el) && !is_non_interactive_element {
+        if is_interactive_element(ctx, element_type.as_ref(), jsx_el) && !is_non_interactive_element
+        {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -134,7 +134,7 @@ impl Rule for NoNoninteractiveTabindex {
             return;
         }
 
-        if is_interactive_element(component, jsx_el) {
+        if is_interactive_element(ctx, component, jsx_el) {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_static_element_interactions.rs
@@ -125,7 +125,7 @@ impl Rule for NoStaticElementInteractions {
             return;
         }
 
-        if is_interactive_element(&element_type, jsx_el) {
+        if is_interactive_element(ctx, &element_type, jsx_el) {
             return;
         }
 
@@ -570,4 +570,46 @@ fn test() {
 
     Tester::new(NoStaticElementInteractions::NAME, NoStaticElementInteractions::PLUGIN, pass, fail)
         .test_and_snapshot();
+
+    // `settings.jsx-a11y.attributes` maps `href` to the prop names a codebase uses
+    // (e.g. react-router's `<Link to>`), so an element mapped to `a` via `components`
+    // is treated as an interactive anchor.
+    let attributes_settings = || {
+        serde_json::json!({
+            "settings": { "jsx-a11y": {
+                "components": { "Link": "a" },
+                "attributes": { "href": ["href", "to"] }
+            } }
+        })
+    };
+
+    let attributes_pass = vec![
+        (r#"<Link to="/x" onClick={() => void 0}>label</Link>"#, None, Some(attributes_settings())),
+        (
+            r#"<Link to="/x" onClick={(e) => { e.preventDefault(); }}>label</Link>"#,
+            None,
+            Some(attributes_settings()),
+        ),
+    ];
+
+    let attributes_fail = vec![
+        // Regression guard: a `<Link>` without any `href` alias prop stays static.
+        (r#"<Link onClick={() => void 0}>label</Link>"#, None, Some(attributes_settings())),
+        // Without the `attributes` setting, `to` is not treated as `href`.
+        (
+            r#"<Link to="/x" onClick={() => void 0}>label</Link>"#,
+            None,
+            Some(serde_json::json!({
+                "settings": { "jsx-a11y": { "components": { "Link": "a" } } }
+            })),
+        ),
+    ];
+
+    Tester::new(
+        NoStaticElementInteractions::NAME,
+        NoStaticElementInteractions::PLUGIN,
+        attributes_pass,
+        attributes_fail,
+    )
+    .test();
 }

--- a/crates/oxc_linter/src/snapshots/jsx_a11y_click_events_have_key_events.snap
+++ b/crates/oxc_linter/src/snapshots/jsx_a11y_click_events_have_key_events.snap
@@ -85,3 +85,17 @@ source: crates/oxc_linter/src/tester.rs
    · ──────────────────────────
    ╰────
   help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
+
+  ⚠ jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
+   ╭─[click_events_have_key_events.tsx:1:1]
+ 1 │ <Link onClick={() => void 0}>label</Link>
+   · ─────────────────────────────
+   ╰────
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.
+
+  ⚠ jsx-a11y(click-events-have-key-events): Enforce a clickable non-interactive element has at least one keyboard event listener.
+   ╭─[click_events_have_key_events.tsx:1:1]
+ 1 │ <Link to="/x" onClick={() => void 0}>label</Link>
+   · ─────────────────────────────────────
+   ╰────
+  help: Visible, non-interactive elements with click handlers must have one of `keyup`, `keydown`, or `keypress` listener.

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -49,7 +49,7 @@ pub fn is_create_element_call(call_expr: &CallExpression) -> bool {
 
 pub fn has_jsx_prop<'a, 'b>(
     node: &'b JSXOpeningElement<'a>,
-    target_prop: &'b str,
+    target_prop: &str,
 ) -> Option<&'b JSXAttributeItem<'a>> {
     node.attributes
         .iter()
@@ -63,6 +63,27 @@ pub fn has_jsx_prop_ignore_case<'a, 'b>(
     node.attributes.iter().find(|attr| {
         attr.as_attribute().is_some_and(|attr| attr.is_identifier_ignore_case(target_prop))
     })
+}
+
+/// Like [`has_jsx_prop`], but resolves `canonical` through the
+/// `settings.jsx-a11y.attributes` alias map first.
+///
+/// `settings['jsx-a11y'].attributes` lets a project remap a DOM attribute name
+/// to the prop names its codebase actually uses (e.g. `{ "href": ["href", "to"] }`
+/// so that react-router's `<Link to>` is recognized as an anchor with an `href`).
+/// When `canonical` is present in the map, every listed alias is checked;
+/// otherwise this falls back to looking up `canonical` itself.
+///
+/// ref: <https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#attributes>
+pub fn has_jsx_prop_aliased<'a, 'b>(
+    ctx: &LintContext<'a>,
+    node: &'b JSXOpeningElement<'a>,
+    canonical: &str,
+) -> Option<&'b JSXAttributeItem<'a>> {
+    match ctx.settings().jsx_a11y.attributes.get(canonical) {
+        Some(aliases) => aliases.iter().find_map(|alias| has_jsx_prop(node, alias.as_str())),
+        None => has_jsx_prop(node, canonical),
+    }
 }
 
 pub fn get_prop_value<'a, 'b>(item: &'b JSXAttributeItem<'a>) -> Option<&'b JSXAttributeValue<'a>> {
@@ -192,7 +213,11 @@ pub fn is_abstract_role<'a>(ctx: &LintContext<'a>, jsx_opening_el: &JSXOpeningEl
 // ref: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/4c7e7815c12a797587bb8e3cdced7f3003848964/src/util/isInteractiveElement.js
 //
 // See also https://html.spec.whatwg.org/multipage/dom.html#interactive-content
-pub fn is_interactive_element(element_type: &str, jsx_opening_el: &JSXOpeningElement) -> bool {
+pub fn is_interactive_element<'a>(
+    ctx: &LintContext<'a>,
+    element_type: &str,
+    jsx_opening_el: &JSXOpeningElement<'a>,
+) -> bool {
     // Interactive contents are...
     // - a, area (when they have `href`)
     // - audio, video
@@ -212,7 +237,10 @@ pub fn is_interactive_element(element_type: &str, jsx_opening_el: &JSXOpeningEle
             }
             true
         }
-        "a" | "area" => has_jsx_prop(jsx_opening_el, "href").is_some(),
+        // `href` is resolved through `settings.jsx-a11y.attributes` so that a
+        // component mapped to `a` via `settings.jsx-a11y.components` (e.g.
+        // `<Link to>`) is still recognized as an interactive anchor.
+        "a" | "area" => has_jsx_prop_aliased(ctx, jsx_opening_el, "href").is_some(),
         "img" => has_jsx_prop(jsx_opening_el, "usemap").is_some(),
         _ => false,
     }


### PR DESCRIPTION
## What

`jsx-a11y`'s interactivity rules now honor the `settings.jsx-a11y.attributes` alias map when checking for the `href` attribute, so a component mapped to `a` via `settings.jsx-a11y.components` whose href-carrying prop is renamed (e.g. react-router's `<Link to>`) is correctly recognized as an interactive anchor.

## Problem

`eslint-plugin-jsx-a11y` supports a [`settings['jsx-a11y'].attributes`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y#attributes) map that remaps a DOM attribute name to the prop names a codebase actually uses. The canonical use case is react-router's `<Link to="...">`: telling the linter that `to` should be treated as `href` so a `<Link>` (mapped to `<a>` via `components`) is recognized as a real, interactive anchor.

oxlint already parsed this setting and applied it in `anchor-is-valid` and the label-association rules, but the shared `is_interactive_element` helper still looked up the **literal** `href` prop. As a result the following config had no effect on interactivity-based rules:

```jsonc
{
  "settings": {
    "jsx-a11y": {
      "components": { "Link": "a" },
      "attributes": { "href": ["href", "to"] }
    }
  }
}
```

and this valid anchor was flagged with two false positives:

```jsx
import { Link } from "react-router";

<Link to="/x" onClick={(e) => { e.preventDefault(); doThing(); }}>label</Link>;
// jsx-a11y/no-static-element-interactions — "Static HTML elements with event handlers require a role."
// jsx-a11y/click-events-have-key-events   — "...must have at least one keyboard event listener."
```

## Root cause

`is_interactive_element` treats `<a>`/`<area>` as interactive only when a literal `href` prop is present:

```rust
"a" | "area" => has_jsx_prop(jsx_opening_el, "href").is_some(),
```

`components: { Link: "a" }` produces an `a`-typed element, but its href-carrying prop is named `to`, and the function had no access to the `attributes` map (it didn't even take `ctx`), so there was no way to recognize `to` as `href`. The element was therefore considered href-less → static → the rules fired.

## Fix

- Add `has_jsx_prop_aliased(ctx, node, canonical)` in `utils/react.rs`: it resolves an attribute name through `settings.jsx-a11y.attributes` (checking every listed alias) and falls back to the canonical name when no mapping exists. Semantics match upstream — the configured list **replaces** the default, matching is case-sensitive (same as the existing `anchor-is-valid` implementation).
- `is_interactive_element` now takes `ctx` and uses the aliased lookup for the `href` check on `a`/`area`.
- All interactivity-based `jsx-a11y` rules thread `ctx` through, so the setting is honored consistently across the rule set (not just the two reported rules).
- Behavior is unchanged when the setting is absent.

## Affected rules

  - `no-static-element-interactions`
  - `click-events-have-key-events`
  - `interactive-supports-focus`
  - `no-noninteractive-tabindex`
  - `aria-activedescendant-has-tabindex`
  - `no-interactive-element-to-noninteractive-role`
  - `no-noninteractive-element-interactions`
  - `control-has-associated-label`
