### PR TITLE
fix(linter/eslint/no-negated-condition): add autofix for negated conditions

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_negated_condition.rs
@@ -17,7 +17,7 @@ declare_oxc_lint!(
     NoNegatedCondition,
     eslint,
     pedantic,
-    pending,
+    fix,
     docs = DOCUMENTATION,
     version = "0.0.18",
     short_description = "Disallow negated conditions.",
@@ -30,7 +30,7 @@ impl Rule for NoNegatedCondition {
                 run_on_if_statement(if_stmt, ctx);
             }
             AstKind::ConditionalExpression(conditional_expr) => {
-                run_on_conditional_expression(conditional_expr, ctx);
+                run_on_conditional_expression(node, conditional_expr, ctx);
             }
             _ => {}
         }
@@ -66,6 +66,16 @@ fn test() {
         "a !== b ? c : d",
     ];
 
+    let fix = vec![
+        ("if (!a) {;} else {;}", "if (a) {;} else {;}"),
+        ("if (a != b) {;} else {;}", "if (a == b) {;} else {;}"),
+        ("if (a !== b) {;} else {;}", "if (a === b) {;} else {;}"),
+        ("!a ? b : c", "a ? c : b"),
+        ("a != b ? c : d", "a == b ? d : c"),
+        ("a !== b ? c : d", "a === b ? d : c"),
+    ];
+
     Tester::new(NoNegatedCondition::NAME, NoNegatedCondition::PLUGIN, pass, fail)
+        .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -1,9 +1,15 @@
 use oxc_ast::ast::{ConditionalExpression, Expression, IfStatement, Statement};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
+use oxc_syntax::identifier::is_identifier_start;
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
-use crate::context::LintContext;
+use crate::{
+    AstNode,
+    ast_util::could_be_asi_hazard,
+    context::LintContext,
+    fixer::{RuleFix, RuleFixer},
+};
 
 fn no_negated_condition_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected negated condition.")
@@ -44,29 +50,38 @@ a ? doSomethingB() : doSomethingC()
 ```
 ";
 
-pub fn run_on_if_statement(if_stmt: &IfStatement<'_>, ctx: &LintContext) {
-    let Some(if_stmt_alternate) = &if_stmt.alternate else {
+pub fn run_on_if_statement<'a>(if_stmt: &IfStatement<'a>, ctx: &LintContext<'a>) {
+    let Some(alternate) = &if_stmt.alternate else {
         return;
     };
 
-    if matches!(if_stmt_alternate, Statement::IfStatement(_)) {
+    if matches!(alternate, Statement::IfStatement(_)) {
         return;
     }
 
     let test = if_stmt.test.without_parentheses();
-    if is_negated_expression(test) {
-        ctx.diagnostic(no_negated_condition_diagnostic(test.span()));
+    if !is_negated_expression(test) {
+        return;
     }
+
+    ctx.diagnostic_with_fix(no_negated_condition_diagnostic(test.span()), |fixer| {
+        fix_if_statement(fixer, if_stmt, alternate, test, ctx)
+    });
 }
 
-pub fn run_on_conditional_expression(
-    conditional_expr: &ConditionalExpression<'_>,
-    ctx: &LintContext,
+pub fn run_on_conditional_expression<'a>(
+    node: &AstNode<'a>,
+    conditional_expr: &ConditionalExpression<'a>,
+    ctx: &LintContext<'a>,
 ) {
     let test = conditional_expr.test.without_parentheses();
-    if is_negated_expression(test) {
-        ctx.diagnostic(no_negated_condition_diagnostic(test.span()));
+    if !is_negated_expression(test) {
+        return;
     }
+
+    ctx.diagnostic_with_fix(no_negated_condition_diagnostic(test.span()), |fixer| {
+        fix_conditional_expression(fixer, node, conditional_expr, test, ctx)
+    });
 }
 
 fn is_negated_expression(expr: &Expression) -> bool {
@@ -78,4 +93,159 @@ fn is_negated_expression(expr: &Expression) -> bool {
         ),
         _ => false,
     }
+}
+
+fn invert_test_text(test: &Expression<'_>, ctx: &LintContext<'_>, for_if_statement: bool) -> String {
+    match test {
+        Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::LogicalNot => {
+            // For `if` statements, drop parentheses around the argument so
+            // `if (!((a)))` becomes `if (a)` rather than `if (((a)))`.
+            let argument = if for_if_statement {
+                unary.argument.get_inner_expression()
+            } else {
+                &unary.argument
+            };
+            ctx.source_range(argument.span()).to_string()
+        }
+        Expression::BinaryExpression(binary) => {
+            let op = match binary.operator {
+                BinaryOperator::Inequality => "==",
+                BinaryOperator::StrictInequality => "===",
+                _ => unreachable!(),
+            };
+            format!(
+                "{} {op} {}",
+                ctx.source_range(binary.left.span()),
+                ctx.source_range(binary.right.span())
+            )
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Rebuild the test expression text while preserving any outer parentheses that
+/// were around the negated expression (e.g. `(( !a ))` → `(( a ))`).
+fn invert_test_preserving_outer_parens(
+    full_test: &Expression<'_>,
+    negated: &Expression<'_>,
+    ctx: &LintContext<'_>,
+    for_if_statement: bool,
+) -> String {
+    let inverted = invert_test_text(negated, ctx, for_if_statement);
+    let full_span = full_test.span();
+    let neg_span = negated.span();
+    if full_span == neg_span {
+        return inverted;
+    }
+    let source = ctx.source_text();
+    let prefix = &source[full_span.start as usize..neg_span.start as usize];
+    let suffix = &source[neg_span.end as usize..full_span.end as usize];
+    format!("{prefix}{inverted}{suffix}")
+}
+
+fn statement_text_for_swap(stmt: &Statement<'_>, ctx: &LintContext<'_>) -> String {
+    let text = ctx.source_range(stmt.span());
+    if matches!(stmt, Statement::BlockStatement(_)) {
+        text.to_string()
+    } else {
+        // Non-block branches must be wrapped so ASI / dangling `else` stay valid
+        // after the swap, e.g. `if (!a) b(); else c()` → `if (a) {c()} else {b()}`.
+        format!("{{{text}}}")
+    }
+}
+
+fn fix_if_statement<'a>(
+    fixer: RuleFixer<'_, 'a>,
+    if_stmt: &IfStatement<'a>,
+    alternate: &Statement<'a>,
+    negated_test: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> RuleFix {
+    let inverted_test =
+        invert_test_preserving_outer_parens(&if_stmt.test, negated_test, ctx, true);
+    let consequent_text = statement_text_for_swap(&if_stmt.consequent, ctx);
+    let alternate_text = statement_text_for_swap(alternate, ctx);
+
+    let source = ctx.source_text();
+    let if_start = if_stmt.span.start as usize;
+    let test_start = if_stmt.test.span().start as usize;
+    let test_end = if_stmt.test.span().end as usize;
+    let cons_start = if_stmt.consequent.span().start as usize;
+    let cons_end = if_stmt.consequent.span().end as usize;
+    let alt_start = alternate.span().start as usize;
+
+    let before_test = &source[if_start..test_start];
+    let after_test = &source[test_end..cons_start];
+    let between_consequent_and_else = &source[cons_end..alt_start];
+
+    let replacement = format!(
+        "{before_test}{inverted_test}{after_test}{alternate_text}{between_consequent_and_else}{consequent_text}"
+    );
+
+    fixer.replace(if_stmt.span, replacement)
+}
+
+fn fix_conditional_expression<'a>(
+    fixer: RuleFixer<'_, 'a>,
+    node: &AstNode<'a>,
+    conditional_expr: &ConditionalExpression<'a>,
+    negated_test: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) -> RuleFix {
+    let mut inverted_test =
+        invert_test_preserving_outer_parens(&conditional_expr.test, negated_test, ctx, false);
+    let consequent_text = ctx.source_range(conditional_expr.consequent.span());
+    let alternate_text = ctx.source_range(conditional_expr.alternate.span());
+
+    let source = ctx.source_text();
+    let test_span = conditional_expr.test.span();
+    let cons_span = conditional_expr.consequent.span();
+    let alt_span = conditional_expr.alternate.span();
+    let expr_span = conditional_expr.span;
+
+    let before_test = &source[expr_span.start as usize..test_span.start as usize];
+    let between_test_and_cons = &source[test_span.end as usize..cons_span.start as usize];
+    let between_cons_and_alt = &source[cons_span.end as usize..alt_span.start as usize];
+    let after_alt = &source[alt_span.end as usize..expr_span.end as usize];
+
+    // `return!a` / `throw!a` → insert space after keyword when removing `!`
+    let is_unary = matches!(negated_test, Expression::UnaryExpression(_));
+    if is_unary {
+        let start = expr_span.start as usize;
+        if start > 0 {
+            let char_before = source[..start].chars().next_back();
+            let first_of_inverted = inverted_test.chars().next();
+            if char_before.is_some_and(is_identifier_start)
+                && first_of_inverted.is_some_and(|c| {
+                    is_identifier_start(c)
+                        || c == '('
+                        || c == '['
+                        || c == '`'
+                        || c == '/'
+                        || c == '+'
+                        || c == '-'
+                })
+            {
+                inverted_test.insert(0, ' ');
+            }
+        }
+    }
+
+    let mut replacement = format!(
+        "{before_test}{inverted_test}{between_test_and_cons}{alternate_text}{between_cons_and_alt}{consequent_text}{after_alt}"
+    );
+
+    // ASI hazard when removing leading `!` leaves `(`, `[`, etc. at statement start.
+    if is_unary {
+        let trimmed = inverted_test.trim_start();
+        let first_char = trimmed.chars().next();
+        if matches!(first_char, Some('(' | '[' | '`' | '+' | '-' | '/'))
+            && could_be_asi_hazard(node, ctx)
+            && !replacement.starts_with([';', ' '])
+        {
+            replacement.insert(0, ';');
+        }
+    }
+
+    fixer.replace(expr_span, replacement)
 }

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -254,9 +254,8 @@ fn binary_operator_span(binary: &BinaryExpression<'_>, ctx: &LintContext<'_>) ->
         if chunk != op_bytes {
             return None;
         }
-        #[expect(clippy::cast_possible_truncation)]
-        let pos_start = left_end + index as u32;
-        let pos_end = pos_start + op_bytes.len() as u32;
+        let pos_start = left_end.checked_add(u32::try_from(index).ok()?)?;
+        let pos_end = pos_start.checked_add(u32::try_from(op_bytes.len()).ok()?)?;
         // Skip matches that sit inside comments between the operands.
         if ctx.comments().iter().any(|c| c.span.start <= pos_start && pos_end <= c.span.end) {
             return None;

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -1,4 +1,7 @@
-use oxc_ast::ast::{ConditionalExpression, Expression, IfStatement, Statement};
+use oxc_ast::{
+    AstKind,
+    ast::{ConditionalExpression, Expression, IfStatement, Statement},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::identifier::is_identifier_start;
@@ -102,14 +105,20 @@ fn invert_test_text(
 ) -> String {
     match test {
         Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::LogicalNot => {
-            // For `if` statements, drop parentheses around the argument so
-            // `if (!((a)))` becomes `if (a)` rather than `if (((a)))`.
-            let argument = if for_if_statement {
-                unary.argument.get_inner_expression()
-            } else {
-                &unary.argument
-            };
-            ctx.source_range(argument.span()).to_string()
+            // Prefer keeping trivia (comments/whitespace) between `!` and the operand by
+            // only dropping the `!` operator character — same idea as unicorn's token remove.
+            //
+            // For `if` statements, also drop parentheses around the argument so
+            // `if (!((a)))` becomes `if (a)` rather than `if (((a)))`. Only do that when the
+            // argument itself is parenthesized; otherwise comments after `!` are preserved.
+            if for_if_statement {
+                let inner = unary.argument.get_inner_expression();
+                if inner.span() != unary.argument.span() {
+                    return ctx.source_range(inner.span()).to_string();
+                }
+            }
+            // `!` is always a single-byte punctuator in JS source.
+            ctx.source_range(Span::new(unary.span.start + 1, unary.span.end)).to_string()
         }
         Expression::BinaryExpression(binary) => {
             let op = match binary.operator {
@@ -213,7 +222,18 @@ fn fix_conditional_expression<'a>(
 
     // `return!a` / `throw!a` → insert space after keyword when removing `!`
     let is_unary = matches!(negated_test, Expression::UnaryExpression(_));
-    if is_unary {
+    // When `!` and its operand are not on the same line, `return`/`throw` cannot be
+    // followed by a newline before the expression — parenthesize (unicorn does the same).
+    // Skip when the test is already parenthesized (`return (!…\na) ? b : c`).
+    let needs_return_throw_parens = is_unary
+        && inverted_test.contains('\n')
+        && !matches!(conditional_expr.test, Expression::ParenthesizedExpression(_))
+        && matches!(
+            ctx.nodes().parent_kind(node.id()),
+            AstKind::ReturnStatement(_) | AstKind::ThrowStatement(_)
+        );
+
+    if is_unary && !needs_return_throw_parens {
         let start = expr_span.start as usize;
         if start > 0 {
             let char_before = source[..start].chars().next_back();
@@ -238,8 +258,12 @@ fn fix_conditional_expression<'a>(
         "{before_test}{inverted_test}{between_test_and_cons}{alternate_text}{between_cons_and_alt}{consequent_text}{after_alt}"
     );
 
+    if needs_return_throw_parens {
+        replacement = format!("({replacement})");
+    }
+
     // ASI hazard when removing leading `!` leaves `(`, `[`, etc. at statement start.
-    if is_unary {
+    if is_unary && !needs_return_throw_parens {
         let trimmed = inverted_test.trim_start();
         let first_char = trimmed.chars().next();
         if matches!(first_char, Some('(' | '[' | '`' | '+' | '-' | '/'))

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -228,29 +228,21 @@ fn push_invert_test_fixes<'a>(
             }
         }
         Expression::BinaryExpression(binary) => {
-            // Replace only the operator token so surrounding spacing is preserved (`a!=b` → `a==b`).
-            if let Some(op_span) = binary_operator_span(binary, ctx) {
-                let replacement = match binary.operator {
-                    BinaryOperator::Inequality => "==",
-                    BinaryOperator::StrictInequality => "===",
-                    _ => unreachable!(),
-                };
-                fixes.push(fixer.replace(op_span, replacement));
+            let binary_operator_str = binary.operator.as_str();
+            if let Some(op_span) = ctx
+                .find_next_token_within(
+                    binary.left.span().end,
+                    binary.right.span().start,
+                    binary_operator_str,
+                )
+                .map(|s| Span::sized(binary.left.span().end + s, binary_operator_str.len() as u32))
+                && let Some(inverse_op) = binary.operator.equality_inverse_operator()
+            {
+                fixes.push(fixer.replace(op_span, binary_operator_str));
             }
         }
         _ => {}
     }
-}
-
-/// Locate `!=` / `!==` between left and right without copying the operands.
-fn binary_operator_span(binary: &BinaryExpression<'_>, ctx: &LintContext<'_>) -> Option<Span> {
-    let binary_operator_str = binary.operator.as_str();
-    ctx.find_next_token_within(
-        binary.left.span().end,
-        binary.right.span().start,
-        binary_operator_str,
-    )
-    .map(|s| Span::sized(binary.left.span().end + s, binary_operator_str.len() as u32))
 }
 
 fn push_swap_statement_branches<'a>(

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -4,8 +4,11 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
-use oxc_syntax::identifier::is_identifier_start;
-use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
+use oxc_syntax::{
+    identifier::is_identifier_part,
+    line_terminator::is_line_terminator,
+    operator::{BinaryOperator, UnaryOperator},
+};
 
 use crate::{
     AstNode,
@@ -127,51 +130,49 @@ fn fix_conditional_expression<'a>(
     ctx: &LintContext<'a>,
 ) -> RuleFix {
     let fixer = fixer.for_multifix();
-    let mut fixes = fixer.new_fix_with_capacity(6);
+    let mut fixes = fixer.new_fix_with_capacity(10);
 
     let is_unary = matches!(negated_test, Expression::UnaryExpression(_));
     let source = ctx.source_text();
     let expr_span = conditional_expr.span;
 
     // Detect ASI / keyword spacing from what the expression will look like after removing `!`.
-    let (needs_space_before, needs_asi_semi, needs_return_throw_parens) = if is_unary {
-        let Expression::UnaryExpression(unary) = negated_test else { unreachable!() };
-        // Text after deleting the leading `!` (preserves comments between `!` and operand).
-        let after_bang = ctx.source_range(Span::new(unary.span.start + 1, unary.span.end));
-        let first_significant = after_bang.trim_start().chars().next();
-        let has_newline_in_remainder = after_bang.contains('\n');
+    let (needs_space_before, needs_asi_semi, needs_restricted_parens, needs_exposed_expr_parens) =
+        if is_unary {
+            let Expression::UnaryExpression(unary) = negated_test else { unreachable!() };
+            // Text after deleting the leading `!` (preserves comments between `!` and operand).
+            let after_bang = ctx.source_range(Span::new(unary.span.start + 1, unary.span.end));
+            let first_significant = after_bang.trim_start().chars().next();
+            let has_line_terminator_in_remainder = after_bang.chars().any(is_line_terminator);
 
-        let needs_return_throw_parens = has_newline_in_remainder
-            && !matches!(conditional_expr.test, Expression::ParenthesizedExpression(_))
-            && matches!(
-                ctx.nodes().parent_kind(node.id()),
-                AstKind::ReturnStatement(_) | AstKind::ThrowStatement(_)
-            );
+            let needs_restricted_parens = has_line_terminator_in_remainder
+                && !matches!(conditional_expr.test, Expression::ParenthesizedExpression(_))
+                && is_restricted_statement_or_yield_argument(node, ctx);
 
-        let needs_space_before = !needs_return_throw_parens && {
-            let start = expr_span.start as usize;
-            start > 0
-                && source[..start].chars().next_back().is_some_and(is_identifier_start)
-                && first_significant.is_some_and(|c| {
-                    is_identifier_start(c)
-                        || c == '('
-                        || c == '['
-                        || c == '`'
-                        || c == '/'
-                        || c == '+'
-                        || c == '-'
-                })
+            let needs_space_before = !needs_restricted_parens && {
+                let start = expr_span.start as usize;
+                start > 0
+                    && source[..start].chars().next_back().is_some_and(can_continue_token)
+                    && first_significant.is_some_and(needs_separator_after_keyword)
+            };
+
+            let needs_asi_semi = !needs_restricted_parens
+                && !needs_space_before
+                && matches!(first_significant, Some('(' | '[' | '`' | '+' | '-' | '/'))
+                && could_be_asi_hazard(node, ctx);
+
+            let needs_exposed_expr_parens = is_expression_statement_start(node, ctx)
+                && matches!(
+                    unary.argument.without_parentheses(),
+                    Expression::ObjectExpression(_)
+                        | Expression::FunctionExpression(_)
+                        | Expression::ClassExpression(_)
+                );
+
+            (needs_space_before, needs_asi_semi, needs_restricted_parens, needs_exposed_expr_parens)
+        } else {
+            (false, false, false, false)
         };
-
-        let needs_asi_semi = !needs_return_throw_parens
-            && !needs_space_before
-            && matches!(first_significant, Some('(' | '[' | '`' | '+' | '-' | '/'))
-            && could_be_asi_hazard(node, ctx);
-
-        (needs_space_before, needs_asi_semi, needs_return_throw_parens)
-    } else {
-        (false, false, false)
-    };
 
     if needs_asi_semi {
         fixes.push(fixer.insert_text_before_range(expr_span, ";"));
@@ -179,15 +180,23 @@ fn fix_conditional_expression<'a>(
         fixes.push(fixer.insert_text_before_range(expr_span, " "));
     }
 
-    if needs_return_throw_parens {
+    if needs_restricted_parens {
         fixes.push(fixer.insert_text_before_range(expr_span, "("));
         fixes.push(fixer.insert_text_after_range(expr_span, ")"));
+    }
+
+    if needs_exposed_expr_parens && let Expression::UnaryExpression(unary) = negated_test {
+        let argument_span = unary.argument.span();
+        fixes.push(fixer.insert_text_before_range(argument_span, "("));
+        fixes.push(fixer.insert_text_after_range(argument_span, ")"));
     }
 
     push_invert_test_fixes(&mut fixes, &fixer, negated_test, ctx);
     push_swap_expression_branches(
         &mut fixes,
         &fixer,
+        node,
+        conditional_expr,
         &conditional_expr.consequent,
         &conditional_expr.alternate,
         ctx,
@@ -261,6 +270,8 @@ fn push_swap_statement_branches<'a>(
 fn push_swap_expression_branches<'a>(
     fixes: &mut RuleFix,
     fixer: &RuleFixer<'_, 'a>,
+    node: &AstNode<'a>,
+    conditional_expr: &ConditionalExpression<'a>,
     consequent: &Expression<'a>,
     alternate: &Expression<'a>,
     ctx: &LintContext<'a>,
@@ -276,5 +287,71 @@ fn push_swap_expression_branches<'a>(
 
     // Must own the replacement strings because both edits reference the other branch's text.
     fixes.push(fixer.replace(cons_span, alt_src.to_string()));
-    fixes.push(fixer.replace(alt_span, cons_src.to_string()));
+    let new_alt = if is_for_statement_init(node, conditional_expr, ctx)
+        && contains_unparenthesized_in_expression(consequent)
+    {
+        format!("({cons_src})")
+    } else {
+        cons_src.to_string()
+    };
+    fixes.push(fixer.replace(alt_span, new_alt));
+}
+
+fn is_restricted_statement_or_yield_argument(node: &AstNode, ctx: &LintContext) -> bool {
+    matches!(
+        ctx.nodes().parent_kind(node.id()),
+        AstKind::ReturnStatement(_) | AstKind::ThrowStatement(_) | AstKind::YieldExpression(_)
+    )
+}
+
+fn can_continue_token(c: char) -> bool {
+    is_identifier_part(c) || c.is_ascii_digit()
+}
+
+fn needs_separator_after_keyword(c: char) -> bool {
+    is_identifier_part(c) || c == '\\' || matches!(c, '(' | '[' | '`' | '/' | '+' | '-' | '.')
+}
+
+fn is_expression_statement_start(node: &AstNode, ctx: &LintContext) -> bool {
+    let node_span = node.span();
+    for ancestor in ctx.nodes().ancestors(node.id()) {
+        match ancestor.kind() {
+            AstKind::ExpressionStatement(expr_stmt) => {
+                return node_span.start == expr_stmt.span.start;
+            }
+            AstKind::ParenthesizedExpression(_)
+            | AstKind::ChainExpression(_)
+            | AstKind::SequenceExpression(_)
+            | AstKind::AssignmentExpression(_)
+            | AstKind::LogicalExpression(_)
+            | AstKind::BinaryExpression(_)
+            | AstKind::ConditionalExpression(_)
+            | AstKind::TSAsExpression(_)
+            | AstKind::TSSatisfiesExpression(_)
+            | AstKind::TSNonNullExpression(_)
+            | AstKind::TSTypeAssertion(_)
+            | AstKind::TSInstantiationExpression(_) => {}
+            _ => return false,
+        }
+    }
+    false
+}
+
+fn is_for_statement_init(
+    node: &AstNode,
+    conditional_expr: &ConditionalExpression,
+    ctx: &LintContext,
+) -> bool {
+    matches!(
+        ctx.nodes().parent_kind(node.id()),
+        AstKind::ForStatement(for_stmt)
+            if for_stmt.init.as_ref().is_some_and(|init| init.span() == conditional_expr.span)
+    )
+}
+
+fn contains_unparenthesized_in_expression(expr: &Expression) -> bool {
+    matches!(
+        expr,
+        Expression::BinaryExpression(binary) if binary.operator == BinaryOperator::In
+    )
 }

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -244,24 +244,13 @@ fn push_invert_test_fixes<'a>(
 
 /// Locate `!=` / `!==` between left and right without copying the operands.
 fn binary_operator_span(binary: &BinaryExpression<'_>, ctx: &LintContext<'_>) -> Option<Span> {
-    let left_end = binary.left.span().end;
-    let right_start = binary.right.span().start;
-    let operator_str = binary.operator.as_str();
-    let between = ctx.source_range(Span::new(left_end, right_start));
-    let op_bytes = operator_str.as_bytes();
-
-    between.as_bytes().windows(op_bytes.len()).enumerate().find_map(|(index, chunk)| {
-        if chunk != op_bytes {
-            return None;
-        }
-        let pos_start = left_end.checked_add(u32::try_from(index).ok()?)?;
-        let pos_end = pos_start.checked_add(u32::try_from(op_bytes.len()).ok()?)?;
-        // Skip matches that sit inside comments between the operands.
-        if ctx.comments().iter().any(|c| c.span.start <= pos_start && pos_end <= c.span.end) {
-            return None;
-        }
-        Some(Span::new(pos_start, pos_end))
-    })
+    let binary_operator_str = binary.operator.as_str();
+    ctx.find_next_token_within(
+        binary.left.span().end,
+        binary.right.span().start,
+        binary_operator_str,
+    )
+    .map(|s| Span::sized(binary.left.span().end + s, binary_operator_str.len() as u32))
 }
 
 fn push_swap_statement_branches<'a>(

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{ConditionalExpression, Expression, IfStatement, Statement},
+    ast::{BinaryExpression, ConditionalExpression, Expression, IfStatement, Statement},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
@@ -98,75 +98,8 @@ fn is_negated_expression(expr: &Expression) -> bool {
     }
 }
 
-fn invert_test_text(
-    test: &Expression<'_>,
-    ctx: &LintContext<'_>,
-    for_if_statement: bool,
-) -> String {
-    match test {
-        Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::LogicalNot => {
-            // Prefer keeping trivia (comments/whitespace) between `!` and the operand by
-            // only dropping the `!` operator character — same idea as unicorn's token remove.
-            //
-            // For `if` statements, also drop parentheses around the argument so
-            // `if (!((a)))` becomes `if (a)` rather than `if (((a)))`. Only do that when the
-            // argument itself is parenthesized; otherwise comments after `!` are preserved.
-            if for_if_statement {
-                let inner = unary.argument.get_inner_expression();
-                if inner.span() != unary.argument.span() {
-                    return ctx.source_range(inner.span()).to_string();
-                }
-            }
-            // `!` is always a single-byte punctuator in JS source.
-            ctx.source_range(Span::new(unary.span.start + 1, unary.span.end)).to_string()
-        }
-        Expression::BinaryExpression(binary) => {
-            let op = match binary.operator {
-                BinaryOperator::Inequality => "==",
-                BinaryOperator::StrictInequality => "===",
-                _ => unreachable!(),
-            };
-            format!(
-                "{} {op} {}",
-                ctx.source_range(binary.left.span()),
-                ctx.source_range(binary.right.span())
-            )
-        }
-        _ => unreachable!(),
-    }
-}
-
-/// Rebuild the test expression text while preserving any outer parentheses that
-/// were around the negated expression (e.g. `(( !a ))` → `(( a ))`).
-fn invert_test_preserving_outer_parens(
-    full_test: &Expression<'_>,
-    negated: &Expression<'_>,
-    ctx: &LintContext<'_>,
-    for_if_statement: bool,
-) -> String {
-    let inverted = invert_test_text(negated, ctx, for_if_statement);
-    let full_span = full_test.span();
-    let neg_span = negated.span();
-    if full_span == neg_span {
-        return inverted;
-    }
-    let source = ctx.source_text();
-    let prefix = &source[full_span.start as usize..neg_span.start as usize];
-    let suffix = &source[neg_span.end as usize..full_span.end as usize];
-    format!("{prefix}{inverted}{suffix}")
-}
-
-fn statement_text_for_swap(stmt: &Statement<'_>, ctx: &LintContext<'_>) -> String {
-    let text = ctx.source_range(stmt.span());
-    if matches!(stmt, Statement::BlockStatement(_)) {
-        text.to_string()
-    } else {
-        // Non-block branches must be wrapped so ASI / dangling `else` stay valid
-        // after the swap, e.g. `if (!a) b(); else c()` → `if (a) {c()} else {b()}`.
-        format!("{{{text}}}")
-    }
-}
-
+/// Span-local edits only: invert the negated test in place, then swap branches.
+/// Avoids rebuilding the whole `if` / ternary (important for large branch bodies).
 fn fix_if_statement<'a>(
     fixer: RuleFixer<'_, 'a>,
     if_stmt: &IfStatement<'a>,
@@ -174,27 +107,16 @@ fn fix_if_statement<'a>(
     negated_test: &Expression<'a>,
     ctx: &LintContext<'a>,
 ) -> RuleFix {
-    let inverted_test = invert_test_preserving_outer_parens(&if_stmt.test, negated_test, ctx, true);
-    let consequent_text = statement_text_for_swap(&if_stmt.consequent, ctx);
-    let alternate_text = statement_text_for_swap(alternate, ctx);
+    let fixer = fixer.for_multifix();
+    // invert test (1–2) + swap branches (2) — capacity 4 is enough
+    let mut fixes = fixer.new_fix_with_capacity(4);
 
-    let source = ctx.source_text();
-    let if_start = if_stmt.span.start as usize;
-    let test_start = if_stmt.test.span().start as usize;
-    let test_end = if_stmt.test.span().end as usize;
-    let cons_start = if_stmt.consequent.span().start as usize;
-    let cons_end = if_stmt.consequent.span().end as usize;
-    let alt_start = alternate.span().start as usize;
+    push_invert_test_fixes(&mut fixes, &fixer, negated_test, /* for_if_statement */ true, ctx);
+    push_swap_statement_branches(&mut fixes, &fixer, &if_stmt.consequent, alternate, ctx);
 
-    let before_test = &source[if_start..test_start];
-    let after_test = &source[test_end..cons_start];
-    let between_consequent_and_else = &source[cons_end..alt_start];
-
-    let replacement = format!(
-        "{before_test}{inverted_test}{after_test}{alternate_text}{between_consequent_and_else}{consequent_text}"
-    );
-
-    fixer.replace(if_stmt.span, replacement)
+    fixes.with_message(
+        "Remove the negation operator and switch the consequent and alternate branches.",
+    )
 }
 
 fn fix_conditional_expression<'a>(
@@ -204,42 +126,33 @@ fn fix_conditional_expression<'a>(
     negated_test: &Expression<'a>,
     ctx: &LintContext<'a>,
 ) -> RuleFix {
-    let mut inverted_test =
-        invert_test_preserving_outer_parens(&conditional_expr.test, negated_test, ctx, false);
-    let consequent_text = ctx.source_range(conditional_expr.consequent.span());
-    let alternate_text = ctx.source_range(conditional_expr.alternate.span());
+    let fixer = fixer.for_multifix();
+    let mut fixes = fixer.new_fix_with_capacity(6);
 
+    let is_unary = matches!(negated_test, Expression::UnaryExpression(_));
     let source = ctx.source_text();
-    let test_span = conditional_expr.test.span();
-    let cons_span = conditional_expr.consequent.span();
-    let alt_span = conditional_expr.alternate.span();
     let expr_span = conditional_expr.span;
 
-    let before_test = &source[expr_span.start as usize..test_span.start as usize];
-    let between_test_and_cons = &source[test_span.end as usize..cons_span.start as usize];
-    let between_cons_and_alt = &source[cons_span.end as usize..alt_span.start as usize];
-    let after_alt = &source[alt_span.end as usize..expr_span.end as usize];
+    // Detect ASI / keyword spacing from what the expression will look like after removing `!`.
+    let (needs_space_before, needs_asi_semi, needs_return_throw_parens) = if is_unary {
+        let Expression::UnaryExpression(unary) = negated_test else { unreachable!() };
+        // Text after deleting the leading `!` (preserves comments between `!` and operand).
+        let after_bang = ctx.source_range(Span::new(unary.span.start + 1, unary.span.end));
+        let first_significant = after_bang.trim_start().chars().next();
+        let has_newline_in_remainder = after_bang.contains('\n');
 
-    // `return!a` / `throw!a` → insert space after keyword when removing `!`
-    let is_unary = matches!(negated_test, Expression::UnaryExpression(_));
-    // When `!` and its operand are not on the same line, `return`/`throw` cannot be
-    // followed by a newline before the expression — parenthesize (unicorn does the same).
-    // Skip when the test is already parenthesized (`return (!…\na) ? b : c`).
-    let needs_return_throw_parens = is_unary
-        && inverted_test.contains('\n')
-        && !matches!(conditional_expr.test, Expression::ParenthesizedExpression(_))
-        && matches!(
-            ctx.nodes().parent_kind(node.id()),
-            AstKind::ReturnStatement(_) | AstKind::ThrowStatement(_)
-        );
+        let needs_return_throw_parens = has_newline_in_remainder
+            && !matches!(conditional_expr.test, Expression::ParenthesizedExpression(_))
+            && matches!(
+                ctx.nodes().parent_kind(node.id()),
+                AstKind::ReturnStatement(_) | AstKind::ThrowStatement(_)
+            );
 
-    if is_unary && !needs_return_throw_parens {
-        let start = expr_span.start as usize;
-        if start > 0 {
-            let char_before = source[..start].chars().next_back();
-            let first_of_inverted = inverted_test.chars().next();
-            if char_before.is_some_and(is_identifier_start)
-                && first_of_inverted.is_some_and(|c| {
+        let needs_space_before = !needs_return_throw_parens && {
+            let start = expr_span.start as usize;
+            start > 0
+                && source[..start].chars().next_back().is_some_and(is_identifier_start)
+                && first_significant.is_some_and(|c| {
                     is_identifier_start(c)
                         || c == '('
                         || c == '['
@@ -248,31 +161,158 @@ fn fix_conditional_expression<'a>(
                         || c == '+'
                         || c == '-'
                 })
-            {
-                inverted_test.insert(0, ' ');
-            }
-        }
-    }
+        };
 
-    let mut replacement = format!(
-        "{before_test}{inverted_test}{between_test_and_cons}{alternate_text}{between_cons_and_alt}{consequent_text}{after_alt}"
-    );
+        let needs_asi_semi = !needs_return_throw_parens
+            && !needs_space_before
+            && matches!(first_significant, Some('(' | '[' | '`' | '+' | '-' | '/'))
+            && could_be_asi_hazard(node, ctx);
+
+        (needs_space_before, needs_asi_semi, needs_return_throw_parens)
+    } else {
+        (false, false, false)
+    };
+
+    if needs_asi_semi {
+        fixes.push(fixer.insert_text_before_range(expr_span, ";"));
+    } else if needs_space_before {
+        fixes.push(fixer.insert_text_before_range(expr_span, " "));
+    }
 
     if needs_return_throw_parens {
-        replacement = format!("({replacement})");
+        fixes.push(fixer.insert_text_before_range(expr_span, "("));
+        fixes.push(fixer.insert_text_after_range(expr_span, ")"));
     }
 
-    // ASI hazard when removing leading `!` leaves `(`, `[`, etc. at statement start.
-    if is_unary && !needs_return_throw_parens {
-        let trimmed = inverted_test.trim_start();
-        let first_char = trimmed.chars().next();
-        if matches!(first_char, Some('(' | '[' | '`' | '+' | '-' | '/'))
-            && could_be_asi_hazard(node, ctx)
-            && !replacement.starts_with([';', ' '])
-        {
-            replacement.insert(0, ';');
+    push_invert_test_fixes(
+        &mut fixes,
+        &fixer,
+        negated_test,
+        /* for_if_statement */ false,
+        ctx,
+    );
+    push_swap_expression_branches(
+        &mut fixes,
+        &fixer,
+        &conditional_expr.consequent,
+        &conditional_expr.alternate,
+        ctx,
+    );
+
+    fixes.with_message(
+        "Remove the negation operator and switch the consequent and alternate branches.",
+    )
+}
+
+fn push_invert_test_fixes<'a>(
+    fixes: &mut RuleFix,
+    fixer: &RuleFixer<'_, 'a>,
+    negated_test: &Expression<'a>,
+    for_if_statement: bool,
+    ctx: &LintContext<'a>,
+) {
+    match negated_test {
+        Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::LogicalNot => {
+            // Delete only the `!` punctuator (1 byte) so comments/whitespace after it stay.
+            fixes.push(fixer.delete_range(Span::new(unary.span.start, unary.span.start + 1)));
+
+            // For `if`, also drop parentheses around the argument (`if (!((a)))` → `if (a)`).
+            if for_if_statement {
+                let inner = unary.argument.get_inner_expression();
+                let arg_span = unary.argument.span();
+                if inner.span() != arg_span {
+                    // Replace the parenthesized argument with the inner expression text only.
+                    let inner_text = ctx.source_range(inner.span());
+                    fixes.push(fixer.replace(arg_span, inner_text.to_string()));
+                }
+            }
         }
+        Expression::BinaryExpression(binary) => {
+            // Replace only the operator token so surrounding spacing is preserved (`a!=b` → `a==b`).
+            if let Some(op_span) = binary_operator_span(binary, ctx) {
+                let replacement = match binary.operator {
+                    BinaryOperator::Inequality => "==",
+                    BinaryOperator::StrictInequality => "===",
+                    _ => unreachable!(),
+                };
+                fixes.push(fixer.replace(op_span, replacement));
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Locate `!=` / `!==` between left and right without copying the operands.
+fn binary_operator_span(binary: &BinaryExpression<'_>, ctx: &LintContext<'_>) -> Option<Span> {
+    let left_end = binary.left.span().end;
+    let right_start = binary.right.span().start;
+    let operator_str = binary.operator.as_str();
+    let between = ctx.source_range(Span::new(left_end, right_start));
+    let op_bytes = operator_str.as_bytes();
+
+    between.as_bytes().windows(op_bytes.len()).enumerate().find_map(|(index, chunk)| {
+        if chunk != op_bytes {
+            return None;
+        }
+        #[expect(clippy::cast_possible_truncation)]
+        let pos_start = left_end + index as u32;
+        let pos_end = pos_start + op_bytes.len() as u32;
+        // Skip matches that sit inside comments between the operands.
+        if ctx.comments().iter().any(|c| c.span.start <= pos_start && pos_end <= c.span.end) {
+            return None;
+        }
+        Some(Span::new(pos_start, pos_end))
+    })
+}
+
+fn push_swap_statement_branches<'a>(
+    fixes: &mut RuleFix,
+    fixer: &RuleFixer<'_, 'a>,
+    consequent: &Statement<'a>,
+    alternate: &Statement<'a>,
+    ctx: &LintContext<'a>,
+) {
+    let cons_span = consequent.span();
+    let alt_span = alternate.span();
+    let cons_src = ctx.source_range(cons_span);
+    let alt_src = ctx.source_range(alt_span);
+
+    // Identical branches: only the test needs changing.
+    if cons_src == alt_src
+        && matches!(consequent, Statement::BlockStatement(_))
+            == matches!(alternate, Statement::BlockStatement(_))
+    {
+        return;
     }
 
-    fixer.replace(expr_span, replacement)
+    let cons_is_block = matches!(consequent, Statement::BlockStatement(_));
+    let alt_is_block = matches!(alternate, Statement::BlockStatement(_));
+
+    // Non-block branches must be wrapped after the swap so ASI / dangling `else` stay valid.
+    let new_cons = if alt_is_block { alt_src.to_string() } else { format!("{{{alt_src}}}") };
+    let new_alt = if cons_is_block { cons_src.to_string() } else { format!("{{{cons_src}}}") };
+
+    fixes.push(fixer.replace(cons_span, new_cons));
+    fixes.push(fixer.replace(alt_span, new_alt));
+}
+
+fn push_swap_expression_branches<'a>(
+    fixes: &mut RuleFix,
+    fixer: &RuleFixer<'_, 'a>,
+    consequent: &Expression<'a>,
+    alternate: &Expression<'a>,
+    ctx: &LintContext<'a>,
+) {
+    let cons_span = consequent.span();
+    let alt_span = alternate.span();
+    let cons_src = ctx.source_range(cons_span);
+    let alt_src = ctx.source_range(alt_span);
+
+    if cons_src == alt_src {
+        return;
+    }
+
+    // Must own the replacement strings because both edits reference the other branch's text.
+    fixes.push(fixer.replace(cons_span, alt_src.to_string()));
+    fixes.push(fixer.replace(alt_span, cons_src.to_string()));
 }

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{BinaryExpression, ConditionalExpression, Expression, IfStatement, Statement},
+    ast::{ConditionalExpression, Expression, IfStatement, Statement},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::{GetSpan, Span};
@@ -111,7 +111,7 @@ fn fix_if_statement<'a>(
     // invert test (1–2) + swap branches (2) — capacity 4 is enough
     let mut fixes = fixer.new_fix_with_capacity(4);
 
-    push_invert_test_fixes(&mut fixes, &fixer, negated_test, /* for_if_statement */ true, ctx);
+    push_invert_test_fixes(&mut fixes, &fixer, negated_test, ctx);
     push_swap_statement_branches(&mut fixes, &fixer, &if_stmt.consequent, alternate, ctx);
 
     fixes.with_message(
@@ -184,13 +184,7 @@ fn fix_conditional_expression<'a>(
         fixes.push(fixer.insert_text_after_range(expr_span, ")"));
     }
 
-    push_invert_test_fixes(
-        &mut fixes,
-        &fixer,
-        negated_test,
-        /* for_if_statement */ false,
-        ctx,
-    );
+    push_invert_test_fixes(&mut fixes, &fixer, negated_test, ctx);
     push_swap_expression_branches(
         &mut fixes,
         &fixer,
@@ -208,24 +202,12 @@ fn push_invert_test_fixes<'a>(
     fixes: &mut RuleFix,
     fixer: &RuleFixer<'_, 'a>,
     negated_test: &Expression<'a>,
-    for_if_statement: bool,
     ctx: &LintContext<'a>,
 ) {
     match negated_test {
         Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::LogicalNot => {
             // Delete only the `!` punctuator (1 byte) so comments/whitespace after it stay.
             fixes.push(fixer.delete_range(Span::new(unary.span.start, unary.span.start + 1)));
-
-            // For `if`, also drop parentheses around the argument (`if (!((a)))` → `if (a)`).
-            if for_if_statement {
-                let inner = unary.argument.get_inner_expression();
-                let arg_span = unary.argument.span();
-                if inner.span() != arg_span {
-                    // Replace the parenthesized argument with the inner expression text only.
-                    let inner_text = ctx.source_range(inner.span());
-                    fixes.push(fixer.replace(arg_span, inner_text.to_string()));
-                }
-            }
         }
         Expression::BinaryExpression(binary) => {
             let binary_operator_str = binary.operator.as_str();
@@ -238,7 +220,7 @@ fn push_invert_test_fixes<'a>(
                 .map(|s| Span::sized(binary.left.span().end + s, binary_operator_str.len() as u32))
                 && let Some(inverse_op) = binary.operator.equality_inverse_operator()
             {
-                fixes.push(fixer.replace(op_span, binary_operator_str));
+                fixes.push(fixer.replace(op_span, inverse_op.as_str()));
             }
         }
         _ => {}

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -207,6 +207,7 @@ fn fix_conditional_expression<'a>(
     )
 }
 
+#[expect(clippy::cast_possible_truncation)]
 fn push_invert_test_fixes<'a>(
     fixes: &mut RuleFix,
     fixer: &RuleFixer<'_, 'a>,

--- a/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/shared/eslint_unicorn/no_negated_condition.rs
@@ -95,7 +95,11 @@ fn is_negated_expression(expr: &Expression) -> bool {
     }
 }
 
-fn invert_test_text(test: &Expression<'_>, ctx: &LintContext<'_>, for_if_statement: bool) -> String {
+fn invert_test_text(
+    test: &Expression<'_>,
+    ctx: &LintContext<'_>,
+    for_if_statement: bool,
+) -> String {
     match test {
         Expression::UnaryExpression(unary) if unary.operator == UnaryOperator::LogicalNot => {
             // For `if` statements, drop parentheses around the argument so
@@ -161,8 +165,7 @@ fn fix_if_statement<'a>(
     negated_test: &Expression<'a>,
     ctx: &LintContext<'a>,
 ) -> RuleFix {
-    let inverted_test =
-        invert_test_preserving_outer_parens(&if_stmt.test, negated_test, ctx, true);
+    let inverted_test = invert_test_preserving_outer_parens(&if_stmt.test, negated_test, ctx, true);
     let consequent_text = statement_text_for_swap(&if_stmt.consequent, ctx);
     let alternate_text = statement_text_for_swap(alternate, ctx);
 

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -17,7 +17,7 @@ declare_oxc_lint!(
     NoNegatedCondition,
     unicorn,
     pedantic,
-    pending,
+    fix,
     docs = DOCUMENTATION,
     version = "0.0.18",
     short_description = "Disallow negated conditions.",
@@ -30,7 +30,7 @@ impl Rule for NoNegatedCondition {
                 run_on_if_statement(if_stmt, ctx);
             }
             AstKind::ConditionalExpression(conditional_expr) => {
-                run_on_conditional_expression(conditional_expr, ctx);
+                run_on_conditional_expression(node, conditional_expr, ctx);
             }
             _ => {}
         }
@@ -78,6 +78,40 @@ fn test() {
         r"(!!a) ? b() : c();",
     ];
 
+    let fix = vec![
+        (r"if (!a) {;} else {;}", r"if (a) {;} else {;}"),
+        (r"if (a != b) {;} else {;}", r"if (a == b) {;} else {;}"),
+        (r"if (a !== b) {;} else {;}", r"if (a === b) {;} else {;}"),
+        (r"!a ? b : c", r"a ? c : b"),
+        (r"a != b ? c : d", r"a == b ? d : c"),
+        (r"a !== b ? c : d", r"a === b ? d : c"),
+        (r"(( !a )) ? b : c", r"(( a )) ? c : b"),
+        (r"!(( a )) ? b : c", r"(( a )) ? c : b"),
+        (r"if(!(( a ))) b(); else c();", r"if(a) {c();} else {b();}"),
+        (r"if((( !a ))) b(); else c();", r"if((( a ))) {c();} else {b();}"),
+        (r"function a() {return!a ? b : c}", r"function a() {return a ? c : b}"),
+        (r"function a() {return!(( a )) ? b : c}", r"function a() {return (( a )) ? c : b}"),
+        (r"!a ? b : c ? d : e", r"a ? c ? d : e : b"),
+        (r"!a ? b : (( c ? d : e ))", r"a ? (( c ? d : e )) : b"),
+        (r"if(!a) b(); else c()", r"if(a) {c()} else {b();}"),
+        (r"if(!a) {b()} else {c()}", r"if(a) {c()} else {b()}"),
+        (r"if(!!a) b(); else c();", r"if(!a) {c();} else {b();}"),
+        (r"(!!a) ? b() : c();", r"(!a) ? c() : b();"),
+        (
+            "a
+![] ? b : c",
+            "a
+;[] ? c : b",
+        ),
+        (
+            "a
+!(b) ? c : d",
+            "a
+;(b) ? d : c",
+        ),
+    ];
+
     Tester::new(NoNegatedCondition::NAME, NoNegatedCondition::PLUGIN, pass, fail)
+        .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -131,7 +131,7 @@ e();
         (r"a !== b ? c : d", r"a === b ? d : c"),
         (r"(( !a )) ? b : c", r"(( a )) ? c : b"),
         (r"!(( a )) ? b : c", r"(( a )) ? c : b"),
-        (r"if(!(( a ))) b(); else c();", r"if(a) {c();} else {b();}"),
+        (r"if(!(( a ))) b(); else c();", r"if((( a ))) {c();} else {b();}"),
         (r"if((( !a ))) b(); else c();", r"if((( a ))) {c();} else {b();}"),
         (r"function a() {return!a ? b : c}", r"function a() {return a ? c : b}"),
         (r"function a() {return!(( a )) ? b : c}", r"function a() {return (( a )) ? c : b}"),

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -70,6 +70,8 @@ fn test() {
         r"if(!(( a ))) b(); else c();",
         r"if((( !a ))) b(); else c();",
         r"function a() {return!a ? b : c}",
+        r"function a() {return!0 ? b:c}",
+        r"function a() {return!\u0061 ? b:c}",
         r"function a() {return!(( a )) ? b : c}",
         "function a() {
 return ! // comment
@@ -88,6 +90,17 @@ a) ? b : c;
 throw ! // comment
 a ? b : c;
 }",
+        "function* a() {
+yield ! // comment
+a ? b : c;
+}",
+        "function a() {return !\r a ? b : c;}",
+        "function a() {throw !\u{2028}a ? b : c;}",
+        "function a() {return !\u{2029}a ? b : c;}",
+        r"!{} ? a : b",
+        r"!function(){} ? a : b",
+        r"!class {} ? a : b",
+        r"for (!a ? x in y : z;;) {}",
         r"!a ? b : c ? d : e",
         r"!a ? b : (( c ? d : e ))",
         "a
@@ -134,6 +147,8 @@ e();
         (r"if(!(( a ))) b(); else c();", r"if((( a ))) {c();} else {b();}"),
         (r"if((( !a ))) b(); else c();", r"if((( a ))) {c();} else {b();}"),
         (r"function a() {return!a ? b : c}", r"function a() {return a ? c : b}"),
+        (r"function a() {return!0 ? b:c}", r"function a() {return 0 ? c:b}"),
+        (r"function a() {return!\u0061 ? b:c}", r"function a() {return \u0061 ? c:b}"),
         (r"function a() {return!(( a )) ? b : c}", r"function a() {return (( a )) ? c : b}"),
         (
             "function a() {
@@ -177,6 +192,23 @@ throw ( // comment
 a ? c : b);
 }",
         ),
+        (
+            "function* a() {
+yield ! // comment
+a ? b : c;
+}",
+            "function* a() {
+yield ( // comment
+a ? c : b);
+}",
+        ),
+        ("function a() {return !\r a ? b : c;}", "function a() {return (\r a ? c : b);}"),
+        ("function a() {throw !\u{2028}a ? b : c;}", "function a() {throw (\u{2028}a ? c : b);}"),
+        ("function a() {return !\u{2029}a ? b : c;}", "function a() {return (\u{2029}a ? c : b);}"),
+        (r"!{} ? a : b", r"({}) ? b : a"),
+        (r"!function(){} ? a : b", r"(function(){}) ? b : a"),
+        (r"!class {} ? a : b", r"(class {}) ? b : a"),
+        (r"for (!a ? x in y : z;;) {}", r"for (a ? z : (x in y);;) {}"),
         (r"!a ? b : c ? d : e", r"a ? c ? d : e : b"),
         (r"!a ? b : (( c ? d : e ))", r"a ? (( c ? d : e )) : b"),
         (

--- a/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_negated_condition.rs
@@ -41,6 +41,7 @@ impl Rule for NoNegatedCondition {
 fn test() {
     use crate::tester::Tester;
 
+    // Cases from eslint-plugin-unicorn `test/no-negated-condition.js`
     let pass = vec![
         r"if (a) {}",
         r"if (a) {} else {}",
@@ -70,12 +71,55 @@ fn test() {
         r"if((( !a ))) b(); else c();",
         r"function a() {return!a ? b : c}",
         r"function a() {return!(( a )) ? b : c}",
+        "function a() {
+return ! // comment
+a ? b : c;
+}",
+        "function a() {
+return (! // ReturnStatement argument is parenthesized
+a ? b : c);
+}",
+        "function a() {
+return (
+! // UnaryExpression argument is parenthesized
+a) ? b : c;
+}",
+        "function a() {
+throw ! // comment
+a ? b : c;
+}",
         r"!a ? b : c ? d : e",
         r"!a ? b : (( c ? d : e ))",
+        "a
+![] ? b : c",
+        "a
+!+b ? c : d",
+        "a
+!(b) ? c : d",
+        "a
+!b ? c : d",
+        "if (!a)
+b()
+else
+c()",
         r"if(!a) b(); else c()",
+        "function fn() {
+if(!a) b(); else return
+}",
         r"if(!a) {b()} else {c()}",
         r"if(!!a) b(); else c();",
         r"(!!a) ? b() : c();",
+        "function fn() {
+return!a !== b ? c : d
+return((!((a)) != b)) ? c : d
+}",
+        "if (!a) {
+b();
+} else if (!c) {
+d();
+} else {
+e();
+}",
     ];
 
     let fix = vec![
@@ -91,12 +135,50 @@ fn test() {
         (r"if((( !a ))) b(); else c();", r"if((( a ))) {c();} else {b();}"),
         (r"function a() {return!a ? b : c}", r"function a() {return a ? c : b}"),
         (r"function a() {return!(( a )) ? b : c}", r"function a() {return (( a )) ? c : b}"),
+        (
+            "function a() {
+return ! // comment
+a ? b : c;
+}",
+            "function a() {
+return ( // comment
+a ? c : b);
+}",
+        ),
+        (
+            "function a() {
+return (! // ReturnStatement argument is parenthesized
+a ? b : c);
+}",
+            "function a() {
+return ( // ReturnStatement argument is parenthesized
+a ? c : b);
+}",
+        ),
+        (
+            "function a() {
+return (
+! // UnaryExpression argument is parenthesized
+a) ? b : c;
+}",
+            "function a() {
+return (
+ // UnaryExpression argument is parenthesized
+a) ? c : b;
+}",
+        ),
+        (
+            "function a() {
+throw ! // comment
+a ? b : c;
+}",
+            "function a() {
+throw ( // comment
+a ? c : b);
+}",
+        ),
         (r"!a ? b : c ? d : e", r"a ? c ? d : e : b"),
         (r"!a ? b : (( c ? d : e ))", r"a ? (( c ? d : e )) : b"),
-        (r"if(!a) b(); else c()", r"if(a) {c()} else {b();}"),
-        (r"if(!a) {b()} else {c()}", r"if(a) {c()} else {b()}"),
-        (r"if(!!a) b(); else c();", r"if(!a) {c();} else {b();}"),
-        (r"(!!a) ? b() : c();", r"(!a) ? c() : b();"),
         (
             "a
 ![] ? b : c",
@@ -105,9 +187,69 @@ fn test() {
         ),
         (
             "a
+!+b ? c : d",
+            "a
+;+b ? d : c",
+        ),
+        (
+            "a
 !(b) ? c : d",
             "a
 ;(b) ? d : c",
+        ),
+        (
+            "a
+!b ? c : d",
+            "a
+b ? d : c",
+        ),
+        (
+            "if (!a)
+b()
+else
+c()",
+            "if (a)
+{c()}
+else
+{b()}",
+        ),
+        (r"if(!a) b(); else c()", r"if(a) {c()} else {b();}"),
+        (
+            "function fn() {
+if(!a) b(); else return
+}",
+            "function fn() {
+if(a) {return} else {b();}
+}",
+        ),
+        (r"if(!a) {b()} else {c()}", r"if(a) {c()} else {b()}"),
+        (r"if(!!a) b(); else c();", r"if(!a) {c();} else {b();}"),
+        (r"(!!a) ? b() : c();", r"(!a) ? c() : b();"),
+        (
+            "function fn() {
+return!a !== b ? c : d
+return((!((a)) != b)) ? c : d
+}",
+            "function fn() {
+return!a === b ? d : c
+return((!((a)) == b)) ? d : c
+}",
+        ),
+        (
+            "if (!a) {
+b();
+} else if (!c) {
+d();
+} else {
+e();
+}",
+            "if (!a) {
+b();
+} else if (c) {
+e();
+} else {
+d();
+}",
         ),
     ];
 

--- a/crates/oxc_linter/src/snapshots/unicorn_no_negated_condition.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_negated_condition.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 490
 ---
 
   ⚠ unicorn(no-negated-condition): Unexpected negated condition.
@@ -87,6 +88,42 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and switch the consequent and alternate branches.
 
   ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:8]
+ 1 │     function a() {
+ 2 │ ╭─▶ return ! // comment
+ 3 │ ╰─▶ a ? b : c;
+ 4 │     }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:9]
+ 1 │     function a() {
+ 2 │ ╭─▶ return (! // ReturnStatement argument is parenthesized
+ 3 │ ╰─▶ a ? b : c);
+ 4 │     }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:3:1]
+ 2 │     return (
+ 3 │ ╭─▶ ! // UnaryExpression argument is parenthesized
+ 4 │ ╰─▶ a) ? b : c;
+ 5 │     }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:7]
+ 1 │     function a() {
+ 2 │ ╭─▶ throw ! // comment
+ 3 │ ╰─▶ a ? b : c;
+ 4 │     }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
    ╭─[no_negated_condition.tsx:1:1]
  1 │ !a ? b : c ? d : e
    · ──
@@ -101,9 +138,58 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the negation operator and switch the consequent and alternate branches.
 
   ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:1]
+ 1 │ a
+ 2 │ ![] ? b : c
+   · ───
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:1]
+ 1 │ a
+ 2 │ !+b ? c : d
+   · ───
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:1]
+ 1 │ a
+ 2 │ !(b) ? c : d
+   · ────
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:1]
+ 1 │ a
+ 2 │ !b ? c : d
+   · ──
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:5]
+ 1 │ if (!a)
+   ·     ──
+ 2 │ b()
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
    ╭─[no_negated_condition.tsx:1:4]
  1 │ if(!a) b(); else c()
    ·    ──
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:4]
+ 1 │ function fn() {
+ 2 │ if(!a) b(); else return
+   ·    ──
+ 3 │ }
    ╰────
   help: Remove the negation operator and switch the consequent and alternate branches.
 
@@ -125,5 +211,32 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_negated_condition.tsx:1:2]
  1 │ (!!a) ? b() : c();
    ·  ───
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:7]
+ 1 │ function fn() {
+ 2 │ return!a !== b ? c : d
+   ·       ────────
+ 3 │ return((!((a)) != b)) ? c : d
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:3:9]
+ 2 │ return!a !== b ? c : d
+ 3 │ return((!((a)) != b)) ? c : d
+   ·         ───────────
+ 4 │ }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:3:12]
+ 2 │ b();
+ 3 │ } else if (!c) {
+   ·            ──
+ 4 │ d();
    ╰────
   help: Remove the negation operator and switch the consequent and alternate branches.

--- a/crates/oxc_linter/src/snapshots/unicorn_no_negated_condition.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_negated_condition.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 490
 ---
 
   ⚠ unicorn(no-negated-condition): Unexpected negated condition.
@@ -82,6 +81,20 @@ assertion_line: 490
 
   ⚠ unicorn(no-negated-condition): Unexpected negated condition.
    ╭─[no_negated_condition.tsx:1:21]
+ 1 │ function a() {return!0 ? b:c}
+   ·                     ──
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:21]
+ 1 │ function a() {return!\u0061 ? b:c}
+   ·                     ───────
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:21]
  1 │ function a() {return!(( a )) ? b : c}
    ·                     ────────
    ╰────
@@ -120,6 +133,64 @@ assertion_line: 490
  2 │ ╭─▶ throw ! // comment
  3 │ ╰─▶ a ? b : c;
  4 │     }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:2:7]
+ 1 │     function* a() {
+ 2 │ ╭─▶ yield ! // comment
+ 3 │ ╰─▶ a ? b : c;
+ 4 │     }
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:22]
+ 1 │ function a() {return ! a ? b : c;}
+   ·                      ────
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:21]
+ 1 │ function a() {throw ! a ? b : c;}
+   ·                     ───
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:22]
+ 1 │ function a() {return ! a ? b : c;}
+   ·                      ───
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:1]
+ 1 │ !{} ? a : b
+   · ───
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:1]
+ 1 │ !function(){} ? a : b
+   · ─────────────
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:1]
+ 1 │ !class {} ? a : b
+   · ─────────
+   ╰────
+  help: Remove the negation operator and switch the consequent and alternate branches.
+
+  ⚠ unicorn(no-negated-condition): Unexpected negated condition.
+   ╭─[no_negated_condition.tsx:1:6]
+ 1 │ for (!a ? x in y : z;;) {}
+   ·      ──
    ╰────
   help: Remove the negation operator and switch the consequent and alternate branches.
 


### PR DESCRIPTION
## Summary

- Add safe autofix for `eslint/no-negated-condition` and `unicorn/no-negated-condition` (shared implementation)
- Invert `!` / `!=` / `!==` tests and swap consequent/alternate branches
- Handle if non-block branches (`{}` wrapping), outer parentheses, `return!`/`throw!` spacing, and ASI hazards

## Test plan

- [x] `cargo test -p oxc_linter no_negated_condition`
- [ ] CI on this PR