### PR TITLE
feat(codegen): expose `Codegen::print_string` API

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -422,6 +422,11 @@ impl<'a> Codegen<'a> {
     pub fn print_expression(&mut self, expr: &Expression<'_>) {
         expr.print_expr(self, Precedence::Lowest, Context::empty());
     }
+
+    /// Print a string as a JavaScript string literal.
+    pub fn print_string(&mut self, s: &str) {
+        self.print_string_impl(s, false, false);
+    }
 }
 
 // Private APIs

--- a/crates/oxc_codegen/src/str.rs
+++ b/crates/oxc_codegen/src/str.rs
@@ -30,7 +30,15 @@ impl Codegen<'_> {
     /// Print a [`StringLiteral`].
     pub(crate) fn print_string_literal(&mut self, s: &StringLiteral<'_>, allow_backtick: bool) {
         self.add_source_mapping(s.span);
+        self.print_string_impl(s.value.as_str(), s.lone_surrogates, allow_backtick);
+    }
 
+    pub(super) fn print_string_impl(
+        &mut self,
+        s: &str,
+        lone_surrogates: bool,
+        allow_backtick: bool,
+    ) {
         // If `minify` option enabled, quote will be chosen depending on what produces shortest output.
         // What is the best quote to use will be determined when first character needing escape is found.
         // This avoids iterating through the string twice if it contains no quotes (common case).
@@ -47,12 +55,12 @@ impl Codegen<'_> {
 
         // Loop through bytes, looking for any which need to be escaped.
         // String is written to buffer in chunks.
-        let bytes = s.value.as_bytes().iter();
+        let bytes = s.as_bytes().iter();
         let mut state = PrintStringState {
             chunk_start: bytes.ptr(),
             bytes,
             quote,
-            lone_surrogates: s.lone_surrogates,
+            lone_surrogates,
             allow_backtick,
         };
 

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -765,6 +765,24 @@ fn string() {
 }
 
 #[test]
+fn print_string() {
+    fn print(value: &str, options: CodegenOptions) -> String {
+        let mut codegen = Codegen::new().with_options(options);
+        codegen.print_string(value);
+        codegen.into_source_text()
+    }
+
+    assert_eq!(print("hello \"world\"", CodegenOptions::default()), r#""hello \"world\"""#);
+    assert_eq!(
+        print("hello 'world'", CodegenOptions { single_quote: true, ..Default::default() }),
+        r"'hello \'world\''"
+    );
+    assert_eq!(print("line\n\u{00a0}🦄", CodegenOptions::default()), "\"line\\n\\xA0🦄\"");
+    assert_eq!(print("\"\"''", CodegenOptions::minify()), r#""\"\"''""#);
+    assert_eq!(print("\"\"''${", CodegenOptions::minify()), r#""\"\"''${""#);
+}
+
+#[test]
 fn v8_intrinsics() {
     let parse_opts = oxc_parser::ParseOptions {
         allow_v8_intrinsics: true,


### PR DESCRIPTION
## Summary

- expose `Codegen::print_string` for printing an escaped JavaScript string literal from `&str`
- share the existing string escaping implementation without constructing an AST
- disallow template literal output so the API is safe in string-literal-only contexts
- add coverage for quote selection, escaping, Unicode, and minified output

Part of #23780.

**Stack:**
 - https://github.com/oxc-project/oxc/pull/23786
 - https://github.com/oxc-project/oxc/pull/23785 (this PR)
 - https://github.com/oxc-project/oxc/pull/23782