### PR TITLE
test(napi/parser): run async tests sequentially

### DIFF
--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -311,7 +311,7 @@ async function getTestFailurePaths(snapshotPath: string, pathPrefix: string) {
   );
 }
 
-describe.concurrent("`parse`", () => {
+describe("`parse`", { concurrent: false }, () => {
   it("matches `parseSync`", async () => {
     const path = benchFixturePaths[0],
       filename = basename(path),


### PR DESCRIPTION
A little breakdown of what was going on:
 
 - the failing test case was testing that raw transfer vs non raw transfer was the same. This was parsing checker.ts (a 3.2mb file)
 - this test was running concurrently (via vitest's describe.concurrently) with a memory exhaustion test that was running parse with raw transfer 10,000x concurrently
 - as a result of these concurrent tests, it resulted in a large number of JS objects being created (and hence needing to be GC-ed)
 - since CI is not deterministic, it caused a flakiness roughly 2% of the time
 - this can clearly be seen from the attached flamegraph - the  readFile  call (reading checker.ts from the disk) was sometimes taking up to 3 seconds to read the file from the disk

This seems to be fixed by no longer using describe.concurrent, as it reduces the amount of concurrent work and reduces the chance of the timeout.

<img width="4096" height="1724" alt="image" src="https://github.com/user-attachments/assets/0fd5bc59-8d28-4453-adda-bf33834aafa8" />
