### PR TITLE
test(codegen): switch to new `AstBuilder`

### DIFF
--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -37,6 +37,9 @@ itoa = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]
+# `AstBuilder` is only used in tests
+oxc_ast = { workspace = true, features = ["builder_new"] }
+
 insta = { workspace = true }
 oxc_parser = { workspace = true }
 pico-args = { workspace = true }

--- a/crates/oxc_codegen/tests/integration/js.rs
+++ b/crates/oxc_codegen/tests/integration/js.rs
@@ -1,5 +1,5 @@
-use oxc_allocator::Allocator;
-use oxc_ast::AstBuilder;
+use oxc_allocator::{Allocator, ArenaVec};
+use oxc_ast::{ast::*, builder::AstBuilder};
 use oxc_codegen::{Codegen, CodegenOptions, IndentChar};
 use oxc_span::SPAN;
 
@@ -848,8 +848,6 @@ fn indentation() {
 
 #[test]
 fn template_literal_escape_when_building_ast() {
-    use oxc_ast::ast::TemplateElementValue;
-
     let allocator = Allocator::default();
     let ast = AstBuilder::new(&allocator);
 
@@ -857,25 +855,30 @@ fn template_literal_escape_when_building_ast() {
     // backtick, ${, and backslash
     // Use `template_element_escape_raw` to automatically escape the raw field
     let cooked = "hello`world${foo}\\bar";
-    let value = TemplateElementValue { raw: ast.str(cooked), cooked: Some(ast.str(cooked)) };
-    let element = ast.template_element_escape_raw(SPAN, value, true);
-    let quasis = ast.vec1(element);
-    let template_literal = ast.template_literal(SPAN, quasis, ast.vec());
+    let value = TemplateElementValue {
+        raw: Str::from_str_in(cooked, &ast),
+        cooked: Some(Str::from_str_in(cooked, &ast)),
+    };
+    let element = TemplateElement::new_escape_raw(SPAN, value, true, &ast);
+    let quasis = ArenaVec::from_value_in(element, &ast);
+    let template_literal = TemplateLiteral::new(SPAN, quasis, ArenaVec::new_in(&ast), &ast);
 
-    let expr = ast.expression_template_literal(
+    let expr = Expression::new_template_literal(
         SPAN,
         template_literal.quasis,
         template_literal.expressions,
+        &ast,
     );
-    let stmt = ast.statement_expression(SPAN, expr);
-    let program = ast.program(
+    let stmt = Statement::new_expression_statement(SPAN, expr, &ast);
+    let program = Program::new(
         SPAN,
         oxc_span::SourceType::mjs(),
         "",
-        ast.vec(),
+        ArenaVec::new_in(&ast),
         None,
-        ast.vec(),
-        ast.vec1(stmt),
+        ArenaVec::new_in(&ast),
+        ArenaVec::from_value_in(stmt, &ast),
+        &ast,
     );
 
     let result = Codegen::new().build(&program).code;


### PR DESCRIPTION
Part of #23043. Migrate `oxc_codegen` over to new `AstBuilder`.

It only uses `AstBuilder` in one test, not in the main code.