### PR TITLE
test(linter/no-useless-assignment): cover conditional for updates

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_assignment.rs
@@ -1234,6 +1234,20 @@ function useResource(unsafe: (resource: { readonly release: () => void }) => voi
 
   return resource;
 }",
+        "function collectIds(ids: readonly string[], forward: boolean): string[] {
+  const collected: string[] = [];
+  const startIndex = forward ? 0 : ids.length - 1;
+
+  for (
+    let index = startIndex;
+    forward ? index < ids.length : index >= 0;
+    forward ? index++ : index--
+  ) {
+    collected.push(ids[index]!);
+  }
+
+  return collected;
+}",
     ];
 
     let fail = vec![


### PR DESCRIPTION
fixes https://github.com/oxc-project/oxc/issues/23789

closes #23789 by adding a regression test case.

The test verifies that both branches of a conditional `for` update expression are considered used by the next loop iteration:

```ts
forward ? index++ : index--
```

Note, this was fixed via the CFG correction in #23791 - the update branches were disconnected from the loop test and incorrectly reported as useless assignments.

Stacked on #23791.

