### PR TITLE
refactor(isolated_declarations): switch to new `AstBuilder`

### DIFF
--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -22,7 +22,7 @@ test = false
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true }
+oxc_ast = { workspace = true, features = ["builder_new"] }
 oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -111,7 +111,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         None
                     } else if Self::is_non_const_array_literal(expr) {
                         self.error(array_inferred(expr.span()));
-                        Some(self.ast.ts_type_unknown_keyword(expr.span()))
+                        Some(TSType::new_ts_unknown_keyword(expr.span(), self))
                     } else {
                         self.transform_expression_to_ts_type(expr)
                     }
@@ -119,7 +119,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     self.infer_type_from_expression(expr)
                 };
 
-                type_annotation = ts_type.map(|t| self.ast.alloc_ts_type_annotation(SPAN, t));
+                type_annotation = ts_type.map(|t| TSTypeAnnotation::boxed(SPAN, t, self));
             }
 
             if type_annotation.is_none() && value.is_none() {
@@ -127,10 +127,10 @@ impl<'a> IsolatedDeclarations<'a> {
             }
         }
 
-        self.ast.class_element_property_definition(
+        ClassElement::new_property_definition(
             property.span,
             property.r#type,
-            self.ast.vec(),
+            ArenaVec::new_in(self),
             property.key.clone_in(self.ast.allocator),
             type_annotation,
             value,
@@ -142,6 +142,7 @@ impl<'a> IsolatedDeclarations<'a> {
             false,
             property.readonly,
             Self::transform_accessibility(property.accessibility),
+            self,
         )
     }
 
@@ -188,7 +189,7 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> ClassElement<'a> {
         let function = &definition.value;
 
-        let value = self.ast.alloc_function(
+        let value = Function::boxed(
             function.span,
             FunctionType::TSEmptyBodyFunctionExpression,
             function.id.clone_in(self.ast.allocator),
@@ -200,12 +201,13 @@ impl<'a> IsolatedDeclarations<'a> {
             params,
             return_type,
             NONE,
+            self,
         );
 
-        self.ast.class_element_method_definition(
+        ClassElement::new_method_definition(
             definition.span,
             definition.r#type,
-            self.ast.vec(),
+            ArenaVec::new_in(self),
             definition.key.clone_in(self.ast.allocator),
             value,
             definition.kind,
@@ -214,6 +216,7 @@ impl<'a> IsolatedDeclarations<'a> {
             definition.r#override,
             definition.optional,
             Self::transform_accessibility(definition.accessibility),
+            self,
         )
     }
 
@@ -226,10 +229,10 @@ impl<'a> IsolatedDeclarations<'a> {
         r#override: bool,
         accessibility: Option<TSAccessibility>,
     ) -> ClassElement<'a> {
-        self.ast.class_element_property_definition(
+        ClassElement::new_property_definition(
             span,
             r#type,
-            self.ast.vec(),
+            ArenaVec::new_in(self),
             key,
             NONE,
             None,
@@ -241,6 +244,7 @@ impl<'a> IsolatedDeclarations<'a> {
             false,
             false,
             accessibility,
+            self,
         )
     }
 
@@ -253,11 +257,11 @@ impl<'a> IsolatedDeclarations<'a> {
             // A parameter property may not be declared using a binding pattern.(1187)
             return None;
         };
-        let key = self.ast.property_key_static_identifier(SPAN, ident_name);
-        Some(self.ast.class_element_property_definition(
+        let key = PropertyKey::new_static_identifier(SPAN, ident_name, self);
+        Some(ClassElement::new_property_definition(
             param.span,
             PropertyDefinitionType::PropertyDefinition,
-            self.ast.vec(),
+            ArenaVec::new_in(self),
             key,
             type_annotation,
             None,
@@ -269,6 +273,7 @@ impl<'a> IsolatedDeclarations<'a> {
             false,
             param.readonly,
             Self::transform_accessibility(param.accessibility),
+            self,
         ))
     }
 
@@ -293,18 +298,19 @@ impl<'a> IsolatedDeclarations<'a> {
                 )
             }
             MethodDefinitionKind::Get | MethodDefinitionKind::Constructor => {
-                let params = self.ast.alloc_formal_parameters(
+                let params = FormalParameters::boxed(
                     SPAN,
                     FormalParameterKind::Signature,
-                    self.ast.vec(),
+                    ArenaVec::new_in(self),
                     NONE,
+                    self,
                 );
                 self.transform_class_method_definition(method, params, None)
             }
             MethodDefinitionKind::Set => {
-                let params = self.create_formal_parameters(
-                    self.ast.binding_pattern_binding_identifier(SPAN, "value"),
-                );
+                let params = self.create_formal_parameters(BindingPattern::new_binding_identifier(
+                    SPAN, "value", self,
+                ));
                 self.transform_class_method_definition(method, params, None)
             }
         }
@@ -324,7 +330,7 @@ impl<'a> IsolatedDeclarations<'a> {
         function: &Function<'a>,
         typed_params: &FormalParameters<'a>,
     ) -> ArenaVec<'a, ClassElement<'a>> {
-        self.ast.vec_from_iter(
+        ArenaVec::from_iter_in(
             function
                 .params
                 .items
@@ -347,6 +353,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         };
                     self.transform_formal_parameter_to_class_property(param, type_annotation)
                 }),
+            self,
         )
     }
 
@@ -451,7 +458,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
         let accessor_annotations = self.collect_accessor_annotations(decl);
         let mut has_private_key = false;
-        let mut elements = self.ast.vec();
+        let mut elements = ArenaVec::new_in(self);
         let mut is_function_overloads = false;
         for element in &decl.body.body {
             match element {
@@ -491,7 +498,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             let params = &method.value.params;
                             if params.items.is_empty() {
                                 self.create_formal_parameters(
-                                    self.ast.binding_pattern_binding_identifier(SPAN, "value"),
+                                    BindingPattern::new_binding_identifier(SPAN, "value", self),
                                 )
                             } else {
                                 let mut params = params.clone_in(self.ast.allocator);
@@ -619,10 +626,10 @@ impl<'a> IsolatedDeclarations<'a> {
                     };
 
                     // FIXME: missing many fields
-                    let new_element = self.ast.class_element_accessor_property(
+                    let new_element = ClassElement::new_accessor_property(
                         property.span,
                         property.r#type,
-                        self.ast.vec(),
+                        ArenaVec::new_in(self),
                         property.key.clone_in(self.ast.allocator),
                         type_annotation,
                         None,
@@ -631,6 +638,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         property.r#override,
                         false,
                         Self::transform_accessibility(property.accessibility),
+                        self,
                     );
                     elements.push(new_element);
                 }
@@ -648,23 +656,23 @@ impl<'a> IsolatedDeclarations<'a> {
             // <https://github.com/microsoft/TypeScript/blob/64d2eeea7b9c7f1a79edf42cb99f302535136a2e/src/compiler/transformers/declarations.ts#L1699-L1709>
             // When the class has at least one private identifier, create a unique constant identifier to retain the nominal typing behavior
             // Prevents other classes with the same public members from being used in place of the current class
-            let ident = self.ast.property_key_private_identifier(SPAN, "private");
+            let ident = PropertyKey::new_private_identifier(SPAN, "private", self);
             let r#type = PropertyDefinitionType::PropertyDefinition;
-            let decorators = self.ast.vec();
-            let element = self.ast.class_element_property_definition(
+            let decorators = ArenaVec::new_in(self);
+            let element = ClassElement::new_property_definition(
                 SPAN, r#type, decorators, ident, NONE, None, false, false, false, false, false,
-                false, false, None,
+                false, false, None, self,
             );
 
             elements.insert(0, element);
         }
 
-        let body = self.ast.class_body(decl.body.span, elements);
+        let body = ClassBody::new(decl.body.span, elements, self);
 
-        self.ast.alloc_class(
+        Class::boxed(
             decl.span,
             decl.r#type,
-            self.ast.vec(),
+            ArenaVec::new_in(self),
             decl.id.clone_in(self.ast.allocator),
             decl.type_parameters.clone_in(self.ast.allocator),
             decl.super_class.clone_in(self.ast.allocator),
@@ -673,6 +681,7 @@ impl<'a> IsolatedDeclarations<'a> {
             body,
             decl.r#abstract,
             declare.unwrap_or_else(|| self.is_declare()),
+            self,
         )
     }
 
@@ -680,9 +689,9 @@ impl<'a> IsolatedDeclarations<'a> {
         &self,
         kind: BindingPattern<'a>,
     ) -> ArenaBox<'a, FormalParameters<'a>> {
-        let parameter = self.ast.formal_parameter(
+        let parameter = FormalParameter::new(
             SPAN,
-            self.ast.vec(),
+            ArenaVec::new_in(self),
             kind,
             NONE,
             NONE,
@@ -690,8 +699,9 @@ impl<'a> IsolatedDeclarations<'a> {
             None,
             false,
             false,
+            self,
         );
-        let items = self.ast.vec1(parameter);
-        self.ast.alloc_formal_parameters(SPAN, FormalParameterKind::Signature, items, NONE)
+        let items = ArenaVec::from_value_in(parameter, self);
+        FormalParameters::boxed(SPAN, FormalParameterKind::Signature, items, NONE, self)
     }
 }

--- a/crates/oxc_isolated_declarations/src/declaration.rs
+++ b/crates/oxc_isolated_declarations/src/declaration.rs
@@ -25,10 +25,12 @@ impl<'a> IsolatedDeclarations<'a> {
         if decl.declare {
             None
         } else {
-            let declarations =
-                self.ast.vec_from_iter(decl.declarations.iter().filter_map(|declarator| {
+            let declarations = ArenaVec::from_iter_in(
+                decl.declarations.iter().filter_map(|declarator| {
                     self.transform_variable_declarator(declarator, check_binding)
-                }));
+                }),
+                self,
+            );
             Some(self.transform_variable_declaration_with_new_declarations(decl, declarations))
         }
     }
@@ -38,7 +40,7 @@ impl<'a> IsolatedDeclarations<'a> {
         decl: &VariableDeclaration<'a>,
         declarations: ArenaVec<'a, VariableDeclarator<'a>>,
     ) -> ArenaBox<'a, VariableDeclaration<'a>> {
-        self.ast.alloc_variable_declaration(decl.span, decl.kind, declarations, self.is_declare())
+        VariableDeclaration::boxed(decl.span, decl.kind, declarations, self.is_declare(), self)
     }
 
     pub(crate) fn transform_variable_declarator(
@@ -82,7 +84,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 }
             }
             if init.is_none() && binding_type.is_none() {
-                binding_type = Some(self.ast.ts_type_unknown_keyword(SPAN));
+                binding_type = Some(TSType::new_ts_unknown_keyword(SPAN, self));
                 if !decl.init.as_ref().is_some_and(Expression::is_function) {
                     self.error(variable_must_have_explicit_type(decl.id.span()));
                 }
@@ -97,15 +99,16 @@ impl<'a> IsolatedDeclarations<'a> {
         }
 
         let type_annotation =
-            binding_type.map(|ts_type| self.ast.ts_type_annotation(SPAN, ts_type));
+            binding_type.map(|ts_type| TSTypeAnnotation::new(SPAN, ts_type, self));
 
-        Some(self.ast.variable_declarator(
+        Some(VariableDeclarator::new(
             decl.span,
             decl.kind,
             id,
             type_annotation,
             init,
             decl.definite,
+            self,
         ))
     }
 
@@ -118,7 +121,7 @@ impl<'a> IsolatedDeclarations<'a> {
         self.scope.enter_scope(ScopeFlags::TsModuleBlock, &Cell::default());
         let stmts = self.transform_statements_on_demand(&block.body);
         self.scope.leave_scope();
-        self.ast.alloc_ts_module_block(SPAN, self.ast.vec(), stmts)
+        TSModuleBlock::boxed(SPAN, ArenaVec::new_in(self), stmts, self)
     }
 
     pub(crate) fn transform_ts_module_declaration(
@@ -138,22 +141,24 @@ impl<'a> IsolatedDeclarations<'a> {
         match body {
             TSModuleDeclarationBody::TSModuleDeclaration(inner_decl) => {
                 let inner = self.transform_ts_module_declaration(inner_decl);
-                self.ast.alloc_ts_module_declaration(
+                TSModuleDeclaration::boxed(
                     decl.span,
                     decl.id.clone_in(self.ast.allocator),
                     Some(TSModuleDeclarationBody::TSModuleDeclaration(inner)),
                     kind,
                     self.is_declare(),
+                    self,
                 )
             }
             TSModuleDeclarationBody::TSModuleBlock(block) => {
                 let body = self.transform_ts_module_block(block);
-                self.ast.alloc_ts_module_declaration(
+                TSModuleDeclaration::boxed(
                     decl.span,
                     decl.id.clone_in(self.ast.allocator),
                     Some(TSModuleDeclarationBody::TSModuleBlock(body)),
                     kind,
                     self.is_declare(),
+                    self,
                 )
             }
         }

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::CloneIn;
+use oxc_allocator::{ArenaVec, CloneIn};
 use oxc_ast::ast::*;
 use oxc_ecmascript::{ToInt32, ToUint32};
 use oxc_span::{GetSpan, SPAN};
@@ -21,7 +21,7 @@ enum ConstantValue {
 impl<'a> IsolatedDeclarations<'a> {
     /// Transform a TypeScript enum declaration into its declaration output form.
     pub fn transform_ts_enum_declaration(&self, decl: &TSEnumDeclaration<'a>) -> Declaration<'a> {
-        let mut members = self.ast.vec();
+        let mut members = ArenaVec::new_in(self);
         let mut prev_initializer_value = Some(ConstantValue::Number(-1.0));
         let mut prev_members = FxHashMap::default();
         for member in &decl.body.members {
@@ -47,7 +47,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 prev_members.insert(member_name, value.clone());
             }
 
-            let member = self.ast.ts_enum_member(
+            let member = TSEnumMember::new(
                 member.span,
                 member.id.clone_in(self.ast.allocator),
                 value.map(|v| match v {
@@ -56,38 +56,46 @@ impl<'a> IsolatedDeclarations<'a> {
 
                         // Infinity
                         let expr = if v.is_infinite() {
-                            self.ast.expression_identifier(SPAN, "Infinity")
+                            Expression::new_identifier(SPAN, "Infinity", self)
                         } else {
                             let value = if is_negative { -v } else { v };
-                            self.ast.expression_numeric_literal(
+                            Expression::new_numeric_literal(
                                 SPAN,
                                 value,
                                 None,
                                 NumberBase::Decimal,
+                                self,
                             )
                         };
 
                         if is_negative {
-                            self.ast.expression_unary(SPAN, UnaryOperator::UnaryNegation, expr)
+                            Expression::new_unary_expression(
+                                SPAN,
+                                UnaryOperator::UnaryNegation,
+                                expr,
+                                self,
+                            )
                         } else {
                             expr
                         }
                     }
                     ConstantValue::String(v) => {
-                        self.ast.expression_string_literal(SPAN, self.ast.str(&v), None)
+                        Expression::new_string_literal(SPAN, Str::from_str_in(&v, self), None, self)
                     }
                 }),
+                self,
             );
 
             members.push(member);
         }
 
-        self.ast.declaration_ts_enum(
+        Declaration::new_ts_enum_declaration(
             decl.span,
             decl.id.clone_in(self.ast.allocator),
-            self.ast.ts_enum_body(decl.body.span, members),
+            TSEnumBody::new(decl.body.span, members, self),
             decl.r#const,
             self.is_declare(),
+            self,
         )
     }
 

--- a/crates/oxc_isolated_declarations/src/formal_parameter_binding_pattern.rs
+++ b/crates/oxc_isolated_declarations/src/formal_parameter_binding_pattern.rs
@@ -1,23 +1,28 @@
-use oxc_allocator::CloneIn;
-use oxc_ast::{AstBuilder, ast::BindingPattern};
+use oxc_allocator::{Allocator, CloneIn, GetAllocator};
+use oxc_ast::ast::BindingPattern;
 use oxc_ast_visit::{VisitMut, walk_mut::walk_binding_pattern};
 
+use crate::IsolatedDeclarations;
+
 pub struct FormalParameterBindingPattern<'a> {
-    ast: AstBuilder<'a>,
+    allocator: &'a Allocator,
 }
 
 impl<'a> VisitMut<'a> for FormalParameterBindingPattern<'a> {
     fn visit_binding_pattern(&mut self, pattern: &mut BindingPattern<'a>) {
         if let BindingPattern::AssignmentPattern(assignment) = pattern {
-            *pattern = assignment.left.clone_in(self.ast.allocator);
+            *pattern = assignment.left.clone_in(self.allocator);
         }
         walk_binding_pattern(self, pattern);
     }
 }
 
 impl<'a> FormalParameterBindingPattern<'a> {
-    pub fn remove_assignments_from_kind(ast: AstBuilder<'a>, pattern: &mut BindingPattern<'a>) {
-        let mut visitor = FormalParameterBindingPattern { ast };
+    pub fn remove_assignments_from_kind(
+        transformer: &IsolatedDeclarations<'a>,
+        pattern: &mut BindingPattern<'a>,
+    ) {
+        let mut visitor = FormalParameterBindingPattern { allocator: transformer.allocator() };
         visitor.visit_binding_pattern(pattern);
     }
 }

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, CloneIn};
+use oxc_allocator::{ArenaBox, ArenaVec, CloneIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{SPAN, Span};
 
@@ -22,7 +22,7 @@ impl<'a> IsolatedDeclarations<'a> {
             self.error(function_must_have_explicit_return_type(get_function_span(func)));
         }
         let params = self.transform_formal_parameters(&func.params, false);
-        self.ast.alloc_function(
+        Function::boxed(
             func.span,
             func.r#type,
             func.id.clone_in(self.ast.allocator),
@@ -34,6 +34,7 @@ impl<'a> IsolatedDeclarations<'a> {
             params,
             return_type,
             NONE,
+            self,
         )
     }
 
@@ -59,7 +60,7 @@ impl<'a> IsolatedDeclarations<'a> {
             param.pattern.clone_in(self.ast.allocator)
         };
 
-        FormalParameterBindingPattern::remove_assignments_from_kind(self.ast, &mut pattern);
+        FormalParameterBindingPattern::remove_assignments_from_kind(self, &mut pattern);
 
         if is_assignment_pattern
             || param.type_annotation.is_none()
@@ -91,27 +92,29 @@ impl<'a> IsolatedDeclarations<'a> {
                             self.error(implicitly_adding_undefined_to_type(param.span));
                         } else if !ts_type.is_maybe_undefined() {
                             // union with `undefined`
-                            return self.ast.ts_type_annotation(
+                            return TSTypeAnnotation::new(
                                 SPAN,
-                                self.ast.ts_type_union_type(
+                                TSType::new_ts_union_type(
                                     SPAN,
-                                    self.ast.vec_from_array([
-                                        ts_type,
-                                        self.ast.ts_type_undefined_keyword(SPAN),
-                                    ]),
+                                    ArenaVec::from_array_in(
+                                        [ts_type, TSType::new_ts_undefined_keyword(SPAN, self)],
+                                        self,
+                                    ),
+                                    self,
                                 ),
+                                self,
                             );
                         }
                     }
 
-                    self.ast.ts_type_annotation(SPAN, ts_type)
+                    TSTypeAnnotation::new(SPAN, ts_type, self)
                 });
 
             let optional =
                 param.optional || (!is_remaining_params_have_required && is_assignment_pattern);
-            return Some(self.ast.formal_parameter(
+            return Some(FormalParameter::new(
                 param.span,
-                self.ast.vec(),
+                ArenaVec::new_in(self),
                 pattern.clone_in(self.ast.allocator),
                 type_annotation,
                 NONE,
@@ -119,12 +122,13 @@ impl<'a> IsolatedDeclarations<'a> {
                 None,
                 false,
                 false,
+                self,
             ));
         }
 
-        Some(self.ast.formal_parameter(
+        Some(FormalParameter::new(
             param.span,
-            self.ast.vec(),
+            ArenaVec::new_in(self),
             pattern,
             param.type_annotation.clone_in(self.ast.allocator),
             NONE,
@@ -132,6 +136,7 @@ impl<'a> IsolatedDeclarations<'a> {
             None,
             false,
             false,
+            self,
         ))
     }
 
@@ -144,7 +149,7 @@ impl<'a> IsolatedDeclarations<'a> {
             return params.clone_in(self.ast.allocator);
         }
 
-        let items = self.ast.vec_from_iter(
+        let items = ArenaVec::from_iter_in(
             params
                 .items
                 .iter()
@@ -162,6 +167,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         in_private_constructor,
                     )
                 }),
+            self,
         );
 
         if let Some(rest) = &params.rest
@@ -173,13 +179,13 @@ impl<'a> IsolatedDeclarations<'a> {
         let rest = params.rest.as_ref().map(|rest| {
             let mut rest = rest.clone_in(self.ast.allocator);
             FormalParameterBindingPattern::remove_assignments_from_kind(
-                self.ast,
+                self,
                 &mut rest.rest.argument,
             );
             rest
         });
 
-        self.ast.alloc_formal_parameters(params.span, FormalParameterKind::Signature, items, rest)
+        FormalParameters::boxed(params.span, FormalParameterKind::Signature, items, rest, self)
     }
 }
 

--- a/crates/oxc_isolated_declarations/src/inferrer.rs
+++ b/crates/oxc_isolated_declarations/src/inferrer.rs
@@ -18,15 +18,15 @@ impl<'a> IsolatedDeclarations<'a> {
 
     pub(crate) fn infer_type_from_expression(&self, expr: &Expression<'a>) -> Option<TSType<'a>> {
         match expr {
-            Expression::BooleanLiteral(_) => Some(self.ast.ts_type_boolean_keyword(SPAN)),
-            Expression::NullLiteral(_) => Some(self.ast.ts_type_null_keyword(SPAN)),
-            Expression::NumericLiteral(_) => Some(self.ast.ts_type_number_keyword(SPAN)),
-            Expression::BigIntLiteral(_) => Some(self.ast.ts_type_big_int_keyword(SPAN)),
+            Expression::BooleanLiteral(_) => Some(TSType::new_ts_boolean_keyword(SPAN, self)),
+            Expression::NullLiteral(_) => Some(TSType::new_ts_null_keyword(SPAN, self)),
+            Expression::NumericLiteral(_) => Some(TSType::new_ts_number_keyword(SPAN, self)),
+            Expression::BigIntLiteral(_) => Some(TSType::new_ts_big_int_keyword(SPAN, self)),
             Expression::StringLiteral(_) | Expression::TemplateLiteral(_) => {
-                Some(self.ast.ts_type_string_keyword(SPAN))
+                Some(TSType::new_ts_string_keyword(SPAN, self))
             }
             Expression::Identifier(ident) => match ident.name.as_str() {
-                "undefined" => Some(self.ast.ts_type_undefined_keyword(SPAN)),
+                "undefined" => Some(TSType::new_ts_undefined_keyword(SPAN, self)),
                 _ => None,
             },
             Expression::FunctionExpression(func) => self.transform_function_to_ts_type(func),
@@ -38,7 +38,7 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             Expression::ArrayExpression(expr) => {
                 self.error(array_inferred(expr.span));
-                Some(self.ast.ts_type_unknown_keyword(expr.span))
+                Some(TSType::new_ts_unknown_keyword(expr.span, self))
             }
             Expression::TSAsExpression(expr) => {
                 if expr.type_annotation.is_const_type_reference() {
@@ -56,7 +56,7 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             Expression::ClassExpression(expr) => {
                 self.error(inferred_type_of_class_expression(expr.span));
-                Some(self.ast.ts_type_unknown_keyword(SPAN))
+                Some(TSType::new_ts_unknown_keyword(SPAN, self))
             }
             Expression::ParenthesizedExpression(expr) => {
                 self.infer_type_from_expression(&expr.expression)
@@ -100,7 +100,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
         function.body.as_ref().and_then(|body| {
             FunctionReturnType::infer(self, body)
-                .map(|type_annotation| self.ast.alloc_ts_type_annotation(SPAN, type_annotation))
+                .map(|type_annotation| TSTypeAnnotation::boxed(SPAN, type_annotation, self))
         })
     }
 
@@ -121,11 +121,11 @@ impl<'a> IsolatedDeclarations<'a> {
         {
             return self
                 .infer_type_from_expression(&stmt.expression)
-                .map(|type_annotation| self.ast.alloc_ts_type_annotation(SPAN, type_annotation));
+                .map(|type_annotation| TSTypeAnnotation::boxed(SPAN, type_annotation, self));
         }
 
         FunctionReturnType::infer(self, &function.body)
-            .map(|type_annotation| self.ast.alloc_ts_type_annotation(SPAN, type_annotation))
+            .map(|type_annotation| TSTypeAnnotation::boxed(SPAN, type_annotation, self))
     }
 
     pub(crate) fn is_need_to_infer_type_from_expression(expr: &Expression<'a>) -> bool {

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -10,7 +10,11 @@ use std::{cell::RefCell, iter::repeat_with, mem};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::{Allocator, ArenaVec, CloneIn, GetAllocator};
-use oxc_ast::{AstBuilder, NONE, ast::*};
+use oxc_ast::{
+    NONE,
+    ast::*,
+    builder::{AstBuilder, GetAstBuilder},
+};
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};
 use oxc_span::{GetSpan, SPAN, SourceType};
@@ -93,16 +97,20 @@ impl<'a> IsolatedDeclarations<'a> {
             FxHashSet::default()
         };
         let source_type = SourceType::d_ts();
-        let directives = self.ast.vec();
+        let directives = ArenaVec::new_in(&self);
         let stmts = self.transform_program(program);
-        let program = self.ast.program(
+        let program = Program::new(
             SPAN,
             source_type,
             program.source_text,
-            self.ast.vec_from_iter(program.comments.iter().filter(|c| c.is_jsdoc()).copied()),
+            ArenaVec::from_iter_in(
+                program.comments.iter().filter(|c| c.is_jsdoc()).copied(),
+                &self,
+            ),
             None,
             directives,
             stmts,
+            &self,
         );
         IsolatedDeclarationsReturn { program, diagnostics: self.take_errors() }
     }
@@ -163,13 +171,19 @@ impl<'a> IsolatedDeclarations<'a> {
 
         Self::remove_function_overloads_implementation(&mut stmts);
 
-        self.ast.vec_from_iter(stmts.iter().map(|stmt| {
-            if let Some(new_decl) = self.transform_declaration(stmt.to_declaration(), false) {
-                Statement::from(new_decl)
-            } else {
-                stmt.clone_in(self.ast.allocator)
-            }
-        }))
+        // `from_iter_in`'s closure needs `&mut self` (`self.transform_declaration`),
+        // so the allocator can't be borrowed from `self` simultaneously — extract it first
+        let allocator = self.allocator();
+        ArenaVec::from_iter_in(
+            stmts.iter().map(|stmt| {
+                if let Some(new_decl) = self.transform_declaration(stmt.to_declaration(), false) {
+                    Statement::from(new_decl)
+                } else {
+                    stmt.clone_in(allocator)
+                }
+            }),
+            &allocator,
+        )
     }
 
     fn transform_statements_on_demand(
@@ -332,16 +346,18 @@ impl<'a> IsolatedDeclarations<'a> {
                         }
                     }
                     if all_declarator_has_transformed {
-                        let declarations = self.ast.vec_from_iter(
+                        let declarations = ArenaVec::from_iter_in(
                             declaration.declarations.iter().map(|declarator| {
                                 transformed_variable_declarator.remove(&declarator.span).unwrap()
                             }),
+                            self,
                         );
-                        let decl = self.ast.alloc_variable_declaration(
+                        let decl = VariableDeclaration::boxed(
                             declaration.span,
                             declaration.kind,
                             declarations,
                             self.is_declare(),
+                            self,
                         );
                         transformed_stmts[idx] = Some(Statement::VariableDeclaration(decl));
                         transformed_count += 1;
@@ -361,10 +377,11 @@ impl<'a> IsolatedDeclarations<'a> {
         }
 
         // 6. Transform variable/using declarations, import statements, remove unused imports
-        let mut new_stmts = self.ast.vec_with_capacity(
+        let mut new_stmts = ArenaVec::with_capacity_in(
             stmts.len()
                 + usize::from(extra_export_var_statement.is_some())
                 + usize::from(need_empty_export_marker),
+            self,
         );
         for (idx, stmt) in stmts.into_iter().enumerate() {
             if let Some(new_stmt) = transformed_stmts[idx].take() {
@@ -389,20 +406,21 @@ impl<'a> IsolatedDeclarations<'a> {
                 }
                 Statement::VariableDeclaration(decl) if decl.declarations.len() > 1 => {
                     // Remove unreferenced declarations
-                    let declarations =
-                        self.ast.vec_from_iter(decl.declarations.iter().filter_map(|declarator| {
+                    let declarations = ArenaVec::from_iter_in(
+                        decl.declarations.iter().filter_map(|declarator| {
                             transformed_variable_declarator.remove(&declarator.span)
-                        }));
+                        }),
+                        self,
+                    );
                     if declarations.is_empty() {
                         continue;
                     }
-                    new_stmts.push(Statement::VariableDeclaration(
-                        self.ast.alloc_variable_declaration(
-                            decl.span,
-                            decl.kind,
-                            declarations,
-                            self.is_declare(),
-                        ),
+                    new_stmts.push(Statement::new_variable_declaration(
+                        decl.span,
+                        decl.kind,
+                        declarations,
+                        self.is_declare(),
+                        self,
                     ));
                 }
                 _ => {}
@@ -410,12 +428,11 @@ impl<'a> IsolatedDeclarations<'a> {
         }
 
         if need_empty_export_marker {
-            let specifiers = self.ast.vec();
+            let specifiers = ArenaVec::new_in(self);
             let kind = ImportOrExportKind::Value;
-            let empty_export =
-                self.ast.alloc_export_named_declaration(SPAN, None, specifiers, None, kind, NONE);
-            new_stmts
-                .push(Statement::from(ModuleDeclaration::ExportNamedDeclaration(empty_export)));
+            new_stmts.push(Statement::new_export_named_declaration(
+                SPAN, None, specifiers, None, kind, NONE, self,
+            ));
         } else if self.scope.is_ts_module_block() {
             // If we are in a module block and we don't need to add `export {}`, in that case we need to remove `export` keyword from all ExportNamedDeclaration
             // <https://github.com/microsoft/TypeScript/blob/a709f9899c2a544b6de65a0f2623ecbbe1394eab/src/compiler/transformers/declarations.ts#L1556-L1563>
@@ -638,5 +655,14 @@ impl<'a> GetAllocator<'a> for IsolatedDeclarations<'a> {
     #[inline]
     fn allocator(&self) -> &'a Allocator {
         self.ast.allocator()
+    }
+}
+
+impl<'a> GetAstBuilder<'a> for IsolatedDeclarations<'a> {
+    type Builder = AstBuilder<'a>;
+
+    #[inline]
+    fn builder(&self) -> &AstBuilder<'a> {
+        &self.ast
     }
 }

--- a/crates/oxc_isolated_declarations/src/literal.rs
+++ b/crates/oxc_isolated_declarations/src/literal.rs
@@ -10,10 +10,11 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> Option<ArenaBox<'a, StringLiteral<'a>>> {
         if lit.expressions.is_empty() {
             lit.quasis.first().map(|item| {
-                self.ast.alloc_string_literal(
+                StringLiteral::boxed(
                     lit.span,
                     item.value.cooked.unwrap_or(item.value.raw),
                     None,
+                    self,
                 )
             })
         } else {

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -12,21 +12,22 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> Option<ArenaBox<'a, ExportNamedDeclaration<'a>>> {
         let decl = self.transform_declaration(prev_decl.declaration.as_ref()?, false)?;
 
-        Some(self.ast.alloc_export_named_declaration(
+        Some(ExportNamedDeclaration::boxed(
             prev_decl.span,
             Some(decl),
-            self.ast.vec(),
+            ArenaVec::new_in(self),
             None,
             ImportOrExportKind::Value,
             NONE,
+            self,
         ))
     }
 
     pub(crate) fn create_unique_name(&self, name: &str) -> Str<'a> {
-        let mut binding = self.ast.str(name);
+        let mut binding = Str::from_str_in(name, self);
         let mut i = 1;
         while self.scope.has_reference(&binding) {
-            binding = self.ast.str(format!("{name}_{i}").as_str());
+            binding = Str::from_str_in(format!("{name}_{i}").as_str(), self);
             i += 1;
         }
         binding
@@ -80,9 +81,8 @@ impl<'a> IsolatedDeclarations<'a> {
             // ```
 
             let span = if var_decl.is_some() { SPAN } else { decl.span };
-            let declaration =
-                self.ast.module_declaration_export_default_declaration(span, declaration);
-            (var_decl, Statement::from(declaration))
+            let declaration = Statement::new_export_default_declaration(span, declaration, self);
+            (var_decl, declaration)
         })
     }
 
@@ -97,31 +97,28 @@ impl<'a> IsolatedDeclarations<'a> {
             // declare const _default: Type
             let kind = VariableDeclarationKind::Const;
             let name = self.create_unique_name("_default");
-            let id = self.ast.binding_pattern_binding_identifier(SPAN, name);
+            let id = BindingPattern::new_binding_identifier(SPAN, name, self);
             let type_annotation = self
                 .infer_type_from_expression(expr)
-                .map(|ts_type| self.ast.ts_type_annotation(SPAN, ts_type));
+                .map(|ts_type| TSTypeAnnotation::new(SPAN, ts_type, self));
 
             if type_annotation.is_none() {
                 self.error(default_export_inferred(expr.span()));
             }
 
-            let declarations = self.ast.vec1(self.ast.variable_declarator(
-                SPAN,
-                kind,
-                id,
-                type_annotation,
-                None,
-                false,
-            ));
+            let declarations = ArenaVec::from_value_in(
+                VariableDeclarator::new(SPAN, kind, id, type_annotation, None, false, self),
+                self,
+            );
 
-            let variable_statement = Statement::from(self.ast.declaration_variable(
+            let variable_statement = Statement::new_variable_declaration(
                 decl_span,
                 kind,
                 declarations,
                 self.is_declare(),
-            ));
-            Some((Some(variable_statement), self.ast.expression_identifier(SPAN, name)))
+                self,
+            );
+            Some((Some(variable_statement), Expression::new_identifier(SPAN, name, self)))
         }
     }
 
@@ -130,10 +127,7 @@ impl<'a> IsolatedDeclarations<'a> {
         decl: &TSExportAssignment<'a>,
     ) -> Option<(Option<Statement<'a>>, Statement<'a>)> {
         self.transform_export_expression(decl.span, &decl.expression).map(|(var_decl, expr)| {
-            (
-                var_decl,
-                Statement::from(self.ast.module_declaration_ts_export_assignment(SPAN, expr)),
-            )
+            (var_decl, Statement::new_ts_export_assignment(SPAN, expr, self))
         })
     }
 
@@ -143,7 +137,7 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> Option<ArenaBox<'a, ImportDeclaration<'a>>> {
         let specifiers = decl.specifiers.as_ref()?;
 
-        let mut new_specifiers = self.ast.vec_with_capacity(specifiers.len());
+        let mut new_specifiers = ArenaVec::with_capacity_in(specifiers.len(), self);
         specifiers.iter().for_each(|specifier| {
             let is_referenced = match specifier {
                 ImportDeclarationSpecifier::ImportSpecifier(specifier) => {
@@ -165,13 +159,14 @@ impl<'a> IsolatedDeclarations<'a> {
             // We don't need to print this import statement
             None
         } else {
-            Some(self.ast.alloc_import_declaration(
+            Some(ImportDeclaration::boxed(
                 decl.span,
                 Some(new_specifiers),
                 decl.source.clone(),
                 None,
                 decl.with_clause.clone_in(self.ast.allocator),
                 decl.import_kind,
+                self,
             ))
         }
     }

--- a/crates/oxc_isolated_declarations/src/return_type.rs
+++ b/crates/oxc_isolated_declarations/src/return_type.rs
@@ -1,12 +1,9 @@
 use std::cell::Cell;
 
-use oxc_allocator::CloneIn;
-use oxc_ast::{
-    AstBuilder,
-    ast::{
-        ArrowFunctionExpression, BindingIdentifier, Expression, Function, FunctionBody,
-        ReturnStatement, TSType, TSTypeAliasDeclaration, TSTypeName, TSTypeQueryExprName,
-    },
+use oxc_allocator::{Allocator, ArenaVec, CloneIn, GetAllocator};
+use oxc_ast::ast::{
+    ArrowFunctionExpression, BindingIdentifier, Expression, Function, FunctionBody,
+    ReturnStatement, TSType, TSTypeAliasDeclaration, TSTypeName, TSTypeQueryExprName,
 };
 use oxc_ast_visit::Visit;
 use oxc_span::{GetSpan, SPAN};
@@ -40,7 +37,7 @@ use crate::{IsolatedDeclarations, diagnostics::type_containing_private_name};
 /// ```
 #[expect(clippy::option_option)]
 pub struct FunctionReturnType<'a> {
-    ast: AstBuilder<'a>,
+    allocator: &'a Allocator,
     return_expression: Option<Option<Expression<'a>>>,
     value_bindings: Vec<Str<'a>>,
     type_bindings: Vec<Str<'a>>,
@@ -54,7 +51,7 @@ impl<'a> FunctionReturnType<'a> {
         body: &FunctionBody<'a>,
     ) -> Option<TSType<'a>> {
         let mut visitor = FunctionReturnType {
-            ast: transformer.ast,
+            allocator: transformer.allocator(),
             return_expression: None,
             return_statement_count: 0,
             scope_depth: 0,
@@ -68,7 +65,7 @@ impl<'a> FunctionReturnType<'a> {
         let Some(mut expr_type) = transformer.infer_type_from_expression(&expr) else {
             // Avoid report error in parent function
             return if expr.is_function() {
-                Some(transformer.ast.ts_type_unknown_keyword(SPAN))
+                Some(TSType::new_ts_unknown_keyword(SPAN, transformer))
             } else {
                 None
             };
@@ -112,13 +109,14 @@ impl<'a> FunctionReturnType<'a> {
         if visitor.return_statement_count > 1 {
             // Here is a union type, if the return type is a function type, we need to wrap it in parentheses
             if matches!(expr_type, TSType::TSFunctionType(_)) {
-                expr_type = transformer.ast.ts_type_parenthesized_type(SPAN, expr_type);
+                expr_type = TSType::new_ts_parenthesized_type(SPAN, expr_type, transformer);
             }
 
-            let types = transformer
-                .ast
-                .vec_from_array([expr_type, transformer.ast.ts_type_undefined_keyword(SPAN)]);
-            expr_type = transformer.ast.ts_type_union_type(SPAN, types);
+            let types = ArenaVec::from_array_in(
+                [expr_type, TSType::new_ts_undefined_keyword(SPAN, transformer)],
+                transformer,
+            );
+            expr_type = TSType::new_ts_union_type(SPAN, types, transformer);
         }
         Some(expr_type)
     }
@@ -167,6 +165,6 @@ impl<'a> Visit<'a> for FunctionReturnType<'a> {
             }
         }
 
-        self.return_expression = Some(stmt.argument.clone_in(self.ast.allocator));
+        self.return_expression = Some(stmt.argument.clone_in(self.allocator));
     }
 }

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -1,10 +1,11 @@
-use oxc_allocator::CloneIn;
+use oxc_allocator::{ArenaVec, CloneIn};
 use oxc_ast::{
     NONE,
     ast::{
         ArrayExpression, ArrayExpressionElement, ArrowFunctionExpression, Expression, Function,
         ObjectExpression, ObjectPropertyKind, PropertyKey, PropertyKind, TSLiteral,
-        TSMethodSignatureKind, TSTupleElement, TSType, TSTypeOperatorOperator,
+        TSMethodSignatureKind, TSSignature, TSTupleElement, TSType, TSTypeAnnotation,
+        TSTypeOperatorOperator,
     },
 };
 use oxc_span::{ContentEq, GetSpan, SPAN, Span};
@@ -30,12 +31,13 @@ impl<'a> IsolatedDeclarations<'a> {
         let params = self.transform_formal_parameters(&func.params, false);
 
         return_type.map(|return_type| {
-            self.ast.ts_type_function_type(
+            TSType::new_ts_function_type(
                 func.span,
                 func.type_parameters.clone_in(self.ast.allocator),
                 func.this_param.clone_in(self.ast.allocator),
                 params,
                 return_type,
+                self,
             )
         })
     }
@@ -56,12 +58,13 @@ impl<'a> IsolatedDeclarations<'a> {
         let params = self.transform_formal_parameters(&func.params, false);
 
         return_type.map(|return_type| {
-            self.ast.ts_type_function_type(
+            TSType::new_ts_function_type(
                 func.span,
                 func.type_parameters.clone_in(self.ast.allocator),
                 NONE,
                 params,
                 return_type,
+                self,
             )
         })
     }
@@ -71,13 +74,13 @@ impl<'a> IsolatedDeclarations<'a> {
         match key {
             // ["string"] -> string
             PropertyKey::StringLiteral(literal) if is_identifier_name(&literal.value) => {
-                self.ast.property_key_static_identifier(literal.span, literal.value.as_str())
+                PropertyKey::new_static_identifier(literal.span, literal.value.as_str(), self)
             }
             // [`string`] -> string
             PropertyKey::TemplateLiteral(literal)
                 if is_identifier_name(&literal.quasis[0].value.raw) =>
             {
-                self.ast.property_key_static_identifier(literal.span, literal.quasis[0].value.raw)
+                PropertyKey::new_static_identifier(literal.span, literal.quasis[0].value.raw, self)
             }
             // [100] -> 100
             // number literal will be cloned as-is
@@ -109,8 +112,8 @@ impl<'a> IsolatedDeclarations<'a> {
         // `Hash` trait, fortunately, the number of accessors is small.
         let mut accessor_inferred: Vec<&PropertyKey<'a>> = Vec::new();
 
-        let members =
-            self.ast.vec_from_iter(expr.properties.iter().filter_map(|property| match property {
+        let members = ArenaVec::from_iter_in(
+            expr.properties.iter().filter_map(|property| match property {
                 ObjectPropertyKind::ObjectProperty(object) => {
                     if object.computed && self.report_property_key(&object.key) {
                         return None;
@@ -139,7 +142,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             .as_expression()
                             .is_some_and(|k| !k.is_string_literal() && !k.is_number_literal());
 
-                        return Some(self.ast.ts_signature_method_signature(
+                        return Some(TSSignature::new_ts_method_signature(
                             object.span,
                             key,
                             computed,
@@ -149,6 +152,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             function.this_param.clone_in(self.ast.allocator),
                             params,
                             return_type,
+                            self,
                         ));
                     }
 
@@ -207,13 +211,13 @@ impl<'a> IsolatedDeclarations<'a> {
                             }
 
                             type_annotation.map(|type_annotation| {
-                                self.ast.alloc_ts_type_annotation(SPAN, type_annotation)
+                                TSTypeAnnotation::boxed(SPAN, type_annotation, self)
                             })
                         }
                     };
 
                     let key = self.transform_property_key(key);
-                    let property_signature = self.ast.ts_signature_property_signature(
+                    let property_signature = TSSignature::new_ts_property_signature(
                         object.span,
                         key.as_expression()
                             .is_some_and(|k| !k.is_string_literal() && !k.is_number_literal()),
@@ -221,6 +225,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         is_const,
                         key,
                         type_annotation,
+                        self,
                     );
                     Some(property_signature)
                 }
@@ -228,7 +233,9 @@ impl<'a> IsolatedDeclarations<'a> {
                     self.error(object_with_spread_assignments(spread.span));
                     None
                 }
-            }));
+            }),
+            self,
+        );
 
         // Report an error if the type of neither the setter nor the getter is inferred.
         for (key, span) in accessor_spans {
@@ -237,7 +244,7 @@ impl<'a> IsolatedDeclarations<'a> {
             }
         }
 
-        self.ast.ts_type_type_literal(SPAN, members)
+        TSType::new_ts_type_literal(SPAN, members, self)
     }
 
     pub(crate) fn transform_array_expression_to_ts_type(
@@ -245,14 +252,14 @@ impl<'a> IsolatedDeclarations<'a> {
         expr: &ArrayExpression<'a>,
         is_const: bool,
     ) -> TSType<'a> {
-        let element_types = self.ast.vec_from_iter(expr.elements.iter().filter_map(|element| {
-            match element {
+        let element_types = ArenaVec::from_iter_in(
+            expr.elements.iter().filter_map(|element| match element {
                 ArrayExpressionElement::SpreadElement(spread) => {
                     self.error(arrays_with_spread_elements(spread.span));
                     None
                 }
                 ArrayExpressionElement::Elision(elision) => {
-                    Some(TSTupleElement::from(self.ast.ts_type_undefined_keyword(elision.span)))
+                    Some(TSTupleElement::new_ts_undefined_keyword(elision.span, self))
                 }
                 _ => self
                     .transform_expression_to_ts_type_with_const_context(
@@ -264,12 +271,13 @@ impl<'a> IsolatedDeclarations<'a> {
                         self.error(inferred_type_of_expression(element.span()));
                         None
                     }),
-            }
-        }));
+            }),
+            self,
+        );
 
-        let ts_type = self.ast.ts_type_tuple_type(SPAN, element_types);
+        let ts_type = TSType::new_ts_tuple_type(SPAN, element_types, self);
         if is_const {
-            self.ast.ts_type_type_operator_type(SPAN, TSTypeOperatorOperator::Readonly, ts_type)
+            TSType::new_ts_type_operator_type(SPAN, TSTypeOperatorOperator::Readonly, ts_type, self)
         } else {
             ts_type
         }
@@ -296,37 +304,42 @@ impl<'a> IsolatedDeclarations<'a> {
         is_const: bool,
     ) -> Option<TSType<'a>> {
         match expr {
-            Expression::BooleanLiteral(lit) => Some(self.ast.ts_type_literal_type(
+            Expression::BooleanLiteral(lit) => Some(TSType::new_ts_literal_type(
                 SPAN,
                 TSLiteral::BooleanLiteral(lit.clone_in(self.ast.allocator)),
+                self,
             )),
-            Expression::NumericLiteral(lit) => Some(self.ast.ts_type_literal_type(
+            Expression::NumericLiteral(lit) => Some(TSType::new_ts_literal_type(
                 SPAN,
                 TSLiteral::NumericLiteral(lit.clone_in(self.ast.allocator)),
+                self,
             )),
-            Expression::BigIntLiteral(lit) => Some(self.ast.ts_type_literal_type(
+            Expression::BigIntLiteral(lit) => Some(TSType::new_ts_literal_type(
                 SPAN,
                 TSLiteral::BigIntLiteral(lit.clone_in(self.ast.allocator)),
+                self,
             )),
-            Expression::StringLiteral(lit) => Some(self.ast.ts_type_literal_type(
+            Expression::StringLiteral(lit) => Some(TSType::new_ts_literal_type(
                 SPAN,
                 TSLiteral::StringLiteral(lit.clone_in(self.ast.allocator)),
+                self,
             )),
-            Expression::NullLiteral(lit) => Some(self.ast.ts_type_null_keyword(lit.span)),
+            Expression::NullLiteral(lit) => Some(TSType::new_ts_null_keyword(lit.span, self)),
             Expression::Identifier(ident) => match ident.name.as_str() {
-                "undefined" => Some(self.ast.ts_type_undefined_keyword(ident.span)),
+                "undefined" => Some(TSType::new_ts_undefined_keyword(ident.span, self)),
                 _ => None,
             },
             Expression::TemplateLiteral(lit) => {
                 self.transform_template_to_string(lit).map(|string| {
-                    self.ast.ts_type_literal_type(lit.span, TSLiteral::StringLiteral(string))
+                    TSType::new_ts_literal_type(lit.span, TSLiteral::StringLiteral(string), self)
                 })
             }
             Expression::UnaryExpression(expr) => {
                 if Self::can_infer_unary_expression(expr) {
-                    Some(self.ast.ts_type_literal_type(
+                    Some(TSType::new_ts_literal_type(
                         SPAN,
                         TSLiteral::UnaryExpression(expr.clone_in(self.ast.allocator)),
+                        self,
                     ))
                 } else {
                     None


### PR DESCRIPTION
Part of #23043. Migrate `oxc_isolated_declarations` over to new `AstBuilder`.