### PR TITLE
fix(linter/react/exhaustive-deps): skip wrapper expression when analyzing hook initializers

### DIFF
--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -1114,7 +1114,7 @@ fn is_stable_value<'a, 'b>(
                 return true;
             }
 
-            let Expression::CallExpression(init_expr) = &init else {
+            let Expression::CallExpression(init_expr) = init.get_inner_expression() else {
                 return false;
             };
 
@@ -2869,6 +2869,19 @@ const Component = ({ filter }) => {
 
     return <div>test</div>;
 };",
+        r"const Component = () => {
+          const setRef = React.useRef<(value: string) => void | null>(
+            null,
+          ) as React.MutableRefObject<(value: string) => void | null>;
+
+          React.useEffect(() => {
+            if (setRef.current) {
+              console.log(setRef.current);
+            }
+          }, []);
+
+          return <div>test</div>;
+        };",
     ];
 
     let fail = vec![


### PR DESCRIPTION
fixes #23652

When identifying stable values, it now unwrapps TS assersion wrappers (as/satisfies/parenthesis/non null assertions).