### PR TITLE
perf(linter/unicorn/prefer-number-properties): gate identifier name before global lookup

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -117,8 +117,14 @@ impl Rule for PreferNumberProperties {
                     }
                 }
             }
+            // `run` fires on every `IdentifierReference`, but only these names can
+            // produce a diagnostic. Gate on the name before the global-variable
+            // lookup (two hash-map lookups) so the common reference skips it.
             AstKind::IdentifierReference(ident_ref)
-                if ctx.is_reference_to_global_variable(ident_ref) =>
+                if matches!(
+                    ident_ref.name.as_str(),
+                    "NaN" | "Infinity" | "isNaN" | "isFinite" | "parseFloat" | "parseInt"
+                ) && ctx.is_reference_to_global_variable(ident_ref) =>
             {
                 let ident_name = ident_ref.name.as_str();
                 if (ident_name == "NaN" && self.check_nan)


### PR DESCRIPTION
## What

`PreferNumberProperties::run` fires on every `IdentifierReference`, and the
`IdentifierReference` arm's guard called `ctx.is_reference_to_global_variable`
(two hash-map lookups) for each one before looking at the name. Only `NaN`,
`Infinity`, `isNaN`, `isFinite`, `parseFloat`, and `parseInt` can produce a
diagnostic, so this gates on that name set first and lets the overwhelmingly
common reference short-circuit past the global-variable lookup.

The `CallExpression` arm already checks the name before the lookup; this brings
the `IdentifierReference` arm in line, matching the recent "delay symbol lookup"
perf changes to other rules.

## Correctness

The name gate is exactly the set of names the body can act on, so it never
excludes a reference that would have been flagged; `is_reference_to_global_variable`
is still required and both checks are side-effect-free, so reordering preserves the
exact diagnostic. The full pass/fail/fix suite and the snapshot are unchanged.

---

_Disclosure: developed with AI assistance (Claude), reviewed and verified by the author._
