### PR TITLE
feat(transformer)!: switch to new `AstBuilder`

### DIFF
--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true }
+oxc_ast = { workspace = true, features = ["builder_new"] }
 oxc_ast_visit = { workspace = true }
 oxc_compat = { workspace = true }
 oxc_data_structures = { workspace = true, features = [

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -525,7 +525,7 @@ impl<'a> ArrowFunctionConverter<'a> {
         // TODO: Add `BoundIdentifier::create_spanned_read_reference_boxed` method (and friends)
         // for this use case, so we can avoid `alloc()` call here.
         // I (@overlookmotel) doubt it'd make a perf difference, but it'd be cleaner code.
-        Some(ctx.ast.alloc(this_var.create_spanned_read_reference(span, ctx)))
+        Some(ArenaBox::new_in(this_var.create_spanned_read_reference(span, ctx), ctx))
     }
 
     /// Traverses upward through ancestor nodes to find the `ScopeId` of the block
@@ -642,11 +642,12 @@ impl<'a> ArrowFunctionConverter<'a> {
             let stmt = body.statements.pop().unwrap();
             let Statement::ExpressionStatement(stmt) = stmt else { unreachable!() };
             let stmt = stmt.unbox();
-            let return_statement = ctx.ast.statement_return(stmt.span, Some(stmt.expression));
+            let return_statement =
+                Statement::new_return_statement(stmt.span, Some(stmt.expression), ctx);
             body.statements.push(return_statement);
         }
 
-        ctx.ast.expression_function_with_scope_id_and_pure_and_pife(
+        Expression::new_function_expression_with_scope_id_and_pure_and_pife(
             arrow_function_expr.span,
             FunctionType::FunctionExpression,
             None,
@@ -661,6 +662,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             scope_id,
             false,
             false,
+            ctx,
         )
     }
 
@@ -772,8 +774,9 @@ impl<'a> ArrowFunctionConverter<'a> {
         });
 
         let callee = super_info.binding.create_read_expression(ctx);
-        let mut arguments = ctx.ast.vec_with_capacity(
+        let mut arguments = ArenaVec::with_capacity_in(
             usize::from(assign_value.is_some()) + usize::from(argument.is_some()),
+            ctx,
         );
         // _prop
         if let Some(argument) = argument {
@@ -783,7 +786,8 @@ impl<'a> ArrowFunctionConverter<'a> {
         if let Some(assign_value) = assign_value {
             arguments.push(Argument::from(assign_value.take_in(ctx)));
         }
-        let call = ctx.ast.expression_call(expr.span(), callee, NONE, arguments, false);
+        let call =
+            Expression::new_call_expression(expr.span(), callee, NONE, arguments, false, ctx);
         Some(call)
     }
 
@@ -816,14 +820,15 @@ impl<'a> ArrowFunctionConverter<'a> {
 
         let object = self.transform_member_expression_for_super(&mut call.callee, None, ctx)?;
         // Add `this` as the first argument and original arguments as the rest.
-        let mut arguments = ctx.ast.vec_with_capacity(call.arguments.len() + 1);
-        arguments.push(Argument::from(ctx.ast.expression_this(SPAN)));
+        let mut arguments = ArenaVec::with_capacity_in(call.arguments.len() + 1, ctx);
+        arguments.push(Argument::from(Expression::new_this_expression(SPAN, ctx)));
         arguments.extend(call.arguments.take_in(ctx));
 
-        let property = ctx.ast.identifier_name(SPAN, "call");
-        let callee = ctx.ast.member_expression_static(SPAN, object, property, false);
+        let property = IdentifierName::new(SPAN, "call", ctx);
+        let callee =
+            MemberExpression::new_static_member_expression(SPAN, object, property, false, ctx);
         let callee = Expression::from(callee);
-        Some(ctx.ast.expression_call(call.span, callee, NONE, arguments, false))
+        Some(Expression::new_call_expression(call.span, callee, NONE, arguments, false, ctx))
     }
 
     /// Transform an `AssignmentExpression` whose assignment target is a `super` member expression.
@@ -897,7 +902,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             ctx.create_child_scope(target_scope_id, ScopeFlags::Arrow | ScopeFlags::Function);
 
         let mut items =
-            ctx.ast.vec_with_capacity(usize::from(is_computed) + usize::from(is_assignment));
+            ArenaVec::with_capacity_in(usize::from(is_computed) + usize::from(is_assignment), ctx);
 
         // Create a parameter for the prop if it's a computed member expression.
         if is_computed {
@@ -905,9 +910,9 @@ impl<'a> ArrowFunctionConverter<'a> {
             // in `prop => super[prop]` or `(prop, value) => super[prop] = value` which can clash.
             let param_binding =
                 ctx.generate_uid("prop", scope_id, SymbolFlags::FunctionScopedVariable);
-            let param = ctx.ast.formal_parameter(
+            let param = FormalParameter::new(
                 SPAN,
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 param_binding.create_binding_pattern(ctx),
                 NONE,
                 NONE,
@@ -915,15 +920,17 @@ impl<'a> ArrowFunctionConverter<'a> {
                 None,
                 false,
                 false,
+                ctx,
             );
             items.push(param);
 
             // `super` -> `super[prop]`
-            init = Expression::from(ctx.ast.member_expression_computed(
+            init = Expression::from(MemberExpression::new_computed_member_expression(
                 SPAN,
                 init,
                 param_binding.create_read_expression(ctx),
                 false,
+                ctx,
             ));
         }
 
@@ -933,9 +940,9 @@ impl<'a> ArrowFunctionConverter<'a> {
             // in `value => super.prop = value` or `(prop, value) => super[prop] = value` which can clash.
             let param_binding =
                 ctx.generate_uid("value", scope_id, SymbolFlags::FunctionScopedVariable);
-            let param = ctx.ast.formal_parameter(
+            let param = FormalParameter::new(
                 SPAN,
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 param_binding.create_binding_pattern(ctx),
                 NONE,
                 NONE,
@@ -943,6 +950,7 @@ impl<'a> ArrowFunctionConverter<'a> {
                 None,
                 false,
                 false,
+                ctx,
             );
             items.push(param);
 
@@ -950,27 +958,36 @@ impl<'a> ArrowFunctionConverter<'a> {
             let left = SimpleAssignmentTarget::from(init.into_member_expression());
             let left = AssignmentTarget::from(left);
             let right = param_binding.create_read_expression(ctx);
-            init = ctx.ast.expression_assignment(SPAN, AssignmentOperator::Assign, left, right);
+            init = Expression::new_assignment_expression(
+                SPAN,
+                AssignmentOperator::Assign,
+                left,
+                right,
+                ctx,
+            );
         }
 
-        let params = ctx.ast.formal_parameters(
+        let params = FormalParameters::new(
             SPAN,
             FormalParameterKind::ArrowFormalParameters,
             items,
             NONE,
+            ctx,
         );
-        let statements = ctx.ast.vec1(ctx.ast.statement_expression(SPAN, init));
-        let body = ctx.ast.function_body(SPAN, ctx.ast.vec(), statements);
-        let init = ctx.ast.expression_arrow_function_with_scope_id_and_pure_and_pife(
-            SPAN, true, false, NONE, params, NONE, body, scope_id, false, false,
+        let statements =
+            ArenaVec::from_value_in(Statement::new_expression_statement(SPAN, init, ctx), ctx);
+        let body = FunctionBody::new(SPAN, ArenaVec::new_in(ctx), statements, ctx);
+        let init = Expression::new_arrow_function_expression_with_scope_id_and_pure_and_pife(
+            SPAN, true, false, NONE, params, NONE, body, scope_id, false, false, ctx,
         );
-        ctx.ast.variable_declarator(
+        VariableDeclarator::new(
             SPAN,
             VariableDeclarationKind::Var,
             binding.create_binding_pattern(ctx),
             NONE,
             Some(init),
             false,
+            ctx,
         )
     }
 
@@ -1121,24 +1138,33 @@ impl<'a> ArrowFunctionConverter<'a> {
                 static_ident!("arguments"),
                 ReferenceFlags::Read,
             );
-            let typeof_arguments = ctx.ast.expression_unary(SPAN, UnaryOperator::Typeof, argument);
-            let undefined_literal = ctx.ast.expression_string_literal(SPAN, "undefined", None);
-            let test = ctx.ast.expression_binary(
+            let typeof_arguments =
+                Expression::new_unary_expression(SPAN, UnaryOperator::Typeof, argument, ctx);
+            let undefined_literal = Expression::new_string_literal(SPAN, "undefined", None, ctx);
+            let test = Expression::new_binary_expression(
                 SPAN,
                 typeof_arguments,
                 BinaryOperator::StrictEquality,
                 undefined_literal,
+                ctx,
             );
-            init = ctx.ast.expression_conditional(SPAN, test, ctx.ast.void_0(SPAN), init);
+            init = Expression::new_conditional_expression(
+                SPAN,
+                test,
+                Expression::new_void_0(SPAN, ctx),
+                init,
+                ctx,
+            );
         }
 
-        Some(ctx.ast.variable_declarator(
+        Some(VariableDeclarator::new(
             SPAN,
             VariableDeclarationKind::Var,
             arguments_var.create_binding_pattern(ctx),
             NONE,
             Some(init),
             false,
+            ctx,
         ))
     }
 
@@ -1164,7 +1190,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             return;
         }
 
-        let mut declarations = ctx.ast.vec_with_capacity(declarations_count);
+        let mut declarations = ArenaVec::with_capacity_in(declarations_count, ctx);
 
         if let Some(arguments) = arguments {
             declarations.push(arguments);
@@ -1189,27 +1215,29 @@ impl<'a> ArrowFunctionConverter<'a> {
                     .visit_statements(statements);
                 None
             } else {
-                Some(ctx.ast.expression_this(SPAN))
+                Some(Expression::new_this_expression(SPAN, ctx))
             };
             Self::adjust_binding_scope(target_scope_id, &this_var, ctx);
-            let variable_declarator = ctx.ast.variable_declarator(
+            let variable_declarator = VariableDeclarator::new(
                 SPAN,
                 VariableDeclarationKind::Var,
                 this_var.create_binding_pattern(ctx),
                 NONE,
                 init,
                 false,
+                ctx,
             );
             declarations.push(variable_declarator);
         }
 
         debug_assert_eq!(declarations_count, declarations.len());
 
-        let stmt = ctx.ast.alloc_variable_declaration(
+        let stmt = VariableDeclaration::boxed(
             SPAN,
             VariableDeclarationKind::Var,
             declarations,
             false,
+            ctx,
         );
 
         let stmt = Statement::VariableDeclaration(stmt);
@@ -1295,7 +1323,7 @@ impl<'a> VisitMut<'a> for ConstructorBodyThisAfterSuperInserter<'a, '_> {
 
                 // Insert `_this = this;` after `super();`
                 let assignment = self.create_assignment_to_this_temp_var();
-                let assignment = self.ctx.ast.statement_expression(SPAN, assignment);
+                let assignment = Statement::new_expression_statement(SPAN, assignment, self.ctx);
                 statements.insert(index + 1, assignment);
 
                 // `super();` found as top-level statement in this block of statements.
@@ -1328,17 +1356,18 @@ impl<'a> ConstructorBodyThisAfterSuperInserter<'a, '_> {
     fn transform_super_call_expression(&mut self, expr: &mut Expression<'a>) {
         let assignment = self.create_assignment_to_this_temp_var();
         let span = expr.span();
-        let exprs = self.ctx.ast.vec_from_array([expr.take_in(self.ctx), assignment]);
-        *expr = self.ctx.ast.expression_sequence(span, exprs);
+        let exprs = ArenaVec::from_array_in([expr.take_in(self.ctx), assignment], self.ctx);
+        *expr = Expression::new_sequence_expression(span, exprs, self.ctx);
     }
 
     /// `_this = this`
     fn create_assignment_to_this_temp_var(&mut self) -> Expression<'a> {
-        self.ctx.ast.expression_assignment(
+        Expression::new_assignment_expression(
             SPAN,
             AssignmentOperator::Assign,
             self.this_var_binding.create_write_target(self.ctx),
-            self.ctx.ast.expression_this(SPAN),
+            Expression::new_this_expression(SPAN, self.ctx),
+            self.ctx,
         )
     }
 }

--- a/crates/oxc_transformer/src/common/computed_key.rs
+++ b/crates/oxc_transformer/src/common/computed_key.rs
@@ -66,7 +66,7 @@ pub fn create_computed_key_temp_var<'a>(
     let binding =
         ctx.generate_uid_based_on_node(&key, outer_scope_id, SymbolFlags::BlockScopedVariable);
 
-    ctx.state.var_declarations.insert_let(&binding, None, ctx.ast);
+    ctx.state.var_declarations.insert_let(&binding, None, &ctx.ast);
 
     let assignment = create_assignment(&binding, key, SPAN, ctx);
     let ident = binding.create_read_expression(ctx);

--- a/crates/oxc_transformer/src/common/duplicate.rs
+++ b/crates/oxc_transformer/src/common/duplicate.rs
@@ -2,7 +2,7 @@
 
 use std::array;
 
-use oxc_allocator::CloneIn;
+use oxc_allocator::{ArenaVec, CloneIn};
 use oxc_ast::ast::{AssignmentOperator, Expression};
 use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
@@ -121,10 +121,11 @@ pub fn duplicate_expression_multiple<'a, const N: usize>(
         // Note: "`x${foo}`" *can* have side effects if `foo` is an object with a `toString` method.
         Expression::TemplateLiteral(lit) if lit.expressions.is_empty() => {
             let references = array::from_fn(|_| {
-                ctx.ast.expression_template_literal(
+                Expression::new_template_literal(
                     lit.span,
-                    ctx.ast.vec_from_iter(lit.quasis.iter().cloned()),
-                    ctx.ast.vec(),
+                    ArenaVec::from_iter_in(lit.quasis.iter().cloned(), ctx),
+                    ArenaVec::new_in(ctx),
+                    ctx,
                 )
             });
             return (expr, references);
@@ -133,11 +134,12 @@ pub fn duplicate_expression_multiple<'a, const N: usize>(
         _ => VarDeclarationsStore::create_uid_var_based_on_node(&expr, ctx),
     };
 
-    let assignment = ctx.ast.expression_assignment(
+    let assignment = Expression::new_assignment_expression(
         SPAN,
         AssignmentOperator::Assign,
         temp_var_binding.create_target(ReferenceFlags::Write, ctx),
         expr,
+        ctx,
     );
 
     let references = array::from_fn(|_| temp_var_binding.create_read_expression(ctx));

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -73,7 +73,7 @@ use serde::Deserialize;
 use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{
     NONE,
-    ast::{Argument, CallExpression, Expression},
+    ast::{Argument, CallExpression, Expression, IdentifierName, MemberExpression},
 };
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
 use oxc_span::SPAN;
@@ -276,7 +276,7 @@ pub fn helper_call<'a>(
 ) -> ArenaBox<'a, CallExpression<'a>> {
     let callee = helper_load(helper, ctx);
     let pure = helper.pure();
-    ctx.ast.alloc_call_expression_with_pure(SPAN, callee, NONE, arguments, false, pure)
+    CallExpression::boxed_with_pure(SPAN, callee, NONE, arguments, false, pure, ctx)
 }
 
 /// Same as [`helper_call`], but returns a `CallExpression` wrapped in an `Expression`.
@@ -289,7 +289,7 @@ pub fn helper_call_expr<'a>(
 ) -> Expression<'a> {
     let callee = helper_load(helper, ctx);
     let pure = helper.pure();
-    ctx.ast.expression_call_with_pure(SPAN, callee, NONE, arguments, false, pure)
+    Expression::new_call_expression_with_pure(SPAN, callee, NONE, arguments, false, pure, ctx)
 }
 
 /// Load a helper function and return a callee expression.
@@ -330,14 +330,16 @@ pub fn helper_load<'a>(helper: Helper, ctx: &mut TraverseCtx<'a>) -> Expression<
 impl<'a> HelperLoaderStore<'a> {
     // Construct string directly in arena without an intermediate temp allocation
     fn get_runtime_source(&self, helper: Helper, ctx: &TraverseCtx<'a>) -> Str<'a> {
-        ctx.ast.str_from_strs_array([&self.module_name, "/helpers/", helper.name()])
+        Str::from_strs_array_in([&self.module_name, "/helpers/", helper.name()], ctx)
     }
 
     fn transform_for_external_helper(helper: Helper, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         let helper_var = static_ident!("babelHelpers");
         let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), helper_var);
         let object = ctx.create_ident_expr(SPAN, helper_var, symbol_id, ReferenceFlags::Read);
-        let property = ctx.ast.identifier_name(SPAN, helper.name());
-        Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))
+        let property = IdentifierName::new(SPAN, helper.name(), ctx);
+        Expression::from(MemberExpression::new_static_member_expression(
+            SPAN, object, property, false, ctx,
+        ))
     }
 }

--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -57,7 +57,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for Common<'a> {
         // Var declarations: insert var/let statements at program level.
         // Pop from the stack into a local, then build statements.
         {
-            let var_stmt = ctx.state.var_declarations.get_var_statement(ctx.ast);
+            let var_stmt = ctx.state.var_declarations.get_var_statement(&ctx.ast);
             if let Some((var_statement, let_statement)) = var_stmt {
                 let stmts: Vec<Statement<'a>> =
                     var_statement.into_iter().chain(let_statement).collect();
@@ -88,8 +88,8 @@ impl<'a> Traverse<'a, TransformState<'a>> for Common<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         let is_program_body = matches!(ctx.parent(), Ancestor::ProgramBody(_));
-        ctx.state.var_declarations.insert_into_statements(stmts, is_program_body, ctx.ast);
-        ctx.state.statement_injector.insert_into_statements(stmts, ctx.ast);
+        ctx.state.var_declarations.insert_into_statements(stmts, is_program_body, &ctx.ast);
+        ctx.state.statement_injector.insert_into_statements(stmts, &ctx.ast);
     }
 
     fn enter_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -32,6 +32,7 @@
 
 use indexmap::{IndexMap, map::Entry as IndexMapEntry};
 
+use oxc_allocator::ArenaVec;
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::ReferenceFlags;
 use oxc_span::SPAN;
@@ -140,29 +141,36 @@ impl<'a> ModuleImportsStore<'a> {
         names: Vec<Import<'a>>,
         ctx: &TraverseCtx<'a>,
     ) -> Statement<'a> {
-        let specifiers = ctx.ast.vec_from_iter(names.into_iter().map(|import| match import {
-            Import::Named(import) => {
-                ImportDeclarationSpecifier::ImportSpecifier(ctx.ast.alloc_import_specifier(
-                    SPAN,
-                    ModuleExportName::IdentifierName(
-                        ctx.ast.identifier_name(SPAN, import.imported),
-                    ),
-                    import.local.create_binding_identifier(ctx),
-                    ImportOrExportKind::Value,
-                ))
-            }
-            Import::Default(local) => ImportDeclarationSpecifier::ImportDefaultSpecifier(
-                ctx.ast.alloc_import_default_specifier(SPAN, local.create_binding_identifier(ctx)),
-            ),
-        }));
+        let specifiers = ArenaVec::from_iter_in(
+            names.into_iter().map(|import| match import {
+                Import::Named(import) => {
+                    ImportDeclarationSpecifier::ImportSpecifier(ImportSpecifier::boxed(
+                        SPAN,
+                        ModuleExportName::IdentifierName(IdentifierName::new(
+                            SPAN,
+                            import.imported,
+                            ctx,
+                        )),
+                        import.local.create_binding_identifier(ctx),
+                        ImportOrExportKind::Value,
+                        ctx,
+                    ))
+                }
+                Import::Default(local) => ImportDeclarationSpecifier::ImportDefaultSpecifier(
+                    ImportDefaultSpecifier::boxed(SPAN, local.create_binding_identifier(ctx), ctx),
+                ),
+            }),
+            ctx,
+        );
 
-        Statement::from(ctx.ast.module_declaration_import_declaration(
+        Statement::from(ModuleDeclaration::new_import_declaration(
             SPAN,
             Some(specifiers),
-            ctx.ast.string_literal(SPAN, source, None),
+            StringLiteral::new(SPAN, source, None, ctx),
             None,
             NONE,
             ImportOrExportKind::Value,
+            ctx,
         ))
     }
 
@@ -180,17 +188,17 @@ impl<'a> ModuleImportsStore<'a> {
         );
 
         let args = {
-            let arg = Argument::from(ctx.ast.expression_string_literal(SPAN, source, None));
-            ctx.ast.vec1(arg)
+            let arg = Argument::from(Expression::new_string_literal(SPAN, source, None, ctx));
+            ArenaVec::from_value_in(arg, ctx)
         };
         let Some(Import::Default(local)) = names.into_iter().next() else { unreachable!() };
         let id = local.create_binding_pattern(ctx);
         let var_kind = VariableDeclarationKind::Var;
         let decl = {
-            let init = ctx.ast.expression_call(SPAN, callee, NONE, args, false);
-            let decl = ctx.ast.variable_declarator(SPAN, var_kind, id, NONE, Some(init), false);
-            ctx.ast.vec1(decl)
+            let init = Expression::new_call_expression(SPAN, callee, NONE, args, false, ctx);
+            let decl = VariableDeclarator::new(SPAN, var_kind, id, NONE, Some(init), false, ctx);
+            ArenaVec::from_value_in(decl, ctx)
         };
-        Statement::from(ctx.ast.declaration_variable(SPAN, var_kind, decl, false))
+        Statement::from(Declaration::new_variable_declaration(SPAN, var_kind, decl, false, ctx))
     }
 }

--- a/crates/oxc_transformer/src/common/statement_injector.rs
+++ b/crates/oxc_transformer/src/common/statement_injector.rs
@@ -18,7 +18,7 @@ use std::collections::hash_map::Entry;
 use rustc_hash::FxHashMap;
 
 use oxc_allocator::{Address, ArenaVec, GetAddress};
-use oxc_ast::{AstBuilder, ast::*};
+use oxc_ast::{ast::*, builder::AstBuilder};
 
 /// Store for statements to be added to the statements.
 pub struct StatementInjectorStore<'a> {
@@ -155,7 +155,7 @@ impl<'a> StatementInjectorStore<'a> {
     pub(crate) fn insert_into_statements(
         &mut self,
         statements: &mut ArenaVec<'a, Statement<'a>>,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) {
         if self.insertions.is_empty() {
             return;
@@ -169,7 +169,8 @@ impl<'a> StatementInjectorStore<'a> {
             return;
         }
 
-        let mut new_statements = ast.vec_with_capacity(statements.len() + new_statement_count);
+        let mut new_statements =
+            ArenaVec::with_capacity_in(statements.len() + new_statement_count, ast);
 
         for stmt in statements.drain(..) {
             match self.insertions.remove(&stmt.address()) {

--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -10,12 +10,12 @@
 //! Other transforms can add declarators to the store by calling methods of `VarDeclarationsStore`:
 //!
 //! ```rs
-//! ctx.state.var_declarations.insert_var(name, binding, None, ctx.ast);
-//! ctx.state.var_declarations.insert_let(name2, binding2, None, ctx.ast);
+//! ctx.state.var_declarations.insert_var(name, binding, None, &ctx.ast);
+//! ctx.state.var_declarations.insert_let(name2, binding2, None, &ctx.ast);
 //! ```
 
 use oxc_allocator::ArenaVec;
-use oxc_ast::{AstBuilder, NONE, ast::*};
+use oxc_ast::{NONE, ast::*, builder::AstBuilder};
 use oxc_data_structures::stack::SparseStack;
 use oxc_span::SPAN;
 use oxc_traverse::{BoundIdentifier, ast_operations::GatherNodeParts};
@@ -34,8 +34,8 @@ struct Declarators<'a> {
 }
 
 impl<'a> Declarators<'a> {
-    fn new(ast: AstBuilder<'a>) -> Self {
-        Self { var_declarators: ast.vec(), let_declarators: ast.vec() }
+    fn new(ast: &AstBuilder<'a>) -> Self {
+        Self { var_declarators: ArenaVec::new_in(ast), let_declarators: ArenaVec::new_in(ast) }
     }
 }
 
@@ -49,11 +49,12 @@ impl<'a> VarDeclarationsStore<'a> {
     /// Add a `var` declaration to be inserted at top of current enclosing statement block,
     /// given a `BoundIdentifier`.
     #[inline]
-    pub fn insert_var(&mut self, binding: &BoundIdentifier<'a>, ast: AstBuilder<'a>) {
-        let pattern = ast.binding_pattern_binding_identifier_with_symbol_id(
+    pub fn insert_var(&mut self, binding: &BoundIdentifier<'a>, ast: &AstBuilder<'a>) {
+        let pattern = BindingPattern::new_binding_identifier_with_symbol_id(
             SPAN,
             binding.name,
             binding.symbol_id,
+            ast,
         );
         self.insert_var_binding_pattern(pattern, None, ast);
     }
@@ -65,12 +66,13 @@ impl<'a> VarDeclarationsStore<'a> {
         &mut self,
         binding: &BoundIdentifier<'a>,
         init: Expression<'a>,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) {
-        let pattern = ast.binding_pattern_binding_identifier_with_symbol_id(
+        let pattern = BindingPattern::new_binding_identifier_with_symbol_id(
             SPAN,
             binding.name,
             binding.symbol_id,
+            ast,
         );
         self.insert_var_binding_pattern(pattern, Some(init), ast);
     }
@@ -83,7 +85,7 @@ impl<'a> VarDeclarationsStore<'a> {
     #[inline]
     pub fn create_uid_var(name: &str, ctx: &mut TraverseCtx<'a>) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_current_hoist_scope(name);
-        ctx.state.var_declarations.insert_var(&binding, ctx.ast);
+        ctx.state.var_declarations.insert_var(&binding, &ctx.ast);
         binding
     }
 
@@ -100,7 +102,7 @@ impl<'a> VarDeclarationsStore<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_current_hoist_scope(name);
-        ctx.state.var_declarations.insert_var_with_init(&binding, expression, ctx.ast);
+        ctx.state.var_declarations.insert_var_with_init(&binding, expression, &ctx.ast);
         binding
     }
 
@@ -115,7 +117,7 @@ impl<'a> VarDeclarationsStore<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
         let binding = ctx.generate_uid_in_current_hoist_scope_based_on_node(node);
-        ctx.state.var_declarations.insert_var(&binding, ctx.ast);
+        ctx.state.var_declarations.insert_var(&binding, &ctx.ast);
         binding
     }
 
@@ -125,12 +127,13 @@ impl<'a> VarDeclarationsStore<'a> {
         &mut self,
         binding: &BoundIdentifier<'a>,
         init: Option<Expression<'a>>,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) {
-        let pattern = ast.binding_pattern_binding_identifier_with_symbol_id(
+        let pattern = BindingPattern::new_binding_identifier_with_symbol_id(
             SPAN,
             binding.name,
             binding.symbol_id,
+            ast,
         );
         self.insert_let_binding_pattern(pattern, init, ast);
     }
@@ -141,10 +144,17 @@ impl<'a> VarDeclarationsStore<'a> {
         &mut self,
         ident: BindingPattern<'a>,
         init: Option<Expression<'a>>,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) {
-        let declarator =
-            ast.variable_declarator(SPAN, VariableDeclarationKind::Var, ident, NONE, init, false);
+        let declarator = VariableDeclarator::new(
+            SPAN,
+            VariableDeclarationKind::Var,
+            ident,
+            NONE,
+            init,
+            false,
+            ast,
+        );
         self.insert_var_declarator(declarator, ast);
     }
 
@@ -154,10 +164,17 @@ impl<'a> VarDeclarationsStore<'a> {
         &mut self,
         ident: BindingPattern<'a>,
         init: Option<Expression<'a>>,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) {
-        let declarator =
-            ast.variable_declarator(SPAN, VariableDeclarationKind::Let, ident, NONE, init, false);
+        let declarator = VariableDeclarator::new(
+            SPAN,
+            VariableDeclarationKind::Let,
+            ident,
+            NONE,
+            init,
+            false,
+            ast,
+        );
         self.insert_let_declarator(declarator, ast);
     }
 
@@ -165,7 +182,7 @@ impl<'a> VarDeclarationsStore<'a> {
     pub fn insert_var_declarator(
         &mut self,
         declarator: VariableDeclarator<'a>,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) {
         let declarators = self.stack.last_mut_or_init(|| Declarators::new(ast));
         declarators.var_declarators.push(declarator);
@@ -175,7 +192,7 @@ impl<'a> VarDeclarationsStore<'a> {
     pub fn insert_let_declarator(
         &mut self,
         declarator: VariableDeclarator<'a>,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) {
         let declarators = self.stack.last_mut_or_init(|| Declarators::new(ast));
         declarators.let_declarators.push(declarator);
@@ -192,7 +209,7 @@ impl<'a> VarDeclarationsStore<'a> {
         &mut self,
         stmts: &mut ArenaVec<'a, Statement<'a>>,
         is_program_body: bool,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) {
         if is_program_body {
             // Handle in `insert_into_program` instead
@@ -200,7 +217,7 @@ impl<'a> VarDeclarationsStore<'a> {
         }
 
         if let Some((var_statement, let_statement)) = self.get_var_statement(ast) {
-            let mut new_stmts = ast.vec_with_capacity(stmts.len() + 2);
+            let mut new_stmts = ArenaVec::with_capacity_in(stmts.len() + 2, ast);
             match (var_statement, let_statement) {
                 (Some(var_statement), Some(let_statement)) => {
                     // Insert `var` and `let` statements
@@ -220,7 +237,7 @@ impl<'a> VarDeclarationsStore<'a> {
     /// Pop the var/let declarations from the stack and return as statements.
     pub(crate) fn get_var_statement(
         &mut self,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) -> Option<(Option<Statement<'a>>, Option<Statement<'a>>)> {
         let Declarators { var_declarators, let_declarators } = self.stack.pop()?;
 
@@ -244,13 +261,8 @@ impl<'a> VarDeclarationsStore<'a> {
     fn create_declaration(
         kind: VariableDeclarationKind,
         declarators: ArenaVec<'a, VariableDeclarator<'a>>,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) -> Statement<'a> {
-        Statement::VariableDeclaration(ast.alloc_variable_declaration(
-            SPAN,
-            kind,
-            declarators,
-            false,
-        ))
+        Statement::new_variable_declaration(SPAN, kind, declarators, false, ast)
     }
 }

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -77,7 +77,7 @@
 ///
 /// ## References
 /// * TypeScript's [emitDecoratorMetadata](https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata)
-use oxc_allocator::ArenaBox;
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::ast::*;
 use oxc_data_structures::stack::SparseStack;
 use oxc_semantic::{Reference, ReferenceFlags, SymbolId};
@@ -361,12 +361,12 @@ impl<'a> LegacyDecoratorMetadata<'a> {
             TSType::TSVoidKeyword(_)
             | TSType::TSUndefinedKeyword(_)
             | TSType::TSNullKeyword(_)
-            | TSType::TSNeverKeyword(_) => ctx.ast.void_0(SPAN),
+            | TSType::TSNeverKeyword(_) => Expression::new_void_0(SPAN, ctx),
             TSType::TSFunctionType(_) | TSType::TSConstructorType(_) => Self::global_function(ctx),
             TSType::TSArrayType(_) | TSType::TSTupleType(_) => Self::global_array(ctx),
             TSType::TSTypePredicate(t) => {
                 if t.asserts {
-                    ctx.ast.void_0(SPAN)
+                    Expression::new_void_0(SPAN, ctx)
                 } else {
                     Self::global_boolean(ctx)
                 }
@@ -428,8 +428,10 @@ impl<'a> LegacyDecoratorMetadata<'a> {
         params: &FormalParameters<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let mut elements =
-            ctx.ast.vec_with_capacity(params.items.len() + usize::from(params.rest.is_some()));
+        let mut elements = ArenaVec::with_capacity_in(
+            params.items.len() + usize::from(params.rest.is_some()),
+            ctx,
+        );
         elements.extend(params.items.iter().map(|param| {
             ArrayExpressionElement::from(self.serialize_parameter_types_of_node(param, ctx))
         }));
@@ -439,7 +441,7 @@ impl<'a> LegacyDecoratorMetadata<'a> {
                 self.serialize_type_annotation(rest.type_annotation.as_ref(), ctx),
             ));
         }
-        ctx.ast.expression_array(SPAN, elements)
+        Expression::new_array_expression(SPAN, elements, ctx)
     }
 
     fn serialize_parameter_types_of_node(
@@ -462,7 +464,7 @@ impl<'a> LegacyDecoratorMetadata<'a> {
         } else if let Some(return_type) = &func.return_type {
             self.serialize_type_node(&return_type.type_annotation, ctx)
         } else {
-            ctx.ast.void_0(SPAN)
+            Expression::new_void_0(SPAN, ctx)
         }
     }
 
@@ -562,11 +564,11 @@ impl<'a> LegacyDecoratorMetadata<'a> {
         for i in 1..=properties.len() {
             let prefix = Self::build_path(&binding, ref_flags, &properties[..i], ctx);
             let next = Self::typeof_undefined(prefix, ctx);
-            test = ctx.ast.expression_logical(SPAN, test, LogicalOperator::Or, next);
+            test = Expression::new_logical_expression(SPAN, test, LogicalOperator::Or, next, ctx);
         }
 
         let alternate = Self::build_path(&binding, ref_flags, properties, ctx);
-        ctx.ast.expression_conditional(SPAN, test, Self::global_object(ctx), alternate)
+        Expression::new_conditional_expression(SPAN, test, Self::global_object(ctx), alternate, ctx)
     }
 
     fn build_path(
@@ -583,9 +585,15 @@ impl<'a> LegacyDecoratorMetadata<'a> {
     }
 
     fn typeof_undefined(expr: Expression<'a>, ctx: &TraverseCtx<'a>) -> Expression<'a> {
-        let typeof_expr = ctx.ast.expression_unary(SPAN, UnaryOperator::Typeof, expr);
-        let undefined_str = ctx.ast.expression_string_literal(SPAN, "undefined", None);
-        ctx.ast.expression_binary(SPAN, typeof_expr, BinaryOperator::StrictEquality, undefined_str)
+        let typeof_expr = Expression::new_unary_expression(SPAN, UnaryOperator::Typeof, expr, ctx);
+        let undefined_str = Expression::new_string_literal(SPAN, "undefined", None, ctx);
+        Expression::new_binary_expression(
+            SPAN,
+            typeof_expr,
+            BinaryOperator::StrictEquality,
+            undefined_str,
+            ctx,
+        )
     }
 
     fn serialize_literal_of_literal_type_node(
@@ -623,7 +631,7 @@ impl<'a> LegacyDecoratorMetadata<'a> {
                 TSType::TSNeverKeyword(_) => {
                     if is_intersection {
                         // Reduce to `never` in an intersection
-                        return ctx.ast.void_0(SPAN);
+                        return Expression::new_void_0(SPAN, ctx);
                     }
                     // Elide `never` in a union
                     continue;
@@ -675,7 +683,7 @@ impl<'a> LegacyDecoratorMetadata<'a> {
         // If we were able to find common type, use it
         serialized_type.unwrap_or_else(|| {
             // Fallback is only hit if all union constituents are null/undefined/never
-            ctx.ast.void_0(SPAN)
+            Expression::new_void_0(SPAN, ctx)
         })
     }
 
@@ -766,10 +774,13 @@ impl<'a> LegacyDecoratorMetadata<'a> {
         value: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let arguments = ctx.ast.vec_from_array([
-            Argument::from(ctx.ast.expression_string_literal(SPAN, key, None)),
-            Argument::from(value),
-        ]);
+        let arguments = ArenaVec::from_array_in(
+            [
+                Argument::from(Expression::new_string_literal(SPAN, key, None, ctx)),
+                Argument::from(value),
+            ],
+            ctx,
+        );
         helper_call_expr(Helper::DecorateMetadata, arguments, ctx)
     }
 
@@ -780,7 +791,7 @@ impl<'a> LegacyDecoratorMetadata<'a> {
         value: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Decorator<'a> {
-        ctx.ast.decorator(SPAN, self.create_metadata(key, value, ctx))
+        Decorator::new(SPAN, self.create_metadata(key, value, ctx), ctx)
     }
 
     /// `_metadata("design:type", type)`

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -238,7 +238,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for LegacyDecorator<'a> {
 
         if let Some(decorations) = self.get_all_decorators_of_class_method(method, ctx) {
             // We emit `null` here to indicate to `_decorate` that it can invoke `Object.getOwnPropertyDescriptor` directly.
-            let descriptor = ctx.ast.expression_null_literal(SPAN);
+            let descriptor = Expression::new_null_literal(SPAN, ctx);
             self.handle_decorated_class_element(
                 method.r#static,
                 &mut method.key,
@@ -263,7 +263,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for LegacyDecorator<'a> {
             Self::convert_decorators_to_array_expression(prop.decorators.drain(..), ctx);
 
         // We emit `void 0` here to indicate to `_decorate` that it can invoke `Object.defineProperty` directly.
-        let descriptor = ctx.ast.void_0(SPAN);
+        let descriptor = Expression::new_void_0(SPAN, ctx);
         self.handle_decorated_class_element(
             prop.r#static,
             &mut prop.key,
@@ -286,7 +286,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for LegacyDecorator<'a> {
         let decorations =
             Self::convert_decorators_to_array_expression(accessor.decorators.drain(..), ctx);
         // We emit `null` here to indicate to `_decorate` that it can invoke `Object.getOwnPropertyDescriptor` directly.
-        let descriptor = ctx.ast.expression_null_literal(SPAN);
+        let descriptor = Expression::new_null_literal(SPAN, ctx);
         self.handle_decorated_class_element(
             accessor.r#static,
             &mut accessor.key,
@@ -343,7 +343,7 @@ impl<'a> LegacyDecorator<'a> {
         };
 
         let class_scope_id = class.scope_id();
-        let mut new_body = ctx.ast.vec_with_capacity(class.body.body.len() * 3);
+        let mut new_body = ArenaVec::with_capacity_in(class.body.body.len() * 3, ctx);
 
         for element in class.body.body.drain(..) {
             let ClassElement::AccessorProperty(accessor) = element else {
@@ -360,7 +360,7 @@ impl<'a> LegacyDecorator<'a> {
             let computed = accessor.computed;
 
             // Transfer decorators to the getter so legacy decorator transform can process them.
-            let decorators = std::mem::replace(&mut accessor.decorators, ctx.ast.vec());
+            let decorators = std::mem::replace(&mut accessor.decorators, ArenaVec::new_in(ctx));
             // Transfer the type annotation to the getter's return type so that
             // `emitDecoratorMetadata` can derive `design:type` from it. Without this,
             // the lowered getter is untyped and `design:type` falls through to `Object`.
@@ -385,7 +385,7 @@ impl<'a> LegacyDecorator<'a> {
                 let getter_key = PropertyKey::from(assignment);
                 let setter_key = PropertyKey::from(reference);
                 let storage_name =
-                    ctx.ast.str_from_strs_array(["_", &key_name, "_computed_accessor_storage"]);
+                    Str::from_strs_array_in(["_", &key_name, "_computed_accessor_storage"], ctx);
                 (storage_name, getter_key, setter_key)
             } else {
                 // Use `name()` to get the raw property name, avoiding `get_var_name_from_node`
@@ -395,7 +395,7 @@ impl<'a> LegacyDecorator<'a> {
                     .name()
                     .unwrap_or_else(|| Cow::Owned(get_var_name_from_node(&accessor.key)));
                 let storage_name =
-                    ctx.ast.str_from_strs_array(["_", &key_name, "_accessor_storage"]);
+                    Str::from_strs_array_in(["_", &key_name, "_accessor_storage"], ctx);
                 let getter_key = accessor.key.clone_in(ctx.ast.allocator);
                 let setter_key = accessor.key.clone_in(ctx.ast.allocator);
                 (storage_name, getter_key, setter_key)
@@ -405,11 +405,11 @@ impl<'a> LegacyDecorator<'a> {
             let object_binding = if is_static { static_class_binding.as_ref() } else { None };
 
             // 1. Private backing field: `#<name>_accessor_storage = <value>`
-            new_body.push(ctx.ast.class_element_property_definition(
+            new_body.push(ClassElement::new_property_definition(
                 SPAN,
                 PropertyDefinitionType::PropertyDefinition,
-                ctx.ast.vec(),
-                ctx.ast.property_key_private_identifier(SPAN, storage_name),
+                ArenaVec::new_in(ctx),
+                PropertyKey::new_private_identifier(SPAN, storage_name, ctx),
                 NONE,
                 accessor.value.take(),
                 false,
@@ -420,6 +420,7 @@ impl<'a> LegacyDecorator<'a> {
                 false,
                 false,
                 None,
+                ctx,
             ));
 
             // 2. Getter: `get <name>() { return <object>.#<name>_accessor_storage; }`
@@ -438,7 +439,7 @@ impl<'a> LegacyDecorator<'a> {
 
             // 3. Setter: `set <name>(value) { <object>.#<name>_accessor_storage = value; }`
             new_body.push(Self::create_accessor_method(
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 setter_key,
                 MethodDefinitionKind::Set,
                 computed,
@@ -489,24 +490,26 @@ impl<'a> LegacyDecorator<'a> {
             if let Some(binding) = object_binding {
                 binding.create_read_expression(ctx)
             } else {
-                ctx.ast.expression_this(SPAN)
+                Expression::new_this_expression(SPAN, ctx)
             }
         };
 
         let (params, body_stmt) = if is_getter {
-            let params = ctx.ast.alloc_formal_parameters(
+            let params = FormalParameters::boxed(
                 SPAN,
                 FormalParameterKind::FormalParameter,
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 NONE,
+                ctx,
             );
-            let field_expr = Expression::from(ctx.ast.member_expression_private_field_expression(
+            let field_expr = Expression::from(MemberExpression::new_private_field_expression(
                 SPAN,
                 create_object(ctx),
-                ctx.ast.private_identifier(SPAN, storage_name),
+                PrivateIdentifier::new(SPAN, storage_name, ctx),
                 false,
+                ctx,
             ));
-            let stmt = ctx.ast.statement_return(SPAN, Some(field_expr));
+            let stmt = Statement::new_return_statement(SPAN, Some(field_expr), ctx);
             (params, stmt)
         } else {
             let value_binding = ctx.generate_binding(
@@ -514,9 +517,9 @@ impl<'a> LegacyDecorator<'a> {
                 scope_id,
                 SymbolFlags::FunctionScopedVariable,
             );
-            let param = ctx.ast.formal_parameter(
+            let param = FormalParameter::new(
                 SPAN,
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 value_binding.create_binding_pattern(ctx),
                 NONE,
                 NONE,
@@ -524,27 +527,31 @@ impl<'a> LegacyDecorator<'a> {
                 None,
                 false,
                 false,
+                ctx,
             );
-            let params = ctx.ast.alloc_formal_parameters(
+            let params = FormalParameters::boxed(
                 SPAN,
                 FormalParameterKind::FormalParameter,
-                ctx.ast.vec1(param),
+                ArenaVec::from_value_in(param, ctx),
                 NONE,
+                ctx,
             );
-            let assign = ctx.ast.expression_assignment(
+            let assign = Expression::new_assignment_expression(
                 SPAN,
                 AssignmentOperator::Assign,
                 AssignmentTarget::from(SimpleAssignmentTarget::from(
-                    ctx.ast.member_expression_private_field_expression(
+                    MemberExpression::new_private_field_expression(
                         SPAN,
                         create_object(ctx),
-                        ctx.ast.private_identifier(SPAN, storage_name),
+                        PrivateIdentifier::new(SPAN, storage_name, ctx),
                         false,
+                        ctx,
                     ),
                 )),
                 value_binding.create_read_expression(ctx),
+                ctx,
             );
-            let stmt = ctx.ast.statement_expression(SPAN, assign);
+            let stmt = Statement::new_expression_statement(SPAN, assign, ctx);
             (params, stmt)
         };
 
@@ -554,7 +561,7 @@ impl<'a> LegacyDecorator<'a> {
             kind,
             params,
             return_type,
-            ctx.ast.vec1(body_stmt),
+            ArenaVec::from_value_in(body_stmt, ctx),
             computed,
             is_static,
             scope_id,
@@ -928,19 +935,20 @@ impl<'a> LegacyDecorator<'a> {
 
                 if has_static_field_or_block {
                     // `_Class = this`;
-                    let class_alias_with_this_assignment = ctx.ast.statement_expression(
+                    let class_alias_with_this_assignment = Statement::new_expression_statement(
                         SPAN,
                         create_assignment(
                             class_alias_binding,
-                            ctx.ast.expression_this(SPAN),
+                            Expression::new_this_expression(SPAN, ctx),
                             SPAN,
                             ctx,
                         ),
+                        ctx,
                     );
-                    let body = ctx.ast.vec1(class_alias_with_this_assignment);
+                    let body = ArenaVec::from_value_in(class_alias_with_this_assignment, ctx);
                     let scope_id = ctx.create_child_scope_of_current(ScopeFlags::ClassStaticBlock);
                     let element =
-                        ctx.ast.class_element_static_block_with_scope_id(SPAN, body, scope_id);
+                        ClassElement::new_static_block_with_scope_id(SPAN, body, scope_id, ctx);
                     Some(element)
                 } else {
                     None
@@ -1000,19 +1008,21 @@ impl<'a> LegacyDecorator<'a> {
             alias_binding,
             ctx,
         );
-        let declarator = ctx.ast.variable_declarator(
+        let declarator = VariableDeclarator::new(
             SPAN,
             VariableDeclarationKind::Let,
             binding.create_binding_pattern(ctx),
             NONE,
             Some(initializer),
             false,
+            ctx,
         );
-        let var_declaration = ctx.ast.declaration_variable(
+        let var_declaration = Declaration::new_variable_declaration(
             span,
             VariableDeclarationKind::Let,
-            ctx.ast.vec1(declarator),
+            ArenaVec::from_value_in(declarator, ctx),
             false,
+            ctx,
         );
         Statement::from(var_declaration)
     }
@@ -1105,16 +1115,19 @@ impl<'a> LegacyDecorator<'a> {
         };
 
         // `Class = _decorate(decorations, Class)`
-        let arguments = ctx.ast.vec_from_array([
-            Argument::from(decorations),
-            Argument::from(class_binding.create_read_expression(ctx)),
-        ]);
+        let arguments = ArenaVec::from_array_in(
+            [
+                Argument::from(decorations),
+                Argument::from(class_binding.create_read_expression(ctx)),
+            ],
+            ctx,
+        );
         let helper = helper_call_expr(Helper::Decorate, arguments, ctx);
         let operator = AssignmentOperator::Assign;
         let left = class_binding.create_write_target(ctx);
         let right = Self::get_class_initializer(helper, class_alias_binding, ctx);
-        let assignment = ctx.ast.expression_assignment(SPAN, operator, left, right);
-        ctx.ast.statement_expression(SPAN, assignment)
+        let assignment = Expression::new_assignment_expression(SPAN, operator, left, right, ctx);
+        Statement::new_expression_statement(SPAN, assignment, ctx)
     }
 
     /// Insert all decorations into a static block of a class because there is a
@@ -1147,8 +1160,9 @@ impl<'a> LegacyDecorator<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         let scope_id = ctx.create_child_scope(class.scope_id(), ScopeFlags::ClassStaticBlock);
-        let decorations = ctx.ast.vec_from_iter(decorations);
-        let element = ctx.ast.class_element_static_block_with_scope_id(SPAN, decorations, scope_id);
+        let decorations = ArenaVec::from_iter_in(decorations, ctx);
+        let element =
+            ClassElement::new_static_block_with_scope_id(SPAN, decorations, scope_id, ctx);
         class.body.body.push(element);
     }
 
@@ -1166,15 +1180,17 @@ impl<'a> LegacyDecorator<'a> {
             }
             decorations.extend(param.decorators.drain(..).map(|decorator| {
                 // (index, decorator)
-                let index = ctx.ast.expression_numeric_literal(
+                let index = Expression::new_numeric_literal(
                     SPAN,
                     index as f64,
                     None,
                     NumberBase::Decimal,
+                    ctx,
                 );
-                let arguments = ctx
-                    .ast
-                    .vec_from_array([Argument::from(index), Argument::from(decorator.expression)]);
+                let arguments = ArenaVec::from_array_in(
+                    [Argument::from(index), Argument::from(decorator.expression)],
+                    ctx,
+                );
                 // _decorateParam(index, decorator)
                 ArrayExpressionElement::from(helper_call_expr(
                     Helper::DecorateParam,
@@ -1198,10 +1214,11 @@ impl<'a> LegacyDecorator<'a> {
         decorators_iter: impl Iterator<Item = Decorator<'a>>,
         ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let decorations = ctx.ast.vec_from_iter(
+        let decorations = ArenaVec::from_iter_in(
             decorators_iter.map(|decorator| ArrayExpressionElement::from(decorator.expression)),
+            ctx,
         );
-        ctx.ast.expression_array(SPAN, decorations)
+        Expression::new_array_expression(SPAN, decorations, ctx)
     }
 
     /// Get all decorators of a class method.
@@ -1247,7 +1264,7 @@ impl<'a> LegacyDecorator<'a> {
             return None;
         }
 
-        let mut decorations = ctx.ast.vec_with_capacity(method_decoration_count);
+        let mut decorations = ArenaVec::with_capacity_in(method_decoration_count, ctx);
 
         // Method decorators should always be injected before all other decorators
         decorations.extend(
@@ -1278,7 +1295,7 @@ impl<'a> LegacyDecorator<'a> {
             }
         }
 
-        Some(ctx.ast.expression_array(SPAN, decorations))
+        Some(Expression::new_array_expression(SPAN, decorations, ctx))
     }
 
     /// * class_alias_binding is `Some`: `Class = _Class = expr`
@@ -1290,7 +1307,7 @@ impl<'a> LegacyDecorator<'a> {
     ) -> Expression<'a> {
         if let Some(class_alias_binding) = class_alias_binding {
             let left = class_alias_binding.create_write_target(ctx);
-            ctx.ast.expression_assignment(SPAN, AssignmentOperator::Assign, left, expr)
+            Expression::new_assignment_expression(SPAN, AssignmentOperator::Assign, left, expr, ctx)
         } else {
             expr
         }
@@ -1346,10 +1363,12 @@ impl<'a> LegacyDecorator<'a> {
     ) -> Expression<'a> {
         match key {
             PropertyKey::StaticIdentifier(ident) => {
-                ctx.ast.expression_string_literal(SPAN, ident.name, None)
+                Expression::new_string_literal(SPAN, ident.name, None, ctx)
             }
             // Legacy decorators do not support private key
-            PropertyKey::PrivateIdentifier(_) => ctx.ast.expression_string_literal(SPAN, "", None),
+            PropertyKey::PrivateIdentifier(_) => {
+                Expression::new_string_literal(SPAN, "", None, ctx)
+            }
             // Copiable literals
             PropertyKey::NumericLiteral(literal) => {
                 Expression::NumericLiteral(literal.clone_in(ctx.ast.allocator))
@@ -1359,9 +1378,9 @@ impl<'a> LegacyDecorator<'a> {
             }
             PropertyKey::TemplateLiteral(literal) if literal.expressions.is_empty() => {
                 let quasis = literal.quasis.clone_in(ctx.ast.allocator);
-                ctx.ast.expression_template_literal(SPAN, quasis, ctx.ast.vec())
+                Expression::new_template_literal(SPAN, quasis, ArenaVec::new_in(ctx), ctx)
             }
-            PropertyKey::NullLiteral(_) => ctx.ast.expression_null_literal(SPAN),
+            PropertyKey::NullLiteral(_) => Expression::new_null_literal(SPAN, ctx),
             _ => {
                 // ```ts
                 // Input:
@@ -1381,7 +1400,8 @@ impl<'a> LegacyDecorator<'a> {
                 let operator = AssignmentOperator::Assign;
                 let left = binding.create_write_target(ctx);
                 let right = key.to_expression_mut().take_in(ctx);
-                let key_expr = ctx.ast.expression_assignment(SPAN, operator, left, right);
+                let key_expr =
+                    Expression::new_assignment_expression(SPAN, operator, left, right, ctx);
                 *key = PropertyKey::from(key_expr);
                 binding.create_read_expression(ctx)
             }
@@ -1398,14 +1418,17 @@ impl<'a> LegacyDecorator<'a> {
         descriptor: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
-        let arguments = ctx.ast.vec_from_array([
-            Argument::from(decorations),
-            Argument::from(prefix),
-            Argument::from(name),
-            Argument::from(descriptor),
-        ]);
+        let arguments = ArenaVec::from_array_in(
+            [
+                Argument::from(decorations),
+                Argument::from(prefix),
+                Argument::from(name),
+                Argument::from(descriptor),
+            ],
+            ctx,
+        );
         let helper = helper_call_expr(Helper::Decorate, arguments, ctx);
-        ctx.ast.statement_expression(SPAN, helper)
+        Statement::new_expression_statement(SPAN, helper, ctx)
     }
 
     /// `export default Class`
@@ -1413,11 +1436,13 @@ impl<'a> LegacyDecorator<'a> {
         class_binding: &BoundIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
-        let export_default_class_reference = ctx.ast.module_declaration_export_default_declaration(
+        let export_default_class_reference = ModuleDeclaration::new_export_default_declaration(
             SPAN,
-            ExportDefaultDeclarationKind::Identifier(
-                ctx.ast.alloc(class_binding.create_read_reference(ctx)),
-            ),
+            ExportDefaultDeclarationKind::Identifier(ArenaBox::new_in(
+                class_binding.create_read_reference(ctx),
+                ctx,
+            )),
+            ctx,
         );
         Statement::from(export_default_class_reference)
     }
@@ -1429,11 +1454,12 @@ impl<'a> LegacyDecorator<'a> {
     ) -> Statement<'a> {
         let kind = ImportOrExportKind::Value;
         let local = ModuleExportName::IdentifierReference(class_binding.create_read_reference(ctx));
-        let exported = ctx.ast.module_export_name_identifier_name(SPAN, class_binding.name);
-        let specifiers = ctx.ast.vec1(ctx.ast.export_specifier(SPAN, local, exported, kind));
-        let export_class_reference = ctx
-            .ast
-            .module_declaration_export_named_declaration(SPAN, None, specifiers, None, kind, NONE);
+        let exported = ModuleExportName::new_identifier_name(SPAN, class_binding.name, ctx);
+        let specifiers =
+            ArenaVec::from_value_in(ExportSpecifier::new(SPAN, local, exported, kind, ctx), ctx);
+        let export_class_reference = ModuleDeclaration::new_export_named_declaration(
+            SPAN, None, specifiers, None, kind, NONE, ctx,
+        );
         Statement::from(export_class_reference)
     }
 }

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -151,7 +151,7 @@ impl<'a> ExponentiationOperator<'a> {
         // Temporary var initializations
         ArenaVec<'a, Expression<'a>>,
     ) {
-        let mut temp_var_inits = ctx.ast.vec();
+        let mut temp_var_inits = ArenaVec::new_in(ctx);
 
         // Make sure side-effects of evaluating `left` only happen once
         let reference = ctx.scoping.scoping_mut().get_reference_mut(ident.reference_id());
@@ -232,7 +232,7 @@ impl<'a> ExponentiationOperator<'a> {
         // obj["prop"] = Math.pow(obj["prop"], right)
         //                        ^^^
         // ```
-        let mut temp_var_inits = ctx.ast.vec();
+        let mut temp_var_inits = ArenaVec::new_in(ctx);
         let obj = self.get_second_member_expression_object(
             &mut member_expr.object,
             &mut temp_var_inits,
@@ -246,14 +246,16 @@ impl<'a> ExponentiationOperator<'a> {
         // ```
         let prop_span = member_expr.property.span;
         let prop_name = member_expr.property.name;
-        let prop = ctx.ast.expression_string_literal(prop_span, prop_name, None);
+        let prop = Expression::new_string_literal(prop_span, prop_name, None, ctx);
 
         // Complete 2nd member expression
         // ```
         // obj["prop"] = Math.pow(obj["prop"], right)
         //                        ^^^^^^^^^^^
         // ```
-        let pow_left = Expression::from(ctx.ast.member_expression_computed(SPAN, obj, prop, false));
+        let pow_left = Expression::from(MemberExpression::new_computed_member_expression(
+            SPAN, obj, prop, false, ctx,
+        ));
 
         // Replacement for original member expression
         // ```
@@ -261,11 +263,12 @@ impl<'a> ExponentiationOperator<'a> {
         // ^^^^^^^^^^^
         // ```
         let replacement_left =
-            AssignmentTarget::ComputedMemberExpression(ctx.ast.alloc_computed_member_expression(
+            AssignmentTarget::ComputedMemberExpression(ComputedMemberExpression::boxed(
                 member_expr.span,
                 member_expr.object.take_in(ctx),
-                ctx.ast.expression_string_literal(prop_span, prop_name, None),
+                Expression::new_string_literal(prop_span, prop_name, None, ctx),
                 false,
+                ctx,
             ));
 
         (replacement_left, pow_left, temp_var_inits)
@@ -327,7 +330,7 @@ impl<'a> ExponentiationOperator<'a> {
         // obj[_prop] = Math.pow(obj[_prop], right)
         //                       ^^^
         // ```
-        let mut temp_var_inits = ctx.ast.vec();
+        let mut temp_var_inits = ArenaVec::new_in(ctx);
         let obj = self.get_second_member_expression_object(
             &mut member_expr.object,
             &mut temp_var_inits,
@@ -354,7 +357,9 @@ impl<'a> ExponentiationOperator<'a> {
         // obj[_prop] = Math.pow(obj[_prop], right)
         //                       ^^^^^^^^^^
         // ```
-        let pow_left = Expression::from(ctx.ast.member_expression_computed(SPAN, obj, prop, false));
+        let pow_left = Expression::from(MemberExpression::new_computed_member_expression(
+            SPAN, obj, prop, false, ctx,
+        ));
 
         (pow_left, temp_var_inits)
     }
@@ -410,7 +415,7 @@ impl<'a> ExponentiationOperator<'a> {
         // obj.#prop = Math.pow(obj.#prop, right)
         //                      ^^^
         // ```
-        let mut temp_var_inits = ctx.ast.vec();
+        let mut temp_var_inits = ArenaVec::new_in(ctx);
         let obj = self.get_second_member_expression_object(
             &mut field_expr.object,
             &mut temp_var_inits,
@@ -429,9 +434,9 @@ impl<'a> ExponentiationOperator<'a> {
         // obj.#prop = Math.pow(obj.#prop, right)
         //                      ^^^^^^^^^
         // ```
-        let pow_left = Expression::from(
-            ctx.ast.member_expression_private_field_expression(SPAN, obj, field, false),
-        );
+        let pow_left = Expression::from(MemberExpression::new_private_field_expression(
+            SPAN, obj, field, false, ctx,
+        ));
 
         (pow_left, temp_var_inits)
     }
@@ -484,7 +489,7 @@ impl<'a> ExponentiationOperator<'a> {
         // will not trigger getters or setters. `super` cannot be directly assigned, so use it directly too.
         // TODO(improve-on-babel): We could also skip creating a temp var for `this.x **= 2`.
         match obj {
-            Expression::Super(super_) => return ctx.ast.expression_super(super_.span),
+            Expression::Super(super_) => return Expression::new_super(super_.span, ctx),
             Expression::Identifier(ident) => {
                 let symbol_id = ctx.scoping().get_reference(ident.reference_id()).symbol_id();
                 if let Some(symbol_id) = symbol_id {
@@ -532,7 +537,7 @@ impl<'a> ExponentiationOperator<'a> {
         if !temp_var_inits.is_empty() {
             temp_var_inits.reserve_exact(1);
             temp_var_inits.push(expr.take_in(ctx));
-            *expr = ctx.ast.expression_sequence(span, temp_var_inits);
+            *expr = Expression::new_sequence_expression(span, temp_var_inits, ctx);
         }
     }
 
@@ -546,11 +551,12 @@ impl<'a> ExponentiationOperator<'a> {
         let math = static_ident!("Math");
         let math_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), math);
         let object = ctx.create_ident_expr(SPAN, math, math_symbol_id, ReferenceFlags::Read);
-        let property = ctx.ast.identifier_name(SPAN, "pow");
-        let callee =
-            Expression::from(ctx.ast.member_expression_static(span, object, property, false));
-        let arguments = ctx.ast.vec_from_array([Argument::from(left), Argument::from(right)]);
-        ctx.ast.expression_call(span, callee, NONE, arguments, false)
+        let property = IdentifierName::new(SPAN, "pow", ctx);
+        let callee = Expression::from(MemberExpression::new_static_member_expression(
+            span, object, property, false, ctx,
+        ));
+        let arguments = ArenaVec::from_array_in([Argument::from(left), Argument::from(right)], ctx);
+        Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
     }
 
     /// Create a temporary variable.
@@ -568,11 +574,12 @@ impl<'a> ExponentiationOperator<'a> {
         let binding = VarDeclarationsStore::create_uid_var_based_on_node(&expr, ctx);
 
         // Add new reference `_name = name` to `temp_var_inits`
-        temp_var_inits.push(ctx.ast.expression_assignment(
+        temp_var_inits.push(Expression::new_assignment_expression(
             SPAN,
             AssignmentOperator::Assign,
             binding.create_write_target(ctx),
             expr,
+            ctx,
         ));
 
         binding

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -53,7 +53,7 @@
 
 use std::{borrow::Cow, mem};
 
-use oxc_allocator::{ArenaBox, ArenaStringBuilder, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
@@ -180,7 +180,12 @@ impl<'a> AsyncToGenerator<'a> {
     ) -> Option<Expression<'a>> {
         // We don't need to handle top-level await.
         if Self::is_inside_async_function(ctx) {
-            Some(ctx.ast.expression_yield(expr.span, false, Some(expr.argument.take_in(ctx))))
+            Some(Expression::new_yield_expression(
+                expr.span,
+                false,
+                Some(expr.argument.take_in(ctx)),
+                ctx,
+            ))
         } else {
             None
         }
@@ -270,30 +275,36 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         let callee = self.create_async_to_generator_call(params, body, generator_scope_id, ctx);
         let (callee, arguments) = if needs_move_parameters_to_inner_function {
             // callee.apply(this, arguments)
-            let property = ctx.ast.identifier_name(SPAN, "apply");
-            let callee =
-                Expression::from(ctx.ast.member_expression_static(SPAN, callee, property, false));
+            let property = IdentifierName::new(SPAN, "apply", ctx);
+            let callee = Expression::from(MemberExpression::new_static_member_expression(
+                SPAN, callee, property, false, ctx,
+            ));
 
             // this, arguments
-            let this_argument = Argument::from(ctx.ast.expression_this(SPAN));
+            let this_argument = Argument::from(Expression::new_this_expression(SPAN, ctx));
             let arguments_argument = Argument::from(ctx.create_unbound_ident_expr(
                 SPAN,
                 static_ident!("arguments"),
                 ReferenceFlags::Read,
             ));
-            (callee, ctx.ast.vec_from_array([this_argument, arguments_argument]))
+            (callee, ArenaVec::from_array_in([this_argument, arguments_argument], ctx))
         } else {
             // callee()
-            (callee, ctx.ast.vec())
+            (callee, ArenaVec::new_in(ctx))
         };
 
-        let expression = ctx.ast.expression_call(SPAN, callee, NONE, arguments, false);
-        let statement = ctx.ast.statement_return(SPAN, Some(expression));
+        let expression = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
+        let statement = Statement::new_return_statement(SPAN, Some(expression), ctx);
 
         // Modify the wrapper function
         func.r#async = false;
         func.generator = false;
-        func.body = Some(ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), ctx.ast.vec1(statement)));
+        func.body = Some(FunctionBody::boxed(
+            SPAN,
+            ArenaVec::new_in(ctx),
+            ArenaVec::from_value_in(statement, ctx),
+            ctx,
+        ));
         func.scope_id.set(Some(wrapper_scope_id));
         sync_function_symbol_flags(func, ctx);
     }
@@ -347,8 +358,9 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         let caller_function = {
             let scope_id = ctx.create_child_scope(wrapper_scope_id, ScopeFlags::Function);
             let params = Self::create_placeholder_params(&params, scope_id, ctx);
-            let statements = ctx.ast.vec1(Self::create_apply_call_statement(&bound_ident, ctx));
-            let body = ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), statements);
+            let statements =
+                ArenaVec::from_value_in(Self::create_apply_call_statement(&bound_ident, ctx), ctx);
+            let body = FunctionBody::boxed(SPAN, ArenaVec::new_in(ctx), statements, ctx);
             let (r#type, id) = if id.is_some() {
                 // Caller is emitted as a function declaration inside the wrapper; its binding
                 // was already moved to `wrapper_scope_id` above.
@@ -385,29 +397,40 @@ impl<'a> AsyncGeneratorExecutor<'a> {
                     ReferenceFlags::Read,
                 );
                 let func_decl = Statement::FunctionDeclaration(caller_function);
-                let statement_return = ctx.ast.statement_return(SPAN, Some(reference));
-                ctx.ast.vec_from_array([async_to_gen_decl, func_decl, statement_return])
+                let statement_return = Statement::new_return_statement(SPAN, Some(reference), ctx);
+                ArenaVec::from_array_in([async_to_gen_decl, func_decl, statement_return], ctx)
             } else {
                 // If the function doesn't have an id, then we need to return the function itself.
                 // `function() { ... }` -> `return function() { ... };`
-                let statement_return = ctx
-                    .ast
-                    .statement_return(SPAN, Some(Expression::FunctionExpression(caller_function)));
-                ctx.ast.vec_from_array([async_to_gen_decl, statement_return])
+                let statement_return = Statement::new_return_statement(
+                    SPAN,
+                    Some(Expression::FunctionExpression(caller_function)),
+                    ctx,
+                );
+                ArenaVec::from_array_in([async_to_gen_decl, statement_return], ctx)
             };
             debug_assert!(wrapper_function.body.is_none());
             wrapper_function.r#async = false;
             wrapper_function.generator = false;
-            wrapper_function.body.replace(ctx.ast.alloc_function_body(
+            wrapper_function.body.replace(FunctionBody::boxed(
                 SPAN,
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 statements,
+                ctx,
             ));
         }
 
         // Construct the IIFE
         let callee = Expression::FunctionExpression(wrapper_function.take_in_box(ctx));
-        ctx.ast.expression_call_with_pure(span, callee, NONE, ctx.ast.vec(), false, true)
+        Expression::new_call_expression_with_pure(
+            span,
+            callee,
+            NONE,
+            ArenaVec::new_in(ctx),
+            false,
+            true,
+            ctx,
+        )
     }
 
     /// Transforms async function declarations into generator functions wrapped in the asyncToGenerator helper.
@@ -441,28 +464,33 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             wrapper_function.r#async = false;
             wrapper_function.generator = false;
             sync_function_symbol_flags(wrapper_function, ctx);
-            let statements = ctx.ast.vec1(Self::create_apply_call_statement(&bound_ident, ctx));
+            let statements =
+                ArenaVec::from_value_in(Self::create_apply_call_statement(&bound_ident, ctx), ctx);
             debug_assert!(wrapper_function.body.is_none());
-            wrapper_function.body.replace(ctx.ast.alloc_function_body(
+            wrapper_function.body.replace(FunctionBody::boxed(
                 SPAN,
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 statements,
+                ctx,
             ));
         }
 
         // function _name() { _ref.apply(this, arguments); }
         {
-            let statements = ctx.ast.vec_from_array([
-                self.create_async_to_generator_assignment(
-                    &bound_ident,
-                    params,
-                    body,
-                    generator_scope_id,
-                    ctx,
-                ),
-                Self::create_apply_call_statement(&bound_ident, ctx),
-            ]);
-            let body = ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), statements);
+            let statements = ArenaVec::from_array_in(
+                [
+                    self.create_async_to_generator_assignment(
+                        &bound_ident,
+                        params,
+                        body,
+                        generator_scope_id,
+                        ctx,
+                    ),
+                    Self::create_apply_call_statement(&bound_ident, ctx),
+                ],
+                ctx,
+            );
+            let body = FunctionBody::boxed(SPAN, ArenaVec::new_in(ctx), statements, ctx);
 
             let scope_id = ctx.create_child_scope(ctx.current_scope_id(), ScopeFlags::Function);
             // The generator function will move to this function, so we need
@@ -499,7 +527,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
                 Statement::ExpressionStatement(es) => es.expression.take_in(ctx),
                 _ => unreachable!(),
             };
-            *statement = ctx.ast.statement_return(expression.span(), Some(expression));
+            *statement = Statement::new_return_statement(expression.span(), Some(expression), ctx);
         }
 
         let params = arrow.params.take_in_box(ctx);
@@ -527,8 +555,9 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         let caller_function = {
             let scope_id = ctx.create_child_scope(wrapper_scope_id, ScopeFlags::Function);
             let params = Self::create_placeholder_params(&params, scope_id, ctx);
-            let statements = ctx.ast.vec1(Self::create_apply_call_statement(&bound_ident, ctx));
-            let body = ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), statements);
+            let statements =
+                ArenaVec::from_value_in(Self::create_apply_call_statement(&bound_ident, ctx), ctx);
+            let body = FunctionBody::boxed(SPAN, ArenaVec::new_in(ctx), statements, ctx);
             let id = function_name.map(|name| {
                 ctx.generate_binding(name, scope_id, SymbolFlags::Function)
                     .create_binding_identifier(ctx)
@@ -542,7 +571,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
                 ctx,
             );
             let argument = Some(Expression::FunctionExpression(function));
-            ctx.ast.statement_return(SPAN, argument)
+            Statement::new_return_statement(SPAN, argument, ctx)
         };
 
         // Wrapper function
@@ -554,8 +583,8 @@ impl<'a> AsyncGeneratorExecutor<'a> {
                 generator_function_id,
                 ctx,
             );
-            let statements = ctx.ast.vec_from_array([statement, caller_function]);
-            let body = ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), statements);
+            let statements = ArenaVec::from_array_in([statement, caller_function], ctx);
+            let body = FunctionBody::boxed(SPAN, ArenaVec::new_in(ctx), statements, ctx);
             let params = Self::create_empty_params(ctx);
             let wrapper_function = Self::create_function(
                 FunctionType::FunctionExpression,
@@ -567,7 +596,14 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             );
             // Construct the IIFE
             let callee = Expression::FunctionExpression(wrapper_function);
-            ctx.ast.expression_call(arrow_span, callee, NONE, ctx.ast.vec(), false)
+            Expression::new_call_expression(
+                arrow_span,
+                callee,
+                NONE,
+                ArenaVec::new_in(ctx),
+                false,
+                ctx,
+            )
         }
     }
 
@@ -612,7 +648,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
     fn normalize_function_name(input: &Cow<'a, str>, ctx: &TraverseCtx<'a>) -> Ident<'a> {
         let input_str = input.as_ref();
         if !is_reserved_keyword(input_str) && is_identifier_name(input_str) {
-            return ctx.ast.ident_from_cow(input);
+            return Ident::from_cow_in(input, ctx);
         }
 
         let mut name = ArenaStringBuilder::with_capacity_in(input_str.len() + 1, ctx.ast.allocator);
@@ -659,7 +695,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         scope_id: ScopeId,
         ctx: &mut TraverseCtx<'a>,
     ) -> ArenaBox<'a, Function<'a>> {
-        let function = ctx.ast.alloc_function_with_scope_id(
+        let function = Function::boxed_with_scope_id(
             SPAN,
             r#type,
             id,
@@ -672,6 +708,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             NONE,
             Some(body),
             scope_id,
+            ctx,
         );
         sync_function_symbol_flags(&function, ctx);
         function
@@ -693,17 +730,18 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             Argument::from(ctx.create_ident_expr(SPAN, arguments, symbol_id, ReferenceFlags::Read));
 
         // (this, arguments)
-        let this = Argument::from(ctx.ast.expression_this(SPAN));
-        let arguments = ctx.ast.vec_from_array([this, arguments_ident]);
+        let this = Argument::from(Expression::new_this_expression(SPAN, ctx));
+        let arguments = ArenaVec::from_array_in([this, arguments_ident], ctx);
         // _ref.apply
-        let callee = Expression::from(ctx.ast.member_expression_static(
+        let callee = Expression::from(MemberExpression::new_static_member_expression(
             SPAN,
             bound_ident.create_read_expression(ctx),
-            ctx.ast.identifier_name(SPAN, "apply"),
+            IdentifierName::new(SPAN, "apply", ctx),
             false,
+            ctx,
         ));
-        let argument = ctx.ast.expression_call(SPAN, callee, NONE, arguments, false);
-        ctx.ast.statement_return(SPAN, Some(argument))
+        let argument = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
+        Statement::new_return_statement(SPAN, Some(argument), ctx)
     }
 
     /// Creates an [`Expression`] that calls the [`AsyncGeneratorExecutor::helper`] helper function.
@@ -733,7 +771,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             ctx,
         );
         function.generator = true;
-        let arguments = ctx.ast.vec1(Argument::FunctionExpression(function));
+        let arguments = ArenaVec::from_value_in(Argument::FunctionExpression(function), ctx);
         helper_call_expr(self.helper, arguments, ctx)
     }
 
@@ -754,19 +792,24 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let init = self.create_async_to_generator_call(params, body, scope_id, ctx);
-        let declarations = ctx.ast.vec1(ctx.ast.variable_declarator(
-            SPAN,
-            VariableDeclarationKind::Var,
-            bound_ident.create_binding_pattern(ctx),
-            NONE,
-            Some(init),
-            false,
-        ));
-        Statement::from(ctx.ast.declaration_variable(
+        let declarations = ArenaVec::from_value_in(
+            VariableDeclarator::new(
+                SPAN,
+                VariableDeclarationKind::Var,
+                bound_ident.create_binding_pattern(ctx),
+                NONE,
+                Some(init),
+                false,
+                ctx,
+            ),
+            ctx,
+        );
+        Statement::from(Declaration::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
             declarations,
             false,
+            ctx,
         ))
     }
 
@@ -787,13 +830,14 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let right = self.create_async_to_generator_call(params, body, scope_id, ctx);
-        let expression = ctx.ast.expression_assignment(
+        let expression = Expression::new_assignment_expression(
             SPAN,
             AssignmentOperator::Assign,
             bound.create_write_target(ctx),
             right,
+            ctx,
         );
-        ctx.ast.statement_expression(SPAN, expression)
+        Statement::new_expression_statement(SPAN, expression, ctx)
     }
 
     /// Creates placeholder [`FormalParameters`] which named `_x` based on the passed-in parameters.
@@ -803,33 +847,31 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         scope_id: ScopeId,
         ctx: &mut TraverseCtx<'a>,
     ) -> ArenaBox<'a, FormalParameters<'a>> {
-        let mut parameters = ctx.ast.vec_with_capacity(params.items.len());
+        let mut parameters = ArenaVec::with_capacity_in(params.items.len(), ctx);
         for param in &params.items {
             if param.initializer.is_some() {
                 break;
             }
             let binding = ctx.generate_uid("x", scope_id, SymbolFlags::FunctionScopedVariable);
-            parameters.push(
-                ctx.ast.plain_formal_parameter(param.span(), binding.create_binding_pattern(ctx)),
-            );
+            parameters.push(FormalParameter::new_plain(
+                param.span(),
+                binding.create_binding_pattern(ctx),
+                ctx,
+            ));
         }
 
-        ctx.ast.alloc_formal_parameters(
-            SPAN,
-            FormalParameterKind::FormalParameter,
-            parameters,
-            NONE,
-        )
+        FormalParameters::boxed(SPAN, FormalParameterKind::FormalParameter, parameters, NONE, ctx)
     }
 
     /// Creates an empty [FormalParameters] with [FormalParameterKind::FormalParameter].
     #[inline]
     fn create_empty_params(ctx: &TraverseCtx<'a>) -> ArenaBox<'a, FormalParameters<'a>> {
-        ctx.ast.alloc_formal_parameters(
+        FormalParameters::boxed(
             SPAN,
             FormalParameterKind::FormalParameter,
-            ctx.ast.vec(),
+            ArenaVec::new_in(ctx),
             NONE,
+            ctx,
         )
     }
 

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -74,10 +74,11 @@ impl<'a> AsyncGeneratorFunctions<'a> {
             };
             let try_statement_block_body = &mut try_statement.block.body;
             let for_statement = try_statement_block_body.pop().unwrap();
-            try_statement_block_body.push(ctx.ast.statement_labeled(
+            try_statement_block_body.push(Statement::new_labeled_statement(
                 for_of_span,
                 label.clone(),
                 for_statement,
+                ctx,
             ));
         }
         ctx.state.statement_injector.insert_many_before(&new_stmt, statements);
@@ -86,10 +87,11 @@ impl<'a> AsyncGeneratorFunctions<'a> {
         // with a block statement, this way we can ensure can insert statement correctly.
         // e.g. `if (true) statement` to `if (true) { statement }`
         if !allow_multiple_statements {
-            new_stmt = ctx.ast.statement_block_with_scope_id(
+            new_stmt = Statement::new_block_statement_with_scope_id(
                 SPAN,
-                ctx.ast.vec1(new_stmt),
+                ArenaVec::from_value_in(new_stmt, ctx),
                 parent_scope_id,
+                ctx,
             );
         }
         *stmt = new_stmt;
@@ -109,11 +111,12 @@ impl<'a> AsyncGeneratorFunctions<'a> {
             SymbolFlags::FunctionScopedVariable,
         );
         // step.value
-        let step_value = Expression::from(ctx.ast.member_expression_static(
+        let step_value = Expression::from(MemberExpression::new_static_member_expression(
             SPAN,
             step_key.create_read_expression(ctx),
-            ctx.ast.identifier_name(SPAN, "value"),
+            IdentifierName::new(SPAN, "value", ctx),
             false,
+            ctx,
         ));
 
         let assignment_statement = match &mut stmt.left {
@@ -121,28 +124,30 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                 // for await (let i of test)
                 let mut declarator = variable.declarations.pop().unwrap();
                 declarator.init = Some(step_value);
-                Statement::VariableDeclaration(ctx.ast.alloc_variable_declaration(
+                Statement::VariableDeclaration(VariableDeclaration::boxed(
                     SPAN,
                     declarator.kind,
-                    ctx.ast.vec1(declarator),
+                    ArenaVec::from_value_in(declarator, ctx),
                     false,
+                    ctx,
                 ))
             }
             left @ match_assignment_target!(ForStatementLeft) => {
                 // for await (i of test), for await ({ i } of test)
                 let target = left.to_assignment_target_mut().take_in(ctx);
-                let expression = ctx.ast.expression_assignment(
+                let expression = Expression::new_assignment_expression(
                     SPAN,
                     AssignmentOperator::Assign,
                     target,
                     step_value,
+                    ctx,
                 );
-                ctx.ast.statement_expression(SPAN, expression)
+                Statement::new_expression_statement(SPAN, expression, ctx)
             }
         };
 
         let body = {
-            let mut statements = ctx.ast.vec_with_capacity(2);
+            let mut statements = ArenaVec::with_capacity_in(2, ctx);
             statements.push(assignment_statement);
             let stmt_body = &mut stmt.body;
             match stmt_body {
@@ -153,8 +158,11 @@ impl<'a> AsyncGeneratorFunctions<'a> {
         };
 
         let iterator = stmt.right.take_in(ctx);
-        let iterator =
-            helper_call_expr(Helper::AsyncIterator, ctx.ast.vec1(Argument::from(iterator)), ctx);
+        let iterator = helper_call_expr(
+            Helper::AsyncIterator,
+            ArenaVec::from_value_in(Argument::from(iterator), ctx),
+            ctx,
+        );
         Self::build_for_await(
             iterator,
             &step_key,
@@ -220,45 +228,60 @@ impl<'a> AsyncGeneratorFunctions<'a> {
         let iterator_error_key =
             ctx.generate_uid("iteratorError", var_scope_id, SymbolFlags::FunctionScopedVariable);
 
-        let mut items = ctx.ast.vec_with_capacity(4);
-        items.push(Statement::from(ctx.ast.declaration_variable(
+        let mut items = ArenaVec::with_capacity_in(4, ctx);
+        items.push(Statement::from(Declaration::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ctx.ast.vec1(ctx.ast.variable_declarator(
-                SPAN,
-                VariableDeclarationKind::Var,
-                iterator_abrupt_completion.create_binding_pattern(ctx),
-                NONE,
-                Some(ctx.ast.expression_boolean_literal(SPAN, false)),
-                false,
-            )),
+            ArenaVec::from_value_in(
+                VariableDeclarator::new(
+                    SPAN,
+                    VariableDeclarationKind::Var,
+                    iterator_abrupt_completion.create_binding_pattern(ctx),
+                    NONE,
+                    Some(Expression::new_boolean_literal(SPAN, false, ctx)),
+                    false,
+                    ctx,
+                ),
+                ctx,
+            ),
             false,
+            ctx,
         )));
-        items.push(Statement::from(ctx.ast.declaration_variable(
+        items.push(Statement::from(Declaration::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ctx.ast.vec1(ctx.ast.variable_declarator(
-                SPAN,
-                VariableDeclarationKind::Var,
-                iterator_had_error_key.create_binding_pattern(ctx),
-                NONE,
-                Some(ctx.ast.expression_boolean_literal(SPAN, false)),
-                false,
-            )),
+            ArenaVec::from_value_in(
+                VariableDeclarator::new(
+                    SPAN,
+                    VariableDeclarationKind::Var,
+                    iterator_had_error_key.create_binding_pattern(ctx),
+                    NONE,
+                    Some(Expression::new_boolean_literal(SPAN, false, ctx)),
+                    false,
+                    ctx,
+                ),
+                ctx,
+            ),
             false,
+            ctx,
         )));
-        items.push(Statement::from(ctx.ast.declaration_variable(
+        items.push(Statement::from(Declaration::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ctx.ast.vec1(ctx.ast.variable_declarator(
-                SPAN,
-                VariableDeclarationKind::Var,
-                iterator_error_key.create_binding_pattern(ctx),
-                NONE,
-                None,
-                false,
-            )),
+            ArenaVec::from_value_in(
+                VariableDeclarator::new(
+                    SPAN,
+                    VariableDeclarationKind::Var,
+                    iterator_error_key.create_binding_pattern(ctx),
+                    NONE,
+                    None,
+                    false,
+                    ctx,
+                ),
+                ctx,
+            ),
             false,
+            ctx,
         )));
 
         let iterator_key =
@@ -268,73 +291,90 @@ impl<'a> AsyncGeneratorFunctions<'a> {
             let for_statement_scope_id =
                 ctx.create_child_scope(block_scope_id, ScopeFlags::empty());
 
-            let for_statement = ctx.ast.statement_for_with_scope_id(
+            let for_statement = Statement::new_for_statement_with_scope_id(
                 span,
-                Some(ctx.ast.for_statement_init_variable_declaration(
+                Some(ForStatementInit::new_variable_declaration(
                     SPAN,
                     VariableDeclarationKind::Var,
-                    ctx.ast.vec_from_array([
-                        ctx.ast.variable_declarator(
-                            SPAN,
-                            VariableDeclarationKind::Var,
-                            iterator_key.create_binding_pattern(ctx),
-                            NONE,
-                            Some(iterator),
-                            false,
-                        ),
-                        ctx.ast.variable_declarator(
-                            SPAN,
-                            VariableDeclarationKind::Var,
-                            step_key.create_binding_pattern(ctx),
-                            NONE,
-                            None,
-                            false,
-                        ),
-                    ]),
+                    ArenaVec::from_array_in(
+                        [
+                            VariableDeclarator::new(
+                                SPAN,
+                                VariableDeclarationKind::Var,
+                                iterator_key.create_binding_pattern(ctx),
+                                NONE,
+                                Some(iterator),
+                                false,
+                                ctx,
+                            ),
+                            VariableDeclarator::new(
+                                SPAN,
+                                VariableDeclarationKind::Var,
+                                step_key.create_binding_pattern(ctx),
+                                NONE,
+                                None,
+                                false,
+                                ctx,
+                            ),
+                        ],
+                        ctx,
+                    ),
                     false,
+                    ctx,
                 )),
-                Some(ctx.ast.expression_assignment(
+                Some(Expression::new_assignment_expression(
                     SPAN,
                     AssignmentOperator::Assign,
                     iterator_abrupt_completion.create_write_target(ctx),
-                    ctx.ast.expression_unary(
+                    Expression::new_unary_expression(
                         SPAN,
                         UnaryOperator::LogicalNot,
-                        Expression::from(ctx.ast.member_expression_static(
+                        Expression::from(MemberExpression::new_static_member_expression(
                             SPAN,
-                            ctx.ast.expression_parenthesized(
+                            Expression::new_parenthesized_expression(
                                 SPAN,
-                                ctx.ast.expression_assignment(
+                                Expression::new_assignment_expression(
                                     SPAN,
                                     AssignmentOperator::Assign,
                                     step_key.create_write_target(ctx),
-                                    ctx.ast.expression_await(
+                                    Expression::new_await_expression(
                                         SPAN,
-                                        ctx.ast.expression_call(
+                                        Expression::new_call_expression(
                                             SPAN,
-                                            Expression::from(ctx.ast.member_expression_static(
-                                                SPAN,
-                                                iterator_key.create_read_expression(ctx),
-                                                ctx.ast.identifier_name(SPAN, "next"),
-                                                false,
-                                            )),
+                                            Expression::from(
+                                                MemberExpression::new_static_member_expression(
+                                                    SPAN,
+                                                    iterator_key.create_read_expression(ctx),
+                                                    IdentifierName::new(SPAN, "next", ctx),
+                                                    false,
+                                                    ctx,
+                                                ),
+                                            ),
                                             NONE,
-                                            ctx.ast.vec(),
+                                            ArenaVec::new_in(ctx),
                                             false,
+                                            ctx,
                                         ),
+                                        ctx,
                                     ),
+                                    ctx,
                                 ),
+                                ctx,
                             ),
-                            ctx.ast.identifier_name(SPAN, "done"),
+                            IdentifierName::new(SPAN, "done", ctx),
                             false,
+                            ctx,
                         )),
+                        ctx,
                     ),
+                    ctx,
                 )),
-                Some(ctx.ast.expression_assignment(
+                Some(Expression::new_assignment_expression(
                     SPAN,
                     AssignmentOperator::Assign,
                     iterator_abrupt_completion.create_write_target(ctx),
-                    ctx.ast.expression_boolean_literal(SPAN, false),
+                    Expression::new_boolean_literal(SPAN, false, ctx),
+                    ctx,
                 )),
                 {
                     // Handle the for-of statement move to the body of new for-statement
@@ -346,12 +386,18 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                         );
                     }
 
-                    ctx.ast.statement_block_with_scope_id(SPAN, body, for_of_scope_id)
+                    Statement::new_block_statement_with_scope_id(SPAN, body, for_of_scope_id, ctx)
                 },
                 for_statement_scope_id,
+                ctx,
             );
 
-            ctx.ast.block_statement_with_scope_id(SPAN, ctx.ast.vec1(for_statement), block_scope_id)
+            BlockStatement::new_with_scope_id(
+                SPAN,
+                ArenaVec::from_value_in(for_statement, ctx),
+                block_scope_id,
+                ctx,
+            )
         };
 
         let catch_clause = {
@@ -362,133 +408,135 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                 block_scope_id,
                 SymbolFlags::CatchVariable | SymbolFlags::FunctionScopedVariable,
             );
-            Some(ctx.ast.catch_clause_with_scope_id(
+            Some(CatchClause::new_with_scope_id(
                 SPAN,
-                Some(ctx.ast.catch_parameter(SPAN, err_ident.create_binding_pattern(ctx), NONE)),
+                Some(CatchParameter::new(SPAN, err_ident.create_binding_pattern(ctx), NONE, ctx)),
                 {
-                    ctx.ast.block_statement_with_scope_id(
+                    BlockStatement::new_with_scope_id(
                         SPAN,
-                        ctx.ast.vec_from_array([
-                            ctx.ast.statement_expression(
-                                SPAN,
-                                ctx.ast.expression_assignment(
+                        ArenaVec::from_array_in(
+                            [
+                                Statement::new_expression_statement(
                                     SPAN,
-                                    AssignmentOperator::Assign,
-                                    iterator_had_error_key.create_write_target(ctx),
-                                    ctx.ast.expression_boolean_literal(SPAN, true),
+                                    Expression::new_assignment_expression(
+                                        SPAN,
+                                        AssignmentOperator::Assign,
+                                        iterator_had_error_key.create_write_target(ctx),
+                                        Expression::new_boolean_literal(SPAN, true, ctx),
+                                        ctx,
+                                    ),
+                                    ctx,
                                 ),
-                            ),
-                            ctx.ast.statement_expression(
-                                SPAN,
-                                ctx.ast.expression_assignment(
+                                Statement::new_expression_statement(
                                     SPAN,
-                                    AssignmentOperator::Assign,
-                                    iterator_error_key.create_write_target(ctx),
-                                    err_ident.create_read_expression(ctx),
+                                    Expression::new_assignment_expression(
+                                        SPAN,
+                                        AssignmentOperator::Assign,
+                                        iterator_error_key.create_write_target(ctx),
+                                        err_ident.create_read_expression(ctx),
+                                        ctx,
+                                    ),
+                                    ctx,
                                 ),
-                            ),
-                        ]),
+                            ],
+                            ctx,
+                        ),
                         block_scope_id,
+                        ctx,
                     )
                 },
                 catch_scope_id,
+                ctx,
             ))
         };
 
         let finally = {
             let finally_scope_id = ctx.create_child_scope(parent_scope_id, ScopeFlags::empty());
-            let try_statement = {
-                let try_block_scope_id =
-                    ctx.create_child_scope(finally_scope_id, ScopeFlags::empty());
-                let if_statement = {
-                    let if_block_scope_id =
-                        ctx.create_child_scope(try_block_scope_id, ScopeFlags::empty());
-                    ctx.ast.statement_if(
-                        SPAN,
-                        ctx.ast.expression_logical(
-                            SPAN,
-                            iterator_abrupt_completion.create_read_expression(ctx),
-                            LogicalOperator::And,
-                            ctx.ast.expression_binary(
-                                SPAN,
-                                Expression::from(ctx.ast.member_expression_static(
-                                    SPAN,
-                                    iterator_key.create_read_expression(ctx),
-                                    ctx.ast.identifier_name(SPAN, "return"),
-                                    false,
-                                )),
-                                BinaryOperator::Inequality,
-                                ctx.ast.expression_null_literal(SPAN),
-                            ),
-                        ),
-                        ctx.ast.statement_block_with_scope_id(
-                            SPAN,
-                            ctx.ast.vec1(ctx.ast.statement_expression(
-                                SPAN,
-                                ctx.ast.expression_await(
-                                    SPAN,
-                                    ctx.ast.expression_call(
-                                        SPAN,
-                                        Expression::from(ctx.ast.member_expression_static(
-                                            SPAN,
-                                            iterator_key.create_read_expression(ctx),
-                                            ctx.ast.identifier_name(SPAN, "return"),
-                                            false,
-                                        )),
-                                        NONE,
-                                        ctx.ast.vec(),
-                                        false,
-                                    ),
-                                ),
-                            )),
-                            if_block_scope_id,
-                        ),
-                        None,
-                    )
-                };
-                let block = ctx.ast.block_statement_with_scope_id(
-                    SPAN,
-                    ctx.ast.vec1(if_statement),
-                    try_block_scope_id,
-                );
-                let finally = {
-                    let finally_scope_id =
+            let try_statement =
+                {
+                    let try_block_scope_id =
                         ctx.create_child_scope(finally_scope_id, ScopeFlags::empty());
-                    let if_statement = {
-                        let if_block_scope_id =
+                    let if_statement =
+                        {
+                            let if_block_scope_id =
+                                ctx.create_child_scope(try_block_scope_id, ScopeFlags::empty());
+                            Statement::new_if_statement(SPAN,
+                    Expression::new_logical_expression(SPAN,
+                    iterator_abrupt_completion.create_read_expression(ctx),
+                    LogicalOperator::And,
+                    Expression::new_binary_expression(SPAN,
+                    Expression::from(MemberExpression::new_static_member_expression(SPAN,
+                    iterator_key.create_read_expression(ctx),
+                    IdentifierName::new(SPAN, "return", ctx),
+                    false, ctx)),
+                    BinaryOperator::Inequality,
+                    Expression::new_null_literal(SPAN, ctx), ctx), ctx),
+                    Statement::new_block_statement_with_scope_id(SPAN,
+                    ArenaVec::from_value_in(Statement::new_expression_statement(SPAN,
+                    Expression::new_await_expression(SPAN,
+                    Expression::new_call_expression(SPAN,
+                    Expression::from(MemberExpression::new_static_member_expression(SPAN,
+                    iterator_key.create_read_expression(ctx),
+                    IdentifierName::new(SPAN, "return", ctx),
+                    false, ctx)),
+                    NONE,
+                    ArenaVec::new_in(ctx),
+                    false, ctx), ctx), ctx), ctx),
+                    if_block_scope_id, ctx),
+                    None, ctx)
+                        };
+                    let block = BlockStatement::new_with_scope_id(
+                        SPAN,
+                        ArenaVec::from_value_in(if_statement, ctx),
+                        try_block_scope_id,
+                        ctx,
+                    );
+                    let finally = {
+                        let finally_scope_id =
                             ctx.create_child_scope(finally_scope_id, ScopeFlags::empty());
-                        ctx.ast.statement_if(
-                            SPAN,
-                            iterator_had_error_key.create_read_expression(ctx),
-                            ctx.ast.statement_block_with_scope_id(
+                        let if_statement = {
+                            let if_block_scope_id =
+                                ctx.create_child_scope(finally_scope_id, ScopeFlags::empty());
+                            Statement::new_if_statement(
                                 SPAN,
-                                ctx.ast.vec1(ctx.ast.statement_throw(
+                                iterator_had_error_key.create_read_expression(ctx),
+                                Statement::new_block_statement_with_scope_id(
                                     SPAN,
-                                    iterator_error_key.create_read_expression(ctx),
-                                )),
-                                if_block_scope_id,
-                            ),
-                            None,
+                                    ArenaVec::from_value_in(
+                                        Statement::new_throw_statement(
+                                            SPAN,
+                                            iterator_error_key.create_read_expression(ctx),
+                                            ctx,
+                                        ),
+                                        ctx,
+                                    ),
+                                    if_block_scope_id,
+                                    ctx,
+                                ),
+                                None,
+                                ctx,
+                            )
+                        };
+                        BlockStatement::new_with_scope_id(
+                            SPAN,
+                            ArenaVec::from_value_in(if_statement, ctx),
+                            finally_scope_id,
+                            ctx,
                         )
                     };
-                    ctx.ast.block_statement_with_scope_id(
-                        SPAN,
-                        ctx.ast.vec1(if_statement),
-                        finally_scope_id,
-                    )
+                    Statement::new_try_statement(SPAN, block, NONE, Some(finally), ctx)
                 };
-                ctx.ast.statement_try(SPAN, block, NONE, Some(finally))
-            };
 
-            let block_statement = ctx.ast.block_statement_with_scope_id(
+            let block_statement = BlockStatement::new_with_scope_id(
                 SPAN,
-                ctx.ast.vec1(try_statement),
+                ArenaVec::from_value_in(try_statement, ctx),
                 finally_scope_id,
+                ctx,
             );
             Some(block_statement)
         };
 
-        let try_statement = ctx.ast.statement_try(span, block, catch_clause, finally);
+        let try_statement = Statement::new_try_statement(span, block, catch_clause, finally, ctx);
 
         items.push(try_statement);
         items

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/mod.rs
@@ -66,7 +66,7 @@
 
 mod for_await;
 
-use oxc_allocator::TakeIn;
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_traverse::{Ancestor, Traverse};
@@ -173,11 +173,11 @@ impl<'a> AsyncGeneratorFunctions<'a> {
 
         expr.argument.as_mut().map(|argument| {
             let argument = Argument::from(argument.take_in(ctx));
-            let arguments = ctx.ast.vec1(argument);
+            let arguments = ArenaVec::from_value_in(argument, ctx);
             let mut argument = helper_call_expr(Helper::AsyncIterator, arguments, ctx);
-            let arguments = ctx.ast.vec1(Argument::from(argument));
+            let arguments = ArenaVec::from_value_in(Argument::from(argument), ctx);
             argument = helper_call_expr(Helper::AsyncGeneratorDelegate, arguments, ctx);
-            ctx.ast.expression_yield(SPAN, expr.delegate, Some(argument))
+            Expression::new_yield_expression(SPAN, expr.delegate, Some(argument), ctx)
         })
     }
 
@@ -207,10 +207,10 @@ impl<'a> AsyncGeneratorFunctions<'a> {
         }
 
         let mut argument = expr.argument.take_in(ctx);
-        let arguments = ctx.ast.vec1(Argument::from(argument));
+        let arguments = ArenaVec::from_value_in(Argument::from(argument), ctx);
         argument = helper_call_expr(Helper::AwaitAsyncGenerator, arguments, ctx);
 
-        Some(ctx.ast.expression_yield(SPAN, false, Some(argument)))
+        Some(Expression::new_yield_expression(SPAN, false, Some(argument), ctx))
     }
 
     /// Check whether `await` is inside an async generator function.

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -31,7 +31,7 @@ use std::mem;
 
 use serde::Deserialize;
 
-use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, TakeIn};
+use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, GetAllocator, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{BoundNames, ToJsString, WithoutGlobalReferenceInformation};
@@ -90,9 +90,10 @@ impl<'a> Traverse<'a, TransformState<'a>> for ObjectRestSpread<'a> {
     // `function foo() { ({a, ...b} = c) }` -> `const _excluded = ["a"]; function foo() { ... }`
     fn exit_program(&mut self, _node: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         if !self.excluded_variable_declarators.is_empty() {
-            let declarators = ctx.ast.vec_from_iter(self.excluded_variable_declarators.drain(..));
+            let declarators =
+                ArenaVec::from_iter_in(self.excluded_variable_declarators.drain(..), ctx);
             let kind = VariableDeclarationKind::Const;
-            let declaration = ctx.ast.alloc_variable_declaration(SPAN, kind, declarators, false);
+            let declaration = VariableDeclaration::boxed(SPAN, kind, declarators, false, ctx);
             let statement = Statement::VariableDeclaration(declaration);
             ctx.state.top_level_statements.insert_statement(statement);
         }
@@ -214,7 +215,7 @@ impl<'a> ObjectRestSpread<'a> {
         let mut new_decls = vec![];
 
         if let Some(id) = reference_builder.binding.take() {
-            new_decls.push(ctx.ast.variable_declarator(SPAN, state.kind, id, NONE, None, false));
+            new_decls.push(VariableDeclarator::new(SPAN, state.kind, id, NONE, None, false, ctx));
         }
 
         let data = Self::walk_assignment_target(&mut assign_expr.left, &mut new_decls, state, ctx);
@@ -222,25 +223,27 @@ impl<'a> ObjectRestSpread<'a> {
         Self::insert_var_declaration_before_containing_statement(new_decls, ctx);
 
         // Make an sequence expression.
-        let mut expressions = ctx.ast.vec();
+        let mut expressions = ArenaVec::new_in(ctx);
         let op = AssignmentOperator::Assign;
 
         // Insert `_foo = rhs`
         if let Some(expr) = reference_builder.expr.take() {
-            expressions.push(ctx.ast.expression_assignment(
+            expressions.push(Expression::new_assignment_expression(
                 SPAN,
                 op,
                 reference_builder.maybe_bound_identifier.create_write_target(ctx),
                 expr,
+                ctx,
             ));
         }
 
         // Insert `{} = _foo`
-        expressions.push(ctx.ast.expression_assignment(
+        expressions.push(Expression::new_assignment_expression(
             SPAN,
             op,
             assign_expr.left.take_in(ctx),
             reference_builder.create_read_expression(ctx),
+            ctx,
         ));
 
         // Insert all `rest = _extends({}, (_objectDestructuringEmpty(_foo), _foo))`
@@ -251,7 +254,7 @@ impl<'a> ObjectRestSpread<'a> {
                 ctx,
             );
             if let BindingPatternOrAssignmentTarget::AssignmentTarget(lhs) = lhs {
-                expressions.push(ctx.ast.expression_assignment(SPAN, op, lhs, rhs));
+                expressions.push(Expression::new_assignment_expression(SPAN, op, lhs, rhs, ctx));
             }
         }
 
@@ -265,7 +268,7 @@ impl<'a> ObjectRestSpread<'a> {
             expressions.push(reference_builder.create_read_expression(ctx));
         }
 
-        *expr = ctx.ast.expression_sequence(assign_expr.span, expressions);
+        *expr = Expression::new_sequence_expression(assign_expr.span, expressions, ctx);
     }
 
     fn walk_assignment_target(
@@ -312,25 +315,26 @@ impl<'a> ObjectRestSpread<'a> {
         let rest = object_assignment_target.rest.take()?;
         let rest_target = rest.unbox().target;
         let mut all_primitives = true;
-        let keys =
-            ctx.ast.vec_from_iter(object_assignment_target.properties.iter_mut().filter_map(|e| {
-                match e {
-                    AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(ident) => {
-                        let name = ident.binding.name;
-                        let expr = ctx.ast.expression_string_literal(SPAN, name, None);
-                        Some(ArrayExpressionElement::from(expr))
-                    }
-                    AssignmentTargetProperty::AssignmentTargetPropertyProperty(p) => {
-                        Self::transform_property_key(
-                            &mut p.name,
-                            new_decls,
-                            &mut all_primitives,
-                            state,
-                            ctx,
-                        )
-                    }
+        let allocator = ctx.allocator();
+        let keys = ArenaVec::from_iter_in(
+            object_assignment_target.properties.iter_mut().filter_map(|e| match e {
+                AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(ident) => {
+                    let name = ident.binding.name;
+                    let expr = Expression::new_string_literal(SPAN, name, None, ctx);
+                    Some(ArrayExpressionElement::from(expr))
                 }
-            }));
+                AssignmentTargetProperty::AssignmentTargetPropertyProperty(p) => {
+                    Self::transform_property_key(
+                        &mut p.name,
+                        new_decls,
+                        &mut all_primitives,
+                        state,
+                        ctx,
+                    )
+                }
+            }),
+            &allocator,
+        );
         Some(SpreadPair {
             lhs: BindingPatternOrAssignmentTarget::AssignmentTarget(rest_target),
             keys,
@@ -380,9 +384,9 @@ impl<'a> ObjectRestSpread<'a> {
         let mut exprs = vec![];
         Self::recursive_walk_assignment_target(&mut assign_expr.left, &mut decls, &mut exprs, ctx);
         Self::insert_var_declaration_before_containing_statement(decls, ctx);
-        let mut expressions = ctx.ast.vec1(expr.take_in(ctx));
+        let mut expressions = ArenaVec::from_value_in(expr.take_in(ctx), ctx);
         expressions.extend(exprs);
-        *expr = ctx.ast.expression_sequence(SPAN, expressions);
+        *expr = Expression::new_sequence_expression(SPAN, expressions, ctx);
     }
 
     // Insert `var _foo` before the statement that contains the transformed assignment.
@@ -399,7 +403,7 @@ impl<'a> ObjectRestSpread<'a> {
         let Some(address) = Self::containing_statement_address(ctx) else { return };
         let kind = VariableDeclarationKind::Var;
         let declaration =
-            ctx.ast.alloc_variable_declaration(SPAN, kind, ctx.ast.vec_from_iter(decls), false);
+            VariableDeclaration::boxed(SPAN, kind, ArenaVec::from_iter_in(decls, ctx), false, ctx);
         let statement = Statement::VariableDeclaration(declaration);
         ctx.state.statement_injector.insert_before(&address, statement);
     }
@@ -452,12 +456,13 @@ impl<'a> ObjectRestSpread<'a> {
                 let bound_identifier = ctx.generate_uid_in_current_hoist_scope("ref");
                 let id = bound_identifier.create_binding_pattern(ctx);
                 let kind = VariableDeclarationKind::Var;
-                decls.push(ctx.ast.variable_declarator(SPAN, kind, id, NONE, None, false));
-                exprs.push(ctx.ast.expression_assignment(
+                decls.push(VariableDeclarator::new(SPAN, kind, id, NONE, None, false, ctx));
+                exprs.push(Expression::new_assignment_expression(
                     SPAN,
                     AssignmentOperator::Assign,
                     pat.take_in(ctx),
                     bound_identifier.create_read_expression(ctx),
+                    ctx,
                 ));
                 *pat = bound_identifier.create_spanned_write_target(SPAN, ctx);
             }
@@ -501,7 +506,7 @@ impl<'a> ObjectRestSpread<'a> {
 
         let span = obj_expr.span;
         let mut call_expr: Option<ArenaBox<'a, CallExpression<'a>>> = None;
-        let mut props = ctx.ast.vec_with_capacity(obj_expr.properties.len());
+        let mut props = ArenaVec::with_capacity_in(obj_expr.properties.len(), ctx);
 
         for prop in obj_expr.properties.drain(..) {
             if let ObjectPropertyKind::SpreadProperty(mut spread_prop) = prop {
@@ -528,22 +533,27 @@ impl<'a> ObjectRestSpread<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         let had_props = !props.is_empty();
-        let obj = ctx.ast.expression_object(
+        let obj = Expression::new_object_expression(
             SPAN,
             // Reserve maximize might be used space for new vec
-            mem::replace(props, ctx.ast.vec_with_capacity(props.capacity() - props.len())),
+            mem::replace(props, ArenaVec::with_capacity_in(props.capacity() - props.len(), ctx)),
+            ctx,
         );
         let arguments = if let Some(call_expr) = expr.take() {
             let arg = Expression::CallExpression(call_expr);
             let arg = Argument::from(arg);
             if had_props {
-                let empty_object = ctx.ast.expression_object(SPAN, ctx.ast.vec());
-                ctx.ast.vec_from_array([arg, Argument::from(empty_object), Argument::from(obj)])
+                let empty_object =
+                    Expression::new_object_expression(SPAN, ArenaVec::new_in(ctx), ctx);
+                ArenaVec::from_array_in(
+                    [arg, Argument::from(empty_object), Argument::from(obj)],
+                    ctx,
+                )
             } else {
-                ctx.ast.vec1(arg)
+                ArenaVec::from_value_in(arg, ctx)
             }
         } else {
-            ctx.ast.vec1(Argument::from(obj))
+            ArenaVec::from_value_in(Argument::from(obj), ctx)
         };
         let new_expr = helper_call(Helper::ObjectSpread2, arguments, ctx);
         expr.replace(new_expr);
@@ -585,8 +595,11 @@ impl<'a> ObjectRestSpread<'a> {
                             "`arrow.expression` is true, which means it has only one ExpressionStatement."
                         );
                     };
-                    let return_stmt =
-                        ctx.ast.statement_return(stmt.span, Some(stmt.unbox().expression));
+                    let return_stmt = Statement::new_return_statement(
+                        stmt.span,
+                        Some(stmt.unbox().expression),
+                        ctx,
+                    );
                     arrow.body.statements.push(return_stmt);
                 }
                 Self::replace_rest_element(
@@ -677,9 +690,11 @@ impl<'a> ObjectRestSpread<'a> {
         let bound_identifier = ctx.generate_uid("ref", ctx.current_hoist_scope_id(), flags);
         let id = bound_identifier.create_binding_pattern(ctx);
         let kind = VariableDeclarationKind::Var;
-        let declarations =
-            ctx.ast.vec1(ctx.ast.variable_declarator(SPAN, kind, id, NONE, None, false));
-        let decl = ctx.ast.alloc_variable_declaration(SPAN, kind, declarations, false);
+        let declarations = ArenaVec::from_value_in(
+            VariableDeclarator::new(SPAN, kind, id, NONE, None, false, ctx),
+            ctx,
+        );
+        let decl = VariableDeclaration::boxed(SPAN, kind, declarations, false, ctx);
         *left = ForStatementLeft::VariableDeclaration(decl);
         Self::try_replace_statement_with_block(body, scope_id, ctx);
         let Statement::BlockStatement(block) = body else {
@@ -687,8 +702,8 @@ impl<'a> ObjectRestSpread<'a> {
         };
         let operator = AssignmentOperator::Assign;
         let right = bound_identifier.create_read_expression(ctx);
-        let expr = ctx.ast.expression_assignment(SPAN, operator, assign_left, right);
-        let stmt = ctx.ast.statement_expression(SPAN, expr);
+        let expr = Expression::new_assignment_expression(SPAN, operator, assign_left, right, ctx);
+        let stmt = Statement::new_expression_statement(SPAN, expr, ctx);
         block.body.insert(0, stmt);
     }
 
@@ -702,12 +717,12 @@ impl<'a> ObjectRestSpread<'a> {
         }
         let scope_id = ctx.create_child_scope(parent_scope_id, ScopeFlags::empty());
         let (span, stmts) = if let Statement::EmptyStatement(empty_stmt) = stmt {
-            (empty_stmt.span, ctx.ast.vec())
+            (empty_stmt.span, ArenaVec::new_in(ctx))
         } else {
             let span = stmt.span();
-            (span, ctx.ast.vec1(stmt.take_in(ctx)))
+            (span, ArenaVec::from_value_in(stmt.take_in(ctx), ctx))
         };
-        *stmt = ctx.ast.statement_block_with_scope_id(span, stmts, scope_id);
+        *stmt = Statement::new_block_statement_with_scope_id(span, stmts, scope_id, ctx);
         scope_id
     }
 
@@ -797,9 +812,11 @@ impl<'a> ObjectRestSpread<'a> {
                 SymbolFlags::BlockScopedVariable;
         });
         let init = bound_identifier.create_read_expression(ctx);
-        let declarations =
-            ctx.ast.vec1(ctx.ast.variable_declarator(SPAN, kind, id, NONE, Some(init), false));
-        ctx.ast.alloc_variable_declaration(SPAN, kind, declarations, false)
+        let declarations = ArenaVec::from_value_in(
+            VariableDeclarator::new(SPAN, kind, id, NONE, Some(init), false, ctx),
+            ctx,
+        );
+        VariableDeclaration::boxed(SPAN, kind, declarations, false, ctx)
     }
 }
 
@@ -858,13 +875,14 @@ impl<'a> ObjectRestSpread<'a> {
 
         // Add `_foo = foo()`
         if let Some(id) = reference_builder.binding.take() {
-            let decl = ctx.ast.variable_declarator(
+            let decl = VariableDeclarator::new(
                 SPAN,
                 state.kind,
                 id,
                 NONE,
                 Some(reference_builder.create_read_expression(ctx)),
                 false,
+                ctx,
             );
             new_decls.push(decl);
         }
@@ -888,8 +906,9 @@ impl<'a> ObjectRestSpread<'a> {
                 let mut all_primitives = true;
                 // Create the access keys.
                 // `let { a, b, ...c } = foo` -> `["a", "b"]`
-                let keys = ctx.ast.vec_from_iter(pat.properties.iter_mut().filter_map(
-                    |binding_property| {
+                let allocator = ctx.allocator();
+                let keys = ArenaVec::from_iter_in(
+                    pat.properties.iter_mut().filter_map(|binding_property| {
                         Self::transform_property_key(
                             &mut binding_property.key,
                             &mut temp_keys,
@@ -897,8 +916,9 @@ impl<'a> ObjectRestSpread<'a> {
                             state,
                             ctx,
                         )
-                    },
-                ));
+                    }),
+                    &allocator,
+                );
                 let datum = SpreadPair {
                     lhs,
                     keys,
@@ -913,13 +933,14 @@ impl<'a> ObjectRestSpread<'a> {
                     ctx,
                 );
                 if let BindingPatternOrAssignmentTarget::BindingPattern(lhs) = lhs {
-                    let decl = ctx.ast.variable_declarator(
+                    let decl = VariableDeclarator::new(
                         lhs.span(),
                         decl.kind,
                         lhs,
                         NONE,
                         Some(rhs),
                         false,
+                        ctx,
                     );
                     temp_decls.push(decl);
                 }
@@ -935,21 +956,22 @@ impl<'a> ObjectRestSpread<'a> {
         // Insert the original declarator by copying its data out.
         if !remove_empty_object_pattern {
             let mut binding_pattern =
-                ctx.ast.binding_pattern_object_pattern(decl.span, ctx.ast.vec(), NONE);
+                BindingPattern::new_object_pattern(decl.span, ArenaVec::new_in(ctx), NONE, ctx);
             mem::swap(&mut binding_pattern, &mut decl.id);
-            let decl = ctx.ast.variable_declarator(
+            let decl = VariableDeclarator::new(
                 decl.span,
                 decl.kind,
                 binding_pattern,
                 NONE,
                 Some(reference_builder.create_read_expression(ctx)),
                 false,
+                ctx,
             );
             new_decls.push(decl);
         }
 
         new_decls.extend(temp_decls);
-        ctx.ast.vec_from_iter(new_decls)
+        ArenaVec::from_iter_in(new_decls, ctx)
     }
 
     // Returns all temporary references
@@ -983,7 +1005,7 @@ impl<'a> ObjectRestSpread<'a> {
 
                     let init = bound_identifier.create_read_expression(ctx);
                     let mut decl =
-                        ctx.ast.variable_declarator(SPAN, state.kind, id, NONE, Some(init), false);
+                        VariableDeclarator::new(SPAN, state.kind, id, NONE, Some(init), false, ctx);
                     let mut decls = self
                         .transform_variable_declarator(&mut decl, ctx)
                         .into_iter()
@@ -1008,21 +1030,21 @@ impl<'a> ObjectRestSpread<'a> {
             // `let { a, ... rest }`
             PropertyKey::StaticIdentifier(ident) => {
                 let name = ident.name;
-                let expr = ctx.ast.expression_string_literal(ident.span, name, None);
+                let expr = Expression::new_string_literal(ident.span, name, None, ctx);
                 Some(ArrayExpressionElement::from(expr))
             }
             // `let { 'a', ... rest }`
             // `let { ['a'], ... rest }`
             PropertyKey::StringLiteral(lit) => {
                 let name = lit.value;
-                let expr = ctx.ast.expression_string_literal(lit.span, name, None);
+                let expr = Expression::new_string_literal(lit.span, name, None, ctx);
                 Some(ArrayExpressionElement::from(expr))
             }
             // `let { [`a`], ... rest }`
             PropertyKey::TemplateLiteral(lit) if lit.is_no_substitution_template() => {
-                let quasis = ctx.ast.vec1(lit.quasis[0].clone());
-                let expressions = ctx.ast.vec();
-                let expr = ctx.ast.expression_template_literal(lit.span, quasis, expressions);
+                let quasis = ArenaVec::from_value_in(lit.quasis[0].clone(), ctx);
+                let expressions = ArenaVec::new_in(ctx);
+                let expr = Expression::new_template_literal(lit.span, quasis, expressions, ctx);
                 Some(ArrayExpressionElement::from(expr))
             }
             PropertyKey::PrivateIdentifier(_) => {
@@ -1035,8 +1057,8 @@ impl<'a> ObjectRestSpread<'a> {
                 if expr.is_literal() {
                     let span = expr.span();
                     let s = expr.to_js_string(&WithoutGlobalReferenceInformation {}).unwrap();
-                    let s = ctx.ast.str_from_cow(&s);
-                    let expr = ctx.ast.expression_string_literal(span, s, None);
+                    let s = Str::from_cow_in(&s, ctx);
+                    let expr = Expression::new_string_literal(span, s, None, ctx);
                     return Some(ArrayExpressionElement::from(expr));
                 }
                 *all_primitives = false;
@@ -1052,13 +1074,14 @@ impl<'a> ObjectRestSpread<'a> {
                 let p = bound_identifier.create_binding_pattern(ctx);
                 let mut lhs = bound_identifier.create_read_expression(ctx);
                 mem::swap(&mut lhs, expr);
-                new_decls.push(ctx.ast.variable_declarator(
+                new_decls.push(VariableDeclarator::new(
                     SPAN,
                     state.kind,
                     p,
                     NONE,
                     Some(lhs),
                     false,
+                    ctx,
                 ));
                 Some(ArrayExpressionElement::from(bound_identifier.create_read_expression(ctx)))
             }
@@ -1115,32 +1138,40 @@ impl<'a> SpreadPair<'a> {
         let rhs = if self.has_no_properties {
             // The `ObjectDestructuringEmpty` function throws a type error when destructuring null.
             // `function _objectDestructuringEmpty(t) { if (null == t) throw new TypeError("Cannot destructure " + t); }`
-            let mut arguments = ctx.ast.vec();
+            let mut arguments = ArenaVec::new_in(ctx);
             // Add `{}`.
-            arguments.push(Argument::ObjectExpression(
-                ctx.ast.alloc_object_expression(SPAN, ctx.ast.vec()),
-            ));
+            arguments.push(Argument::ObjectExpression(ObjectExpression::boxed(
+                SPAN,
+                ArenaVec::new_in(ctx),
+                ctx,
+            )));
             // Add `(_objectDestructuringEmpty(b), b);`
-            arguments.push(Argument::SequenceExpression(ctx.ast.alloc_sequence_expression(
+            arguments.push(Argument::SequenceExpression(SequenceExpression::boxed(
                 SPAN,
                 {
-                    let mut sequence = ctx.ast.vec();
+                    let mut sequence = ArenaVec::new_in(ctx);
                     sequence.push(helper_call_expr(
                         Helper::ObjectDestructuringEmpty,
-                        ctx.ast.vec1(Argument::from(reference_builder.create_read_expression(ctx))),
+                        ArenaVec::from_value_in(
+                            Argument::from(reference_builder.create_read_expression(ctx)),
+                            ctx,
+                        ),
                         ctx,
                     ));
                     sequence.push(reference_builder.create_read_expression(ctx));
                     sequence
                 },
+                ctx,
             )));
             helper_call_expr(Helper::Extends, arguments, ctx)
         } else {
             // / `let { a, b, ...c } = z` -> _objectWithoutProperties(_z, ["a", "b"]);
             // / `_objectWithoutProperties(_z, ["a", "b"])`
-            let mut arguments =
-                ctx.ast.vec1(Argument::from(reference_builder.create_read_expression(ctx)));
-            let key_expression = ctx.ast.expression_array(SPAN, self.keys);
+            let mut arguments = ArenaVec::from_value_in(
+                Argument::from(reference_builder.create_read_expression(ctx)),
+                ctx,
+            );
+            let key_expression = Expression::new_array_expression(SPAN, self.keys, ctx);
 
             let key_expression = if self.all_primitives
                 && ctx.scoping.current_scope_id() != ctx.scoping().root_scope_id()
@@ -1151,26 +1182,33 @@ impl<'a> SpreadPair<'a> {
                     SymbolFlags::BlockScopedVariable | SymbolFlags::ConstVariable,
                 );
                 let kind = VariableDeclarationKind::Const;
-                let declarator = ctx.ast.variable_declarator(
+                let declarator = VariableDeclarator::new(
                     SPAN,
                     kind,
                     bound_identifier.create_binding_pattern(ctx),
                     NONE,
                     Some(key_expression),
                     false,
+                    ctx,
                 );
                 excluded_variable_declarators.push(declarator);
                 bound_identifier.create_read_expression(ctx)
             } else if !self.all_primitives {
                 // map to `toPropertyKey` to handle the possible non-string values
                 // `[_ref].map(babelHelpers.toPropertyKey))`
-                let property = ctx.ast.identifier_name(SPAN, "map");
-                let callee = Expression::StaticMemberExpression(
-                    ctx.ast.alloc_static_member_expression(SPAN, key_expression, property, false),
+                let property = IdentifierName::new(SPAN, "map", ctx);
+                let callee = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+                    SPAN,
+                    key_expression,
+                    property,
+                    false,
+                    ctx,
+                ));
+                let arguments = ArenaVec::from_value_in(
+                    Argument::from(helper_load(Helper::ToPropertyKey, ctx)),
+                    ctx,
                 );
-                let arguments =
-                    ctx.ast.vec1(Argument::from(helper_load(Helper::ToPropertyKey, ctx)));
-                ctx.ast.expression_call(SPAN, callee, NONE, arguments, false)
+                Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx)
             } else {
                 key_expression
             };

--- a/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
+++ b/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
@@ -61,7 +61,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for OptionalCatchBinding {
             SymbolFlags::CatchVariable | SymbolFlags::FunctionScopedVariable,
         );
         let binding_pattern = binding.create_binding_pattern(ctx);
-        let param = ctx.ast.catch_parameter(SPAN, binding_pattern, NONE);
+        let param = CatchParameter::new(SPAN, binding_pattern, NONE, ctx);
         clause.param = Some(param);
     }
 }

--- a/crates/oxc_transformer/src/es2020/export_namespace_from.rs
+++ b/crates/oxc_transformer/src/es2020/export_namespace_from.rs
@@ -25,7 +25,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.28.4/packages/babel-plugin-transform-export-namespace-from>
 //! * "export ns from" TC39 proposal: <https://github.com/tc39/proposal-export-ns-from>
 
-use oxc_allocator::TakeIn;
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::SymbolFlags;
 use oxc_span::SPAN;
@@ -51,7 +51,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExportNamespaceFrom {
             return;
         }
 
-        let mut new_statements = ctx.ast.vec_with_capacity(program.body.len());
+        let mut new_statements = ArenaVec::with_capacity_in(program.body.len(), ctx);
 
         for stmt in program.body.take_in(ctx) {
             match stmt {
@@ -72,19 +72,21 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExportNamespaceFrom {
 
                     // Create `import * as _ns from "mod"`
                     let import_specifier = ImportDeclarationSpecifier::ImportNamespaceSpecifier(
-                        ctx.ast.alloc_import_namespace_specifier(
+                        ImportNamespaceSpecifier::boxed(
                             SPAN,
                             binding.create_binding_identifier(ctx),
+                            ctx,
                         ),
                     );
 
-                    let import_decl = ctx.ast.alloc_import_declaration(
+                    let import_decl = ImportDeclaration::boxed(
                         SPAN,
-                        Some(ctx.ast.vec1(import_specifier)),
+                        Some(ArenaVec::from_value_in(import_specifier, ctx)),
                         source,
                         None,
                         NONE,
                         export_kind,
+                        ctx,
                     );
                     new_statements.push(Statement::ImportDeclaration(import_decl));
 
@@ -92,15 +94,16 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExportNamespaceFrom {
                     let local =
                         ModuleExportName::IdentifierReference(binding.create_read_reference(ctx));
                     let export_specifier =
-                        ctx.ast.export_specifier(span, local, exported_name, export_kind);
+                        ExportSpecifier::new(span, local, exported_name, export_kind, ctx);
 
-                    let export_named_decl = ctx.ast.alloc_export_named_declaration(
+                    let export_named_decl = ExportNamedDeclaration::boxed(
                         span,
                         None,
-                        ctx.ast.vec1(export_specifier),
+                        ArenaVec::from_value_in(export_specifier, ctx),
                         None,
                         export_kind,
                         NONE,
+                        ctx,
                     );
                     new_statements.push(Statement::ExportNamedDeclaration(export_named_decl));
                 }

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -28,7 +28,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-nullish-coalescing-operator>
 //! * Nullish coalescing TC39 proposal: <https://github.com/tc39-transfer/proposal-nullish-coalescing>
 
-use oxc_allocator::{ArenaBox, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{ScopeFlags, SymbolFlags};
 use oxc_span::SPAN;
@@ -75,8 +75,8 @@ impl<'a> NullishCoalescingOperator {
                 let this_span = this.span;
                 return Self::create_conditional_expression(
                     logical_expr.left,
-                    ctx.ast.expression_this(this_span),
-                    ctx.ast.expression_this(this_span),
+                    Expression::new_this_expression(this_span, ctx),
+                    Expression::new_this_expression(this_span, ctx),
                     logical_expr.right,
                     logical_expr.span,
                     ctx,
@@ -123,11 +123,12 @@ impl<'a> NullishCoalescingOperator {
             SymbolFlags::FunctionScopedVariable,
         );
 
-        let assignment = ctx.ast.expression_assignment(
+        let assignment = Expression::new_assignment_expression(
             SPAN,
             AssignmentOperator::Assign,
             binding.create_write_target(ctx),
             logical_expr.left,
+            ctx,
         );
         let mut new_expr = Self::create_conditional_expression(
             assignment,
@@ -142,9 +143,9 @@ impl<'a> NullishCoalescingOperator {
             // Replace `function (a, x = a.b ?? c) {}` to `function (a, x = (() => a.b ?? c)() ){}`
             // so the temporary variable can be injected in correct scope
             let id = binding.create_binding_pattern(ctx);
-            let param = ctx.ast.formal_parameter(
+            let param = FormalParameter::new(
                 SPAN,
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 id,
                 NONE,
                 NONE,
@@ -152,34 +153,49 @@ impl<'a> NullishCoalescingOperator {
                 None,
                 false,
                 false,
+                ctx,
             );
-            let params = ctx.ast.formal_parameters(
+            let params = FormalParameters::new(
                 SPAN,
                 FormalParameterKind::ArrowFormalParameters,
-                ctx.ast.vec1(param),
+                ArenaVec::from_value_in(param, ctx),
                 NONE,
+                ctx,
             );
-            let body = ctx.ast.function_body(
+            let body = FunctionBody::new(
                 SPAN,
-                ctx.ast.vec(),
-                ctx.ast.vec1(ctx.ast.statement_expression(SPAN, new_expr)),
+                ArenaVec::new_in(ctx),
+                ArenaVec::from_value_in(
+                    Statement::new_expression_statement(SPAN, new_expr, ctx),
+                    ctx,
+                ),
+                ctx,
             );
-            let arrow_function = ctx.ast.expression_arrow_function_with_scope_id_and_pure_and_pife(
-                SPAN,
-                true,
-                false,
-                NONE,
-                params,
-                NONE,
-                body,
-                current_scope_id,
-                false,
-                false,
-            );
+            let arrow_function =
+                Expression::new_arrow_function_expression_with_scope_id_and_pure_and_pife(
+                    SPAN,
+                    true,
+                    false,
+                    NONE,
+                    params,
+                    NONE,
+                    body,
+                    current_scope_id,
+                    false,
+                    false,
+                    ctx,
+                );
             // `(x) => x;` -> `((x) => x)();`
-            new_expr = ctx.ast.expression_call(SPAN, arrow_function, NONE, ctx.ast.vec(), false);
+            new_expr = Expression::new_call_expression(
+                SPAN,
+                arrow_function,
+                NONE,
+                ArenaVec::new_in(ctx),
+                false,
+                ctx,
+            );
         } else {
-            ctx.state.var_declarations.insert_var(&binding, ctx.ast);
+            ctx.state.var_declarations.insert_var(&binding, &ctx.ast);
         }
 
         new_expr
@@ -215,11 +231,17 @@ impl<'a> NullishCoalescingOperator {
         ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
         let op = BinaryOperator::StrictInequality;
-        let null = ctx.ast.expression_null_literal(SPAN);
-        let left = ctx.ast.expression_binary(SPAN, assignment, op, null);
-        let right = ctx.ast.expression_binary(SPAN, reference1, op, ctx.ast.void_0(SPAN));
-        let test = ctx.ast.expression_logical(SPAN, left, LogicalOperator::And, right);
+        let null = Expression::new_null_literal(SPAN, ctx);
+        let left = Expression::new_binary_expression(SPAN, assignment, op, null, ctx);
+        let right = Expression::new_binary_expression(
+            SPAN,
+            reference1,
+            op,
+            Expression::new_void_0(SPAN, ctx),
+            ctx,
+        );
+        let test = Expression::new_logical_expression(SPAN, left, LogicalOperator::And, right, ctx);
 
-        ctx.ast.expression_conditional(span, test, reference2, default)
+        Expression::new_conditional_expression(span, test, reference2, default, ctx)
     }
 }

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -49,7 +49,7 @@
 
 use std::mem;
 
-use oxc_allocator::{CloneIn, TakeIn};
+use oxc_allocator::{ArenaVec, CloneIn, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{GetSpan, SPAN, Span};
 use oxc_traverse::{Ancestor, BoundIdentifier, MaybeBoundIdentifier, Traverse};
@@ -140,7 +140,7 @@ impl<'a> OptionalChaining<'a> {
         Argument::from(if let CallContext::Binding(binding) = &self.call_context {
             binding.create_read_expression(ctx)
         } else {
-            ctx.ast.expression_this(SPAN)
+            Expression::new_this_expression(SPAN, ctx)
         })
     }
 
@@ -196,13 +196,25 @@ impl<'a> OptionalChaining<'a> {
         } else {
             BinaryOperator::StrictEquality
         };
-        ctx.ast.expression_binary(SPAN, left, operator, ctx.ast.expression_null_literal(SPAN))
+        Expression::new_binary_expression(
+            SPAN,
+            left,
+            operator,
+            Expression::new_null_literal(SPAN, ctx),
+            ctx,
+        )
     }
 
     /// Return `left === void 0`
     fn wrap_void0_check(left: Expression<'a>, ctx: &TraverseCtx<'a>) -> Expression<'a> {
         let operator = BinaryOperator::StrictEquality;
-        ctx.ast.expression_binary(SPAN, left, operator, ctx.ast.void_0(SPAN))
+        Expression::new_binary_expression(
+            SPAN,
+            left,
+            operator,
+            Expression::new_void_0(SPAN, ctx),
+            ctx,
+        )
     }
 
     /// Return `left1 === null || left2 === void 0`
@@ -223,7 +235,7 @@ impl<'a> OptionalChaining<'a> {
         right: Expression<'a>,
         ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
-        ctx.ast.expression_logical(SPAN, left, LogicalOperator::Or, right)
+        Expression::new_logical_expression(SPAN, left, LogicalOperator::Or, right, ctx)
     }
 
     /// Return `left ? void 0 : alternative`
@@ -238,11 +250,11 @@ impl<'a> OptionalChaining<'a> {
         ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
         let consequent = if is_delete {
-            ctx.ast.expression_boolean_literal(SPAN, true)
+            Expression::new_boolean_literal(SPAN, true, ctx)
         } else {
-            ctx.ast.void_0(SPAN)
+            Expression::new_void_0(SPAN, ctx)
         };
-        ctx.ast.expression_conditional(span, test, consequent, alternate)
+        Expression::new_conditional_expression(span, test, consequent, alternate, ctx)
     }
 
     /// Convert chain expression to expression
@@ -275,7 +287,7 @@ impl<'a> OptionalChaining<'a> {
         right: Expression<'a>,
         ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
-        ctx.ast.expression_assignment(SPAN, AssignmentOperator::Assign, left, right)
+        Expression::new_assignment_expression(SPAN, AssignmentOperator::Assign, left, right, ctx)
     }
 
     /// Transform chain expression
@@ -336,7 +348,8 @@ impl<'a> OptionalChaining<'a> {
         // `delete foo?.bar` -> `... || delete _Foo.bar;`
         //                              ^^^^^^ ^^^^^^^^ Here we will wrap the right part with a `delete` unary expression
         if is_delete {
-            chain_expr = ctx.ast.expression_unary(SPAN, UnaryOperator::Delete, chain_expr);
+            chain_expr =
+                Expression::new_unary_expression(SPAN, UnaryOperator::Delete, chain_expr, ctx);
         }
 
         // If this chain expression is a callee of a CallExpression, we need to transform it to accept a proper context
@@ -387,11 +400,12 @@ impl<'a> OptionalChaining<'a> {
         };
 
         // `expr.bind(context)`
-        let arguments = ctx.ast.vec1(context);
-        let property = ctx.ast.identifier_name(SPAN, "bind");
-        let callee = ctx.ast.member_expression_static(SPAN, expr, property, false);
+        let arguments = ArenaVec::from_value_in(context, ctx);
+        let property = IdentifierName::new(SPAN, "bind", ctx);
+        let callee =
+            MemberExpression::new_static_member_expression(SPAN, expr, property, false, ctx);
         let callee = Expression::from(callee);
-        ctx.ast.expression_call(SPAN, callee, NONE, arguments, false)
+        Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx)
     }
 
     /// Recursively transform chain expression elements
@@ -492,9 +506,10 @@ impl<'a> OptionalChaining<'a> {
                         {
                             // `foo$bar(...)` -> `foo$bar.call(context, ...)`
                             let callee = callee.take_in(ctx);
-                            let property = ctx.ast.identifier_name(SPAN, "call");
-                            let member =
-                                ctx.ast.member_expression_static(SPAN, callee, property, false);
+                            let property = IdentifierName::new(SPAN, "call", ctx);
+                            let member = MemberExpression::new_static_member_expression(
+                                SPAN, callee, property, false, ctx,
+                            );
                             call.callee = Expression::from(member);
                             call.arguments.insert(0, self.get_call_context(ctx));
                         }
@@ -536,10 +551,10 @@ impl<'a> OptionalChaining<'a> {
         {
             if ident.name == "eval" {
                 // `eval?.()` is an indirect eval call transformed to `(0,eval)()`
-                let zero = ctx.ast.number_0();
+                let zero = Expression::new_number_0(ctx);
                 let original_callee = expr.take_in(ctx);
-                let expressions = ctx.ast.vec_from_array([zero, original_callee]);
-                *expr = ctx.ast.expression_sequence(SPAN, expressions);
+                let expressions = ArenaVec::from_array_in([zero, original_callee], ctx);
+                *expr = Expression::new_sequence_expression(SPAN, expressions, ctx);
             }
 
             let left1 = binding.create_read_expression(ctx);

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -126,9 +126,11 @@ impl<'a> LogicalAssignmentOperators {
         let span = assignment_expr.span;
         let assign_op = AssignmentOperator::Assign;
         let right = assignment_expr.right.take_in(ctx);
-        let right = ctx.ast.expression_assignment(SPAN, assign_op, assign_target, right);
+        let right =
+            Expression::new_assignment_expression(SPAN, assign_op, assign_target, right, ctx);
 
-        let logical_expr = ctx.ast.expression_logical(span, left_expr, operator, right);
+        let logical_expr =
+            Expression::new_logical_expression(span, left_expr, operator, right, ctx);
 
         *expr = logical_expr;
     }
@@ -142,7 +144,7 @@ impl<'a> LogicalAssignmentOperators {
         *reference.flags_mut() = ReferenceFlags::Read;
         let symbol_id = reference.symbol_id();
         let left_expr =
-            ctx.ast.expression_identifier_with_reference_id(ident.span, ident.name, reference_id);
+            Expression::new_identifier_with_reference_id(ident.span, ident.name, reference_id, ctx);
 
         let ident = ctx.create_ident_reference(SPAN, ident.name, symbol_id, ReferenceFlags::Write);
         let assign_target = AssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(ident));
@@ -158,18 +160,20 @@ impl<'a> LogicalAssignmentOperators {
         let object = static_expr.object.take_in(ctx);
         let (object, object_ref) = duplicate_expression(object, true, ctx);
 
-        let left_expr = Expression::from(ctx.ast.member_expression_static(
+        let left_expr = Expression::from(MemberExpression::new_static_member_expression(
             static_expr.span,
             object,
             static_expr.property.clone(),
             false,
+            ctx,
         ));
 
-        let assign_expr = ctx.ast.member_expression_static(
+        let assign_expr = MemberExpression::new_static_member_expression(
             static_expr.span,
             object_ref,
             static_expr.property.clone(),
             false,
+            ctx,
         );
         let assign_target = AssignmentTarget::from(assign_expr);
 
@@ -188,19 +192,22 @@ impl<'a> LogicalAssignmentOperators {
         let expression = computed_expr.expression.take_in(ctx);
         let (expression, expression_ref) = duplicate_expression(expression, true, ctx);
 
-        let left_expr = Expression::from(ctx.ast.member_expression_computed(
+        let left_expr = Expression::from(MemberExpression::new_computed_member_expression(
             computed_expr.span,
             object,
             expression,
             false,
+            ctx,
         ));
 
-        let assign_target = AssignmentTarget::from(ctx.ast.member_expression_computed(
-            computed_expr.span,
-            object_ref,
-            expression_ref,
-            false,
-        ));
+        let assign_target =
+            AssignmentTarget::from(MemberExpression::new_computed_member_expression(
+                computed_expr.span,
+                object_ref,
+                expression_ref,
+                false,
+                ctx,
+            ));
 
         (left_expr, assign_target)
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -1,7 +1,7 @@
 //! ES2022: Class Properties
 //! Transform of class itself.
 
-use oxc_allocator::{Address, GetAddress, TakeIn, UnstableAddress};
+use oxc_allocator::{Address, ArenaVec, GetAddress, TakeIn, UnstableAddress};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::SPAN;
 use oxc_str::{Ident, static_ident};
@@ -206,7 +206,7 @@ impl<'a> ClassProperties<'a> {
                 // TODO(improve-on-babel): Inserting the temp var `var _Class` statement here is only
                 // to match Babel's output. It'd be simpler just to insert it at the end and get rid of
                 // `temp_var_is_created` that tracks whether it's done already or not.
-                ctx.state.var_declarations.insert_var(&temp_binding, ctx.ast);
+                ctx.state.var_declarations.insert_var(&temp_binding, &ctx.ast);
             }
             Some(temp_binding)
         } else {
@@ -454,7 +454,7 @@ impl<'a> ClassProperties<'a> {
             if let Some(ident) = &class.id {
                 // Insert `var _Class` statement, if it wasn't already in entry phase
                 if !class_details.bindings.temp_var_is_created {
-                    ctx.state.var_declarations.insert_var(temp_binding, ctx.ast);
+                    ctx.state.var_declarations.insert_var(temp_binding, &ctx.ast);
                 }
 
                 // Insert `_Class = Class` after class.
@@ -463,7 +463,7 @@ impl<'a> ClassProperties<'a> {
                 let class_name =
                     BoundIdentifier::from_binding_ident(ident).create_read_expression(ctx);
                 let expr = create_assignment(temp_binding, class_name, SPAN, ctx);
-                let stmt = ctx.ast.statement_expression(SPAN, expr);
+                let stmt = Statement::new_expression_statement(SPAN, expr, ctx);
                 self.insert_after_stmts.insert(0, stmt);
             } else {
                 // Class must be default export `export default class {}`, as all other class declarations
@@ -484,7 +484,7 @@ impl<'a> ClassProperties<'a> {
         if !self.insert_before.is_empty() {
             ctx.state.statement_injector.insert_many_before(
                 &stmt_address,
-                exprs_into_stmts(self.insert_before.drain(..), ctx.ast),
+                exprs_into_stmts(self.insert_before.drain(..), &ctx.ast),
             );
         }
 
@@ -632,7 +632,7 @@ impl<'a> ClassProperties<'a> {
 
         expr_count += 1 + usize::from(class_details.bindings.temp.is_some());
 
-        let mut exprs = ctx.ast.vec_with_capacity(expr_count);
+        let mut exprs = ArenaVec::with_capacity_in(expr_count, ctx);
 
         // Insert `_prop = new WeakMap()` expressions for private instance props
         // (or `_prop = _classPrivateFieldLooseKey("prop")` if loose mode).
@@ -651,7 +651,7 @@ impl<'a> ClassProperties<'a> {
                     }
 
                     // Insert `var _prop;` declaration
-                    ctx.state.var_declarations.insert_var(&prop.binding, ctx.ast);
+                    ctx.state.var_declarations.insert_var(&prop.binding, &ctx.ast);
 
                     // `_prop = _classPrivateFieldLooseKey("prop")`
                     let value = Self::create_private_prop_key_loose(name, ctx);
@@ -672,13 +672,13 @@ impl<'a> ClassProperties<'a> {
                         has_method = true;
                         // `_C_brand = new WeakSet()`
                         let binding = class_details.bindings.brand();
-                        ctx.state.var_declarations.insert_var(binding, ctx.ast);
+                        ctx.state.var_declarations.insert_var(binding, &ctx.ast);
                         let value = create_new_weakset(ctx);
                         return Some(create_assignment(binding, value, SPAN, ctx));
                     }
 
                     // Insert `var _prop;` declaration
-                    ctx.state.var_declarations.insert_var(&prop.binding, ctx.ast);
+                    ctx.state.var_declarations.insert_var(&prop.binding, &ctx.ast);
 
                     if prop.is_static {
                         return None;
@@ -714,7 +714,7 @@ impl<'a> ClassProperties<'a> {
         if let Some(binding) = &class_details.bindings.temp {
             // Insert `var _Class` statement, if it wasn't already in entry phase
             if !class_details.bindings.temp_var_is_created {
-                ctx.state.var_declarations.insert_var(binding, ctx.ast);
+                ctx.state.var_declarations.insert_var(binding, &ctx.ast);
             }
 
             // `_Class = class {}`
@@ -754,7 +754,7 @@ impl<'a> ClassProperties<'a> {
         debug_assert!(exprs.len() > 1);
         debug_assert!(exprs.len() <= expr_count);
 
-        *expr = ctx.ast.expression_sequence(SPAN, exprs);
+        *expr = Expression::new_sequence_expression(SPAN, exprs, ctx);
     }
 
     /// Transform class elements.
@@ -854,7 +854,10 @@ impl<'a> ClassProperties<'a> {
     fn create_private_prop_key_loose(name: Ident<'a>, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         helper_call_expr(
             Helper::ClassPrivateFieldLooseKey,
-            ctx.ast.vec1(Argument::from(ctx.ast.expression_string_literal(SPAN, name, None))),
+            ArenaVec::from_value_in(
+                Argument::from(Expression::new_string_literal(SPAN, name, None, ctx)),
+                ctx,
+            ),
             ctx,
         )
     }
@@ -862,7 +865,7 @@ impl<'a> ClassProperties<'a> {
     /// Insert an expression after the class.
     pub(super) fn insert_expr_after_class(&mut self, expr: Expression<'a>, ctx: &TraverseCtx<'a>) {
         if self.current_class().is_declaration {
-            self.insert_after_stmts.push(ctx.ast.statement_expression(SPAN, expr));
+            self.insert_after_stmts.push(Statement::new_expression_statement(SPAN, expr, ctx));
         } else {
             self.insert_after_exprs.push(expr);
         }
@@ -888,7 +891,7 @@ fn create_new_weakmap<'a>(
     let symbol_id = *symbol_id
         .get_or_insert_with(|| ctx.scoping().find_binding(ctx.current_scope_id(), weak_map));
     let ident = ctx.create_ident_expr(SPAN, weak_map, symbol_id, ReferenceFlags::Read);
-    ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
+    Expression::new_new_expression_with_pure(SPAN, ident, NONE, ArenaVec::new_in(ctx), true, ctx)
 }
 
 /// Create `new WeakSet()` expression.
@@ -896,5 +899,5 @@ fn create_new_weakset<'a>(ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
     let weak_set = static_ident!("WeakSet");
     let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), weak_set);
     let ident = ctx.create_ident_expr(SPAN, weak_set, symbol_id, ReferenceFlags::Read);
-    ctx.ast.expression_new_with_pure(SPAN, ident, NONE, ctx.ast.vec(), true)
+    Expression::new_new_expression_with_pure(SPAN, ident, NONE, ArenaVec::new_in(ctx), true, ctx)
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -101,7 +101,7 @@
 
 use std::iter;
 
-use oxc_allocator::TakeIn;
+use oxc_allocator::{ArenaVec, TakeIn};
 use rustc_hash::FxHashMap;
 
 use oxc_ast::{NONE, ast::*};
@@ -227,7 +227,7 @@ impl<'a> ClassProperties<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         // Create statements to go in function body
-        let mut stmts = ctx.ast.vec_with_capacity(inits.len() + usize::from(has_super_class));
+        let mut stmts = ArenaVec::with_capacity_in(inits.len() + usize::from(has_super_class), ctx);
 
         // Add `super(..._args);` statement and `..._args` param if class has a super class.
         // `constructor(..._args) { super(..._args); /* prop initialization */ }`
@@ -236,19 +236,29 @@ impl<'a> ClassProperties<'a> {
             let args_binding =
                 ctx.generate_uid("args", constructor_scope_id, SymbolFlags::FunctionScopedVariable);
             let rest_element =
-                ctx.ast.binding_rest_element(SPAN, args_binding.create_binding_pattern(ctx));
-            params_rest =
-                Some(ctx.ast.alloc_formal_parameter_rest(SPAN, ctx.ast.vec(), rest_element, NONE));
-            stmts.push(ctx.ast.statement_expression(SPAN, create_super_call(&args_binding, ctx)));
+                BindingRestElement::new(SPAN, args_binding.create_binding_pattern(ctx), ctx);
+            params_rest = Some(FormalParameterRest::boxed(
+                SPAN,
+                ArenaVec::new_in(ctx),
+                rest_element,
+                NONE,
+                ctx,
+            ));
+            stmts.push(Statement::new_expression_statement(
+                SPAN,
+                create_super_call(&args_binding, ctx),
+                ctx,
+            ));
         }
         // TODO: Should these have the span of the original `PropertyDefinition`s?
-        stmts.extend(exprs_into_stmts(inits, ctx.ast));
+        stmts.extend(exprs_into_stmts(inits, &ctx.ast));
 
-        let params = ctx.ast.alloc_formal_parameters(
+        let params = FormalParameters::boxed(
             SPAN,
             FormalParameterKind::FormalParameter,
-            ctx.ast.vec(),
+            ArenaVec::new_in(ctx),
             params_rest,
+            ctx,
         );
 
         let ctor = create_class_constructor_with_params(stmts, params, constructor_scope_id, ctx);
@@ -270,7 +280,7 @@ impl<'a> ClassProperties<'a> {
 
         // Insert inits into constructor body
         let body_stmts = &mut constructor.body.as_mut().unwrap().statements;
-        body_stmts.splice(insertion_index..insertion_index, exprs_into_stmts(inits, ctx.ast));
+        body_stmts.splice(insertion_index..insertion_index, exprs_into_stmts(inits, &ctx.ast));
     }
 
     /// Create `_super` function containing instance property initializers,
@@ -297,51 +307,70 @@ impl<'a> ClassProperties<'a> {
         let args_binding =
             ctx.generate_uid("args", super_func_scope_id, SymbolFlags::FunctionScopedVariable);
         let super_call = create_super_call(&args_binding, ctx);
-        let this_expr = ctx.ast.expression_this(SPAN);
-        let body_exprs = ctx.ast.expression_sequence(
+        let this_expr = Expression::new_this_expression(SPAN, ctx);
+        let body_exprs = Expression::new_sequence_expression(
             SPAN,
-            ctx.ast.vec_from_iter(iter::once(super_call).chain(inits).chain(iter::once(this_expr))),
+            ArenaVec::from_iter_in(
+                iter::once(super_call).chain(inits).chain(iter::once(this_expr)),
+                ctx,
+            ),
+            ctx,
         );
-        let body = ctx.ast.vec1(ctx.ast.statement_expression(SPAN, body_exprs));
+        let body = ArenaVec::from_value_in(
+            Statement::new_expression_statement(SPAN, body_exprs, ctx),
+            ctx,
+        );
 
         // `(..._args) => (super(..._args), <inits>, this)`
-        let super_func = ctx.ast.expression_arrow_function_with_scope_id_and_pure_and_pife(
+        let super_func = Expression::new_arrow_function_expression_with_scope_id_and_pure_and_pife(
             SPAN,
             true,
             false,
             NONE,
             {
                 let rest_element =
-                    ctx.ast.binding_rest_element(SPAN, args_binding.create_binding_pattern(ctx));
-                let rest =
-                    ctx.ast.alloc_formal_parameter_rest(SPAN, ctx.ast.vec(), rest_element, NONE);
-                ctx.ast.alloc_formal_parameters(
+                    BindingRestElement::new(SPAN, args_binding.create_binding_pattern(ctx), ctx);
+                let rest = FormalParameterRest::boxed(
+                    SPAN,
+                    ArenaVec::new_in(ctx),
+                    rest_element,
+                    NONE,
+                    ctx,
+                );
+                FormalParameters::boxed(
                     SPAN,
                     FormalParameterKind::ArrowFormalParameters,
-                    ctx.ast.vec(),
+                    ArenaVec::new_in(ctx),
                     Some(rest),
+                    ctx,
                 )
             },
             NONE,
-            ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), body),
+            FunctionBody::boxed(SPAN, ArenaVec::new_in(ctx), body, ctx),
             super_func_scope_id,
             false,
             false,
+            ctx,
         );
 
         // `var _super = (..._args) => ( ... );`
-        let super_func_decl = Statement::from(ctx.ast.declaration_variable(
+        let super_func_decl = Statement::from(Declaration::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ctx.ast.vec1(ctx.ast.variable_declarator(
-                SPAN,
-                VariableDeclarationKind::Var,
-                super_binding.create_binding_pattern(ctx),
-                NONE,
-                Some(super_func),
-                false,
-            )),
+            ArenaVec::from_value_in(
+                VariableDeclarator::new(
+                    SPAN,
+                    VariableDeclarationKind::Var,
+                    super_binding.create_binding_pattern(ctx),
+                    NONE,
+                    Some(super_func),
+                    false,
+                    ctx,
+                ),
+                ctx,
+            ),
             false,
+            ctx,
         ));
 
         // Insert at top of function
@@ -363,18 +392,22 @@ impl<'a> ClassProperties<'a> {
         // TODO: This should be parent scope if insert `_super` function as expression before class expression.
         let outer_scope_id = ctx.current_block_scope_id();
         let directives = if ctx.scoping().scope_flags(outer_scope_id).is_strict_mode() {
-            ctx.ast.vec()
+            ArenaVec::new_in(ctx)
         } else {
-            ctx.ast.vec1(ctx.ast.use_strict_directive())
+            ArenaVec::from_value_in(Directive::new_use_strict(ctx), ctx)
         };
 
         // `return this;`
-        let return_stmt = ctx.ast.statement_return(SPAN, Some(ctx.ast.expression_this(SPAN)));
+        let return_stmt = Statement::new_return_statement(
+            SPAN,
+            Some(Expression::new_this_expression(SPAN, ctx)),
+            ctx,
+        );
         // `<inits>; return this;`
         let body_stmts =
-            ctx.ast.vec_from_iter(exprs_into_stmts(inits, ctx.ast).chain([return_stmt]));
+            ArenaVec::from_iter_in(exprs_into_stmts(inits, &ctx.ast).chain([return_stmt]), ctx);
         // `function() { <inits>; return this; }`
-        let super_func = ctx.ast.expression_function_with_scope_id_and_pure_and_pife(
+        let super_func = Expression::new_function_expression_with_scope_id_and_pure_and_pife(
             SPAN,
             FunctionType::FunctionExpression,
             None,
@@ -383,17 +416,19 @@ impl<'a> ClassProperties<'a> {
             false,
             NONE,
             NONE,
-            ctx.ast.alloc_formal_parameters(
+            FormalParameters::boxed(
                 SPAN,
                 FormalParameterKind::FormalParameter,
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 NONE,
+                ctx,
             ),
             NONE,
-            Some(ctx.ast.alloc_function_body(SPAN, directives, body_stmts)),
+            Some(FunctionBody::boxed(SPAN, directives, body_stmts, ctx)),
             super_func_scope_id,
             false,
             false,
+            ctx,
         );
 
         // Insert `_super` function after class.
@@ -412,7 +447,7 @@ impl<'a> ClassProperties<'a> {
             self.insert_after_exprs.push(assignment);
             None
         };
-        ctx.state.var_declarations.insert_let(super_binding, init, ctx.ast);
+        ctx.state.var_declarations.insert_let(super_binding, init, &ctx.ast);
     }
 
     /// Rename any symbols in constructor which clash with symbols used in initializers
@@ -578,17 +613,19 @@ impl<'a> ConstructorParamsSuperReplacer<'a, '_> {
 
         let ctx = &mut *self.ctx;
         let super_call = expr.take_in(ctx);
-        *expr = ctx.ast.expression_call(
+        *expr = Expression::new_call_expression(
             span,
-            Expression::from(ctx.ast.member_expression_static(
+            Expression::from(MemberExpression::new_static_member_expression(
                 SPAN,
                 super_binding.create_read_expression(ctx),
-                ctx.ast.identifier_name(SPAN, "call"),
+                IdentifierName::new(SPAN, "call", ctx),
                 false,
+                ctx,
             )),
             NONE,
-            ctx.ast.vec1(Argument::from(super_call)),
+            ArenaVec::from_value_in(Argument::from(super_call), ctx),
             false,
+            ctx,
         );
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -3,7 +3,7 @@
 
 use std::mem;
 
-use oxc_allocator::{ArenaBox, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::SPAN;
 use oxc_str::static_ident;
@@ -295,12 +295,13 @@ impl<'a> ClassProperties<'a> {
         ctx: &TraverseCtx<'a>,
     ) {
         // Substitute `<callee>.call` as callee of call expression
-        call_expr.callee = Expression::from(ctx.ast.member_expression_static(
+        call_expr.callee = Expression::from(MemberExpression::new_static_member_expression(
             SPAN,
             callee,
-            ctx.ast.identifier_name(SPAN, "call"),
+            IdentifierName::new(SPAN, "call", ctx),
             // Make sure the `callee` can access `call` safely. i.e `callee?.()` -> `callee?.call()`
             mem::replace(&mut call_expr.optional, false),
+            ctx,
         ));
         // Insert `context` to call arguments
         call_expr.arguments.insert(0, Argument::from(context));
@@ -633,14 +634,16 @@ impl<'a> ClassProperties<'a> {
                     // `Class.#prop += value` -> `_prop._ = _prop._ + value`
                     let value = assign_expr.right.take_in(ctx);
                     assign_expr.operator = AssignmentOperator::Assign;
-                    assign_expr.right = ctx.ast.expression_binary(SPAN, prop_obj, operator, value);
+                    assign_expr.right =
+                        Expression::new_binary_expression(SPAN, prop_obj, operator, value, ctx);
                 } else if let Some(operator) = operator.to_logical_operator() {
                     // `Class.#prop &&= value` -> `_prop._ && (_prop._ = value)`
                     let span = assign_expr.span;
                     assign_expr.span = SPAN;
                     assign_expr.operator = AssignmentOperator::Assign;
                     let right = expr.take_in(ctx);
-                    *expr = ctx.ast.expression_logical(span, prop_obj, operator, right);
+                    *expr =
+                        Expression::new_logical_expression(span, prop_obj, operator, right, ctx);
                 } else {
                     // The above covers all types of `AssignmentOperator`
                     unreachable!();
@@ -692,7 +695,8 @@ impl<'a> ClassProperties<'a> {
                         ctx,
                     );
                     // `_assertClassBrand(Class, object, _prop)._ + value`
-                    let value = ctx.ast.expression_binary(SPAN, get_expr, operator, value);
+                    let value =
+                        Expression::new_binary_expression(SPAN, get_expr, operator, value, ctx);
                     // `_assertClassBrand(Class, object, _assertClassBrand(Class, object, _prop)._ + value)`
                     assign_expr.right =
                         self.create_assert_class_brand(class_ident2, object1, value, SPAN, ctx);
@@ -720,7 +724,7 @@ impl<'a> ClassProperties<'a> {
                         self.create_assert_class_brand(class_ident2, object2, value, SPAN, ctx);
                     let right = expr.take_in(ctx);
                     // `_assertClassBrand(Class, object, _prop)._ && (_prop._ = _assertClassBrand(Class, object, value))`
-                    *expr = ctx.ast.expression_logical(span, left, operator, right);
+                    *expr = Expression::new_logical_expression(span, left, operator, right, ctx);
                 } else {
                     // The above covers all types of `AssignmentOperator`
                     unreachable!();
@@ -788,7 +792,7 @@ impl<'a> ClassProperties<'a> {
                 );
 
                 // `_classPrivateFieldGet2(_prop, object) + value`
-                let value = ctx.ast.expression_binary(SPAN, get_call, operator, value);
+                let value = Expression::new_binary_expression(SPAN, get_call, operator, value, ctx);
 
                 // `_classPrivateFieldSet2(_prop, object, _classPrivateFieldGet2(_prop, object) + value)`
                 *expr = self.create_private_setter(
@@ -825,7 +829,7 @@ impl<'a> ClassProperties<'a> {
                     ctx,
                 );
                 // `_classPrivateFieldGet2(_prop, object) && _classPrivateFieldSet2(_prop, object, value)`
-                *expr = ctx.ast.expression_logical(span, get_call, operator, set_call);
+                *expr = Expression::new_logical_expression(span, get_call, operator, set_call, ctx);
             } else {
                 // The above covers all types of `AssignmentOperator`
                 unreachable!();
@@ -1025,9 +1029,11 @@ impl<'a> ClassProperties<'a> {
                 // Source = `++object.#prop` (prefix `++`)
 
                 // `(_object$prop = _assertClassBrand(Class, object, _prop)._, ++_object$prop)`
-                let mut value = ctx
-                    .ast
-                    .expression_sequence(SPAN, ctx.ast.vec_from_array([assignment, update_expr]));
+                let mut value = Expression::new_sequence_expression(
+                    SPAN,
+                    ArenaVec::from_array_in([assignment, update_expr], ctx),
+                    ctx,
+                );
 
                 // If no shortcut, wrap in `_assertClassBrand(Class, object, <value>)`
                 if let Some(class_ident) = class_ident {
@@ -1035,11 +1041,12 @@ impl<'a> ClassProperties<'a> {
                 }
 
                 // `_prop._ = <value>`
-                *expr = ctx.ast.expression_assignment(
+                *expr = Expression::new_assignment_expression(
                     span,
                     AssignmentOperator::Assign,
                     Self::create_underscore_member_expr_target(prop_ident2, SPAN, ctx),
                     value,
+                    ctx,
                 );
             } else {
                 // Source = `object.#prop++` (postfix `++`)
@@ -1049,13 +1056,13 @@ impl<'a> ClassProperties<'a> {
                 let assignment2 = create_assignment(&temp_binding2, update_expr, SPAN, ctx);
 
                 // `(_object$prop = _assertClassBrand(Class, object, _prop)._, _object$prop2 = _object$prop++, _object$prop)`
-                let mut value = ctx.ast.expression_sequence(
+                let mut value = Expression::new_sequence_expression(
                     SPAN,
-                    ctx.ast.vec_from_array([
-                        assignment,
-                        assignment2,
-                        temp_binding.create_read_expression(ctx),
-                    ]),
+                    ArenaVec::from_array_in(
+                        [assignment, assignment2, temp_binding.create_read_expression(ctx)],
+                        ctx,
+                    ),
+                    ctx,
                 );
 
                 // If no shortcut, wrap in `_assertClassBrand(Class, object, <value>)`
@@ -1064,20 +1071,24 @@ impl<'a> ClassProperties<'a> {
                 }
 
                 // `_prop._ = <value>`
-                let assignment3 = ctx.ast.expression_assignment(
+                let assignment3 = Expression::new_assignment_expression(
                     SPAN,
                     AssignmentOperator::Assign,
                     Self::create_underscore_member_expr_target(prop_ident2, SPAN, ctx),
                     value,
+                    ctx,
                 );
 
                 // `(_prop._ = <value>, _object$prop2)`
                 // TODO(improve-on-babel): Final `_object$prop2` is only needed if this expression
                 // is consumed (i.e. not in an `ExpressionStatement`)
-                *expr = ctx.ast.expression_sequence(
+                *expr = Expression::new_sequence_expression(
                     span,
-                    ctx.ast
-                        .vec_from_array([assignment3, temp_binding2.create_read_expression(ctx)]),
+                    ArenaVec::from_array_in(
+                        [assignment3, temp_binding2.create_read_expression(ctx)],
+                        ctx,
+                    ),
+                    ctx,
                 );
             }
         } else {
@@ -1120,9 +1131,11 @@ impl<'a> ClassProperties<'a> {
             if prefix {
                 // Source = `++object.#prop` (prefix `++`)
                 // `(_object$prop = _classPrivateFieldGet(_prop, object), ++_object$prop)`
-                let value = ctx
-                    .ast
-                    .expression_sequence(SPAN, ctx.ast.vec_from_array([assignment, update_expr]));
+                let value = Expression::new_sequence_expression(
+                    SPAN,
+                    ArenaVec::from_array_in([assignment, update_expr], ctx),
+                    ctx,
+                );
                 // `_classPrivateFieldSet(_prop, object, <value>)`
                 *expr = self.create_private_setter(
                     &private_name,
@@ -1140,13 +1153,13 @@ impl<'a> ClassProperties<'a> {
                 let assignment2 = create_assignment(&temp_binding2, update_expr, SPAN, ctx);
 
                 // `(_object$prop = _classPrivateFieldGet(_prop, object), _object$prop2 = _object$prop++, _object$prop)`
-                let value = ctx.ast.expression_sequence(
+                let value = Expression::new_sequence_expression(
                     SPAN,
-                    ctx.ast.vec_from_array([
-                        assignment,
-                        assignment2,
-                        temp_binding.create_read_expression(ctx),
-                    ]),
+                    ArenaVec::from_array_in(
+                        [assignment, assignment2, temp_binding.create_read_expression(ctx)],
+                        ctx,
+                    ),
+                    ctx,
                 );
 
                 // `_classPrivateFieldSet(_prop, object, <value>)`
@@ -1162,9 +1175,13 @@ impl<'a> ClassProperties<'a> {
                 // `(_classPrivateFieldSet(_prop, object, <value>), _object$prop2)`
                 // TODO(improve-on-babel): Final `_object$prop2` is only needed if this expression
                 // is consumed (i.e. not in an `ExpressionStatement`)
-                *expr = ctx.ast.expression_sequence(
+                *expr = Expression::new_sequence_expression(
                     span,
-                    ctx.ast.vec_from_array([set_call, temp_binding2.create_read_expression(ctx)]),
+                    ArenaVec::from_array_in(
+                        [set_call, temp_binding2.create_read_expression(ctx)],
+                        ctx,
+                    ),
+                    ctx,
                 );
             }
         }
@@ -1488,7 +1505,7 @@ impl<'a> ClassProperties<'a> {
                 }
                 _ => unreachable!(),
             };
-            ctx.ast.expression_chain(SPAN, chain_element)
+            Expression::new_chain_expression(SPAN, chain_element, ctx)
         } else {
             expr
         }
@@ -1603,13 +1620,25 @@ impl<'a> ClassProperties<'a> {
         } else {
             BinaryOperator::StrictEquality
         };
-        ctx.ast.expression_binary(SPAN, left, operator, ctx.ast.expression_null_literal(SPAN))
+        Expression::new_binary_expression(
+            SPAN,
+            left,
+            operator,
+            Expression::new_null_literal(SPAN, ctx),
+            ctx,
+        )
     }
 
     /// Returns `left === void 0`
     fn wrap_void0_check(left: Expression<'a>, ctx: &TraverseCtx<'a>) -> Expression<'a> {
         let operator = BinaryOperator::StrictEquality;
-        ctx.ast.expression_binary(SPAN, left, operator, ctx.ast.void_0(SPAN))
+        Expression::new_binary_expression(
+            SPAN,
+            left,
+            operator,
+            Expression::new_void_0(SPAN, ctx),
+            ctx,
+        )
     }
 
     /// Returns `left1 === null || left2 === void 0`
@@ -1624,7 +1653,13 @@ impl<'a> ClassProperties<'a> {
             null_check
         } else {
             let void0_check = Self::wrap_void0_check(left2, ctx);
-            ctx.ast.expression_logical(SPAN, null_check, LogicalOperator::Or, void0_check)
+            Expression::new_logical_expression(
+                SPAN,
+                null_check,
+                LogicalOperator::Or,
+                void0_check,
+                ctx,
+            )
         }
     }
 
@@ -1634,7 +1669,13 @@ impl<'a> ClassProperties<'a> {
         alternative: Expression<'a>,
         ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
-        ctx.ast.expression_conditional(SPAN, test, ctx.ast.void_0(SPAN), alternative)
+        Expression::new_conditional_expression(
+            SPAN,
+            test,
+            Expression::new_void_0(SPAN, ctx),
+            alternative,
+            ctx,
+        )
     }
 
     /// Transform chain expression inside unary expression.
@@ -1681,15 +1722,16 @@ impl<'a> ClassProperties<'a> {
         if let Some((result, chain_expr)) =
             self.transform_chain_expression_impl(&mut unary_expr.argument, ctx)
         {
-            *expr = ctx.ast.expression_conditional(
+            *expr = Expression::new_conditional_expression(
                 unary_expr.span,
                 result,
-                ctx.ast.expression_boolean_literal(SPAN, true),
+                Expression::new_boolean_literal(SPAN, true, ctx),
                 {
                     // We still need this unary expr, but it needs to be used as the alternative of the conditional
                     unary_expr.argument = chain_expr;
                     expr.take_in(ctx)
                 },
+                ctx,
             );
         }
     }
@@ -1769,14 +1811,15 @@ impl<'a> ClassProperties<'a> {
         let (callee, context) = self.transform_private_field_callee(field_expr, ctx);
 
         // Return `<callee>.bind(object)`, to be substituted as tag of tagged template expression
-        let callee = Expression::from(ctx.ast.member_expression_static(
+        let callee = Expression::from(MemberExpression::new_static_member_expression(
             SPAN,
             callee,
-            ctx.ast.identifier_name(SPAN, "bind"),
+            IdentifierName::new(SPAN, "bind", ctx),
             false,
+            ctx,
         ));
-        let arguments = ctx.ast.vec1(Argument::from(context));
-        ctx.ast.expression_call(field_expr.span, callee, NONE, arguments, false)
+        let arguments = ArenaVec::from_value_in(Argument::from(context), ctx);
+        Expression::new_call_expression(field_expr.span, callee, NONE, arguments, false, ctx)
     }
 
     /// Transform private field in assignment pattern.
@@ -1858,11 +1901,12 @@ impl<'a> ClassProperties<'a> {
             let class_binding = class_bindings.get_or_init_static_binding(ctx);
             let class_ident = class_binding.create_read_expression(ctx);
             let left = self.create_check_in_rhs(right, ctx);
-            return ctx.ast.expression_binary(
+            return Expression::new_binary_expression(
                 span,
                 left,
                 BinaryOperator::StrictEquality,
                 class_ident,
+                ctx,
             );
         }
 
@@ -1873,7 +1917,14 @@ impl<'a> ClassProperties<'a> {
         };
         let callee = create_member_callee(callee, static_ident!("has"), span, ctx);
         let argument = self.create_check_in_rhs(right, ctx);
-        ctx.ast.expression_call(span, callee, NONE, ctx.ast.vec1(Argument::from(argument)), false)
+        Expression::new_call_expression(
+            span,
+            callee,
+            NONE,
+            ArenaVec::from_value_in(Argument::from(argument), ctx),
+            false,
+            ctx,
+        )
     }
 
     /// Duplicate object to be used in get/set pair.
@@ -1928,17 +1979,18 @@ impl<'a> ClassProperties<'a> {
     ) -> MemberExpression<'a> {
         let call_expr = helper_call_expr(
             Helper::ClassPrivateFieldLooseBase,
-            ctx.ast.vec_from_array([
-                Argument::from(object),
-                Argument::from(prop_binding.create_read_expression(ctx)),
-            ]),
+            ArenaVec::from_array_in(
+                [Argument::from(object), Argument::from(prop_binding.create_read_expression(ctx))],
+                ctx,
+            ),
             ctx,
         );
-        ctx.ast.member_expression_computed(
+        MemberExpression::new_computed_member_expression(
             span,
             call_expr,
             prop_binding.create_read_expression(ctx),
             false,
+            ctx,
         )
     }
 
@@ -1952,7 +2004,7 @@ impl<'a> ClassProperties<'a> {
     ) -> Expression<'a> {
         helper_call_expr(
             Helper::ClassPrivateFieldGet2,
-            ctx.ast.vec_from_array([Argument::from(prop_ident), Argument::from(object)]),
+            ArenaVec::from_array_in([Argument::from(prop_ident), Argument::from(object)], ctx),
             ctx,
         )
     }
@@ -1968,11 +2020,10 @@ impl<'a> ClassProperties<'a> {
     ) -> Expression<'a> {
         helper_call_expr(
             Helper::ClassPrivateFieldSet2,
-            ctx.ast.vec_from_array([
-                Argument::from(prop_ident),
-                Argument::from(object),
-                Argument::from(value),
-            ]),
+            ArenaVec::from_array_in(
+                [Argument::from(prop_ident), Argument::from(object), Argument::from(value)],
+                ctx,
+            ),
             ctx,
         )
     }
@@ -1986,17 +2037,21 @@ impl<'a> ClassProperties<'a> {
         span: Span,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let arguments = ctx.ast.expression_array(
+        let arguments = Expression::new_array_expression(
             SPAN,
-            ctx.ast.vec_from_array([
-                ArrayExpressionElement::from(prop_ident),
-                ArrayExpressionElement::from(object),
-            ]),
+            ArenaVec::from_array_in(
+                [ArrayExpressionElement::from(prop_ident), ArrayExpressionElement::from(object)],
+                ctx,
+            ),
+            ctx,
         );
-        let arguments = ctx.ast.vec_from_array([
-            Argument::from(helper_load(Helper::ClassPrivateFieldSet2, ctx)),
-            Argument::from(arguments),
-        ]);
+        let arguments = ArenaVec::from_array_in(
+            [
+                Argument::from(helper_load(Helper::ClassPrivateFieldSet2, ctx)),
+                Argument::from(arguments),
+            ],
+            ctx,
+        );
         let call = helper_call_expr(Helper::ToSetter, arguments, ctx);
         Self::create_underscore_member_expression(call, span, ctx)
     }
@@ -2011,7 +2066,7 @@ impl<'a> ClassProperties<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let prop_call = create_bind_call(prop_ident, object, span, ctx);
-        let arguments = ctx.ast.vec_from_array([Argument::from(prop_call)]);
+        let arguments = ArenaVec::from_array_in([Argument::from(prop_call)], ctx);
         let call = helper_call_expr(Helper::ToSetter, arguments, ctx);
         Self::create_underscore_member_expression(call, span, ctx)
     }
@@ -2028,11 +2083,14 @@ impl<'a> ClassProperties<'a> {
     ) -> Expression<'a> {
         helper_call_expr(
             Helper::AssertClassBrand,
-            ctx.ast.vec_from_array([
-                Argument::from(class_ident),
-                Argument::from(object),
-                Argument::from(value_or_prop_ident),
-            ]),
+            ArenaVec::from_array_in(
+                [
+                    Argument::from(class_ident),
+                    Argument::from(object),
+                    Argument::from(value_or_prop_ident),
+                ],
+                ctx,
+            ),
             ctx,
         )
     }
@@ -2046,7 +2104,7 @@ impl<'a> ClassProperties<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let arguments =
-            ctx.ast.vec_from_array([Argument::from(class_ident), Argument::from(object)]);
+            ArenaVec::from_array_in([Argument::from(class_ident), Argument::from(object)], ctx);
         helper_call_expr(Helper::AssertClassBrand, arguments, ctx)
     }
 
@@ -2087,7 +2145,13 @@ impl<'a> ClassProperties<'a> {
         span: Span,
         ctx: &TraverseCtx<'a>,
     ) -> MemberExpression<'a> {
-        ctx.ast.member_expression_static(span, object, create_underscore_ident_name(ctx), false)
+        MemberExpression::new_static_member_expression(
+            span,
+            object,
+            create_underscore_ident_name(ctx),
+            false,
+            ctx,
+        )
     }
 
     /// * Getter: `_prop.call(_assertClassBrand(Class, object))`
@@ -2145,10 +2209,11 @@ impl<'a> ClassProperties<'a> {
         if let Some(class_binding) = class_binding {
             let class_ident = class_binding.create_read_expression(ctx);
             let object = self.create_assert_class_brand_without_value(class_ident, object, ctx);
-            let arguments = ctx.ast.vec_from_array([Argument::from(object), Argument::from(value)]);
+            let arguments =
+                ArenaVec::from_array_in([Argument::from(object), Argument::from(value)], ctx);
             let callee = create_member_callee(prop_ident, static_ident!("call"), span, ctx);
             // `_prop.call(_assertClassBrand(Class, object), value)`
-            ctx.ast.expression_call(span, callee, NONE, arguments, false)
+            Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
         } else {
             // `_privateFieldSet(_prop, object, value)`
             self.create_private_field_set(prop_ident, object, value, ctx)
@@ -2164,9 +2229,9 @@ impl<'a> ClassProperties<'a> {
         private_name: &str,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let message = ctx.ast.str_from_strs_array(["#", private_name]);
-        let message = ctx.ast.expression_string_literal(SPAN, message, None);
-        helper_call_expr(helper, ctx.ast.vec1(Argument::from(message)), ctx)
+        let message = Str::from_strs_array_in(["#", private_name], ctx);
+        let message = Expression::new_string_literal(SPAN, message, None, ctx);
+        helper_call_expr(helper, ArenaVec::from_value_in(Argument::from(message), ctx), ctx)
     }
 
     /// `object, value, _readOnlyError("#method")`
@@ -2181,11 +2246,11 @@ impl<'a> ClassProperties<'a> {
         let has_value = value.is_some();
         let error = self.create_throw_error(Helper::ReadOnlyError, private_name, ctx);
         let expressions = if let Some(value) = value {
-            ctx.ast.vec_from_array([object, value, error])
+            ArenaVec::from_array_in([object, value, error], ctx)
         } else {
-            ctx.ast.vec_from_array([object, error])
+            ArenaVec::from_array_in([object, error], ctx)
         };
-        let expr = ctx.ast.expression_sequence(span, expressions);
+        let expr = Expression::new_sequence_expression(span, expressions, ctx);
         if has_value {
             expr
         } else {
@@ -2202,8 +2267,8 @@ impl<'a> ClassProperties<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let error = self.create_throw_error(Helper::WriteOnlyError, private_name, ctx);
-        let expressions = ctx.ast.vec_from_array([object, error]);
-        ctx.ast.expression_sequence(span, expressions)
+        let expressions = ArenaVec::from_array_in([object, error], ctx);
+        Expression::new_sequence_expression(span, expressions, ctx)
     }
 
     /// _checkInRHS(object)
@@ -2213,6 +2278,10 @@ impl<'a> ClassProperties<'a> {
         object: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        helper_call_expr(Helper::CheckInRHS, ctx.ast.vec1(Argument::from(object)), ctx)
+        helper_call_expr(
+            Helper::CheckInRHS,
+            ArenaVec::from_value_in(Argument::from(object), ctx),
+            ctx,
+        )
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -3,7 +3,7 @@
 
 use std::cell::Cell;
 
-use oxc_allocator::TakeIn;
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::ast::*;
 use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_semantic::{ScopeFlags, ScopeId};
@@ -97,10 +97,13 @@ impl<'a> ClassProperties<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let brand = self.classes_stack.last().bindings.brand.as_ref().unwrap();
-        let arguments = ctx.ast.vec_from_array([
-            Argument::from(ctx.ast.expression_this(SPAN)),
-            Argument::from(brand.create_read_expression(ctx)),
-        ]);
+        let arguments = ArenaVec::from_array_in(
+            [
+                Argument::from(Expression::new_this_expression(SPAN, ctx)),
+                Argument::from(brand.create_read_expression(ctx)),
+            ],
+            ctx,
+        );
         helper_call_expr(Helper::ClassPrivateMethodInitSpec, arguments, ctx)
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -1,6 +1,7 @@
 //! ES2022: Class Properties
 //! Transform of class property declarations (instance or static properties).
 
+use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{SPAN, Span};
 use oxc_str::static_ident;
@@ -32,7 +33,7 @@ impl<'a> ClassProperties<'a> {
 
         let span = prop.span;
         let init_expr = if let PropertyKey::PrivateIdentifier(ident) = &mut prop.key {
-            let value = value.unwrap_or_else(|| ctx.ast.void_0(SPAN));
+            let value = value.unwrap_or_else(|| Expression::new_void_0(SPAN, ctx));
             self.create_private_instance_init_assignment(ident, value, span, ctx)
         } else {
             let value = match value {
@@ -46,11 +47,11 @@ impl<'a> ClassProperties<'a> {
                 {
                     return;
                 }
-                None => ctx.ast.void_0(SPAN),
+                None => Expression::new_void_0(SPAN, ctx),
             };
 
             // Convert to assignment or `_defineProperty` call, depending on `loose` option
-            let this = ctx.ast.expression_this(SPAN);
+            let this = Expression::new_this_expression(SPAN, ctx);
             self.create_init_assignment(prop, value, this, false, ctx)
         };
         instance_inits.push(init_expr);
@@ -68,7 +69,7 @@ impl<'a> ClassProperties<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         if self.private_fields_as_properties {
-            let this = ctx.ast.expression_this(SPAN);
+            let this = Expression::new_this_expression(SPAN, ctx);
             self.create_private_init_assignment_loose(ident, value, this, span, ctx)
         } else {
             self.create_private_instance_init_assignment_not_loose(ident, value, ctx)
@@ -84,11 +85,14 @@ impl<'a> ClassProperties<'a> {
     ) -> Expression<'a> {
         let private_props = self.current_class().private_props.as_ref().unwrap();
         let prop = &private_props[&ident.name];
-        let arguments = ctx.ast.vec_from_array([
-            Argument::from(ctx.ast.expression_this(SPAN)),
-            Argument::from(prop.binding.create_read_expression(ctx)),
-            Argument::from(value),
-        ]);
+        let arguments = ArenaVec::from_array_in(
+            [
+                Argument::from(Expression::new_this_expression(SPAN, ctx)),
+                Argument::from(prop.binding.create_read_expression(ctx)),
+                Argument::from(value),
+            ],
+            ctx,
+        );
         helper_call_expr(Helper::ClassPrivateFieldInitSpec, arguments, ctx)
     }
 }
@@ -112,7 +116,7 @@ impl<'a> ClassProperties<'a> {
 
         let span = prop.span;
         if let PropertyKey::PrivateIdentifier(ident) = &mut prop.key {
-            let value = value.unwrap_or_else(|| ctx.ast.void_0(SPAN));
+            let value = value.unwrap_or_else(|| Expression::new_void_0(SPAN, ctx));
             self.insert_private_static_init_assignment(ident, value, span, ctx);
         } else {
             let value = match value {
@@ -126,7 +130,7 @@ impl<'a> ClassProperties<'a> {
                 {
                     return self.extract_computed_key(prop, ctx);
                 }
-                None => ctx.ast.void_0(SPAN),
+                None => Expression::new_void_0(SPAN, ctx),
             };
 
             // Convert to assignment or `_defineProperty` call, depending on `loose` option
@@ -205,16 +209,18 @@ impl<'a> ClassProperties<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         // `_prop = {_: value}`
-        let property = ctx.ast.object_property_kind_object_property(
+        let property = ObjectPropertyKind::new_object_property(
             SPAN,
             PropertyKind::Init,
-            PropertyKey::StaticIdentifier(ctx.ast.alloc(create_underscore_ident_name(ctx))),
+            PropertyKey::StaticIdentifier(ArenaBox::new_in(create_underscore_ident_name(ctx), ctx)),
             value,
             false,
             false,
             false,
+            ctx,
         );
-        let obj = ctx.ast.expression_object(SPAN, ctx.ast.vec1(property));
+        let obj =
+            Expression::new_object_expression(SPAN, ArenaVec::from_value_in(property, ctx), ctx);
 
         // Insert after class
         let class_details = self.current_class();
@@ -274,7 +280,13 @@ impl<'a> ClassProperties<'a> {
                     return self
                         .create_init_assignment_not_loose(prop, value, assignee, is_static, ctx);
                 }
-                ctx.ast.member_expression_static(SPAN, assignee, ident.as_ref().clone(), false)
+                MemberExpression::new_static_member_expression(
+                    SPAN,
+                    assignee,
+                    ident.as_ref().clone(),
+                    false,
+                    ctx,
+                )
             }
             PropertyKey::StringLiteral(str_lit) if needs_define(&str_lit.value) => {
                 return self
@@ -287,7 +299,7 @@ impl<'a> ClassProperties<'a> {
                 // No temp var is created for these.
                 // TODO: Any other possible static key types?
                 let key = self.create_computed_key_temp_var_if_required(key, is_static, ctx);
-                ctx.ast.member_expression_computed(SPAN, assignee, key, false)
+                MemberExpression::new_computed_member_expression(SPAN, assignee, key, false, ctx)
             }
             PropertyKey::PrivateIdentifier(_) => {
                 // Handled in `convert_instance_property` and `convert_static_property`
@@ -295,11 +307,12 @@ impl<'a> ClassProperties<'a> {
             }
         };
 
-        ctx.ast.expression_assignment(
+        Expression::new_assignment_expression(
             prop.span,
             AssignmentOperator::Assign,
             AssignmentTarget::from(left),
             value,
+            ctx,
         )
     }
 
@@ -314,7 +327,7 @@ impl<'a> ClassProperties<'a> {
     ) -> Expression<'a> {
         let key = match &mut prop.key {
             PropertyKey::StaticIdentifier(ident) => {
-                ctx.ast.expression_string_literal(ident.span, ident.name, None)
+                Expression::new_string_literal(ident.span, ident.name, None, ctx)
             }
             key @ match_expression!(PropertyKey) => {
                 let key = key.to_expression_mut();
@@ -330,11 +343,10 @@ impl<'a> ClassProperties<'a> {
             }
         };
 
-        let arguments = ctx.ast.vec_from_array([
-            Argument::from(assignee),
-            Argument::from(key),
-            Argument::from(value),
-        ]);
+        let arguments = ArenaVec::from_array_in(
+            [Argument::from(assignee), Argument::from(key), Argument::from(value)],
+            ctx,
+        );
         helper_call_expr(Helper::DefineProperty, arguments, ctx)
     }
 
@@ -352,42 +364,52 @@ impl<'a> ClassProperties<'a> {
         let object_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), object_name);
         let object =
             ctx.create_ident_expr(SPAN, object_name, object_symbol_id, ReferenceFlags::Read);
-        let property = ctx.ast.identifier_name(SPAN, "defineProperty");
-        let callee =
-            Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false));
+        let property = IdentifierName::new(SPAN, "defineProperty", ctx);
+        let callee = Expression::from(MemberExpression::new_static_member_expression(
+            SPAN, object, property, false, ctx,
+        ));
 
         // `{writable: true, value: <value>}`
-        let prop_def = ctx.ast.expression_object(
+        let prop_def = Expression::new_object_expression(
             SPAN,
-            ctx.ast.vec_from_array([
-                ctx.ast.object_property_kind_object_property(
-                    SPAN,
-                    PropertyKind::Init,
-                    ctx.ast.property_key_static_identifier(SPAN, "writable"),
-                    ctx.ast.expression_boolean_literal(SPAN, true),
-                    false,
-                    false,
-                    false,
-                ),
-                ctx.ast.object_property_kind_object_property(
-                    SPAN,
-                    PropertyKind::Init,
-                    ctx.ast.property_key_static_identifier(SPAN, "value"),
-                    value,
-                    false,
-                    false,
-                    false,
-                ),
-            ]),
+            ArenaVec::from_array_in(
+                [
+                    ObjectPropertyKind::new_object_property(
+                        SPAN,
+                        PropertyKind::Init,
+                        PropertyKey::new_static_identifier(SPAN, "writable", ctx),
+                        Expression::new_boolean_literal(SPAN, true, ctx),
+                        false,
+                        false,
+                        false,
+                        ctx,
+                    ),
+                    ObjectPropertyKind::new_object_property(
+                        SPAN,
+                        PropertyKind::Init,
+                        PropertyKey::new_static_identifier(SPAN, "value", ctx),
+                        value,
+                        false,
+                        false,
+                        false,
+                        ctx,
+                    ),
+                ],
+                ctx,
+            ),
+            ctx,
         );
 
         let private_props = self.current_class().private_props.as_ref().unwrap();
         let prop_binding = &private_props[&ident.name].binding;
-        let arguments = ctx.ast.vec_from_array([
-            Argument::from(assignee),
-            Argument::from(prop_binding.create_read_expression(ctx)),
-            Argument::from(prop_def),
-        ]);
-        ctx.ast.expression_call(span, callee, NONE, arguments, false)
+        let arguments = ArenaVec::from_array_in(
+            [
+                Argument::from(assignee),
+                Argument::from(prop_binding.create_read_expression(ctx)),
+                Argument::from(prop_def),
+            ],
+            ctx,
+        );
+        Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
@@ -260,7 +260,7 @@ impl<'a> VisitMut<'a> for StaticVisitor<'a, '_> {
                     && meta_property.meta.name == "new"
                     && meta_property.property.name == "target" =>
             {
-                *expr = self.ctx.ast.void_0(meta_property.span);
+                *expr = Expression::new_void_0(meta_property.span, self.ctx);
                 return;
             }
             // `delete this`
@@ -538,7 +538,7 @@ impl<'a> StaticVisitor<'a, '_> {
     /// Replace `delete this` with `true`.
     fn replace_delete_this_with_true(&self, expr: &mut Expression<'a>, span: Span) {
         if self.this_depth == 0 {
-            *expr = self.ctx.ast.expression_boolean_literal(span, true);
+            *expr = Expression::new_boolean_literal(span, true, self.ctx);
         }
     }
 

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -65,7 +65,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let property = &member.property;
-        let property = ctx.ast.expression_string_literal(property.span, property.name, None);
+        let property = Expression::new_string_literal(property.span, property.name, None, ctx);
         self.create_super_prop_get(member.span, property, is_callee, ctx)
     }
 
@@ -149,8 +149,8 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         ctx: &TraverseCtx<'a>,
     ) {
         let elements = arguments.drain(..).map(ArrayExpressionElement::from);
-        let elements = ctx.ast.vec_from_iter(elements);
-        let array = ctx.ast.expression_array(SPAN, elements);
+        let elements = ArenaVec::from_iter_in(elements, ctx);
+        let array = Expression::new_array_expression(SPAN, elements, ctx);
         arguments.push(Argument::from(array));
     }
 
@@ -213,7 +213,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         let AssignmentExpression { span, operator, right: value, left, .. } = assign_expr.unbox();
         let AssignmentTarget::StaticMemberExpression(member) = left else { unreachable!() };
         let property =
-            ctx.ast.expression_string_literal(member.property.span, member.property.name, None);
+            Expression::new_string_literal(member.property.span, member.property.name, None, ctx);
         *expr =
             self.transform_super_assignment_expression_impl(span, operator, property, value, ctx);
     }
@@ -274,7 +274,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
                 let get_call = self.create_super_prop_get(SPAN, property2, false, ctx);
 
                 // `_superPropGet(_Class, prop, _Class) + value`
-                let value = ctx.ast.expression_binary(SPAN, get_call, operator, value);
+                let value = Expression::new_binary_expression(SPAN, get_call, operator, value, ctx);
 
                 // `_superPropSet(_Class, prop, _superPropGet(_Class, prop, _Class) + value, 1)`
                 self.create_super_prop_set(span, property1, value, ctx)
@@ -289,7 +289,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
                 let set_call = self.create_super_prop_set(span, property2, value, ctx);
 
                 // `_superPropGet(_Class, prop, _Class) && _superPropSet(_Class, prop, value, _Class, 1)`
-                ctx.ast.expression_logical(span, get_call, operator, set_call)
+                Expression::new_logical_expression(span, get_call, operator, set_call, ctx)
             } else {
                 // The above covers all types of `AssignmentOperator`
                 unreachable!();
@@ -381,7 +381,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         let temp_var_name_base = get_var_name_from_node(member.as_ref());
 
         let property =
-            ctx.ast.expression_string_literal(member.property.span, member.property.name, None);
+            Expression::new_string_literal(member.property.span, member.property.name, None, ctx);
 
         *expr = self.transform_super_update_expression_impl(
             &temp_var_name_base,
@@ -513,9 +513,11 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         if prefix {
             // Source = `++super$prop` (prefix `++`)
             // `(_super$prop = _superPropGet(_Class, prop, _Class), ++_super$prop)`
-            let value = ctx
-                .ast
-                .expression_sequence(SPAN, ctx.ast.vec_from_array([assignment, update_expr]));
+            let value = Expression::new_sequence_expression(
+                SPAN,
+                ArenaVec::from_array_in([assignment, update_expr], ctx),
+                ctx,
+            );
             // `_superPropSet(_Class, prop, value, _Class, 1)`
             self.create_super_prop_set(span, property1, value, ctx)
         } else {
@@ -525,21 +527,22 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
             let assignment2 = create_assignment(&temp_binding2, update_expr, SPAN, ctx);
 
             // `(_super$prop = _superPropGet(_Class, prop, _Class), _super$prop2 = _super$prop++, _super$prop)`
-            let value = ctx.ast.expression_sequence(
+            let value = Expression::new_sequence_expression(
                 SPAN,
-                ctx.ast.vec_from_array([
-                    assignment,
-                    assignment2,
-                    temp_binding.create_read_expression(ctx),
-                ]),
+                ArenaVec::from_array_in(
+                    [assignment, assignment2, temp_binding.create_read_expression(ctx)],
+                    ctx,
+                ),
+                ctx,
             );
 
             // `_superPropSet(_Class, prop, value, _Class, 1)`
             let set_call = self.create_super_prop_set(span, property1, value, ctx);
             // `(_superPropSet(_Class, prop, value, _Class, 1), _super$prop2)`
-            ctx.ast.expression_sequence(
+            Expression::new_sequence_expression(
                 span,
-                ctx.ast.vec_from_array([set_call, temp_binding2.create_read_expression(ctx)]),
+                ArenaVec::from_array_in([set_call, temp_binding2.create_read_expression(ctx)], ctx),
+                ctx,
             )
         }
     }
@@ -561,11 +564,11 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
 
         let arguments = if is_callee {
             // `(_Class, prop, _Class, 2)`
-            let two = ctx.ast.expression_numeric_literal(SPAN, 2.0, None, NumberBase::Decimal);
-            ctx.ast.vec_from_array([class, property, receiver, Argument::from(two)])
+            let two = Expression::new_numeric_literal(SPAN, 2.0, None, NumberBase::Decimal, ctx);
+            ArenaVec::from_array_in([class, property, receiver, Argument::from(two)], ctx)
         } else {
             // `(_Class, prop, _Class)`
-            ctx.ast.vec_from_array([class, property, receiver])
+            ArenaVec::from_array_in([class, property, receiver], ctx)
         };
 
         // `_superPropGet(_Class, prop, _Class)` or `_superPropGet(_Class, prop, _Class, 2)`
@@ -581,18 +584,22 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let (class, receiver) = self.get_class_binding_arguments(ctx);
-        let arguments = ctx.ast.vec_from_array([
-            class,
-            Argument::from(property),
-            Argument::from(value),
-            receiver,
-            Argument::from(ctx.ast.expression_numeric_literal(
-                SPAN,
-                1.0,
-                None,
-                NumberBase::Decimal,
-            )),
-        ]);
+        let arguments = ArenaVec::from_array_in(
+            [
+                class,
+                Argument::from(property),
+                Argument::from(value),
+                receiver,
+                Argument::from(Expression::new_numeric_literal(
+                    SPAN,
+                    1.0,
+                    None,
+                    NumberBase::Decimal,
+                    ctx,
+                )),
+            ],
+            ctx,
+        );
         helper_call_expr(Helper::SuperPropSet, arguments, ctx)
     }
 
@@ -618,9 +625,11 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
                 // to use `class.prototype` rather than `class`. We should consider using that flag here.
                 // <https://github.com/babel/babel/blob/1fbdb64a7fcc3488797e312506dbacff746d4e41/packages/babel-helpers/src/helpers/superPropGet.ts>
                 class = create_prototype_member(class, SPAN, ctx);
-                ctx.ast.expression_this(SPAN)
+                Expression::new_this_expression(SPAN, ctx)
             }
-            ClassPropertiesSuperConverterMode::StaticPrivateMethod => ctx.ast.expression_this(SPAN),
+            ClassPropertiesSuperConverterMode::StaticPrivateMethod => {
+                Expression::new_this_expression(SPAN, ctx)
+            }
         };
 
         (Argument::from(class), Argument::from(receiver))

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -3,7 +3,8 @@
 
 use std::path::Path;
 
-use oxc_ast::{AstBuilder, NONE, ast::*};
+use oxc_allocator::ArenaVec;
+use oxc_ast::{NONE, ast::*, builder::AstBuilder};
 use oxc_span::SPAN;
 use oxc_traverse::BoundIdentifier;
 
@@ -16,31 +17,38 @@ pub(super) fn create_variable_declaration<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Statement<'a> {
     let kind = VariableDeclarationKind::Var;
-    let declarator = ctx.ast.variable_declarator(
+    let declarator = VariableDeclarator::new(
         SPAN,
         kind,
         binding.create_binding_pattern(ctx),
         NONE,
         Some(init),
         false,
+        ctx,
     );
-    Statement::from(ctx.ast.declaration_variable(SPAN, kind, ctx.ast.vec1(declarator), false))
+    Statement::from(Declaration::new_variable_declaration(
+        SPAN,
+        kind,
+        ArenaVec::from_value_in(declarator, ctx),
+        false,
+        ctx,
+    ))
 }
 
 /// Convert an iterator of `Expression`s into an iterator of `Statement::ExpressionStatement`s.
 pub(super) fn exprs_into_stmts<'a, E>(
     exprs: E,
-    ast: AstBuilder<'a>,
+    ast: &AstBuilder<'a>,
 ) -> impl Iterator<Item = Statement<'a>>
 where
     E: IntoIterator<Item = Expression<'a>>,
 {
-    exprs.into_iter().map(move |expr| ast.statement_expression(SPAN, expr))
+    exprs.into_iter().map(move |expr| Statement::new_expression_statement(SPAN, expr, ast))
 }
 
 /// Create `IdentifierName` for `_`.
 pub(super) fn create_underscore_ident_name<'a>(ctx: &TraverseCtx<'a>) -> IdentifierName<'a> {
-    ctx.ast.identifier_name(SPAN, "_")
+    IdentifierName::new(SPAN, "_", ctx)
 }
 
 /// Debug assert that an `Expression` is not `ParenthesizedExpression` or TS syntax

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -41,7 +41,7 @@
 
 use itoa::Buffer as ItoaBuffer;
 
-use oxc_allocator::TakeIn;
+use oxc_allocator::{ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::SPAN;
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
@@ -112,12 +112,12 @@ impl ClassStaticBlock {
         let expr = Self::convert_block_to_expression(block, ctx);
 
         let key = keys.get_unique(ctx);
-        let key = ctx.ast.property_key_private_identifier(SPAN, key);
+        let key = PropertyKey::new_private_identifier(SPAN, key, ctx);
 
-        ctx.ast.class_element_property_definition(
+        ClassElement::new_property_definition(
             block.span,
             PropertyDefinitionType::PropertyDefinition,
-            ctx.ast.vec(),
+            ArenaVec::new_in(ctx),
             key,
             NONE,
             Some(expr),
@@ -129,6 +129,7 @@ impl ClassStaticBlock {
             false,
             false,
             None,
+            ctx,
         )
     }
 
@@ -254,7 +255,7 @@ impl<'a> Keys<'a> {
             i += 1;
         }
 
-        let key = ctx.ast.str_from_strs_array(["_", num_str]);
+        let key = Str::from_strs_array_in(["_", num_str], ctx);
         self.numbered.push(&key.as_str()[1..]);
 
         key

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -102,18 +102,23 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
             mem::replace(&mut variable_declarator.id, temp_id.create_binding_pattern(ctx));
 
         // `using x = _x;`
-        let using_stmt = Statement::from(ctx.ast.declaration_variable(
+        let using_stmt = Statement::from(Declaration::new_variable_declaration(
             SPAN,
             variable_decl_kind,
-            ctx.ast.vec1(ctx.ast.variable_declarator(
-                SPAN,
-                variable_decl_kind,
-                binding_pattern,
-                NONE,
-                Some(temp_id.create_read_expression(ctx)),
-                false,
-            )),
+            ArenaVec::from_value_in(
+                VariableDeclarator::new(
+                    SPAN,
+                    variable_decl_kind,
+                    binding_pattern,
+                    NONE,
+                    Some(temp_id.create_read_expression(ctx)),
+                    false,
+                    ctx,
+                ),
+                ctx,
+            ),
             false,
+            ctx,
         ));
 
         if let Statement::BlockStatement(body) = &mut for_of_stmt.body {
@@ -136,8 +141,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                 );
 
                 let old_body = for_of_stmt.body.take_in(ctx);
-                let new_body = ctx.ast.vec_from_array([using_stmt, old_body]);
-                for_of_stmt.body = ctx.ast.statement_block_with_scope_id(SPAN, new_body, scope_id);
+                let new_body = ArenaVec::from_array_in([using_stmt, old_body], ctx);
+                for_of_stmt.body =
+                    Statement::new_block_statement_with_scope_id(SPAN, new_body, scope_id, ctx);
                 return;
             }
 
@@ -164,8 +170,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
 
             let old_body = for_of_stmt.body.take_in(ctx);
 
-            let new_body = ctx.ast.vec_from_array([using_stmt, old_body]);
-            for_of_stmt.body = ctx.ast.statement_block_with_scope_id(SPAN, new_body, scope_id);
+            let new_body = ArenaVec::from_array_in([using_stmt, old_body], ctx);
+            for_of_stmt.body =
+                Statement::new_block_statement_with_scope_id(SPAN, new_body, scope_id, ctx);
         }
     }
 
@@ -208,14 +215,17 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
             *ctx.scoping_mut().scope_flags_mut(scope_id) = ScopeFlags::StrictMode;
 
             block.set_scope_id(static_block_new_scope_id);
-            block.body = ctx.ast.vec1(Self::create_try_stmt(
-                ctx.ast.block_statement_with_scope_id(SPAN, new_stmts, scope_id),
-                &using_ctx,
-                static_block_new_scope_id,
-                needs_await,
-                SPAN,
+            block.body = ArenaVec::from_value_in(
+                Self::create_try_stmt(
+                    BlockStatement::new_with_scope_id(SPAN, new_stmts, scope_id, ctx),
+                    &using_ctx,
+                    static_block_new_scope_id,
+                    needs_await,
+                    SPAN,
+                    ctx,
+                ),
                 ctx,
-            ));
+            );
         }
     }
 
@@ -270,14 +280,17 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                 );
             }
 
-            body.statements = ctx.ast.vec1(Self::create_try_stmt(
-                ctx.ast.block_statement_with_scope_id(SPAN, new_stmts, block_stmt_scope_id),
-                &using_ctx,
-                current_scope_id,
-                needs_await,
-                SPAN,
+            body.statements = ArenaVec::from_value_in(
+                Self::create_try_stmt(
+                    BlockStatement::new_with_scope_id(SPAN, new_stmts, block_stmt_scope_id, ctx),
+                    &using_ctx,
+                    current_scope_id,
+                    needs_await,
+                    SPAN,
+                    ctx,
+                ),
                 ctx,
-            ));
+            );
         }
     }
 
@@ -330,14 +343,17 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                 ScopeFlags::empty(),
             );
 
-            node.block.body = ctx.ast.vec1(Self::create_try_stmt(
-                ctx.ast.block_statement_with_scope_id(SPAN, new_stmts, scope_id),
-                &using_ctx,
-                block_stmt_scope_id,
-                needs_await,
-                SPAN,
+            node.block.body = ArenaVec::from_value_in(
+                Self::create_try_stmt(
+                    BlockStatement::new_with_scope_id(SPAN, new_stmts, scope_id, ctx),
+                    &using_ctx,
+                    block_stmt_scope_id,
+                    needs_await,
+                    SPAN,
+                    ctx,
+                ),
                 ctx,
-            ));
+            );
 
             let current_hoist_scope_id = ctx.current_hoist_scope_id();
             node.block.set_scope_id(block_stmt_scope_id);
@@ -371,7 +387,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
             ArenaVec<'a, Statement<'a>>,
             ArenaVec<'a, Statement<'a>>,
         ) = program_body.into_iter().fold(
-            (ctx.ast.vec(), ctx.ast.vec()),
+            (ArenaVec::new_in(ctx), ArenaVec::new_in(ctx)),
             |(mut program_body, mut inner_block), mut stmt| {
                 let address = stmt.address();
                 match stmt {
@@ -402,9 +418,9 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
 
                         let decl = mem::replace(
                             &mut export_default_decl.declaration,
-                            ExportDefaultDeclarationKind::NullLiteral(
-                                ctx.ast.alloc_null_literal(SPAN),
-                            ),
+                            ExportDefaultDeclarationKind::NullLiteral(NullLiteral::boxed(
+                                SPAN, ctx,
+                            )),
                         );
 
                         let expr = match decl {
@@ -419,36 +435,46 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                         };
 
                         inner_block.push(Statement::VariableDeclaration(
-                            ctx.ast.alloc_variable_declaration(
+                            VariableDeclaration::boxed(
                                 span,
                                 VariableDeclarationKind::Var,
-                                ctx.ast.vec1(ctx.ast.variable_declarator(
-                                    span,
-                                    VariableDeclarationKind::Var,
-                                    var_id.create_spanned_binding_pattern(span, ctx),
-                                    NONE,
-                                    Some(expr),
-                                    false,
-                                )),
+                                ArenaVec::from_value_in(
+                                    VariableDeclarator::new(
+                                        span,
+                                        VariableDeclarationKind::Var,
+                                        var_id.create_spanned_binding_pattern(span, ctx),
+                                        NONE,
+                                        Some(expr),
+                                        false,
+                                        ctx,
+                                    ),
+                                    ctx,
+                                ),
                                 false,
+                                ctx,
                             ),
                         ));
 
                         program_body.push(Statement::ExportNamedDeclaration(
-                            ctx.ast.alloc_export_named_declaration(
+                            ExportNamedDeclaration::boxed(
                                 SPAN,
                                 None,
-                                ctx.ast.vec1(ctx.ast.export_specifier(
-                                    SPAN,
-                                    ModuleExportName::IdentifierReference(
-                                        var_id.create_read_reference(ctx),
+                                ArenaVec::from_value_in(
+                                    ExportSpecifier::new(
+                                        SPAN,
+                                        ModuleExportName::IdentifierReference(
+                                            var_id.create_read_reference(ctx),
+                                        ),
+                                        ModuleExportName::new_identifier_name(SPAN, "default", ctx),
+                                        ImportOrExportKind::Value,
+                                        ctx,
                                     ),
-                                    ctx.ast.module_export_name_identifier_name(SPAN, "default"),
-                                    ImportOrExportKind::Value,
-                                )),
+                                    ctx,
+                                ),
                                 None,
                                 ImportOrExportKind::Value,
                                 NONE,
+                                ctx,
                             ),
                         ));
                     }
@@ -485,19 +511,25 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
 
                                 let local =
                                     ModuleExportName::IdentifierReference(class_binding_reference);
-                                let exported = ctx
-                                    .ast
-                                    .module_export_name_identifier_name(SPAN, class_binding_name);
-                                ctx.ast.vec1(ctx.ast.export_specifier(
+                                let exported = ModuleExportName::new_identifier_name(
                                     SPAN,
-                                    local,
-                                    exported,
-                                    ImportOrExportKind::Value,
-                                ))
+                                    class_binding_name,
+                                    ctx,
+                                );
+                                ArenaVec::from_value_in(
+                                    ExportSpecifier::new(
+                                        SPAN,
+                                        local,
+                                        exported,
+                                        ImportOrExportKind::Value,
+                                        ctx,
+                                    ),
+                                    ctx,
+                                )
                             }
                             Declaration::VariableDeclaration(mut var_decl) => {
                                 var_decl.kind = VariableDeclarationKind::Var;
-                                let mut export_specifiers = ctx.ast.vec();
+                                let mut export_specifiers = ArenaVec::new_in(ctx);
 
                                 for decl in &mut var_decl.declarations {
                                     decl.kind = VariableDeclarationKind::Var;
@@ -507,19 +539,18 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                                     *ctx.scoping_mut().symbol_flags_mut(ident.symbol_id()) =
                                         SymbolFlags::FunctionScopedVariable;
 
-                                    export_specifiers.push(
-                                        ctx.ast.export_specifier(
-                                            SPAN,
-                                            ModuleExportName::IdentifierReference(
-                                                BoundIdentifier::from_binding_ident(ident)
-                                                    .create_read_reference(ctx),
-                                            ),
-                                            ctx.ast.module_export_name_identifier_name(
-                                                SPAN, ident.name,
-                                            ),
-                                            ImportOrExportKind::Value,
+                                    export_specifiers.push(ExportSpecifier::new(
+                                        SPAN,
+                                        ModuleExportName::IdentifierReference(
+                                            BoundIdentifier::from_binding_ident(ident)
+                                                .create_read_reference(ctx),
                                         ),
-                                    );
+                                        ModuleExportName::new_identifier_name(
+                                            SPAN, ident.name, ctx,
+                                        ),
+                                        ImportOrExportKind::Value,
+                                        ctx,
+                                    ));
                                 });
                                 inner_block.push(Statement::VariableDeclaration(var_decl));
                                 export_specifiers
@@ -528,13 +559,14 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                         };
 
                         program_body.push(Statement::ExportNamedDeclaration(
-                            ctx.ast.alloc_export_named_declaration(
+                            ExportNamedDeclaration::boxed(
                                 SPAN,
                                 None,
                                 export_specifiers,
                                 None,
                                 export_named_declaration.export_kind,
                                 NONE,
+                                ctx,
                             ),
                         ));
                     }
@@ -567,7 +599,12 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
         );
 
         let block_scope_id = ctx.insert_scope_below_statements(&inner_block, ScopeFlags::empty());
-        program_body.push(ctx.ast.statement_block_with_scope_id(SPAN, inner_block, block_scope_id));
+        program_body.push(Statement::new_block_statement_with_scope_id(
+            SPAN,
+            inner_block,
+            block_scope_id,
+            ctx,
+        ));
 
         std::mem::swap(&mut program.body, &mut program_body);
     }
@@ -603,7 +640,7 @@ impl<'a> ExplicitResourceManagement<'a> {
             let current_scope_id = ctx.current_scope_id();
 
             *stmt = Self::create_try_stmt(
-                ctx.ast.block_statement_with_scope_id(SPAN, new_stmts, block_stmt.scope_id()),
+                BlockStatement::new_with_scope_id(SPAN, new_stmts, block_stmt.scope_id(), ctx),
                 &using_ctx,
                 current_scope_id,
                 needs_await,
@@ -675,32 +712,31 @@ impl<'a> ExplicitResourceManagement<'a> {
 
                 for decl in &mut var_decl.declarations {
                     if let Some(old_init) = decl.init.take() {
-                        decl.init = Some(
-                            ctx.ast.expression_call(
+                        decl.init = Some(Expression::new_call_expression(
+                            SPAN,
+                            Expression::from(MemberExpression::new_static_member_expression(
                                 SPAN,
-                                Expression::from(
-                                    ctx.ast.member_expression_static(
-                                        SPAN,
-                                        using_ctx
-                                            .as_ref()
-                                            .expect("`using_ctx` should have been set")
-                                            .create_read_expression(ctx),
-                                        ctx.ast.identifier_name(
-                                            SPAN,
-                                            if needs_await {
-                                                static_ident!("a")
-                                            } else {
-                                                static_ident!("u")
-                                            },
-                                        ),
-                                        false,
-                                    ),
+                                using_ctx
+                                    .as_ref()
+                                    .expect("`using_ctx` should have been set")
+                                    .create_read_expression(ctx),
+                                IdentifierName::new(
+                                    SPAN,
+                                    if needs_await {
+                                        static_ident!("a")
+                                    } else {
+                                        static_ident!("u")
+                                    },
+                                    ctx,
                                 ),
-                                NONE,
-                                ctx.ast.vec1(Argument::from(old_init)),
                                 false,
-                            ),
-                        );
+                                ctx,
+                            )),
+                            NONE,
+                            ArenaVec::from_value_in(Argument::from(old_init), ctx),
+                            false,
+                            ctx,
+                        ));
                     }
                 }
             }
@@ -715,29 +751,44 @@ impl<'a> ExplicitResourceManagement<'a> {
         let callee = helper_load(Helper::UsingCtx, ctx);
 
         let block = {
-            let vec = ctx.ast.vec_from_array([
-                Statement::from(ctx.ast.declaration_variable(
-                    SPAN,
-                    VariableDeclarationKind::Var,
-                    ctx.ast.vec1(ctx.ast.variable_declarator(
+            let vec = ArenaVec::from_array_in(
+                [
+                    Statement::from(Declaration::new_variable_declaration(
                         SPAN,
                         VariableDeclarationKind::Var,
-                        using_ctx.create_binding_pattern(ctx),
-                        NONE,
-                        Some(ctx.ast.expression_call(SPAN, callee, NONE, ctx.ast.vec(), false)),
+                        ArenaVec::from_value_in(
+                            VariableDeclarator::new(
+                                SPAN,
+                                VariableDeclarationKind::Var,
+                                using_ctx.create_binding_pattern(ctx),
+                                NONE,
+                                Some(Expression::new_call_expression(
+                                    SPAN,
+                                    callee,
+                                    NONE,
+                                    ArenaVec::new_in(ctx),
+                                    false,
+                                    ctx,
+                                )),
+                                false,
+                                ctx,
+                            ),
+                            ctx,
+                        ),
                         false,
+                        ctx,
                     )),
-                    false,
-                )),
-                stmt.take_in(ctx),
-            ]);
+                    stmt.take_in(ctx),
+                ],
+                ctx,
+            );
 
-            ctx.ast.block_statement_with_scope_id(SPAN, vec, block_stmt_sid)
+            BlockStatement::new_with_scope_id(SPAN, vec, block_stmt_sid, ctx)
         };
 
         let catch = Self::create_catch_clause(&using_ctx, current_scope_id, ctx);
         let finally = Self::create_finally_block(&using_ctx, current_scope_id, needs_await, ctx);
-        *stmt = ctx.ast.statement_try(span, block, Some(catch), Some(finally));
+        *stmt = Statement::new_try_statement(span, block, Some(catch), Some(finally), ctx);
     }
 
     /// Transforms:
@@ -806,24 +857,27 @@ impl<'a> ExplicitResourceManagement<'a> {
             // `await using foo = bar;` -> `const foo = _usingCtx.a(bar);`
             for decl in &mut variable_declaration.declarations {
                 if let Some(old_init) = decl.init.take() {
-                    decl.init = Some(ctx.ast.expression_call(
+                    decl.init = Some(Expression::new_call_expression(
                         SPAN,
-                        Expression::from(ctx.ast.member_expression_static(
+                        Expression::from(MemberExpression::new_static_member_expression(
                             SPAN,
                             using_ctx.as_ref().unwrap().create_read_expression(ctx),
-                            ctx.ast.identifier_name(
+                            IdentifierName::new(
                                 SPAN,
                                 if is_await_using {
                                     static_ident!("a")
                                 } else {
                                     static_ident!("u")
                                 },
+                                ctx,
                             ),
                             false,
+                            ctx,
                         )),
                         NONE,
-                        ctx.ast.vec1(Argument::from(old_init)),
+                        ArenaVec::from_value_in(Argument::from(old_init), ctx),
                         false,
+                        ctx,
                     ));
                 }
             }
@@ -835,18 +889,30 @@ impl<'a> ExplicitResourceManagement<'a> {
 
         // `var _usingCtx = babelHelpers.usingCtx();`
         let callee = helper_load(Helper::UsingCtx, ctx);
-        let helper = ctx.ast.declaration_variable(
+        let helper = Declaration::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ctx.ast.vec1(ctx.ast.variable_declarator(
-                SPAN,
-                VariableDeclarationKind::Var,
-                using_ctx.create_binding_pattern(ctx),
-                NONE,
-                Some(ctx.ast.expression_call(SPAN, callee, NONE, ctx.ast.vec(), false)),
-                false,
-            )),
+            ArenaVec::from_value_in(
+                VariableDeclarator::new(
+                    SPAN,
+                    VariableDeclarationKind::Var,
+                    using_ctx.create_binding_pattern(ctx),
+                    NONE,
+                    Some(Expression::new_call_expression(
+                        SPAN,
+                        callee,
+                        NONE,
+                        ArenaVec::new_in(ctx),
+                        false,
+                        ctx,
+                    )),
+                    false,
+                    ctx,
+                ),
+                ctx,
+            ),
             false,
+            ctx,
         );
         stmts.insert(0, Statement::from(helper));
 
@@ -863,7 +929,7 @@ impl<'a> ExplicitResourceManagement<'a> {
     ) -> Statement<'a> {
         let catch = Self::create_catch_clause(using_ctx, parent_scope_id, ctx);
         let finally = Self::create_finally_block(using_ctx, parent_scope_id, needs_await, ctx);
-        ctx.ast.statement_try(span, body, Some(catch), Some(finally))
+        Statement::new_try_statement(span, body, Some(catch), Some(finally), ctx)
     }
 
     /// `catch (_) { _usingCtx.e = _; }`
@@ -887,30 +953,39 @@ impl<'a> ExplicitResourceManagement<'a> {
         );
 
         let catch_parameter =
-            ctx.ast.catch_parameter(SPAN, ident.create_binding_pattern(ctx), NONE);
+            CatchParameter::new(SPAN, ident.create_binding_pattern(ctx), NONE, ctx);
 
         // `_usingCtx.e = _;`
-        let stmt = ctx.ast.statement_expression(
+        let stmt = Statement::new_expression_statement(
             SPAN,
-            ctx.ast.expression_assignment(
+            Expression::new_assignment_expression(
                 SPAN,
                 AssignmentOperator::Assign,
-                AssignmentTarget::from(ctx.ast.member_expression_static(
+                AssignmentTarget::from(MemberExpression::new_static_member_expression(
                     SPAN,
                     using_ctx.create_read_expression(ctx),
-                    ctx.ast.identifier_name(SPAN, "e"),
+                    IdentifierName::new(SPAN, "e", ctx),
                     false,
+                    ctx,
                 )),
                 ident.create_read_expression(ctx),
+                ctx,
             ),
+            ctx,
         );
 
         // `catch (_) { _usingCtx.e = _; }`
-        ctx.ast.alloc_catch_clause_with_scope_id(
+        CatchClause::boxed_with_scope_id(
             SPAN,
             Some(catch_parameter),
-            ctx.ast.block_statement_with_scope_id(SPAN, ctx.ast.vec1(stmt), block_scope_id),
+            BlockStatement::new_with_scope_id(
+                SPAN,
+                ArenaVec::from_value_in(stmt, ctx),
+                block_scope_id,
+                ctx,
+            ),
             catch_scope_id,
+            ctx,
         )
     }
 
@@ -924,25 +999,29 @@ impl<'a> ExplicitResourceManagement<'a> {
         let finally_scope_id = ctx.create_child_scope(parent_scope_id, ScopeFlags::empty());
 
         // `_usingCtx.d()`
-        let expr = ctx.ast.expression_call(
+        let expr = Expression::new_call_expression(
             SPAN,
-            Expression::from(ctx.ast.member_expression_static(
+            Expression::from(MemberExpression::new_static_member_expression(
                 SPAN,
                 using_ctx.create_read_expression(ctx),
-                ctx.ast.identifier_name(SPAN, "d"),
+                IdentifierName::new(SPAN, "d", ctx),
                 false,
+                ctx,
             )),
             NONE,
-            ctx.ast.vec(),
+            ArenaVec::new_in(ctx),
             false,
+            ctx,
         );
 
-        let stmt = if needs_await { ctx.ast.expression_await(SPAN, expr) } else { expr };
+        let stmt =
+            if needs_await { Expression::new_await_expression(SPAN, expr, ctx) } else { expr };
 
-        ctx.ast.alloc_block_statement_with_scope_id(
+        BlockStatement::boxed_with_scope_id(
             SPAN,
-            ctx.ast.vec1(ctx.ast.statement_expression(SPAN, stmt)),
+            ArenaVec::from_value_in(Statement::new_expression_statement(SPAN, stmt, ctx), ctx),
             finally_scope_id,
+            ctx,
         )
     }
 
@@ -956,18 +1035,23 @@ impl<'a> ExplicitResourceManagement<'a> {
         class_decl.r#type = ClassType::ClassExpression;
         let class_expr = Expression::ClassExpression(class_decl);
 
-        Statement::VariableDeclaration(ctx.ast.alloc_variable_declaration(
+        Statement::VariableDeclaration(VariableDeclaration::boxed(
             SPAN,
             VariableDeclarationKind::Var,
-            ctx.ast.vec1(ctx.ast.variable_declarator(
-                SPAN,
-                VariableDeclarationKind::Var,
-                binding.create_spanned_binding_pattern(original_span, ctx),
-                NONE,
-                Some(class_expr),
-                false,
-            )),
+            ArenaVec::from_value_in(
+                VariableDeclarator::new(
+                    SPAN,
+                    VariableDeclarationKind::Var,
+                    binding.create_spanned_binding_pattern(original_span, ctx),
+                    NONE,
+                    Some(class_expr),
+                    false,
+                    ctx,
+                ),
+                ctx,
+            ),
             false,
+            ctx,
         ))
     }
 

--- a/crates/oxc_transformer/src/jsx/display_name.rs
+++ b/crates/oxc_transformer/src/jsx/display_name.rs
@@ -108,14 +108,14 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactDisplayName {
                     // whereas we also handle e.g. `{"foo-bar": React.createClass({})}`,
                     // so we diverge from Babel here, but that's probably an improvement
                     if let Some(name) = prop.key().static_name() {
-                        break ctx.ast.str(&name);
+                        break Str::from_str_in(&name, ctx);
                     }
                     return;
                 }
                 // `export default React.createClass({})`
                 // Uses the current file name as the display name.
                 Ancestor::ExportDefaultDeclarationDeclaration(_) => {
-                    break ctx.ast.str(&ctx.state.filename);
+                    break Str::from_str_in(&ctx.state.filename, ctx);
                 }
                 // Stop crawling up when hit a statement
                 _ if ancestor.is_parent_of_statement() => return,
@@ -165,14 +165,15 @@ impl<'a> ReactDisplayName {
         }
         obj_expr.properties.insert(
             0,
-            ctx.ast.object_property_kind_object_property(
+            ObjectPropertyKind::new_object_property(
                 SPAN,
                 PropertyKind::Init,
-                ctx.ast.property_key_static_identifier(SPAN, DISPLAY_NAME),
-                ctx.ast.expression_string_literal(SPAN, name, None),
+                PropertyKey::new_static_identifier(SPAN, DISPLAY_NAME, ctx),
+                Expression::new_string_literal(SPAN, name, None, ctx),
                 false,
                 false,
                 false,
+                ctx,
             ),
         );
     }

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -88,8 +88,8 @@
 //!
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-helper-builder-react-jsx>
 
-use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, TakeIn};
-use oxc_ast::{AstBuilder, NONE, ast::*};
+use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, TakeIn};
+use oxc_ast::{NONE, ast::*, builder::AstBuilder};
 use oxc_ecmascript::PropName;
 use oxc_span::{SPAN, Span};
 use oxc_str::{Ident, Str};
@@ -340,7 +340,7 @@ impl<'a> Pragma<'a> {
     fn parse(
         pragma: Option<&str>,
         default_property_name: &'static str,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
         ctx: &mut TransformState<'a>,
     ) -> Self {
         if let Some(pragma) = pragma {
@@ -361,7 +361,7 @@ impl<'a> Pragma<'a> {
     fn parse_no_ctx(
         pragma: Option<&str>,
         default_property_name: &'static str,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
     ) -> Self {
         if let Some(pragma) = pragma
             && !pragma.is_empty()
@@ -373,8 +373,9 @@ impl<'a> Pragma<'a> {
         Self::Double(Str::from("React"), Str::from(default_property_name))
     }
 
-    fn parse_impl(pragma: &str, ast: AstBuilder<'a>) -> Option<Self> {
-        let strs_to_arena_strs = |parts: &[&str]| parts.iter().map(|part| ast.str(part)).collect();
+    fn parse_impl(pragma: &str, ast: &AstBuilder<'a>) -> Option<Self> {
+        let strs_to_arena_strs =
+            |parts: &[&str]| parts.iter().map(|part| Str::from_str_in(part, ast)).collect();
 
         let parts = pragma.split('.').collect::<Vec<_>>();
         let [root, tail @ ..] = &parts[..] else {
@@ -408,8 +409,10 @@ impl<'a> Pragma<'a> {
         }
 
         Some(match &parts[..] {
-            [first, second] => Self::Double(ast.str(first), ast.str(second)),
-            [only] => Self::Single(ast.str(only)),
+            [first, second] => {
+                Self::Double(Str::from_str_in(first, ast), Str::from_str_in(second, ast))
+            }
+            [only] => Self::Single(Str::from_str_in(only, ast)),
             parts => Self::Multiple(strs_to_arena_strs(parts)),
         })
     }
@@ -417,11 +420,12 @@ impl<'a> Pragma<'a> {
         let (object, parts) = match self {
             Self::Double(first, second) => {
                 let object = get_read_identifier_reference(SPAN, *first, ctx);
-                return Expression::from(ctx.ast.member_expression_static(
+                return Expression::from(MemberExpression::new_static_member_expression(
                     SPAN,
                     object,
-                    ctx.ast.identifier_name(SPAN, *second),
+                    IdentifierName::new(SPAN, *second, ctx),
                     false,
+                    ctx,
                 ));
             }
             Self::Single(single) => {
@@ -434,14 +438,15 @@ impl<'a> Pragma<'a> {
                 (object, parts)
             }
             Self::This(parts) => {
-                let object = ctx.ast.expression_this(SPAN);
+                let object = Expression::new_this_expression(SPAN, ctx);
                 (object, parts.iter())
             }
             Self::ImportMeta(parts) => {
-                let object = ctx.ast.expression_meta_property(
+                let object = Expression::new_meta_property(
                     SPAN,
-                    ctx.ast.identifier_name(SPAN, "import"),
-                    ctx.ast.identifier_name(SPAN, "meta"),
+                    IdentifierName::new(SPAN, "import", ctx),
+                    IdentifierName::new(SPAN, "meta", ctx),
+                    ctx,
                 );
                 (object, parts.iter())
             }
@@ -449,8 +454,9 @@ impl<'a> Pragma<'a> {
 
         let mut expr = object;
         for &item in parts {
-            let name = ctx.ast.identifier_name(SPAN, item);
-            expr = ctx.ast.member_expression_static(SPAN, expr, name, false).into();
+            let name = IdentifierName::new(SPAN, item, ctx);
+            expr =
+                MemberExpression::new_static_member_expression(SPAN, expr, name, false, ctx).into();
         }
         expr
     }
@@ -460,7 +466,7 @@ impl<'a> JsxImpl<'a> {
     pub fn new(
         options: JsxOptions,
         object_rest_spread_options: Option<ObjectRestSpreadOptions>,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
         source_type: oxc_span::SourceType,
     ) -> Self {
         // Only add `pure` when `pure` is explicitly set to `true` or all JSX options are default.
@@ -485,11 +491,14 @@ impl<'a> JsxImpl<'a> {
                             }
                             Ok(source_len) => source_len,
                         };
-                        let jsx_runtime_importer = ast.str(&format!(
-                            "{}/jsx-{}runtime",
-                            import_source,
-                            if is_development { "dev-" } else { "" }
-                        ));
+                        let jsx_runtime_importer = Str::from_str_in(
+                            &format!(
+                                "{}/jsx-{}runtime",
+                                import_source,
+                                if is_development { "dev-" } else { "" }
+                            ),
+                            ast,
+                        );
                         (jsx_runtime_importer, source_len)
                     }
                     None => {
@@ -557,16 +566,17 @@ impl<'a> JsxImpl<'a> {
         // TODO(improve-on-babel): Simplify this once we don't need to follow Babel exactly.
         if self.bindings.is_classic() || ctx.state.source_type.is_module() {
             // Insert before imports - add to `top_level_statements` immediately
-            let stmt = Statement::VariableDeclaration(ctx.ast.alloc_variable_declaration(
+            let stmt = Statement::VariableDeclaration(VariableDeclaration::boxed(
                 SPAN,
                 VariableDeclarationKind::Var,
-                ctx.ast.vec1(declarator),
+                ArenaVec::from_value_in(declarator, ctx),
                 false,
+                ctx,
             ));
             ctx.state.top_level_statements.insert_statement(stmt);
         } else {
             // Insert after imports - add to `var_declarations`, which are inserted after `require` statements
-            ctx.state.var_declarations.insert_var_declarator(declarator, ctx.ast);
+            ctx.state.var_declarations.insert_var_declarator(declarator, &ctx.ast);
         }
     }
 
@@ -597,7 +607,7 @@ impl<'a> JsxImpl<'a> {
 
         // The maximum capacity length of arguments allowed.
         let capacity = if is_classic { 3 + children.len() } else { 6 };
-        let mut arguments = ctx.ast.vec_with_capacity(capacity);
+        let mut arguments = ArenaVec::with_capacity_in(capacity, ctx);
 
         // The key prop in `<div key={true} />`
         let mut key_prop = None;
@@ -605,8 +615,10 @@ impl<'a> JsxImpl<'a> {
         // The object properties for the second argument of `React.createElement`.
         // Pre-size to the attribute count (one property per attribute in the common case) to avoid
         // regrowing the arena vec, mirroring `arguments` above.
-        let mut properties =
-            ctx.ast.vec_with_capacity(opening_element.as_ref().map_or(0, |e| e.attributes.len()));
+        let mut properties = ArenaVec::with_capacity_in(
+            opening_element.as_ref().map_or(0, |e| e.attributes.len()),
+            ctx,
+        );
         let (element_name, attributes) = opening_element
             .map(|e| {
                 let e = e.unbox();
@@ -638,8 +650,8 @@ impl<'a> JsxImpl<'a> {
                         let kind = PropertyKind::Init;
                         let key = Self::get_attribute_name(name, ctx);
                         let value = self.transform_jsx_attribute_value(value, ctx);
-                        let object_property = ctx.ast.object_property_kind_object_property(
-                            span, kind, key, value, false, false, false,
+                        let object_property = ObjectPropertyKind::new_object_property(
+                            span, kind, key, value, false, false, false, ctx,
                         );
                         properties.push(object_property);
                     }
@@ -667,7 +679,7 @@ impl<'a> JsxImpl<'a> {
                             }
                             argument => {
                                 let object_property =
-                                    ctx.ast.object_property_kind_spread_property(span, argument);
+                                    ObjectPropertyKind::new_spread_property(span, argument, ctx);
                                 properties.push(object_property);
                             }
                         }
@@ -680,10 +692,12 @@ impl<'a> JsxImpl<'a> {
 
         // Append children to object properties in automatic mode
         if is_automatic {
-            let mut children = ctx.ast.vec_from_iter(
+            let allocator = ctx.allocator();
+            let mut children = ArenaVec::from_iter_in(
                 children
                     .into_iter()
                     .filter_map(|child| self.transform_jsx_child_automatic(child, ctx)),
+                &allocator,
             );
             let children_len = children.len();
             if children_len != 0 {
@@ -696,18 +710,18 @@ impl<'a> JsxImpl<'a> {
                     Expression::try_from(children.pop().unwrap()).unwrap()
                 } else {
                     need_jsxs = children_len > 1;
-                    ctx.ast.expression_array(span, children)
+                    Expression::new_array_expression(span, children, ctx)
                 };
-                let children = ctx.ast.property_key_static_identifier(SPAN, "children");
+                let children = PropertyKey::new_static_identifier(SPAN, "children", ctx);
                 let kind = PropertyKind::Init;
-                let property = ctx.ast.object_property_kind_object_property(
-                    SPAN, kind, children, value, false, false, false,
+                let property = ObjectPropertyKind::new_object_property(
+                    SPAN, kind, children, value, false, false, false, ctx,
                 );
                 properties.push(property);
             }
 
             // If runtime is automatic that means we always to add `{ .. }` as the second argument even if it's empty
-            let mut object_expression = ctx.ast.expression_object(span, properties);
+            let mut object_expression = Expression::new_object_expression(span, properties, ctx);
             if let Some(options) = self.object_rest_spread_options {
                 ObjectRestSpread::transform_object_expression(options, &mut object_expression, ctx);
             }
@@ -718,14 +732,16 @@ impl<'a> JsxImpl<'a> {
             if key_prop.is_some() {
                 arguments.push(Argument::from(self.transform_jsx_attribute_value(key_prop, ctx)));
             } else if is_development {
-                arguments.push(Argument::from(ctx.ast.void_0(SPAN)));
+                arguments.push(Argument::from(Expression::new_void_0(SPAN, ctx)));
             }
 
             // isStaticChildren
             if is_development {
-                arguments.push(Argument::from(
-                    ctx.ast.expression_boolean_literal(SPAN, children_len > 1),
-                ));
+                arguments.push(Argument::from(Expression::new_boolean_literal(
+                    SPAN,
+                    children_len > 1,
+                    ctx,
+                )));
             }
 
             // { __source: { fileName, lineNumber, columnNumber } }
@@ -737,7 +753,7 @@ impl<'a> JsxImpl<'a> {
 
             // this
             if self.options.jsx_self_plugin && JsxSelf::can_add_self_attribute(ctx) {
-                arguments.push(Argument::from(ctx.ast.expression_this(SPAN)));
+                arguments.push(Argument::from(Expression::new_this_expression(SPAN, ctx)));
             }
         } else {
             // React.createElement's second argument
@@ -755,7 +771,8 @@ impl<'a> JsxImpl<'a> {
             }
 
             if !properties.is_empty() {
-                let mut object_expression = ctx.ast.expression_object(span, properties);
+                let mut object_expression =
+                    Expression::new_object_expression(span, properties, ctx);
                 if let Some(options) = self.object_rest_spread_options {
                     ObjectRestSpread::transform_object_expression(
                         options,
@@ -766,7 +783,7 @@ impl<'a> JsxImpl<'a> {
                 arguments.push(Argument::from(object_expression));
             } else if arguments.is_empty() {
                 // If not and second argument doesn't exist, we should add `null` as the second argument
-                let null_expr = ctx.ast.expression_null_literal(SPAN);
+                let null_expr = Expression::new_null_literal(SPAN, ctx);
                 arguments.push(Argument::from(null_expr));
             }
 
@@ -792,7 +809,9 @@ impl<'a> JsxImpl<'a> {
         debug_assert!(arguments.len() <= capacity);
 
         let callee = self.get_create_element(has_key_after_props_spread, need_jsxs, ctx);
-        ctx.ast.expression_call_with_pure(span, callee, NONE, arguments, false, self.pure)
+        Expression::new_call_expression_with_pure(
+            span, callee, NONE, arguments, false, self.pure, ctx,
+        )
     }
 
     fn transform_element_name(
@@ -802,7 +821,7 @@ impl<'a> JsxImpl<'a> {
     ) -> Expression<'a> {
         match name {
             JSXElementName::Identifier(ident) => {
-                ctx.ast.expression_string_literal(ident.span, ident.name, None)
+                Expression::new_string_literal(ident.span, ident.name, None, ctx)
             }
             JSXElementName::IdentifierReference(ident) => Expression::Identifier(ident),
             JSXElementName::MemberExpression(member_expr) => {
@@ -812,14 +831,13 @@ impl<'a> JsxImpl<'a> {
                 if self.options.throw_if_namespace {
                     ctx.state.error(diagnostics::namespace_does_not_support(namespaced.span));
                 }
-                let namespace_name = ctx.ast.str_from_strs_array([
-                    &namespaced.namespace.name,
-                    ":",
-                    &namespaced.name.name,
-                ]);
-                ctx.ast.expression_string_literal(namespaced.span, namespace_name, None)
+                let namespace_name = Str::from_strs_array_in(
+                    [&namespaced.namespace.name, ":", &namespaced.name.name],
+                    ctx,
+                );
+                Expression::new_string_literal(namespaced.span, namespace_name, None, ctx)
             }
-            JSXElementName::ThisExpression(expr) => ctx.ast.expression_this(expr.span),
+            JSXElementName::ThisExpression(expr) => Expression::new_this_expression(expr.span, ctx),
         }
     }
 
@@ -883,10 +901,12 @@ impl<'a> JsxImpl<'a> {
             JSXMemberExpressionObject::MemberExpression(expr) => {
                 Self::transform_jsx_member_expression(expr, ctx)
             }
-            JSXMemberExpressionObject::ThisExpression(expr) => ctx.ast.expression_this(expr.span),
+            JSXMemberExpressionObject::ThisExpression(expr) => {
+                Expression::new_this_expression(expr.span, ctx)
+            }
         };
-        let property = ctx.ast.identifier_name(property.span, property.name);
-        ctx.ast.member_expression_static(span, object, property, false).into()
+        let property = IdentifierName::new(property.span, property.name, ctx);
+        MemberExpression::new_static_member_expression(span, object, property, false, ctx).into()
     }
 
     fn transform_jsx_attribute_value(
@@ -906,7 +926,7 @@ impl<'a> JsxImpl<'a> {
                     // No HTML entities needed to be decoded. Use the original `Str` without copying.
                     s.value
                 };
-                ctx.ast.expression_string_literal(s.span, jsx_text, None)
+                Expression::new_string_literal(s.span, jsx_text, None, ctx)
             }
             Some(JSXAttributeValue::Element(e)) => self.transform_jsx_element(e, ctx),
             Some(JSXAttributeValue::Fragment(e)) => {
@@ -915,10 +935,10 @@ impl<'a> JsxImpl<'a> {
             Some(JSXAttributeValue::ExpressionContainer(c)) => match c.unbox().expression {
                 jsx_expr @ match_expression!(JSXExpression) => jsx_expr.into_expression(),
                 JSXExpression::EmptyExpression(e) => {
-                    ctx.ast.expression_boolean_literal(e.span, true)
+                    Expression::new_boolean_literal(e.span, true, ctx)
                 }
             },
-            None => ctx.ast.expression_boolean_literal(SPAN, true),
+            None => Expression::new_boolean_literal(SPAN, true, ctx),
         }
     }
 
@@ -932,7 +952,7 @@ impl<'a> JsxImpl<'a> {
         // `<>{...foo}</>` -> `jsxs(Fragment, { children: [ ...foo ] })`
         if let JSXChild::Spread(e) = child {
             let JSXSpreadChild { span, expression, .. } = e.unbox();
-            Some(ctx.ast.array_expression_element_spread_element(span, expression))
+            Some(ArrayExpressionElement::new_spread_element(span, expression, ctx))
         } else {
             self.transform_jsx_child(child, ctx).map(ArrayExpressionElement::from)
         }
@@ -948,7 +968,7 @@ impl<'a> JsxImpl<'a> {
         // `<>{...foo}</>` -> `React.createElement(React.Fragment, null, ...foo)`
         if let JSXChild::Spread(e) = child {
             let JSXSpreadChild { span, expression, .. } = e.unbox();
-            Some(ctx.ast.argument_spread_element(span, expression))
+            Some(Argument::new_spread_element(span, expression, ctx))
         } else {
             self.transform_jsx_child(child, ctx).map(Argument::from)
         }
@@ -978,21 +998,21 @@ impl<'a> JsxImpl<'a> {
             JSXAttributeName::Identifier(ident) => {
                 let name = ident.name;
                 if ident.name.contains('-') {
-                    PropertyKey::from(ctx.ast.expression_string_literal(ident.span, name, None))
+                    PropertyKey::from(Expression::new_string_literal(ident.span, name, None, ctx))
                 } else {
-                    ctx.ast.property_key_static_identifier(ident.span, name)
+                    PropertyKey::new_static_identifier(ident.span, name, ctx)
                 }
             }
             JSXAttributeName::NamespacedName(namespaced) => {
-                let name = ctx.ast.str(&namespaced.to_string());
-                PropertyKey::from(ctx.ast.expression_string_literal(namespaced.span, name, None))
+                let name = Str::from_str_in(&namespaced.to_string(), ctx);
+                PropertyKey::from(Expression::new_string_literal(namespaced.span, name, None, ctx))
             }
         }
     }
 
     fn transform_jsx_text(text: &JSXText<'a>, ctx: &TraverseCtx<'a>) -> Option<Expression<'a>> {
         Self::fixup_whitespace_and_decode_entities(text.value, ctx)
-            .map(|value| ctx.ast.expression_string_literal(text.span, value, None))
+            .map(|value| Expression::new_string_literal(text.span, value, None, ctx))
     }
 
     /// JSX trims whitespace at the end and beginning of lines, except that the
@@ -1218,7 +1238,7 @@ fn get_read_identifier_reference<'a>(
 ) -> Expression<'a> {
     let name = Ident::from(name);
     let reference_id = ctx.create_reference_in_current_scope(name, ReferenceFlags::Read);
-    let ident = ctx.ast.alloc_identifier_reference_with_reference_id(span, name, reference_id);
+    let ident = IdentifierReference::boxed_with_reference_id(span, name, reference_id, ctx);
     Expression::Identifier(ident)
 }
 
@@ -1228,8 +1248,8 @@ fn create_static_member_expression<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let object = Expression::Identifier(object_ident);
-    let property = ctx.ast.identifier_name(SPAN, property_name);
-    ctx.ast.member_expression_static(SPAN, object, property, false).into()
+    let property = IdentifierName::new(SPAN, property_name, ctx);
+    MemberExpression::new_static_member_expression(SPAN, object, property, false, ctx).into()
 }
 
 /// Check if an `ObjectExpression` has a property called `__proto__`.
@@ -1281,7 +1301,7 @@ mod test {
         setup!(traverse_ctx, transform_ctx);
 
         let pragma = None;
-        let pragma = Pragma::parse(pragma, "createElement", traverse_ctx.ast, &mut transform_ctx);
+        let pragma = Pragma::parse(pragma, "createElement", &traverse_ctx.ast, &mut transform_ctx);
         let expr = pragma.create_expression(traverse_ctx);
 
         let Expression::StaticMemberExpression(member) = &expr else { panic!() };
@@ -1295,7 +1315,7 @@ mod test {
         setup!(traverse_ctx, transform_ctx);
 
         let pragma = Some("single");
-        let pragma = Pragma::parse(pragma, "createElement", traverse_ctx.ast, &mut transform_ctx);
+        let pragma = Pragma::parse(pragma, "createElement", &traverse_ctx.ast, &mut transform_ctx);
         let expr = pragma.create_expression(traverse_ctx);
 
         let Expression::Identifier(ident) = &expr else { panic!() };
@@ -1307,7 +1327,7 @@ mod test {
         setup!(traverse_ctx, transform_ctx);
 
         let pragma = Some("first.second");
-        let pragma = Pragma::parse(pragma, "createElement", traverse_ctx.ast, &mut transform_ctx);
+        let pragma = Pragma::parse(pragma, "createElement", &traverse_ctx.ast, &mut transform_ctx);
         let expr = pragma.create_expression(traverse_ctx);
 
         let Expression::StaticMemberExpression(member) = &expr else { panic!() };
@@ -1321,7 +1341,7 @@ mod test {
         setup!(traverse_ctx, transform_ctx);
 
         let pragma = Some("first.second.third");
-        let pragma = Pragma::parse(pragma, "createElement", traverse_ctx.ast, &mut transform_ctx);
+        let pragma = Pragma::parse(pragma, "createElement", &traverse_ctx.ast, &mut transform_ctx);
         let expr = pragma.create_expression(traverse_ctx);
 
         let Expression::StaticMemberExpression(outer_member) = &expr else { panic!() };
@@ -1339,7 +1359,7 @@ mod test {
         setup!(traverse_ctx, transform_ctx);
 
         let pragma = Some("this");
-        let pragma = Pragma::parse(pragma, "createElement", traverse_ctx.ast, &mut transform_ctx);
+        let pragma = Pragma::parse(pragma, "createElement", &traverse_ctx.ast, &mut transform_ctx);
         let expr = pragma.create_expression(traverse_ctx);
 
         assert!(matches!(&expr, Expression::ThisExpression(_)));
@@ -1350,7 +1370,7 @@ mod test {
         setup!(traverse_ctx, transform_ctx);
 
         let pragma = Some("this.a.b");
-        let pragma = Pragma::parse(pragma, "createElement", traverse_ctx.ast, &mut transform_ctx);
+        let pragma = Pragma::parse(pragma, "createElement", &traverse_ctx.ast, &mut transform_ctx);
         let expr = pragma.create_expression(traverse_ctx);
 
         let Expression::StaticMemberExpression(outer_member) = &expr else { panic!() };
@@ -1367,7 +1387,7 @@ mod test {
         setup!(traverse_ctx, transform_ctx);
 
         let pragma = Some("import.meta");
-        let pragma = Pragma::parse(pragma, "createElement", traverse_ctx.ast, &mut transform_ctx);
+        let pragma = Pragma::parse(pragma, "createElement", &traverse_ctx.ast, &mut transform_ctx);
         let expr = pragma.create_expression(traverse_ctx);
 
         let Expression::MetaProperty(meta_prop) = &expr else { panic!() };
@@ -1380,7 +1400,7 @@ mod test {
         setup!(traverse_ctx, transform_ctx);
 
         let pragma = Some("import.meta.prop");
-        let pragma = Pragma::parse(pragma, "createElement", traverse_ctx.ast, &mut transform_ctx);
+        let pragma = Pragma::parse(pragma, "createElement", &traverse_ctx.ast, &mut transform_ctx);
         let expr = pragma.create_expression(traverse_ctx);
 
         let Expression::StaticMemberExpression(member) = &expr else { panic!() };
@@ -1395,7 +1415,7 @@ mod test {
         setup!(traverse_ctx, _transform_ctx);
 
         let pragma = Some("`");
-        let pragma = Pragma::parse_no_ctx(pragma, "Fragment", traverse_ctx.ast);
+        let pragma = Pragma::parse_no_ctx(pragma, "Fragment", &traverse_ctx.ast);
         let expr = pragma.create_expression(traverse_ctx);
 
         let Expression::StaticMemberExpression(member) = &expr else { panic!() };

--- a/crates/oxc_transformer/src/jsx/jsx_self.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_self.rs
@@ -80,9 +80,9 @@ impl<'a> JsxSelf {
         ctx: &TraverseCtx<'a>,
     ) -> ObjectPropertyKind<'a> {
         let kind = PropertyKind::Init;
-        let key = ctx.ast.property_key_static_identifier(SPAN, SELF);
-        let value = ctx.ast.expression_this(SPAN);
-        ctx.ast.object_property_kind_object_property(SPAN, kind, key, value, false, false, false)
+        let key = PropertyKey::new_static_identifier(SPAN, SELF, ctx);
+        let value = Expression::new_this_expression(SPAN, ctx);
+        ObjectPropertyKind::new_object_property(SPAN, kind, key, value, false, false, false, ctx)
     }
 
     pub fn can_add_self_attribute(ctx: &TraverseCtx<'a>) -> bool {
@@ -101,12 +101,12 @@ impl<'a> JsxSelf {
             return;
         }
 
-        let name = ctx.ast.jsx_attribute_name_identifier(SPAN, SELF);
+        let name = JSXAttributeName::new_identifier(SPAN, SELF, ctx);
         let value = {
-            let jsx_expr = JSXExpression::from(ctx.ast.expression_this(SPAN));
-            ctx.ast.jsx_attribute_value_expression_container(SPAN, jsx_expr)
+            let jsx_expr = JSXExpression::from(Expression::new_this_expression(SPAN, ctx));
+            JSXAttributeValue::new_expression_container(SPAN, jsx_expr, ctx)
         };
-        let attribute = ctx.ast.jsx_attribute_item_attribute(SPAN, name, Some(value));
+        let attribute = JSXAttributeItem::new_attribute(SPAN, name, Some(value), ctx);
         elem.attributes.push(attribute);
     }
 }

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -33,6 +33,7 @@
 //!
 //! * Babel plugin implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-react-jsx-source/src/index.ts>
 
+use oxc_allocator::ArenaVec;
 use oxc_ast::{NONE, ast::*};
 use oxc_data_structures::rope::{Rope, get_line_column};
 use oxc_span::SPAN;
@@ -93,9 +94,9 @@ impl<'a> JsxSource<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> ObjectPropertyKind<'a> {
         let kind = PropertyKind::Init;
-        let key = ctx.ast.property_key_static_identifier(SPAN, SOURCE);
+        let key = PropertyKey::new_static_identifier(SPAN, SOURCE, ctx);
         let value = self.get_source_object(line, column, ctx);
-        ctx.ast.object_property_kind_object_property(SPAN, kind, key, value, false, false, false)
+        ObjectPropertyKind::new_object_property(SPAN, kind, key, value, false, false, false, ctx)
     }
 
     /// `<sometag __source={ { fileName: 'this/file.js', lineNumber: 10, columnNumber: 1 } } />`
@@ -118,15 +119,15 @@ impl<'a> JsxSource<'a> {
             return;
         }
 
-        let key = ctx.ast.jsx_attribute_name_identifier(SPAN, SOURCE);
+        let key = JSXAttributeName::new_identifier(SPAN, SOURCE, ctx);
         // TODO: We shouldn't calculate line + column from scratch each time as it's expensive.
         // Build a table of byte indexes of each line's start on first usage, and save it.
         // Then calculate line and column from that.
         let (line, column) = self.get_line_column(elem.span.start, ctx);
         let object = self.get_source_object(line, column, ctx);
         let value =
-            ctx.ast.jsx_attribute_value_expression_container(SPAN, JSXExpression::from(object));
-        let attribute_item = ctx.ast.jsx_attribute_item_attribute(SPAN, key, Some(value));
+            JSXAttributeValue::new_expression_container(SPAN, JSXExpression::from(object), ctx);
+        let attribute_item = JSXAttributeItem::new_attribute(SPAN, key, Some(value), ctx);
         elem.attributes.push(attribute_item);
     }
 
@@ -140,40 +141,49 @@ impl<'a> JsxSource<'a> {
         let kind = PropertyKind::Init;
 
         let filename = {
-            let key = ctx.ast.property_key_static_identifier(SPAN, "fileName");
+            let key = PropertyKey::new_static_identifier(SPAN, "fileName", ctx);
             let value = self.get_filename_var(ctx).create_read_expression(ctx);
-            ctx.ast
-                .object_property_kind_object_property(SPAN, kind, key, value, false, false, false)
+            ObjectPropertyKind::new_object_property(
+                SPAN, kind, key, value, false, false, false, ctx,
+            )
         };
 
         let line_number = {
-            let key = ctx.ast.property_key_static_identifier(SPAN, "lineNumber");
+            let key = PropertyKey::new_static_identifier(SPAN, "lineNumber", ctx);
             let value =
-                ctx.ast.expression_numeric_literal(SPAN, line as f64, None, NumberBase::Decimal);
-            ctx.ast
-                .object_property_kind_object_property(SPAN, kind, key, value, false, false, false)
+                Expression::new_numeric_literal(SPAN, line as f64, None, NumberBase::Decimal, ctx);
+            ObjectPropertyKind::new_object_property(
+                SPAN, kind, key, value, false, false, false, ctx,
+            )
         };
 
         let column_number = {
-            let key = ctx.ast.property_key_static_identifier(SPAN, "columnNumber");
-            let value =
-                ctx.ast.expression_numeric_literal(SPAN, column as f64, None, NumberBase::Decimal);
-            ctx.ast
-                .object_property_kind_object_property(SPAN, kind, key, value, false, false, false)
+            let key = PropertyKey::new_static_identifier(SPAN, "columnNumber", ctx);
+            let value = Expression::new_numeric_literal(
+                SPAN,
+                column as f64,
+                None,
+                NumberBase::Decimal,
+                ctx,
+            );
+            ObjectPropertyKind::new_object_property(
+                SPAN, kind, key, value, false, false, false, ctx,
+            )
         };
 
-        let properties = ctx.ast.vec_from_array([filename, line_number, column_number]);
-        ctx.ast.expression_object(SPAN, properties)
+        let properties = ArenaVec::from_array_in([filename, line_number, column_number], ctx);
+        Expression::new_object_expression(SPAN, properties, ctx)
     }
 
     pub fn get_filename_var_statement(&self, ctx: &TraverseCtx<'a>) -> Option<Statement<'a>> {
         let decl = self.get_filename_var_declarator(ctx)?;
 
-        let var_decl = Statement::VariableDeclaration(ctx.ast.alloc_variable_declaration(
+        let var_decl = Statement::VariableDeclaration(VariableDeclaration::boxed(
             SPAN,
             VariableDeclarationKind::Var,
-            ctx.ast.vec1(decl),
+            ArenaVec::from_value_in(decl, ctx),
             false,
+            ctx,
         ));
         Some(var_decl)
     }
@@ -185,15 +195,16 @@ impl<'a> JsxSource<'a> {
         let filename_var = self.filename_var.as_ref()?;
 
         let id = filename_var.create_binding_pattern(ctx);
-        let source_path = ctx.ast.str(&ctx.state.source_path.to_string_lossy());
-        let init = ctx.ast.expression_string_literal(SPAN, source_path, None);
-        let decl = ctx.ast.variable_declarator(
+        let source_path = Str::from_str_in(&ctx.state.source_path.to_string_lossy(), ctx);
+        let init = Expression::new_string_literal(SPAN, source_path, None, ctx);
+        let decl = VariableDeclarator::new(
             SPAN,
             VariableDeclarationKind::Var,
             id,
             NONE,
             Some(init),
             false,
+            ctx,
         );
         Some(decl)
     }

--- a/crates/oxc_transformer/src/jsx/mod.rs
+++ b/crates/oxc_transformer/src/jsx/mod.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{AstBuilder, ast::*};
+use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_traverse::Traverse;
 
 use crate::{context::TraverseCtx, es2018::ObjectRestSpreadOptions, state::TransformState};
@@ -42,7 +42,7 @@ impl<'a> Jsx<'a> {
     pub fn new(
         mut options: JsxOptions,
         object_rest_spread_options: Option<ObjectRestSpreadOptions>,
-        ast: AstBuilder<'a>,
+        ast: &AstBuilder<'a>,
         source_type: oxc_span::SourceType,
     ) -> Self {
         if options.jsx_plugin || options.development {

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -8,7 +8,7 @@ use hmac_sha1_compact::Hash as Sha1;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::{ArenaStringBuilder, ArenaVec, CloneIn, GetAddress, TakeIn, UnstableAddress};
-use oxc_ast::{AstBuilder, NONE, ast::*, match_expression};
+use oxc_ast::{NONE, ast::*, builder::AstBuilder, match_expression};
 use oxc_ast_visit::{
     Visit,
     walk::{walk_call_expression, walk_declaration},
@@ -38,36 +38,42 @@ enum RefreshIdentifierResolver<'a> {
 
 impl<'a> RefreshIdentifierResolver<'a> {
     /// Parses a string into a RefreshIdentifierResolver
-    pub fn parse(input: &str, ast: AstBuilder<'a>) -> Self {
+    pub fn parse(input: &str, ast: &AstBuilder<'a>) -> Self {
         let mut parts = input.split('.');
 
         let first_part = parts.next().unwrap();
         let Some(second_part) = parts.next() else {
             // Handle simple identifier reference
-            return Self::Identifier(ast.identifier_reference(SPAN, ast.str(input)));
+            return Self::Identifier(IdentifierReference::new(
+                SPAN,
+                Str::from_str_in(input, ast),
+                ast,
+            ));
         };
 
         if first_part == "import" {
             // Handle `import.meta.$RefreshReg$` expression
-            let mut expr = ast.expression_meta_property(
+            let mut expr = Expression::new_meta_property(
                 SPAN,
-                ast.identifier_name(SPAN, "import"),
-                ast.identifier_name(SPAN, ast.str(second_part)),
+                IdentifierName::new(SPAN, "import", ast),
+                IdentifierName::new(SPAN, Str::from_str_in(second_part, ast), ast),
+                ast,
             );
             if let Some(property) = parts.next() {
-                expr = Expression::from(ast.member_expression_static(
+                expr = Expression::new_static_member_expression(
                     SPAN,
                     expr,
-                    ast.identifier_name(SPAN, ast.str(property)),
+                    IdentifierName::new(SPAN, Str::from_str_in(property, ast), ast),
                     false,
-                ));
+                    ast,
+                );
             }
             return Self::Expression(expr);
         }
 
         // Handle `window.$RefreshReg$` member expression
-        let object = ast.identifier_reference(SPAN, ast.str(first_part));
-        let property = ast.identifier_name(SPAN, ast.str(second_part));
+        let object = IdentifierReference::new(SPAN, Str::from_str_in(first_part, ast), ast);
+        let property = IdentifierName::new(SPAN, Str::from_str_in(second_part, ast), ast);
         Self::Member((object, property))
     }
 
@@ -76,24 +82,27 @@ impl<'a> RefreshIdentifierResolver<'a> {
         match self {
             Self::Identifier(ident) => {
                 let reference_id = ctx.create_unbound_reference(ident.name, ReferenceFlags::Read);
-                ctx.ast.expression_identifier_with_reference_id(
+                Expression::new_identifier_with_reference_id(
                     ident.span,
                     ident.name,
                     reference_id,
+                    ctx,
                 )
             }
             Self::Member((ident, property)) => {
                 let reference_id = ctx.create_unbound_reference(ident.name, ReferenceFlags::Read);
-                let ident = ctx.ast.expression_identifier_with_reference_id(
+                let ident = Expression::new_identifier_with_reference_id(
                     ident.span,
                     ident.name,
                     reference_id,
+                    ctx,
                 );
-                Expression::from(ctx.ast.member_expression_static(
+                Expression::from(MemberExpression::new_static_member_expression(
                     SPAN,
                     ident,
                     property.clone(),
                     false,
+                    ctx,
                 ))
             }
             Self::Expression(expr) => expr.clone_in(ctx.ast.allocator),
@@ -126,7 +135,7 @@ pub struct ReactRefresh<'a> {
 }
 
 impl<'a> ReactRefresh<'a> {
-    pub fn new(options: &ReactRefreshOptions, ast: AstBuilder<'a>) -> Self {
+    pub fn new(options: &ReactRefreshOptions, ast: &AstBuilder<'a>) -> Self {
         Self {
             refresh_reg: RefreshIdentifierResolver::parse(&options.refresh_reg, ast),
             refresh_sig: RefreshIdentifierResolver::parse(&options.refresh_sig, ast),
@@ -144,7 +153,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
     fn enter_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
         self.used_in_jsx_bindings = UsedInJSXBindingsCollector::collect(program, ctx);
 
-        let mut new_statements = ctx.ast.vec_with_capacity(program.body.len() * 2);
+        let mut new_statements = ArenaVec::with_capacity_in(program.body.len() * 2, ctx);
         for mut statement in program.body.take_in(ctx) {
             let next_statement = self.process_statement(&mut statement, ctx);
             new_statements.push(statement);
@@ -160,32 +169,39 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
             return;
         }
 
-        let var_decl = Statement::from(ctx.ast.declaration_variable(
+        let var_decl = Statement::from(Declaration::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ctx.ast.vec(), // This is replaced at the end
+            ArenaVec::new_in(ctx), // This is replaced at the end
             false,
+            ctx,
         ));
 
-        let mut variable_declarator_items = ctx.ast.vec_with_capacity(self.registrations.len());
+        let mut variable_declarator_items =
+            ArenaVec::with_capacity_in(self.registrations.len(), ctx);
         let calls = self.registrations.iter().map(|(binding, persistent_id)| {
-            variable_declarator_items.push(ctx.ast.variable_declarator(
+            variable_declarator_items.push(VariableDeclarator::new(
                 SPAN,
                 VariableDeclarationKind::Var,
                 binding.create_binding_pattern(ctx),
                 NONE,
                 None,
                 false,
+                ctx,
             ));
 
             let callee = self.refresh_reg.to_expression(ctx);
-            let arguments = ctx.ast.vec_from_array([
-                Argument::from(binding.create_read_expression(ctx)),
-                Argument::from(ctx.ast.expression_string_literal(SPAN, *persistent_id, None)),
-            ]);
-            ctx.ast.statement_expression(
+            let arguments = ArenaVec::from_array_in(
+                [
+                    Argument::from(binding.create_read_expression(ctx)),
+                    Argument::from(Expression::new_string_literal(SPAN, *persistent_id, None, ctx)),
+                ],
+                ctx,
+            );
+            Statement::new_expression_statement(
                 SPAN,
-                ctx.ast.expression_call(SPAN, callee, NONE, arguments, false),
+                Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx),
+                ctx,
             )
         });
 
@@ -256,12 +272,13 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
 
         let span = expr.span();
         arguments.insert(0, Argument::from(expr.take_in(ctx)));
-        *expr = ctx.ast.expression_call(
+        *expr = Expression::new_call_expression(
             span,
             binding.create_read_expression(ctx),
             NONE,
             arguments,
             false,
+            ctx,
         );
     }
 
@@ -287,8 +304,8 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
 
         let binding = BoundIdentifier::from_binding_ident(&binding_identifier);
         let callee = binding.create_read_expression(ctx);
-        let expr = ctx.ast.expression_call(func.span, callee, NONE, arguments, false);
-        let statement = ctx.ast.statement_expression(func.span, expr);
+        let expr = Expression::new_call_expression(func.span, callee, NONE, arguments, false, ctx);
+        let statement = Statement::new_expression_statement(func.span, expr, ctx);
 
         // Get the address of the statement containing this `FunctionDeclaration`
         let address = match ctx.parent() {
@@ -370,20 +387,26 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
                             if is_member_expression {
                                 if let Some(middle_property) = middle_property {
                                     // binding_name.middle_property
-                                    expr = Expression::from(ctx.ast.member_expression_static(
-                                        SPAN,
-                                        expr,
-                                        ctx.ast.identifier_name(SPAN, middle_property),
-                                        false,
-                                    ));
+                                    expr = Expression::from(
+                                        MemberExpression::new_static_member_expression(
+                                            SPAN,
+                                            expr,
+                                            IdentifierName::new(SPAN, middle_property, ctx),
+                                            false,
+                                            ctx,
+                                        ),
+                                    );
                                 }
                                 // binding_name.hook_name
-                                expr = Expression::from(ctx.ast.member_expression_static(
-                                    SPAN,
-                                    expr,
-                                    ctx.ast.identifier_name(SPAN, hook_name),
-                                    false,
-                                ));
+                                expr = Expression::from(
+                                    MemberExpression::new_static_member_expression(
+                                        SPAN,
+                                        expr,
+                                        IdentifierName::new(SPAN, hook_name, ctx),
+                                        false,
+                                        ctx,
+                                    ),
+                                );
                             }
                             expr
                         }),
@@ -525,11 +548,12 @@ impl<'a> ReactRefresh<'a> {
         }
 
         if !is_variable_declarator {
-            *expr = ctx.ast.expression_assignment(
+            *expr = Expression::new_assignment_expression(
                 SPAN,
                 AssignmentOperator::Assign,
-                self.create_registration(ctx.ast.str(inferred_name), ctx),
+                self.create_registration(Str::from_str_in(inferred_name, ctx), ctx),
                 expr.take_in(ctx),
+                ctx,
             );
         }
 
@@ -545,8 +569,14 @@ impl<'a> ReactRefresh<'a> {
         let left = self.create_registration(id.name.into(), ctx);
         let right =
             ctx.create_bound_ident_expr(SPAN, id.name, id.symbol_id(), ReferenceFlags::Read);
-        let expr = ctx.ast.expression_assignment(SPAN, AssignmentOperator::Assign, left, right);
-        ctx.ast.statement_expression(SPAN, expr)
+        let expr = Expression::new_assignment_expression(
+            SPAN,
+            AssignmentOperator::Assign,
+            left,
+            right,
+            ctx,
+        );
+        Statement::new_expression_statement(SPAN, expr, ctx)
     }
 
     fn create_signature_call_expression(
@@ -558,7 +588,7 @@ impl<'a> ReactRefresh<'a> {
         let key = self.function_signature_keys.remove(&scope_id)?;
 
         let key = if self.emit_full_signatures {
-            ctx.ast.str(&key)
+            Str::from_str_in(&key, ctx)
         } else {
             // Prefer to hash when we can (e.g. outside of ASTExplorer).
             // This makes it deterministically compact, even if there's
@@ -600,38 +630,45 @@ impl<'a> ReactRefresh<'a> {
 
         let callee_list = self.non_builtin_hooks_callee.remove(&scope_id).unwrap_or_default();
         let callee_len = callee_list.len();
-        let custom_hooks_in_scope = ctx.ast.vec_from_iter(
+        let custom_hooks_in_scope = ArenaVec::from_iter_in(
             callee_list.into_iter().filter_map(|e| e.map(ArrayExpressionElement::from)),
+            ctx,
         );
 
         let force_reset = custom_hooks_in_scope.len() != callee_len;
 
-        let mut arguments = ctx.ast.vec();
-        arguments.push(Argument::from(ctx.ast.expression_string_literal(SPAN, key, None)));
+        let mut arguments = ArenaVec::new_in(ctx);
+        arguments.push(Argument::from(Expression::new_string_literal(SPAN, key, None, ctx)));
 
         if force_reset || !custom_hooks_in_scope.is_empty() {
-            arguments.push(Argument::from(ctx.ast.expression_boolean_literal(SPAN, force_reset)));
+            arguments.push(Argument::from(Expression::new_boolean_literal(SPAN, force_reset, ctx)));
         }
 
         if !custom_hooks_in_scope.is_empty() {
             // function () { return custom_hooks_in_scope }
-            let formal_parameters = ctx.ast.formal_parameters(
+            let formal_parameters = FormalParameters::new(
                 SPAN,
                 FormalParameterKind::FormalParameter,
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 NONE,
+                ctx,
             );
-            let function_body = ctx.ast.function_body(
+            let function_body = FunctionBody::new(
                 SPAN,
-                ctx.ast.vec(),
-                ctx.ast.vec1(ctx.ast.statement_return(
-                    SPAN,
-                    Some(ctx.ast.expression_array(SPAN, custom_hooks_in_scope)),
-                )),
+                ArenaVec::new_in(ctx),
+                ArenaVec::from_value_in(
+                    Statement::new_return_statement(
+                        SPAN,
+                        Some(Expression::new_array_expression(SPAN, custom_hooks_in_scope, ctx)),
+                        ctx,
+                    ),
+                    ctx,
+                ),
+                ctx,
             );
             let scope_id = ctx.create_child_scope_of_current(ScopeFlags::Function);
-            let function =
-                Argument::from(ctx.ast.expression_function_with_scope_id_and_pure_and_pife(
+            let function = Argument::from(
+                Expression::new_function_expression_with_scope_id_and_pure_and_pife(
                     SPAN,
                     FunctionType::FunctionExpression,
                     None,
@@ -646,30 +683,35 @@ impl<'a> ReactRefresh<'a> {
                     scope_id,
                     false,
                     false,
-                ));
+                    ctx,
+                ),
+            );
             arguments.push(function);
         }
 
         // _s = refresh_sig();
-        let init = ctx.ast.expression_call(
+        let init = Expression::new_call_expression(
             SPAN,
             self.refresh_sig.to_expression(ctx),
             NONE,
-            ctx.ast.vec(),
+            ArenaVec::new_in(ctx),
             false,
+            ctx,
         );
         let binding = VarDeclarationsStore::create_uid_var_with_init("s", init, ctx);
 
         // _s();
-        let call_expression = ctx.ast.statement_expression(
+        let call_expression = Statement::new_expression_statement(
             SPAN,
-            ctx.ast.expression_call(
+            Expression::new_call_expression(
                 SPAN,
                 binding.create_read_expression(ctx),
                 NONE,
-                ctx.ast.vec(),
+                ArenaVec::new_in(ctx),
                 false,
+                ctx,
             ),
+            ctx,
         );
 
         body.statements.insert(0, call_expression);
@@ -853,15 +895,17 @@ impl<'a> ReactRefresh<'a> {
 
         // Result: let Foo = () => {}; __signature(Foo, ...);
         arguments.insert(0, Argument::from(id_binding.create_read_expression(ctx)));
-        let statement = ctx.ast.statement_expression(
+        let statement = Statement::new_expression_statement(
             SPAN,
-            ctx.ast.expression_call(
+            Expression::new_call_expression(
                 SPAN,
                 binding.create_read_expression(ctx),
                 NONE,
                 arguments,
                 false,
+                ctx,
             ),
+            ctx,
         );
 
         // Get the address of the statement containing this `VariableDeclarator`
@@ -902,10 +946,11 @@ impl<'a> ReactRefresh<'a> {
             unreachable!("arrow function body is never empty")
         };
 
-        arrow
-            .body
-            .statements
-            .push(ctx.ast.statement_return(SPAN, Some(statement.unbox().expression)));
+        arrow.body.statements.push(Statement::new_return_statement(
+            SPAN,
+            Some(statement.unbox().expression),
+            ctx,
+        ));
     }
 }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -8,7 +8,7 @@
 use std::path::Path;
 
 use oxc_allocator::{Allocator, ArenaVec, TakeIn};
-use oxc_ast::{AstBuilder, ast::*};
+use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_diagnostics::Diagnostics;
 #[cfg(feature = "react_compiler")]
 use oxc_react_compiler::{PluginOptions, transform as react_compiler_transform};
@@ -190,7 +190,7 @@ impl<'a> Transformer<'a> {
             x1_jsx: Jsx::new(
                 self.jsx,
                 self.env.es2018.object_rest_spread,
-                ast_builder,
+                &ast_builder,
                 program.source_type,
             ),
             x2_es2026: ES2026::new(self.env.es2026),
@@ -646,7 +646,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TransformerImpl<'a> {
                     continue;
                 };
                 let expression = Some(expr_stmt.expression.take_in(ctx));
-                *stmt = ctx.ast.statement_return(SPAN, expression);
+                *stmt = Statement::new_return_statement(SPAN, expression, ctx);
                 return;
             }
             unreachable!("At least one statement should be expression statement")

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -64,7 +64,7 @@ use rustc_hash::FxHasher;
 use serde::Deserialize;
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{AstBuilder, NONE, ast::*};
+use oxc_ast::{NONE, ast::*, builder::AstBuilder};
 use oxc_data_structures::{inline_string::InlineString, slice_iter::SliceIter};
 use oxc_semantic::SymbolId;
 use oxc_span::SPAN;
@@ -372,7 +372,7 @@ impl<'a> StyledComponents<'a> {
         }
 
         if self.options.minify {
-            minify_template_literal(&mut tagged.quasi, ctx.ast);
+            minify_template_literal(&mut tagged.quasi, &ctx.ast);
         }
 
         if self.options.transpile_template_literals {
@@ -413,18 +413,25 @@ impl<'a> StyledComponents<'a> {
             ..
         } = expr.take_in(ctx);
 
-        let quasis_elements = ctx.ast.vec_from_iter(quasis.into_iter().map(|quasi| {
-            ArrayExpressionElement::from(ctx.ast.expression_string_literal(
-                quasi.span,
-                quasi.value.raw,
-                None,
-            ))
-        }));
+        let quasis_elements = ArenaVec::from_iter_in(
+            quasis.into_iter().map(|quasi| {
+                ArrayExpressionElement::from(Expression::new_string_literal(
+                    quasi.span,
+                    quasi.value.raw,
+                    None,
+                    ctx,
+                ))
+            }),
+            ctx,
+        );
 
-        let quasis = Argument::from(ctx.ast.expression_array(quasi_span, quasis_elements));
-        let arguments =
-            ctx.ast.vec_from_iter(once(quasis).chain(expressions.into_iter().map(Argument::from)));
-        ctx.ast.expression_call(span, tag, type_arguments, arguments, false)
+        let quasis =
+            Argument::from(Expression::new_array_expression(quasi_span, quasis_elements, ctx));
+        let arguments = ArenaVec::from_iter_in(
+            once(quasis).chain(expressions.into_iter().map(Argument::from)),
+            ctx,
+        );
+        Expression::new_call_expression(span, tag, type_arguments, arguments, false, ctx)
     }
 
     /// Add `displayName` and `componentId` to `withConfig({})`
@@ -449,17 +456,19 @@ impl<'a> StyledComponents<'a> {
                 self.add_properties(&mut object.properties, ctx);
             }
         } else if self.is_styled(expr, ctx) {
-            let mut properties = ctx.ast.vec_with_capacity(
+            let mut properties = ArenaVec::with_capacity_in(
                 usize::from(self.options.display_name) + usize::from(self.options.ssr),
+                ctx,
             );
             self.add_properties(&mut properties, ctx);
-            let object = ctx.ast.alloc_object_expression(SPAN, properties);
-            let arguments = ctx.ast.vec1(Argument::ObjectExpression(object));
+            let object = ObjectExpression::boxed(SPAN, properties, ctx);
+            let arguments = ArenaVec::from_value_in(Argument::ObjectExpression(object), ctx);
             let object = expr.take_in(ctx);
-            let property = ctx.ast.identifier_name(SPAN, "withConfig");
-            let callee =
-                Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false));
-            let call = ctx.ast.expression_call(SPAN, callee, NONE, arguments, false);
+            let property = IdentifierName::new(SPAN, "withConfig", ctx);
+            let callee = Expression::from(MemberExpression::new_static_member_expression(
+                SPAN, object, property, false, ctx,
+            ));
+            let call = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
             *expr = call;
         } else {
             return false;
@@ -630,7 +639,7 @@ impl<'a> StyledComponents<'a> {
         let mut buffer = itoa::Buffer::new();
         let count = buffer.format(self.component_count);
         self.component_count += 1;
-        ctx.ast.str_from_strs_array([prefix, count])
+        Str::from_strs_array_in([prefix, count], ctx)
     }
 
     /// Generates a unique file hash based on the source path or source code.
@@ -685,7 +694,7 @@ impl<'a> StyledComponents<'a> {
                     file_stem
                 };
 
-            ctx.ast.str(block_name)
+            Str::from_str_in(block_name, ctx)
         }))
     }
 
@@ -701,7 +710,7 @@ impl<'a> StyledComponents<'a> {
             if block_name == component_name {
                 component_name
             } else {
-                ctx.ast.str_from_strs_array([&block_name, "__", &component_name])
+                Str::from_strs_array_in([&block_name, "__", &component_name], ctx)
             }
         } else {
             block_name
@@ -802,9 +811,9 @@ impl<'a> StyledComponents<'a> {
         value: Str<'a>,
         ctx: &TraverseCtx<'a>,
     ) -> ObjectPropertyKind<'a> {
-        let key = ctx.ast.property_key_static_identifier(SPAN, key);
-        let value = ctx.ast.expression_string_literal(SPAN, value, None);
-        ctx.ast.object_property_kind_object_property(
+        let key = PropertyKey::new_static_identifier(SPAN, key, ctx);
+        let value = Expression::new_string_literal(SPAN, value, None, ctx);
+        ObjectPropertyKind::new_object_property(
             SPAN,
             PropertyKind::Init,
             key,
@@ -812,6 +821,7 @@ impl<'a> StyledComponents<'a> {
             false,
             false,
             false,
+            ctx,
         )
     }
 }
@@ -868,7 +878,7 @@ fn is_valid_styled_component_source(source: &str) -> bool {
 /// quasis = ["width:", "px;color:red;height:100px;"]
 /// expressions = [width]
 /// ```
-fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a>) {
+fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: &AstBuilder<'a>) {
     const NOT_IN_STRING: u8 = 0;
     /// `Span` used as a sentinel indicating quasi should be removed.
     /// Source text is limited to max `u32::MAX` bytes, so it's impossible for a `TemplateElement`
@@ -955,7 +965,7 @@ fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a
                 // Set `raw` for previous quasi to `output`
                 // SAFETY: Output is all picked from the original `raw` values and is guaranteed to be valid UTF-8.
                 let output_str = unsafe { std::str::from_utf8_unchecked(&output) };
-                quasis[quasi_index - 1].value.raw = ast.str(output_str);
+                quasis[quasi_index - 1].value.raw = Str::from_str_in(output_str, ast);
                 output.clear();
                 is_first_output = false;
             }
@@ -1097,7 +1107,7 @@ fn minify_template_literal<'a>(lit: &mut TemplateLiteral<'a>, ast: AstBuilder<'a
     // Update last quasi.
     // SAFETY: Output is all picked from the original `raw` values and is guaranteed to be valid UTF-8.
     let output_str = unsafe { std::str::from_utf8_unchecked(&output) };
-    quasis.last_mut().unwrap().value.raw = ast.str(output_str);
+    quasis.last_mut().unwrap().value.raw = Str::from_str_in(output_str, ast);
 
     // Remove quasis that are marked for removal, and the expressions following them.
     // TODO: Remove scopes, symbols, and references for removed `Expression`s.
@@ -1145,24 +1155,32 @@ fn insert_space_if_required(output: &mut Vec<u8>, is_first_output: bool) {
 mod tests {
     use super::*;
     use oxc_allocator::Allocator;
-    use oxc_ast::{AstBuilder, ast::TemplateElementValue};
+    use oxc_ast::{ast::TemplateElementValue, builder::AstBuilder};
     use oxc_span::SPAN;
 
     fn minify_raw(input: &str) -> String {
         let allocator = Allocator::default();
         let ast = AstBuilder::new(&allocator);
 
-        let mut lit = ast.template_literal(
+        let mut lit = TemplateLiteral::new(
             SPAN,
-            ast.vec1(ast.template_element(
-                SPAN,
-                TemplateElementValue { raw: ast.str(input), cooked: Some(ast.str(input)) },
-                true,
-            )),
-            ast.vec(),
+            ArenaVec::from_value_in(
+                TemplateElement::new(
+                    SPAN,
+                    TemplateElementValue {
+                        raw: Str::from_str_in(input, &ast),
+                        cooked: Some(Str::from_str_in(input, &ast)),
+                    },
+                    true,
+                    &ast,
+                ),
+                &ast,
+            ),
+            ArenaVec::new_in(&ast),
+            &ast,
         );
 
-        minify_template_literal(&mut lit, ast);
+        minify_template_literal(&mut lit, &ast);
 
         assert!(lit.quasis.len() == 1);
 

--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -92,7 +92,7 @@ impl<'a> TaggedTemplateTransform {
 
         let binding = self.create_top_level_binding(ctx);
         let arguments = self.transform_template_literal(&binding, template_lit, ctx);
-        *expr = ctx.ast.expression_call(span, tag, type_arguments, arguments, false);
+        *expr = Expression::new_call_expression(span, tag, type_arguments, arguments, false, ctx);
     }
 
     /// Check if the template literal contains a `</script` tag; note it is case-insensitive.
@@ -152,31 +152,39 @@ impl<'a> TaggedTemplateTransform {
         // Use `void 0` for elements with invalid escape sequences (where `cooked` is `None`).
         // Also check if we need to pass the raw array separately.
         let mut needs_raw_array = false;
-        let cooked_elements = ctx.ast.vec_from_iter(template_lit.quasis.iter().map(|quasi| {
-            let expr = if let Some(cooked) = &quasi.value.cooked {
-                if cooked.as_str() != quasi.value.raw.as_str() {
+        let cooked_elements = ArenaVec::from_iter_in(
+            template_lit.quasis.iter().map(|quasi| {
+                let expr = if let Some(cooked) = &quasi.value.cooked {
+                    if cooked.as_str() != quasi.value.raw.as_str() {
+                        needs_raw_array = true;
+                    }
+                    Expression::new_string_literal(SPAN, *cooked, None, ctx)
+                } else {
+                    // Invalid escape sequence - cooked is None
                     needs_raw_array = true;
-                }
-                ctx.ast.expression_string_literal(SPAN, *cooked, None)
-            } else {
-                // Invalid escape sequence - cooked is None
-                needs_raw_array = true;
-                ctx.ast.void_0(SPAN)
-            };
-            ArrayExpressionElement::from(expr)
-        }));
-        let cooked_argument = Argument::from(ctx.ast.expression_array(SPAN, cooked_elements));
+                    Expression::new_void_0(SPAN, ctx)
+                };
+                ArrayExpressionElement::from(expr)
+            }),
+            ctx,
+        );
+        let cooked_argument =
+            Argument::from(Expression::new_array_expression(SPAN, cooked_elements, ctx));
 
         // Add raw array if needed: `[raw0, raw1, ...]`
         let template_arguments = if needs_raw_array {
-            let elements = ctx.ast.vec_from_iter(template_lit.quasis.iter().map(|quasi| {
-                let string = ctx.ast.expression_string_literal(SPAN, quasi.value.raw, None);
-                ArrayExpressionElement::from(string)
-            }));
-            let raws_argument = Argument::from(ctx.ast.expression_array(SPAN, elements));
-            ctx.ast.vec_from_array([cooked_argument, raws_argument])
+            let elements = ArenaVec::from_iter_in(
+                template_lit.quasis.iter().map(|quasi| {
+                    let string = Expression::new_string_literal(SPAN, quasi.value.raw, None, ctx);
+                    ArrayExpressionElement::from(string)
+                }),
+                ctx,
+            );
+            let raws_argument =
+                Argument::from(Expression::new_array_expression(SPAN, elements, ctx));
+            ArenaVec::from_array_in([cooked_argument, raws_argument], ctx)
         } else {
-            ctx.ast.vec1(cooked_argument)
+            ArenaVec::from_value_in(cooked_argument, ctx)
         };
 
         // `babelHelpers.taggedTemplateLiteral([<...cooked>], [<...raw>]?)`
@@ -187,10 +195,11 @@ impl<'a> TaggedTemplateTransform {
             Argument::from(Self::create_logical_or_expression(binding, template_call, ctx));
 
         // `(binding || (binding = babelHelpers.taggedTemplateLiteral([<...cooked>], [<...raw>]?)), <...expressions>)`
-        ctx.ast.vec_from_iter(
+        ArenaVec::from_iter_in(
             // Add the template expressions as the remaining arguments
             iter::once(template_call)
                 .chain(template_lit.expressions.into_iter().map(Argument::from)),
+            ctx,
         )
     }
 
@@ -201,13 +210,14 @@ impl<'a> TaggedTemplateTransform {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let left = binding.create_read_expression(ctx);
-        let right = ctx.ast.expression_assignment(
+        let right = Expression::new_assignment_expression(
             SPAN,
             AssignmentOperator::Assign,
             binding.create_write_target(ctx),
             expr,
+            ctx,
         );
-        ctx.ast.expression_logical(SPAN, left, LogicalOperator::Or, right)
+        Expression::new_logical_expression(SPAN, left, LogicalOperator::Or, right, ctx)
     }
 
     /// Creates a `var binding;` variable declaration at the top level and returns the binding
@@ -219,20 +229,22 @@ impl<'a> TaggedTemplateTransform {
             SymbolFlags::FunctionScopedVariable,
         );
 
-        let variable = ctx.ast.variable_declarator(
+        let variable = VariableDeclarator::new(
             SPAN,
             VariableDeclarationKind::Var,
             binding.create_binding_pattern(ctx),
             NONE,
             None,
             false,
+            ctx,
         );
 
-        let stmt = Statement::from(ctx.ast.declaration_variable(
+        let stmt = Statement::from(Declaration::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
-            ctx.ast.vec1(variable),
+            ArenaVec::from_value_in(variable, ctx),
             false,
+            ctx,
         ));
 
         ctx.state.top_level_statements.insert_statement(stmt);

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -44,6 +44,7 @@
 //! TODO(improve-on-babel): When flags is empty, we could output `RegExp("(?<=x)")` instead of `RegExp("(?<=x)", "")`.
 //! (actually these would be improvements on ESBuild, not Babel)
 
+use oxc_allocator::ArenaVec;
 use oxc_ast::{NONE, ast::*};
 use oxc_regular_expression::{
     RegexUnsupportedPatterns, has_unsupported_regular_expression_pattern,
@@ -164,15 +165,19 @@ impl<'a> RegExp {
             ctx.create_ident_expr(SPAN, regexp, symbol_id, ReferenceFlags::read())
         };
 
-        let arguments = ctx.ast.vec_from_array([
-            Argument::from(ctx.ast.expression_string_literal(SPAN, pattern_text, None)),
-            Argument::from(ctx.ast.expression_string_literal(
-                SPAN,
-                ctx.ast.str(flags.to_inline_string().as_str()),
-                None,
-            )),
-        ]);
+        let arguments = ArenaVec::from_array_in(
+            [
+                Argument::from(Expression::new_string_literal(SPAN, pattern_text, None, ctx)),
+                Argument::from(Expression::new_string_literal(
+                    SPAN,
+                    Str::from_str_in(flags.to_inline_string().as_str(), ctx),
+                    None,
+                    ctx,
+                )),
+            ],
+            ctx,
+        );
 
-        *expr = ctx.ast.expression_new(regexp.span, callee, NONE, arguments);
+        *expr = Expression::new_new_expression(regexp.span, callee, NONE, arguments, ctx);
     }
 }

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -160,7 +160,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptAnnotations<'a> {
         // still considered a module
         if no_modules_remaining && some_modules_deleted && ctx.state.module_imports.is_empty() {
             let export_decl = Statement::ExportNamedDeclaration(
-                ctx.ast.plain_export_named_declaration(SPAN, ctx.ast.vec(), None),
+                ExportNamedDeclaration::boxed_plain(SPAN, ArenaVec::new_in(ctx), None, ctx),
             );
             program.body.push(export_decl);
         }
@@ -556,7 +556,12 @@ impl<'a> TypeScriptAnnotations<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let scope_id = ctx.insert_scope_below_statement(&stmt, ScopeFlags::empty());
-        ctx.ast.statement_block_with_scope_id(span, ctx.ast.vec1(stmt), scope_id)
+        Statement::new_block_statement_with_scope_id(
+            span,
+            ArenaVec::from_value_in(stmt, ctx),
+            scope_id,
+            ctx,
+        )
     }
 
     fn replace_for_statement_body_with_empty_block_if_ts(
@@ -574,7 +579,12 @@ impl<'a> TypeScriptAnnotations<'a> {
     ) {
         if stmt.is_typescript_syntax() {
             let scope_id = ctx.create_child_scope(parent_scope_id, ScopeFlags::empty());
-            *stmt = ctx.ast.statement_block_with_scope_id(stmt.span(), ctx.ast.vec(), scope_id);
+            *stmt = Statement::new_block_statement_with_scope_id(
+                stmt.span(),
+                ArenaVec::new_in(ctx),
+                scope_id,
+                ctx,
+            );
         }
     }
 
@@ -625,26 +635,26 @@ impl<'a> Assignment<'a> {
     // Creates `this.name = name`
     fn create_this_property_assignment(&self, ctx: &mut TraverseCtx<'a>) -> Statement<'a> {
         let reference_id = ctx.create_bound_reference(self.symbol_id, ReferenceFlags::Read);
-        let id = ctx.ast.alloc_identifier_reference_with_reference_id(
-            self.span,
-            self.name,
-            reference_id,
-        );
+        let id =
+            IdentifierReference::boxed_with_reference_id(self.span, self.name, reference_id, ctx);
 
-        ctx.ast.statement_expression(
+        Statement::new_expression_statement(
             SPAN,
-            ctx.ast.expression_assignment(
+            Expression::new_assignment_expression(
                 SPAN,
                 AssignmentOperator::Assign,
-                SimpleAssignmentTarget::from(ctx.ast.member_expression_static(
+                SimpleAssignmentTarget::from(MemberExpression::new_static_member_expression(
                     SPAN,
-                    ctx.ast.expression_this(SPAN),
-                    ctx.ast.identifier_name(self.span, self.name),
+                    Expression::new_this_expression(SPAN, ctx),
+                    IdentifierName::new(self.span, self.name, ctx),
                     false,
+                    ctx,
                 ))
                 .into(),
                 Expression::Identifier(id),
+                ctx,
             ),
+            ctx,
         )
     }
 }

--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -130,7 +130,7 @@ impl<'a> TypeScript<'a> {
                             // Convert static property to static block
                             // `class C { static x = 1; }` -> `class C { static { this.x = 1; } }`
                             // `class C { static [x] = 1; }` -> `let _x; class C { static { this[_x] = 1; } }`
-                            let body = ctx.ast.vec1(assignment);
+                            let body = ArenaVec::from_value_in(assignment, ctx);
                             *element = Self::create_class_static_block(body, class_scope_id, ctx);
                         } else {
                             property_assignments.push(assignment);
@@ -174,11 +174,17 @@ impl<'a> TypeScript<'a> {
 
         let computed_key_assignment_static_block =
             (!computed_key_assignments.is_empty()).then(|| {
-                let sequence_expression = ctx
-                    .ast
-                    .expression_sequence(SPAN, ctx.ast.vec_from_iter(computed_key_assignments));
-                let statement = ctx.ast.statement_expression(SPAN, sequence_expression);
-                Self::create_class_static_block(ctx.ast.vec1(statement), class_scope_id, ctx)
+                let sequence_expression = Expression::new_sequence_expression(
+                    SPAN,
+                    ArenaVec::from_iter_in(computed_key_assignments, ctx),
+                    ctx,
+                );
+                let statement = Statement::new_expression_statement(SPAN, sequence_expression, ctx);
+                Self::create_class_static_block(
+                    ArenaVec::from_value_in(statement, ctx),
+                    class_scope_id,
+                    ctx,
+                )
             });
 
         if let Some(constructor) = constructor {
@@ -272,13 +278,14 @@ impl<'a> TypeScript<'a> {
         }
 
         let mut declared_names = Self::collect_instance_field_names(class);
-        let fields = ctx.ast.vec_from_iter(
+        let fields = ArenaVec::from_iter_in(
             params
                 .iter()
                 .filter(|param| param.has_modifier())
                 .filter_map(|param| param.pattern.get_binding_identifier())
                 .filter(|id| declared_names.insert(id.name))
                 .map(|id| Self::build_uninitialized_field(id, ctx)),
+            ctx,
         );
 
         class.body.body.splice(0..0, fields);
@@ -339,11 +346,11 @@ impl<'a> TypeScript<'a> {
         id: &BindingIdentifier<'a>,
         ctx: &TraverseCtx<'a>,
     ) -> ClassElement<'a> {
-        let key = ctx.ast.property_key_static_identifier(id.span, id.name);
-        ctx.ast.class_element_property_definition(
+        let key = PropertyKey::new_static_identifier(id.span, id.name, ctx);
+        ClassElement::new_property_definition(
             id.span,
             PropertyDefinitionType::PropertyDefinition,
-            ctx.ast.vec(),
+            ArenaVec::new_in(ctx),
             key,
             NONE,
             None,
@@ -355,6 +362,7 @@ impl<'a> TypeScript<'a> {
             false,
             false,
             None,
+            ctx,
         )
     }
 
@@ -435,12 +443,13 @@ impl<'a> TypeScript<'a> {
             }
             PropertyKey::PrivateIdentifier(ident) => {
                 // Accessor backing fields: `this.#prop = value`
-                let ident = ctx.ast.private_identifier(SPAN, ident.name);
-                ctx.ast.member_expression_private_field_expression(
+                let ident = PrivateIdentifier::new(SPAN, ident.name, ctx);
+                MemberExpression::new_private_field_expression(
                     SPAN,
-                    ctx.ast.expression_this(SPAN),
+                    Expression::new_this_expression(SPAN, ctx),
                     ident,
                     false,
+                    ctx,
                 )
             }
             key @ match_expression!(PropertyKey) => {
@@ -457,11 +466,12 @@ impl<'a> TypeScript<'a> {
                     key.take_in(ctx)
                 };
 
-                ctx.ast.member_expression_computed(
+                MemberExpression::new_computed_member_expression(
                     SPAN,
-                    ctx.ast.expression_this(SPAN),
+                    Expression::new_this_expression(SPAN, ctx),
                     new_key,
                     false,
+                    ctx,
                 )
             }
         };
@@ -524,11 +534,13 @@ impl<'a> TypeScript<'a> {
             // If the key is already an expression, we need to create a new expression sequence
             // to insert the assignments into.
             let original_key = key.take_in(ctx);
-            let new_key = ctx.ast.expression_sequence(
+            let new_key = Expression::new_sequence_expression(
                 SPAN,
-                ctx.ast.vec_from_iter(
+                ArenaVec::from_iter_in(
                     assignments.split_off(0).into_iter().chain(std::iter::once(original_key)),
+                    ctx,
                 ),
+                ctx,
             );
             *key = new_key;
         }
@@ -559,9 +571,16 @@ impl<'a> TypeScript<'a> {
         value: Expression<'a>,
         ctx: &TraverseCtx<'a>,
     ) -> Statement<'a> {
-        ctx.ast.statement_expression(
+        Statement::new_expression_statement(
             SPAN,
-            ctx.ast.expression_assignment(SPAN, AssignmentOperator::Assign, target, value),
+            Expression::new_assignment_expression(
+                SPAN,
+                AssignmentOperator::Assign,
+                target,
+                value,
+                ctx,
+            ),
+            ctx,
         )
     }
 
@@ -581,6 +600,6 @@ impl<'a> TypeScript<'a> {
             ScopeFlags::StrictMode | ScopeFlags::ClassStaticBlock,
         );
 
-        ctx.ast.class_element_static_block_with_scope_id(SPAN, body, scope_id)
+        ClassElement::new_static_block_with_scope_id(SPAN, body, scope_id, ctx)
     }
 }

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -134,7 +134,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptEnum {
             *expr = match value {
                 ConstantValue::Number(n) => Self::get_initializer_expr(n, ctx),
                 ConstantValue::String(s) => {
-                    ctx.ast.expression_string_literal(SPAN, ctx.ast.str(&s), None)
+                    Expression::new_string_literal(SPAN, Str::from_str_in(&s, ctx), None, ctx)
                 }
             };
         }
@@ -175,8 +175,6 @@ impl<'a> TypeScriptEnum {
             decl.id.name,
         );
 
-        let ast = ctx.ast;
-
         let is_export = export_span.is_some();
         let is_not_top_scope = !ctx.scoping().scope_flags(ctx.current_scope_id()).is_top();
 
@@ -188,14 +186,25 @@ impl<'a> TypeScriptEnum {
         let id = param_binding.create_binding_pattern(ctx);
 
         // ((Foo) => {
-        let params =
-            ast.formal_parameter(SPAN, ast.vec(), id, NONE, NONE, false, None, false, false);
-        let params = ast.vec1(params);
-        let params = ast.alloc_formal_parameters(
+        let params = FormalParameter::new(
+            SPAN,
+            ArenaVec::new_in(ctx),
+            id,
+            NONE,
+            NONE,
+            false,
+            None,
+            false,
+            false,
+            ctx,
+        );
+        let params = ArenaVec::from_value_in(params, ctx);
+        let params = FormalParameters::boxed(
             SPAN,
             FormalParameterKind::ArrowFormalParameters,
             params,
             NONE,
+            ctx,
         );
 
         let has_potential_side_effect = decl.body.members.iter().any(|member| {
@@ -212,8 +221,8 @@ impl<'a> TypeScriptEnum {
             ctx,
         );
         let span = decl.span;
-        let body = ast.alloc_function_body(span, ast.vec(), statements);
-        let callee = ctx.ast.expression_function_with_scope_id_and_pure_and_pife(
+        let body = FunctionBody::boxed(span, ArenaVec::new_in(ctx), statements, ctx);
+        let callee = Expression::new_function_expression_with_scope_id_and_pure_and_pife(
             span,
             FunctionType::FunctionExpression,
             None,
@@ -228,6 +237,7 @@ impl<'a> TypeScriptEnum {
             func_scope_id,
             false,
             false,
+            ctx,
         );
 
         let enum_symbol_id = decl.id.symbol_id();
@@ -239,8 +249,8 @@ impl<'a> TypeScriptEnum {
 
         let arguments = if (is_export || is_not_top_scope) && !is_already_declared {
             // }({});
-            let object_expr = ast.expression_object(SPAN, ast.vec());
-            ast.vec1(Argument::from(object_expr))
+            let object_arg = Argument::new_object_expression(SPAN, ArenaVec::new_in(ctx), ctx);
+            ArenaVec::from_value_in(object_arg, ctx)
         } else {
             // }(Foo || {});
             let op = LogicalOperator::Or;
@@ -250,18 +260,19 @@ impl<'a> TypeScriptEnum {
                 enum_symbol_id,
                 ReferenceFlags::Read,
             );
-            let right = ast.expression_object(SPAN, ast.vec());
-            let expression = ast.expression_logical(span, left, op, right);
-            ast.vec1(Argument::from(expression))
+            let right = Expression::new_object_expression(SPAN, ArenaVec::new_in(ctx), ctx);
+            let argument = Argument::new_logical_expression(span, left, op, right, ctx);
+            ArenaVec::from_value_in(argument, ctx)
         };
 
-        let call_expression = ast.expression_call_with_pure(
+        let call_expression = Expression::new_call_expression_with_pure(
             span,
             callee,
             NONE,
             arguments,
             false,
             !has_potential_side_effect,
+            ctx,
         );
 
         if is_already_declared {
@@ -273,8 +284,8 @@ impl<'a> TypeScriptEnum {
                 ReferenceFlags::Write,
             );
             let left = AssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(left));
-            let expr = ast.expression_assignment(span, op, left, call_expression);
-            return Some(ast.statement_expression(span, expr));
+            let expr = Expression::new_assignment_expression(span, op, left, call_expression, ctx);
+            return Some(Statement::new_expression_statement(span, expr, ctx));
         }
 
         let kind = if is_export || is_not_top_scope {
@@ -283,21 +294,32 @@ impl<'a> TypeScriptEnum {
             VariableDeclarationKind::Var
         };
         let decls = {
-            let binding = ast.binding_pattern_binding_identifier_with_symbol_id(
+            let binding = BindingPattern::new_binding_identifier_with_symbol_id(
                 decl.id.span,
                 decl.id.name,
                 enum_symbol_id,
+                ctx,
             );
-            let decl =
-                ast.variable_declarator(span, kind, binding, NONE, Some(call_expression), false);
-            ast.vec1(decl)
+            let decl = VariableDeclarator::new(
+                span,
+                kind,
+                binding,
+                NONE,
+                Some(call_expression),
+                false,
+                ctx,
+            );
+            ArenaVec::from_value_in(decl, ctx)
         };
-        let variable_declaration = ast.declaration_variable(span, kind, decls, false);
+        let variable_declaration =
+            Declaration::new_variable_declaration(span, kind, decls, false, ctx);
 
         let stmt = if let Some(export_span) = export_span {
-            let declaration = ctx
-                .ast
-                .plain_export_named_declaration_declaration(export_span, variable_declaration);
+            let declaration = ExportNamedDeclaration::boxed_plain_declaration(
+                export_span,
+                variable_declaration,
+                ctx,
+            );
             Statement::ExportNamedDeclaration(declaration)
         } else {
             Statement::from(variable_declaration)
@@ -311,11 +333,9 @@ impl<'a> TypeScriptEnum {
         param_binding: &BoundIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> ArenaVec<'a, Statement<'a>> {
-        let ast = ctx.ast;
-
         // Each member pushes exactly one statement, plus a final `return` statement,
         // so the length is known up front — pre-size to avoid growth reallocations.
-        let mut statements = ast.vec_with_capacity(members.len() + 1);
+        let mut statements = ArenaVec::with_capacity_in(members.len() + 1, ctx);
 
         // If enum number has no initializer, its value will be the previous member value + 1,
         // if it's the first member, it will be `0`.
@@ -352,7 +372,12 @@ impl<'a> TypeScriptEnum {
                         }
                         ConstantValue::String(s) => {
                             prev_constant_number = None;
-                            ast.expression_string_literal(SPAN, ctx.ast.str(&s), None)
+                            Expression::new_string_literal(
+                                SPAN,
+                                Str::from_str_in(&s, ctx),
+                                None,
+                                ctx,
+                            )
                         }
                     },
                 }
@@ -364,13 +389,19 @@ impl<'a> TypeScriptEnum {
             } else if let Some(prev_member_name) = prev_member_name {
                 let self_ref = {
                     let obj = param_binding.create_read_expression(ctx);
-                    let expr = ctx.ast.expression_string_literal(SPAN, prev_member_name, None);
-                    ast.member_expression_computed(SPAN, obj, expr, false).into()
+                    let expr = Expression::new_string_literal(SPAN, prev_member_name, None, ctx);
+                    Expression::new_computed_member_expression(SPAN, obj, expr, false, ctx)
                 };
 
                 // 1 + Foo["x"]
                 let one = Self::get_number_literal_expression(1.0, ctx);
-                ast.expression_binary(SPAN, one, BinaryOperator::Addition, self_ref)
+                Expression::new_binary_expression(
+                    SPAN,
+                    one,
+                    BinaryOperator::Addition,
+                    self_ref,
+                    ctx,
+                )
             } else {
                 Self::get_number_literal_expression(0.0, ctx)
             };
@@ -380,41 +411,43 @@ impl<'a> TypeScriptEnum {
             // Foo["x"] = init
             let member_expr = {
                 let obj = param_binding.create_read_expression(ctx);
-                let expr = ast.expression_string_literal(SPAN, member_name, None);
+                let expr = Expression::new_string_literal(SPAN, member_name, None, ctx);
 
-                ast.member_expression_computed(SPAN, obj, expr, false)
+                MemberExpression::new_computed_member_expression(SPAN, obj, expr, false, ctx)
             };
             let left = SimpleAssignmentTarget::from(member_expr);
-            let mut expr = ast.expression_assignment(
+            let mut expr = Expression::new_assignment_expression(
                 member_span,
                 AssignmentOperator::Assign,
                 left.into(),
                 init,
+                ctx,
             );
 
             // Foo[Foo["x"] = init] = "x"
             if !is_str {
                 let member_expr = {
                     let obj = param_binding.create_read_expression(ctx);
-                    ast.member_expression_computed(SPAN, obj, expr, false)
+                    MemberExpression::new_computed_member_expression(SPAN, obj, expr, false, ctx)
                 };
                 let left = SimpleAssignmentTarget::from(member_expr);
-                let right = ast.expression_string_literal(SPAN, member_name, None);
-                expr = ast.expression_assignment(
+                let right = Expression::new_string_literal(SPAN, member_name, None, ctx);
+                expr = Expression::new_assignment_expression(
                     member_span,
                     AssignmentOperator::Assign,
                     left.into(),
                     right,
+                    ctx,
                 );
             }
 
             prev_member_name = Some(member_name);
-            statements.push(ast.statement_expression(member_span, expr));
+            statements.push(Statement::new_expression_statement(member_span, expr, ctx));
         }
 
         let enum_ref = param_binding.create_read_expression(ctx);
         // return Foo;
-        let return_stmt = ast.statement_return(SPAN, Some(enum_ref));
+        let return_stmt = Statement::new_return_statement(SPAN, Some(enum_ref), ctx);
         statements.push(return_stmt);
 
         statements
@@ -473,7 +506,7 @@ impl<'a> TypeScriptEnum {
     }
 
     fn get_number_literal_expression(value: f64, ctx: &TraverseCtx<'a>) -> Expression<'a> {
-        ctx.ast.expression_numeric_literal(SPAN, value, None, NumberBase::Decimal)
+        Expression::new_numeric_literal(SPAN, value, None, NumberBase::Decimal, ctx)
     }
 
     fn get_initializer_expr(value: f64, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
@@ -490,7 +523,7 @@ impl<'a> TypeScriptEnum {
         };
 
         if is_negative {
-            ctx.ast.expression_unary(SPAN, UnaryOperator::UnaryNegation, expr)
+            Expression::new_unary_expression(SPAN, UnaryOperator::UnaryNegation, expr, ctx)
         } else {
             expr
         }
@@ -677,9 +710,12 @@ impl<'a> VisitMut<'a> for IdentifierReferenceRename<'a, '_> {
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         match expr {
             Expression::Identifier(ident) if self.should_reference_enum_member(ident) => {
-                let object = self.ctx.ast.expression_identifier(SPAN, self.enum_name);
-                let property = self.ctx.ast.identifier_name(SPAN, ident.name);
-                *expr = self.ctx.ast.member_expression_static(SPAN, object, property, false).into();
+                let object = Expression::new_identifier(SPAN, self.enum_name, self.ctx);
+                let property = IdentifierName::new(SPAN, ident.name, self.ctx);
+                *expr = MemberExpression::new_static_member_expression(
+                    SPAN, object, property, false, self.ctx,
+                )
+                .into();
             }
             _ => {
                 walk_mut::walk_expression(self, expr);

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::TakeIn;
+use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::{Reference, SymbolFlags};
 use oxc_span::SPAN;
@@ -34,7 +34,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptModule {
         if self.module.is_commonjs() {
             let has_use_strict = program.directives.iter().any(Directive::is_use_strict);
             if !has_use_strict {
-                program.directives.insert(0, ctx.ast.use_strict_directive());
+                program.directives.insert(0, Directive::new_use_strict(ctx));
             }
         }
     }
@@ -73,17 +73,22 @@ impl<'a> TypeScriptModule {
             let module = static_ident!("module");
             let reference_id = ctx.create_reference_in_current_scope(module, ReferenceFlags::Read);
             let reference =
-                ctx.ast.alloc_identifier_reference_with_reference_id(SPAN, module, reference_id);
+                IdentifierReference::boxed_with_reference_id(SPAN, module, reference_id, ctx);
             let object = Expression::Identifier(reference);
-            let property = ctx.ast.identifier_name(SPAN, "exports");
-            ctx.ast.member_expression_static(SPAN, object, property, false)
+            let property = IdentifierName::new(SPAN, "exports", ctx);
+            MemberExpression::new_static_member_expression(SPAN, object, property, false, ctx)
         };
 
         let left = AssignmentTarget::from(SimpleAssignmentTarget::from(module_exports));
         let right = export_assignment.expression.take_in(ctx);
-        let assignment_expr =
-            ctx.ast.expression_assignment(SPAN, AssignmentOperator::Assign, left, right);
-        ctx.ast.statement_expression(SPAN, assignment_expr)
+        let assignment_expr = Expression::new_assignment_expression(
+            SPAN,
+            AssignmentOperator::Assign,
+            left,
+            right,
+            ctx,
+        );
+        Statement::new_expression_statement(SPAN, assignment_expr, ctx)
     }
 
     /// Transform TSImportEqualsDeclaration to a VariableDeclaration.
@@ -111,7 +116,7 @@ impl<'a> TypeScriptModule {
             return None;
         }
 
-        let binding = BindingPattern::BindingIdentifier(ctx.ast.alloc(decl.id.clone()));
+        let binding = BindingPattern::BindingIdentifier(ArenaBox::new_in(decl.id.clone(), ctx));
         let decl_span = decl.span;
 
         let flags = ctx.scoping_mut().symbol_flags_mut(decl.id.symbol_id());
@@ -125,25 +130,25 @@ impl<'a> TypeScriptModule {
                 let reference = ctx.scoping_mut().get_reference_mut(reference_id);
                 *reference.flags_mut() = ReferenceFlags::Read;
 
-                let ident = ctx.ast.expression_identifier_with_reference_id(
+                let ident = Expression::new_identifier_with_reference_id(
                     ident.span,
                     ident.name,
                     reference_id,
+                    ctx,
                 );
                 (VariableDeclarationKind::Var, ident)
             }
             TSModuleReference::QualifiedName(qualified_name) => {
                 flags.insert(SymbolFlags::FunctionScopedVariable);
 
-                let init = ctx
-                    .ast
-                    .member_expression_static(
-                        SPAN,
-                        self.transform_ts_type_name(&mut qualified_name.left, ctx),
-                        qualified_name.right.clone(),
-                        false,
-                    )
-                    .into();
+                let init = MemberExpression::new_static_member_expression(
+                    SPAN,
+                    self.transform_ts_type_name(&mut qualified_name.left, ctx),
+                    qualified_name.right.clone(),
+                    false,
+                    ctx,
+                )
+                .into();
                 (VariableDeclarationKind::Var, init)
             }
             TSModuleReference::ExternalModuleReference(reference) => {
@@ -158,23 +163,26 @@ impl<'a> TypeScriptModule {
                 let callee =
                     ctx.create_ident_expr(SPAN, require, require_symbol_id, ReferenceFlags::Read);
                 let str_lit = &reference.expression;
-                let str_lit = ctx.ast.alloc_string_literal_with_lone_surrogates(
+                let str_lit = StringLiteral::boxed_with_lone_surrogates(
                     str_lit.span,
                     str_lit.value,
                     str_lit.raw,
                     str_lit.lone_surrogates,
+                    ctx,
                 );
-                let arguments = ctx.ast.vec1(Argument::StringLiteral(str_lit));
+                let arguments = ArenaVec::from_value_in(Argument::StringLiteral(str_lit), ctx);
                 (
                     VariableDeclarationKind::Const,
-                    ctx.ast.expression_call(SPAN, callee, NONE, arguments, false),
+                    Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx),
                 )
             }
         };
-        let decls =
-            ctx.ast.vec1(ctx.ast.variable_declarator(SPAN, kind, binding, NONE, Some(init), false));
+        let decls = ArenaVec::from_value_in(
+            VariableDeclarator::new(SPAN, kind, binding, NONE, Some(init), false, ctx),
+            ctx,
+        );
 
-        Some(ctx.ast.declaration_variable(SPAN, kind, decls, false))
+        Some(Declaration::new_variable_declaration(SPAN, kind, decls, false, ctx))
     }
 
     #[expect(clippy::self_only_used_in_recursion)]
@@ -188,21 +196,23 @@ impl<'a> TypeScriptModule {
                 let reference_id = ident.reference_id();
                 let reference = ctx.scoping_mut().get_reference_mut(reference_id);
                 *reference.flags_mut() = ReferenceFlags::Read;
-                ctx.ast.expression_identifier_with_reference_id(
+                Expression::new_identifier_with_reference_id(
                     ident.span,
                     ident.name,
                     reference_id,
+                    ctx,
                 )
             }
             TSTypeName::QualifiedName(qualified_name) => {
-                Expression::from(ctx.ast.member_expression_static(
+                Expression::from(MemberExpression::new_static_member_expression(
                     SPAN,
                     self.transform_ts_type_name(&mut qualified_name.left, ctx),
                     qualified_name.right.clone(),
                     false,
+                    ctx,
                 ))
             }
-            TSTypeName::ThisExpression(e) => ctx.ast.expression_this(e.span),
+            TSTypeName::ThisExpression(e) => Expression::new_this_expression(e.span, ctx),
         }
     }
 

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -40,7 +40,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for TypeScriptNamespace {
         // every time a namespace declaration is encountered. Pre-size to the current body length
         // (a lower bound — namespaces expand) to avoid the growth reallocations for the common
         // pass-through statements.
-        let mut new_stmts = ctx.ast.vec_with_capacity(program.body.len());
+        let mut new_stmts = ArenaVec::with_capacity_in(program.body.len(), ctx);
 
         for stmt in program.body.take_in(ctx) {
             match stmt {
@@ -189,14 +189,14 @@ impl<'a> TypeScriptNamespace {
             TSModuleDeclarationBody::TSModuleDeclaration(declaration) => {
                 let declaration = Declaration::TSModuleDeclaration(declaration);
                 let export_named_decl =
-                    ctx.ast.plain_export_named_declaration_declaration(SPAN, declaration);
+                    ExportNamedDeclaration::boxed_plain_declaration(SPAN, declaration, ctx);
                 let stmt = Statement::ExportNamedDeclaration(export_named_decl);
-                directives = ctx.ast.vec();
-                namespace_top_level = ctx.ast.vec1(stmt);
+                directives = ArenaVec::new_in(ctx);
+                namespace_top_level = ArenaVec::from_value_in(stmt, ctx);
             }
         }
 
-        let mut new_stmts = ctx.ast.vec();
+        let mut new_stmts = ArenaVec::new_in(ctx);
 
         for stmt in namespace_top_level {
             match stmt {
@@ -285,14 +285,14 @@ impl<'a> TypeScriptNamespace {
             let declaration = Self::create_variable_declaration(&binding, span, ctx);
             if is_export {
                 let export_named_decl =
-                    ctx.ast.plain_export_named_declaration_declaration(span, declaration);
+                    ExportNamedDeclaration::boxed_plain_declaration(span, declaration, ctx);
                 let stmt = Statement::ExportNamedDeclaration(export_named_decl);
                 parent_stmts.push(stmt);
             } else {
                 parent_stmts.push(Statement::from(declaration));
             }
         }
-        let func_body = ctx.ast.function_body(SPAN, directives, new_stmts);
+        let func_body = FunctionBody::new(SPAN, directives, new_stmts, ctx);
 
         parent_stmts.push(Self::transform_namespace(
             span,
@@ -315,10 +315,10 @@ impl<'a> TypeScriptNamespace {
         let kind = VariableDeclarationKind::Let;
         let declarations = {
             let pattern = binding.create_binding_pattern(ctx);
-            let decl = ctx.ast.variable_declarator(span, kind, pattern, NONE, None, false);
-            ctx.ast.vec1(decl)
+            let decl = VariableDeclarator::new(span, kind, pattern, NONE, None, false, ctx);
+            ArenaVec::from_value_in(decl, ctx)
         };
-        ctx.ast.declaration_variable(span, kind, declarations, false)
+        Declaration::new_variable_declaration(span, kind, declarations, false, ctx)
     }
 
     // `namespace Foo { }` -> `let Foo; (function (_Foo) { })(Foo || (Foo = {}));`
@@ -336,21 +336,23 @@ impl<'a> TypeScriptNamespace {
         let callee = {
             let params = {
                 let pattern = param_binding.create_binding_pattern(ctx);
-                let items = ctx.ast.vec1(ctx.ast.plain_formal_parameter(SPAN, pattern));
-                ctx.ast.formal_parameters(SPAN, FormalParameterKind::FormalParameter, items, NONE)
+                let items =
+                    ArenaVec::from_value_in(FormalParameter::new_plain(SPAN, pattern, ctx), ctx);
+                FormalParameters::new(SPAN, FormalParameterKind::FormalParameter, items, NONE, ctx)
             };
             let function_expr =
-                Expression::FunctionExpression(ctx.ast.alloc_plain_function_with_scope_id(
+                Expression::FunctionExpression(Function::boxed_plain_with_scope_id(
                     FunctionType::FunctionExpression,
                     span,
                     None,
                     params,
                     func_body,
                     scope_id,
+                    ctx,
                 ));
             *ctx.scoping_mut().scope_flags_mut(scope_id) =
                 ScopeFlags::Function | ScopeFlags::StrictMode;
-            ctx.ast.expression_parenthesized(span, function_expr)
+            Expression::new_parenthesized_expression(span, function_expr, ctx)
         };
 
         // (function (_N) { var M; (function (_M) { var x; })(M || (M = _N.M || (_N.M = {})));})(N || (N = {}));
@@ -364,50 +366,65 @@ impl<'a> TypeScriptNamespace {
             let mut logical_right = {
                 // _N.M
                 let assign_left = if let Some(parent_binding) = parent_binding {
-                    AssignmentTarget::from(ctx.ast.member_expression_static(
+                    AssignmentTarget::from(MemberExpression::new_static_member_expression(
                         SPAN,
                         parent_binding.create_read_expression(ctx),
-                        ctx.ast.identifier_name(SPAN, binding.name),
+                        IdentifierName::new(SPAN, binding.name, ctx),
                         false,
+                        ctx,
                     ))
                 } else {
                     // _N
                     binding.create_write_target(ctx)
                 };
 
-                let assign_right = ctx.ast.expression_object(SPAN, ctx.ast.vec());
+                let assign_right =
+                    Expression::new_object_expression(SPAN, ArenaVec::new_in(ctx), ctx);
                 let op = AssignmentOperator::Assign;
                 let assign_expr =
-                    ctx.ast.expression_assignment(SPAN, op, assign_left, assign_right);
-                ctx.ast.expression_parenthesized(SPAN, assign_expr)
+                    Expression::new_assignment_expression(SPAN, op, assign_left, assign_right, ctx);
+                Expression::new_parenthesized_expression(SPAN, assign_expr, ctx)
             };
 
             // (M = _N.M || (_N.M = {}))
             if let Some(parent_binding) = parent_binding {
                 let assign_left = binding.create_write_target(ctx);
                 let assign_right = {
-                    let property = ctx.ast.identifier_name(SPAN, binding.name);
-                    let logical_left = ctx.ast.member_expression_static(
+                    let property = IdentifierName::new(SPAN, binding.name, ctx);
+                    let logical_left = MemberExpression::new_static_member_expression(
                         SPAN,
                         parent_binding.create_read_expression(ctx),
                         property,
                         false,
+                        ctx,
                     );
                     let op = LogicalOperator::Or;
-                    ctx.ast.expression_logical(SPAN, logical_left.into(), op, logical_right)
+                    Expression::new_logical_expression(
+                        SPAN,
+                        logical_left.into(),
+                        op,
+                        logical_right,
+                        ctx,
+                    )
                 };
                 let op = AssignmentOperator::Assign;
-                logical_right = ctx.ast.expression_assignment(SPAN, op, assign_left, assign_right);
-                logical_right = ctx.ast.expression_parenthesized(SPAN, logical_right);
+                logical_right =
+                    Expression::new_assignment_expression(SPAN, op, assign_left, assign_right, ctx);
+                logical_right = Expression::new_parenthesized_expression(SPAN, logical_right, ctx);
             }
 
-            let expr =
-                ctx.ast.expression_logical(SPAN, logical_left, LogicalOperator::Or, logical_right);
-            ctx.ast.vec1(Argument::from(expr))
+            let expr = Expression::new_logical_expression(
+                SPAN,
+                logical_left,
+                LogicalOperator::Or,
+                logical_right,
+                ctx,
+            );
+            ArenaVec::from_value_in(Argument::from(expr), ctx)
         };
 
-        let expr = ctx.ast.expression_call(span, callee, NONE, arguments, false);
-        ctx.ast.statement_expression(span, expr)
+        let expr = Expression::new_call_expression(span, callee, NONE, arguments, false, ctx);
+        Statement::new_expression_statement(span, expr, ctx)
     }
 
     /// Add assignment statement for decl id
@@ -420,7 +437,8 @@ impl<'a> TypeScriptNamespace {
     ) {
         let assignment_statement =
             Self::create_assignment_statement(namespace_binding, value_binding, ctx);
-        let assignment_statement = ctx.ast.statement_expression(SPAN, assignment_statement);
+        let assignment_statement =
+            Statement::new_expression_statement(SPAN, assignment_statement, ctx);
         new_stmts.push(assignment_statement);
     }
 
@@ -431,12 +449,13 @@ impl<'a> TypeScriptNamespace {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let object = object_binding.create_read_expression(ctx);
-        let property = ctx.ast.identifier_name(SPAN, value_binding.name);
-        let left = ctx.ast.member_expression_static(SPAN, object, property, false);
+        let property = IdentifierName::new(SPAN, value_binding.name, ctx);
+        let left =
+            MemberExpression::new_static_member_expression(SPAN, object, property, false, ctx);
         let left = AssignmentTarget::from(left);
         let right = value_binding.create_read_expression(ctx);
         let op = AssignmentOperator::Assign;
-        ctx.ast.expression_assignment(SPAN, op, left, right)
+        Expression::new_assignment_expression(SPAN, op, left, right, ctx)
     }
 
     /// Convert `export const foo = 1` to `Namespace.foo = 1`;
@@ -456,28 +475,30 @@ impl<'a> TypeScriptNamespace {
                     return;
                 };
                 if let Some(init) = &mut declarator.init {
-                    declarator.init = Some(
-                        ctx.ast.expression_assignment(
-                            SPAN,
-                            AssignmentOperator::Assign,
-                            SimpleAssignmentTarget::from(ctx.ast.member_expression_static(
+                    declarator.init = Some(Expression::new_assignment_expression(
+                        SPAN,
+                        AssignmentOperator::Assign,
+                        SimpleAssignmentTarget::from(
+                            MemberExpression::new_static_member_expression(
                                 SPAN,
                                 binding.create_read_expression(ctx),
-                                ctx.ast.identifier_name(SPAN, property_name),
+                                IdentifierName::new(SPAN, property_name, ctx),
                                 false,
-                            ))
-                            .into(),
-                            init.take_in(ctx),
-                        ),
-                    );
+                                ctx,
+                            ),
+                        )
+                        .into(),
+                        init.take_in(ctx),
+                        ctx,
+                    ));
                 }
             });
-            return ctx.ast.vec1(Statement::VariableDeclaration(var_decl));
+            return ArenaVec::from_value_in(Statement::VariableDeclaration(var_decl), ctx);
         }
 
         // Now we have pattern in declarators
         // `export const [a] = 1` transforms to `const [a] = 1; N.a = a`
-        let mut assignments = ctx.ast.vec();
+        let mut assignments = ArenaVec::new_in(ctx);
         var_decl.bound_names(&mut |id| {
             assignments.push(Self::create_assignment_statement(
                 binding,
@@ -486,10 +507,17 @@ impl<'a> TypeScriptNamespace {
             ));
         });
 
-        ctx.ast.vec_from_array([
-            Statement::VariableDeclaration(var_decl),
-            ctx.ast.statement_expression(SPAN, ctx.ast.expression_sequence(SPAN, assignments)),
-        ])
+        ArenaVec::from_array_in(
+            [
+                Statement::VariableDeclaration(var_decl),
+                Statement::new_expression_statement(
+                    SPAN,
+                    Expression::new_sequence_expression(SPAN, assignments, ctx),
+                    ctx,
+                ),
+            ],
+            ctx,
+        )
     }
 
     /// Check the namespace binding identifier if it is a redeclaration

--- a/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
+++ b/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
@@ -43,7 +43,7 @@ fn rewritten_specifier<'a>(
     Some(if mode.is_remove() {
         Str::from(without_extension)
     } else {
-        ctx.ast.str_from_strs_array([without_extension, replace])
+        Str::from_strs_array_in([without_extension, replace], ctx)
     })
 }
 

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -16,8 +16,10 @@ pub fn create_member_callee<'a>(
     span: Span,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, property);
-    Expression::from(ctx.ast.member_expression_static(span, object, property, false))
+    let property = IdentifierName::new(SPAN, property, ctx);
+    Expression::from(MemberExpression::new_static_member_expression(
+        span, object, property, false, ctx,
+    ))
 }
 
 /// `object` -> `object.bind(this)`.
@@ -28,8 +30,8 @@ pub fn create_bind_call<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let callee = create_member_callee(callee, static_ident!("bind"), span, ctx);
-    let arguments = ctx.ast.vec1(Argument::from(this));
-    ctx.ast.expression_call(span, callee, NONE, arguments, false)
+    let arguments = ArenaVec::from_value_in(Argument::from(this), ctx);
+    Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
 }
 
 /// `object` -> `object.call(...arguments)`.
@@ -40,8 +42,8 @@ pub fn create_call_call<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let callee = create_member_callee(callee, static_ident!("call"), span, ctx);
-    let arguments = ctx.ast.vec1(Argument::from(this));
-    ctx.ast.expression_call(span, callee, NONE, arguments, false)
+    let arguments = ArenaVec::from_value_in(Argument::from(this), ctx);
+    Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
 }
 
 /// Wrap an `Expression` in an arrow function IIFE (immediately invoked function expression)
@@ -55,7 +57,8 @@ pub fn wrap_expression_in_arrow_function_iife<'a>(
     let scope_id =
         ctx.insert_scope_below_expression(&expr, ScopeFlags::Arrow | ScopeFlags::Function);
     let span = expr.span();
-    let stmts = ctx.ast.vec1(ctx.ast.statement_return(SPAN, Some(expr)));
+    let stmts =
+        ArenaVec::from_value_in(Statement::new_return_statement(SPAN, Some(expr), ctx), ctx);
     wrap_statements_in_arrow_function_iife(stmts, scope_id, span, ctx)
 }
 
@@ -69,12 +72,12 @@ pub fn wrap_statements_in_arrow_function_iife<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let kind = FormalParameterKind::ArrowFormalParameters;
-    let params = ctx.ast.alloc_formal_parameters(SPAN, kind, ctx.ast.vec(), NONE);
-    let body = ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), stmts);
-    let arrow = ctx.ast.expression_arrow_function_with_scope_id_and_pure_and_pife(
-        SPAN, false, false, NONE, params, NONE, body, scope_id, false, false,
+    let params = FormalParameters::boxed(SPAN, kind, ArenaVec::new_in(ctx), NONE, ctx);
+    let body = FunctionBody::boxed(SPAN, ArenaVec::new_in(ctx), stmts, ctx);
+    let arrow = Expression::new_arrow_function_expression_with_scope_id_and_pure_and_pife(
+        SPAN, false, false, NONE, params, NONE, body, scope_id, false, false, ctx,
     );
-    ctx.ast.expression_call(span, arrow, NONE, ctx.ast.vec(), false)
+    Expression::new_call_expression(span, arrow, NONE, ArenaVec::new_in(ctx), false, ctx)
 }
 
 /// `object` -> `object.prototype`.
@@ -83,8 +86,9 @@ pub fn create_prototype_member<'a>(
     span: Span,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, "prototype");
-    let static_member = ctx.ast.member_expression_static(span, object, property, false);
+    let property = IdentifierName::new(SPAN, "prototype", ctx);
+    let static_member =
+        MemberExpression::new_static_member_expression(span, object, property, false, ctx);
     Expression::from(static_member)
 }
 
@@ -95,8 +99,10 @@ pub fn create_property_access<'a>(
     property: &str,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, ctx.ast.str(property));
-    Expression::from(ctx.ast.member_expression_static(span, object, property, false))
+    let property = IdentifierName::new(SPAN, Str::from_str_in(property, ctx), ctx);
+    Expression::from(MemberExpression::new_static_member_expression(
+        span, object, property, false, ctx,
+    ))
 }
 
 /// `this.property`
@@ -106,9 +112,9 @@ pub fn create_this_property_access<'a>(
     property: Ident<'a>,
     ctx: &TraverseCtx<'a>,
 ) -> MemberExpression<'a> {
-    let object = ctx.ast.expression_this(span);
-    let property = ctx.ast.identifier_name(SPAN, property);
-    ctx.ast.member_expression_static(span, object, property, false)
+    let object = Expression::new_this_expression(span, ctx);
+    let property = IdentifierName::new(SPAN, property, ctx);
+    MemberExpression::new_static_member_expression(span, object, property, false, ctx)
 }
 
 /// `this.property`
@@ -128,11 +134,12 @@ pub fn create_assignment<'a>(
     span: Span,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
-    ctx.ast.expression_assignment(
+    Expression::new_assignment_expression(
         span,
         AssignmentOperator::Assign,
         binding.create_target(ReferenceFlags::Write, ctx),
         value,
+        ctx,
     )
 }
 
@@ -141,13 +148,16 @@ pub fn create_super_call<'a>(
     args_binding: &BoundIdentifier<'a>,
     ctx: &mut TraverseCtx<'a>,
 ) -> Expression<'a> {
-    ctx.ast.expression_call(
+    Expression::new_call_expression(
         SPAN,
-        ctx.ast.expression_super(SPAN),
+        Expression::new_super(SPAN, ctx),
         NONE,
-        ctx.ast
-            .vec1(ctx.ast.argument_spread_element(SPAN, args_binding.create_read_expression(ctx))),
+        ArenaVec::from_value_in(
+            Argument::new_spread_element(SPAN, args_binding.create_read_expression(ctx), ctx),
+            ctx,
+        ),
         false,
+        ctx,
     )
 }
 
@@ -168,22 +178,28 @@ pub fn create_class_constructor<'a, 'c>(
     let stmts = if has_super_class {
         let args_binding = ctx.generate_uid("args", scope_id, SymbolFlags::FunctionScopedVariable);
         let rest_element =
-            ctx.ast.binding_rest_element(SPAN, args_binding.create_binding_pattern(ctx));
+            BindingRestElement::new(SPAN, args_binding.create_binding_pattern(ctx), ctx);
         params_rest =
-            Some(ctx.ast.alloc_formal_parameter_rest(SPAN, ctx.ast.vec(), rest_element, NONE));
-        ctx.ast.vec_from_iter(
-            iter::once(ctx.ast.statement_expression(SPAN, create_super_call(&args_binding, ctx)))
-                .chain(stmts_iter),
+            Some(FormalParameterRest::boxed(SPAN, ArenaVec::new_in(ctx), rest_element, NONE, ctx));
+        ArenaVec::from_iter_in(
+            iter::once(Statement::new_expression_statement(
+                SPAN,
+                create_super_call(&args_binding, ctx),
+                ctx,
+            ))
+            .chain(stmts_iter),
+            ctx,
         )
     } else {
-        ctx.ast.vec_from_iter(stmts_iter)
+        ArenaVec::from_iter_in(stmts_iter, ctx)
     };
 
-    let params = ctx.ast.alloc_formal_parameters(
+    let params = FormalParameters::boxed(
         SPAN,
         FormalParameterKind::FormalParameter,
-        ctx.ast.vec(),
+        ArenaVec::new_in(ctx),
         params_rest,
+        ctx,
     );
 
     create_class_constructor_with_params(stmts, params, scope_id, ctx)
@@ -197,8 +213,8 @@ pub fn create_class_constructor_with_params<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> ClassElement<'a> {
     create_class_method(
-        ctx.ast.vec(),
-        PropertyKey::StaticIdentifier(ctx.ast.alloc_identifier_name(SPAN, "constructor")),
+        ArenaVec::new_in(ctx),
+        PropertyKey::StaticIdentifier(IdentifierName::boxed(SPAN, "constructor", ctx)),
         MethodDefinitionKind::Constructor,
         params,
         None,
@@ -223,12 +239,12 @@ pub fn create_class_method<'a>(
     scope_id: ScopeId,
     ctx: &TraverseCtx<'a>,
 ) -> ClassElement<'a> {
-    ClassElement::MethodDefinition(ctx.ast.alloc_method_definition(
+    ClassElement::MethodDefinition(MethodDefinition::boxed(
         SPAN,
         MethodDefinitionType::MethodDefinition,
         decorators,
         key,
-        ctx.ast.alloc_function_with_scope_id(
+        Function::boxed_with_scope_id(
             SPAN,
             FunctionType::FunctionExpression,
             None,
@@ -239,8 +255,9 @@ pub fn create_class_method<'a>(
             NONE,
             params,
             return_type,
-            Some(ctx.ast.alloc_function_body(SPAN, ctx.ast.vec(), stmts)),
+            Some(FunctionBody::boxed(SPAN, ArenaVec::new_in(ctx), stmts, ctx)),
             scope_id,
+            ctx,
         ),
         kind,
         computed,
@@ -248,5 +265,6 @@ pub fn create_class_method<'a>(
         false,
         false,
         None,
+        ctx,
     ))
 }

--- a/crates/oxc_transformer_plugins/Cargo.toml
+++ b/crates/oxc_transformer_plugins/Cargo.toml
@@ -24,7 +24,7 @@ doctest = false
 cow-utils = { workspace = true }
 itoa = { workspace = true }
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true }
+oxc_ast = { workspace = true, features = ["builder_new"] }
 oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }

--- a/crates/oxc_transformer_plugins/src/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/src/inject_global_variables.rs
@@ -2,8 +2,12 @@ use std::{borrow::Cow, sync::Arc};
 
 use cow_utils::CowUtils;
 
-use oxc_allocator::Allocator;
-use oxc_ast::{AstBuilder, NONE, ast::*};
+use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
+use oxc_ast::{
+    NONE,
+    ast::*,
+    builder::{AstBuilder, GetAstBuilder},
+};
 use oxc_semantic::Scoping;
 use oxc_span::SPAN;
 use oxc_str::{CompactStr, format_compact_str};
@@ -212,12 +216,14 @@ impl<'a> InjectGlobalVariables<'a> {
 
     fn inject_imports(&mut self, injects: &[InjectImport], program: &mut Program<'a>) {
         let imports = injects.iter().map(|inject| {
-            let specifiers = Some(self.ast.vec1(self.inject_import_to_specifier(inject)));
-            let source = self.ast.string_literal(SPAN, self.ast.str(&inject.source), None);
+            let specifiers =
+                Some(ArenaVec::from_value_in(self.inject_import_to_specifier(inject), self));
+            let source =
+                StringLiteral::new(SPAN, Str::from_str_in(&inject.source, self), None, self);
             let kind = ImportOrExportKind::Value;
-            let import_decl = self
-                .ast
-                .module_declaration_import_declaration(SPAN, specifiers, source, None, NONE, kind);
+            let import_decl = ModuleDeclaration::new_import_declaration(
+                SPAN, specifiers, source, None, NONE, kind, self,
+            );
             Statement::from(import_decl)
         });
         program.body.splice(0..0, imports);
@@ -229,34 +235,35 @@ impl<'a> InjectGlobalVariables<'a> {
             InjectImportSpecifier::Specifier { imported, local } => {
                 let imported = match imported {
                     Some(imported_name) => {
-                        let imported_name = self.ast.str(imported_name);
+                        let imported_name = Str::from_str_in(imported_name, self);
                         if identifier::is_identifier_name(&imported_name) {
-                            self.ast.module_export_name_identifier_name(SPAN, imported_name)
+                            ModuleExportName::new_identifier_name(SPAN, imported_name, self)
                         } else {
-                            self.ast.module_export_name_string_literal(SPAN, imported_name, None)
+                            ModuleExportName::new_string_literal(SPAN, imported_name, None, self)
                         }
                     }
-                    None => self.ast.module_export_name_identifier_name(SPAN, "default"),
+                    None => ModuleExportName::new_identifier_name(SPAN, "default", self),
                 };
 
                 let local = inject.replace_value.as_ref().unwrap_or(local).as_str();
 
-                self.ast.import_declaration_specifier_import_specifier(
+                ImportDeclarationSpecifier::new_import_specifier(
                     SPAN,
                     imported,
-                    self.ast.binding_identifier(SPAN, self.ast.str(local)),
+                    BindingIdentifier::new(SPAN, Str::from_str_in(local, self), self),
                     ImportOrExportKind::Value,
+                    self,
                 )
             }
             InjectImportSpecifier::DefaultSpecifier { local } => {
                 let local = inject.replace_value.as_ref().unwrap_or(local).as_str();
-                let local = self.ast.binding_identifier(SPAN, self.ast.str(local));
-                self.ast.import_declaration_specifier_import_default_specifier(SPAN, local)
+                let local = BindingIdentifier::new(SPAN, Str::from_str_in(local, self), self);
+                ImportDeclarationSpecifier::new_import_default_specifier(SPAN, local, self)
             }
             InjectImportSpecifier::NamespaceSpecifier { local } => {
                 let local = inject.replace_value.as_ref().unwrap_or(local).as_str();
-                let local = self.ast.binding_identifier(SPAN, self.ast.str(local));
-                self.ast.import_declaration_specifier_import_namespace_specifier(SPAN, local)
+                let local = BindingIdentifier::new(SPAN, Str::from_str_in(local, self), self);
+                ImportDeclarationSpecifier::new_import_namespace_specifier(SPAN, local, self)
             }
         }
     }
@@ -276,10 +283,10 @@ impl<'a> InjectGlobalVariables<'a> {
                         let value_str = *value_str.get_or_insert_with(|| {
                             self.replaced_dot_defines
                                 .push((dot_define.parts[0].clone(), dot_define.value.clone()));
-                            self.ast.str(dot_define.value.as_str())
+                            Str::from_str_in(dot_define.value.as_str(), &self.ast)
                         });
 
-                        let value = self.ast.expression_identifier(SPAN, value_str);
+                        let value = Expression::new_identifier(SPAN, value_str, self);
                         *expr = value;
                         self.mark_as_changed();
                         break;
@@ -300,10 +307,10 @@ impl<'a> InjectGlobalVariables<'a> {
                             let value_str = *value_str.get_or_insert_with(|| {
                                 self.replaced_dot_defines
                                     .push((dot_define.parts[0].clone(), dot_define.value.clone()));
-                                self.ast.str(dot_define.value.as_str())
+                                Str::from_str_in(dot_define.value.as_str(), &self.ast)
                             });
 
-                            let value = self.ast.expression_identifier(SPAN, value_str);
+                            let value = Expression::new_identifier(SPAN, value_str, self);
                             *expr = value;
                             self.mark_as_changed();
                             break;
@@ -312,5 +319,21 @@ impl<'a> InjectGlobalVariables<'a> {
                 }
             _ => {}
         }
+    }
+}
+
+impl<'a> GetAllocator<'a> for InjectGlobalVariables<'a> {
+    #[inline]
+    fn allocator(&self) -> &'a Allocator {
+        self.ast.allocator()
+    }
+}
+
+impl<'a> GetAstBuilder<'a> for InjectGlobalVariables<'a> {
+    type Builder = AstBuilder<'a>;
+
+    #[inline]
+    fn builder(&self) -> &AstBuilder<'a> {
+        &self.ast
     }
 }

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -50,7 +50,7 @@ use std::iter;
 use itoa::Buffer as ItoaBuffer;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, TakeIn};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, Scoping, SymbolFlags, SymbolId};
@@ -128,7 +128,7 @@ impl<'a> ModuleRunnerTransform<'a> {
 
         // Reserve enough space for new statements
         let mut new_stmts: ArenaVec<'a, Statement<'a>> =
-            ctx.ast.vec_with_capacity(program.body.len() * 2);
+            ArenaVec::with_capacity_in(program.body.len() * 2, ctx);
 
         let mut hoist_imports = Vec::with_capacity(program.body.len());
         let mut hoist_exports = Vec::with_capacity(program.body.len());
@@ -231,9 +231,9 @@ impl<'a> ModuleRunnerTransform<'a> {
                 // wrap with (0, ...) to avoid method binding `this`
                 // <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#method_binding>
                 let zero =
-                    ctx.ast.expression_numeric_literal(SPAN, 0f64, None, NumberBase::Decimal);
-                let expressions = ctx.ast.vec_from_array([zero, expr]);
-                ctx.ast.expression_sequence(ident.span, expressions)
+                    Expression::new_numeric_literal(SPAN, 0f64, None, NumberBase::Decimal, ctx);
+                let expressions = ArenaVec::from_array_in([zero, expr], ctx);
+                Expression::new_sequence_expression(ident.span, expressions, ctx)
             } else {
                 expr
             }
@@ -262,8 +262,9 @@ impl<'a> ModuleRunnerTransform<'a> {
             flags,
         );
         let arguments = options.into_iter().map(Argument::from);
-        let arguments = ctx.ast.vec_from_iter(iter::once(Argument::from(source)).chain(arguments));
-        *expr = ctx.ast.expression_call(span, callee, NONE, arguments, false);
+        let arguments =
+            ArenaVec::from_iter_in(iter::once(Argument::from(source)).chain(arguments), ctx);
+        *expr = Expression::new_call_expression(span, callee, NONE, arguments, false, ctx);
     }
 
     /// Transform `import.meta` to `__vite_ssr_import_meta__`.
@@ -312,8 +313,8 @@ impl<'a> ModuleRunnerTransform<'a> {
         self.deps.insert(source.value.to_string());
 
         // ['vue', { importedNames: ['foo'] }]`
-        let mut arguments = ctx.ast.vec_with_capacity(1 + usize::from(specifiers.is_some()));
-        arguments.push(Argument::from(Expression::StringLiteral(ctx.ast.alloc(source))));
+        let mut arguments = ArenaVec::with_capacity_in(1 + usize::from(specifiers.is_some()), ctx);
+        arguments.push(Argument::from(Expression::StringLiteral(ArenaBox::new_in(source, ctx))));
         let pattern = if let Some(mut specifiers) = specifiers {
             // `import * as vue from 'vue';` -> `const __vite_ssr_import_0__ = await __vite_ssr_import__('vue');`
             if matches!(
@@ -430,15 +431,22 @@ impl<'a> ModuleRunnerTransform<'a> {
                 self.deps.insert(source.value.to_string());
                 let binding = self.generate_import_binding(ctx);
                 let pattern = binding.create_binding_pattern(ctx);
-                let imported_names = ctx.ast.vec_from_iter(specifiers.iter().map(|specifier| {
-                    let local_name = specifier.local.name();
-                    let local_name_expr = ctx.ast.expression_string_literal(SPAN, local_name, None);
-                    ArrayExpressionElement::from(local_name_expr)
-                }));
-                let arguments = ctx.ast.vec_from_array([
-                    Argument::StringLiteral(ctx.ast.alloc(source)),
-                    Self::create_imported_names_object(imported_names, ctx),
-                ]);
+                let imported_names = ArenaVec::from_iter_in(
+                    specifiers.iter().map(|specifier| {
+                        let local_name = specifier.local.name();
+                        let local_name_expr =
+                            Expression::new_string_literal(SPAN, local_name, None, ctx);
+                        ArrayExpressionElement::from(local_name_expr)
+                    }),
+                    ctx,
+                );
+                let arguments = ArenaVec::from_array_in(
+                    [
+                        Argument::StringLiteral(ArenaBox::new_in(source, ctx)),
+                        Self::create_imported_names_object(imported_names, ctx),
+                    ],
+                    ctx,
+                );
                 hoist_imports.push(Self::create_import(SPAN, pattern, arguments, ctx));
                 binding
             });
@@ -459,7 +467,7 @@ impl<'a> ModuleRunnerTransform<'a> {
                     let ModuleExportName::IdentifierReference(ident) = local else {
                         unreachable!()
                     };
-                    Expression::Identifier(ctx.ast.alloc(ident))
+                    Expression::Identifier(ArenaBox::new_in(ident, ctx))
                 };
                 Self::create_export(span, expr, exported.name().into(), ctx)
             }));
@@ -494,8 +502,10 @@ impl<'a> ModuleRunnerTransform<'a> {
         self.deps.insert(source.value.to_string());
         let binding = self.generate_import_binding(ctx);
         let pattern = binding.create_binding_pattern(ctx);
-        let arguments =
-            ctx.ast.vec1(Argument::from(Expression::StringLiteral(ctx.ast.alloc(source))));
+        let arguments = ArenaVec::from_value_in(
+            Argument::from(Expression::StringLiteral(ArenaBox::new_in(source, ctx))),
+            ctx,
+        );
         let import = Self::create_import(span, pattern, arguments, ctx);
 
         let ident = binding.create_read_expression(ctx);
@@ -508,11 +518,11 @@ impl<'a> ModuleRunnerTransform<'a> {
             hoist_exports.push(export);
         } else {
             let callee =
-                ctx.ast.expression_identifier(SPAN, static_ident!("__vite_ssr_exportAll__"));
-            let arguments = ctx.ast.vec1(Argument::from(ident));
+                Expression::new_identifier(SPAN, static_ident!("__vite_ssr_exportAll__"), ctx);
+            let arguments = ArenaVec::from_value_in(Argument::from(ident), ctx);
             // `export * from 'vue'` -> `__vite_ssr_exportAll__(__vite_ssr_import_0__);`
-            let call = ctx.ast.expression_call(SPAN, callee, NONE, arguments, false);
-            let export = ctx.ast.statement_expression(span, call);
+            let call = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
+            let export = Statement::new_expression_statement(span, call, ctx);
             // names from `export *` cannot be known, so add it right after the import.
             hoist_imports.extend([import, export]);
         }
@@ -607,8 +617,9 @@ impl<'a> ModuleRunnerTransform<'a> {
         specifiers: ArenaVec<'a, ImportDeclarationSpecifier<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Argument<'a> {
-        let elements =
-            ctx.ast.vec_from_iter(specifiers.into_iter().map(|specifier| match specifier {
+        let allocator = ctx.allocator();
+        let elements = ArenaVec::from_iter_in(
+            specifiers.into_iter().map(|specifier| match specifier {
                 ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
                     let ImportSpecifier { span, local, imported, .. } = specifier.unbox();
                     self.insert_import_binding(span, binding, local, imported.name(), ctx)
@@ -626,7 +637,9 @@ impl<'a> ModuleRunnerTransform<'a> {
                 ImportDeclarationSpecifier::ImportNamespaceSpecifier(_) => {
                     unreachable!()
                 }
-            }));
+            }),
+            &allocator,
+        );
         Self::create_imported_names_object(elements, ctx)
     }
 
@@ -650,7 +663,7 @@ impl<'a> ModuleRunnerTransform<'a> {
             self.import_bindings.insert(symbol_id, (binding.clone(), Some(key)));
         }
 
-        ArrayExpressionElement::from(ctx.ast.expression_string_literal(span, key, None))
+        ArrayExpressionElement::from(Expression::new_string_literal(span, key, None, ctx))
     }
 
     #[inline]
@@ -669,7 +682,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         let mut buffer = ItoaBuffer::new();
         let uid_str = buffer.format(self.import_uid);
         self.import_uid += 1;
-        ctx.ast.ident_from_strs_array(["__vite_ssr_import_", uid_str, "__"])
+        Ident::from_strs_array_in(["__vite_ssr_import_", uid_str, "__"], ctx)
     }
 
     /// Generate a unique import binding whose name is like `__vite_ssr_import_{uid}__`.
@@ -684,9 +697,9 @@ impl<'a> ModuleRunnerTransform<'a> {
         elements: ArenaVec<'a, ArrayExpressionElement<'a>>,
         ctx: &TraverseCtx<'a>,
     ) -> Argument<'a> {
-        let value = ctx.ast.expression_array(SPAN, elements);
-        let key = ctx.ast.property_key_static_identifier(SPAN, Str::from("importedNames"));
-        let imported_names = ctx.ast.object_property_kind_object_property(
+        let value = Expression::new_array_expression(SPAN, elements, ctx);
+        let key = PropertyKey::new_static_identifier(SPAN, Str::from("importedNames"), ctx);
+        let imported_names = ObjectPropertyKind::new_object_property(
             SPAN,
             PropertyKind::Init,
             key,
@@ -694,8 +707,13 @@ impl<'a> ModuleRunnerTransform<'a> {
             false,
             false,
             false,
+            ctx,
         );
-        Argument::from(ctx.ast.expression_object(SPAN, ctx.ast.vec1(imported_names)))
+        Argument::from(Expression::new_object_expression(
+            SPAN,
+            ArenaVec::from_value_in(imported_names, ctx),
+            ctx,
+        ))
     }
 
     // `const __vite_ssr_import_0__ = await __vite_ssr_import__('vue', { importedNames: ['foo'] });`
@@ -710,12 +728,18 @@ impl<'a> ModuleRunnerTransform<'a> {
             static_ident!("__vite_ssr_import__"),
             ReferenceFlags::Read,
         );
-        let call = ctx.ast.expression_call(SPAN, callee, NONE, arguments, false);
-        let init = ctx.ast.expression_await(SPAN, call);
+        let call = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
+        let init = Expression::new_await_expression(SPAN, call, ctx);
 
         let kind = VariableDeclarationKind::Const;
-        let declarator = ctx.ast.variable_declarator(SPAN, kind, pattern, NONE, Some(init), false);
-        let declaration = ctx.ast.declaration_variable(span, kind, ctx.ast.vec1(declarator), false);
+        let declarator = VariableDeclarator::new(SPAN, kind, pattern, NONE, Some(init), false, ctx);
+        let declaration = Declaration::new_variable_declaration(
+            span,
+            kind,
+            ArenaVec::from_value_in(declarator, ctx),
+            false,
+            ctx,
+        );
         Statement::from(declaration)
     }
 
@@ -727,7 +751,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         let object =
             ctx.create_unbound_ident_expr(SPAN, static_ident!("Object"), ReferenceFlags::Read);
         let member = create_member_callee(object, static_ident!("defineProperty"), ctx);
-        ctx.ast.expression_call(SPAN, member, NONE, arguments, false)
+        Expression::new_call_expression(SPAN, member, NONE, arguments, false, ctx)
     }
 
     // `key: value` or `key() {}`
@@ -737,14 +761,15 @@ impl<'a> ModuleRunnerTransform<'a> {
         ctx: &TraverseCtx<'a>,
     ) -> ObjectPropertyKind<'a> {
         let is_method = value.is_some();
-        ctx.ast.object_property_kind_object_property(
+        ObjectPropertyKind::new_object_property(
             SPAN,
             PropertyKind::Init,
-            ctx.ast.property_key_static_identifier(SPAN, key),
-            value.unwrap_or_else(|| ctx.ast.expression_boolean_literal(SPAN, true)),
+            PropertyKey::new_static_identifier(SPAN, key, ctx),
+            value.unwrap_or_else(|| Expression::new_boolean_literal(SPAN, true, ctx)),
             is_method,
             false,
             false,
+            ctx,
         )
     }
 
@@ -754,12 +779,17 @@ impl<'a> ModuleRunnerTransform<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let kind = FormalParameterKind::FormalParameter;
-        let params = ctx.ast.formal_parameters(SPAN, kind, ctx.ast.vec(), NONE);
-        let statement = ctx.ast.statement_return(SPAN, Some(expr));
-        let body = ctx.ast.function_body(SPAN, ctx.ast.vec(), ctx.ast.vec1(statement));
+        let params = FormalParameters::new(SPAN, kind, ArenaVec::new_in(ctx), NONE, ctx);
+        let statement = Statement::new_return_statement(SPAN, Some(expr), ctx);
+        let body = FunctionBody::new(
+            SPAN,
+            ArenaVec::new_in(ctx),
+            ArenaVec::from_value_in(statement, ctx),
+            ctx,
+        );
         let r#type = FunctionType::FunctionExpression;
         let scope_id = ctx.create_child_scope(ctx.scoping().root_scope_id(), ScopeFlags::Function);
-        ctx.ast.expression_function_with_scope_id_and_pure_and_pife(
+        Expression::new_function_expression_with_scope_id_and_pure_and_pife(
             SPAN,
             r#type,
             None,
@@ -774,6 +804,7 @@ impl<'a> ModuleRunnerTransform<'a> {
             scope_id,
             false,
             false,
+            ctx,
         )
     }
 
@@ -785,26 +816,33 @@ impl<'a> ModuleRunnerTransform<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         let getter = Self::create_function_with_return_statement(expr, ctx);
-        let object = ctx.ast.expression_object(
+        let object = Expression::new_object_expression(
             SPAN,
-            ctx.ast.vec_from_array([
-                Self::create_object_property("enumerable", None, ctx),
-                Self::create_object_property("configurable", None, ctx),
-                Self::create_object_property("get", Some(getter), ctx),
-            ]),
+            ArenaVec::from_array_in(
+                [
+                    Self::create_object_property("enumerable", None, ctx),
+                    Self::create_object_property("configurable", None, ctx),
+                    Self::create_object_property("get", Some(getter), ctx),
+                ],
+                ctx,
+            ),
+            ctx,
         );
 
-        let arguments = ctx.ast.vec_from_array([
-            Argument::from(ctx.create_unbound_ident_expr(
-                SPAN,
-                static_ident!("__vite_ssr_exports__"),
-                ReferenceFlags::Read,
-            )),
-            Argument::from(ctx.ast.expression_string_literal(SPAN, exported_name, None)),
-            Argument::from(object),
-        ]);
+        let arguments = ArenaVec::from_array_in(
+            [
+                Argument::from(ctx.create_unbound_ident_expr(
+                    SPAN,
+                    static_ident!("__vite_ssr_exports__"),
+                    ReferenceFlags::Read,
+                )),
+                Argument::from(Expression::new_string_literal(SPAN, exported_name, None, ctx)),
+                Argument::from(object),
+            ],
+            ctx,
+        );
 
-        ctx.ast.statement_expression(span, Self::create_define_property(arguments, ctx))
+        Statement::new_expression_statement(span, Self::create_define_property(arguments, ctx), ctx)
     }
 
     fn create_export_default(span: Span, ctx: &mut TraverseCtx<'a>) -> Statement<'a> {
@@ -832,8 +870,15 @@ impl<'a> ModuleRunnerTransform<'a> {
         );
         let pattern = binding.create_binding_pattern(ctx);
         let kind = VariableDeclarationKind::Const;
-        let declarator = ctx.ast.variable_declarator(SPAN, kind, pattern, NONE, Some(right), false);
-        let declaration = ctx.ast.declaration_variable(span, kind, ctx.ast.vec1(declarator), false);
+        let declarator =
+            VariableDeclarator::new(SPAN, kind, pattern, NONE, Some(right), false, ctx);
+        let declaration = Declaration::new_variable_declaration(
+            span,
+            kind,
+            ArenaVec::from_value_in(declarator, ctx),
+            false,
+            ctx,
+        );
         Statement::from(declaration)
     }
 }
@@ -845,8 +890,11 @@ fn create_compute_property_access<'a>(
     property: &str,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let expression = ctx.ast.expression_string_literal(SPAN, ctx.ast.str(property), None);
-    Expression::from(ctx.ast.member_expression_computed(span, object, expression, false))
+    let expression =
+        Expression::new_string_literal(SPAN, Str::from_str_in(property, ctx), None, ctx);
+    Expression::from(MemberExpression::new_computed_member_expression(
+        span, object, expression, false, ctx,
+    ))
 }
 
 /// `object` -> `object.call`.
@@ -855,8 +903,10 @@ pub fn create_member_callee<'a>(
     property: Ident<'a>,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, property);
-    Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))
+    let property = IdentifierName::new(SPAN, property, ctx);
+    Expression::from(MemberExpression::new_static_member_expression(
+        SPAN, object, property, false, ctx,
+    ))
 }
 
 /// `object` -> `object.a`.
@@ -866,8 +916,10 @@ pub fn create_property_access<'a>(
     property: &str,
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, ctx.ast.str(property));
-    Expression::from(ctx.ast.member_expression_static(span, object, property, false))
+    let property = IdentifierName::new(SPAN, Str::from_str_in(property, ctx), ctx);
+    Expression::from(MemberExpression::new_static_member_expression(
+        span, object, property, false, ctx,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -24,7 +24,7 @@ doctest = true
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true }
+oxc_ast = { workspace = true, features = ["builder_new"] }
 oxc_ast_visit = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["stack"] }
 oxc_ecmascript = { workspace = true }

--- a/crates/oxc_traverse/src/context/bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/bound_identifier.rs
@@ -81,7 +81,7 @@ impl<'a> BoundIdentifier<'a> {
         span: Span,
         ctx: &TraverseCtx<'a, State>,
     ) -> BindingIdentifier<'a> {
-        ctx.ast.binding_identifier_with_symbol_id(span, self.name, self.symbol_id)
+        BindingIdentifier::new_with_symbol_id(span, self.name, self.symbol_id, ctx)
     }
 
     /// Create `BindingPattern` for this binding, with specified `Span`

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator};
 use oxc_ast::{
-    AstBuilder,
     ast::{Expression, IdentifierReference, Statement},
+    builder::{AstBuilder, GetAstBuilder},
 };
 use oxc_semantic::Scoping;
 use oxc_span::Span;
@@ -129,7 +129,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     /// Shortcut for `ctx.ast.alloc`.
     #[inline]
     pub fn alloc<T>(&self, node: T) -> ArenaBox<'a, T> {
-        self.ast.alloc(node)
+        ArenaBox::new_in(node, self)
     }
 
     /// Get parent of current node.
@@ -518,7 +518,7 @@ impl<'a, State> TraverseCtx<'a, State> {
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         let reference_id = self.create_bound_reference(symbol_id, flags);
-        self.ast.identifier_reference_with_reference_id(span, name, reference_id)
+        IdentifierReference::new_with_reference_id(span, name, reference_id, self)
     }
 
     /// Create an `Expression::Identifier` bound to a `SymbolId`.
@@ -530,7 +530,7 @@ impl<'a, State> TraverseCtx<'a, State> {
         flags: ReferenceFlags,
     ) -> Expression<'a> {
         let ident = self.create_bound_ident_reference(span, name, symbol_id, flags);
-        Expression::Identifier(self.ast.alloc(ident))
+        Expression::Identifier(ArenaBox::new_in(ident, self))
     }
 
     /// Create an unbound reference.
@@ -553,7 +553,7 @@ impl<'a, State> TraverseCtx<'a, State> {
         flags: ReferenceFlags,
     ) -> IdentifierReference<'a> {
         let reference_id = self.create_unbound_reference(name, flags);
-        self.ast.identifier_reference_with_reference_id(span, name, reference_id)
+        IdentifierReference::new_with_reference_id(span, name, reference_id, self)
     }
 
     /// Create an unbound `Expression::Identifier`.
@@ -564,7 +564,7 @@ impl<'a, State> TraverseCtx<'a, State> {
         flags: ReferenceFlags,
     ) -> Expression<'a> {
         let ident = self.create_unbound_ident_reference(span, name, flags);
-        Expression::Identifier(self.ast.alloc(ident))
+        Expression::Identifier(ArenaBox::new_in(ident, self))
     }
 
     /// Create a reference optionally bound to a `SymbolId`.
@@ -714,5 +714,14 @@ impl<'a, State> GetAllocator<'a> for TraverseCtx<'a, State> {
     #[inline]
     fn allocator(&self) -> &'a Allocator {
         self.ast.allocator()
+    }
+}
+
+impl<'a, State> GetAstBuilder<'a> for TraverseCtx<'a, State> {
+    type Builder = AstBuilder<'a>;
+
+    #[inline]
+    fn builder(&self) -> &AstBuilder<'a> {
+        &self.ast
     }
 }


### PR DESCRIPTION
Part of #23043. Migrate `oxc_transformer` and `oxc_traverse` over to new `AstBuilder`.

This PR is a breaking change to users of `Traverse`, but I intend to rectify that in a later PR (before next crates release), so that these changes to `AstBuilder` are not a breaking change, and downstream projects can incrementally migrate over to the new `AstBuilder`.