### PR TITLE
refactor(ast): hide `allocator` field of new `AstBuilder`

### DIFF
--- a/crates/oxc_ast/src/builder/mod.rs
+++ b/crates/oxc_ast/src/builder/mod.rs
@@ -43,7 +43,7 @@ pub trait GetAstBuilder<'a> {
 /// e.g. parser, because `NodeId`s are assigned later when building `Semantic`.
 pub struct AstBuilder<'a> {
     /// The memory allocator used to allocate AST nodes in the arena.
-    pub allocator: &'a Allocator,
+    allocator: &'a Allocator,
 }
 
 impl<'a> AstBuilder<'a> {

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{ContentEq, GetSpan, SPAN};
 
@@ -102,7 +102,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
         if property.accessibility.is_none_or(|a| !a.is_private()) {
             if property.type_annotation.is_some() {
-                type_annotation = property.type_annotation.clone_in(self.ast.allocator);
+                type_annotation = property.type_annotation.clone_in(self.allocator());
             } else if let Some(expr) = property.value.as_ref() {
                 let ts_type = if property.readonly {
                     // Keep literal const initializers on readonly class properties to match TS d.ts emit.
@@ -131,7 +131,7 @@ impl<'a> IsolatedDeclarations<'a> {
             property.span,
             property.r#type,
             ArenaVec::new_in(self),
-            property.key.clone_in(self.ast.allocator),
+            property.key.clone_in(self.allocator()),
             type_annotation,
             value,
             property.computed,
@@ -151,12 +151,12 @@ impl<'a> IsolatedDeclarations<'a> {
             Expression::BooleanLiteral(_)
             | Expression::NumericLiteral(_)
             | Expression::BigIntLiteral(_)
-            | Expression::StringLiteral(_) => Some(expr.clone_in(self.ast.allocator)),
+            | Expression::StringLiteral(_) => Some(expr.clone_in(self.allocator())),
             Expression::TemplateLiteral(lit) if lit.expressions.is_empty() => {
                 self.transform_template_to_string(lit).map(Expression::StringLiteral)
             }
             Expression::UnaryExpression(expr) if Self::can_infer_unary_expression(expr) => {
-                Some(Expression::UnaryExpression(expr.clone_in(self.ast.allocator)))
+                Some(Expression::UnaryExpression(expr.clone_in(self.allocator())))
             }
             Expression::ParenthesizedExpression(expr) => {
                 self.get_literal_const_initializer(&expr.expression)
@@ -192,12 +192,12 @@ impl<'a> IsolatedDeclarations<'a> {
         let value = Function::boxed(
             function.span,
             FunctionType::TSEmptyBodyFunctionExpression,
-            function.id.clone_in(self.ast.allocator),
+            function.id.clone_in(self.allocator()),
             false,
             false,
             false,
-            function.type_parameters.clone_in(self.ast.allocator),
-            function.this_param.clone_in(self.ast.allocator),
+            function.type_parameters.clone_in(self.allocator()),
+            function.this_param.clone_in(self.allocator()),
             params,
             return_type,
             NONE,
@@ -208,7 +208,7 @@ impl<'a> IsolatedDeclarations<'a> {
             definition.span,
             definition.r#type,
             ArenaVec::new_in(self),
-            definition.key.clone_in(self.ast.allocator),
+            definition.key.clone_in(self.allocator()),
             value,
             definition.kind,
             definition.computed,
@@ -291,7 +291,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 self.create_class_property(
                     r#type,
                     method.span,
-                    method.key.clone_in(self.ast.allocator),
+                    method.key.clone_in(self.allocator()),
                     method.r#static,
                     method.r#override,
                     Self::transform_accessibility(method.accessibility),
@@ -349,7 +349,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             None
                         } else {
                             // transformed params will definitely have type annotation
-                            typed_params.items[index].type_annotation.clone_in(self.ast.allocator)
+                            typed_params.items[index].type_annotation.clone_in(self.allocator())
                         };
                     self.transform_formal_parameter_to_class_property(param, type_annotation)
                 }),
@@ -389,7 +389,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             continue;
                         };
                         if let Some(annotation) =
-                            first_param.type_annotation.clone_in(self.ast.allocator)
+                            first_param.type_annotation.clone_in(self.allocator())
                         {
                             if let Some(entry) = method_annotations
                                 .iter_mut()
@@ -398,7 +398,7 @@ impl<'a> IsolatedDeclarations<'a> {
                                 entry.1.setter = Some(annotation);
                             } else {
                                 method_annotations.push((
-                                    method.key.clone_in(self.ast.allocator),
+                                    method.key.clone_in(self.allocator()),
                                     AccessorAnnotation { setter: Some(annotation), getter: None },
                                 ));
                             }
@@ -412,7 +412,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         // type-erased class member.
                         let annotation =
                             if method.accessibility.is_some_and(TSAccessibility::is_private) {
-                                function.return_type.clone_in(self.ast.allocator)
+                                function.return_type.clone_in(self.allocator())
                             } else {
                                 self.infer_function_return_type(function)
                             };
@@ -424,7 +424,7 @@ impl<'a> IsolatedDeclarations<'a> {
                                 entry.1.getter = Some(annotation);
                             } else {
                                 method_annotations.push((
-                                    method.key.clone_in(self.ast.allocator),
+                                    method.key.clone_in(self.allocator()),
                                     AccessorAnnotation { setter: None, getter: Some(annotation) },
                                 ));
                             }
@@ -501,14 +501,14 @@ impl<'a> IsolatedDeclarations<'a> {
                                     BindingPattern::new_binding_identifier(SPAN, "value", self),
                                 )
                             } else {
-                                let mut params = params.clone_in(self.ast.allocator);
+                                let mut params = params.clone_in(self.allocator());
                                 if let Some(param) = params.items.first_mut()
                                     && let Some(annotation) =
                                         accessor_annotations.iter().find_map(|(key, annotation)| {
                                             if method.key.content_eq(key) {
                                                 Some(
                                                     annotation
-                                                        .get_setter_annotation(self.ast.allocator),
+                                                        .get_setter_annotation(self.allocator()),
                                                 )
                                             } else {
                                                 None
@@ -570,9 +570,9 @@ impl<'a> IsolatedDeclarations<'a> {
                                     // No explicit return type for getter, should infer it from the first parameter of setter, if not exists,
                                     // use the inferred return type of getter.
                                     if method.value.return_type.is_none() {
-                                        annotation.get_setter_annotation(self.ast.allocator)
+                                        annotation.get_setter_annotation(self.allocator())
                                     } else {
-                                        annotation.get_getter_annotation(self.ast.allocator)
+                                        annotation.get_getter_annotation(self.allocator())
                                     }
                                 } else {
                                     None
@@ -622,7 +622,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
                     let type_annotation = match property.accessibility {
                         Some(TSAccessibility::Private) => None,
-                        _ => property.type_annotation.clone_in(self.ast.allocator),
+                        _ => property.type_annotation.clone_in(self.allocator()),
                     };
 
                     // FIXME: missing many fields
@@ -630,7 +630,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         property.span,
                         property.r#type,
                         ArenaVec::new_in(self),
-                        property.key.clone_in(self.ast.allocator),
+                        property.key.clone_in(self.allocator()),
                         type_annotation,
                         None,
                         property.computed,
@@ -647,7 +647,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         continue;
                     }
 
-                    element.clone_in(self.ast.allocator)
+                    element.clone_in(self.allocator())
                 }),
             }
         }
@@ -673,11 +673,11 @@ impl<'a> IsolatedDeclarations<'a> {
             decl.span,
             decl.r#type,
             ArenaVec::new_in(self),
-            decl.id.clone_in(self.ast.allocator),
-            decl.type_parameters.clone_in(self.ast.allocator),
-            decl.super_class.clone_in(self.ast.allocator),
-            decl.super_type_arguments.clone_in(self.ast.allocator),
-            decl.implements.clone_in(self.ast.allocator),
+            decl.id.clone_in(self.allocator()),
+            decl.type_parameters.clone_in(self.allocator()),
+            decl.super_class.clone_in(self.allocator()),
+            decl.super_type_arguments.clone_in(self.allocator()),
+            decl.implements.clone_in(self.allocator()),
             body,
             decl.r#abstract,
             declare.unwrap_or_else(|| self.is_declare()),

--- a/crates/oxc_isolated_declarations/src/declaration.rs
+++ b/crates/oxc_isolated_declarations/src/declaration.rs
@@ -1,6 +1,6 @@
 use std::cell::Cell;
 
-use oxc_allocator::{ArenaBox, ArenaVec, CloneIn};
+use oxc_allocator::{ArenaBox, ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::ast::*;
 use oxc_ast_visit::{Visit, VisitMut, walk_mut::walk_ts_signatures};
 use oxc_ecmascript::BoundNames;
@@ -74,7 +74,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         init =
                             self.transform_template_to_string(lit).map(Expression::StringLiteral);
                     } else {
-                        init = Some(init_expr.clone_in(self.ast.allocator));
+                        init = Some(init_expr.clone_in(self.allocator()));
                     }
                 } else if !decl.kind.is_const()
                     || !matches!(init_expr, Expression::TemplateLiteral(_))
@@ -90,12 +90,12 @@ impl<'a> IsolatedDeclarations<'a> {
                 }
             }
         }
-        let id = decl.id.clone_in(self.ast.allocator);
+        let id = decl.id.clone_in(self.allocator());
 
         if binding_type.is_none()
             && let Some(ts_type) = &decl.type_annotation
         {
-            binding_type = Some(ts_type.type_annotation.clone_in(self.ast.allocator));
+            binding_type = Some(ts_type.type_annotation.clone_in(self.allocator()));
         }
 
         let type_annotation =
@@ -129,11 +129,11 @@ impl<'a> IsolatedDeclarations<'a> {
         decl: &ArenaBox<'a, TSModuleDeclaration<'a>>,
     ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
         if decl.declare {
-            return decl.clone_in(self.ast.allocator);
+            return decl.clone_in(self.allocator());
         }
 
         let Some(body) = &decl.body else {
-            return decl.clone_in(self.ast.allocator);
+            return decl.clone_in(self.allocator());
         };
 
         // Follows https://github.com/microsoft/TypeScript/pull/54134
@@ -143,7 +143,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 let inner = self.transform_ts_module_declaration(inner_decl);
                 TSModuleDeclaration::boxed(
                     decl.span,
-                    decl.id.clone_in(self.ast.allocator),
+                    decl.id.clone_in(self.allocator()),
                     Some(TSModuleDeclarationBody::TSModuleDeclaration(inner)),
                     kind,
                     self.is_declare(),
@@ -154,7 +154,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 let body = self.transform_ts_module_block(block);
                 TSModuleDeclaration::boxed(
                     decl.span,
-                    decl.id.clone_in(self.ast.allocator),
+                    decl.id.clone_in(self.allocator()),
                     Some(TSModuleDeclarationBody::TSModuleBlock(body)),
                     kind,
                     self.is_declare(),
@@ -187,7 +187,7 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             Declaration::TSTypeAliasDeclaration(alias_decl) => {
                 if !check_binding || self.scope.has_reference(&alias_decl.id.name) {
-                    let mut decl = decl.clone_in(self.ast.allocator);
+                    let mut decl = decl.clone_in(self.allocator());
                     self.visit_declaration(&mut decl);
                     Some(decl)
                 } else {
@@ -196,7 +196,7 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             Declaration::TSInterfaceDeclaration(interface_decl) => {
                 if !check_binding || self.scope.has_reference(&interface_decl.id.name) {
-                    let mut decl = decl.clone_in(self.ast.allocator);
+                    let mut decl = decl.clone_in(self.allocator());
                     self.visit_declaration(&mut decl);
                     Some(decl)
                 } else {
@@ -226,11 +226,11 @@ impl<'a> IsolatedDeclarations<'a> {
                 }
             }
             Declaration::TSGlobalDeclaration(decl) => {
-                Some(Declaration::TSGlobalDeclaration(decl.clone_in(self.ast.allocator)))
+                Some(Declaration::TSGlobalDeclaration(decl.clone_in(self.allocator())))
             }
             Declaration::TSImportEqualsDeclaration(decl) => {
                 if !check_binding || self.scope.has_reference(&decl.id.name) {
-                    Some(Declaration::TSImportEqualsDeclaration(decl.clone_in(self.ast.allocator)))
+                    Some(Declaration::TSImportEqualsDeclaration(decl.clone_in(self.allocator())))
                 } else {
                     None
                 }

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{ArenaVec, CloneIn};
+use oxc_allocator::{ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::ast::*;
 use oxc_ecmascript::{ToInt32, ToUint32};
 use oxc_span::{GetSpan, SPAN};
@@ -49,7 +49,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
             let member = TSEnumMember::new(
                 member.span,
-                member.id.clone_in(self.ast.allocator),
+                member.id.clone_in(self.allocator()),
                 value.map(|v| match v {
                     ConstantValue::Number(v) => {
                         let is_negative = v < 0.0;
@@ -91,7 +91,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
         Declaration::new_ts_enum_declaration(
             decl.span,
-            decl.id.clone_in(self.ast.allocator),
+            decl.id.clone_in(self.allocator()),
             TSEnumBody::new(decl.body.span, members, self),
             decl.r#const,
             self.is_declare(),

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec, CloneIn};
+use oxc_allocator::{ArenaBox, ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{SPAN, Span};
 
@@ -25,12 +25,12 @@ impl<'a> IsolatedDeclarations<'a> {
         Function::boxed(
             func.span,
             func.r#type,
-            func.id.clone_in(self.ast.allocator),
+            func.id.clone_in(self.allocator()),
             false,
             false,
             declare.unwrap_or_else(|| self.is_declare()),
-            func.type_parameters.clone_in(self.ast.allocator),
-            func.this_param.clone_in(self.ast.allocator),
+            func.type_parameters.clone_in(self.allocator()),
+            func.this_param.clone_in(self.allocator()),
             params,
             return_type,
             NONE,
@@ -55,9 +55,9 @@ impl<'a> IsolatedDeclarations<'a> {
 
         let is_assignment_pattern = param.initializer.is_some();
         let mut pattern = if let BindingPattern::AssignmentPattern(pattern) = &param.pattern {
-            pattern.left.clone_in(self.ast.allocator)
+            pattern.left.clone_in(self.allocator())
         } else {
-            param.pattern.clone_in(self.ast.allocator)
+            param.pattern.clone_in(self.allocator())
         };
 
         FormalParameterBindingPattern::remove_assignments_from_kind(self, &mut pattern);
@@ -69,7 +69,7 @@ impl<'a> IsolatedDeclarations<'a> {
             let type_annotation = param
                 .type_annotation
                 .as_ref()
-                .map(|type_annotation| type_annotation.type_annotation.clone_in(self.ast.allocator))
+                .map(|type_annotation| type_annotation.type_annotation.clone_in(self.allocator()))
                 .or_else(|| {
                     let new_type = self.infer_type_from_formal_parameter(param);
                     // A private parameter property on a private constructor needs no
@@ -115,7 +115,7 @@ impl<'a> IsolatedDeclarations<'a> {
             return Some(FormalParameter::new(
                 param.span,
                 ArenaVec::new_in(self),
-                pattern.clone_in(self.ast.allocator),
+                pattern.clone_in(self.allocator()),
                 type_annotation,
                 NONE,
                 optional,
@@ -130,7 +130,7 @@ impl<'a> IsolatedDeclarations<'a> {
             param.span,
             ArenaVec::new_in(self),
             pattern,
-            param.type_annotation.clone_in(self.ast.allocator),
+            param.type_annotation.clone_in(self.allocator()),
             NONE,
             param.optional,
             None,
@@ -146,7 +146,7 @@ impl<'a> IsolatedDeclarations<'a> {
         in_private_constructor: bool,
     ) -> ArenaBox<'a, FormalParameters<'a>> {
         if params.kind.is_signature() || (params.rest.is_none() && params.items.is_empty()) {
-            return params.clone_in(self.ast.allocator);
+            return params.clone_in(self.allocator());
         }
 
         let items = ArenaVec::from_iter_in(
@@ -177,7 +177,7 @@ impl<'a> IsolatedDeclarations<'a> {
         }
 
         let rest = params.rest.as_ref().map(|rest| {
-            let mut rest = rest.clone_in(self.ast.allocator);
+            let mut rest = rest.clone_in(self.allocator());
             FormalParameterBindingPattern::remove_assignments_from_kind(
                 self,
                 &mut rest.rest.argument,

--- a/crates/oxc_isolated_declarations/src/inferrer.rs
+++ b/crates/oxc_isolated_declarations/src/inferrer.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, CloneIn};
+use oxc_allocator::{ArenaBox, CloneIn, GetAllocator};
 use oxc_ast::ast::{
     ArrowFunctionExpression, Expression, FormalParameter, Function, Statement, TSType,
     TSTypeAnnotation, UnaryExpression,
@@ -44,14 +44,14 @@ impl<'a> IsolatedDeclarations<'a> {
                 if expr.type_annotation.is_const_type_reference() {
                     self.transform_const_expression_to_ts_type(&expr.expression)
                 } else {
-                    Some(expr.type_annotation.clone_in(self.ast.allocator))
+                    Some(expr.type_annotation.clone_in(self.allocator()))
                 }
             }
             Expression::TSTypeAssertion(expr) => {
                 if expr.type_annotation.is_const_type_reference() {
                     self.transform_const_expression_to_ts_type(&expr.expression)
                 } else {
-                    Some(expr.type_annotation.clone_in(self.ast.allocator))
+                    Some(expr.type_annotation.clone_in(self.allocator()))
                 }
             }
             Expression::ClassExpression(expr) => {
@@ -91,7 +91,7 @@ impl<'a> IsolatedDeclarations<'a> {
         function: &Function<'a>,
     ) -> Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         if function.return_type.is_some() {
-            return function.return_type.clone_in(self.ast.allocator);
+            return function.return_type.clone_in(self.allocator());
         }
 
         if function.r#async || function.generator {
@@ -109,7 +109,7 @@ impl<'a> IsolatedDeclarations<'a> {
         function: &ArrowFunctionExpression<'a>,
     ) -> Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         if function.return_type.is_some() {
-            return function.return_type.clone_in(self.ast.allocator);
+            return function.return_type.clone_in(self.allocator());
         }
 
         if function.r#async {

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -224,7 +224,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         // `declare module "foo" { ... }`
                         // We need to emit it anyway
                         if decl.id.is_string_literal() {
-                            let mut decl = decl.clone_in(self.ast.allocator);
+                            let mut decl = decl.clone_in(self.allocator());
                             // Remove export keyword from all statements in `declare module "xxx" { ... }`
                             if let Some(body) =
                                 decl.body.as_mut().and_then(|body| body.as_module_block_mut())
@@ -241,7 +241,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     } else if let Statement::TSGlobalDeclaration(decl) = stmt {
                         // `declare global { ... }`
                         // We need to emit it anyway
-                        let decl = decl.clone_in(self.ast.allocator);
+                        let decl = decl.clone_in(self.allocator());
                         // We need to visit the module declaration to collect all references
                         self.scope.visit_ts_global_declaration(decl.as_ref());
 
@@ -264,7 +264,7 @@ impl<'a> IsolatedDeclarations<'a> {
                                 transformed_stmts[idx] = Some(new_decl);
                             } else {
                                 self.scope.visit_ts_export_assignment(decl);
-                                transformed_stmts[idx] = Some(stmt.clone_in(self.ast.allocator));
+                                transformed_stmts[idx] = Some(stmt.clone_in(self.allocator()));
                             }
                             transformed_count += 1;
                             need_empty_export_marker = false;
@@ -282,7 +282,7 @@ impl<'a> IsolatedDeclarations<'a> {
                                 transformed_stmts[idx] = Some(new_decl);
                             } else {
                                 self.scope.visit_export_default_declaration(decl);
-                                transformed_stmts[idx] = Some(stmt.clone_in(self.ast.allocator));
+                                transformed_stmts[idx] = Some(stmt.clone_in(self.allocator()));
                             }
                             transformed_count += 1;
                             need_empty_export_marker = false;
@@ -296,10 +296,10 @@ impl<'a> IsolatedDeclarations<'a> {
                             } else if decl.declaration.is_none() {
                                 need_empty_export_marker = false;
                                 self.scope.visit_export_named_declaration(decl);
-                                transformed_stmts[idx] = Some(stmt.clone_in(self.ast.allocator));
+                                transformed_stmts[idx] = Some(stmt.clone_in(self.allocator()));
                             } else {
                                 // Declaration couldn't be transformed; preserve as-is
-                                transformed_stmts[idx] = Some(stmt.clone_in(self.ast.allocator));
+                                transformed_stmts[idx] = Some(stmt.clone_in(self.allocator()));
                             }
                             transformed_count += 1;
                         }
@@ -308,7 +308,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         }
                         module_declaration => {
                             self.scope.visit_module_declaration(module_declaration);
-                            transformed_stmts[idx] = Some(stmt.clone_in(self.ast.allocator));
+                            transformed_stmts[idx] = Some(stmt.clone_in(self.allocator()));
                             transformed_count += 1;
                         }
                     }
@@ -399,7 +399,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 Statement::ImportDeclaration(decl) => {
                     // We must transform this in the end, because we need to know all references
                     if decl.specifiers.is_none() {
-                        new_stmts.push(stmt.clone_in(self.ast.allocator));
+                        new_stmts.push(stmt.clone_in(self.allocator()));
                     } else if let Some(new_decl) = self.transform_import_declaration(decl) {
                         new_stmts.push(Statement::ImportDeclaration(new_decl));
                     }

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaBox, ArenaVec, CloneIn, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, CloneIn, GetAllocator, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{GetSpan, SPAN};
 use oxc_str::Str;
@@ -51,7 +51,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 ),
             )),
             ExportDefaultDeclarationKind::TSInterfaceDeclaration(_) => {
-                Some((None, decl.declaration.clone_in(self.ast.allocator)))
+                Some((None, decl.declaration.clone_in(self.allocator())))
             }
             declaration @ match_expression!(ExportDefaultDeclarationKind) => self
                 .transform_export_expression(decl.span, declaration.to_expression())
@@ -151,7 +151,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 }
             };
             if is_referenced {
-                new_specifiers.push(specifier.clone_in(self.ast.allocator));
+                new_specifiers.push(specifier.clone_in(self.allocator()));
             }
         });
 
@@ -164,7 +164,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 Some(new_specifiers),
                 decl.source.clone(),
                 None,
-                decl.with_clause.clone_in(self.ast.allocator),
+                decl.with_clause.clone_in(self.allocator()),
                 decl.import_kind,
                 self,
             ))

--- a/crates/oxc_isolated_declarations/src/signatures.rs
+++ b/crates/oxc_isolated_declarations/src/signatures.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{ArenaVec, CloneIn};
+use oxc_allocator::{ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::ast::{TSMethodSignatureKind, TSSignature};
 use oxc_span::GetSpan;
 
@@ -48,7 +48,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 && let (Some(Some(annotation)), Some(option))
                 | (Some(option), Some(Some(annotation))) = (param, return_type)
             {
-                option.replace(annotation.clone_in(self.ast.allocator));
+                option.replace(annotation.clone_in(self.allocator()));
             }
         }
     }

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{ArenaVec, CloneIn};
+use oxc_allocator::{ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::{
     NONE,
     ast::{
@@ -33,8 +33,8 @@ impl<'a> IsolatedDeclarations<'a> {
         return_type.map(|return_type| {
             TSType::new_ts_function_type(
                 func.span,
-                func.type_parameters.clone_in(self.ast.allocator),
-                func.this_param.clone_in(self.ast.allocator),
+                func.type_parameters.clone_in(self.allocator()),
+                func.this_param.clone_in(self.allocator()),
                 params,
                 return_type,
                 self,
@@ -60,7 +60,7 @@ impl<'a> IsolatedDeclarations<'a> {
         return_type.map(|return_type| {
             TSType::new_ts_function_type(
                 func.span,
-                func.type_parameters.clone_in(self.ast.allocator),
+                func.type_parameters.clone_in(self.allocator()),
                 NONE,
                 params,
                 return_type,
@@ -84,7 +84,7 @@ impl<'a> IsolatedDeclarations<'a> {
             }
             // [100] -> 100
             // number literal will be cloned as-is
-            _ => key.clone_in(self.ast.allocator),
+            _ => key.clone_in(self.allocator()),
         }
     }
 
@@ -148,8 +148,8 @@ impl<'a> IsolatedDeclarations<'a> {
                             computed,
                             false,
                             TSMethodSignatureKind::Method,
-                            function.type_parameters.clone_in(self.ast.allocator),
-                            function.this_param.clone_in(self.ast.allocator),
+                            function.type_parameters.clone_in(self.allocator()),
+                            function.this_param.clone_in(self.allocator()),
                             params,
                             return_type,
                             self,
@@ -187,9 +187,10 @@ impl<'a> IsolatedDeclarations<'a> {
                                     "`object.kind` being `Set` guarantees that it is a function"
                                 );
                             };
-                            let annotation = function.params.items.first().and_then(|param| {
-                                param.type_annotation.clone_in(self.ast.allocator)
-                            });
+                            let annotation =
+                                function.params.items.first().and_then(|param| {
+                                    param.type_annotation.clone_in(self.allocator())
+                                });
                             if annotation.is_none() {
                                 accessor_spans.push((key, function.params.span));
                                 return None;
@@ -306,22 +307,22 @@ impl<'a> IsolatedDeclarations<'a> {
         match expr {
             Expression::BooleanLiteral(lit) => Some(TSType::new_ts_literal_type(
                 SPAN,
-                TSLiteral::BooleanLiteral(lit.clone_in(self.ast.allocator)),
+                TSLiteral::BooleanLiteral(lit.clone_in(self.allocator())),
                 self,
             )),
             Expression::NumericLiteral(lit) => Some(TSType::new_ts_literal_type(
                 SPAN,
-                TSLiteral::NumericLiteral(lit.clone_in(self.ast.allocator)),
+                TSLiteral::NumericLiteral(lit.clone_in(self.allocator())),
                 self,
             )),
             Expression::BigIntLiteral(lit) => Some(TSType::new_ts_literal_type(
                 SPAN,
-                TSLiteral::BigIntLiteral(lit.clone_in(self.ast.allocator)),
+                TSLiteral::BigIntLiteral(lit.clone_in(self.allocator())),
                 self,
             )),
             Expression::StringLiteral(lit) => Some(TSType::new_ts_literal_type(
                 SPAN,
-                TSLiteral::StringLiteral(lit.clone_in(self.ast.allocator)),
+                TSLiteral::StringLiteral(lit.clone_in(self.allocator())),
                 self,
             )),
             Expression::NullLiteral(lit) => Some(TSType::new_ts_null_keyword(lit.span, self)),
@@ -338,7 +339,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 if Self::can_infer_unary_expression(expr) {
                     Some(TSType::new_ts_literal_type(
                         SPAN,
-                        TSLiteral::UnaryExpression(expr.clone_in(self.ast.allocator)),
+                        TSLiteral::UnaryExpression(expr.clone_in(self.allocator())),
                         self,
                     ))
                 } else {
@@ -359,14 +360,14 @@ impl<'a> IsolatedDeclarations<'a> {
                 if expr.type_annotation.is_const_type_reference() {
                     self.transform_const_expression_to_ts_type(&expr.expression)
                 } else {
-                    Some(expr.type_annotation.clone_in(self.ast.allocator))
+                    Some(expr.type_annotation.clone_in(self.allocator()))
                 }
             }
             Expression::TSTypeAssertion(expr) => {
                 if expr.type_annotation.is_const_type_reference() {
                     self.transform_const_expression_to_ts_type(&expr.expression)
                 } else {
-                    Some(expr.type_annotation.clone_in(self.ast.allocator))
+                    Some(expr.type_annotation.clone_in(self.allocator()))
                 }
             }
             Expression::ParenthesizedExpression(expr) => {

--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -25,7 +25,7 @@ use oxc_syntax::{
 };
 use rustc_hash::FxHashSet;
 
-use oxc_allocator::{ArenaVec, BitSet};
+use oxc_allocator::{ArenaVec, BitSet, GetAllocator};
 use oxc_ast::ast::*;
 
 use crate::{
@@ -298,7 +298,7 @@ impl<'a> PeepholeOptimizations {
                 }
             }
         }
-        let mut live = BitSet::new_in(initial_references_len, ctx.ast.allocator);
+        let mut live = BitSet::new_in(initial_references_len, ctx.allocator());
         LiveRefCollector { live: &mut live }.visit_program(program);
         for reference_ids in ctx.scoping().resolved_references() {
             for reference_id in reference_ids {
@@ -425,7 +425,7 @@ impl<'a> PeepholeOptimizations {
                 ctx.state.dirty.dead_refs.clear();
             }
         } else {
-            ctx.state.dirty.dead_refs = BitSet::new_in(refs_len, ctx.ast.allocator);
+            ctx.state.dirty.dead_refs = BitSet::new_in(refs_len, ctx.allocator());
         }
         ctx.state.dirty.eval_dropped = false;
     }

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use cow_utils::CowUtils;
 
-use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_compat::ESFeature;
 use oxc_ecmascript::{
@@ -462,7 +462,7 @@ impl<'a> PeepholeOptimizations {
                         };
 
                     if regex.regex.pattern.pattern.is_none()
-                        && let Ok(pattern) = regex.parse_pattern(ctx.ast.allocator)
+                        && let Ok(pattern) = regex.parse_pattern(ctx.allocator())
                     {
                         regex.regex.pattern.pattern = Some(ArenaBox::new_in(pattern, ctx));
                     }

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1,7 +1,7 @@
 use std::iter::repeat_with;
 
 use crate::generated::ancestor::Ancestor;
-use oxc_allocator::{ArenaVec, CloneIn, TakeIn};
+use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_compat::ESFeature;
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
@@ -576,7 +576,7 @@ impl<'a> PeepholeOptimizations {
         // Plain `clone_in` resets every `reference_id` to `None`, making id
         // aliasing structurally impossible; the loop below installs the one
         // fresh reference the clone needs.
-        let mut new_left_expr = typeof_binary_expr.clone_in(ctx.ast.allocator);
+        let mut new_left_expr = typeof_binary_expr.clone_in(ctx.allocator());
         if let Expression::BinaryExpression(new_left_expr_binary) = &mut new_left_expr {
             new_left_expr_binary.operator =
                 if inversed { BinaryOperator::Inequality } else { BinaryOperator::Equality };

--- a/crates/oxc_minifier/src/traverse_context/ecma_context.rs
+++ b/crates/oxc_minifier/src/traverse_context/ecma_context.rs
@@ -1,3 +1,4 @@
+use oxc_allocator::GetAllocator;
 use oxc_ast::ast::*;
 use oxc_compat::ESFeature;
 use oxc_ecmascript::{
@@ -207,7 +208,7 @@ impl<'a> TraverseCtx<'a, MinifierState<'a>> {
                 Expression::new_numeric_literal(span, n, None, number_base, self)
             }
             ConstantValue::BigInt(bigint) => {
-                let value = format_str!(self.ast.allocator, "{bigint}");
+                let value = format_str!(self.allocator(), "{bigint}");
                 Expression::new_big_int_literal(span, value, None, BigintBase::Decimal, self)
             }
             ConstantValue::String(s) => {

--- a/crates/oxc_minifier/src/traverse_context/mod.rs
+++ b/crates/oxc_minifier/src/traverse_context/mod.rs
@@ -407,7 +407,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     ///
     /// This is a shortcut for `ctx.scoping.generate_uid_name`.
     pub fn generate_uid_name(&mut self, name: &str) -> Ident<'a> {
-        self.scoping.generate_uid_name(name, self.ast.allocator)
+        self.scoping.generate_uid_name(name, self.allocator())
     }
 
     /// Generate UID.

--- a/crates/oxc_parser/src/error_handler.rs
+++ b/crates/oxc_parser/src/error_handler.rs
@@ -1,6 +1,6 @@
 //! Code related to error handling.
 
-use oxc_allocator::Dummy;
+use oxc_allocator::{Dummy, GetAllocator};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 
@@ -48,7 +48,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     #[cold]
     pub(crate) fn unexpected<T: Dummy<'a>>(&mut self) -> T {
         self.set_unexpected();
-        Dummy::dummy(self.ast.allocator)
+        Dummy::dummy(self.allocator())
     }
 
     /// Push a Syntax Error
@@ -88,7 +88,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     #[cold]
     pub(crate) fn fatal_error<T: Dummy<'a>>(&mut self, error: OxcDiagnostic) -> T {
         self.set_fatal_error(error);
-        Dummy::dummy(self.ast.allocator)
+        Dummy::dummy(self.allocator())
     }
 
     pub(crate) fn has_fatal_error(&self) -> bool {

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1,5 +1,5 @@
 use cow_utils::CowUtils;
-use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator, TakeIn};
 use oxc_ast::ast::*;
 #[cfg(feature = "regular_expression")]
 use oxc_regular_expression::ast::Pattern;
@@ -402,7 +402,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let span = token.span();
         let raw = self.cur_src();
         let src = raw.strip_suffix('n').unwrap();
-        let value = parse_big_int(src, number_kind, has_separator, self.ast.allocator);
+        let value = parse_big_int(src, number_kind, has_separator, self.allocator());
 
         self.bump_any();
         BigIntLiteral::boxed(span, value, Some(Str::from(raw)), base, self)
@@ -453,7 +453,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
     ) -> Option<ArenaBox<'a, Pattern<'a>>> {
         use oxc_regular_expression::{LiteralParser, Options};
         match LiteralParser::new(
-            self.ast.allocator,
+            self.allocator(),
             pattern,
             Some(flags),
             Options { pattern_span_offset, flags_span_offset },

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -1,6 +1,6 @@
 //! [JSX](https://facebook.github.io/jsx)
 
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, Dummy, GetAllocator};
 use oxc_ast::ast::*;
 use oxc_span::{GetSpan, Span};
 use oxc_str::Str;
@@ -157,7 +157,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         }
 
         if self.fatal_error.is_some() {
-            return JSXElementName::dummy(self.ast.allocator);
+            return JSXElementName::dummy(self.allocator());
         }
 
         // Determine if this JSX element name is a reference (component) or an intrinsic element.

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -681,7 +681,7 @@ impl<'a, C: ParserConfig> ParserImpl<'a, C> {
                 self.error(fatal_error.error);
             }
 
-            program = Program::dummy(self.ast.allocator);
+            program = Program::dummy(self.allocator());
             program.source_type = self.source_type;
             program.source_text = self.source_text;
         }

--- a/crates/oxc_transformer/src/common/duplicate.rs
+++ b/crates/oxc_transformer/src/common/duplicate.rs
@@ -2,7 +2,7 @@
 
 use std::array;
 
-use oxc_allocator::{ArenaVec, CloneIn};
+use oxc_allocator::{ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::ast::{AssignmentOperator, Expression};
 use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
@@ -111,7 +111,7 @@ pub fn duplicate_expression_multiple<'a, const N: usize>(
         | Expression::BigIntLiteral(_)
         | Expression::RegExpLiteral(_)
         | Expression::StringLiteral(_) => {
-            let references = array::from_fn(|_| expr.clone_in(ctx.ast.allocator));
+            let references = array::from_fn(|_| expr.clone_in(ctx.allocator()));
             return (expr, references);
         }
         // Template literal cannot have side effects if it has no expressions.

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -48,7 +48,9 @@ mod metadata;
 use std::borrow::Cow;
 use std::mem;
 
-use oxc_allocator::{Address, ArenaBox, ArenaVec, CloneIn, GetAddress, TakeIn, UnstableAddress};
+use oxc_allocator::{
+    Address, ArenaBox, ArenaVec, CloneIn, GetAddress, GetAllocator, TakeIn, UnstableAddress,
+};
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::{Visit, VisitMut};
 use oxc_data_structures::stack::NonEmptyStack;
@@ -396,8 +398,8 @@ impl<'a> LegacyDecorator<'a> {
                     .unwrap_or_else(|| Cow::Owned(get_var_name_from_node(&accessor.key)));
                 let storage_name =
                     Str::from_strs_array_in(["_", &key_name, "_accessor_storage"], ctx);
-                let getter_key = accessor.key.clone_in(ctx.ast.allocator);
-                let setter_key = accessor.key.clone_in(ctx.ast.allocator);
+                let getter_key = accessor.key.clone_in(ctx.ast.allocator());
+                let setter_key = accessor.key.clone_in(ctx.ast.allocator());
                 (storage_name, getter_key, setter_key)
             };
 
@@ -1369,13 +1371,13 @@ impl<'a> LegacyDecorator<'a> {
             }
             // Copiable literals
             PropertyKey::NumericLiteral(literal) => {
-                Expression::NumericLiteral(literal.clone_in(ctx.ast.allocator))
+                Expression::NumericLiteral(literal.clone_in(ctx.allocator()))
             }
             PropertyKey::StringLiteral(literal) => {
-                Expression::StringLiteral(literal.clone_in(ctx.ast.allocator))
+                Expression::StringLiteral(literal.clone_in(ctx.allocator()))
             }
             PropertyKey::TemplateLiteral(literal) if literal.expressions.is_empty() => {
-                let quasis = literal.quasis.clone_in(ctx.ast.allocator);
+                let quasis = literal.quasis.clone_in(ctx.allocator());
                 Expression::new_template_literal(SPAN, quasis, ArenaVec::new_in(ctx), ctx)
             }
             PropertyKey::NullLiteral(_) => Expression::new_null_literal(SPAN, ctx),

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -32,7 +32,7 @@
 //! * Exponentiation operator TC39 proposal: <https://github.com/tc39/proposal-exponentiation-operator>
 //! * Exponentiation operator specification: <https://tc39.es/ecma262/#sec-exp-operator>
 
-use oxc_allocator::{ArenaVec, CloneIn, TakeIn};
+use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_semantic::ReferenceFlags;
 use oxc_span::{SPAN, Span};
@@ -341,7 +341,7 @@ impl<'a> ExponentiationOperator<'a> {
         // ```
         let prop = &mut member_expr.expression;
         let prop = if prop.is_literal() {
-            prop.clone_in(ctx.ast.allocator)
+            prop.clone_in(ctx.allocator())
         } else {
             let owned_prop = prop.take_in(ctx);
             let binding = self.create_temp_var(owned_prop, &mut temp_var_inits, ctx);

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -53,7 +53,7 @@
 
 use std::{borrow::Cow, mem};
 
-use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, TakeIn};
+use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::Visit;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
@@ -650,7 +650,7 @@ impl<'a> AsyncGeneratorExecutor<'a> {
             return Ident::from_cow_in(input, ctx);
         }
 
-        let mut name = ArenaStringBuilder::with_capacity_in(input_str.len() + 1, ctx.ast.allocator);
+        let mut name = ArenaStringBuilder::with_capacity_in(input_str.len() + 1, ctx.allocator());
         let mut capitalize_next = false;
 
         let mut chars = input_str.chars();

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -49,7 +49,7 @@
 
 use std::mem;
 
-use oxc_allocator::{ArenaVec, CloneIn, TakeIn};
+use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, TakeIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{GetSpan, SPAN, Span};
 use oxc_traverse::{Ancestor, BoundIdentifier, MaybeBoundIdentifier, Traverse};
@@ -380,7 +380,7 @@ impl<'a> OptionalChaining<'a> {
             let object = member.object_mut().get_inner_expression_mut();
             let context = if ctx.state.assumptions.pure_getters {
                 // TODO: `clone_in` causes reference loss of reference id
-                object.clone_in(ctx.ast.allocator)
+                object.clone_in(ctx.allocator())
             } else if let Expression::Identifier(ident) = object {
                 MaybeBoundIdentifier::from_identifier_reference(ident, ctx)
                     .create_read_expression(ctx)

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -1106,7 +1106,7 @@ impl<'a> JsxImpl<'a> {
             // This is the 2nd line containing text. Previous line did not contain any HTML entities.
             // Generate an accumulator containing previous line and a trailing space.
             // Current line will be added to the accumulator after it.
-            let mut buffer = ArenaStringBuilder::with_capacity_in(text_len, ctx.ast.allocator);
+            let mut buffer = ArenaStringBuilder::with_capacity_in(text_len, ctx.allocator());
             buffer.push_str(only_line.as_str());
             buffer.push(' ');
             *acc = Some(buffer);
@@ -1157,7 +1157,7 @@ impl<'a> JsxImpl<'a> {
                 }
                 if let Some(end) = end {
                     let buffer = acc.get_or_insert_with(|| {
-                        ArenaStringBuilder::with_capacity_in(text_len, ctx.ast.allocator)
+                        ArenaStringBuilder::with_capacity_in(text_len, ctx.allocator())
                     });
 
                     buffer.push_str(&s[prev..start]);

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -7,7 +7,9 @@ use base64::{
 use hmac_sha1_compact::Hash as Sha1;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use oxc_allocator::{ArenaStringBuilder, ArenaVec, CloneIn, GetAddress, TakeIn, UnstableAddress};
+use oxc_allocator::{
+    ArenaStringBuilder, ArenaVec, CloneIn, GetAddress, GetAllocator, TakeIn, UnstableAddress,
+};
 use oxc_ast::{NONE, ast::*, builder::AstBuilder, match_expression};
 use oxc_ast_visit::{
     Visit,
@@ -99,7 +101,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
                 );
                 Expression::new_static_member_expression(SPAN, ident, property.clone(), false, ctx)
             }
-            Self::Expression(expr) => expr.clone_in(ctx.ast.allocator),
+            Self::Expression(expr) => expr.clone_in(ctx.allocator()),
         }
     }
 }
@@ -261,7 +263,7 @@ impl<'a> Traverse<'a, TransformState<'a>> for ReactRefresh<'a> {
 
         if found_call_expression {
             self.last_signature =
-                Some((binding_identifier.clone(), arguments.clone_in(ctx.ast.allocator)));
+                Some((binding_identifier.clone(), arguments.clone_in(ctx.allocator())));
         }
 
         let span = expr.span();
@@ -609,7 +611,7 @@ impl<'a> ReactRefresh<'a> {
                 }
             };
 
-            let mut hashed_key = ArenaStringBuilder::from_str_in(ZEROS_STR, ctx.ast.allocator);
+            let mut hashed_key = ArenaStringBuilder::from_str_in(ZEROS_STR, ctx.allocator());
             // SAFETY: Base64 encoding only produces ASCII bytes. Even if our assumptions are incorrect,
             // and Base64 bytes do not fill `hashed_key` completely, the remaining bytes are 0, so also ASCII.
             let hashed_key_bytes = unsafe { hashed_key.as_mut_str().as_bytes_mut() };

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -44,7 +44,7 @@
 //! TODO(improve-on-babel): When flags is empty, we could output `RegExp("(?<=x)")` instead of `RegExp("(?<=x)", "")`.
 //! (actually these would be improvements on ESBuild, not Babel)
 
-use oxc_allocator::ArenaVec;
+use oxc_allocator::{ArenaVec, GetAllocator};
 use oxc_ast::{NONE, ast::*};
 use oxc_regular_expression::{
     RegexUnsupportedPatterns, has_unsupported_regular_expression_pattern,
@@ -142,7 +142,7 @@ impl<'a> RegExp {
             let pattern = if let Some(pattern) = &regexp.regex.pattern.pattern {
                 pattern
             } else {
-                match regexp.parse_pattern(ctx.ast.allocator) {
+                match regexp.parse_pattern(ctx.allocator()) {
                     Ok(pattern) => {
                         owned_pattern = Some(pattern);
                         owned_pattern.as_ref().unwrap()

--- a/crates/oxc_transformer_plugins/src/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/src/inject_global_variables.rs
@@ -177,7 +177,7 @@ impl<'a> InjectGlobalVariables<'a> {
 
         if !dot_defines.is_empty() {
             self.dot_defines = dot_defines;
-            scoping = traverse_mut(self, self.ast.allocator, program, scoping, ());
+            scoping = traverse_mut(self, self.allocator(), program, scoping, ());
         }
 
         // Step 2: find all the injects that are referenced.

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -399,7 +399,7 @@ impl<'a, State> TraverseCtx<'a, State> {
     ///
     /// This is a shortcut for `ctx.scoping.generate_uid_name`.
     pub fn generate_uid_name(&mut self, name: &str) -> Ident<'a> {
-        self.scoping.generate_uid_name(name, self.ast.allocator)
+        self.scoping.generate_uid_name(name, self.allocator())
     }
 
     /// Generate UID.


### PR DESCRIPTION
Part of #23043.

Do not expose `allocator` field of new `AstBuilder`. It's available via `allocator` method provided by `GetAllocator` trait.

This gives us more flexibility in future.