### PR TITLE
feat(linter/unicorn): implement no-chained-comparison rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -1528,6 +1528,7 @@ export interface DummyRuleMap {
   "unicorn/no-array-sort"?: RuleNoConfig | [AllowWarnDeny, NoArraySort];
   "unicorn/no-await-expression-member"?: RuleNoConfig;
   "unicorn/no-await-in-promise-methods"?: RuleNoConfig;
+  "unicorn/no-chained-comparison"?: RuleNoConfig;
   "unicorn/no-console-spaces"?: RuleNoConfig;
   "unicorn/no-document-cookie"?: RuleNoConfig;
   "unicorn/no-empty-file"?: RuleNoConfig;

--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2912,6 +2912,12 @@ impl RuleRunner for crate::rules::react_perf::jsx_no_new_object_as_prop::JsxNoNe
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
 }
 
+impl RuleRunner for crate::rules::unicorn::no_chained_comparison::NoChainedComparison {
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::BinaryExpression]));
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+}
+
 impl RuleRunner for crate::rules::unicorn::catch_error_name::CatchErrorName {
     const NODE_TYPES: Option<&AstTypesBitset> =
         Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::CatchParameter]));

--- a/crates/oxc_linter/src/generated/rules_enum.rs
+++ b/crates/oxc_linter/src/generated/rules_enum.rs
@@ -622,6 +622,7 @@ pub use crate::rules::unicorn::no_array_reverse::NoArrayReverse as UnicornNoArra
 pub use crate::rules::unicorn::no_array_sort::NoArraySort as UnicornNoArraySort;
 pub use crate::rules::unicorn::no_await_expression_member::NoAwaitExpressionMember as UnicornNoAwaitExpressionMember;
 pub use crate::rules::unicorn::no_await_in_promise_methods::NoAwaitInPromiseMethods as UnicornNoAwaitInPromiseMethods;
+pub use crate::rules::unicorn::no_chained_comparison::NoChainedComparison as UnicornNoChainedComparison;
 pub use crate::rules::unicorn::no_console_spaces::NoConsoleSpaces as UnicornNoConsoleSpaces;
 pub use crate::rules::unicorn::no_document_cookie::NoDocumentCookie as UnicornNoDocumentCookie;
 pub use crate::rules::unicorn::no_empty_file::NoEmptyFile as UnicornNoEmptyFile;
@@ -1314,6 +1315,7 @@ pub enum RuleEnum {
     ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp),
     ReactPerfJsxNoNewFunctionAsProp(ReactPerfJsxNoNewFunctionAsProp),
     ReactPerfJsxNoNewObjectAsProp(ReactPerfJsxNoNewObjectAsProp),
+    UnicornNoChainedComparison(UnicornNoChainedComparison),
     UnicornCatchErrorName(UnicornCatchErrorName),
     UnicornConsistentAssert(UnicornConsistentAssert),
     UnicornConsistentDateClone(UnicornConsistentDateClone),
@@ -2211,7 +2213,8 @@ const REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID: usize =
     REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID + 1usize;
 const REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID: usize =
     REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID + 1usize;
-const UNICORN_CATCH_ERROR_NAME_ID: usize = REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID + 1usize;
+const UNICORN_NO_CHAINED_COMPARISON_ID: usize = REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID + 1usize;
+const UNICORN_CATCH_ERROR_NAME_ID: usize = UNICORN_NO_CHAINED_COMPARISON_ID + 1usize;
 const UNICORN_CONSISTENT_ASSERT_ID: usize = UNICORN_CATCH_ERROR_NAME_ID + 1usize;
 const UNICORN_CONSISTENT_DATE_CLONE_ID: usize = UNICORN_CONSISTENT_ASSERT_ID + 1usize;
 const UNICORN_CONSISTENT_EMPTY_ARRAY_SPREAD_ID: usize = UNICORN_CONSISTENT_DATE_CLONE_ID + 1usize;
@@ -3184,6 +3187,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => REACT_PERF_JSX_NO_NEW_ARRAY_AS_PROP_ID,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => REACT_PERF_JSX_NO_NEW_FUNCTION_AS_PROP_ID,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => REACT_PERF_JSX_NO_NEW_OBJECT_AS_PROP_ID,
+            Self::UnicornNoChainedComparison(_) => UNICORN_NO_CHAINED_COMPARISON_ID,
             Self::UnicornCatchErrorName(_) => UNICORN_CATCH_ERROR_NAME_ID,
             Self::UnicornConsistentAssert(_) => UNICORN_CONSISTENT_ASSERT_ID,
             Self::UnicornConsistentDateClone(_) => UNICORN_CONSISTENT_DATE_CLONE_ID,
@@ -4150,6 +4154,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::NAME,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::NAME,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::NAME,
+            Self::UnicornNoChainedComparison(_) => UnicornNoChainedComparison::NAME,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::NAME,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::NAME,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::NAME,
@@ -5132,6 +5137,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::CATEGORY,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::CATEGORY,
+            Self::UnicornNoChainedComparison(_) => UnicornNoChainedComparison::CATEGORY,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::CATEGORY,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::CATEGORY,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::CATEGORY,
@@ -6121,6 +6127,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::FIX,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::FIX,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::FIX,
+            Self::UnicornNoChainedComparison(_) => UnicornNoChainedComparison::FIX,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::FIX,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::FIX,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::FIX,
@@ -7196,6 +7203,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewObjectAsProp(_) => {
                 ReactPerfJsxNoNewObjectAsProp::documentation()
             }
+            Self::UnicornNoChainedComparison(_) => UnicornNoChainedComparison::documentation(),
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::documentation(),
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::documentation(),
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::documentation(),
@@ -9060,6 +9068,10 @@ impl RuleEnum {
                 ReactPerfJsxNoNewObjectAsProp::config_schema(generator)
                     .or_else(|| ReactPerfJsxNoNewObjectAsProp::schema(generator))
             }
+            Self::UnicornNoChainedComparison(_) => {
+                UnicornNoChainedComparison::config_schema(generator)
+                    .or_else(|| UnicornNoChainedComparison::schema(generator))
+            }
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::config_schema(generator)
                 .or_else(|| UnicornCatchErrorName::schema(generator)),
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::config_schema(generator)
@@ -10641,6 +10653,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => "react_perf",
             Self::ReactPerfJsxNoNewObjectAsProp(_) => "react_perf",
+            Self::UnicornNoChainedComparison(_) => "unicorn",
             Self::UnicornCatchErrorName(_) => "unicorn",
             Self::UnicornConsistentAssert(_) => "unicorn",
             Self::UnicornConsistentDateClone(_) => "unicorn",
@@ -12486,6 +12499,9 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewObjectAsProp(_) => Ok(Self::ReactPerfJsxNoNewObjectAsProp(
                 ReactPerfJsxNoNewObjectAsProp::from_configuration(value)?,
             )),
+            Self::UnicornNoChainedComparison(_) => Ok(Self::UnicornNoChainedComparison(
+                UnicornNoChainedComparison::from_configuration(value)?,
+            )),
             Self::UnicornCatchErrorName(_) => {
                 Ok(Self::UnicornCatchErrorName(UnicornCatchErrorName::from_configuration(value)?))
             }
@@ -14190,6 +14206,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.to_configuration(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.to_configuration(),
+            Self::UnicornNoChainedComparison(rule) => rule.to_configuration(),
             Self::UnicornCatchErrorName(rule) => rule.to_configuration(),
             Self::UnicornConsistentAssert(rule) => rule.to_configuration(),
             Self::UnicornConsistentDateClone(rule) => rule.to_configuration(),
@@ -15035,6 +15052,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run(node, ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run(node, ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run(node, ctx),
+            Self::UnicornNoChainedComparison(rule) => rule.run(node, ctx),
             Self::UnicornCatchErrorName(rule) => rule.run(node, ctx),
             Self::UnicornConsistentAssert(rule) => rule.run(node, ctx),
             Self::UnicornConsistentDateClone(rule) => rule.run(node, ctx),
@@ -15890,6 +15908,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_once(ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_once(ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_once(ctx),
+            Self::UnicornNoChainedComparison(rule) => rule.run_once(ctx),
             Self::UnicornCatchErrorName(rule) => rule.run_once(ctx),
             Self::UnicornConsistentAssert(rule) => rule.run_once(ctx),
             Self::UnicornConsistentDateClone(rule) => rule.run_once(ctx),
@@ -16818,6 +16837,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_on_jest_node(jest_node, ctx),
+            Self::UnicornNoChainedComparison(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornCatchErrorName(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornConsistentAssert(rule) => rule.run_on_jest_node(jest_node, ctx),
             Self::UnicornConsistentDateClone(rule) => rule.run_on_jest_node(jest_node, ctx),
@@ -17718,6 +17738,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.should_run(ctx),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.should_run(ctx),
+            Self::UnicornNoChainedComparison(rule) => rule.should_run(ctx),
             Self::UnicornCatchErrorName(rule) => rule.should_run(ctx),
             Self::UnicornConsistentAssert(rule) => rule.should_run(ctx),
             Self::UnicornConsistentDateClone(rule) => rule.should_run(ctx),
@@ -18748,6 +18769,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewObjectAsProp(_) => {
                 ReactPerfJsxNoNewObjectAsProp::IS_TSGOLINT_RULE
             }
+            Self::UnicornNoChainedComparison(_) => UnicornNoChainedComparison::IS_TSGOLINT_RULE,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::IS_TSGOLINT_RULE,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::IS_TSGOLINT_RULE,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::IS_TSGOLINT_RULE,
@@ -19878,6 +19900,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::VERSION,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::VERSION,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::VERSION,
+            Self::UnicornNoChainedComparison(_) => UnicornNoChainedComparison::VERSION,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::VERSION,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::VERSION,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::VERSION,
@@ -20909,6 +20932,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::HAS_CONFIG,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::HAS_CONFIG,
+            Self::UnicornNoChainedComparison(_) => UnicornNoChainedComparison::HAS_CONFIG,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::HAS_CONFIG,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::HAS_CONFIG,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::HAS_CONFIG,
@@ -21921,6 +21945,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(_) => ReactPerfJsxNoNewArrayAsProp::INFO,
             Self::ReactPerfJsxNoNewFunctionAsProp(_) => ReactPerfJsxNoNewFunctionAsProp::INFO,
             Self::ReactPerfJsxNoNewObjectAsProp(_) => ReactPerfJsxNoNewObjectAsProp::INFO,
+            Self::UnicornNoChainedComparison(_) => UnicornNoChainedComparison::INFO,
             Self::UnicornCatchErrorName(_) => UnicornCatchErrorName::INFO,
             Self::UnicornConsistentAssert(_) => UnicornConsistentAssert::INFO,
             Self::UnicornConsistentDateClone(_) => UnicornConsistentDateClone::INFO,
@@ -22812,6 +22837,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.types_info(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.types_info(),
+            Self::UnicornNoChainedComparison(rule) => rule.types_info(),
             Self::UnicornCatchErrorName(rule) => rule.types_info(),
             Self::UnicornConsistentAssert(rule) => rule.types_info(),
             Self::UnicornConsistentDateClone(rule) => rule.types_info(),
@@ -23654,6 +23680,7 @@ impl RuleEnum {
             Self::ReactPerfJsxNoNewArrayAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewFunctionAsProp(rule) => rule.run_info(),
             Self::ReactPerfJsxNoNewObjectAsProp(rule) => rule.run_info(),
+            Self::UnicornNoChainedComparison(rule) => rule.run_info(),
             Self::UnicornCatchErrorName(rule) => rule.run_info(),
             Self::UnicornConsistentAssert(rule) => rule.run_info(),
             Self::UnicornConsistentDateClone(rule) => rule.run_info(),
@@ -24588,6 +24615,7 @@ pub static RULES: std::sync::LazyLock<Vec<RuleEnum>> = std::sync::LazyLock::new(
         RuleEnum::ReactPerfJsxNoNewArrayAsProp(ReactPerfJsxNoNewArrayAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewFunctionAsProp(ReactPerfJsxNoNewFunctionAsProp::default()),
         RuleEnum::ReactPerfJsxNoNewObjectAsProp(ReactPerfJsxNoNewObjectAsProp::default()),
+        RuleEnum::UnicornNoChainedComparison(UnicornNoChainedComparison::default()),
         RuleEnum::UnicornCatchErrorName(UnicornCatchErrorName::default()),
         RuleEnum::UnicornConsistentAssert(UnicornConsistentAssert::default()),
         RuleEnum::UnicornConsistentDateClone(UnicornConsistentDateClone::default()),

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -511,6 +511,7 @@ pub(crate) mod unicorn {
     pub mod no_array_sort;
     pub mod no_await_expression_member;
     pub mod no_await_in_promise_methods;
+    pub mod no_chained_comparison;
     pub mod no_console_spaces;
     pub mod no_document_cookie;
     pub mod no_empty_file;

--- a/crates/oxc_linter/src/rules/unicorn/no_chained_comparison.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_chained_comparison.rs
@@ -1,0 +1,227 @@
+use oxc_ast::{AstKind, ast::Expression};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use oxc_syntax::operator::UnaryOperator;
+
+use crate::{AstNode, ast_util::get_declaration_of_variable, context::LintContext, rule::Rule};
+
+fn no_chained_comparison_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Comparison operators cannot be chained")
+        .with_help(
+            "The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.",
+        )
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoChainedComparison;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Disallow chained comparisons such as `a < b < c`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Unlike in math (or Python), chained comparisons in JavaScript do not
+    /// check a range. Comparison operators are binary and left-associative, so
+    /// `a < b < c` parses as `(a < b) < c`. The first comparison evaluates to a
+    /// boolean, which is then coerced to `0` or `1` and compared with `c`. This
+    /// is almost always a bug.
+    ///
+    /// Use `&&` to compare each pair of operands separately.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// if (a < b < c) {}
+    /// if (a === b === c) {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// if (a < b && b < c) {}
+    /// if (a === b && b === c) {}
+    /// // Intentionally comparing two boolean results.
+    /// if ((a > 0) === (b > 0)) {}
+    /// ```
+    NoChainedComparison,
+    unicorn,
+    correctness,
+    version = "next",
+    short_description = "Disallow chained comparisons such as `a < b < c`.",
+);
+
+impl Rule for NoChainedComparison {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::BinaryExpression(binary) = node.kind() else {
+            return;
+        };
+
+        if !is_comparison_operator(binary) {
+            return;
+        }
+
+        // One operand must itself be a comparison: `(a OP b) OP c` or `a OP (b OP c)`.
+        let sibling = if is_comparison(&binary.left) {
+            &binary.right
+        } else if is_comparison(&binary.right) {
+            &binary.left
+        } else {
+            return;
+        };
+
+        // For equality operators, comparing a comparison result against another boolean value
+        // (`(a > 0) === (b > 0)`, `(a < b) === true`, `(a > 0) !== Boolean(b)`) is an intentional
+        // boolean comparison, not a chained comparison.
+        if binary.operator.is_equality() && is_boolean(sibling, ctx) {
+            return;
+        }
+
+        ctx.diagnostic(no_chained_comparison_diagnostic(binary.span));
+    }
+}
+
+fn is_comparison_operator(binary: &oxc_ast::ast::BinaryExpression) -> bool {
+    binary.operator.is_compare() || binary.operator.is_equality()
+}
+
+/// A comparison is an ordering (`<`, `>`, `<=`, `>=`) or equality
+/// (`==`, `!=`, `===`, `!==`) binary expression.
+fn is_comparison(expr: &Expression) -> bool {
+    matches!(expr.without_parentheses(), Expression::BinaryExpression(binary) if is_comparison_operator(binary))
+}
+
+/// Whether `expr` is known to evaluate to a boolean.
+fn is_boolean<'a>(expr: &Expression<'a>, ctx: &LintContext<'a>) -> bool {
+    match expr.without_parentheses() {
+        Expression::BooleanLiteral(_) => true,
+        Expression::BinaryExpression(binary) => {
+            binary.operator.is_compare()
+                || binary.operator.is_equality()
+                || binary.operator.is_relational()
+        }
+        Expression::UnaryExpression(unary) => {
+            matches!(unary.operator, UnaryOperator::LogicalNot | UnaryOperator::Delete)
+        }
+        Expression::LogicalExpression(logical) => {
+            is_boolean(&logical.left, ctx) && is_boolean(&logical.right, ctx)
+        }
+        Expression::ConditionalExpression(conditional) => {
+            is_boolean(&conditional.consequent, ctx) && is_boolean(&conditional.alternate, ctx)
+        }
+        // `Boolean(…)`
+        Expression::CallExpression(call) => {
+            call.arguments.len() == 1
+                && matches!(&call.callee, Expression::Identifier(ident) if ident.name == "Boolean")
+        }
+        // A `const` binding whose initializer is itself a boolean.
+        Expression::Identifier(ident) => {
+            let Some(declaration) = get_declaration_of_variable(ident, ctx) else {
+                return false;
+            };
+            let Some(declarator) = declaration.kind().as_variable_declarator() else {
+                return false;
+            };
+            let is_const = matches!(
+                ctx.nodes().parent_kind(declaration.id()),
+                AstKind::VariableDeclaration(declaration) if declaration.kind.is_const()
+            );
+            is_const && declarator.init.as_ref().is_some_and(|init| is_boolean(init, ctx))
+        }
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "a < b",
+        "a === b",
+        "a < b && b < c",
+        "a < b && b < c && c < d",
+        "(a > 0) === (b > 0)",
+        "(a > 0) !== (b > 0)",
+        "(a > 0) == (b > 0)",
+        "(a < b) === true",
+        "(a < b) !== false",
+        "(a < b) == true",
+        "true === (a < b)",
+        "a == b == true",
+        "(a > 0) !== Boolean(b)",
+        "(a < b) === !c",
+        "(a < b) === (c ? true : false)",
+        "const d = a > b; (a < b) === d;",
+        "a < b || c < d",
+        "!(a < b)",
+        "foo(a < b, c)",
+        "a < b ? c : d",
+        "const x = a < b;",
+        "f(a < b) === g(c < d)",
+        "a instanceof b instanceof c",
+        "a in b in c",
+        "a + b + c",
+        "(a < b) + c",
+        "(a < b) & c",
+        "typeof a < b",
+        "a << b < c",
+        "(a as number) < b", // {"parser": parsers.typescript}
+    ];
+
+    let fail = vec![
+        "a < b < c",
+        "a > b > c",
+        "a <= b <= c",
+        "a >= b >= c",
+        "a < b <= c",
+        "a < b > c",
+        "a == b == c",
+        "a === b === c",
+        "a != b != c",
+        "a !== b !== c",
+        "a <= b >= c",
+        "a === b !== c",
+        "(a < b) < c",
+        "(a == b) == c",
+        "0 < x < 10",
+        "min <= value <= max",
+        "-1 < x < 1",
+        "a < b.c < d",
+        "a < b[c] < d",
+        "a < b?.c < d",
+        "a < b + c < d",
+        "a < b === c",
+        "a === b < c",
+        "(a > 0) == 0",
+        "(a > 0) === isEnabled",
+        "a == b < c",
+        "a === b > c",
+        "a < f() < c",
+        "a < (b = c) < d",
+        "a < b++ < c",
+        "a < /* comment */ b < c",
+        "(a < b) < true",
+        "a < b < false",
+        "(a < b) < (c < d)",
+        "a < b < c < d",
+        "foo === a < b < c",
+        "a < b < c === foo",
+        "x & a < b < c",
+        "a ?? b < c < d",
+        "foo === (a < b < c)",
+        "a && b < c < d",
+        "a || b < c < d",
+        "a < b < c ? x : y",
+        "a < (b ?? 0) < c",
+        "a < b < c",             // {"parser": parsers.typescript},
+        "a < b! < c",            // {"parser": parsers.typescript},
+        "a < (b as number) < c", // {"parser": parsers.typescript}
+    ];
+
+    Tester::new(NoChainedComparison::NAME, NoChainedComparison::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_chained_comparison.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_chained_comparison.snap
@@ -1,0 +1,360 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b < c
+   · ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a > b > c
+   · ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a <= b <= c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a >= b >= c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b <= c
+   · ──────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b > c
+   · ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a == b == c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a === b === c
+   · ─────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a != b != c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a !== b !== c
+   · ─────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a <= b >= c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a === b !== c
+   · ─────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ (a < b) < c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ (a == b) == c
+   · ─────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ 0 < x < 10
+   · ──────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ min <= value <= max
+   · ───────────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ -1 < x < 1
+   · ──────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b.c < d
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b[c] < d
+   · ────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b?.c < d
+   · ────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b + c < d
+   · ─────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b === c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a === b < c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ (a > 0) == 0
+   · ────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ (a > 0) === isEnabled
+   · ─────────────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a == b < c
+   · ──────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a === b > c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < f() < c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < (b = c) < d
+   · ───────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b++ < c
+   · ───────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < /* comment */ b < c
+   · ───────────────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ (a < b) < true
+   · ──────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b < false
+   · ─────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ (a < b) < (c < d)
+   · ─────────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b < c < d
+   · ─────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b < c < d
+   · ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ foo === a < b < c
+   · ─────────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:9]
+ 1 │ foo === a < b < c
+   ·         ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b < c === foo
+   · ─────────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b < c === foo
+   · ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:5]
+ 1 │ x & a < b < c
+   ·     ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:6]
+ 1 │ a ?? b < c < d
+   ·      ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ foo === (a < b < c)
+   · ───────────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:10]
+ 1 │ foo === (a < b < c)
+   ·          ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:6]
+ 1 │ a && b < c < d
+   ·      ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:6]
+ 1 │ a || b < c < d
+   ·      ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b < c ? x : y
+   · ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < (b ?? 0) < c
+   · ────────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b < c
+   · ─────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < b! < c
+   · ──────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.
+
+  ⚠ unicorn(no-chained-comparison): Comparison operators cannot be chained
+   ╭─[no_chained_comparison.tsx:1:1]
+ 1 │ a < (b as number) < c
+   · ─────────────────────
+   ╰────
+  help: The inner comparison evaluates to a boolean, which is then compared instead of the operands. Compare each pair of operands separately with `&&`.

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -8767,6 +8767,9 @@
         "unicorn/no-await-in-promise-methods": {
           "$ref": "#/definitions/RuleNoConfig"
         },
+        "unicorn/no-chained-comparison": {
+          "$ref": "#/definitions/RuleNoConfig"
+        },
         "unicorn/no-console-spaces": {
           "$ref": "#/definitions/RuleNoConfig"
         },


### PR DESCRIPTION
> [!NOTE]
> 👋 First-time contributor. I did use Claude to help me with this (I know some Rust but am not an expert), however I did read & review it myself before submitting this PR.

Implements `no-chained-comparison` from eslint-plugin-unicorn. Part of #684.

Flags chained comparisons such as `a < b < c`, which JavaScript parses left-associatively as `(a < b) < c` — the inner comparison evaluates to a boolean that is then coerced to `0`/`1` and compared, almost always a bug.

The intentional pattern of comparing a comparison result against another boolean with an equality operator (e.g. `(a > 0) === (b > 0)`, `(a < b) === true`, `(a > 0) !== Boolean(b)`) is left alone.

Implemented as a `correctness` rule, report-only. The upstream editor suggestion (rewrite to `&&`) is not yet ported and can be added as a follow-up.

All 31 pass / 47 fail upstream test cases are covered.

AI assistance was used in writing this rule (per AGENTS.md disclosure policy).