### PR TITLE
fix(linter): forbid-elements should not apply jsx-a11y components mapping

### DIFF
--- a/crates/oxc_linter/src/rules/react/forbid_elements.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_elements.rs
@@ -11,7 +11,7 @@ use crate::{
     AstNode,
     context::{ContextHost, LintContext},
     rule::{DefaultRuleConfig, Rule},
-    utils::{get_element_type, is_react_function_call},
+    utils::{get_jsx_element_name, is_react_function_call},
 };
 
 fn forbid_elements_diagnostic(
@@ -136,9 +136,13 @@ impl Rule for ForbidElements {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXOpeningElement(jsx_el) => {
-                let name = &get_element_type(ctx, jsx_el);
+                // Use the literal JSX element name here, matching `jsx-ast-utils/elementType`
+                // used by eslint-plugin-react. Do NOT use `get_element_type`, which applies
+                // the jsx-a11y `components` alias map and polymorphic prop — those settings are
+                // scoped to jsx-a11y rules and must not influence `forbid-elements`.
+                let name = get_jsx_element_name(&jsx_el.name);
 
-                self.add_diagnostic_if_invalid_element(ctx, name, jsx_el.name.span());
+                self.add_diagnostic_if_invalid_element(ctx, &name, jsx_el.name.span());
             }
             AstKind::CallExpression(call_expr) => {
                 if !is_react_function_call(call_expr, r"createElement") {
@@ -206,94 +210,148 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        ("<button />", Some(serde_json::json!([]))),
-        ("<button />", Some(serde_json::json!([{ "forbid": [] }]))),
-        ("<Button />", Some(serde_json::json!([{ "forbid": ["button"] }]))),
-        ("<Button />", Some(serde_json::json!([{ "forbid": [{ "element": "button" }] }]))),
-        ("React.createElement(button)", Some(serde_json::json!([{ "forbid": ["button"] }]))),
+        ("<button />", Some(serde_json::json!([])), None),
+        ("<button />", Some(serde_json::json!([{ "forbid": [] }])), None),
+        ("<Button />", Some(serde_json::json!([{ "forbid": ["button"] }])), None),
+        ("<Button />", Some(serde_json::json!([{ "forbid": [{ "element": "button" }] }])), None),
+        ("React.createElement(button)", Some(serde_json::json!([{ "forbid": ["button"] }])), None),
         (
             r#"NotReact.createElement("button")"#,
             Some(serde_json::json!([{ "forbid": ["button"] }])),
+            None,
         ),
-        (r#"React.createElement("_thing")"#, Some(serde_json::json!([{ "forbid": ["_thing"] }]))),
-        (r#"React.createElement("Modal")"#, Some(serde_json::json!([{ "forbid": ["Modal"] }]))),
+        (
+            r#"React.createElement("_thing")"#,
+            Some(serde_json::json!([{ "forbid": ["_thing"] }])),
+            None,
+        ),
+        (
+            r#"React.createElement("Modal")"#,
+            Some(serde_json::json!([{ "forbid": ["Modal"] }])),
+            None,
+        ),
         (
             r#"React.createElement("dotted.component")"#,
             Some(serde_json::json!([{ "forbid": ["dotted.component"] }])),
+            None,
         ),
-        ("React.createElement(function() {})", Some(serde_json::json!([{ "forbid": ["button"] }]))),
-        ("React.createElement({})", Some(serde_json::json!([{ "forbid": ["button"] }]))),
-        ("React.createElement(1)", Some(serde_json::json!([{ "forbid": ["button"] }]))),
-        ("React.createElement()", None),
+        (
+            "React.createElement(function() {})",
+            Some(serde_json::json!([{ "forbid": ["button"] }])),
+            None,
+        ),
+        ("React.createElement({})", Some(serde_json::json!([{ "forbid": ["button"] }])), None),
+        ("React.createElement(1)", Some(serde_json::json!([{ "forbid": ["button"] }])), None),
+        ("React.createElement()", None, None),
+        // A custom component aliased to a DOM element via the jsx-a11y `components`
+        // setting must NOT be treated as that DOM element here: `<Link>` is not `<a>`.
+        // This setting is scoped to jsx-a11y rules only.
+        (
+            r#"<Link href="https://example.com">hi</Link>"#,
+            Some(serde_json::json!([{ "forbid": ["a"] }])),
+            Some(
+                serde_json::json!({ "settings": { "jsx-a11y": { "components": { "Link": "a" } } } }),
+            ),
+        ),
     ];
 
     let fail = vec![
-        ("<button />", Some(serde_json::json!([{ "forbid": ["button"] }]))),
-        ("[<Modal />, <button />]", Some(serde_json::json!([{ "forbid": ["button", "Modal"] }]))),
-        ("<dotted.component />", Some(serde_json::json!([{ "forbid": ["dotted.component"] }]))),
+        ("<button />", Some(serde_json::json!([{ "forbid": ["button"] }])), None),
+        (
+            "[<Modal />, <button />]",
+            Some(serde_json::json!([{ "forbid": ["button", "Modal"] }])),
+            None,
+        ),
+        (
+            "<dotted.component />",
+            Some(serde_json::json!([{ "forbid": ["dotted.component"] }])),
+            None,
+        ),
         (
             "<dotted.Component />",
             Some(
                 serde_json::json!([{ "forbid": [{ "element": "dotted.Component", "message": "that ain\"t cool" }] }]),
             ),
+            None,
         ),
         (
             "<button />",
             Some(
                 serde_json::json!([{ "forbid": [{ "element": "button", "message": "use <Button> instead" }] }]),
             ),
+            None,
         ),
         (
             "<button><input /></button>",
             Some(
                 serde_json::json!([{ "forbid": [{ "element": "button" }, { "element": "input" }] }]),
             ),
+            None,
         ),
         (
             "<button><input /></button>",
             Some(serde_json::json!([{ "forbid": [{ "element": "button" }, "input"] }])),
+            None,
         ),
         (
             "<button><input /></button>",
             Some(serde_json::json!([{ "forbid": ["input", { "element": "button" }] }])),
+            None,
         ),
         (
             "<button />",
             Some(
                 serde_json::json!([{ "forbid": [{ "element": "button", "message": "use <Button> instead" }, { "element": "button", "message": "use <Button2> instead" } ] }]),
             ),
+            None,
         ),
         (
             r#"React.createElement("button", {}, child)"#,
             Some(serde_json::json!([{ "forbid": ["button"] }])),
+            None,
         ),
         (
             r#"[React.createElement(Modal), React.createElement("button")]"#,
             Some(serde_json::json!([{ "forbid": ["button", "Modal"] }])),
+            None,
         ),
         (
             "React.createElement(dotted.Component)",
             Some(
                 serde_json::json!([{ "forbid": [{ "element": "dotted.Component", "message": "that ain\"t cool" }] }]),
             ),
+            None,
         ),
         (
             "React.createElement(dotted.component)",
             Some(serde_json::json!([{ "forbid": ["dotted.component"] }])),
+            None,
         ),
-        ("React.createElement(_comp)", Some(serde_json::json!([{ "forbid": ["_comp"] }]))),
+        ("React.createElement(_comp)", Some(serde_json::json!([{ "forbid": ["_comp"] }])), None),
         (
             r#"React.createElement("button")"#,
             Some(
                 serde_json::json!([{ "forbid": [{ "element": "button", "message": "use <Button> instead" }] }]),
             ),
+            None,
         ),
         (
             r#"React.createElement("button", {}, React.createElement("input"))"#,
             Some(
                 serde_json::json!([{ "forbid": [{ "element": "button" }, { "element": "input" }] }]),
             ),
+            None,
         ),
+        // A literal `<a>` is still forbidden even when a `components` alias exists for it.
+        (
+            r#"<a href="https://example.com">hi</a>"#,
+            Some(serde_json::json!([{ "forbid": ["a"] }])),
+            Some(
+                serde_json::json!({ "settings": { "jsx-a11y": { "components": { "Link": "a" } } } }),
+            ),
+        ),
+        // Custom components are still forbidden by their real name.
+        ("<Foo />", Some(serde_json::json!([{ "forbid": ["Foo"] }])), None),
     ];
 
     Tester::new(ForbidElements::NAME, ForbidElements::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/react_forbid_elements.snap
+++ b/crates/oxc_linter/src/snapshots/react_forbid_elements.snap
@@ -138,3 +138,15 @@ source: crates/oxc_linter/src/tester.rs
  1 │ React.createElement("button", {}, React.createElement("input"))
    ·                                                       ───────
    ╰────
+
+  ⚠ react(forbid-elements): <a> is forbidden.
+   ╭─[forbid_elements.tsx:1:2]
+ 1 │ <a href="https://example.com">hi</a>
+   ·  ─
+   ╰────
+
+  ⚠ react(forbid-elements): <Foo> is forbidden.
+   ╭─[forbid_elements.tsx:1:2]
+ 1 │ <Foo />
+   ·  ───
+   ╰────


### PR DESCRIPTION
`react/forbid-elements` resolved JSX element names through `get_element_type`,
which is oxc's mirror of `eslint-plugin-jsx-a11y`'s `getElementType`. That helper
applies the `settings."jsx-a11y".components` alias map (and the `polymorphicProp`).
As a result, a custom component aliased to a DOM element for accessibility purposes
was reported as if it were that DOM element.

This switches the rule to `get_jsx_element_name` (the equivalent of
`jsx-ast-utils/elementType`), which derives the name purely from the AST and is
settings-agnostic — matching upstream `eslint-plugin-react`.

## Reproduction

```jsonc
{
  "plugins": ["react", "jsx-a11y"],
  "rules": {
    "react/forbid-elements": ["error", { "forbid": [{ "element": "a" }] }]
  },
  "settings": {
    "jsx-a11y": { "components": { "Link": "a" } }
  }
}
```

```jsx
// custom component, NOT a raw <a>
<Link href="https://example.com">hi</Link>
```

**Before:** `react(forbid-elements): <a> is forbidden.` (false positive)
**After:** no diagnostic.

## Why this is correct

- Upstream `eslint-plugin-react/forbid-elements` uses `jsx-ast-utils/elementType`,
  which ignores ESLint settings. The `components` map is consulted only by
  `eslint-plugin-jsx-a11y`'s own rules — never by `eslint-plugin-react`.
- The `components` setting is scoped to jsx-a11y rules; letting it leak into
  `forbid-elements` made it impossible to forbid a literal `<a>` while keeping a
  `Link → a` a11y alias.
- Other react-plugin rules that need a tag name (`forbid_component_props`,
  `jsx_props_no_spreading`) already use `get_jsx_element_name`; `forbid-elements`
  was the lone outlier.
- Forbidding custom components by their real name (`Foo`, `Foo.Bar`) still works,
  since plain name extraction already handles identifiers, member, and namespaced names.