### PR TITLE
fix(rulegen): escape Rust keywords in config fields

### DIFF
--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -874,10 +874,14 @@ impl RuleConfigOutput {
                     else {
                         continue;
                     };
-                    if key.to_case(Case::Camel) != *raw_key {
+                    let field_name = key.to_case(Case::Snake);
+                    let rust_field_name = rust_field_name(&field_name);
+                    let serialized_field_name =
+                        rust_field_name.strip_prefix("r#").unwrap_or(&rust_field_name);
+                    if key.to_case(Case::Camel) != *raw_key || serialized_field_name != field_name {
                         let _ = writeln!(output, "    #[serde(rename = \"{raw_key}\")]");
                     }
-                    let _ = writeln!(output, "    {}: {value_label},", key.to_case(Case::Snake));
+                    let _ = writeln!(output, "    {rust_field_name}: {value_label},");
                     if let Some(value_output) = value_output {
                         let _ = writeln!(fields_output, "{value_output}\n");
                     }
@@ -919,6 +923,24 @@ impl RuleConfigOutput {
                 None
             }
         }
+    }
+}
+
+/// Convert a config property name into a valid Rust field identifier.
+///
+/// Most Rust keywords can be used as raw identifiers. `self`, `Self`, `super`, and `crate`
+/// cannot, so append an underscore for those names. The caller adds a serde rename when the
+/// returned identifier does not serialize back to `name`.
+fn rust_field_name(name: &str) -> Cow<'_, str> {
+    if syn::parse_str::<syn::Ident>(name).is_ok() {
+        return Cow::Borrowed(name);
+    }
+
+    let raw_name = format!("r#{name}");
+    if syn::parse_str::<syn::Ident>(&raw_name).is_ok() {
+        Cow::Owned(raw_name)
+    } else {
+        Cow::Owned(format!("{name}_"))
     }
 }
 


### PR DESCRIPTION
fixes #23634

When valid Rust identifiers are generated for rule configurations that match reserved keywords, we convert it to the`r#`... form