### PR TITLE
refactor(oxfmt,formatter): clean up tailwind sorter usage

### DIFF
--- a/apps/oxfmt/src/core/external_formatter.rs
+++ b/apps/oxfmt/src/core/external_formatter.rs
@@ -227,11 +227,42 @@ impl ExternalFormatter {
     /// Convert this external formatter to the `oxc_formatter::ExternalCallbacks` type.
     /// The options (including `filepath`) are captured in the closures and passed to JS on each call.
     ///
-    /// `graphql_options` / `css_options` are dual mappings of the same resolved
-    /// config for the dispatcher's Rust branches (gql-in-js / css-in-js).
+    /// `graphql_options` / `css_options` are dual mappings of the same resolved config
+    /// for the dispatcher's Rust branches (gql-in-js / css-in-js).
     ///
-    /// Actual closure assembly lives in `core::embed::{string_channel, dispatcher}`;
+    /// Actual closure assembly lives in `core::embed::{string_channel, ir_channel}`;
     /// this method just bridges the napi-held callback `Arc`s into those factories.
+    ///
+    /// NOTE: Tailwind data paths
+    /// `sort_tailwindcss_classes` is wired into THREE distinct callback slots,
+    /// because Tailwind class sorting has four legitimate paths depending on
+    /// where the classes live and how they reach printing:
+    ///
+    /// 1. Standalone JS/TS (`className` / functions / custom attributes):
+    ///    `oxc_formatter` collects classes into `FormatElement::TailwindClass`.
+    ///    When the entry document is finalized,
+    ///    the printer sorts them in one host batch via the `tailwind_callback` set by `with_tailwind` below.
+    /// 2. Standalone CSS / SCSS / LESS (`@apply` at top level):
+    ///    `oxc_formatter_css::format()` receives the sort closure directly
+    ///    (via `CssFormatOptions::sort_tailwindcss` + the host sorter on the CSS format context)
+    ///    and sorts as it prints, no embedded boundary is involved.
+    /// 3. Embedded CSS (css-in-js + Angular `@Component({ styles })`):
+    ///    `oxc_formatter_css::format_to_ir()` returns pre-sort `@apply` classes
+    ///    in `DispatchResult::tailwind_classes`.
+    ///    The JS parent re-indexes them into its own collector (`remap_tailwind_into`)
+    ///    so they ride the SAME parent batch as path 1.
+    ///    The standalone CSS sort closure is NOT invoked here.
+    /// 4. JSDoc fenced CSS (Markdown code fence in JSDoc descriptions):
+    ///    Goes through the string channel,
+    ///    `format_embedded()` returns a formatted string (not parent-integrated IR),
+    ///    so the sort must run inside that call, not via `DispatchResult` remapping.
+    ///    The `string_channel::build_embedded_callback` factory receives the sorter for this case.
+    ///
+    /// All four paths use the SAME `sort_tailwindcss_classes` napi callback;
+    /// only the wiring differs.
+    /// Moving sorting to the wrong layer (e.g. sorting inside embedded CSS instead of remapping)
+    /// would double-sort or drop classes.
+    /// `DispatchResult::remap_tailwind_into`'s printer `debug_assert` catches dropped remaps.
     pub fn to_external_callbacks(
         &self,
         format_options: &JsFormatOptions,

--- a/apps/oxfmt/src/core/options/to_oxc_formatter.rs
+++ b/apps/oxfmt/src/core/options/to_oxc_formatter.rs
@@ -128,13 +128,13 @@ pub fn to_oxc_formatter(config: &FormatConfig) -> Result<JsFormatOptions, String
     if let Some(tw_config) =
         config.sort_tailwindcss.clone().and_then(SortTailwindcssUserConfig::into_config)
     {
+        // `config` / `stylesheet` / `preserve_duplicates` are JS-sorter-only
+        // and travel through `to_prettier::inject_tailwind_plugin_payload`,
+        // not the Rust formatter options.
         format_options.sort_tailwindcss = Some(SortTailwindcssOptions {
-            config: tw_config.config,
-            stylesheet: tw_config.stylesheet,
             functions: tw_config.functions.unwrap_or_default(),
             attributes: tw_config.attributes.unwrap_or_default(),
             preserve_whitespace: tw_config.preserve_whitespace.unwrap_or(false),
-            preserve_duplicates: tw_config.preserve_duplicates.unwrap_or(false),
         });
     }
 

--- a/crates/oxc_formatter/src/options.rs
+++ b/crates/oxc_formatter/src/options.rs
@@ -173,54 +173,30 @@ impl Default for JsdocOptions {
     }
 }
 
-/// Options for Tailwind CSS class sorting.
-/// Based on options from `prettier-plugin-tailwindcss`.
+/// Tailwind class sorting options that affect Rust-side collection.
 ///
-/// See <https://github.com/tailwindlabs/prettier-plugin-tailwindcss#options>
+/// The actual class ordering is performed by the host (Oxfmt)-supplied JS sorter
+/// (`prettier-plugin-tailwindcss/sorter`), so the JS-only payload is NOT carried here.
 ///
-/// NOTE: The actual sorting is performed by
-/// the host(Oxfmt)-supplied sorter (`prettier-plugin-tailwindcss/sorter` on the JS side).
-/// Therefore, this struct should only contain options that are relevant to `oxc_formatter`.
-/// (e.g. `config`, `stylesheet` can be removed here)
+/// This struct only carries fields the Rust formatter needs while
+/// - detecting classes (`functions`, `attributes`)
+/// - or preserving original whitespace (`preserve_whitespace`)
 #[derive(Debug, Default, Clone)]
 pub struct SortTailwindcssOptions {
-    /// Path to your Tailwind CSS configuration file (v3).
-    ///
-    /// Note: Paths are resolved relative to the Oxfmt configuration file.
-    ///
-    /// Default: `"./tailwind.config.js"`
-    pub config: Option<String>,
-
-    /// Path to your Tailwind CSS stylesheet (v4).
-    ///
-    /// Note: Paths are resolved relative to the Oxfmt configuration file.
-    ///
-    /// Example: `"./src/app.css"`
-    pub stylesheet: Option<String>,
-
     /// List of custom function names that contain Tailwind CSS classes.
     ///
     /// Example: `["clsx", "cn", "cva", "tw"]`
-    ///
     /// Default: `[]`
     pub functions: Vec<String>,
-
     /// List of additional attributes to sort (beyond `class` and `className`).
     ///
     /// Example: `["myClassProp", ":class"]`
-    ///
     /// Default: `[]`
     pub attributes: Vec<String>,
-
     /// Preserve whitespace around classes.
     ///
     /// Default: `false`
     pub preserve_whitespace: bool,
-
-    /// Preserve duplicate classes.
-    ///
-    /// Default: `false`
-    pub preserve_duplicates: bool,
 }
 
 impl JsFormatOptions {

--- a/crates/oxc_formatter/src/print/template/embed/css.rs
+++ b/crates/oxc_formatter/src/print/template/embed/css.rs
@@ -61,7 +61,7 @@ pub(super) fn format_css_doc<'a>(
             return false;
         };
         result.remap_tailwind_into(f.context_mut());
-        let Some(ir) = result.into_single_doc() else {
+        let Some(ir) = result.docs.into_iter().next() else {
             return false;
         };
 
@@ -98,7 +98,7 @@ pub(super) fn format_css_doc<'a>(
         return false;
     };
     result.remap_tailwind_into(f.context_mut());
-    let Some(ir) = result.into_single_doc() else {
+    let Some(ir) = result.docs.into_iter().next() else {
         return false;
     };
 

--- a/crates/oxc_formatter/src/print/template/embed/html.rs
+++ b/crates/oxc_formatter/src/print/template/embed/html.rs
@@ -63,10 +63,6 @@ pub(super) fn format_html_doc<'a>(
         ) else {
             return false;
         };
-        // No-op today (the Prettier Doc path never carries classes), but the
-        // boundary contract is "merge at every embed site" — a Rust HTML
-        // formatter collecting `class` attributes will rely on this.
-        result.remap_tailwind_into(f.context_mut());
         let Some(html_has_multiple_root_elements) = result
             .meta
             .as_ref()
@@ -75,7 +71,11 @@ pub(super) fn format_html_doc<'a>(
         else {
             return false;
         };
-        let Some(mut ir) = result.into_single_doc() else {
+        // Remap is a no-op today (the Prettier Doc path never carries classes),
+        // but the boundary contract is "merge at every embed site".
+        // A Rust HTML formatter collecting `class` attributes will rely on this.
+        result.remap_tailwind_into(f.context_mut());
+        let Some(mut ir) = result.docs.into_iter().next() else {
             return false;
         };
 
@@ -143,8 +143,6 @@ pub(super) fn format_html_doc<'a>(
         return format_js_in_html_as_fallback(joined, &expressions, f);
     };
 
-    // See the Phase 0 note: no-op today, load-bearing once HTML is Rust.
-    result.remap_tailwind_into(f.context_mut());
     let Some(html_has_multiple_root_elements) = result
         .meta
         .as_ref()
@@ -153,7 +151,9 @@ pub(super) fn format_html_doc<'a>(
     else {
         return false;
     };
-    let Some(mut ir) = result.into_single_doc() else {
+    // See the Phase 0 note: remap is no-op today, load-bearing once `oxc_formatter_html` lands
+    result.remap_tailwind_into(f.context_mut());
+    let Some(mut ir) = result.docs.into_iter().next() else {
         return false;
     };
 

--- a/crates/oxc_formatter/src/print/template/embed/markdown.rs
+++ b/crates/oxc_formatter/src/print/template/embed/markdown.rs
@@ -40,7 +40,7 @@ pub(super) fn try_embed_markdown<'a>(
     ) else {
         return false;
     };
-    let Some(mut ir) = result.into_single_doc() else {
+    let Some(mut ir) = result.docs.into_iter().next() else {
         return false;
     };
 

--- a/crates/oxc_formatter_core/src/embedded.rs
+++ b/crates/oxc_formatter_core/src/embedded.rs
@@ -75,37 +75,31 @@ pub struct EmbeddedIr<'a> {
 pub struct DispatchResult<'a> {
     /// One IR per input text (usually one; GraphQL returns one per quasi).
     /// Each IR is arena-allocated alongside its elements.
+    /// Single-doc consumers extract the IR via `docs.into_iter().next()` after calling
+    /// [`Self::remap_tailwind_into`]; multi-doc consumers (GraphQL) walk `docs`.
     pub docs: Vec<ArenaVec<'a, FormatElement<'a>>>,
     /// Pre-sort Tailwind classes referenced by the docs'
     /// `FormatElement::TailwindClass` indices (0-based, local to this result).
-    /// The receiving parent MUST merge them into its own class space via
-    /// [`Self::remap_tailwind_into`] — the printer asserts on dangling indices.
+    /// The receiving parent MUST merge them into its own class space via [`Self::remap_tailwind_into`] before printing,
+    /// the printer's `debug_assert` catches a forgotten merge.
     pub tailwind_classes: Vec<String>,
     /// Child→parent language-specific metadata; the parent downcasts it
     /// (e.g. HTML's `has_multiple_root_elements`).
     pub meta: Option<Box<dyn Any>>,
 }
 
-impl<'a> DispatchResult<'a> {
-    /// Extract the IR for single-text dispatches (every language except GraphQL).
-    /// Returns `None` when the dispatcher produced no docs.
-    pub fn into_single_doc(self) -> Option<ArenaVec<'a, FormatElement<'a>>> {
-        self.docs.into_iter().next()
-    }
-
-    /// Move the child's pre-sort Tailwind classes into the parent's class
-    /// space and shift the docs' `TailwindClass` indices to match.
-    ///
-    /// Call this once per received dispatch result (a no-op when the child
-    /// collected nothing). The entry formatter's document then sorts all
-    /// collected classes in one host-supplied batch.
+impl DispatchResult<'_> {
+    /// Move the child's pre-sort Tailwind classes into the parent's class space
+    /// and shift the docs' `TailwindClass` indices to match. Call once per
+    /// received result before consuming `docs` (a no-op when the child collected nothing).
+    /// The entry formatter's document then sorts all collected classes in one host-supplied batch.
     pub fn remap_tailwind_into(&mut self, collector: &mut dyn TailwindCollector) {
         let mut classes = std::mem::take(&mut self.tailwind_classes).into_iter();
         let Some(first) = classes.next() else {
             return;
         };
-        // The collector hands out consecutive indices, so the first one is
-        // the base offset for every local index.
+        // The collector hands out consecutive indices,
+        // so the first one is the base offset for every local index.
         let base = collector.add_class(first);
         for class in classes {
             collector.add_class(class);
@@ -127,7 +121,7 @@ impl<'a> DispatchResult<'a> {
 /// formatter's document is finalized. A child formatter collects classes
 /// locally (0-based) and returns them in [`DispatchResult::tailwind_classes`];
 /// the receiving parent implements this trait on its format context and
-/// merges them with [`DispatchResult::remap_tailwind_into`].
+/// calls [`DispatchResult::remap_tailwind_into`] before consuming `docs`.
 ///
 /// NOTE: an alternative design — threading one shared collector through
 /// [`EmbeddedContext`] so children allocate parent indices directly — was


### PR DESCRIPTION
Tailwind sorting is handled by JS, while the Rust side only collects class names.
Therefore, not all options are used on the Rust side (in the case of CSS, a `bool` is sufficient).

Because of this, unnecessary options are not passed to the Rust side.
(Previously, they were being passed even though they were not used.)