### PR TITLE
perf(linter/eslint/prefer-named-capture-group): only dispatch for relevant node types

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -1312,7 +1312,11 @@ impl RuleRunner
 }
 
 impl RuleRunner for crate::rules::eslint::prefer_named_capture_group::PreferNamedCaptureGroup {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::CallExpression,
+        AstType::NewExpression,
+        AstType::RegExpLiteral,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -744,6 +744,10 @@ mod test {
             &promise::always_return::AlwaysReturn::default(),
             &[Function, ArrowFunctionExpression],
         );
+        assert_rule_runs_on_node_types(
+            &eslint::prefer_named_capture_group::PreferNamedCaptureGroup,
+            &[RegExpLiteral, CallExpression, NewExpression],
+        );
     }
 
     #[test]

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -71,9 +71,7 @@ declare_oxc_lint!(
 impl Rule for PreferNamedCaptureGroup {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
-            AstKind::RegExpLiteral(_)
-            | AstKind::CallExpression(_)
-            | AstKind::NewExpression(_) => {}
+            AstKind::RegExpLiteral(_) | AstKind::CallExpression(_) | AstKind::NewExpression(_) => {}
             _ => return,
         }
 

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -79,8 +79,6 @@ impl Rule for PreferNamedCaptureGroup {
             check_pattern(pattern, ctx, None);
         });
 
-        // `run_on_regex_node` only covers directly-supported arguments; additionally handle
-        // statically-resolvable concatenated arguments like `'a' + '(b)'`.
         let (callee, arguments) = match node.kind() {
             AstKind::CallExpression(expr) => (&expr.callee, &expr.arguments),
             AstKind::NewExpression(expr) => (&expr.callee, &expr.arguments),
@@ -102,11 +100,6 @@ fn check_pattern(pattern: &Pattern<'_>, ctx: &LintContext<'_>, span_override: Op
     }
 }
 
-/// Handles statically-resolvable concatenated arguments like `'a' + '(b)'` for `RegExp(...)` /
-/// `new RegExp(...)` calls. This is complementary to `run_on_regex_node`, which only covers
-/// directly-supported arguments (regex literal, string literal, plain template):
-/// `check_static_arguments` ignores those (see `is_directly_supported_regex_argument`), so a
-/// pattern is never reported twice.
 fn check_static_arguments(arg0: Option<&Argument>, arg1: Option<&Argument>, ctx: &LintContext<'_>) {
     let Some(pattern_expr) = arg0
         .and_then(Argument::as_expression)

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -16,7 +16,7 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::Rule,
-    utils::{is_regexp_callee, run_on_arguments, run_on_regex_node, static_string_value},
+    utils::{is_regexp_callee, run_on_regex_node, static_string_value},
 };
 
 fn prefer_named_capture_group_diagnostic(span: Span, unnamed_count: usize) -> OxcDiagnostic {
@@ -71,18 +71,25 @@ declare_oxc_lint!(
 impl Rule for PreferNamedCaptureGroup {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
-            AstKind::RegExpLiteral(_) => {
-                run_on_regex_node(node, ctx, |pattern, _span| {
-                    check_pattern(pattern, ctx, None);
-                });
-            }
-            AstKind::CallExpression(expr) => {
-                check_regexp_call(&expr.callee, expr.arguments.first(), expr.arguments.get(1), ctx);
-            }
-            AstKind::NewExpression(expr) => {
-                check_regexp_call(&expr.callee, expr.arguments.first(), expr.arguments.get(1), ctx);
-            }
-            _ => {}
+            AstKind::RegExpLiteral(_)
+            | AstKind::CallExpression(_)
+            | AstKind::NewExpression(_) => {}
+            _ => return,
+        }
+
+        run_on_regex_node(node, ctx, |pattern, _span| {
+            check_pattern(pattern, ctx, None);
+        });
+
+        // `run_on_regex_node` only covers directly-supported arguments; additionally handle
+        // statically-resolvable concatenated arguments like `'a' + '(b)'`.
+        let (callee, arguments) = match node.kind() {
+            AstKind::CallExpression(expr) => (&expr.callee, &expr.arguments),
+            AstKind::NewExpression(expr) => (&expr.callee, &expr.arguments),
+            _ => return,
+        };
+        if is_regexp_callee(callee, ctx) {
+            check_static_arguments(arguments.first(), arguments.get(1), ctx);
         }
     }
 }
@@ -97,26 +104,11 @@ fn check_pattern(pattern: &Pattern<'_>, ctx: &LintContext<'_>, span_override: Op
     }
 }
 
-/// Handles `new RegExp(...)` / `RegExp(...)` calls. Checks `is_regexp_callee` a single time, then
-/// processes both directly-supported arguments (regex literal, string literal, plain template) via
-/// `run_on_arguments` and statically-resolvable concatenated arguments via `check_static_arguments`.
-/// These two paths are complementary: `check_static_arguments` ignores directly-supported arguments
-/// (see `is_directly_supported_regex_argument`), so a pattern is never reported twice.
-fn check_regexp_call(
-    callee: &Expression<'_>,
-    arg0: Option<&Argument>,
-    arg1: Option<&Argument>,
-    ctx: &LintContext<'_>,
-) {
-    if !is_regexp_callee(callee, ctx) {
-        return;
-    }
-    run_on_arguments(arg0, arg1, ctx, |pattern, _span| {
-        check_pattern(pattern, ctx, None);
-    });
-    check_static_arguments(arg0, arg1, ctx);
-}
-
+/// Handles statically-resolvable concatenated arguments like `'a' + '(b)'` for `RegExp(...)` /
+/// `new RegExp(...)` calls. This is complementary to `run_on_regex_node`, which only covers
+/// directly-supported arguments (regex literal, string literal, plain template):
+/// `check_static_arguments` ignores those (see `is_directly_supported_regex_argument`), so a
+/// pattern is never reported twice.
 fn check_static_arguments(arg0: Option<&Argument>, arg1: Option<&Argument>, ctx: &LintContext<'_>) {
     let Some(pattern_expr) = arg0
         .and_then(Argument::as_expression)

--- a/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_named_capture_group.rs
@@ -16,7 +16,7 @@ use crate::{
     AstNode,
     context::LintContext,
     rule::Rule,
-    utils::{is_regexp_callee, run_on_regex_node, static_string_value},
+    utils::{is_regexp_callee, run_on_arguments, run_on_regex_node, static_string_value},
 };
 
 fn prefer_named_capture_group_diagnostic(span: Span, unnamed_count: usize) -> OxcDiagnostic {
@@ -70,18 +70,19 @@ declare_oxc_lint!(
 
 impl Rule for PreferNamedCaptureGroup {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        run_on_regex_node(node, ctx, |pattern, _span| {
-            check_pattern(pattern, ctx, None);
-        });
-
-        let (callee, arguments) = match node.kind() {
-            AstKind::CallExpression(expr) => (&expr.callee, &expr.arguments),
-            AstKind::NewExpression(expr) => (&expr.callee, &expr.arguments),
-            _ => return,
-        };
-
-        if is_regexp_callee(callee, ctx) {
-            check_static_arguments(arguments.first(), arguments.get(1), ctx);
+        match node.kind() {
+            AstKind::RegExpLiteral(_) => {
+                run_on_regex_node(node, ctx, |pattern, _span| {
+                    check_pattern(pattern, ctx, None);
+                });
+            }
+            AstKind::CallExpression(expr) => {
+                check_regexp_call(&expr.callee, expr.arguments.first(), expr.arguments.get(1), ctx);
+            }
+            AstKind::NewExpression(expr) => {
+                check_regexp_call(&expr.callee, expr.arguments.first(), expr.arguments.get(1), ctx);
+            }
+            _ => {}
         }
     }
 }
@@ -94,6 +95,26 @@ fn check_pattern(pattern: &Pattern<'_>, ctx: &LintContext<'_>, span_override: Op
     for span in collector.unnamed_spans {
         ctx.diagnostic(prefer_named_capture_group_diagnostic(span_override.unwrap_or(span), count));
     }
+}
+
+/// Handles `new RegExp(...)` / `RegExp(...)` calls. Checks `is_regexp_callee` a single time, then
+/// processes both directly-supported arguments (regex literal, string literal, plain template) via
+/// `run_on_arguments` and statically-resolvable concatenated arguments via `check_static_arguments`.
+/// These two paths are complementary: `check_static_arguments` ignores directly-supported arguments
+/// (see `is_directly_supported_regex_argument`), so a pattern is never reported twice.
+fn check_regexp_call(
+    callee: &Expression<'_>,
+    arg0: Option<&Argument>,
+    arg1: Option<&Argument>,
+    ctx: &LintContext<'_>,
+) {
+    if !is_regexp_callee(callee, ctx) {
+        return;
+    }
+    run_on_arguments(arg0, arg1, ctx, |pattern, _span| {
+        check_pattern(pattern, ctx, None);
+    });
+    check_static_arguments(arg0, arg1, ctx);
 }
 
 fn check_static_arguments(arg0: Option<&Argument>, arg1: Option<&Argument>, ctx: &LintContext<'_>) {


### PR DESCRIPTION
Similar to the change in #23867. 

This was generated using Claude Code after I noticed this rule was one of the slowest on the vscode repo. The change was reviewed and tested by me, all violations in the vscode codebase are identical before and after this change, and all tests pass before and after, behavior should be identical.

---

Claude's explanation of the change:

The rule's `run` called `run_on_regex_node` and then did its own `match node.kind()` returning a tuple, so no `linter_codegen` detector fired and `NODE_TYPES` was derived as `None`. This PR rewrites `run` to a flat `match node.kind()` with one bare `AstKind::Variant(_)` arm per node type and an empty `_ => {}`, letting codegen emit the 3 concrete node types the rule cares about (`RegExpLiteral`, `CallExpression`, `NewExpression`).

~~Also dedupe the `is_regexp_callee` check, which previously ran twice per Call/New expression (once inside `run_on_regex_node`'s guard, once before `check_static_arguments`). The new `check_regexp_call` helper checks it once, then runs `run_on_arguments` for directly-supported args and `check_static_arguments` for concatenated static strings — behavior-identical, since `run_on_regex_node` for Call/New is itself `if is_regexp_callee { run_on_arguments(..) }`.~~

----

Results from running `oxlint --debug=timings --quiet -A all -D="eslint/prefer-named-capture-group"` on the vscode repo are below.

Before:
```
Rule timings:
Rule                                Time (ms)  Relative     Calls  Source
---------------------------------  ----------  --------  --------  ------
eslint/prefer-named-capture-group     239.165    100.0%  15251059  native
```

After:
```
Rule timings:
Rule                                Time (ms)  Relative   Calls  Source
---------------------------------  ----------  --------  ------  ------
eslint/prefer-named-capture-group      25.791    100.0%  954008  native
```

The # of calls decreases by 93.7% on the vscode repo (from 15,251,059 to 954,008). The rule very consistently returns timings of 20-30ms now on my Mac.