### PR TITLE
feat(ecmascript)!: switch to new `AstBuilder`

### DIFF
--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true }
+oxc_ast = { workspace = true, features = ["builder_new"] }
 oxc_regular_expression = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true, features = ["to_js_string"] }

--- a/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/call_expr.rs
@@ -118,11 +118,11 @@ fn try_fold_string_casing<'a>(
     };
 
     let result = match name {
-        "toLowerCase" => ctx.ast().str(&value.cow_to_lowercase()),
-        "toUpperCase" => ctx.ast().str(&value.cow_to_uppercase()),
-        "trim" => ctx.ast().str(value.trim()),
-        "trimStart" => ctx.ast().str(value.trim_start()),
-        "trimEnd" => ctx.ast().str(value.trim_end()),
+        "toLowerCase" => Str::from_str_in(&value.cow_to_lowercase(), ctx),
+        "toUpperCase" => Str::from_str_in(&value.cow_to_uppercase(), ctx),
+        "trim" => Str::from_str_in(value.trim(), ctx),
+        "trimStart" => Str::from_str_in(value.trim_start(), ctx),
+        "trimEnd" => Str::from_str_in(value.trim_end(), ctx),
         _ => return None,
     };
     Some(ConstantValue::String(Cow::Borrowed(result.as_str())))

--- a/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
@@ -25,11 +25,12 @@ pub(super) fn abstract_equality_comparison<'a>(
             || matches!(right, ValueType::Boolean)
         {
             if let Some(num) = right_expr.evaluate_value_to_number(ctx) {
-                let number_literal_expr = ctx.ast().expression_numeric_literal(
+                let number_literal_expr = Expression::new_numeric_literal(
                     oxc_span::SPAN,
                     num,
                     None,
                     if num.fract() == 0.0 { NumberBase::Decimal } else { NumberBase::Float },
+                    ctx,
                 );
                 return abstract_equality_comparison(ctx, left_expr, &number_literal_expr);
             }
@@ -40,11 +41,12 @@ pub(super) fn abstract_equality_comparison<'a>(
             || matches!(left, ValueType::Boolean)
         {
             if let Some(num) = left_expr.evaluate_value_to_number(ctx) {
-                let number_literal_expr = ctx.ast().expression_numeric_literal(
+                let number_literal_expr = Expression::new_numeric_literal(
                     oxc_span::SPAN,
                     num,
                     None,
                     if num.fract() == 0.0 { NumberBase::Decimal } else { NumberBase::Float },
+                    ctx,
                 );
                 return abstract_equality_comparison(ctx, &number_literal_expr, right_expr);
             }

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -15,7 +15,8 @@ use std::borrow::Cow;
 
 use num_bigint::BigInt;
 use num_traits::{ToPrimitive, Zero};
-use oxc_ast::{AstBuilder, ast::*};
+use oxc_allocator::GetAllocator;
+use oxc_ast::{ast::*, builder::GetAstBuilder};
 
 use equality_comparison::{abstract_equality_comparison, strict_equality_comparison};
 
@@ -26,8 +27,9 @@ use crate::{
     to_numeric::ToNumeric,
 };
 
-pub trait ConstantEvaluationCtx<'a>: MayHaveSideEffectsContext<'a> {
-    fn ast(&self) -> AstBuilder<'a>;
+pub trait ConstantEvaluationCtx<'a>:
+    MayHaveSideEffectsContext<'a> + GetAstBuilder<'a> + GetAllocator<'a>
+{
 }
 
 pub trait ConstantEvaluation<'a>: MayHaveSideEffects<'a> {

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -1,4 +1,4 @@
-use oxc_ast::{AstBuilder, ast::*};
+use oxc_ast::ast::*;
 use oxc_compat::ESFeature;
 use oxc_ecmascript::{
     GlobalContext,
@@ -148,25 +148,7 @@ impl<'a> MayHaveSideEffectsContext<'a> for &mut TraverseCtx<'a, MinifierState<'a
     }
 }
 
-impl<'a> ConstantEvaluationCtx<'a> for TraverseCtx<'a, MinifierState<'a>> {
-    // `oxc_ecmascript` still uses the old `AstBuilder`.
-    // Bridge to it from the allocator behind the new builder held in `self.ast`.
-    fn ast(&self) -> AstBuilder<'a> {
-        AstBuilder::new(self.ast.allocator)
-    }
-}
-
-impl<'a> ConstantEvaluationCtx<'a> for &TraverseCtx<'a, MinifierState<'a>> {
-    fn ast(&self) -> AstBuilder<'a> {
-        (*self).ast()
-    }
-}
-
-impl<'a> ConstantEvaluationCtx<'a> for &mut TraverseCtx<'a, MinifierState<'a>> {
-    fn ast(&self) -> AstBuilder<'a> {
-        (**self).ast()
-    }
-}
+impl<'a> ConstantEvaluationCtx<'a> for TraverseCtx<'a, MinifierState<'a>> {}
 
 impl<'a> TraverseCtx<'a, MinifierState<'a>> {
     pub fn options(&self) -> &CompressOptions {


### PR DESCRIPTION
Part of #23043. Migrate `oxc_ecmascript` over to new `AstBuilder`.

This is a breaking change for users of `oxc_ecmascript` crate. `ConstantEvaluationCtx` no longer has an `ast` method to get an `AstBuilder`. Instead, any type that implements `ConstantEvaluationCtx` must also implement `oxc_allocator::GetAllocator` and `oxc_ast::builder::GetAstBuilder` - the latter proving a `builder` method which returns a `&AstBuilder`.

I'll aim to fix this to remove the breaking change in a follow-on PR (before next release).