### PR TITLE
perf(linter/eslint/no-extend-native): skip lowercase references early

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -92,19 +92,19 @@ impl Rule for NoExtendNative {
             for reference_id in reference_id_list {
                 let reference = symbols.get_reference(reference_id);
                 let name = ctx.semantic().reference_name(reference);
+                // Lowercase names cannot identify native constructors; skip before other checks.
+                let Some(first_char) = name.chars().next() else {
+                    continue;
+                };
+                if first_char.is_lowercase() {
+                    continue;
+                }
                 // If the referenced name does not appear to be a global object, skip it.
                 if !ctx.is_ecma_script_global(name) {
                     continue;
                 }
                 // If the referenced name is explicitly allowed, skip it.
-                if self.exceptions.iter().any(|exception| name == exception) {
-                    continue;
-                }
-                // If the first letter is capital, like `Object`, we will assume it is a native object
-                let Some(first_char) = name.chars().next() else {
-                    continue;
-                };
-                if first_char.is_lowercase() {
+                if self.exceptions.iter().any(|exception| name == exception.as_str()) {
                     continue;
                 }
                 let node = ctx.nodes().get_node(reference.node_id());


### PR DESCRIPTION
- Split from #23829; original implementation by Yagiz Nizipli, retained as a commit coauthor.
- Skip lowercase identifiers before checking the ECMAScript global tables.
- Preserve the existing Unicode-aware name filtering semantics while avoiding unnecessary global lookups.

Original large-monorepo timings reported in #23829: 7.5 ms before, 5.7 ms after (~1.3x).

Co-authored-by: Yagiz Nizipli <yagiz@nizipli.com>