### PR TITLE
refactor(formatter): clarify jsdoc embedded formatting

### DIFF
--- a/crates/oxc_formatter/src/formatter/jsdoc/embedded.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/embedded.rs
@@ -90,11 +90,20 @@ pub(super) fn update_template_depth(line: &str, mut depth: u32) -> u32 {
     depth
 }
 
-/// Try to format JS/TS/JSX code using the formatter.
-/// Returns `Some(formatted)` on success, `None` if parsing fails.
-/// The `print_width` is the available width for the formatted code.
-/// Uses the parent `format_options` to ensure consistent formatting behavior.
-pub(super) fn format_embedded_js(
+/// Format a JS/TS/JSX snippet extracted from a JSDoc comment.
+///
+/// For now, this is JSDoc-specific helper, NOT a generic embedded-language formatter.
+/// JSDoc snippets are standalone comment fragments rather than parent-integrated IR,
+/// so they go through `format_program` directly (no orchestrator round trip)
+/// and return a string for line-by-line splicing into the surrounding comment.
+///
+/// JSDoc-specific behaviour (inline comments below give the full rationale):
+/// - object-literal wrap for `{`-leading snippets
+/// - TSX → JSX fallback (TSX first so TS generics aren't miss-parsed)
+/// - `sort_imports` / `sort_tailwindcss` are disabled (top-level concerns)
+///
+/// Returns `None` on parse failure, the pass-through gate every caller uses.
+pub(super) fn format_jsdoc_js_snippet(
     code: &str,
     print_width: usize,
     format_options: &JsFormatOptions,
@@ -103,10 +112,6 @@ pub(super) fn format_embedded_js(
     let width = u16::try_from(print_width).unwrap_or(80).clamp(1, 320);
     let line_width = LineWidth::try_from(width).unwrap();
 
-    // Null out sort_imports/sort_tailwindcss — they're top-level concerns irrelevant
-    // to embedded code, and their Vec fields make cloning expensive.
-    // Inherit indent_style from parent so embedded code uses tabs when useTabs=true,
-    // matching upstream prettier-plugin-jsdoc behavior.
     let base_options = JsFormatOptions {
         line_width,
         jsdoc: None,

--- a/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/nodes.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/mdast_serialize/nodes.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use markdown::mdast::Node;
 
-use super::super::embedded::{format_embedded_js, is_js_ts_lang};
+use super::super::embedded::{format_jsdoc_js_snippet, is_js_ts_lang};
 use super::super::line_buffer::LineBuffer;
 use super::super::wrap::{format_table_block, wrap_paragraph};
 use super::SerializeOptions;
@@ -743,11 +743,17 @@ fn serialize_code(
     }
 }
 
-/// Format code block content in JSDoc descriptions.
-/// For JS/TS code (fenced with a JS/TS lang tag, fenced with no lang tag, or
-/// indented code blocks), the code is formatted through Prettier's parser via
-/// `format_embedded_js`. For non-JS/TS fenced code (css, html, etc.), the code
-/// is preserved verbatim.
+/// Format code block content in a JSDoc Markdown description.
+///
+/// Routing:
+/// - JS/TS code (fenced with a JS/TS lang tag, fenced with no lang tag, or indented blocks):
+///   formatted in-process via [`format_jsdoc_js_snippet`] (`oxc_formatter`'s own parser/formatter).
+/// - Non-JS/TS fenced code (css, html, graphql, etc.):
+///   when external callbacks are wired,
+///   routed through `ExternalCallbacks::format_embedded` (the string channel).
+///   When callbacks are absent (Rust-only conformance / pure CLI build), preserved verbatim.
+///
+/// NOTE: `@example` fences diverge here, see `tag_formatters::format_example_fenced_block`.
 fn format_code_value<'a>(
     code: &'a str,
     lang: Option<&str>,
@@ -772,7 +778,7 @@ fn format_code_value<'a>(
             return Cow::Borrowed(code);
         }
         // Fenced JS/TS, fenced with no lang, or indented code: try formatting
-        if let Some(formatted) = format_embedded_js(code, width, format_options, allocator) {
+        if let Some(formatted) = format_jsdoc_js_snippet(code, width, format_options, allocator) {
             return Cow::Owned(formatted);
         }
     }

--- a/crates/oxc_formatter/src/formatter/jsdoc/tag_formatters.rs
+++ b/crates/oxc_formatter/src/formatter/jsdoc/tag_formatters.rs
@@ -4,7 +4,7 @@ use cow_utils::CowUtils;
 
 use super::{
     embedded::{
-        format_embedded_js, format_type_via_formatter, is_js_ts_lang, update_template_depth,
+        format_jsdoc_js_snippet, format_type_via_formatter, is_js_ts_lang, update_template_depth,
     },
     normalize::{
         capitalize_first, normalize_markdown_emphasis, normalize_type,
@@ -137,11 +137,11 @@ impl JsdocFormatter<'_, '_> {
             return;
         }
 
-        // Check for fenced code blocks (```lang ... ```). Triple backticks are
-        // actually valid JavaScript (template literal expressions), so
-        // `format_embedded_js` would parse them as JS and produce wrong output.
-        // Handle fenced blocks by stripping the markers, formatting just the
-        // inner code, and re-adding the fences with proper indentation.
+        // Check for fenced code blocks (```lang ... ```).
+        // Triple backticks are actually valid JavaScript (template literal expressions),
+        // so `format_jsdoc_js_snippet` would parse them as JS and produce wrong output.
+        // Handle fenced blocks by stripping the markers, formatting just the inner code,
+        // and re-adding the fences with proper indentation.
         if let Some((first_line, rest)) = code.split_once('\n')
             && first_line.starts_with("```")
         {
@@ -163,8 +163,8 @@ impl JsdocFormatter<'_, '_> {
         // wrap_width minus the code indent width.
         let effective_width = self.wrap_width.saturating_sub(self.code_indent_width());
         if let Some(formatted) =
-            format_embedded_js(code, effective_width, self.format_options, self.allocator).filter(
-                |f| {
+            format_jsdoc_js_snippet(code, effective_width, self.format_options, self.allocator)
+                .filter(|f| {
                     // Reject pseudo-code that parses as valid JS but produces
                     // structurally different output (e.g., `{undefined}('popup', 'options')`
                     // parsed as block statement + expression). If the line count
@@ -172,8 +172,7 @@ impl JsdocFormatter<'_, '_> {
                     let input_lines = code.lines().count();
                     let output_lines = f.lines().count();
                     output_lines <= input_lines * 2 + 1
-                },
-            )
+                })
         {
             self.push_formatted_code_lines(&formatted, indent);
             return;
@@ -205,7 +204,7 @@ impl JsdocFormatter<'_, '_> {
         if !inner_code.is_empty() {
             let lang = lang_line[3..].trim();
             if is_js_ts_lang(lang) {
-                if let Some(formatted) = format_embedded_js(
+                if let Some(formatted) = format_jsdoc_js_snippet(
                     inner_code,
                     effective_width,
                     self.format_options,
@@ -217,7 +216,8 @@ impl JsdocFormatter<'_, '_> {
                     self.push_raw_code_lines(inner_code, indent);
                 }
             } else {
-                // Non-JS/TS fenced code: preserve with continuation indent
+                // NOTE: Non-JS fences in `@example` stay verbatim (no external callback) for now.
+                // Diverges from description fences; see `mdast_serialize::nodes::format_code_value`.
                 self.push_raw_code_lines(inner_code, indent);
             }
         }


### PR DESCRIPTION
It might not be widely known, but you can embed multiple languages within JSDoc(Markdown code fence, `@example` tag), and those will be formatted as well.

However, because it works a bit differently from other embedded formattings and can be confusing, I will clarify how it works here.