### PR TITLE
refactor(linter): print strings without constructing ASTs

### DIFF
--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -4,7 +4,7 @@ use crate::{
     rule::{DefaultRuleConfig, Rule},
 };
 use lazy_regex::{Lazy, Regex, lazy_regex};
-use oxc_allocator::{Allocator, ArenaVec};
+use oxc_allocator::ArenaVec;
 
 use oxc_ast::{
     AstKind,
@@ -12,7 +12,6 @@ use oxc_ast::{
         Expression, JSXAttributeItem, JSXAttributeValue, JSXChild, JSXElementName, JSXExpression,
         JSXExpressionContainer,
     },
-    builder::AstBuilder,
 };
 use oxc_codegen::CodegenOptions;
 use oxc_diagnostics::{LabeledSpan, OxcDiagnostic};
@@ -615,9 +614,6 @@ fn report_unnecessary_curly_for_attribute_value<'a>(
     inner_span: Span,
 ) {
     ctx.diagnostic_with_fix(jsx_curly_brace_presence_unnecessary_diagnostic(inner_span), |fixer| {
-        let alloc = Allocator::default();
-        let ast_builder = AstBuilder::new(&alloc);
-
         let str = match &container.expression {
             JSXExpression::TemplateLiteral(template_lit) => template_lit.single_quasi().unwrap(),
             JSXExpression::StringLiteral(string_lit) => string_lit.value,
@@ -633,12 +629,7 @@ fn report_unnecessary_curly_for_attribute_value<'a>(
             fix = fix.with_options(CodegenOptions::default());
         }
 
-        fix.print_expression(&Expression::new_string_literal(
-            Span::default(),
-            str.as_str(),
-            None,
-            &ast_builder,
-        ));
+        fix.print_string(str.as_str());
 
         fixer.replace(container.span, fix.into_source_text())
     });
@@ -661,15 +652,7 @@ fn report_missing_curly_for_string_attribute_value(
     ctx.diagnostic_with_fix(jsx_curly_brace_presence_necessary_diagnostic(span), |fixer| {
         let mut replace = fixer.codegen().with_options(CodegenOptions::default());
 
-        let alloc = Allocator::default();
-        let ast_builder = AstBuilder::new(&alloc);
-
-        replace.print_expression(&Expression::new_string_literal(
-            Span::default(),
-            string_value,
-            None,
-            &ast_builder,
-        ));
+        replace.print_string(string_value);
 
         let mut fix = fixer.new_fix_with_capacity(3);
         fix.push(fixer.insert_text_before(&span, "{"));
@@ -681,8 +664,6 @@ fn report_missing_curly_for_string_attribute_value(
 fn report_missing_curly_for_text_node(ctx: &LintContext, span: Span, string_value: &str) {
     ctx.diagnostic_with_fix(jsx_curly_brace_presence_necessary_diagnostic(span), |fixer| {
         let fixer = fixer.for_multifix();
-        let alloc = Allocator::default();
-        let ast_builder = AstBuilder::new(&alloc);
         let line_matches = string_value.match_indices('\n').map(|(i, _)| i).collect::<Vec<_>>();
         let fix_contexts = if line_matches.is_empty() {
             build_missing_curly_fix_context_for_part(span, string_value, 0)
@@ -705,12 +686,7 @@ fn report_missing_curly_for_text_node(ctx: &LintContext, span: Span, string_valu
         let mut fix = fixer.new_fix_with_capacity(fix_contexts.len() * 3);
         for (span_from_first_char, text) in fix_contexts {
             let mut replace = fixer.codegen().with_options(CodegenOptions::default());
-            replace.print_expression(&Expression::new_string_literal(
-                Span::default(),
-                text,
-                None,
-                &ast_builder,
-            ));
+            replace.print_string(text);
             fix.push(fixer.replace(span_from_first_char, replace.into_source_text()));
             fix.push(fixer.insert_text_before(&span_from_first_char, "{"));
             fix.push(fixer.insert_text_after(&span_from_first_char, "}"));

--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_dataset.rs
@@ -1,14 +1,12 @@
 use cow_utils::CowUtils;
-use oxc_allocator::Allocator;
 use oxc_ast::{
     AstKind,
-    ast::{Argument, CallExpression, Expression, Str},
-    builder::AstBuilder,
+    ast::{Argument, CallExpression, Expression},
 };
 use oxc_codegen::CodegenOptions;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{GetSpan, SPAN, Span};
+use oxc_span::{GetSpan, Span};
 use oxc_syntax::identifier::is_identifier_name;
 
 use crate::{
@@ -270,14 +268,7 @@ fn expression_uses_optional_chain(expr: &Expression) -> bool {
 
 fn to_string_literal_text(fixer: RuleFixer, text: &str) -> String {
     let mut codegen = fixer.codegen().with_options(CodegenOptions::default());
-    let alloc = Allocator::default();
-    let ast = AstBuilder::new(&alloc);
-    codegen.print_expression(&Expression::new_string_literal(
-        SPAN,
-        Str::from_str_in(text, &ast),
-        None,
-        &ast,
-    ));
+    codegen.print_string(text);
     codegen.into_source_text()
 }
 

--- a/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_keyboard_event_key.rs
@@ -1,18 +1,17 @@
 use phf::{Map, phf_map};
 
-use oxc_allocator::{Allocator, GetAddress, UnstableAddress};
+use oxc_allocator::{GetAddress, UnstableAddress};
 use oxc_ast::{
     AstKind,
     ast::{
         Argument, BindingPattern, BindingProperty, CallExpression, Expression, Function,
-        MemberExpression, PropertyKey, Str,
+        MemberExpression, PropertyKey,
     },
-    builder::AstBuilder,
 };
 use oxc_codegen::CodegenOptions;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{SPAN, Span};
+use oxc_span::Span;
 
 use crate::{AstNode, context::LintContext, rule::Rule};
 
@@ -419,14 +418,7 @@ impl PreferKeyboardEventKey {
                 let mut codegen = fixer
                     .codegen()
                     .with_options(CodegenOptions { single_quote: true, ..Default::default() });
-                let alloc = Allocator::default();
-                let ast = AstBuilder::new(&alloc);
-                codegen.print_expression(&Expression::new_string_literal(
-                    SPAN,
-                    Str::from_str_in(&key_name, &ast),
-                    None,
-                    &ast,
-                ));
+                codegen.print_string(&key_name);
                 let key_str = codegen.into_source_text();
 
                 let mut fix = fixer.new_fix_with_capacity(2);

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_replace_all.rs
@@ -1,14 +1,12 @@
-use oxc_allocator::Allocator;
 use oxc_ast::{
     AstKind,
-    ast::{Argument, Expression, MemberExpression, RegExpFlags, Str},
-    builder::AstBuilder,
+    ast::{Argument, MemberExpression, RegExpFlags},
 };
 use oxc_codegen::CodegenOptions;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_regular_expression::ast::Term;
-use oxc_span::{GetSpan, SPAN, Span};
+use oxc_span::{GetSpan, Span};
 use oxc_str::CompactStr;
 
 use crate::{AstNode, ast_util::extract_regex_flags, context::LintContext, rule::Rule};
@@ -93,14 +91,7 @@ impl Rule for PreferStringReplaceAll {
                             single_quote: true,
                             ..Default::default()
                         });
-                        let alloc = Allocator::default();
-                        let ast = AstBuilder::new(&alloc);
-                        codegen.print_expression(&Expression::new_string_literal(
-                            SPAN,
-                            Str::from_str_in(&k, &ast),
-                            None,
-                            &ast,
-                        ));
+                        codegen.print_string(&k);
                         fixer.replace(pattern.span(), codegen.into_source_text())
                     });
                 }

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_starts_ends_with.rs
@@ -1,13 +1,11 @@
-use oxc_allocator::Allocator;
 use oxc_ast::{
     AstKind,
-    ast::{CallExpression, Expression, MemberExpression, RegExpFlags, RegExpLiteral, Str},
-    builder::AstBuilder,
+    ast::{CallExpression, Expression, MemberExpression, RegExpFlags, RegExpLiteral},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_regular_expression::ast::{BoundaryAssertionKind, Term};
-use oxc_span::{GetSpan, SPAN, Span};
+use oxc_span::{GetSpan, Span};
 
 use crate::{
     AstNode,
@@ -122,15 +120,8 @@ fn do_fix<'a>(
     };
     let Some(argument) = argument else { return fixer.noop() };
     let mut content = fixer.codegen();
-    let alloc = Allocator::default();
-    let ast = AstBuilder::new(&alloc);
     content.print_str(&format!(r"{}.{}(", fixer.source_range(target_span), method));
-    content.print_expression(&Expression::new_string_literal(
-        SPAN,
-        Str::from_str_in(&argument, &ast),
-        None,
-        &ast,
-    ));
+    content.print_string(&argument);
     content.print_str(r")");
     fixer.replace(call_expr.span, content.into_source_text())
 }


### PR DESCRIPTION
## Summary

- replace seven synthetic string literal AST constructions with `Codegen::print_string`
- remove the associated temporary allocators, AST builders, and unused imports
- preserve existing fixer options and generated output

Closes #23780.


**Stack:**
 - https://github.com/oxc-project/oxc/pull/23786 (this PR)
 - https://github.com/oxc-project/oxc/pull/23785
 - https://github.com/oxc-project/oxc/pull/23782