### PR TITLE
fix(linter/no-negated-condition): add autofix for negated if/ternary

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
@@ -17,7 +17,7 @@ declare_oxc_lint!(
     NoNegatedCondition,
     eslint,
     pedantic,
-    pending,
+    fix,
     docs = DOCUMENTATION,
     version = "0.0.18",
     short_description = "Disallow negated conditions.",
@@ -66,6 +66,16 @@ fn test() {
         "a !== b ? c : d",
     ];
 
+    let fix = vec![
+        ("if (!a) {;} else {;}", "if (a) {;} else {;}", None),
+        ("if (a != b) {;} else {;}", "if (a == b) {;} else {;}", None),
+        ("if (a !== b) {;} else {;}", "if (a === b) {;} else {;}", None),
+        ("!a ? b : c", "a ? c : b", None),
+        ("a != b ? c : d", "a == b ? d : c", None),
+        ("a !== b ? c : d", "a === b ? d : c", None),
+    ];
+
     Tester::new(NoNegatedCondition::NAME, NoNegatedCondition::PLUGIN, pass, fail)
+        .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -3,7 +3,10 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::context::LintContext;
+use crate::{
+    context::LintContext,
+    fixer::{RuleFix, RuleFixer},
+};
 
 fn no_negated_condition_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected negated condition.")
@@ -44,7 +47,7 @@ a ? doSomethingB() : doSomethingC()
 ```
 ";
 
-pub fn run_on_if_statement(if_stmt: &IfStatement<'_>, ctx: &LintContext) {
+pub fn run_on_if_statement<'a>(if_stmt: &IfStatement<'a>, ctx: &LintContext<'a>) {
     let Some(if_stmt_alternate) = &if_stmt.alternate else {
         return;
     };
@@ -54,19 +57,27 @@ pub fn run_on_if_statement(if_stmt: &IfStatement<'_>, ctx: &LintContext) {
     }
 
     let test = if_stmt.test.without_parentheses();
-    if is_negated_expression(test) {
-        ctx.diagnostic(no_negated_condition_diagnostic(test.span()));
+    if !is_negated_expression(test) {
+        return;
     }
+
+    ctx.diagnostic_with_fix(no_negated_condition_diagnostic(test.span()), |fixer| {
+        fix_if_statement(fixer, if_stmt, ctx)
+    });
 }
 
-pub fn run_on_conditional_expression(
-    conditional_expr: &ConditionalExpression<'_>,
-    ctx: &LintContext,
+pub fn run_on_conditional_expression<'a>(
+    conditional_expr: &ConditionalExpression<'a>,
+    ctx: &LintContext<'a>,
 ) {
     let test = conditional_expr.test.without_parentheses();
-    if is_negated_expression(test) {
-        ctx.diagnostic(no_negated_condition_diagnostic(test.span()));
+    if !is_negated_expression(test) {
+        return;
     }
+
+    ctx.diagnostic_with_fix(no_negated_condition_diagnostic(test.span()), |fixer| {
+        fix_conditional_expression(fixer, conditional_expr, ctx)
+    });
 }
 
 fn is_negated_expression(expr: &Expression) -> bool {
@@ -78,4 +89,304 @@ fn is_negated_expression(expr: &Expression) -> bool {
         ),
         _ => false,
     }
+}
+
+fn fix_if_statement<'a>(
+    fixer: RuleFixer<'_, 'a>,
+    if_stmt: &IfStatement<'a>,
+    ctx: &LintContext<'a>,
+) -> RuleFix {
+    let Some(alternate) = &if_stmt.alternate else {
+        return fixer.noop();
+    };
+
+    let fixer = fixer.for_multifix();
+    let mut fixes = fixer.new_fix_with_capacity(4);
+
+    convert_negated_condition(
+        &mut fixes,
+        &fixer,
+        &if_stmt.test,
+        /* is_if_statement */ true,
+        ctx,
+    );
+    swap_if_branches(&mut fixes, &fixer, if_stmt.consequent.span(), alternate.span(), ctx);
+
+    fixes.with_message(
+        "Remove the negation operator and switch the consequent and alternate branches.",
+    )
+}
+
+fn fix_conditional_expression<'a>(
+    fixer: RuleFixer<'_, 'a>,
+    conditional_expr: &ConditionalExpression<'a>,
+    ctx: &LintContext<'a>,
+) -> RuleFix {
+    let fixer = fixer.for_multifix();
+    let mut fixes = fixer.new_fix_with_capacity(6);
+
+    let test_inner = conditional_expr.test.without_parentheses();
+    let is_unary = matches!(
+        test_inner,
+        Expression::UnaryExpression(u) if u.operator == UnaryOperator::LogicalNot
+    );
+
+    convert_negated_condition(
+        &mut fixes,
+        &fixer,
+        &conditional_expr.test,
+        /* is_if_statement */ false,
+        ctx,
+    );
+    swap_expression_branches(
+        &mut fixes,
+        &fixer,
+        conditional_expr.consequent.span(),
+        conditional_expr.alternate.span(),
+        ctx,
+    );
+
+    if is_unary {
+        // `return!a` / `throw!a` — insert space so keyword and operand don't glue.
+        fix_space_around_keyword(&mut fixes, &fixer, conditional_expr, ctx);
+
+        // Multi-line `return !` / `throw !` without parens around the whole conditional.
+        if needs_return_or_throw_parens(conditional_expr, test_inner, ctx) {
+            fixes.push(fixer.insert_text_before_range(conditional_expr.span, "("));
+            fixes.push(fixer.insert_text_after_range(conditional_expr.span, ")"));
+        } else if needs_asi_semicolon(conditional_expr, test_inner, ctx) {
+            // ASI when removing leading `!` would merge with the previous line.
+            fixes.push(fixer.insert_text_before_range(conditional_expr.span, ";"));
+        }
+    }
+
+    fixes.with_message(
+        "Remove the negation operator and switch the consequent and alternate branches.",
+    )
+}
+
+fn convert_negated_condition<'a>(
+    fixes: &mut RuleFix,
+    fixer: &RuleFixer<'_, 'a>,
+    test: &Expression<'a>,
+    is_if_statement: bool,
+    ctx: &LintContext<'a>,
+) {
+    let test_inner = test.without_parentheses();
+    match test_inner {
+        Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::LogicalNot => {
+            // Delete the `!` operator token.
+            let bang_span = Span::sized(unary.span.start, 1);
+            fixes.push(fixer.delete_range(bang_span));
+
+            // For `if` tests only, strip parentheses from the unary argument (unicorn behavior).
+            if is_if_statement {
+                remove_parentheses(fixes, fixer, &unary.argument);
+            }
+        }
+        Expression::BinaryExpression(binary)
+            if matches!(
+                binary.operator,
+                BinaryOperator::Inequality | BinaryOperator::StrictInequality
+            ) =>
+        {
+            let op_span = operator_span(binary.left.span().end, binary.right.span().start, ctx);
+            let replacement = match binary.operator {
+                BinaryOperator::Inequality => "==",
+                BinaryOperator::StrictInequality => "===",
+                _ => unreachable!(),
+            };
+            fixes.push(fixer.replace(op_span, replacement));
+        }
+        _ => {}
+    }
+}
+
+/// Span of the binary operator between left and right operands.
+fn operator_span(left_end: u32, right_start: u32, ctx: &LintContext<'_>) -> Span {
+    let between = ctx.source_range(Span::new(left_end, right_start));
+    let Some(rel) = between.find("!=") else {
+        return Span::new(left_end, right_start);
+    };
+    #[expect(clippy::cast_possible_truncation)]
+    let start = left_end + rel as u32;
+    let len = if between[rel..].starts_with("!==") { 3 } else { 2 };
+    Span::sized(start, len)
+}
+
+fn remove_parentheses(fixes: &mut RuleFix, fixer: &RuleFixer<'_, '_>, expr: &Expression<'_>) {
+    let mut current = expr;
+    while let Expression::ParenthesizedExpression(paren) = current {
+        fixes.push(fixer.delete_range(Span::sized(paren.span.start, 1)));
+        fixes.push(fixer.delete_range(Span::sized(paren.span.end - 1, 1)));
+        current = &paren.expression;
+    }
+}
+
+fn swap_if_branches<'a>(
+    fixes: &mut RuleFix,
+    fixer: &RuleFixer<'_, 'a>,
+    consequent_span: Span,
+    alternate_span: Span,
+    ctx: &LintContext<'a>,
+) {
+    let consequent_text = branch_text_for_if(ctx, consequent_span);
+    let alternate_text = branch_text_for_if(ctx, alternate_span);
+
+    if consequent_text == alternate_text {
+        return;
+    }
+
+    fixes.push(fixer.replace(consequent_span, alternate_text));
+    fixes.push(fixer.replace(alternate_span, consequent_text));
+}
+
+fn branch_text_for_if(ctx: &LintContext<'_>, span: Span) -> String {
+    let text = ctx.source_range(span);
+    // Non-block statement arms need braces after swap (ASI / structure safety).
+    let trimmed = text.trim_start();
+    if trimmed.starts_with('{') { text.to_owned() } else { format!("{{{text}}}") }
+}
+
+fn swap_expression_branches<'a>(
+    fixes: &mut RuleFix,
+    fixer: &RuleFixer<'_, 'a>,
+    consequent_span: Span,
+    alternate_span: Span,
+    ctx: &LintContext<'a>,
+) {
+    let consequent_text = ctx.source_range(consequent_span);
+    let alternate_text = ctx.source_range(alternate_span);
+
+    if consequent_text == alternate_text {
+        return;
+    }
+
+    fixes.push(fixer.replace(consequent_span, alternate_text.to_owned()));
+    fixes.push(fixer.replace(alternate_span, consequent_text.to_owned()));
+}
+
+fn fix_space_around_keyword<'a>(
+    fixes: &mut RuleFix,
+    fixer: &RuleFixer<'_, 'a>,
+    conditional_expr: &ConditionalExpression<'a>,
+    ctx: &LintContext<'a>,
+) {
+    let start = conditional_expr.span.start;
+    if start == 0 {
+        return;
+    }
+    let before = ctx.source_range(Span::new(0, start));
+    let Some(prev) = before.chars().next_back() else {
+        return;
+    };
+    if !is_identifier_part(prev) {
+        return;
+    }
+    let test_inner = conditional_expr.test.without_parentheses();
+    if let Expression::UnaryExpression(unary) = test_inner {
+        // Insert space before `!` so after deletion we get `return a` not `returna`.
+        fixes.push(fixer.insert_text_before_range(Span::sized(unary.span.start, 1), " "));
+    }
+}
+
+fn is_identifier_part(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || c == '$'
+}
+
+fn needs_return_or_throw_parens<'a>(
+    conditional_expr: &ConditionalExpression<'a>,
+    test_inner: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> bool {
+    let Expression::UnaryExpression(unary) = test_inner else {
+        return false;
+    };
+
+    // Bang and operand must be on different lines.
+    let bang_end = unary.span.start + 1;
+    let arg_start = unary.argument.span().start;
+    if same_line(ctx, bang_end, arg_start) {
+        return false;
+    }
+
+    // Whole conditional already parenthesized as return/throw argument
+    // (`return (! … ? … : …)` — conditional.span starts at `(`).
+    let source = ctx.source_text();
+    let cond_start = conditional_expr.span.start as usize;
+    if cond_start > 0 && source.as_bytes().get(cond_start) == Some(&b'(') {
+        return false;
+    }
+
+    // Preceded by `return` or `throw` (keyword immediately before, ignoring whitespace/comments
+    // is hard; match unicorn's common cases: keyword then optional spaces then our expression).
+    let before = ctx.source_range(Span::new(0, conditional_expr.span.start));
+    let trimmed = before.trim_end();
+    let is_return_or_throw = trimmed.ends_with("return") || trimmed.ends_with("throw");
+    if !is_return_or_throw {
+        return false;
+    }
+
+    // `return ( \n ! // … \n a) ? b : c` — test itself is parenthesized around the unary only;
+    // conditional.span still starts at `(`. Already excluded by leading `(` check if AST puts
+    // paren on test. If test is ParenthesizedExpression, conditional.span starts at `(`.
+    if matches!(conditional_expr.test, Expression::ParenthesizedExpression(_)) {
+        // Parenthesized test is not the same as parenthesized conditional; span of conditional
+        // still starts at `!` or `(`. For invalid(15), source is:
+        //   return (
+        //   ! // …
+        //   a) ? b : c
+        // conditional.span starts at `(` of `( \n ! … a)` which is the test paren — so leading
+        // `(` means we must NOT add return parens. Good — returns false above when first char is `(`.
+        // Wait: for invalid(15), first char of conditional IS `(` because test is ParenthesizedExpression.
+        // So we return false. Correct for 15.
+        return false;
+    }
+
+    true
+}
+
+fn needs_asi_semicolon<'a>(
+    conditional_expr: &ConditionalExpression<'a>,
+    test_inner: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> bool {
+    let Expression::UnaryExpression(unary) = test_inner else {
+        return false;
+    };
+
+    // First character of what remains after deleting `!` (start of unary argument).
+    let next_start = unary.argument.span().start;
+    let next_byte = ctx.source_text().as_bytes().get(next_start as usize).copied();
+    let needs_semi_for_next =
+        matches!(next_byte, Some(b'[' | b'(' | b'`' | b'+' | b'-' | b'/' | b'*' | b'.'));
+    if !needs_semi_for_next {
+        return false;
+    }
+
+    let start = conditional_expr.span.start;
+    if start == 0 {
+        return false;
+    }
+    let before = ctx.source_range(Span::new(0, start));
+    let Some(prev_non_ws_idx) = before.rfind(|c: char| !c.is_whitespace()) else {
+        return false;
+    };
+    // Previous token must be on a prior line.
+    if !before[prev_non_ws_idx..].contains('\n') {
+        return false;
+    }
+
+    let prev_char = before.as_bytes()[prev_non_ws_idx] as char;
+    // Statement-ending or continuation-safe tokens don't need ASI.
+    if matches!(prev_char, ';' | '{' | '}' | '(' | '[' | ',' | ':' | '?') {
+        return false;
+    }
+    // Identifier / literal / closing paren on previous line + dangerous next token → ASI.
+    true
+}
+
+fn same_line(ctx: &LintContext<'_>, a: u32, b: u32) -> bool {
+    let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+    !ctx.source_range(Span::new(lo, hi)).contains('\n')
 }

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -8,10 +8,11 @@ use crate::{
     fixer::{RuleFix, RuleFixer},
 };
 
-fn no_negated_condition_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Unexpected negated condition.")
-        .with_help("Remove the negation operator and switch the consequent and alternate branches.")
-        .with_label(span)
+const FIX_MESSAGE: &str =
+    "Remove the negation operator and switch the consequent and alternate branches.";
+
+fn diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Unexpected negated condition.").with_help(FIX_MESSAGE).with_label(span)
 }
 
 pub const DOCUMENTATION: &str = r"### What it does
@@ -48,140 +49,106 @@ a ? doSomethingB() : doSomethingC()
 ";
 
 pub fn run_on_if_statement<'a>(if_stmt: &IfStatement<'a>, ctx: &LintContext<'a>) {
-    let Some(if_stmt_alternate) = &if_stmt.alternate else {
+    // Only `if`/`else` — not `else if` (alternate is another `IfStatement`).
+    let Some(alternate) = &if_stmt.alternate else {
         return;
     };
-
-    if matches!(if_stmt_alternate, Statement::IfStatement(_)) {
+    if matches!(alternate, Statement::IfStatement(_)) {
         return;
     }
 
     let test = if_stmt.test.without_parentheses();
-    if !is_negated_expression(test) {
+    if !is_negated(test) {
         return;
     }
 
-    ctx.diagnostic_with_fix(no_negated_condition_diagnostic(test.span()), |fixer| {
-        fix_if_statement(fixer, if_stmt, ctx)
+    ctx.diagnostic_with_fix(diagnostic(test.span()), |fixer| {
+        let fixer = fixer.for_multifix();
+        let mut fixes = fixer.new_fix_with_capacity(4);
+
+        invert_test(&mut fixes, &fixer, &if_stmt.test, /* strip_arg_parens */ true, ctx);
+        swap_spans(
+            &mut fixes,
+            &fixer,
+            if_stmt.consequent.span(),
+            alternate.span(),
+            /* brace_non_blocks */ true,
+            ctx,
+        );
+
+        fixes.with_message(FIX_MESSAGE)
     });
 }
 
-pub fn run_on_conditional_expression<'a>(
-    conditional_expr: &ConditionalExpression<'a>,
-    ctx: &LintContext<'a>,
-) {
-    let test = conditional_expr.test.without_parentheses();
-    if !is_negated_expression(test) {
+pub fn run_on_conditional_expression<'a>(expr: &ConditionalExpression<'a>, ctx: &LintContext<'a>) {
+    let test = expr.test.without_parentheses();
+    if !is_negated(test) {
         return;
     }
 
-    ctx.diagnostic_with_fix(no_negated_condition_diagnostic(test.span()), |fixer| {
-        fix_conditional_expression(fixer, conditional_expr, ctx)
+    ctx.diagnostic_with_fix(diagnostic(test.span()), |fixer| {
+        let fixer = fixer.for_multifix();
+        let mut fixes = fixer.new_fix_with_capacity(6);
+
+        invert_test(&mut fixes, &fixer, &expr.test, /* strip_arg_parens */ false, ctx);
+        swap_spans(
+            &mut fixes,
+            &fixer,
+            expr.consequent.span(),
+            expr.alternate.span(),
+            /* brace_non_blocks */ false,
+            ctx,
+        );
+
+        // Extra care only for `!… ? … : …` (not `!=` / `!==`).
+        if let Expression::UnaryExpression(unary) = test
+            && unary.operator == UnaryOperator::LogicalNot
+        {
+            fix_unary_ternary_edges(
+                &mut fixes,
+                &fixer,
+                expr,
+                unary.span.start,
+                &unary.argument,
+                ctx,
+            );
+        }
+
+        fixes.with_message(FIX_MESSAGE)
     });
 }
 
-fn is_negated_expression(expr: &Expression) -> bool {
+fn is_negated(expr: &Expression) -> bool {
     match expr {
-        Expression::UnaryExpression(unary_expr) => unary_expr.operator == UnaryOperator::LogicalNot,
-        Expression::BinaryExpression(binary_expr) => matches!(
-            binary_expr.operator,
-            BinaryOperator::Inequality | BinaryOperator::StrictInequality
-        ),
+        Expression::UnaryExpression(u) => u.operator == UnaryOperator::LogicalNot,
+        Expression::BinaryExpression(b) => {
+            matches!(b.operator, BinaryOperator::Inequality | BinaryOperator::StrictInequality)
+        }
         _ => false,
     }
 }
 
-fn fix_if_statement<'a>(
-    fixer: RuleFixer<'_, 'a>,
-    if_stmt: &IfStatement<'a>,
-    ctx: &LintContext<'a>,
-) -> RuleFix {
-    let Some(alternate) = &if_stmt.alternate else {
-        return fixer.noop();
-    };
-
-    let fixer = fixer.for_multifix();
-    let mut fixes = fixer.new_fix_with_capacity(4);
-
-    convert_negated_condition(
-        &mut fixes,
-        &fixer,
-        &if_stmt.test,
-        /* is_if_statement */ true,
-        ctx,
-    );
-    swap_if_branches(&mut fixes, &fixer, if_stmt.consequent.span(), alternate.span(), ctx);
-
-    fixes.with_message(
-        "Remove the negation operator and switch the consequent and alternate branches.",
-    )
-}
-
-fn fix_conditional_expression<'a>(
-    fixer: RuleFixer<'_, 'a>,
-    conditional_expr: &ConditionalExpression<'a>,
-    ctx: &LintContext<'a>,
-) -> RuleFix {
-    let fixer = fixer.for_multifix();
-    let mut fixes = fixer.new_fix_with_capacity(6);
-
-    let test_inner = conditional_expr.test.without_parentheses();
-    let is_unary = matches!(
-        test_inner,
-        Expression::UnaryExpression(u) if u.operator == UnaryOperator::LogicalNot
-    );
-
-    convert_negated_condition(
-        &mut fixes,
-        &fixer,
-        &conditional_expr.test,
-        /* is_if_statement */ false,
-        ctx,
-    );
-    swap_expression_branches(
-        &mut fixes,
-        &fixer,
-        conditional_expr.consequent.span(),
-        conditional_expr.alternate.span(),
-        ctx,
-    );
-
-    if is_unary {
-        // `return!a` / `throw!a` — insert space so keyword and operand don't glue.
-        fix_space_around_keyword(&mut fixes, &fixer, conditional_expr, ctx);
-
-        // Multi-line `return !` / `throw !` without parens around the whole conditional.
-        if needs_return_or_throw_parens(conditional_expr, test_inner, ctx) {
-            fixes.push(fixer.insert_text_before_range(conditional_expr.span, "("));
-            fixes.push(fixer.insert_text_after_range(conditional_expr.span, ")"));
-        } else if needs_asi_semicolon(conditional_expr, test_inner, ctx) {
-            // ASI when removing leading `!` would merge with the previous line.
-            fixes.push(fixer.insert_text_before_range(conditional_expr.span, ";"));
-        }
-    }
-
-    fixes.with_message(
-        "Remove the negation operator and switch the consequent and alternate branches.",
-    )
-}
-
-fn convert_negated_condition<'a>(
+/// Turn `!x` into `x`, or `a != b` / `a !== b` into `a == b` / `a === b`.
+///
+/// When `strip_arg_parens` is set (if-tests only), also remove parens on the `!` operand
+/// so `if (!((a)))` becomes `if (a)` rather than `if ((a))`.
+fn invert_test<'a>(
     fixes: &mut RuleFix,
     fixer: &RuleFixer<'_, 'a>,
     test: &Expression<'a>,
-    is_if_statement: bool,
+    strip_arg_parens: bool,
     ctx: &LintContext<'a>,
 ) {
-    let test_inner = test.without_parentheses();
-    match test_inner {
+    match test.without_parentheses() {
         Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::LogicalNot => {
-            // Delete the `!` operator token.
-            let bang_span = Span::sized(unary.span.start, 1);
-            fixes.push(fixer.delete_range(bang_span));
-
-            // For `if` tests only, strip parentheses from the unary argument (unicorn behavior).
-            if is_if_statement {
-                remove_parentheses(fixes, fixer, &unary.argument);
+            fixes.push(fixer.delete_range(Span::sized(unary.span.start, 1)));
+            if strip_arg_parens {
+                let mut inner = &unary.argument;
+                while let Expression::ParenthesizedExpression(paren) = inner {
+                    fixes.push(fixer.delete_range(Span::sized(paren.span.start, 1)));
+                    fixes.push(fixer.delete_range(Span::sized(paren.span.end - 1, 1)));
+                    inner = &paren.expression;
+                }
             }
         }
         Expression::BinaryExpression(binary)
@@ -190,203 +157,113 @@ fn convert_negated_condition<'a>(
                 BinaryOperator::Inequality | BinaryOperator::StrictInequality
             ) =>
         {
-            let op_span = operator_span(binary.left.span().end, binary.right.span().start, ctx);
-            let replacement = match binary.operator {
-                BinaryOperator::Inequality => "==",
-                BinaryOperator::StrictInequality => "===",
-                _ => unreachable!(),
-            };
-            fixes.push(fixer.replace(op_span, replacement));
+            let op = find_inequality_op(binary.left.span().end, binary.right.span().start, ctx);
+            let replacement =
+                if binary.operator == BinaryOperator::StrictInequality { "===" } else { "==" };
+            fixes.push(fixer.replace(op, replacement));
         }
         _ => {}
     }
 }
 
-/// Span of the binary operator between left and right operands.
-fn operator_span(left_end: u32, right_start: u32, ctx: &LintContext<'_>) -> Span {
+fn find_inequality_op(left_end: u32, right_start: u32, ctx: &LintContext<'_>) -> Span {
     let between = ctx.source_range(Span::new(left_end, right_start));
-    let Some(rel) = between.find("!=") else {
+    let Some(offset) = between.find("!=") else {
         return Span::new(left_end, right_start);
     };
     #[expect(clippy::cast_possible_truncation)]
-    let start = left_end + rel as u32;
-    let len = if between[rel..].starts_with("!==") { 3 } else { 2 };
+    let start = left_end + offset as u32;
+    let len = if between[offset..].starts_with("!==") { 3 } else { 2 };
     Span::sized(start, len)
 }
 
-fn remove_parentheses(fixes: &mut RuleFix, fixer: &RuleFixer<'_, '_>, expr: &Expression<'_>) {
-    let mut current = expr;
-    while let Expression::ParenthesizedExpression(paren) = current {
-        fixes.push(fixer.delete_range(Span::sized(paren.span.start, 1)));
-        fixes.push(fixer.delete_range(Span::sized(paren.span.end - 1, 1)));
-        current = &paren.expression;
-    }
-}
-
-fn swap_if_branches<'a>(
+/// Swap two spans' source text. Optionally wrap non-`{…}` if-arms in braces.
+fn swap_spans<'a>(
     fixes: &mut RuleFix,
     fixer: &RuleFixer<'_, 'a>,
-    consequent_span: Span,
-    alternate_span: Span,
+    left: Span,
+    right: Span,
+    brace_non_blocks: bool,
     ctx: &LintContext<'a>,
 ) {
-    let consequent_text = branch_text_for_if(ctx, consequent_span);
-    let alternate_text = branch_text_for_if(ctx, alternate_span);
-
-    if consequent_text == alternate_text {
+    let left_text = arm_source(ctx, left, brace_non_blocks);
+    let right_text = arm_source(ctx, right, brace_non_blocks);
+    if left_text == right_text {
         return;
     }
-
-    fixes.push(fixer.replace(consequent_span, alternate_text));
-    fixes.push(fixer.replace(alternate_span, consequent_text));
+    fixes.push(fixer.replace(left, right_text));
+    fixes.push(fixer.replace(right, left_text));
 }
 
-fn branch_text_for_if(ctx: &LintContext<'_>, span: Span) -> String {
+fn arm_source(ctx: &LintContext<'_>, span: Span, brace_non_blocks: bool) -> String {
     let text = ctx.source_range(span);
-    // Non-block statement arms need braces after swap (ASI / structure safety).
-    let trimmed = text.trim_start();
-    if trimmed.starts_with('{') { text.to_owned() } else { format!("{{{text}}}") }
+    if brace_non_blocks && !text.trim_start().starts_with('{') {
+        format!("{{{text}}}")
+    } else {
+        text.to_owned()
+    }
 }
 
-fn swap_expression_branches<'a>(
+/// After removing `!` from a ternary, keep the program parseable:
+/// - space after `return`/`throw` (`return!a` → `return a`)
+/// - parens for multi-line `return !` / `throw !`
+/// - leading `;` when ASI would otherwise glue to the previous line
+fn fix_unary_ternary_edges<'a>(
     fixes: &mut RuleFix,
     fixer: &RuleFixer<'_, 'a>,
-    consequent_span: Span,
-    alternate_span: Span,
+    expr: &ConditionalExpression<'a>,
+    bang_start: u32,
+    argument: &Expression<'a>,
     ctx: &LintContext<'a>,
 ) {
-    let consequent_text = ctx.source_range(consequent_span);
-    let alternate_text = ctx.source_range(alternate_span);
+    let before = ctx.source_range(Span::new(0, expr.span.start));
 
-    if consequent_text == alternate_text {
+    // `return!a` — keyword abuts `!`; insert a space before the bang (deleted by invert_test).
+    if before.chars().next_back().is_some_and(is_ident_char) {
+        fixes.push(fixer.insert_text_before_range(Span::sized(bang_start, 1), " "));
+    }
+
+    let bang_and_arg_on_different_lines =
+        ctx.source_range(Span::new(bang_start + 1, argument.span().start)).contains('\n');
+
+    // `return !\n a ? b : c` — without parens, `return` only applies to `!`.
+    // Skip if the test is already `(…)` (e.g. `return (!\n a) ? b : c`).
+    if bang_and_arg_on_different_lines
+        && !matches!(expr.test, Expression::ParenthesizedExpression(_))
+        && {
+            let t = before.trim_end();
+            t.ends_with("return") || t.ends_with("throw")
+        }
+    {
+        fixes.push(fixer.insert_text_before_range(expr.span, "("));
+        fixes.push(fixer.insert_text_after_range(expr.span, ")"));
         return;
     }
 
-    fixes.push(fixer.replace(consequent_span, alternate_text.to_owned()));
-    fixes.push(fixer.replace(alternate_span, consequent_text.to_owned()));
+    // `a\n![] ? b : c` → after deleting `!`, `[]` continues the previous line; insert `;`.
+    if needs_asi_semicolon(before, argument, ctx) {
+        fixes.push(fixer.insert_text_before_range(expr.span, ";"));
+    }
 }
 
-fn fix_space_around_keyword<'a>(
-    fixes: &mut RuleFix,
-    fixer: &RuleFixer<'_, 'a>,
-    conditional_expr: &ConditionalExpression<'a>,
-    ctx: &LintContext<'a>,
-) {
-    let start = conditional_expr.span.start;
-    if start == 0 {
-        return;
+fn needs_asi_semicolon(before: &str, argument: &Expression<'_>, ctx: &LintContext<'_>) -> bool {
+    // Tokens that can continue an expression on the previous line once `!` is gone.
+    let next = ctx.source_text().as_bytes().get(argument.span().start as usize).copied();
+    if !matches!(next, Some(b'[' | b'(' | b'`' | b'+' | b'-' | b'/' | b'*' | b'.')) {
+        return false;
     }
-    let before = ctx.source_range(Span::new(0, start));
-    let Some(prev) = before.chars().next_back() else {
-        return;
+
+    let Some(prev_idx) = before.rfind(|c: char| !c.is_whitespace()) else {
+        return false;
     };
-    if !is_identifier_part(prev) {
-        return;
+    // Previous token must be on an earlier line.
+    if !before[prev_idx..].contains('\n') {
+        return false;
     }
-    let test_inner = conditional_expr.test.without_parentheses();
-    if let Expression::UnaryExpression(unary) = test_inner {
-        // Insert space before `!` so after deletion we get `return a` not `returna`.
-        fixes.push(fixer.insert_text_before_range(Span::sized(unary.span.start, 1), " "));
-    }
+    // Already terminated / continuation-safe.
+    !matches!(before.as_bytes()[prev_idx] as char, ';' | '{' | '}' | '(' | '[' | ',' | ':' | '?')
 }
 
-fn is_identifier_part(c: char) -> bool {
+fn is_ident_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '_' || c == '$'
-}
-
-fn needs_return_or_throw_parens<'a>(
-    conditional_expr: &ConditionalExpression<'a>,
-    test_inner: &Expression<'a>,
-    ctx: &LintContext<'a>,
-) -> bool {
-    let Expression::UnaryExpression(unary) = test_inner else {
-        return false;
-    };
-
-    // Bang and operand must be on different lines.
-    let bang_end = unary.span.start + 1;
-    let arg_start = unary.argument.span().start;
-    if same_line(ctx, bang_end, arg_start) {
-        return false;
-    }
-
-    // Whole conditional already parenthesized as return/throw argument
-    // (`return (! … ? … : …)` — conditional.span starts at `(`).
-    let source = ctx.source_text();
-    let cond_start = conditional_expr.span.start as usize;
-    if cond_start > 0 && source.as_bytes().get(cond_start) == Some(&b'(') {
-        return false;
-    }
-
-    // Preceded by `return` or `throw` (keyword immediately before, ignoring whitespace/comments
-    // is hard; match unicorn's common cases: keyword then optional spaces then our expression).
-    let before = ctx.source_range(Span::new(0, conditional_expr.span.start));
-    let trimmed = before.trim_end();
-    let is_return_or_throw = trimmed.ends_with("return") || trimmed.ends_with("throw");
-    if !is_return_or_throw {
-        return false;
-    }
-
-    // `return ( \n ! // … \n a) ? b : c` — test itself is parenthesized around the unary only;
-    // conditional.span still starts at `(`. Already excluded by leading `(` check if AST puts
-    // paren on test. If test is ParenthesizedExpression, conditional.span starts at `(`.
-    if matches!(conditional_expr.test, Expression::ParenthesizedExpression(_)) {
-        // Parenthesized test is not the same as parenthesized conditional; span of conditional
-        // still starts at `!` or `(`. For invalid(15), source is:
-        //   return (
-        //   ! // …
-        //   a) ? b : c
-        // conditional.span starts at `(` of `( \n ! … a)` which is the test paren — so leading
-        // `(` means we must NOT add return parens. Good — returns false above when first char is `(`.
-        // Wait: for invalid(15), first char of conditional IS `(` because test is ParenthesizedExpression.
-        // So we return false. Correct for 15.
-        return false;
-    }
-
-    true
-}
-
-fn needs_asi_semicolon<'a>(
-    conditional_expr: &ConditionalExpression<'a>,
-    test_inner: &Expression<'a>,
-    ctx: &LintContext<'a>,
-) -> bool {
-    let Expression::UnaryExpression(unary) = test_inner else {
-        return false;
-    };
-
-    // First character of what remains after deleting `!` (start of unary argument).
-    let next_start = unary.argument.span().start;
-    let next_byte = ctx.source_text().as_bytes().get(next_start as usize).copied();
-    let needs_semi_for_next =
-        matches!(next_byte, Some(b'[' | b'(' | b'`' | b'+' | b'-' | b'/' | b'*' | b'.'));
-    if !needs_semi_for_next {
-        return false;
-    }
-
-    let start = conditional_expr.span.start;
-    if start == 0 {
-        return false;
-    }
-    let before = ctx.source_range(Span::new(0, start));
-    let Some(prev_non_ws_idx) = before.rfind(|c: char| !c.is_whitespace()) else {
-        return false;
-    };
-    // Previous token must be on a prior line.
-    if !before[prev_non_ws_idx..].contains('\n') {
-        return false;
-    }
-
-    let prev_char = before.as_bytes()[prev_non_ws_idx] as char;
-    // Statement-ending or continuation-safe tokens don't need ASI.
-    if matches!(prev_char, ';' | '{' | '}' | '(' | '[' | ',' | ':' | '?') {
-        return false;
-    }
-    // Identifier / literal / closing paren on previous line + dangerous next token → ASI.
-    true
-}
-
-fn same_line(ctx: &LintContext<'_>, a: u32, b: u32) -> bool {
-    let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
-    !ctx.source_range(Span::new(lo, hi)).contains('\n')
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -17,7 +17,7 @@ declare_oxc_lint!(
     NoNegatedCondition,
     unicorn,
     pedantic,
-    pending,
+    fix,
     docs = DOCUMENTATION,
     version = "0.0.18",
     short_description = "Disallow negated conditions.",
@@ -70,14 +70,96 @@ fn test() {
         r"if((( !a ))) b(); else c();",
         r"function a() {return!a ? b : c}",
         r"function a() {return!(( a )) ? b : c}",
+        // Multi-line return/throw + comments (unicorn 13–16)
+        "function a() {\nreturn ! // comment\na ? b : c;\n}",
+        "function a() {\nreturn (! // ReturnStatement argument is parenthesized\na ? b : c);\n}",
+        "function a() {\nreturn (\n! // UnaryExpression argument is parenthesized\na) ? b : c;\n}",
+        "function a() {\nthrow ! // comment\na ? b : c;\n}",
         r"!a ? b : c ? d : e",
         r"!a ? b : (( c ? d : e ))",
+        // ASI after removing `!` (unicorn 19–22)
+        "a\n![] ? b : c",
+        "a\n!+b ? c : d",
+        "a\n!(b) ? c : d",
+        "a\n!b ? c : d",
+        // Multi-line non-block if (unicorn 23)
+        "if (!a)\nb()\nelse\nc()",
         r"if(!a) b(); else c()",
+        // Non-block `else return` (unicorn 25)
+        "function fn() {\nif(!a) b(); else return\n}",
         r"if(!a) {b()} else {c()}",
         r"if(!!a) b(); else c();",
         r"(!!a) ? b() : c();",
+        // Inequality whose left is still `!` (unicorn 29) — two diagnostics
+        "function fn() {\nreturn!a !== b ? c : d\nreturn((!((a)) != b)) ? c : d\n}",
+        // Report on inner `else if`, not outer (unicorn 30)
+        "if (!a) {\nb();\n} else if (!c) {\nd();\n} else {\ne();\n}",
+    ];
+
+    let fix = vec![
+        (r"if (!a) {;} else {;}", r"if (a) {;} else {;}", None),
+        (r"if (a != b) {;} else {;}", r"if (a == b) {;} else {;}", None),
+        (r"if (a !== b) {;} else {;}", r"if (a === b) {;} else {;}", None),
+        (r"!a ? b : c", r"a ? c : b", None),
+        (r"a != b ? c : d", r"a == b ? d : c", None),
+        (r"a !== b ? c : d", r"a === b ? d : c", None),
+        (r"(( !a )) ? b : c", r"(( a )) ? c : b", None),
+        (r"!(( a )) ? b : c", r"(( a )) ? c : b", None),
+        (r"if(!(( a ))) b(); else c();", r"if( a ) {c();} else {b();}", None),
+        (r"if((( !a ))) b(); else c();", r"if((( a ))) {c();} else {b();}", None),
+        (r"function a() {return!a ? b : c}", r"function a() {return a ? c : b}", None),
+        (r"function a() {return!(( a )) ? b : c}", r"function a() {return (( a )) ? c : b}", None),
+        (
+            "function a() {\nreturn ! // comment\na ? b : c;\n}",
+            // One space after `(` (unicorn snapshot has two; we preserve a single space after deleting `!`).
+            "function a() {\nreturn ( // comment\na ? c : b);\n}",
+            None,
+        ),
+        (
+            "function a() {\nreturn (! // ReturnStatement argument is parenthesized\na ? b : c);\n}",
+            "function a() {\nreturn ( // ReturnStatement argument is parenthesized\na ? c : b);\n}",
+            None,
+        ),
+        (
+            "function a() {\nreturn (\n! // UnaryExpression argument is parenthesized\na) ? b : c;\n}",
+            "function a() {\nreturn (\n // UnaryExpression argument is parenthesized\na) ? c : b;\n}",
+            None,
+        ),
+        (
+            "function a() {\nthrow ! // comment\na ? b : c;\n}",
+            "function a() {\nthrow ( // comment\na ? c : b);\n}",
+            None,
+        ),
+        (r"!a ? b : c ? d : e", r"a ? c ? d : e : b", None),
+        (r"!a ? b : (( c ? d : e ))", r"a ? (( c ? d : e )) : b", None),
+        ("a\n![] ? b : c", "a\n;[] ? c : b", None),
+        ("a\n!+b ? c : d", "a\n;+b ? d : c", None),
+        ("a\n!(b) ? c : d", "a\n;(b) ? d : c", None),
+        ("a\n!b ? c : d", "a\nb ? d : c", None),
+        ("if (!a)\nb()\nelse\nc()", "if (a)\n{c()}\nelse\n{b()}", None),
+        (r"if(!a) b(); else c()", r"if(a) {c()} else {b();}", None),
+        (
+            "function fn() {\nif(!a) b(); else return\n}",
+            "function fn() {\nif(a) {return} else {b();}\n}",
+            None,
+        ),
+        (r"if(!a) {b()} else {c()}", r"if(a) {c()} else {b()}", None),
+        (r"if(!!a) b(); else c();", r"if(!a) {c();} else {b();}", None),
+        (r"(!!a) ? b() : c();", r"(!a) ? c() : b();", None),
+        // Two separate fixes applied in one file (fixer applies all non-overlapping diagnostics)
+        (
+            "function fn() {\nreturn!a !== b ? c : d\nreturn((!((a)) != b)) ? c : d\n}",
+            "function fn() {\nreturn!a === b ? d : c\nreturn((!((a)) == b)) ? d : c\n}",
+            None,
+        ),
+        (
+            "if (!a) {\nb();\n} else if (!c) {\nd();\n} else {\ne();\n}",
+            "if (!a) {\nb();\n} else if (c) {\ne();\n} else {\nd();\n}",
+            None,
+        ),
     ];
 
     Tester::new(NoNegatedCondition::NAME, NoNegatedCondition::PLUGIN, pass, fail)
+        .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/unicorn_no_negated_condition.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_negated_condition.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
 ---
 
   ⚠ unicorn(no-negated-condition): Unexpected negated condition.
@@ -87,6 +88,42 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and switch the consequent and alternate branches.
 
   ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:8]
+ 1 │     function a() {
+ 2 │ ╭─▶ return ! // comment
+ 3 │ ╰─▶ a ? b : c;
+ 4 │     }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:9]
+ 1 │     function a() {
+ 2 │ ╭─▶ return (! // ReturnStatement argument is parenthesized
+ 3 │ ╰─▶ a ? b : c);
+ 4 │     }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:3:1]
+ 2 │     return (
+ 3 │ ╭─▶ ! // UnaryExpression argument is parenthesized
+ 4 │ ╰─▶ a) ? b : c;
+ 5 │     }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:7]
+ 1 │     function a() {
+ 2 │ ╭─▶ throw ! // comment
+ 3 │ ╰─▶ a ? b : c;
+ 4 │     }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
    ╭─[no_negated_condition.tsx:1:1]
  1 │ !a ? b : c ? d : e
    · ──
@@ -101,9 +138,58 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and switch the consequent and alternate branches.
 
   ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:1]
+ 1 │ a
+ 2 │ ![] ? b : c
+   · ───
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:1]
+ 1 │ a
+ 2 │ !+b ? c : d
+   · ───
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:1]
+ 1 │ a
+ 2 │ !(b) ? c : d
+   · ────
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:1]
+ 1 │ a
+ 2 │ !b ? c : d
+   · ──
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:5]
+ 1 │ if (!a)
+   ·     ──
+ 2 │ b()
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
    ╭─[no_negated_condition.tsx:1:4]
  1 │ if(!a) b(); else c()
    ·    ──
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:4]
+ 1 │ function fn() {
+ 2 │ if(!a) b(); else return
+   ·    ──
+ 3 │ }
    ╰────
   help: Remove the negation operator and switch the consequent and alternate branches.
 
@@ -125,5 +211,32 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_negated_condition.tsx:1:2]
  1 │ (!!a) ? b() : c();
    ·  ───
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:7]
+ 1 │ function fn() {
+ 2 │ return!a !== b ? c : d
+   ·       ────────
+ 3 │ return((!((a)) != b)) ? c : d
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:3:9]
+ 2 │ return!a !== b ? c : d
+ 3 │ return((!((a)) != b)) ? c : d
+   ·         ───────────
+ 4 │ }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:3:12]
+ 2 │ b();
+ 3 │ } else if (!c) {
+   ·            ──
+ 4 │ d();
    ╰────
   help: Remove the negation operator and switch the consequent and alternate branches.


### PR DESCRIPTION
## Summary

- Make `eslint/no-negated-condition` and `unicorn/no-negated-condition` **fixable** via shared logic in `rules/shared/eslint_unicorn/no_negated_condition.rs`.
- Autofix inverts the test (`!` removal, or `!=` / `!==` → `==` / `===`) and swaps consequent/alternate branches.
- Covers unicorn-aligned edge cases: non-block `if` arms (brace wrap), ASI when removing a leading `!`, `return`/`throw` spacing and multi-line paren wrapping, and fixing only the **inner** `else if` in `if / else if / else` chains.
- Binary inequalities whose left operand is still `!` only rewrite the operator (e.g. `!a !== b` → `!a === b`), matching eslint-plugin-unicorn.

**AI usage:** This PR was developed with AI assistance. I reviewed the logic, tests, and unicorn snapshot parity (with one intentional whitespace delta on multi-line `return ! // comment` fixes: one space after `(` vs unicorn’s two).

## Test plan

- [x] `cargo test -p oxc_linter --lib no_negated_condition`
- [ ] CI on this PR
- [ ] Spot-check with oxlint `--fix` on a few negated `if`/`? :` samples if useful