### PR TITLE
perf(linter): skip traversal without this expressions

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/no_this_in_exported_function.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_this_in_exported_function.rs
@@ -113,6 +113,11 @@ impl Rule for NoThisInExportedFunction {
 fn check_function_for_this(func: &Function, ctx: &LintContext) {
     let Some(body) = &func.body else { return };
 
+    // Fast path for the case when there is undoubtedly no `this` inside the body.
+    if !ctx.source_range(body.span).contains("this") {
+        return;
+    }
+
     let mut finder =
         ThisExpressionFinder::new().skip_static_blocks().skip_property_definition_values();
     finder.visit_function_body(body);


### PR DESCRIPTION
- Split from #23829; original implementation by Yagiz Nizipli, retained as a commit coauthor.
- Skip `ThisExpressionFinder` traversal when an exported function body does not contain the `this` substring.

Original large-monorepo timings reported in #23829: 15.5 ms before, 2.1 ms after (~7.5x).

Co-authored-by: Yagiz Nizipli <yagiz@nizipli.com>