### PR TITLE
fix(linter): deduplicate missing plugin errors

### DIFF
--- a/apps/oxlint/test/fixtures/rules_missing_plugins/.oxlintrc.json
+++ b/apps/oxlint/test/fixtures/rules_missing_plugins/.oxlintrc.json
@@ -1,0 +1,17 @@
+{
+  "categories": { "correctness": "off" },
+  "rules": {
+    "@tanstack/query/exhaustive-deps": "error",
+    "@tanstack/query/infinite-query-property-order": "error",
+    "@tanstack/query/mutation-property-order": "error",
+    "@tanstack/query/no-rest-destructuring": "error",
+    "@tanstack/query/no-unstable-deps": "error",
+    "@tanstack/query/no-void-query-fn": "error",
+    "@tanstack/query/stable-query-client": "error",
+    "XXXX/rule": "error",
+    "XXXX/rule-2": "error",
+    "XXXX/rule-3": "error",
+    "YYYY/rule": "error",
+    "ZZZZ/rule": "error"
+  }
+}

--- a/apps/oxlint/test/fixtures/rules_missing_plugins/files/index.js
+++ b/apps/oxlint/test/fixtures/rules_missing_plugins/files/index.js
@@ -1,0 +1,1 @@
+debugger;

--- a/apps/oxlint/test/fixtures/rules_missing_plugins/output.snap.md
+++ b/apps/oxlint/test/fixtures/rules_missing_plugins/output.snap.md
@@ -1,0 +1,19 @@
+# Exit code
+1
+
+# stdout
+```
+Failed to parse oxlint configuration file.
+
+  x Plugin '@tanstack/query' not found
+
+  x Plugin 'XXXX' not found
+
+  x Plugin 'YYYY' not found
+
+  x Plugin 'ZZZZ' not found
+```
+
+# stderr
+```
+```

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -214,7 +214,10 @@ impl OxlintRules {
                                     .or_insert((options_id, severity));
                             }
                             Err(e) => {
-                                errors.push(OverrideRulesError::ExternalRuleLookup(e));
+                                let error = OverrideRulesError::ExternalRuleLookup(e);
+                                if !errors.contains(&error) {
+                                    errors.push(error);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Closes #23840.

When several configured rules reference the same missing JavaScript plugin, report that plugin only once instead of emitting one diagnostic per rule. Distinct missing plugins are still reported separately.

Adds a NAPI CLI snapshot covering repeated scoped and unscoped plugin names.
