### PR TITLE
refactor(minifier): `KeepVar` do not create new `AstBuilder`

### DIFF
--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -7,7 +7,6 @@ use oxc_str::Str;
 use oxc_syntax::symbol::SymbolId;
 
 pub struct KeepVar<'a> {
-    ast: AstBuilder<'a>,
     vars: Vec<(Str<'a>, Span, Option<SymbolId>)>,
     all_hoisted: bool,
 }
@@ -56,11 +55,14 @@ impl<'a> Visit<'a> for KeepVar<'a> {
 }
 
 impl<'a> KeepVar<'a> {
-    pub fn new(ast: &AstBuilder<'a>) -> Self {
-        Self { ast: AstBuilder::new(ast.allocator), vars: std::vec![], all_hoisted: true }
+    pub fn new() -> Self {
+        Self { vars: std::vec![], all_hoisted: true }
     }
 
-    pub fn get_variable_declaration(self) -> Option<ArenaBox<'a, VariableDeclaration<'a>>> {
+    pub fn get_variable_declaration(
+        self,
+        ast: &AstBuilder<'a>,
+    ) -> Option<ArenaBox<'a, VariableDeclaration<'a>>> {
         if self.vars.is_empty() {
             return None;
         }
@@ -69,22 +71,22 @@ impl<'a> KeepVar<'a> {
         let decls = ArenaVec::from_iter_in(
             self.vars.into_iter().map(|(name, span, symbol_id)| {
                 let id = symbol_id.map_or_else(
-                    || BindingPattern::new_binding_identifier(span, name, &self.ast),
+                    || BindingPattern::new_binding_identifier(span, name, ast),
                     |symbol_id| {
                         BindingPattern::new_binding_identifier_with_symbol_id(
-                            span, name, symbol_id, &self.ast,
+                            span, name, symbol_id, ast,
                         )
                     },
                 );
-                VariableDeclarator::new(span, kind, id, NONE, None, false, &self.ast)
+                VariableDeclarator::new(span, kind, id, NONE, None, false, ast)
             }),
-            &self.ast,
+            ast,
         );
 
-        Some(VariableDeclaration::boxed(SPAN, kind, decls, false, &self.ast))
+        Some(VariableDeclaration::boxed(SPAN, kind, decls, false, ast))
     }
 
-    pub fn get_variable_declaration_statement(self) -> Option<Statement<'a>> {
-        self.get_variable_declaration().map(Statement::VariableDeclaration)
+    pub fn get_variable_declaration_statement(self, ast: &AstBuilder<'a>) -> Option<Statement<'a>> {
+        self.get_variable_declaration(ast).map(Statement::VariableDeclaration)
     }
 }

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -50,7 +50,7 @@ impl<'a> PeepholeOptimizations {
     pub fn minimize_statements(stmts: &mut ArenaVec<'a, Statement<'a>>, ctx: &mut TraverseCtx<'a>) {
         let mut old_stmts = stmts.take_in(ctx);
         let mut is_control_flow_dead = false;
-        let mut keep_var = KeepVar::new(&ctx.ast);
+        let mut keep_var = KeepVar::new();
         let mut identity_drops = 0u32;
         for i in 0..old_stmts.len() {
             let stmt = old_stmts[i].take_in(ctx);
@@ -86,7 +86,7 @@ impl<'a> PeepholeOptimizations {
                 break;
             }
         }
-        if let Some(stmt) = keep_var.get_variable_declaration_statement() {
+        if let Some(stmt) = keep_var.get_variable_declaration_statement(&ctx.ast) {
             match Self::remove_unused_variable_declaration(stmt, ctx) {
                 // Multiple identity-dropped `var x;`s coalesce into a single
                 // `var x, y;`. The individual drops looked byte-identical, but

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -97,7 +97,7 @@ impl<'a> PeepholeOptimizations {
                 );
                 ctx.replace_expression(&mut if_stmt.test, new_test);
             }
-            let mut keep_var = KeepVar::new(&ctx.ast);
+            let mut keep_var = KeepVar::new();
             if boolean {
                 if let Some(alternate) = &if_stmt.alternate {
                     keep_var.visit_statement(alternate);
@@ -106,7 +106,7 @@ impl<'a> PeepholeOptimizations {
                 keep_var.visit_statement(&if_stmt.consequent);
             }
             let var_stmt = keep_var
-                .get_variable_declaration_statement()
+                .get_variable_declaration_statement(&ctx.ast)
                 .and_then(|stmt| Self::remove_unused_variable_declaration(stmt, ctx));
             let has_var_stmt = var_stmt.is_some();
             if let Some(var_stmt) = var_stmt {
@@ -198,9 +198,9 @@ impl<'a> PeepholeOptimizations {
         match test_boolean {
             Some(false) => match &for_stmt.init {
                 Some(ForStatementInit::VariableDeclaration(_)) => {
-                    let mut keep_var = KeepVar::new(&ctx.ast);
+                    let mut keep_var = KeepVar::new();
                     keep_var.visit_statement(&for_stmt.body);
-                    let mut var_decl = keep_var.get_variable_declaration();
+                    let mut var_decl = keep_var.get_variable_declaration(&ctx.ast);
                     let Some(ForStatementInit::VariableDeclaration(var_init)) = &mut for_stmt.init
                     else {
                         return;
@@ -219,9 +219,9 @@ impl<'a> PeepholeOptimizations {
                     ctx.replace_statement(stmt, new_stmt);
                 }
                 None => {
-                    let mut keep_var = KeepVar::new(&ctx.ast);
+                    let mut keep_var = KeepVar::new();
                     keep_var.visit_statement(&for_stmt.body);
-                    let new_stmt = keep_var.get_variable_declaration().map_or_else(
+                    let new_stmt = keep_var.get_variable_declaration(&ctx.ast).map_or_else(
                         || Statement::new_empty_statement(for_stmt.span, ctx),
                         Statement::VariableDeclaration,
                     );
@@ -267,9 +267,9 @@ impl<'a> PeepholeOptimizations {
             }
             _ => return
         }
-        let mut var = KeepVar::new(&ctx.ast);
+        let mut var = KeepVar::new();
         var.visit_statement(&s.body);
-        let var_decl = var.get_variable_declaration_statement();
+        let var_decl = var.get_variable_declaration_statement(&ctx.ast);
         let new_stmt = var_decl.unwrap_or_else(|| Statement::new_empty_statement(s.span, ctx));
         ctx.replace_statement(stmt, new_stmt);
     }
@@ -299,14 +299,14 @@ impl<'a> PeepholeOptimizations {
             let is_canonical_body =
                 body.is_empty() || (body.len() == 1 && Self::is_keep_var_canonical(&body[0]));
             if !is_canonical_body {
-                let mut var = KeepVar::new(&ctx.ast);
+                let mut var = KeepVar::new();
                 var.visit_block_statement(&handler.body);
                 let Some(handler) = &mut s.handler else { return };
 
                 for dropped in handler.body.body.take_in(ctx) {
                     ctx.drop_statement(&dropped);
                 }
-                if let Some(var_decl) = var.get_variable_declaration_statement() {
+                if let Some(var_decl) = var.get_variable_declaration_statement(&ctx.ast) {
                     handler.body.body.push(var_decl);
                 }
             }


### PR DESCRIPTION
Part of #23043, following on after #23832.

Avoid cloning `AstBuilder` in `KeepVars`. Instead pass `&AstBuilder` in to `get_variable_declaration` and `get_variable_declaration_statement`, which is the only place it's needed.

This means it will work as intended once `AstBuilder` becomes stateful (to generate unique `NodeId`s for all AST nodes). If we cloned the builder, it would lose that state.