### PR TITLE
refactor(linter/react/no-array-index-key): remove unused argument

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_array_index_key.rs
+++ b/crates/oxc_linter/src/rules/react/no_array_index_key.rs
@@ -56,12 +56,7 @@ declare_oxc_lint!(
     short_description = "Warn if an element uses an Array index in its key.",
 );
 
-fn check_jsx_element<'a>(
-    jsx: &'a JSXElement,
-    node: &'a AstNode,
-    ctx: &'a LintContext,
-    prop_name: &'static str,
-) {
+fn check_jsx_element<'a>(jsx: &'a JSXElement, node: &'a AstNode, ctx: &'a LintContext) {
     let Some(index_param_symbol_id) = find_index_param_symbol_id(node, ctx) else {
         return;
     };
@@ -75,7 +70,7 @@ fn check_jsx_element<'a>(
             continue;
         };
 
-        if ident.name.as_str() != prop_name {
+        if ident.name.as_str() != "key" {
             continue;
         }
 
@@ -248,7 +243,7 @@ impl Rule for NoArrayIndexKey {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(jsx) => {
-                check_jsx_element(jsx, node, ctx, "key");
+                check_jsx_element(jsx, node, ctx);
             }
             AstKind::CallExpression(call_expr) => {
                 check_react_clone_element(call_expr, node, ctx);


### PR DESCRIPTION
Removes the unused `prop_name` argument and inlines its sole `"key"` value.


**Stack**
 - https://github.com/oxc-project/oxc/pull/23857
 - https://github.com/oxc-project/oxc/pull/23856
 - https://github.com/oxc-project/oxc/pull/23855 👈 this PR!