### PR TITLE
fix(linter): skip autofix writeback for paths resolving outside lint roots

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -184,6 +184,9 @@ impl CliRunner {
             paths.push(self.cwd.clone());
         }
 
+        let autofix_write_roots =
+            fix_options.is_enabled().then(|| Self::autofix_write_roots(&paths, &self.cwd));
+
         let walker = Walk::new(&paths, &self.cwd, &ignore_options, override_builder);
         let mut paths = walker.paths();
 
@@ -362,6 +365,9 @@ impl CliRunner {
             || nested_configs.values().any(|config| config.plugins().has_import());
         let mut options =
             LintServiceOptions::new(self.cwd.clone()).with_cross_module(use_cross_module);
+        if let Some(autofix_write_roots) = autofix_write_roots {
+            options = options.with_autofix_write_roots(autofix_write_roots);
+        }
 
         let mut suppression_manager = SuppressionManager::load(
             options.cwd(),
@@ -593,6 +599,16 @@ impl CliRunner {
         )
     }
 
+    fn autofix_write_roots(paths: &[PathBuf], cwd: &Path) -> Vec<PathBuf> {
+        paths
+            .iter()
+            .filter_map(|path| {
+                let path = if path.is_absolute() { path.clone() } else { cwd.join(path) };
+                path.canonicalize().or_else(|_| absolute(path)).ok()
+            })
+            .collect()
+    }
+
     fn handle_no_files_found(
         stdout: &mut dyn Write,
         output_formatter: &OutputFormatter,
@@ -705,6 +721,8 @@ fn render_config_builder_error(
 #[cfg(test)]
 mod test {
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs as unix_fs;
 
     use crate::{DEFAULT_OXLINTRC_NAME, tester::Tester};
     use oxc_linter::rules::RULES;
@@ -1156,6 +1174,60 @@ mod test {
         tester.test_fix("skip_suggestion.js", test_1, test_1);
         let test_2 = "<script>debugger;</script>\n<script>debugger;</script>\n";
         tester.test_fix("skip_suggestion.vue", test_2, test_2);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_fix_does_not_write_outside_lint_root_through_symlink() {
+        let cases = [
+            (
+                "dir-fix-suggestions",
+                true,
+                "--fix-suggestions",
+                "no-debugger",
+                "let before = 1;\ndebugger;\nlet after = 2;\n",
+            ),
+            (
+                "file-fix-suggestions",
+                false,
+                "--fix-suggestions",
+                "no-debugger",
+                "let before = 1;\ndebugger;\nlet after = 2;\n",
+            ),
+            ("dir-fix", true, "--fix", "no-var", "var before = 1;\nvar after = 2;\n"),
+            ("file-fix", false, "--fix", "no-var", "var before = 1;\nvar after = 2;\n"),
+        ];
+
+        for (name, symlink_dir, fix_flag, rule, victim_before) in cases {
+            let temp_dir = tempfile::tempdir().expect("Could not create a temp dir");
+            let repo = temp_dir.path().join("repo");
+            let outside = temp_dir.path().join("outside");
+            let repo_src = repo.join("src");
+            fs::create_dir_all(&repo_src).unwrap();
+            fs::create_dir_all(&outside).unwrap();
+
+            let victim = outside.join("victim.js");
+            fs::write(&victim, victim_before).unwrap();
+
+            if symlink_dir {
+                unix_fs::symlink(&outside, repo_src.join("linked-outside")).unwrap();
+            } else {
+                unix_fs::symlink(&victim, repo_src.join("victim-link.js")).unwrap();
+            }
+
+            let in_tree = repo_src.join(format!("{name}.js"));
+            fs::write(&in_tree, victim_before).unwrap();
+
+            Tester::new().with_cwd(repo).test(&[fix_flag, "--threads", "1", "-D", rule, "."]);
+
+            assert_eq!(fs::read_to_string(&victim).unwrap(), victim_before);
+            let in_tree_after = match rule {
+                "no-debugger" => "let before = 1;\n\nlet after = 2;\n",
+                "no-var" => "const before = 1;\nconst after = 2;\n",
+                _ => unreachable!(),
+            };
+            assert_eq!(fs::read_to_string(&in_tree).unwrap(), in_tree_after);
+        }
     }
 
     #[test]

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -20,6 +20,9 @@ pub struct LintServiceOptions {
     /// TypeScript `tsconfig.json` path for reading path alias and project references
     tsconfig: Option<PathBuf>,
 
+    /// Canonical roots that autofix writeback is allowed to modify.
+    autofix_write_roots: Vec<PathBuf>,
+
     cross_module: bool,
 }
 
@@ -29,7 +32,12 @@ impl LintServiceOptions {
     where
         T: Into<Box<Path>>,
     {
-        Self { cwd: cwd.into(), tsconfig: None, cross_module: false }
+        Self {
+            cwd: cwd.into(),
+            tsconfig: None,
+            autofix_write_roots: Vec::new(),
+            cross_module: false,
+        }
     }
 
     #[inline]
@@ -51,6 +59,13 @@ impl LintServiceOptions {
     #[must_use]
     pub fn with_cross_module(mut self, cross_module: bool) -> Self {
         self.cross_module = cross_module;
+        self
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn with_autofix_write_roots(mut self, roots: Vec<PathBuf>) -> Self {
+        self.autofix_write_roots = roots;
         self
     }
 

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -46,6 +46,7 @@ pub struct Runtime {
     cwd: Box<Path>,
     pub(super) linter: Linter,
     resolver: Option<Resolver>,
+    autofix_write_roots: Vec<PathBuf>,
 
     /// Pool of allocators for parsing and linting.
     allocator_pool: AllocatorPool,
@@ -249,6 +250,7 @@ impl Runtime {
         #[cfg(not(all(target_pointer_width = "64", target_endian = "little")))]
         let allocator_pool = AllocatorPool::new(thread_count);
 
+        let autofix_write_roots = options.autofix_write_roots;
         let resolver = options.cross_module.then(|| Self::get_resolver(options.tsconfig));
 
         Self {
@@ -258,6 +260,7 @@ impl Runtime {
             cwd: options.cwd,
             linter,
             resolver,
+            autofix_write_roots,
             modules_by_path: papaya::HashMap::builder()
                 .hasher(BuildHasherDefault::default())
                 .resize_mode(papaya::ResizeMode::Blocking)
@@ -718,20 +721,42 @@ impl Runtime {
 
                         // If the new source text is owned, that means it was modified,
                         // so we write the new source text to the file.
-                        if let Cow::Owned(new_source_text) = &new_source_text
-                            && let Err(error) = file_system.write_file(path, new_source_text)
-                        {
-                            tx_error
-                                .send(vec![Error::new(OxcDiagnostic::error(format!(
-                                    "Failed to write file {} with error \"{error}\"",
-                                    path.display()
-                                )))])
-                                .unwrap();
+                        if let Cow::Owned(new_source_text) = &new_source_text {
+                            if let Err(error) = me.check_autofix_write_allowed(path) {
+                                tx_error.send(vec![error]).unwrap();
+                            } else if let Err(error) = file_system.write_file(path, new_source_text)
+                            {
+                                tx_error
+                                    .send(vec![Error::new(OxcDiagnostic::error(format!(
+                                        "Failed to write file {} with error \"{error}\"",
+                                        path.display()
+                                    )))])
+                                    .unwrap();
+                            }
                         }
                     });
                 },
             );
         });
+    }
+
+    fn check_autofix_write_allowed(&self, path: &Path) -> Result<(), Error> {
+        if self.autofix_write_roots.is_empty() {
+            return Ok(());
+        }
+
+        let Ok(canonical_path) = path.canonicalize() else {
+            return Ok(());
+        };
+
+        if self.autofix_write_roots.iter().any(|root| canonical_path.starts_with(root)) {
+            return Ok(());
+        }
+
+        Err(Error::new(OxcDiagnostic::warn(format!(
+            "Skipped autofix for {} because it resolves outside the selected lint paths",
+            path.display()
+        ))))
     }
 
     // language_server: the language server needs line and character position


### PR DESCRIPTION
## Summary
When `oxlint` walks targets with `--fix`, `--fix-suggestions`, or `--fix-dangerously`, the walker follows symlinks `(.follow_links(true) in Walk::new)`. If a symlink inside the lint root points to a file or directory outside it, autofix writeback modifies the outside file without any boundary check.

This patch adds a write-side guard: before writing an autofix result, the target path is canonicalized and checked against the canonicalized lint roots. If the resolved path falls outside every lint root, the write is skipped and a warning diagnostic is emitted.

## Reproduction
Create a repository containing an in-tree symlink to an outside directory or file, place a lintable JS file at the symlink target, and run `oxlint --fix-suggestions -D no-debugger .` from the repo root. Without this patch, the outside file is modified through the symlink.

## Changes
- `crates/oxc_linter/src/service/mod.rs:` Add `autofix_write_roots: Vec<PathBuf>` to `LintServiceOptions` with a builder method.

- `crates/oxc_linter/src/service/runtime.rs:` Add `check_autofix_write_allowed()` — canonicalizes the write target and verifies it starts with at least one canonicalized lint root. Writeback calls this before `file_system.write_file()`.

- `apps/oxlint/src/lint.rs:` Populate `autofix_write_roots` from the CLI-provided paths when fix is enabled. Add regression test covering four cases: symlinked directory and symlinked file, each with `--fix` and `--fix-suggestions`.

## Design notes
This takes the less disruptive approach of guarding writes rather than disabling symlink traversal in the walker. Users who intentionally lint through symlinks will still see diagnostics. Only autofix writeback is blocked for out-of-root targets. A stricter alternative would be changing `.follow_links(true)` to `.follow_links(false)` with an opt-in flag, but that is more likely to break existing workflows.

**AI disclosure:** Claude was used for code review, patch analysis, and drafting this PR description. The vulnerability analysis, reproduction, patch implementation, and testing were performed by me.


