### PR TITLE
refactor(minifier): shorten AST builder code

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1862,10 +1862,7 @@ impl<'a> PeepholeOptimizations {
                                 if prop.shorthand && prop.key.is_specific_id("__proto__") {
                                     // { __proto__ } -> { ['__proto__']: value }
                                     prop.computed = true;
-                                    prop.key =
-                                        PropertyKey::from(Expression::new_string_literal(prop.key.span(),
-                                        "__proto__",
-                                        None, ctx));
+                                    prop.key = PropertyKey::new_string_literal(prop.key.span(), "__proto__", None, ctx);
                                 }
                                 prop.shorthand = false;
                                 return Some(changed);

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -985,25 +985,19 @@ impl<'a> PeepholeOptimizations {
             // wrap with `.slice(offset)`
             let arr = if offset > 0.0 {
                 let obj = base_arr;
-                let callee = Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+                let callee = Expression::new_static_member_expression(
                     SPAN,
                     obj,
                     IdentifierName::new(SPAN, "slice", ctx),
                     false,
                     ctx,
-                ));
+                );
                 Expression::new_call_expression(
                     SPAN,
                     callee,
                     NONE,
                     ArenaVec::from_value_in(
-                        Argument::from(Expression::new_numeric_literal(
-                            SPAN,
-                            offset,
-                            None,
-                            NumberBase::Decimal,
-                            ctx,
-                        )),
+                        Argument::new_numeric_literal(SPAN, offset, None, NumberBase::Decimal, ctx),
                         ctx,
                     ),
                     false,
@@ -1431,8 +1425,7 @@ impl<'a> PeepholeOptimizations {
                 if is_identifier_name_patched(value) {
                     // Bool field flip on an existing AST node, not a slot replacement.
                     *computed = false;
-                    let new_key =
-                        PropertyKey::StaticIdentifier(IdentifierName::boxed(s.span, s.value, ctx));
+                    let new_key = PropertyKey::new_static_identifier(s.span, s.value, ctx);
                     ctx.replace_property_key(key, new_key);
                     return;
                 }
@@ -1441,13 +1434,13 @@ impl<'a> PeepholeOptimizations {
                 {
                     // Bool field flip on an existing AST node, not a slot replacement.
                     *computed = false;
-                    let new_key = PropertyKey::NumericLiteral(NumericLiteral::boxed(
+                    let new_key = PropertyKey::new_numeric_literal(
                         s.span,
                         value,
                         None,
                         NumberBase::Decimal,
                         ctx,
-                    ));
+                    );
                     ctx.replace_property_key(key, new_key);
                     return;
                 }
@@ -1773,7 +1766,7 @@ impl<'a> PeepholeOptimizations {
         // "str1,str2".split(',')
         let new_value = Expression::new_call_expression_with_pure(
             expr.span(),
-            Expression::StaticMemberExpression(StaticMemberExpression::boxed(
+            Expression::new_static_member_expression(
                 expr.span(),
                 Expression::new_string_literal(
                     expr.span(),
@@ -1784,15 +1777,15 @@ impl<'a> PeepholeOptimizations {
                 IdentifierName::new(expr.span(), "split", ctx),
                 false,
                 ctx,
-            )),
+            ),
             NONE,
             ArenaVec::from_value_in(
-                Argument::from(Expression::new_string_literal(
+                Argument::new_string_literal(
                     expr.span(),
                     Str::from_str_in(delimiter, ctx),
                     None,
                     ctx,
-                )),
+                ),
                 ctx,
             ),
             false,


### PR DESCRIPTION
Follow-up to the `AstBuilder` migration.

Now everything's on the new builder, a load of call sites were left more verbose than they need to be. This collapses them to the shorthand constructors, e.g.:

```rs
Statement::VariableDeclaration(VariableDeclaration::boxed(span, kind, decls, declare, ctx))
// ->
Statement::new_variable_declaration(span, kind, decls, declare, ctx)
```

Three shapes get shortened:

- `ArenaBox::new_in(Function::new(...), self)` → `Function::boxed(...)`
- `Statement::FunctionDeclaration(Function::boxed(...))` → `Statement::new_function_declaration(...)`
- `Statement::from(Declaration::new_function_declaration(...))` → `Statement::new_function_declaration(...)`

Done with an [ast-grep codemod](https://github.com/oxc-project/oxc/tree/overlookmotel/ast-builder-codemod), so it's purely mechanical - no behaviour change.