### PR TITLE
refactor(ast_tools): switch to new `AstBuilder`

### DIFF
--- a/tasks/ast_tools/Cargo.toml
+++ b/tasks/ast_tools/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 #
 # `features = ["serialize"]` on `oxc_span` and `oxc_syntax` is needed to work around a bug in `oxc_index`.
 oxc_allocator = { workspace = true, optional = true }
-oxc_ast = { workspace = true, optional = true }
+oxc_ast = { workspace = true, optional = true, features = ["builder_new"] }
 oxc_ast_visit = { workspace = true, optional = true }
 oxc_codegen = { workspace = true, optional = true, features = ["sourcemap"] }
 oxc_minifier = { workspace = true, optional = true }

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -10,10 +10,11 @@ use rustc_hash::FxHashSet;
 
 use oxc_allocator::Allocator;
 use oxc_ast::{
-    AstBuilder,
     ast::{
-        Expression, LogicalOperator, ObjectExpression, ObjectPropertyKind, Program, PropertyKind,
+        Expression, LogicalOperator, ObjectExpression, ObjectPropertyKind, Program, PropertyKey,
+        PropertyKind,
     },
+    builder::AstBuilder,
 };
 use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_span::SPAN;
@@ -1809,14 +1810,15 @@ impl<'a> VisitMut<'a> for LocFieldAdder<'a> {
 
         if has_range_field {
             // Insert `__proto__: NodeProto` as first field
-            let prop = self.ast.object_property_kind_object_property(
+            let prop = ObjectPropertyKind::new_object_property(
                 SPAN,
                 PropertyKind::Init,
-                self.ast.property_key_static_identifier(SPAN, "__proto__"),
-                self.ast.expression_identifier(SPAN, "NodeProto"),
+                PropertyKey::new_static_identifier(SPAN, "__proto__", &self.ast),
+                Expression::new_identifier(SPAN, "NodeProto", &self.ast),
                 false,
                 false,
                 false,
+                &self.ast,
             );
             obj_expr.properties.insert(0, prop);
         }

--- a/tasks/ast_tools/src/output/javascript.rs
+++ b/tasks/ast_tools/src/output/javascript.rs
@@ -5,8 +5,8 @@ use rayon::prelude::*;
 
 use oxc_allocator::Allocator;
 use oxc_ast::{
-    AstBuilder,
     ast::{Expression, Program, UnaryOperator},
+    builder::AstBuilder,
 };
 use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_codegen::Codegen;
@@ -378,7 +378,7 @@ impl<'a> VisitMut<'a> for BooleanUnminifier<'a> {
             && unary_expr.operator == UnaryOperator::LogicalNot
             && let Expression::NumericLiteral(lit) = &unary_expr.argument
         {
-            *expr = self.ast.expression_boolean_literal(unary_expr.span, lit.value == 0.0);
+            *expr = Expression::new_boolean_literal(unary_expr.span, lit.value == 0.0, &self.ast);
             return;
         }
         walk_mut::walk_expression(self, expr);


### PR DESCRIPTION
Part of #23043. Migrate `oxc_ast_tools` codegen over to new `AstBuilder`.