### PR TITLE
perf(linter/react/no-array-index-key): delay index symbol lookup

### DIFF
--- a/crates/oxc_linter/src/rules/react/no_array_index_key.rs
+++ b/crates/oxc_linter/src/rules/react/no_array_index_key.rs
@@ -57,29 +57,32 @@ declare_oxc_lint!(
 );
 
 fn check_jsx_element<'a>(jsx: &'a JSXElement, node: &'a AstNode, ctx: &'a LintContext) {
+    let mut key_attrs = jsx
+        .opening_element
+        .attributes
+        .iter()
+        .filter_map(|attr| {
+            if let JSXAttributeItem::Attribute(attr) = attr
+                && let JSXAttributeName::Identifier(ident) = &attr.name
+                && ident.name.as_str() == "key"
+                && let Some(JSXAttributeValue::ExpressionContainer(container)) = &attr.value
+            {
+                return Some((attr.span, &container.expression));
+            }
+            None
+        })
+        .peekable();
+
+    if key_attrs.peek().is_none() {
+        return;
+    }
     let Some(index_param_symbol_id) = find_index_param_symbol_id(node, ctx) else {
         return;
     };
 
-    for attr in &jsx.opening_element.attributes {
-        let JSXAttributeItem::Attribute(attr) = attr else {
-            continue;
-        };
-
-        let JSXAttributeName::Identifier(ident) = &attr.name else {
-            continue;
-        };
-
-        if ident.name.as_str() != "key" {
-            continue;
-        }
-
-        let Some(JSXAttributeValue::ExpressionContainer(container)) = &attr.value else {
-            continue;
-        };
-
-        if jsx_expression_uses_index(ctx, index_param_symbol_id, &container.expression) {
-            ctx.diagnostic(no_array_index_key_diagnostic(attr.span));
+    for (span, expression) in key_attrs {
+        if jsx_expression_uses_index(ctx, index_param_symbol_id, expression) {
+            ctx.diagnostic(no_array_index_key_diagnostic(span));
         }
     }
 }
@@ -89,29 +92,37 @@ fn check_react_clone_element<'a>(
     node: &'a AstNode,
     ctx: &'a LintContext,
 ) {
+    if !is_method_call(call_expr, Some(&["React"]), Some(&["cloneElement"]), Some(2), Some(3)) {
+        return;
+    }
+    let Some(Argument::ObjectExpression(obj_expr)) = call_expr.arguments.get(1) else {
+        return;
+    };
+
+    let mut key_props = obj_expr
+        .properties
+        .iter()
+        .filter_map(|prop_kind| {
+            let ObjectPropertyKind::ObjectProperty(prop) = prop_kind else {
+                return None;
+            };
+            let PropertyKey::StaticIdentifier(key_ident) = &prop.key else {
+                return None;
+            };
+            (key_ident.name.as_str() == "key").then_some((prop.span, &prop.value))
+        })
+        .peekable();
+
+    if key_props.peek().is_none() {
+        return;
+    }
     let Some(index_param_symbol_id) = find_index_param_symbol_id(node, ctx) else {
         return;
     };
 
-    if is_method_call(call_expr, Some(&["React"]), Some(&["cloneElement"]), Some(2), Some(3)) {
-        let Some(Argument::ObjectExpression(obj_expr)) = call_expr.arguments.get(1) else {
-            return;
-        };
-
-        for prop_kind in &obj_expr.properties {
-            let ObjectPropertyKind::ObjectProperty(prop) = prop_kind else {
-                continue;
-            };
-
-            let PropertyKey::StaticIdentifier(key_ident) = &prop.key else {
-                continue;
-            };
-
-            if key_ident.name.as_str() == "key"
-                && expression_uses_index(ctx, index_param_symbol_id, &prop.value)
-            {
-                ctx.diagnostic(no_array_index_key_diagnostic(prop.span));
-            }
+    for (span, value) in key_props {
+        if expression_uses_index(ctx, index_param_symbol_id, value) {
+            ctx.diagnostic(no_array_index_key_diagnostic(span));
         }
     }
 }
@@ -338,7 +349,15 @@ fn test() {
           ));
         ",
         r"things.map((thing, index) => (
+            <Hello key={thing.id} key={index} />
+          ));
+        ",
+        r"things.map((thing, index) => (
             React.cloneElement(thing, { key: index })
+          ));
+        ",
+        r"things.map((thing, index) => (
+            React.cloneElement(thing, { key: thing.id, key: index })
           ));
         ",
         r"things.map((thing, index) => (

--- a/crates/oxc_linter/src/snapshots/react_no_array_index_key.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_array_index_key.snap
@@ -39,10 +39,28 @@ source: crates/oxc_linter/src/tester.rs
   help: Use a unique data-dependent key to avoid unnecessary rerenders
 
   ⚠ react(no-array-index-key): Usage of Array index in keys is not allowed
+   ╭─[no_array_index_key.tsx:2:35]
+ 1 │ things.map((thing, index) => (
+ 2 │             <Hello key={thing.id} key={index} />
+   ·                                   ───────────
+ 3 │           ));
+   ╰────
+  help: Use a unique data-dependent key to avoid unnecessary rerenders
+
+  ⚠ react(no-array-index-key): Usage of Array index in keys is not allowed
    ╭─[no_array_index_key.tsx:2:41]
  1 │ things.map((thing, index) => (
  2 │             React.cloneElement(thing, { key: index })
    ·                                         ──────────
+ 3 │           ));
+   ╰────
+  help: Use a unique data-dependent key to avoid unnecessary rerenders
+
+  ⚠ react(no-array-index-key): Usage of Array index in keys is not allowed
+   ╭─[no_array_index_key.tsx:2:56]
+ 1 │ things.map((thing, index) => (
+ 2 │             React.cloneElement(thing, { key: thing.id, key: index })
+   ·                                                        ──────────
  3 │           ));
    ╰────
   help: Use a unique data-dependent key to avoid unnecessary rerenders


### PR DESCRIPTION
Split from #23829.

Delay `find_index_param_symbol_id` until after finding a relevant JSX `key` attribute or `React.cloneElement` key property.

Use lazy, peekable iterators so the symbol lookup runs once only when needed while still checking every matching key. Add regression coverage for duplicate JSX attributes and object properties.

**Stack**
 - https://github.com/oxc-project/oxc/pull/23857 👈 this PR!
 - https://github.com/oxc-project/oxc/pull/23856
 - https://github.com/oxc-project/oxc/pull/23855

Co-authored-by: Yagiz Nizipli <yagiz@nizipli.com>