### PR TITLE
refactor(linter): migrate to new `AstBuilder`

### DIFF
--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -26,7 +26,7 @@ doctest = true
 
 [dependencies]
 oxc_allocator = { workspace = true, features = ["fixed_size", "bitset"] }
-oxc_ast = { workspace = true }
+oxc_ast = { workspace = true, features = ["builder_new"] }
 oxc_ast_macros = { workspace = true }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_cfg = { workspace = true }

--- a/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
+++ b/crates/oxc_linter/src/rules/import/consistent_type_specifier_style.rs
@@ -2,8 +2,9 @@ use std::{path::Path, str::FromStr};
 
 use oxc_allocator::{Allocator, ArenaVec, CloneIn};
 use oxc_ast::{
-    AstBuilder, AstKind,
+    AstKind,
     ast::{ImportDeclaration, ImportDeclarationSpecifier, ImportOrExportKind},
+    builder::AstBuilder,
 };
 use oxc_codegen::{Context, Gen};
 use oxc_diagnostics::OxcDiagnostic;
@@ -216,13 +217,14 @@ fn gen_value_import_declaration<'c, 'a: 'c>(
     let ast_builder = AstBuilder::new(&alloc);
 
     let specifiers: Vec<_> = specifiers.iter().map(|it| it.clone_in(&alloc)).collect();
-    let import_declaration = ast_builder.alloc_import_declaration(
+    let import_declaration = ImportDeclaration::boxed(
         SPAN,
         Some(ArenaVec::from_iter_in(specifiers, &ast_builder)),
         import_decl.source.clone_in(&alloc),
         None,
         import_decl.with_clause.clone_in(&alloc),
         ImportOrExportKind::Value,
+        &ast_builder,
     );
 
     import_declaration.print(&mut codegen, Context::empty());
@@ -243,23 +245,25 @@ fn gen_type_import_declaration<'c, 'a: 'c>(
         .iter()
         .filter_map(|it| match it {
             ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
-                Some(ast_builder.import_declaration_specifier_import_specifier(
+                Some(ImportDeclarationSpecifier::new_import_specifier(
                     SPAN,
                     specifier.imported.clone_in(&alloc),
                     specifier.local.clone_in(&alloc),
                     ImportOrExportKind::Value,
+                    &ast_builder,
                 ))
             }
             _ => None,
         })
         .collect();
-    let import_declaration = ast_builder.alloc_import_declaration(
+    let import_declaration = ImportDeclaration::boxed(
         SPAN,
         Some(ArenaVec::from_iter_in(specifiers, &ast_builder)),
         import_decl.source.clone_in(&alloc),
         None,
         import_decl.with_clause.clone_in(&alloc),
         ImportOrExportKind::Type,
+        &ast_builder,
     );
 
     import_declaration.print(&mut codegen, Context::empty());

--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -3,6 +3,7 @@ use std::ops::Deref;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use oxc_allocator::ArenaVec;
 use oxc_ast::{
     AstKind,
     ast::{
@@ -466,7 +467,7 @@ fn fix_spread_to_object_assign<'a>(
     obj: &ObjectExpression<'a>,
 ) -> RuleFix {
     use oxc_allocator::{Allocator, CloneIn};
-    use oxc_ast::AstBuilder;
+    use oxc_ast::builder::AstBuilder;
     use oxc_span::SPAN;
 
     if obj.properties.len() <= 1 {
@@ -479,7 +480,7 @@ fn fix_spread_to_object_assign<'a>(
     // almost always overshoots, but will not re-alloc, so it's more performant
     // than creating an empty vec.
     // let mut args = ast.vec_with_capacity::<Argument>(obj.properties.len());
-    let mut curr_obj_properties = ast.vec::<ObjectPropertyKind>();
+    let mut curr_obj_properties = ArenaVec::new_in(&ast);
     let mut codegen = fixer.codegen();
     let mut is_first = true;
     codegen.print_str("Object.assign(");
@@ -491,8 +492,9 @@ fn fix_spread_to_object_assign<'a>(
             }
             ObjectPropertyKind::SpreadProperty(spread) => {
                 if !curr_obj_properties.is_empty() {
-                    let properties = std::mem::replace(&mut curr_obj_properties, ast.vec());
-                    let obj_arg = ast.expression_object(SPAN, properties);
+                    let properties =
+                        std::mem::replace(&mut curr_obj_properties, ArenaVec::new_in(&ast));
+                    let obj_arg = Expression::new_object_expression(SPAN, properties, &ast);
                     if is_first {
                         is_first = false;
                     } else {
@@ -514,8 +516,8 @@ fn fix_spread_to_object_assign<'a>(
         if !is_first {
             codegen.print_str(", ");
         }
-        let properties = std::mem::replace(&mut curr_obj_properties, ast.vec());
-        let obj_arg = ast.expression_object(SPAN, properties);
+        let properties = std::mem::replace(&mut curr_obj_properties, ArenaVec::new_in(&ast));
+        let obj_arg = Expression::new_object_expression(SPAN, properties, &ast);
         codegen.print_expression(&obj_arg);
     }
     codegen.print_ascii_byte(b')');

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -1605,8 +1605,8 @@ mod fix {
     use super::Name;
     use oxc_allocator::{Allocator, ArenaVec, CloneIn};
     use oxc_ast::{
-        AstBuilder,
         ast::{ArrayExpression, Expression},
+        builder::AstBuilder,
     };
     use oxc_span::{GetSpan, SPAN};
     use oxc_str::Str;
@@ -1631,13 +1631,16 @@ mod fix {
 
         for name in names {
             vec.push(
-                ast_builder
-                    .expression_identifier(SPAN, Str::from_cow_in(&name.name, &alloc))
-                    .into(),
+                Expression::new_identifier(
+                    SPAN,
+                    Str::from_cow_in(&name.name, &alloc),
+                    &ast_builder,
+                )
+                .into(),
             );
         }
 
-        codegen.print_expression(&ast_builder.expression_array(SPAN, vec));
+        codegen.print_expression(&Expression::new_array_expression(SPAN, vec, &ast_builder));
         fixer.replace(deps.span, codegen.into_source_text())
     }
 
@@ -1657,9 +1660,10 @@ mod fix {
             .filter(|el| (*el).span() != dependency.span)
             .map(|el| el.clone_in(&alloc));
 
-        codegen.print_expression(&Expression::ArrayExpression(
-            ast_builder
-                .alloc_array_expression(deps.span, ArenaVec::from_iter_in(new_deps, &ast_builder)),
+        codegen.print_expression(&Expression::new_array_expression(
+            deps.span,
+            ArenaVec::from_iter_in(new_deps, &ast_builder),
+            &ast_builder,
         ));
         fixer.replace(deps.span, codegen.into_source_text())
     }

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -7,11 +7,12 @@ use lazy_regex::{Lazy, Regex, lazy_regex};
 use oxc_allocator::{Allocator, ArenaVec};
 
 use oxc_ast::{
-    AstBuilder, AstKind,
+    AstKind,
     ast::{
         Expression, JSXAttributeItem, JSXAttributeValue, JSXChild, JSXElementName, JSXExpression,
         JSXExpressionContainer,
     },
+    builder::AstBuilder,
 };
 use oxc_codegen::CodegenOptions;
 use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
@@ -632,10 +633,11 @@ fn report_unnecessary_curly_for_attribute_value<'a>(
             fix = fix.with_options(CodegenOptions::default());
         }
 
-        fix.print_expression(&ast_builder.expression_string_literal(
+        fix.print_expression(&Expression::new_string_literal(
             Span::default(),
             str.as_str(),
             None,
+            &ast_builder,
         ));
 
         fixer.replace(container.span, fix.into_source_text())
@@ -662,10 +664,11 @@ fn report_missing_curly_for_string_attribute_value(
         let alloc = Allocator::default();
         let ast_builder = AstBuilder::new(&alloc);
 
-        replace.print_expression(&ast_builder.expression_string_literal(
+        replace.print_expression(&Expression::new_string_literal(
             Span::default(),
             string_value,
             None,
+            &ast_builder,
         ));
 
         let mut fix = fixer.new_fix_with_capacity(3);
@@ -702,10 +705,11 @@ fn report_missing_curly_for_text_node(ctx: &LintContext, span: Span, string_valu
         let mut fix = fixer.new_fix_with_capacity(fix_contexts.len() * 3);
         for (span_from_first_char, text) in fix_contexts {
             let mut replace = fixer.codegen().with_options(CodegenOptions::default());
-            replace.print_expression(&ast_builder.expression_string_literal(
+            replace.print_expression(&Expression::new_string_literal(
                 Span::default(),
                 text,
                 None,
+                &ast_builder,
             ));
             fix.push(fixer.replace(span_from_first_char, replace.into_source_text()));
             fix.push(fixer.insert_text_before(&span_from_first_char, "{"));

--- a/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_useless_spread/mod.rs
@@ -1,10 +1,11 @@
-use oxc_allocator::{Allocator, CloneIn};
+use oxc_allocator::{Allocator, ArenaVec, CloneIn};
 use oxc_ast::{
-    AstBuilder, AstKind,
+    AstKind,
     ast::{
         ArrayExpression, ArrayExpressionElement, CallExpression, Expression, NewExpression,
         ObjectExpression, ObjectPropertyKind, SpreadElement,
     },
+    builder::AstBuilder,
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -473,7 +474,7 @@ fn fix_by_removing_object_spread<'a>(
 ) -> RuleFix {
     let alloc = Allocator::default();
     let ast = AstBuilder::new(&alloc);
-    let mut new_properties = ast.vec();
+    let mut new_properties = ArenaVec::new_in(&ast);
     for prop in &outer_obj.properties {
         match prop {
             ObjectPropertyKind::SpreadProperty(s) if s.span == spread.span => {
@@ -486,7 +487,7 @@ fn fix_by_removing_object_spread<'a>(
             }
         }
     }
-    let new_obj = ast.expression_object(SPAN, new_properties);
+    let new_obj = Expression::new_object_expression(SPAN, new_properties, &ast);
     let mut codegen = fixer.codegen();
     codegen.print_expression(&new_obj);
     fixer.replace(outer_obj.span, codegen.into_source_text())

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -1,8 +1,9 @@
 use cow_utils::CowUtils;
 use oxc_allocator::Allocator;
 use oxc_ast::{
-    AstBuilder, AstKind,
-    ast::{Argument, CallExpression, Expression},
+    AstKind,
+    ast::{Argument, CallExpression, Expression, Str},
+    builder::AstBuilder,
 };
 use oxc_codegen::CodegenOptions;
 use oxc_diagnostics::OxcDiagnostic;
@@ -271,7 +272,12 @@ fn to_string_literal_text(fixer: RuleFixer, text: &str) -> String {
     let mut codegen = fixer.codegen().with_options(CodegenOptions::default());
     let alloc = Allocator::default();
     let ast = AstBuilder::new(&alloc);
-    codegen.print_expression(&ast.expression_string_literal(SPAN, ast.str(text), None));
+    codegen.print_expression(&Expression::new_string_literal(
+        SPAN,
+        Str::from_str_in(text, &ast),
+        None,
+        &ast,
+    ));
     codegen.into_source_text()
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
@@ -2,11 +2,12 @@ use phf::{Map, phf_map};
 
 use oxc_allocator::{Allocator, GetAddress, UnstableAddress};
 use oxc_ast::{
-    AstBuilder, AstKind,
+    AstKind,
     ast::{
         Argument, BindingPattern, BindingProperty, CallExpression, Expression, Function,
-        MemberExpression, PropertyKey,
+        MemberExpression, PropertyKey, Str,
     },
+    builder::AstBuilder,
 };
 use oxc_codegen::CodegenOptions;
 use oxc_diagnostics::OxcDiagnostic;
@@ -420,10 +421,11 @@ impl PreferKeyboardEventKey {
                     .with_options(CodegenOptions { single_quote: true, ..Default::default() });
                 let alloc = Allocator::default();
                 let ast = AstBuilder::new(&alloc);
-                codegen.print_expression(&ast.expression_string_literal(
+                codegen.print_expression(&Expression::new_string_literal(
                     SPAN,
-                    ast.str(&key_name),
+                    Str::from_str_in(&key_name, &ast),
                     None,
+                    &ast,
                 ));
                 let key_str = codegen.into_source_text();
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -1,7 +1,8 @@
 use oxc_allocator::Allocator;
 use oxc_ast::{
-    AstBuilder, AstKind,
-    ast::{Argument, MemberExpression, RegExpFlags},
+    AstKind,
+    ast::{Argument, Expression, MemberExpression, RegExpFlags, Str},
+    builder::AstBuilder,
 };
 use oxc_codegen::CodegenOptions;
 use oxc_diagnostics::OxcDiagnostic;
@@ -94,10 +95,11 @@ impl Rule for PreferStringReplaceAll {
                         });
                         let alloc = Allocator::default();
                         let ast = AstBuilder::new(&alloc);
-                        codegen.print_expression(&ast.expression_string_literal(
+                        codegen.print_expression(&Expression::new_string_literal(
                             SPAN,
-                            ast.str(&k),
+                            Str::from_str_in(&k, &ast),
                             None,
+                            &ast,
                         ));
                         fixer.replace(pattern.span(), codegen.into_source_text())
                     });

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -1,7 +1,8 @@
 use oxc_allocator::Allocator;
 use oxc_ast::{
-    AstBuilder, AstKind,
-    ast::{CallExpression, Expression, MemberExpression, RegExpFlags, RegExpLiteral},
+    AstKind,
+    ast::{CallExpression, Expression, MemberExpression, RegExpFlags, RegExpLiteral, Str},
+    builder::AstBuilder,
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -124,7 +125,12 @@ fn do_fix<'a>(
     let alloc = Allocator::default();
     let ast = AstBuilder::new(&alloc);
     content.print_str(&format!(r"{}.{}(", fixer.source_range(target_span), method));
-    content.print_expression(&ast.expression_string_literal(SPAN, ast.str(&argument), None));
+    content.print_expression(&Expression::new_string_literal(
+        SPAN,
+        Str::from_str_in(&argument, &ast),
+        None,
+        &ast,
+    ));
     content.print_str(r")");
     fixer.replace(call_expr.span, content.into_source_text())
 }

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -970,7 +970,7 @@ mod test {
     use super::*;
 
     use oxc_allocator::Allocator;
-    use oxc_ast::AstBuilder;
+    use oxc_ast::{ast::IdentifierName, builder::AstBuilder};
     use oxc_span::Span;
 
     #[test]
@@ -1000,33 +1000,38 @@ mod test {
         let ast = AstBuilder::new(&alloc);
 
         // Identifier: useState
-        let use_state = ast.expression_identifier(Span::default(), "useState");
+        let use_state = Expression::new_identifier(Span::default(), "useState", &ast);
         assert!(is_react_hook(&use_state));
 
         // Identifier: use
-        let just_use = ast.expression_identifier(Span::default(), "use");
+        let just_use = Expression::new_identifier(Span::default(), "use", &ast);
         assert!(is_react_hook(&just_use));
 
         // Identifier: userError, should not be considered a hook despite starting with "use"
-        let user_error = ast.expression_identifier(Span::default(), "userError");
+        let user_error = Expression::new_identifier(Span::default(), "userError", &ast);
         assert!(!is_react_hook(&user_error));
 
         // Identifier that's not a hook
-        let not_hook = ast.expression_identifier(Span::default(), "notAHook");
+        let not_hook = Expression::new_identifier(Span::default(), "notAHook", &ast);
         assert!(!is_react_hook(&not_hook));
 
         // Static member: React.useEffect -> valid
-        let react_obj = ast.expression_identifier(Span::default(), "React");
-        let prop = ast.identifier_name(Span::default(), "useEffect");
+        let react_obj = Expression::new_identifier(Span::default(), "React", &ast);
+        let prop = IdentifierName::new(Span::default(), "useEffect", &ast);
         let react_use_effect =
-            ast.member_expression_static(Span::default(), react_obj, prop, false).into();
+            Expression::new_static_member_expression(Span::default(), react_obj, prop, false, &ast);
         assert!(is_react_hook(&react_use_effect));
 
         // Static member: react.useEffect -> invalid because namespace isn't PascalCase
-        let react_lower = ast.expression_identifier(Span::default(), "react");
-        let prop2 = ast.identifier_name(Span::default(), "useEffect");
-        let react_lower_use_effect =
-            ast.member_expression_static(Span::default(), react_lower, prop2, false).into();
+        let react_lower = Expression::new_identifier(Span::default(), "react", &ast);
+        let prop2 = IdentifierName::new(Span::default(), "useEffect", &ast);
+        let react_lower_use_effect = Expression::new_static_member_expression(
+            Span::default(),
+            react_lower,
+            prop2,
+            false,
+            &ast,
+        );
         assert!(!is_react_hook(&react_lower_use_effect));
     }
 


### PR DESCRIPTION
I created this ontop of #23781 just to avoid any potential conflicts.

Follows on from https://github.com/oxc-project/oxc/pull/23730

It was relatively pain free! Thanks @ overlookmotel for the migration script!