### PR TITLE
refactor(transformer): shorten AST builder code

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -821,7 +821,7 @@ impl<'a> ArrowFunctionConverter<'a> {
         let object = self.transform_member_expression_for_super(&mut call.callee, None, ctx)?;
         // Add `this` as the first argument and original arguments as the rest.
         let mut arguments = ArenaVec::with_capacity_in(call.arguments.len() + 1, ctx);
-        arguments.push(Argument::from(Expression::new_this_expression(SPAN, ctx)));
+        arguments.push(Argument::new_this_expression(SPAN, ctx));
         arguments.extend(call.arguments.take_in(ctx));
 
         let property = IdentifierName::new(SPAN, "call", ctx);
@@ -925,13 +925,13 @@ impl<'a> ArrowFunctionConverter<'a> {
             items.push(param);
 
             // `super` -> `super[prop]`
-            init = Expression::from(MemberExpression::new_computed_member_expression(
+            init = Expression::new_computed_member_expression(
                 SPAN,
                 init,
                 param_binding.create_read_expression(ctx),
                 false,
                 ctx,
-            ));
+            );
         }
 
         // Create a parameter for the value if it's an assignment.

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -73,7 +73,7 @@ use serde::Deserialize;
 use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{
     NONE,
-    ast::{Argument, CallExpression, Expression, IdentifierName, MemberExpression},
+    ast::{Argument, CallExpression, Expression, IdentifierName},
 };
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
 use oxc_span::SPAN;
@@ -338,8 +338,6 @@ impl<'a> HelperLoaderStore<'a> {
         let symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), helper_var);
         let object = ctx.create_ident_expr(SPAN, helper_var, symbol_id, ReferenceFlags::Read);
         let property = IdentifierName::new(SPAN, helper.name(), ctx);
-        Expression::from(MemberExpression::new_static_member_expression(
-            SPAN, object, property, false, ctx,
-        ))
+        Expression::new_static_member_expression(SPAN, object, property, false, ctx)
     }
 }

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -143,27 +143,23 @@ impl<'a> ModuleImportsStore<'a> {
     ) -> Statement<'a> {
         let specifiers = ArenaVec::from_iter_in(
             names.into_iter().map(|import| match import {
-                Import::Named(import) => {
-                    ImportDeclarationSpecifier::ImportSpecifier(ImportSpecifier::boxed(
-                        SPAN,
-                        ModuleExportName::IdentifierName(IdentifierName::new(
-                            SPAN,
-                            import.imported,
-                            ctx,
-                        )),
-                        import.local.create_binding_identifier(ctx),
-                        ImportOrExportKind::Value,
-                        ctx,
-                    ))
-                }
-                Import::Default(local) => ImportDeclarationSpecifier::ImportDefaultSpecifier(
-                    ImportDefaultSpecifier::boxed(SPAN, local.create_binding_identifier(ctx), ctx),
+                Import::Named(import) => ImportDeclarationSpecifier::new_import_specifier(
+                    SPAN,
+                    ModuleExportName::new_identifier_name(SPAN, import.imported, ctx),
+                    import.local.create_binding_identifier(ctx),
+                    ImportOrExportKind::Value,
+                    ctx,
+                ),
+                Import::Default(local) => ImportDeclarationSpecifier::new_import_default_specifier(
+                    SPAN,
+                    local.create_binding_identifier(ctx),
+                    ctx,
                 ),
             }),
             ctx,
         );
 
-        Statement::from(ModuleDeclaration::new_import_declaration(
+        Statement::new_import_declaration(
             SPAN,
             Some(specifiers),
             StringLiteral::new(SPAN, source, None, ctx),
@@ -171,7 +167,7 @@ impl<'a> ModuleImportsStore<'a> {
             NONE,
             ImportOrExportKind::Value,
             ctx,
-        ))
+        )
     }
 
     pub(crate) fn get_require(
@@ -188,7 +184,7 @@ impl<'a> ModuleImportsStore<'a> {
         );
 
         let args = {
-            let arg = Argument::from(Expression::new_string_literal(SPAN, source, None, ctx));
+            let arg = Argument::new_string_literal(SPAN, source, None, ctx);
             ArenaVec::from_value_in(arg, ctx)
         };
         let Some(Import::Default(local)) = names.into_iter().next() else { unreachable!() };
@@ -199,6 +195,6 @@ impl<'a> ModuleImportsStore<'a> {
             let decl = VariableDeclarator::new(SPAN, var_kind, id, NONE, Some(init), false, ctx);
             ArenaVec::from_value_in(decl, ctx)
         };
-        Statement::from(Declaration::new_variable_declaration(SPAN, var_kind, decl, false, ctx))
+        Statement::new_variable_declaration(SPAN, var_kind, decl, false, ctx)
     }
 }

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -775,10 +775,7 @@ impl<'a> LegacyDecoratorMetadata<'a> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let arguments = ArenaVec::from_array_in(
-            [
-                Argument::from(Expression::new_string_literal(SPAN, key, None, ctx)),
-                Argument::from(value),
-            ],
+            [Argument::new_string_literal(SPAN, key, None, ctx), Argument::from(value)],
             ctx,
         );
         helper_call_expr(Helper::DecorateMetadata, arguments, ctx)

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -502,13 +502,13 @@ impl<'a> LegacyDecorator<'a> {
                 NONE,
                 ctx,
             );
-            let field_expr = Expression::from(MemberExpression::new_private_field_expression(
+            let field_expr = Expression::new_private_field_expression(
                 SPAN,
                 create_object(ctx),
                 PrivateIdentifier::new(SPAN, storage_name, ctx),
                 false,
                 ctx,
-            ));
+            );
             let stmt = Statement::new_return_statement(SPAN, Some(field_expr), ctx);
             (params, stmt)
         } else {
@@ -539,15 +539,13 @@ impl<'a> LegacyDecorator<'a> {
             let assign = Expression::new_assignment_expression(
                 SPAN,
                 AssignmentOperator::Assign,
-                AssignmentTarget::from(SimpleAssignmentTarget::from(
-                    MemberExpression::new_private_field_expression(
-                        SPAN,
-                        create_object(ctx),
-                        PrivateIdentifier::new(SPAN, storage_name, ctx),
-                        false,
-                        ctx,
-                    ),
-                )),
+                AssignmentTarget::new_private_field_expression(
+                    SPAN,
+                    create_object(ctx),
+                    PrivateIdentifier::new(SPAN, storage_name, ctx),
+                    false,
+                    ctx,
+                ),
                 value_binding.create_read_expression(ctx),
                 ctx,
             );

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -253,23 +253,20 @@ impl<'a> ExponentiationOperator<'a> {
         // obj["prop"] = Math.pow(obj["prop"], right)
         //                        ^^^^^^^^^^^
         // ```
-        let pow_left = Expression::from(MemberExpression::new_computed_member_expression(
-            SPAN, obj, prop, false, ctx,
-        ));
+        let pow_left = Expression::new_computed_member_expression(SPAN, obj, prop, false, ctx);
 
         // Replacement for original member expression
         // ```
         // obj["prop"] = Math.pow(obj["prop"], right)
         // ^^^^^^^^^^^
         // ```
-        let replacement_left =
-            AssignmentTarget::ComputedMemberExpression(ComputedMemberExpression::boxed(
-                member_expr.span,
-                member_expr.object.take_in(ctx),
-                Expression::new_string_literal(prop_span, prop_name, None, ctx),
-                false,
-                ctx,
-            ));
+        let replacement_left = AssignmentTarget::new_computed_member_expression(
+            member_expr.span,
+            member_expr.object.take_in(ctx),
+            Expression::new_string_literal(prop_span, prop_name, None, ctx),
+            false,
+            ctx,
+        );
 
         (replacement_left, pow_left, temp_var_inits)
     }
@@ -357,9 +354,7 @@ impl<'a> ExponentiationOperator<'a> {
         // obj[_prop] = Math.pow(obj[_prop], right)
         //                       ^^^^^^^^^^
         // ```
-        let pow_left = Expression::from(MemberExpression::new_computed_member_expression(
-            SPAN, obj, prop, false, ctx,
-        ));
+        let pow_left = Expression::new_computed_member_expression(SPAN, obj, prop, false, ctx);
 
         (pow_left, temp_var_inits)
     }
@@ -434,9 +429,7 @@ impl<'a> ExponentiationOperator<'a> {
         // obj.#prop = Math.pow(obj.#prop, right)
         //                      ^^^^^^^^^
         // ```
-        let pow_left = Expression::from(MemberExpression::new_private_field_expression(
-            SPAN, obj, field, false, ctx,
-        ));
+        let pow_left = Expression::new_private_field_expression(SPAN, obj, field, false, ctx);
 
         (pow_left, temp_var_inits)
     }
@@ -552,9 +545,7 @@ impl<'a> ExponentiationOperator<'a> {
         let math_symbol_id = ctx.scoping().find_binding(ctx.current_scope_id(), math);
         let object = ctx.create_ident_expr(SPAN, math, math_symbol_id, ReferenceFlags::Read);
         let property = IdentifierName::new(SPAN, "pow", ctx);
-        let callee = Expression::from(MemberExpression::new_static_member_expression(
-            span, object, property, false, ctx,
-        ));
+        let callee = Expression::new_static_member_expression(span, object, property, false, ctx);
         let arguments = ArenaVec::from_array_in([Argument::from(left), Argument::from(right)], ctx);
         Expression::new_call_expression(span, callee, NONE, arguments, false, ctx)
     }

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -276,12 +276,11 @@ impl<'a> AsyncGeneratorExecutor<'a> {
         let (callee, arguments) = if needs_move_parameters_to_inner_function {
             // callee.apply(this, arguments)
             let property = IdentifierName::new(SPAN, "apply", ctx);
-            let callee = Expression::from(MemberExpression::new_static_member_expression(
-                SPAN, callee, property, false, ctx,
-            ));
+            let callee =
+                Expression::new_static_member_expression(SPAN, callee, property, false, ctx);
 
             // this, arguments
-            let this_argument = Argument::from(Expression::new_this_expression(SPAN, ctx));
+            let this_argument = Argument::new_this_expression(SPAN, ctx);
             let arguments_argument = Argument::from(ctx.create_unbound_ident_expr(
                 SPAN,
                 static_ident!("arguments"),
@@ -730,16 +729,16 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             Argument::from(ctx.create_ident_expr(SPAN, arguments, symbol_id, ReferenceFlags::Read));
 
         // (this, arguments)
-        let this = Argument::from(Expression::new_this_expression(SPAN, ctx));
+        let this = Argument::new_this_expression(SPAN, ctx);
         let arguments = ArenaVec::from_array_in([this, arguments_ident], ctx);
         // _ref.apply
-        let callee = Expression::from(MemberExpression::new_static_member_expression(
+        let callee = Expression::new_static_member_expression(
             SPAN,
             bound_ident.create_read_expression(ctx),
             IdentifierName::new(SPAN, "apply", ctx),
             false,
             ctx,
-        ));
+        );
         let argument = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
         Statement::new_return_statement(SPAN, Some(argument), ctx)
     }
@@ -804,13 +803,13 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             ),
             ctx,
         );
-        Statement::from(Declaration::new_variable_declaration(
+        Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
             declarations,
             false,
             ctx,
-        ))
+        )
     }
 
     /// Creates a helper assignment statement for async-to-generator transformation.

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -111,26 +111,26 @@ impl<'a> AsyncGeneratorFunctions<'a> {
             SymbolFlags::FunctionScopedVariable,
         );
         // step.value
-        let step_value = Expression::from(MemberExpression::new_static_member_expression(
+        let step_value = Expression::new_static_member_expression(
             SPAN,
             step_key.create_read_expression(ctx),
             IdentifierName::new(SPAN, "value", ctx),
             false,
             ctx,
-        ));
+        );
 
         let assignment_statement = match &mut stmt.left {
             ForStatementLeft::VariableDeclaration(variable) => {
                 // for await (let i of test)
                 let mut declarator = variable.declarations.pop().unwrap();
                 declarator.init = Some(step_value);
-                Statement::VariableDeclaration(VariableDeclaration::boxed(
+                Statement::new_variable_declaration(
                     SPAN,
                     declarator.kind,
                     ArenaVec::from_value_in(declarator, ctx),
                     false,
                     ctx,
-                ))
+                )
             }
             left @ match_assignment_target!(ForStatementLeft) => {
                 // for await (i of test), for await ({ i } of test)
@@ -229,7 +229,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
             ctx.generate_uid("iteratorError", var_scope_id, SymbolFlags::FunctionScopedVariable);
 
         let mut items = ArenaVec::with_capacity_in(4, ctx);
-        items.push(Statement::from(Declaration::new_variable_declaration(
+        items.push(Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
             ArenaVec::from_value_in(
@@ -246,8 +246,8 @@ impl<'a> AsyncGeneratorFunctions<'a> {
             ),
             false,
             ctx,
-        )));
-        items.push(Statement::from(Declaration::new_variable_declaration(
+        ));
+        items.push(Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
             ArenaVec::from_value_in(
@@ -264,8 +264,8 @@ impl<'a> AsyncGeneratorFunctions<'a> {
             ),
             false,
             ctx,
-        )));
-        items.push(Statement::from(Declaration::new_variable_declaration(
+        ));
+        items.push(Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
             ArenaVec::from_value_in(
@@ -282,7 +282,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
             ),
             false,
             ctx,
-        )));
+        ));
 
         let iterator_key =
             ctx.generate_uid("iterator", var_scope_id, SymbolFlags::FunctionScopedVariable);
@@ -329,7 +329,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                     Expression::new_unary_expression(
                         SPAN,
                         UnaryOperator::LogicalNot,
-                        Expression::from(MemberExpression::new_static_member_expression(
+                        Expression::new_static_member_expression(
                             SPAN,
                             Expression::new_parenthesized_expression(
                                 SPAN,
@@ -341,14 +341,12 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                                         SPAN,
                                         Expression::new_call_expression(
                                             SPAN,
-                                            Expression::from(
-                                                MemberExpression::new_static_member_expression(
-                                                    SPAN,
-                                                    iterator_key.create_read_expression(ctx),
-                                                    IdentifierName::new(SPAN, "next", ctx),
-                                                    false,
-                                                    ctx,
-                                                ),
+                                            Expression::new_static_member_expression(
+                                                SPAN,
+                                                iterator_key.create_read_expression(ctx),
+                                                IdentifierName::new(SPAN, "next", ctx),
+                                                false,
+                                                ctx,
                                             ),
                                             NONE,
                                             ArenaVec::new_in(ctx),
@@ -364,7 +362,7 @@ impl<'a> AsyncGeneratorFunctions<'a> {
                             IdentifierName::new(SPAN, "done", ctx),
                             false,
                             ctx,
-                        )),
+                        ),
                         ctx,
                     ),
                     ctx,
@@ -452,80 +450,108 @@ impl<'a> AsyncGeneratorFunctions<'a> {
 
         let finally = {
             let finally_scope_id = ctx.create_child_scope(parent_scope_id, ScopeFlags::empty());
-            let try_statement =
-                {
-                    let try_block_scope_id =
-                        ctx.create_child_scope(finally_scope_id, ScopeFlags::empty());
-                    let if_statement =
-                        {
-                            let if_block_scope_id =
-                                ctx.create_child_scope(try_block_scope_id, ScopeFlags::empty());
-                            Statement::new_if_statement(SPAN,
-                    Expression::new_logical_expression(SPAN,
-                    iterator_abrupt_completion.create_read_expression(ctx),
-                    LogicalOperator::And,
-                    Expression::new_binary_expression(SPAN,
-                    Expression::from(MemberExpression::new_static_member_expression(SPAN,
-                    iterator_key.create_read_expression(ctx),
-                    IdentifierName::new(SPAN, "return", ctx),
-                    false, ctx)),
-                    BinaryOperator::Inequality,
-                    Expression::new_null_literal(SPAN, ctx), ctx), ctx),
-                    Statement::new_block_statement_with_scope_id(SPAN,
-                    ArenaVec::from_value_in(Statement::new_expression_statement(SPAN,
-                    Expression::new_await_expression(SPAN,
-                    Expression::new_call_expression(SPAN,
-                    Expression::from(MemberExpression::new_static_member_expression(SPAN,
-                    iterator_key.create_read_expression(ctx),
-                    IdentifierName::new(SPAN, "return", ctx),
-                    false, ctx)),
-                    NONE,
-                    ArenaVec::new_in(ctx),
-                    false, ctx), ctx), ctx), ctx),
-                    if_block_scope_id, ctx),
-                    None, ctx)
-                        };
-                    let block = BlockStatement::new_with_scope_id(
+            let try_statement = {
+                let try_block_scope_id =
+                    ctx.create_child_scope(finally_scope_id, ScopeFlags::empty());
+                let if_statement = {
+                    let if_block_scope_id =
+                        ctx.create_child_scope(try_block_scope_id, ScopeFlags::empty());
+                    Statement::new_if_statement(
                         SPAN,
-                        ArenaVec::from_value_in(if_statement, ctx),
-                        try_block_scope_id,
-                        ctx,
-                    );
-                    let finally = {
-                        let finally_scope_id =
-                            ctx.create_child_scope(finally_scope_id, ScopeFlags::empty());
-                        let if_statement = {
-                            let if_block_scope_id =
-                                ctx.create_child_scope(finally_scope_id, ScopeFlags::empty());
-                            Statement::new_if_statement(
+                        Expression::new_logical_expression(
+                            SPAN,
+                            iterator_abrupt_completion.create_read_expression(ctx),
+                            LogicalOperator::And,
+                            Expression::new_binary_expression(
                                 SPAN,
-                                iterator_had_error_key.create_read_expression(ctx),
-                                Statement::new_block_statement_with_scope_id(
+                                Expression::new_static_member_expression(
                                     SPAN,
-                                    ArenaVec::from_value_in(
-                                        Statement::new_throw_statement(
+                                    iterator_key.create_read_expression(ctx),
+                                    IdentifierName::new(SPAN, "return", ctx),
+                                    false,
+                                    ctx,
+                                ),
+                                BinaryOperator::Inequality,
+                                Expression::new_null_literal(SPAN, ctx),
+                                ctx,
+                            ),
+                            ctx,
+                        ),
+                        Statement::new_block_statement_with_scope_id(
+                            SPAN,
+                            ArenaVec::from_value_in(
+                                Statement::new_expression_statement(
+                                    SPAN,
+                                    Expression::new_await_expression(
+                                        SPAN,
+                                        Expression::new_call_expression(
                                             SPAN,
-                                            iterator_error_key.create_read_expression(ctx),
+                                            Expression::new_static_member_expression(
+                                                SPAN,
+                                                iterator_key.create_read_expression(ctx),
+                                                IdentifierName::new(SPAN, "return", ctx),
+                                                false,
+                                                ctx,
+                                            ),
+                                            NONE,
+                                            ArenaVec::new_in(ctx),
+                                            false,
                                             ctx,
                                         ),
                                         ctx,
                                     ),
-                                    if_block_scope_id,
                                     ctx,
                                 ),
-                                None,
                                 ctx,
-                            )
-                        };
-                        BlockStatement::new_with_scope_id(
+                            ),
+                            if_block_scope_id,
+                            ctx,
+                        ),
+                        None,
+                        ctx,
+                    )
+                };
+                let block = BlockStatement::new_with_scope_id(
+                    SPAN,
+                    ArenaVec::from_value_in(if_statement, ctx),
+                    try_block_scope_id,
+                    ctx,
+                );
+                let finally = {
+                    let finally_scope_id =
+                        ctx.create_child_scope(finally_scope_id, ScopeFlags::empty());
+                    let if_statement = {
+                        let if_block_scope_id =
+                            ctx.create_child_scope(finally_scope_id, ScopeFlags::empty());
+                        Statement::new_if_statement(
                             SPAN,
-                            ArenaVec::from_value_in(if_statement, ctx),
-                            finally_scope_id,
+                            iterator_had_error_key.create_read_expression(ctx),
+                            Statement::new_block_statement_with_scope_id(
+                                SPAN,
+                                ArenaVec::from_value_in(
+                                    Statement::new_throw_statement(
+                                        SPAN,
+                                        iterator_error_key.create_read_expression(ctx),
+                                        ctx,
+                                    ),
+                                    ctx,
+                                ),
+                                if_block_scope_id,
+                                ctx,
+                            ),
+                            None,
                             ctx,
                         )
                     };
-                    Statement::new_try_statement(SPAN, block, NONE, Some(finally), ctx)
+                    BlockStatement::new_with_scope_id(
+                        SPAN,
+                        ArenaVec::from_value_in(if_statement, ctx),
+                        finally_scope_id,
+                        ctx,
+                    )
                 };
+                Statement::new_try_statement(SPAN, block, NONE, Some(finally), ctx)
+            };
 
             let block_statement = BlockStatement::new_with_scope_id(
                 SPAN,

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -1140,13 +1140,9 @@ impl<'a> SpreadPair<'a> {
             // `function _objectDestructuringEmpty(t) { if (null == t) throw new TypeError("Cannot destructure " + t); }`
             let mut arguments = ArenaVec::new_in(ctx);
             // Add `{}`.
-            arguments.push(Argument::ObjectExpression(ObjectExpression::boxed(
-                SPAN,
-                ArenaVec::new_in(ctx),
-                ctx,
-            )));
+            arguments.push(Argument::new_object_expression(SPAN, ArenaVec::new_in(ctx), ctx));
             // Add `(_objectDestructuringEmpty(b), b);`
-            arguments.push(Argument::SequenceExpression(SequenceExpression::boxed(
+            arguments.push(Argument::new_sequence_expression(
                 SPAN,
                 {
                     let mut sequence = ArenaVec::new_in(ctx);
@@ -1162,7 +1158,7 @@ impl<'a> SpreadPair<'a> {
                     sequence
                 },
                 ctx,
-            )));
+            ));
             helper_call_expr(Helper::Extends, arguments, ctx)
         } else {
             // / `let { a, b, ...c } = z` -> _objectWithoutProperties(_z, ["a", "b"]);
@@ -1197,13 +1193,13 @@ impl<'a> SpreadPair<'a> {
                 // map to `toPropertyKey` to handle the possible non-string values
                 // `[_ref].map(babelHelpers.toPropertyKey))`
                 let property = IdentifierName::new(SPAN, "map", ctx);
-                let callee = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+                let callee = Expression::new_static_member_expression(
                     SPAN,
                     key_expression,
                     property,
                     false,
                     ctx,
-                ));
+                );
                 let arguments = ArenaVec::from_value_in(
                     Argument::from(helper_load(Helper::ToPropertyKey, ctx)),
                     ctx,

--- a/crates/oxc_transformer/src/es2020/export_namespace_from.rs
+++ b/crates/oxc_transformer/src/es2020/export_namespace_from.rs
@@ -71,13 +71,12 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExportNamespaceFrom {
                     );
 
                     // Create `import * as _ns from "mod"`
-                    let import_specifier = ImportDeclarationSpecifier::ImportNamespaceSpecifier(
-                        ImportNamespaceSpecifier::boxed(
+                    let import_specifier =
+                        ImportDeclarationSpecifier::new_import_namespace_specifier(
                             SPAN,
                             binding.create_binding_identifier(ctx),
                             ctx,
-                        ),
-                    );
+                        );
 
                     let import_decl = ImportDeclaration::boxed(
                         SPAN,

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -160,13 +160,13 @@ impl<'a> LogicalAssignmentOperators {
         let object = static_expr.object.take_in(ctx);
         let (object, object_ref) = duplicate_expression(object, true, ctx);
 
-        let left_expr = Expression::from(MemberExpression::new_static_member_expression(
+        let left_expr = Expression::new_static_member_expression(
             static_expr.span,
             object,
             static_expr.property.clone(),
             false,
             ctx,
-        ));
+        );
 
         let assign_expr = MemberExpression::new_static_member_expression(
             static_expr.span,
@@ -192,22 +192,21 @@ impl<'a> LogicalAssignmentOperators {
         let expression = computed_expr.expression.take_in(ctx);
         let (expression, expression_ref) = duplicate_expression(expression, true, ctx);
 
-        let left_expr = Expression::from(MemberExpression::new_computed_member_expression(
+        let left_expr = Expression::new_computed_member_expression(
             computed_expr.span,
             object,
             expression,
             false,
             ctx,
-        ));
+        );
 
-        let assign_target =
-            AssignmentTarget::from(MemberExpression::new_computed_member_expression(
-                computed_expr.span,
-                object_ref,
-                expression_ref,
-                false,
-                ctx,
-            ));
+        let assign_target = AssignmentTarget::new_computed_member_expression(
+            computed_expr.span,
+            object_ref,
+            expression_ref,
+            false,
+            ctx,
+        );
 
         (left_expr, assign_target)
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -854,10 +854,7 @@ impl<'a> ClassProperties<'a> {
     fn create_private_prop_key_loose(name: Ident<'a>, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         helper_call_expr(
             Helper::ClassPrivateFieldLooseKey,
-            ArenaVec::from_value_in(
-                Argument::from(Expression::new_string_literal(SPAN, name, None, ctx)),
-                ctx,
-            ),
+            ArenaVec::from_value_in(Argument::new_string_literal(SPAN, name, None, ctx), ctx),
             ctx,
         )
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -354,7 +354,7 @@ impl<'a> ClassProperties<'a> {
         );
 
         // `var _super = (..._args) => ( ... );`
-        let super_func_decl = Statement::from(Declaration::new_variable_declaration(
+        let super_func_decl = Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
             ArenaVec::from_value_in(
@@ -371,7 +371,7 @@ impl<'a> ClassProperties<'a> {
             ),
             false,
             ctx,
-        ));
+        );
 
         // Insert at top of function
         let body_stmts = &mut constructor.body.as_mut().unwrap().statements;
@@ -615,13 +615,13 @@ impl<'a> ConstructorParamsSuperReplacer<'a, '_> {
         let super_call = expr.take_in(ctx);
         *expr = Expression::new_call_expression(
             span,
-            Expression::from(MemberExpression::new_static_member_expression(
+            Expression::new_static_member_expression(
                 SPAN,
                 super_binding.create_read_expression(ctx),
                 IdentifierName::new(SPAN, "call", ctx),
                 false,
                 ctx,
-            )),
+            ),
             NONE,
             ArenaVec::from_value_in(Argument::from(super_call), ctx),
             false,

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -295,14 +295,14 @@ impl<'a> ClassProperties<'a> {
         ctx: &TraverseCtx<'a>,
     ) {
         // Substitute `<callee>.call` as callee of call expression
-        call_expr.callee = Expression::from(MemberExpression::new_static_member_expression(
+        call_expr.callee = Expression::new_static_member_expression(
             SPAN,
             callee,
             IdentifierName::new(SPAN, "call", ctx),
             // Make sure the `callee` can access `call` safely. i.e `callee?.()` -> `callee?.call()`
             mem::replace(&mut call_expr.optional, false),
             ctx,
-        ));
+        );
         // Insert `context` to call arguments
         call_expr.arguments.insert(0, Argument::from(context));
     }
@@ -1811,13 +1811,13 @@ impl<'a> ClassProperties<'a> {
         let (callee, context) = self.transform_private_field_callee(field_expr, ctx);
 
         // Return `<callee>.bind(object)`, to be substituted as tag of tagged template expression
-        let callee = Expression::from(MemberExpression::new_static_member_expression(
+        let callee = Expression::new_static_member_expression(
             SPAN,
             callee,
             IdentifierName::new(SPAN, "bind", ctx),
             false,
             ctx,
-        ));
+        );
         let arguments = ArenaVec::from_value_in(Argument::from(context), ctx);
         Expression::new_call_expression(field_expr.span, callee, NONE, arguments, false, ctx)
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -99,7 +99,7 @@ impl<'a> ClassProperties<'a> {
         let brand = self.classes_stack.last().bindings.brand.as_ref().unwrap();
         let arguments = ArenaVec::from_array_in(
             [
-                Argument::from(Expression::new_this_expression(SPAN, ctx)),
+                Argument::new_this_expression(SPAN, ctx),
                 Argument::from(brand.create_read_expression(ctx)),
             ],
             ctx,

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -87,7 +87,7 @@ impl<'a> ClassProperties<'a> {
         let prop = &private_props[&ident.name];
         let arguments = ArenaVec::from_array_in(
             [
-                Argument::from(Expression::new_this_expression(SPAN, ctx)),
+                Argument::new_this_expression(SPAN, ctx),
                 Argument::from(prop.binding.create_read_expression(ctx)),
                 Argument::from(value),
             ],
@@ -365,9 +365,7 @@ impl<'a> ClassProperties<'a> {
         let object =
             ctx.create_ident_expr(SPAN, object_name, object_symbol_id, ReferenceFlags::Read);
         let property = IdentifierName::new(SPAN, "defineProperty", ctx);
-        let callee = Expression::from(MemberExpression::new_static_member_expression(
-            SPAN, object, property, false, ctx,
-        ));
+        let callee = Expression::new_static_member_expression(SPAN, object, property, false, ctx);
 
         // `{writable: true, value: <value>}`
         let prop_def = Expression::new_object_expression(

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -590,13 +590,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_> {
                 Argument::from(property),
                 Argument::from(value),
                 receiver,
-                Argument::from(Expression::new_numeric_literal(
-                    SPAN,
-                    1.0,
-                    None,
-                    NumberBase::Decimal,
-                    ctx,
-                )),
+                Argument::new_numeric_literal(SPAN, 1.0, None, NumberBase::Decimal, ctx),
             ],
             ctx,
         );

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -26,13 +26,13 @@ pub(super) fn create_variable_declaration<'a>(
         false,
         ctx,
     );
-    Statement::from(Declaration::new_variable_declaration(
+    Statement::new_variable_declaration(
         SPAN,
         kind,
         ArenaVec::from_value_in(declarator, ctx),
         false,
         ctx,
-    ))
+    )
 }
 
 /// Convert an iterator of `Expression`s into an iterator of `Statement::ExpressionStatement`s.

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -102,7 +102,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
             mem::replace(&mut variable_declarator.id, temp_id.create_binding_pattern(ctx));
 
         // `using x = _x;`
-        let using_stmt = Statement::from(Declaration::new_variable_declaration(
+        let using_stmt = Statement::new_variable_declaration(
             SPAN,
             variable_decl_kind,
             ArenaVec::from_value_in(
@@ -119,7 +119,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
             ),
             false,
             ctx,
-        ));
+        );
 
         if let Statement::BlockStatement(body) = &mut for_of_stmt.body {
             let body_scope_id = body.scope_id();
@@ -418,9 +418,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
 
                         let decl = mem::replace(
                             &mut export_default_decl.declaration,
-                            ExportDefaultDeclarationKind::NullLiteral(NullLiteral::boxed(
-                                SPAN, ctx,
-                            )),
+                            ExportDefaultDeclarationKind::new_null_literal(SPAN, ctx),
                         );
 
                         let expr = match decl {
@@ -434,48 +432,44 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                             _ => decl.into_expression(),
                         };
 
-                        inner_block.push(Statement::VariableDeclaration(
-                            VariableDeclaration::boxed(
-                                span,
-                                VariableDeclarationKind::Var,
-                                ArenaVec::from_value_in(
-                                    VariableDeclarator::new(
-                                        span,
-                                        VariableDeclarationKind::Var,
-                                        var_id.create_spanned_binding_pattern(span, ctx),
-                                        NONE,
-                                        Some(expr),
-                                        false,
-                                        ctx,
-                                    ),
+                        inner_block.push(Statement::new_variable_declaration(
+                            span,
+                            VariableDeclarationKind::Var,
+                            ArenaVec::from_value_in(
+                                VariableDeclarator::new(
+                                    span,
+                                    VariableDeclarationKind::Var,
+                                    var_id.create_spanned_binding_pattern(span, ctx),
+                                    NONE,
+                                    Some(expr),
+                                    false,
                                     ctx,
                                 ),
-                                false,
                                 ctx,
                             ),
+                            false,
+                            ctx,
                         ));
 
-                        program_body.push(Statement::ExportNamedDeclaration(
-                            ExportNamedDeclaration::boxed(
-                                SPAN,
-                                None,
-                                ArenaVec::from_value_in(
-                                    ExportSpecifier::new(
-                                        SPAN,
-                                        ModuleExportName::IdentifierReference(
-                                            var_id.create_read_reference(ctx),
-                                        ),
-                                        ModuleExportName::new_identifier_name(SPAN, "default", ctx),
-                                        ImportOrExportKind::Value,
-                                        ctx,
+                        program_body.push(Statement::new_export_named_declaration(
+                            SPAN,
+                            None,
+                            ArenaVec::from_value_in(
+                                ExportSpecifier::new(
+                                    SPAN,
+                                    ModuleExportName::IdentifierReference(
+                                        var_id.create_read_reference(ctx),
                                     ),
+                                    ModuleExportName::new_identifier_name(SPAN, "default", ctx),
+                                    ImportOrExportKind::Value,
                                     ctx,
                                 ),
-                                None,
-                                ImportOrExportKind::Value,
-                                NONE,
                                 ctx,
                             ),
+                            None,
+                            ImportOrExportKind::Value,
+                            NONE,
+                            ctx,
                         ));
                     }
                     Statement::ExportNamedDeclaration(ref mut export_named_declaration) => {
@@ -558,16 +552,14 @@ impl<'a> Traverse<'a, TransformState<'a>> for ExplicitResourceManagement<'a> {
                             _ => unreachable!(),
                         };
 
-                        program_body.push(Statement::ExportNamedDeclaration(
-                            ExportNamedDeclaration::boxed(
-                                SPAN,
-                                None,
-                                export_specifiers,
-                                None,
-                                export_named_declaration.export_kind,
-                                NONE,
-                                ctx,
-                            ),
+                        program_body.push(Statement::new_export_named_declaration(
+                            SPAN,
+                            None,
+                            export_specifiers,
+                            None,
+                            export_named_declaration.export_kind,
+                            NONE,
+                            ctx,
                         ));
                     }
                     Statement::ClassDeclaration(class_decl) => {
@@ -714,7 +706,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                     if let Some(old_init) = decl.init.take() {
                         decl.init = Some(Expression::new_call_expression(
                             SPAN,
-                            Expression::from(MemberExpression::new_static_member_expression(
+                            Expression::new_static_member_expression(
                                 SPAN,
                                 using_ctx
                                     .as_ref()
@@ -731,7 +723,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                                 ),
                                 false,
                                 ctx,
-                            )),
+                            ),
                             NONE,
                             ArenaVec::from_value_in(Argument::from(old_init), ctx),
                             false,
@@ -753,7 +745,7 @@ impl<'a> ExplicitResourceManagement<'a> {
         let block = {
             let vec = ArenaVec::from_array_in(
                 [
-                    Statement::from(Declaration::new_variable_declaration(
+                    Statement::new_variable_declaration(
                         SPAN,
                         VariableDeclarationKind::Var,
                         ArenaVec::from_value_in(
@@ -777,7 +769,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                         ),
                         false,
                         ctx,
-                    )),
+                    ),
                     stmt.take_in(ctx),
                 ],
                 ctx,
@@ -859,7 +851,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                 if let Some(old_init) = decl.init.take() {
                     decl.init = Some(Expression::new_call_expression(
                         SPAN,
-                        Expression::from(MemberExpression::new_static_member_expression(
+                        Expression::new_static_member_expression(
                             SPAN,
                             using_ctx.as_ref().unwrap().create_read_expression(ctx),
                             IdentifierName::new(
@@ -873,7 +865,7 @@ impl<'a> ExplicitResourceManagement<'a> {
                             ),
                             false,
                             ctx,
-                        )),
+                        ),
                         NONE,
                         ArenaVec::from_value_in(Argument::from(old_init), ctx),
                         false,
@@ -961,13 +953,13 @@ impl<'a> ExplicitResourceManagement<'a> {
             Expression::new_assignment_expression(
                 SPAN,
                 AssignmentOperator::Assign,
-                AssignmentTarget::from(MemberExpression::new_static_member_expression(
+                AssignmentTarget::new_static_member_expression(
                     SPAN,
                     using_ctx.create_read_expression(ctx),
                     IdentifierName::new(SPAN, "e", ctx),
                     false,
                     ctx,
-                )),
+                ),
                 ident.create_read_expression(ctx),
                 ctx,
             ),
@@ -1001,13 +993,13 @@ impl<'a> ExplicitResourceManagement<'a> {
         // `_usingCtx.d()`
         let expr = Expression::new_call_expression(
             SPAN,
-            Expression::from(MemberExpression::new_static_member_expression(
+            Expression::new_static_member_expression(
                 SPAN,
                 using_ctx.create_read_expression(ctx),
                 IdentifierName::new(SPAN, "d", ctx),
                 false,
                 ctx,
-            )),
+            ),
             NONE,
             ArenaVec::new_in(ctx),
             false,
@@ -1035,7 +1027,7 @@ impl<'a> ExplicitResourceManagement<'a> {
         class_decl.r#type = ClassType::ClassExpression;
         let class_expr = Expression::ClassExpression(class_decl);
 
-        Statement::VariableDeclaration(VariableDeclaration::boxed(
+        Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
             ArenaVec::from_value_in(
@@ -1052,7 +1044,7 @@ impl<'a> ExplicitResourceManagement<'a> {
             ),
             false,
             ctx,
-        ))
+        )
     }
 
     /// Move the original class id symbol to a new `var`-style outer binding, and create a fresh

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -420,13 +420,13 @@ impl<'a> Pragma<'a> {
         let (object, parts) = match self {
             Self::Double(first, second) => {
                 let object = get_read_identifier_reference(SPAN, *first, ctx);
-                return Expression::from(MemberExpression::new_static_member_expression(
+                return Expression::new_static_member_expression(
                     SPAN,
                     object,
                     IdentifierName::new(SPAN, *second, ctx),
                     false,
                     ctx,
-                ));
+                );
             }
             Self::Single(single) => {
                 return get_read_identifier_reference(SPAN, *single, ctx);
@@ -566,13 +566,13 @@ impl<'a> JsxImpl<'a> {
         // TODO(improve-on-babel): Simplify this once we don't need to follow Babel exactly.
         if self.bindings.is_classic() || ctx.state.source_type.is_module() {
             // Insert before imports - add to `top_level_statements` immediately
-            let stmt = Statement::VariableDeclaration(VariableDeclaration::boxed(
+            let stmt = Statement::new_variable_declaration(
                 SPAN,
                 VariableDeclarationKind::Var,
                 ArenaVec::from_value_in(declarator, ctx),
                 false,
                 ctx,
-            ));
+            );
             ctx.state.top_level_statements.insert_statement(stmt);
         } else {
             // Insert after imports - add to `var_declarations`, which are inserted after `require` statements
@@ -737,11 +737,7 @@ impl<'a> JsxImpl<'a> {
 
             // isStaticChildren
             if is_development {
-                arguments.push(Argument::from(Expression::new_boolean_literal(
-                    SPAN,
-                    children_len > 1,
-                    ctx,
-                )));
+                arguments.push(Argument::new_boolean_literal(SPAN, children_len > 1, ctx));
             }
 
             // { __source: { fileName, lineNumber, columnNumber } }
@@ -753,7 +749,7 @@ impl<'a> JsxImpl<'a> {
 
             // this
             if self.options.jsx_self_plugin && JsxSelf::can_add_self_attribute(ctx) {
-                arguments.push(Argument::from(Expression::new_this_expression(SPAN, ctx)));
+                arguments.push(Argument::new_this_expression(SPAN, ctx));
             }
         } else {
             // React.createElement's second argument
@@ -998,14 +994,14 @@ impl<'a> JsxImpl<'a> {
             JSXAttributeName::Identifier(ident) => {
                 let name = ident.name;
                 if ident.name.contains('-') {
-                    PropertyKey::from(Expression::new_string_literal(ident.span, name, None, ctx))
+                    PropertyKey::new_string_literal(ident.span, name, None, ctx)
                 } else {
                     PropertyKey::new_static_identifier(ident.span, name, ctx)
                 }
             }
             JSXAttributeName::NamespacedName(namespaced) => {
                 let name = Str::from_str_in(&namespaced.to_string(), ctx);
-                PropertyKey::from(Expression::new_string_literal(namespaced.span, name, None, ctx))
+                PropertyKey::new_string_literal(namespaced.span, name, None, ctx)
             }
         }
     }

--- a/crates/oxc_transformer/src/jsx/jsx_self.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_self.rs
@@ -103,7 +103,7 @@ impl<'a> JsxSelf {
 
         let name = JSXAttributeName::new_identifier(SPAN, SELF, ctx);
         let value = {
-            let jsx_expr = JSXExpression::from(Expression::new_this_expression(SPAN, ctx));
+            let jsx_expr = JSXExpression::new_this_expression(SPAN, ctx);
             JSXAttributeValue::new_expression_container(SPAN, jsx_expr, ctx)
         };
         let attribute = JSXAttributeItem::new_attribute(SPAN, name, Some(value), ctx);

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -178,13 +178,13 @@ impl<'a> JsxSource<'a> {
     pub fn get_filename_var_statement(&self, ctx: &TraverseCtx<'a>) -> Option<Statement<'a>> {
         let decl = self.get_filename_var_declarator(ctx)?;
 
-        let var_decl = Statement::VariableDeclaration(VariableDeclaration::boxed(
+        let var_decl = Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
             ArenaVec::from_value_in(decl, ctx),
             false,
             ctx,
-        ));
+        );
         Some(var_decl)
     }
 

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -97,13 +97,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
                     reference_id,
                     ctx,
                 );
-                Expression::from(MemberExpression::new_static_member_expression(
-                    SPAN,
-                    ident,
-                    property.clone(),
-                    false,
-                    ctx,
-                ))
+                Expression::new_static_member_expression(SPAN, ident, property.clone(), false, ctx)
             }
             Self::Expression(expr) => expr.clone_in(ctx.ast.allocator),
         }
@@ -169,13 +163,13 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
             return;
         }
 
-        let var_decl = Statement::from(Declaration::new_variable_declaration(
+        let var_decl = Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
             ArenaVec::new_in(ctx), // This is replaced at the end
             false,
             ctx,
-        ));
+        );
 
         let mut variable_declarator_items =
             ArenaVec::with_capacity_in(self.registrations.len(), ctx);
@@ -194,7 +188,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
             let arguments = ArenaVec::from_array_in(
                 [
                     Argument::from(binding.create_read_expression(ctx)),
-                    Argument::from(Expression::new_string_literal(SPAN, *persistent_id, None, ctx)),
+                    Argument::new_string_literal(SPAN, *persistent_id, None, ctx),
                 ],
                 ctx,
             );
@@ -387,25 +381,21 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
                             if is_member_expression {
                                 if let Some(middle_property) = middle_property {
                                     // binding_name.middle_property
-                                    expr = Expression::from(
-                                        MemberExpression::new_static_member_expression(
-                                            SPAN,
-                                            expr,
-                                            IdentifierName::new(SPAN, middle_property, ctx),
-                                            false,
-                                            ctx,
-                                        ),
+                                    expr = Expression::new_static_member_expression(
+                                        SPAN,
+                                        expr,
+                                        IdentifierName::new(SPAN, middle_property, ctx),
+                                        false,
+                                        ctx,
                                     );
                                 }
                                 // binding_name.hook_name
-                                expr = Expression::from(
-                                    MemberExpression::new_static_member_expression(
-                                        SPAN,
-                                        expr,
-                                        IdentifierName::new(SPAN, hook_name, ctx),
-                                        false,
-                                        ctx,
-                                    ),
+                                expr = Expression::new_static_member_expression(
+                                    SPAN,
+                                    expr,
+                                    IdentifierName::new(SPAN, hook_name, ctx),
+                                    false,
+                                    ctx,
                                 );
                             }
                             expr
@@ -638,10 +628,10 @@ impl<'a> ReactRefresh<'a> {
         let force_reset = custom_hooks_in_scope.len() != callee_len;
 
         let mut arguments = ArenaVec::new_in(ctx);
-        arguments.push(Argument::from(Expression::new_string_literal(SPAN, key, None, ctx)));
+        arguments.push(Argument::new_string_literal(SPAN, key, None, ctx));
 
         if force_reset || !custom_hooks_in_scope.is_empty() {
-            arguments.push(Argument::from(Expression::new_boolean_literal(SPAN, force_reset, ctx)));
+            arguments.push(Argument::new_boolean_literal(SPAN, force_reset, ctx));
         }
 
         if !custom_hooks_in_scope.is_empty() {
@@ -667,24 +657,22 @@ impl<'a> ReactRefresh<'a> {
                 ctx,
             );
             let scope_id = ctx.create_child_scope_of_current(ScopeFlags::Function);
-            let function = Argument::from(
-                Expression::new_function_expression_with_scope_id_and_pure_and_pife(
-                    SPAN,
-                    FunctionType::FunctionExpression,
-                    None,
-                    false,
-                    false,
-                    false,
-                    NONE,
-                    NONE,
-                    formal_parameters,
-                    NONE,
-                    Some(function_body),
-                    scope_id,
-                    false,
-                    false,
-                    ctx,
-                ),
+            let function = Argument::new_function_expression_with_scope_id_and_pure_and_pife(
+                SPAN,
+                FunctionType::FunctionExpression,
+                None,
+                false,
+                false,
+                false,
+                NONE,
+                NONE,
+                formal_parameters,
+                NONE,
+                Some(function_body),
+                scope_id,
+                false,
+                false,
+                ctx,
             );
             arguments.push(function);
         }

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -415,18 +415,12 @@ impl<'a> StyledComponents<'a> {
 
         let quasis_elements = ArenaVec::from_iter_in(
             quasis.into_iter().map(|quasi| {
-                ArrayExpressionElement::from(Expression::new_string_literal(
-                    quasi.span,
-                    quasi.value.raw,
-                    None,
-                    ctx,
-                ))
+                ArrayExpressionElement::new_string_literal(quasi.span, quasi.value.raw, None, ctx)
             }),
             ctx,
         );
 
-        let quasis =
-            Argument::from(Expression::new_array_expression(quasi_span, quasis_elements, ctx));
+        let quasis = Argument::new_array_expression(quasi_span, quasis_elements, ctx);
         let arguments = ArenaVec::from_iter_in(
             once(quasis).chain(expressions.into_iter().map(Argument::from)),
             ctx,
@@ -465,9 +459,8 @@ impl<'a> StyledComponents<'a> {
             let arguments = ArenaVec::from_value_in(Argument::ObjectExpression(object), ctx);
             let object = expr.take_in(ctx);
             let property = IdentifierName::new(SPAN, "withConfig", ctx);
-            let callee = Expression::from(MemberExpression::new_static_member_expression(
-                SPAN, object, property, false, ctx,
-            ));
+            let callee =
+                Expression::new_static_member_expression(SPAN, object, property, false, ctx);
             let call = Expression::new_call_expression(SPAN, callee, NONE, arguments, false, ctx);
             *expr = call;
         } else {

--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -168,8 +168,7 @@ impl<'a> TaggedTemplateTransform {
             }),
             ctx,
         );
-        let cooked_argument =
-            Argument::from(Expression::new_array_expression(SPAN, cooked_elements, ctx));
+        let cooked_argument = Argument::new_array_expression(SPAN, cooked_elements, ctx);
 
         // Add raw array if needed: `[raw0, raw1, ...]`
         let template_arguments = if needs_raw_array {
@@ -180,8 +179,7 @@ impl<'a> TaggedTemplateTransform {
                 }),
                 ctx,
             );
-            let raws_argument =
-                Argument::from(Expression::new_array_expression(SPAN, elements, ctx));
+            let raws_argument = Argument::new_array_expression(SPAN, elements, ctx);
             ArenaVec::from_array_in([cooked_argument, raws_argument], ctx)
         } else {
             ArenaVec::from_value_in(cooked_argument, ctx)
@@ -239,13 +237,13 @@ impl<'a> TaggedTemplateTransform {
             ctx,
         );
 
-        let stmt = Statement::from(Declaration::new_variable_declaration(
+        let stmt = Statement::new_variable_declaration(
             SPAN,
             VariableDeclarationKind::Var,
             ArenaVec::from_value_in(variable, ctx),
             false,
             ctx,
-        ));
+        );
 
         ctx.state.top_level_statements.insert_statement(stmt);
 

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -167,13 +167,13 @@ impl<'a> RegExp {
 
         let arguments = ArenaVec::from_array_in(
             [
-                Argument::from(Expression::new_string_literal(SPAN, pattern_text, None, ctx)),
-                Argument::from(Expression::new_string_literal(
+                Argument::new_string_literal(SPAN, pattern_text, None, ctx),
+                Argument::new_string_literal(
                     SPAN,
                     Str::from_str_in(flags.to_inline_string().as_str(), ctx),
                     None,
                     ctx,
-                )),
+                ),
             ],
             ctx,
         );

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -643,13 +643,13 @@ impl<'a> Assignment<'a> {
             Expression::new_assignment_expression(
                 SPAN,
                 AssignmentOperator::Assign,
-                SimpleAssignmentTarget::from(MemberExpression::new_static_member_expression(
+                SimpleAssignmentTarget::new_static_member_expression(
                     SPAN,
                     Expression::new_this_expression(SPAN, ctx),
                     IdentifierName::new(self.span, self.name, ctx),
                     false,
                     ctx,
-                ))
+                )
                 .into(),
                 Expression::Identifier(id),
                 ctx,

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -203,15 +203,13 @@ impl<'a> TypeScriptModule {
                     ctx,
                 )
             }
-            TSTypeName::QualifiedName(qualified_name) => {
-                Expression::from(MemberExpression::new_static_member_expression(
-                    SPAN,
-                    self.transform_ts_type_name(&mut qualified_name.left, ctx),
-                    qualified_name.right.clone(),
-                    false,
-                    ctx,
-                ))
-            }
+            TSTypeName::QualifiedName(qualified_name) => Expression::new_static_member_expression(
+                SPAN,
+                self.transform_ts_type_name(&mut qualified_name.left, ctx),
+                qualified_name.right.clone(),
+                false,
+                ctx,
+            ),
             TSTypeName::ThisExpression(e) => Expression::new_this_expression(e.span, ctx),
         }
     }

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -366,13 +366,13 @@ impl<'a> TypeScriptNamespace {
             let mut logical_right = {
                 // _N.M
                 let assign_left = if let Some(parent_binding) = parent_binding {
-                    AssignmentTarget::from(MemberExpression::new_static_member_expression(
+                    AssignmentTarget::new_static_member_expression(
                         SPAN,
                         parent_binding.create_read_expression(ctx),
                         IdentifierName::new(SPAN, binding.name, ctx),
                         false,
                         ctx,
-                    ))
+                    )
                 } else {
                     // _N
                     binding.create_write_target(ctx)
@@ -478,14 +478,12 @@ impl<'a> TypeScriptNamespace {
                     declarator.init = Some(Expression::new_assignment_expression(
                         SPAN,
                         AssignmentOperator::Assign,
-                        SimpleAssignmentTarget::from(
-                            MemberExpression::new_static_member_expression(
-                                SPAN,
-                                binding.create_read_expression(ctx),
-                                IdentifierName::new(SPAN, property_name, ctx),
-                                false,
-                                ctx,
-                            ),
+                        SimpleAssignmentTarget::new_static_member_expression(
+                            SPAN,
+                            binding.create_read_expression(ctx),
+                            IdentifierName::new(SPAN, property_name, ctx),
+                            false,
+                            ctx,
                         )
                         .into(),
                         init.take_in(ctx),

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -17,9 +17,7 @@ pub fn create_member_callee<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let property = IdentifierName::new(SPAN, property, ctx);
-    Expression::from(MemberExpression::new_static_member_expression(
-        span, object, property, false, ctx,
-    ))
+    Expression::new_static_member_expression(span, object, property, false, ctx)
 }
 
 /// `object` -> `object.bind(this)`.
@@ -100,9 +98,7 @@ pub fn create_property_access<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let property = IdentifierName::new(SPAN, Str::from_str_in(property, ctx), ctx);
-    Expression::from(MemberExpression::new_static_member_expression(
-        span, object, property, false, ctx,
-    ))
+    Expression::new_static_member_expression(span, object, property, false, ctx)
 }
 
 /// `this.property`
@@ -214,7 +210,7 @@ pub fn create_class_constructor_with_params<'a>(
 ) -> ClassElement<'a> {
     create_class_method(
         ArenaVec::new_in(ctx),
-        PropertyKey::StaticIdentifier(IdentifierName::boxed(SPAN, "constructor", ctx)),
+        PropertyKey::new_static_identifier(SPAN, "constructor", ctx),
         MethodDefinitionKind::Constructor,
         params,
         None,
@@ -239,7 +235,7 @@ pub fn create_class_method<'a>(
     scope_id: ScopeId,
     ctx: &TraverseCtx<'a>,
 ) -> ClassElement<'a> {
-    ClassElement::MethodDefinition(MethodDefinition::boxed(
+    ClassElement::new_method_definition(
         SPAN,
         MethodDefinitionType::MethodDefinition,
         decorators,
@@ -266,5 +262,5 @@ pub fn create_class_method<'a>(
         false,
         None,
         ctx,
-    ))
+    )
 }

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -663,7 +663,7 @@ impl<'a> ModuleRunnerTransform<'a> {
             self.import_bindings.insert(symbol_id, (binding.clone(), Some(key)));
         }
 
-        ArrayExpressionElement::from(Expression::new_string_literal(span, key, None, ctx))
+        ArrayExpressionElement::new_string_literal(span, key, None, ctx)
     }
 
     #[inline]
@@ -709,11 +709,7 @@ impl<'a> ModuleRunnerTransform<'a> {
             false,
             ctx,
         );
-        Argument::from(Expression::new_object_expression(
-            SPAN,
-            ArenaVec::from_value_in(imported_names, ctx),
-            ctx,
-        ))
+        Argument::new_object_expression(SPAN, ArenaVec::from_value_in(imported_names, ctx), ctx)
     }
 
     // `const __vite_ssr_import_0__ = await __vite_ssr_import__('vue', { importedNames: ['foo'] });`
@@ -836,7 +832,7 @@ impl<'a> ModuleRunnerTransform<'a> {
                     static_ident!("__vite_ssr_exports__"),
                     ReferenceFlags::Read,
                 )),
-                Argument::from(Expression::new_string_literal(SPAN, exported_name, None, ctx)),
+                Argument::new_string_literal(SPAN, exported_name, None, ctx),
                 Argument::from(object),
             ],
             ctx,
@@ -892,9 +888,7 @@ fn create_compute_property_access<'a>(
 ) -> Expression<'a> {
     let expression =
         Expression::new_string_literal(SPAN, Str::from_str_in(property, ctx), None, ctx);
-    Expression::from(MemberExpression::new_computed_member_expression(
-        span, object, expression, false, ctx,
-    ))
+    Expression::new_computed_member_expression(span, object, expression, false, ctx)
 }
 
 /// `object` -> `object.call`.
@@ -904,9 +898,7 @@ pub fn create_member_callee<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let property = IdentifierName::new(SPAN, property, ctx);
-    Expression::from(MemberExpression::new_static_member_expression(
-        SPAN, object, property, false, ctx,
-    ))
+    Expression::new_static_member_expression(SPAN, object, property, false, ctx)
 }
 
 /// `object` -> `object.a`.
@@ -917,9 +909,7 @@ pub fn create_property_access<'a>(
     ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let property = IdentifierName::new(SPAN, Str::from_str_in(property, ctx), ctx);
-    Expression::from(MemberExpression::new_static_member_expression(
-        span, object, property, false, ctx,
-    ))
+    Expression::new_static_member_expression(span, object, property, false, ctx)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Follow-up to the `AstBuilder` migration.

Now everything's on the new builder, a load of call sites were left more verbose than they need to be. This collapses them to the shorthand constructors, e.g.:

```rs
Statement::VariableDeclaration(VariableDeclaration::boxed(span, kind, decls, declare, ctx))
// ->
Statement::new_variable_declaration(span, kind, decls, declare, ctx)
```

Three shapes get shortened:

- `ArenaBox::new_in(Function::new(...), self)` → `Function::boxed(...)`
- `Statement::FunctionDeclaration(Function::boxed(...))` → `Statement::new_function_declaration(...)`
- `Statement::from(Declaration::new_function_declaration(...))` → `Statement::new_function_declaration(...)`

Done with an [ast-grep codemod](https://github.com/oxc-project/oxc/tree/overlookmotel/ast-builder-codemod), so it's purely mechanical - no behaviour change.