### PR TITLE
perf(isolated_declarations): use `TakeIn` not `CloneIn`

### DIFF
--- a/crates/oxc_isolated_declarations/src/formal_parameter_binding_pattern.rs
+++ b/crates/oxc_isolated_declarations/src/formal_parameter_binding_pattern.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, CloneIn, GetAllocator};
+use oxc_allocator::{Allocator, GetAllocator, TakeIn};
 use oxc_ast::ast::BindingPattern;
 use oxc_ast_visit::{VisitMut, walk_mut::walk_binding_pattern};
 
@@ -10,9 +10,17 @@ pub struct FormalParameterBindingPattern<'a> {
 
 impl<'a> VisitMut<'a> for FormalParameterBindingPattern<'a> {
     fn visit_binding_pattern(&mut self, pattern: &mut BindingPattern<'a>) {
-        if let BindingPattern::AssignmentPattern(assignment) = pattern {
-            *pattern = assignment.left.clone_in(self.allocator);
+        if let BindingPattern::AssignmentPattern(_) = pattern {
+            // Take the `BindingPattern`, not the `AssignmentPattern` because `BindingPattern::take_in`
+            // performs less allocations. Compiler removes the unreachable branch here.
+            let old_pattern = pattern.take_in(&self.allocator);
+            if let BindingPattern::AssignmentPattern(assignment) = old_pattern {
+                *pattern = assignment.unbox().left;
+            } else {
+                unreachable!();
+            }
         }
+
         walk_binding_pattern(self, pattern);
     }
 }


### PR DESCRIPTION
There's no need to clone the node here. Both call sites already cloned the entire `BindingPattern` before calling `remove_assignments_from_kind`.

Instead use `take_in`, which is much cheaper if the pattern is deeply nested.

`BindingPattern::take_in` is cheaper than `AssignmentPattern::take_in`, so do it that way around.

https://github.com/oxc-project/oxc/blob/84a5aa3246bf514d6544384bbb577cd989c9d3b9/crates/oxc_ast/src/generated/derive_dummy.rs#L1071-L1078

https://github.com/oxc-project/oxc/blob/84a5aa3246bf514d6544384bbb577cd989c9d3b9/crates/oxc_ast/src/generated/derive_dummy.rs#L1080-L1092