### PR TITLE
perf(linter): Run `no-underscore-dangle` only when relevant node types are present

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1086,7 +1086,15 @@ impl RuleRunner for crate::rules::eslint::no_undefined::NoUndefined {
 }
 
 impl RuleRunner for crate::rules::eslint::no_underscore_dangle::NoUnderscoreDangle {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::BindingIdentifier,
+        AstType::Function,
+        AstType::MethodDefinition,
+        AstType::ObjectProperty,
+        AstType::PrivateFieldExpression,
+        AstType::PropertyDefinition,
+        AstType::StaticMemberExpression,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -122,10 +122,6 @@ impl Rule for NoUnderscoreDangle {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // NOTE: Keep this as a flat `match node.kind()` with one bare `AstKind::Variant(_)` arm per
-        // node type and an empty `_ => {}`. This lets `linter_codegen` derive `NODE_TYPES` so the
-        // rule is only dispatched to these node kinds rather than every node in the AST. Avoid
-        // OR-patterns and a non-empty wildcard arm, both of which defeat that derivation.
         match node.kind() {
             AstKind::StaticMemberExpression(expr) => self.check_member(ctx, expr),
             AstKind::PrivateFieldExpression(expr) => self.check_private_member(ctx, expr),

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -122,19 +122,44 @@ impl Rule for NoUnderscoreDangle {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // NOTE: Keep this as a flat `match node.kind()` with one bare `AstKind::Variant(_)` arm per
+        // node type and an empty `_ => {}`. This lets `linter_codegen` derive `NODE_TYPES` so the
+        // rule is only dispatched to these node kinds rather than every node in the AST. Avoid
+        // OR-patterns and a non-empty wildcard arm, both of which defeat that derivation.
         match node.kind() {
             AstKind::StaticMemberExpression(expr) => self.check_member(ctx, expr),
             AstKind::PrivateFieldExpression(expr) => self.check_private_member(ctx, expr),
             AstKind::BindingIdentifier(ident) => self.check_binding(ctx, node.id(), ident),
-            AstKind::MethodDefinition(_) | AstKind::ObjectProperty(_)
-                if !self.enforce_in_method_names => {}
-            AstKind::PropertyDefinition(_) if !self.enforce_in_class_fields => {}
-            AstKind::Function(func) if func.r#type == FunctionType::FunctionExpression => {}
-            _ => {
-                if let Some((name, span)) = get_identifier(node) {
+            AstKind::Function(func) => {
+                if func.r#type != FunctionType::FunctionExpression
+                    && let Some(id) = &func.id
+                {
+                    self.report(ctx, id.span, id.name.as_str());
+                }
+            }
+            AstKind::MethodDefinition(m) => {
+                if self.enforce_in_method_names
+                    && let Some((name, span)) = property_key_name_span(&m.key)
+                {
                     self.report(ctx, span, name);
                 }
             }
+            AstKind::PropertyDefinition(p) => {
+                if self.enforce_in_class_fields
+                    && let Some((name, span)) = property_key_name_span(&p.key)
+                {
+                    self.report(ctx, span, name);
+                }
+            }
+            AstKind::ObjectProperty(o) => {
+                if self.enforce_in_method_names
+                    && o.method
+                    && let Some((name, span)) = property_key_name_span(&o.key)
+                {
+                    self.report(ctx, span, name);
+                }
+            }
+            _ => {}
         }
     }
 }
@@ -162,6 +187,11 @@ impl NoUnderscoreDangle {
 
     fn check_member(&self, ctx: &LintContext, expr: &StaticMemberExpression) {
         let prop = &expr.property;
+        // Cheap early-out before walking the object expression: most member accesses have no
+        // dangling underscore, and an always-allowed name can never be reported regardless of object.
+        if self.is_allowed(prop.name.as_str()) {
+            return;
+        }
         if is_prototype_accessor(prop.name.as_str()) {
             return;
         }
@@ -241,16 +271,6 @@ fn binding_context(ctx: &LintContext, id: NodeId) -> BindingContext {
         }
     }
     BindingContext::NotInteresting
-}
-
-fn get_identifier<'a>(node: &AstNode<'a>) -> Option<(&'a str, Span)> {
-    match node.kind() {
-        AstKind::Function(f) => f.id.as_ref().map(|id| (id.name.as_str(), id.span)),
-        AstKind::MethodDefinition(m) => property_key_name_span(&m.key),
-        AstKind::PropertyDefinition(p) => property_key_name_span(&p.key),
-        AstKind::ObjectProperty(o) if o.method => property_key_name_span(&o.key),
-        _ => None,
-    }
 }
 
 fn has_dangling_underscore(name: &str) -> bool {

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -183,11 +183,6 @@ impl NoUnderscoreDangle {
 
     fn check_member(&self, ctx: &LintContext, expr: &StaticMemberExpression) {
         let prop = &expr.property;
-        // Cheap early-out before walking the object expression: most member accesses have no
-        // dangling underscore, and an always-allowed name can never be reported regardless of object.
-        if self.is_allowed(prop.name.as_str()) {
-            return;
-        }
         if is_prototype_accessor(prop.name.as_str()) {
             return;
         }

--- a/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_underscore_dangle.rs
@@ -126,34 +126,19 @@ impl Rule for NoUnderscoreDangle {
             AstKind::StaticMemberExpression(expr) => self.check_member(ctx, expr),
             AstKind::PrivateFieldExpression(expr) => self.check_private_member(ctx, expr),
             AstKind::BindingIdentifier(ident) => self.check_binding(ctx, node.id(), ident),
-            AstKind::Function(func) => {
-                if func.r#type != FunctionType::FunctionExpression
-                    && let Some(id) = &func.id
-                {
+            AstKind::Function(func) if func.r#type != FunctionType::FunctionExpression => {
+                if let Some(id) = &func.id {
                     self.report(ctx, id.span, id.name.as_str());
                 }
             }
-            AstKind::MethodDefinition(m) => {
-                if self.enforce_in_method_names
-                    && let Some((name, span)) = property_key_name_span(&m.key)
-                {
-                    self.report(ctx, span, name);
-                }
+            AstKind::MethodDefinition(m) if self.enforce_in_method_names => {
+                self.check_property_key(ctx, &m.key);
             }
-            AstKind::PropertyDefinition(p) => {
-                if self.enforce_in_class_fields
-                    && let Some((name, span)) = property_key_name_span(&p.key)
-                {
-                    self.report(ctx, span, name);
-                }
+            AstKind::ObjectProperty(o) if self.enforce_in_method_names && o.method => {
+                self.check_property_key(ctx, &o.key);
             }
-            AstKind::ObjectProperty(o) => {
-                if self.enforce_in_method_names
-                    && o.method
-                    && let Some((name, span)) = property_key_name_span(&o.key)
-                {
-                    self.report(ctx, span, name);
-                }
+            AstKind::PropertyDefinition(p) if self.enforce_in_class_fields => {
+                self.check_property_key(ctx, &p.key);
             }
             _ => {}
         }
@@ -179,6 +164,12 @@ impl NoUnderscoreDangle {
             return;
         }
         ctx.diagnostic(no_underscore_dangle_diagnostic(span, name));
+    }
+
+    fn check_property_key(&self, ctx: &LintContext, key: &PropertyKey) {
+        if let Some((name, span)) = property_key_name_span(key) {
+            self.report(ctx, span, name);
+        }
     }
 
     fn check_member(&self, ctx: &LintContext, expr: &StaticMemberExpression) {


### PR DESCRIPTION
Generated with Claude Code, tested and reviewed by me. This was one of the most time-consuming rules on the vscode codebase before this change (oxlint 1.71.0), and drops considerably after this change.

The `run` method had an OR pattern arm that the codegen didn't understand, so that was split. The `run` method also had a wildcard arm that was non-empty, which caused linter_codegen to bail out of detecting what NODE_TYPES were worth checking. Removing that allows linter_codegen to generate the NODE_TYPES properly and limit this rule to only running on relevant files/nodes.

**Simple Comparison**

Before (`npx oxlint --debug=timings --quiet -W all` on vscode repo):

```
Rule                                                      Time (ms)  Relative     Calls  Source
-------------------------------------------------------  ----------  --------  --------  ------
eslint/no-underscore-dangle                                 259.949      5.3%  15251059  native
```

After:

```
Rule timings:
Rule                                                      Time (ms)  Relative     Calls  Source
-------------------------------------------------------  ----------  --------  --------  ------
eslint/no-underscore-dangle                                 115.713      2.0%   2938968  native
```

Result: `15,251,059` calls down to `2,938,968` (80.7% fewer calls).

I've re-run this a number of times and confirmed that the time savings are consistent thanks to the reduction in call count.

Running the before/after on the VS Code repo with just this rule enabled also results in the same exact # of lint violations being found, and all existing tests pass.

We should probably consider either updating the codegen to handle ORs in AST node arms, or else look for other usages of this pattern to fix them.