### PR TITLE
perf(linter/eslint/no-nonoctal-decimal-escape): scan decimal escapes as bytes

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -85,13 +85,16 @@ impl StickyRegex for Regex {
     }
 }
 
+// Fast path scan for non-octal decimal escape sequences (`\8` or `\9`).
 fn quick_test(s: &str) -> bool {
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '\\' && chars.peek().is_some_and(|c| *c == '8' || *c == '9') {
+    let bytes = s.as_bytes();
+
+    for [a, b] in bytes.array_windows() {
+        if *a == b'\\' && (*b == b'8' || *b == b'9') {
             return true;
         }
     }
+
     false
 }
 


### PR DESCRIPTION
- Split from #23829; original implementation by Yagiz Nizipli, retained as a commit coauthor.
- Scan string literal bytes for non-octal decimal escape sequences instead of decoding UTF-8 characters.
- Use `array_windows` to keep the adjacent-byte scan clear and readable.

Original large-monorepo timings reported in #23829: 6.5 ms before, 3.6 ms after (~1.8x).

Co-authored-by: Yagiz Nizipli <yagiz@nizipli.com>