### PR TITLE
perf(linter/jest-vitest): speed up no-commented-out-tests

### DIFF
--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -39,6 +39,7 @@ fn test() {
         ("testSomething()", None),
         ("// latest(dates)", None),
         ("// TODO: unify with Git implementation from Shipit (?)", None),
+        ("// test['not a method?']()", None),
         ("#!/usr/bin/env node", None),
         (
             r#"
@@ -108,6 +109,7 @@ fn test() {
         ("// it('has title but no callback')", None),
         ("// it()", None),
         ("// test.someNewMethodThatMightBeAddedInTheFuture()", None),
+        ("// test.123()", None),
         ("// test['someNewMethodThatMightBeAddedInTheFuture']()", None),
         ("// test('has title but no callback')", None),
         (

--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_commented_out_tests.rs
@@ -1,4 +1,4 @@
-use lazy_regex::{Lazy, Regex, lazy_regex};
+use memchr::memchr3_iter;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 
@@ -35,17 +35,134 @@ Examples of **incorrect** code for this rule:
 ```
 ";
 
-//  /^\s*[xf]?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\(/mu
-static RE: Lazy<Regex> =
-    lazy_regex!(r#"(?mu)^\s*[xf]?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\("#);
+/// Matches: `/^\s*[xf]?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\(/mu`
+///
+/// Scans the full comment (not line-by-line) so `\s` can span newlines, matching the
+/// original regex without paying for a full regex engine on every comment.
+fn is_commented_out_test(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut line_start = 0usize;
+    while line_start <= bytes.len() {
+        // Skip leading whitespace on this line (and blank lines via loop).
+        let mut i = line_start;
+        while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t' || bytes[i] == b'\r') {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            break;
+        }
+        if bytes[i] == b'\n' {
+            line_start = i + 1;
+            continue;
+        }
+
+        // Optional x/f prefix only when it forms xit/fit/xdescribe/fdescribe/xtest/ftest
+        let start = i;
+        if matches!(bytes[i], b'x' | b'f') {
+            let rest = &text[i + 1..];
+            if rest.starts_with("test") || rest.starts_with("it") || rest.starts_with("describe") {
+                i += 1;
+            }
+        }
+
+        let rest = &text[i..];
+        let keyword_len = if rest.starts_with("describe") {
+            8
+        } else if rest.starts_with("test") {
+            4
+        } else if rest.starts_with("it") {
+            2
+        } else {
+            // Advance to next line
+            line_start = next_line_start(bytes, start);
+            continue;
+        };
+        i += keyword_len;
+
+        // Must not continue as a longer identifier (`item`, `testSomething`)
+        if i < bytes.len()
+            && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'_' || bytes[i] == b'$')
+        {
+            line_start = next_line_start(bytes, start);
+            continue;
+        }
+
+        // Optional `.method` or `['method']` / `["method"]` (no newlines inside in practice,
+        // but allow whitespace via the final `\s*` before `(` only)
+        if i < bytes.len() && bytes[i] == b'.' {
+            i += 1;
+            if i >= bytes.len() || !is_regex_word_byte(bytes[i]) {
+                line_start = next_line_start(bytes, start);
+                continue;
+            }
+            i += 1;
+            while i < bytes.len() && is_regex_word_byte(bytes[i]) {
+                i += 1;
+            }
+        } else if i < bytes.len() && bytes[i] == b'[' {
+            i += 1;
+            let quote = bytes.get(i).copied();
+            if !matches!(quote, Some(b'\'' | b'"')) {
+                line_start = next_line_start(bytes, start);
+                continue;
+            }
+            let q = quote.unwrap();
+            i += 1;
+            let method_start = i;
+            while i < bytes.len() && is_regex_word_byte(bytes[i]) {
+                i += 1;
+            }
+            if i == method_start || bytes.get(i) != Some(&q) {
+                line_start = next_line_start(bytes, start);
+                continue;
+            }
+            i += 1; // closing quote
+            if bytes.get(i) != Some(&b']') {
+                line_start = next_line_start(bytes, start);
+                continue;
+            }
+            i += 1;
+        }
+
+        // Whitespace (including newlines) then `(`
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i < bytes.len() && bytes[i] == b'(' {
+            return true;
+        }
+
+        line_start = next_line_start(bytes, start);
+    }
+    false
+}
+
+#[inline]
+fn is_regex_word_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
+}
+
+#[inline]
+fn next_line_start(bytes: &[u8], from: usize) -> usize {
+    match bytes[from..].iter().position(|&b| b == b'\n') {
+        Some(rel) => from + rel + 1,
+        None => bytes.len() + 1, // terminate outer loop
+    }
+}
+
+#[inline]
+fn might_contain_test_api(text: &str) -> bool {
+    memchr3_iter(b't', b'i', b'd', text.as_bytes()).any(|index| {
+        let rest = &text[index..];
+        rest.starts_with("test") || rest.starts_with("it") || rest.starts_with("describe")
+    })
+}
 
 pub fn run_once(ctx: &LintContext) {
-    let comments = ctx.comments();
-    let commented_tests = comments.iter().filter_map(|comment| {
+    for comment in ctx.comments() {
         let text = ctx.source_range(comment.content_span());
-        if RE.is_match(text) { Some(comment.content_span()) } else { None }
-    });
-    for span in commented_tests {
-        ctx.diagnostic(no_commented_out_tests_diagnostic(span));
+        if might_contain_test_api(text) && is_commented_out_test(text) {
+            ctx.diagnostic(no_commented_out_tests_diagnostic(comment.content_span()));
+        }
     }
 }

--- a/crates/oxc_linter/src/snapshots/jest_no_commented_out_tests.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_commented_out_tests.snap
@@ -144,6 +144,13 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ jest(no-commented-out-tests): Some tests appear to be inside comments.
    ╭─[no_commented_out_tests.tsx:1:3]
+ 1 │ // test.123()
+   ·   ───────────
+   ╰────
+  help: Remove or uncomment this test.
+
+  ⚠ jest(no-commented-out-tests): Some tests appear to be inside comments.
+   ╭─[no_commented_out_tests.tsx:1:3]
  1 │ // test['someNewMethodThatMightBeAddedInTheFuture']()
    ·   ───────────────────────────────────────────────────
    ╰────


### PR DESCRIPTION
Split from #23829.

Adds a fast path when the comment definietly contains no test APIs
Replaces the regex with a manual impl to improve perf

Co-authored-by: Yagiz Nizipli <yagiz@nizipli.com>
