### PR TITLE
perf(linter): Optimize `require-hook` and `prefer-mock-*` rules to run on specific node types

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -2409,12 +2409,14 @@ impl RuleRunner for crate::rules::jest::prefer_lowercase_title::PreferLowercaseT
 }
 
 impl RuleRunner for crate::rules::jest::prefer_mock_promise_shorthand::PreferMockPromiseShorthand {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::jest::prefer_mock_return_shorthand::PreferMockReturnShorthand {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -2467,7 +2469,8 @@ impl RuleRunner for crate::rules::jest::prefer_todo::PreferTodo {
 }
 
 impl RuleRunner for crate::rules::jest::require_hook::RequireHook {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Program]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -4825,12 +4828,14 @@ impl RuleRunner for crate::rules::vitest::prefer_lowercase_title::PreferLowercas
 impl RuleRunner
     for crate::rules::vitest::prefer_mock_promise_shorthand::PreferMockPromiseShorthand
 {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
 impl RuleRunner for crate::rules::vitest::prefer_mock_return_shorthand::PreferMockReturnShorthand {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 
@@ -4905,7 +4910,8 @@ impl RuleRunner for crate::rules::vitest::require_awaited_expect_poll::RequireAw
 }
 
 impl RuleRunner for crate::rules::vitest::require_hook::RequireHook {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::CallExpression, AstType::Program]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_promise_shorthand.rs
@@ -1,3 +1,4 @@
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
 
 use crate::{
@@ -20,6 +21,9 @@ declare_oxc_lint!(
 
 impl Rule for PreferMockPromiseShorthand {
     fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(_) = node.kind() else {
+            return;
+        };
         run(node, ctx);
     }
 }

--- a/crates/oxc_linter/src/rules/jest/prefer_mock_return_shorthand.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_mock_return_shorthand.rs
@@ -1,3 +1,4 @@
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
 
 use crate::{
@@ -21,6 +22,9 @@ declare_oxc_lint!(
 
 impl Rule for PreferMockReturnShorthand {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(_) = node.kind() else {
+            return;
+        };
         run(node, ctx);
     }
 }

--- a/crates/oxc_linter/src/rules/jest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/jest/require_hook.rs
@@ -1,3 +1,4 @@
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;
 use serde::Deserialize;
@@ -26,6 +27,10 @@ impl Rule for RequireHook {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::Program(_) | AstKind::CallExpression(_) => {}
+            _ => return,
+        }
         self.0.run(node, ctx);
     }
 }

--- a/crates/oxc_linter/src/rules/vitest/prefer_mock_promise_shorthand.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_mock_promise_shorthand.rs
@@ -1,3 +1,4 @@
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
 
 use crate::{
@@ -20,6 +21,9 @@ declare_oxc_lint!(
 
 impl Rule for PreferMockPromiseShorthand {
     fn run<'a>(&self, node: &oxc_semantic::AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(_) = node.kind() else {
+            return;
+        };
         run(node, ctx);
     }
 }

--- a/crates/oxc_linter/src/rules/vitest/prefer_mock_return_shorthand.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_mock_return_shorthand.rs
@@ -1,3 +1,4 @@
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
 
 use crate::{
@@ -20,6 +21,9 @@ declare_oxc_lint!(
 );
 impl Rule for PreferMockReturnShorthand {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::CallExpression(_) = node.kind() else {
+            return;
+        };
         run(node, ctx);
     }
 }

--- a/crates/oxc_linter/src/rules/vitest/require_hook.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_hook.rs
@@ -1,3 +1,4 @@
+use oxc_ast::AstKind;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;
 use serde::Deserialize;
@@ -26,6 +27,10 @@ impl Rule for RequireHook {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::Program(_) | AstKind::CallExpression(_) => {}
+            _ => return,
+        }
         self.0.run(node, ctx);
     }
 }


### PR DESCRIPTION
Generated with Claude Code, reviewed and tested by me.

Similar concept to #23868 and #23867, gates the following rules behind specific AST Nodes in their `run` methods to ensure that the rules are only applied when the corresponding AST Node is present.

Most of these regressed when the jest-vitest rules were split into separate rule files, and the AST Node codegen isn't smart enough to handle the separation, so the codegen ran these rules on every node in the entire codebase.

Narrow each rule's `run` to the node kinds it actually handles so codegen generates the correct `NODE_TYPES`:

- jest/vitest require-hook            -> [CallExpression, Program]
- jest/vitest prefer-mock-promise-shorthand -> [CallExpression]
- jest/vitest prefer-mock-return-shorthand  -> [CallExpression]

On the vscode codebase, this cuts each rule's invocations from 15.25M to 870-880K (~17x fewer calls) with no behavior change.

Before:

```
Rule timings:
Rule                                   Time (ms)  Relative     Calls  Source
------------------------------------  ----------  --------  --------  ------
jest/require-hook                        250.566     15.6%  15251059  native
vitest/require-hook                      247.498     15.4%  15251059  native
jest/prefer-mock-promise-shorthand       223.433     13.9%  15251059  native
jest/prefer-mock-return-shorthand        222.515     13.8%  15251059  native
vitest/prefer-mock-promise-shorthand     219.438     13.6%  15251059  native
vitest/prefer-mock-return-shorthand      218.652     13.6%  15251059  native
```

After:

```
Rule timings:
Rule                                   Time (ms)  Relative   Calls  Source
------------------------------------  ----------  --------  ------  ------
jest/require-hook                         92.802     37.9%  881757  native
vitest/require-hook                       79.677     32.5%  881757  native
jest/prefer-mock-promise-shorthand        19.238      7.9%  870119  native
jest/prefer-mock-return-shorthand         16.029      6.5%  870119  native
vitest/prefer-mock-return-shorthand       15.878      6.5%  870119  native
vitest/prefer-mock-promise-shorthand      13.962      5.7%  870119  native
```

Overall: 91,506,354 calls down to 5,243,990 calls, a 94.3% reduction.

I also tried this change with promise/always-return, which has the same problem, but changing it resulted in a very minor difference in the code behavior for the VS Code repo (which our tests did not catch), and so I left that alone for now.

All of these were verified by the tests passing and the violations before and after matching on the VS Code codebase.

The one downside here is that the rules now duplicate the `node.kind()` guard check that exists in the `run` method each one calls. We can also remove the guards from the shared `run` methods if preferred.