### PR TITLE
fix(ast): `ExportNamedDeclaration` plain builder methods return boxed nodes

### DIFF
--- a/crates/oxc_ast/src/builder/custom.rs
+++ b/crates/oxc_ast/src/builder/custom.rs
@@ -174,20 +174,20 @@ impl<'a> Function<'a> {
 
 impl<'a> ExportNamedDeclaration<'a> {
     /// Build an [`ExportNamedDeclaration`] with no modifiers, containing a set of
-    /// [exported symbol names](ExportSpecifier).
+    /// [exported symbol names](ExportSpecifier), and store it in the memory arena.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `specifiers`
     /// * `source`
     #[inline]
-    pub fn new_plain<B: GetAstBuilder<'a>>(
+    pub fn boxed_plain<B: GetAstBuilder<'a>>(
         span: Span,
         specifiers: ArenaVec<'a, ExportSpecifier<'a>>,
         source: Option<StringLiteral<'a>>,
         builder: &B,
-    ) -> Self {
-        ExportNamedDeclaration::new(
+    ) -> ArenaBox<'a, Self> {
+        ExportNamedDeclaration::boxed(
             span,
             None,
             specifiers,
@@ -198,19 +198,20 @@ impl<'a> ExportNamedDeclaration<'a> {
         )
     }
 
-    /// Build an [`ExportNamedDeclaration`] with no modifiers, wrapping a [`Declaration`].
+    /// Build an [`ExportNamedDeclaration`] with no modifiers, wrapping a [`Declaration`],
+    /// and store it in the memory arena.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `declaration`
     #[inline]
-    pub fn new_plain_declaration<B: GetAstBuilder<'a>>(
+    pub fn boxed_plain_declaration<B: GetAstBuilder<'a>>(
         span: Span,
         declaration: Declaration<'a>,
         builder: &B,
-    ) -> Self {
+    ) -> ArenaBox<'a, Self> {
         let specifiers = ArenaVec::new_in(builder.builder());
-        ExportNamedDeclaration::new(
+        ExportNamedDeclaration::boxed(
             span,
             Some(declaration),
             specifiers,


### PR DESCRIPTION
When custom methods were added to new `AstBuilder` (#23651), there was a mistake. The 2 old `AstBuilder` methods `plain_export_named_declaration_declaration` and `plain_export_named_declaration` return an `ArenaBox<ExportNamedDeclaration>`, but the new methods added to new `AstBuilder` were returning unboxed `ExportNamedDeclaration`.

Fix these mistakes, so the new methods are exact replacements for the old ones.