### PR TITLE
feat(ast): unify old and new `AstBuilder`s

### DIFF
--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -17,7 +17,7 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
+doctest = true
 
 [dependencies]
 oxc_allocator = { workspace = true }
@@ -34,7 +34,7 @@ bitflags = { workspace = true }
 
 [features]
 default = []
-builder_new = []
+disable_old_builder = []
 serialize = [
   "oxc_allocator/serialize",
   "oxc_span/serialize",

--- a/crates/oxc_ast/src/builder/custom.rs
+++ b/crates/oxc_ast/src/builder/custom.rs
@@ -10,7 +10,9 @@ use oxc_span::{SPAN, Span};
 use oxc_str::Str;
 use oxc_syntax::{number::NumberBase, operator::UnaryOperator, scope::ScopeId};
 
-use crate::{NONE, ast::*, builder::GetAstBuilder};
+use crate::ast::*;
+
+use super::{GetAstBuilder, NONE};
 
 impl<'a> Expression<'a> {
     /// Build an [`Expression`] representing the number `0`.

--- a/crates/oxc_ast/src/builder/methods.rs
+++ b/crates/oxc_ast/src/builder/methods.rs
@@ -1,44 +1,15 @@
 use std::{alloc::Layout, borrow::Cow, mem::MaybeUninit, slice, str};
 
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, FromIn, GetAllocator, IntoIn};
+use oxc_allocator::{ArenaBox, ArenaVec, FromIn, IntoIn};
 use oxc_span::{SPAN, Span};
 use oxc_str::{Ident, Str};
 use oxc_syntax::{number::NumberBase, operator::UnaryOperator, scope::ScopeId};
 
 use crate::ast::*;
 
-/// Type that can be used in any AST builder method call which requires an `IntoIn<'a, Option<Anything<'a>>>`.
-/// Pass `NONE` instead of `None::<Anything<'a>>`.
-#[expect(clippy::upper_case_acronyms)]
-pub struct NONE;
-
-impl<'a, T> FromIn<'a, NONE> for Option<ArenaBox<'a, T>> {
-    fn from_in(_: NONE, _: &'a Allocator) -> Self {
-        None
-    }
-}
-
-/// AST builder for creating AST nodes.
-#[derive(Clone, Copy)]
-pub struct AstBuilder<'a> {
-    /// The memory allocator used to allocate AST nodes in the arena.
-    pub allocator: &'a Allocator,
-}
-
-impl<'a> GetAllocator<'a> for AstBuilder<'a> {
-    #[inline]
-    fn allocator(&self) -> &'a Allocator {
-        self.allocator
-    }
-}
+use super::{AstBuilder, NONE};
 
 impl<'a> AstBuilder<'a> {
-    /// Create a new AST builder that will allocate nodes in the given allocator.
-    #[inline]
-    pub fn new(allocator: &'a Allocator) -> Self {
-        Self { allocator }
-    }
-
     /// Move a value into the memory arena.
     #[inline]
     pub fn alloc<T>(self, value: T) -> ArenaBox<'a, T> {

--- a/crates/oxc_ast/src/builder/mod.rs
+++ b/crates/oxc_ast/src/builder/mod.rs
@@ -1,10 +1,107 @@
-use oxc_allocator::{Allocator, GetAllocator};
+//! AST builder.
+//!
+//! This is undergoing change at present.
+//!
+//! Explanation of the motivation for this change here: <https://github.com/oxc-project/oxc/issues/23043>.
+//!
+//! ## Old builder
+//!
+//! [`AstBuilder`] used to be a [`Copy`] type, which had own methods for:
+//!
+//! * Creating AST nodes e.g. `builder.statement_expression(span, expr)`
+//! * Creating primitives e.g. `builder.vec()`, `builder.ident(str)`
+//!
+//! These methods are defined in `../generated/ast_builder.rs` and `methods.rs`.
+//!
+//! ## New builder
+//!
+//! We have now added methods to AST types themselves which perform the same role,
+//! and are passed an `&B where B: GetAstBuilder` or `&A where A: GetAllocator`:
+//!
+//! * `Statement::new_expression_statement(span, expr, &builder)`
+//! * `Vec::new_in(&builder)`, `Ident::from_str_in(str, &builder)`
+//!
+//! `AstBuilder` is no longer `Copy` or `Clone`, and is passed by reference.
+//! Its `allocator` field is no longer public. Use `allocator` method provided by `GetAllocator` trait.
+//!
+//! Implementing `GetAstBuilder` on types which hold an `AstBuilder` allows for a shorter syntax:
+//!
+//! * Long: `Vec::new_in(&self.ast)`
+//! * Short: `Vec::new_in(self)`
+//!
+//! e.g.:
+//!
+//! ```
+//! use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
+//! use oxc_ast::{ast::*, builder::{AstBuilder, GetAstBuilder}};
+//! use oxc_span::SPAN;
+//!
+//! struct MyAstProcessor<'a> {
+//!     builder: AstBuilder<'a>,
+//! }
+//!
+//! impl<'a> GetAstBuilder<'a> for MyAstProcessor<'a> {
+//!     type Builder = AstBuilder<'a>;
+//!
+//!     fn builder(&self) -> &AstBuilder<'a> {
+//!         &self.builder
+//!     }
+//! }
+//!
+//! impl<'a> GetAllocator<'a> for MyAstProcessor<'a> {
+//!     fn allocator(&self) -> &'a Allocator {
+//!         self.builder.allocator()
+//!     }
+//! }
+//!
+//! impl<'a> MyAstProcessor<'a> {
+//!     pub fn new(allocator: &'a Allocator) -> Self {
+//!         let builder = AstBuilder::new(allocator);
+//!         Self { builder }
+//!     }
+//!
+//!     /// Create a `Vec` of 3 x `null` expressions.
+//!     pub fn null_literals_array(&self) -> ArenaVec<'a, Expression<'a>> {
+//!         // Can just pass `self` to all these methods, because `GetAstBuilder`
+//!         // and `GetAllocator` are implemented on `MyAstProcessor`
+//!         ArenaVec::from_array_in(
+//!             [
+//!                 Expression::new_null_literal(SPAN, self),
+//!                 Expression::new_null_literal(SPAN, self),
+//!                 Expression::new_null_literal(SPAN, self),
+//!             ],
+//!             self
+//!         )
+//!     }
+//! }
+//! ```
+//!
+//! These AST type builder methods are defined in `../generated/builder_methods.rs` and `custom.rs`.
+//!
+//! ## Migration
+//!
+//! To minimize immediate breaking changes for downstream consumers, and allow them to migrate incrementally,
+//! at present `AstBuilder` still has its own methods, but can also be passed to the AST type builder methods.
+//!
+//! Once a project has migrated, they should enable the `disable_old_builder` Cargo feature,
+//! which will remove the old-style own methods on `AstBuilder`.
+//!
+//! After a few weeks, we will remove `AstBuilder`'s own methods entirely.
+//!
+//! ## Oxc
+//!
+//! All Oxc crates have been migrated to the new usage.
+//!
+//! `disable_old_builder` Cargo feature is enabled in all Oxc crates which utilize `AstBuilder`.
+//! Where those crates expose the `AstBuilder` they use to user code, the feature is only enabled in tests.
+
+use oxc_allocator::{Allocator, ArenaBox, FromIn, GetAllocator};
 use oxc_syntax::node::NodeId;
 
-// Re-export as part of `builder` module
-pub use crate::NONE;
-
 mod custom;
+
+#[cfg(not(feature = "disable_old_builder"))]
+mod methods;
 
 /// Trait for types which can create AST nodes.
 ///
@@ -41,9 +138,15 @@ pub trait GetAstBuilder<'a> {
 ///
 /// For use where no `NodeId`s are required on AST nodes as they are built
 /// e.g. parser, because `NodeId`s are assigned later when building `Semantic`.
+#[cfg_attr(not(feature = "disable_old_builder"), derive(Clone, Copy))]
 pub struct AstBuilder<'a> {
     /// The memory allocator used to allocate AST nodes in the arena.
+    #[cfg(feature = "disable_old_builder")]
     allocator: &'a Allocator,
+
+    /// The memory allocator used to allocate AST nodes in the arena.
+    #[cfg(not(feature = "disable_old_builder"))]
+    pub allocator: &'a Allocator,
 }
 
 impl<'a> AstBuilder<'a> {
@@ -79,5 +182,16 @@ impl<'a> GetAstBuilder<'a> for AstBuilder<'a> {
     #[inline]
     fn builder(&self) -> &Self {
         self
+    }
+}
+
+/// Type that can be used in any AST builder method call which requires an `IntoIn<'a, Option<Anything<'a>>>`.
+/// Pass `NONE` instead of `None::<Anything<'a>>`.
+#[expect(clippy::upper_case_acronyms)]
+pub struct NONE;
+
+impl<'a, T> FromIn<'a, NONE> for Option<ArenaBox<'a, T>> {
+    fn from_in(_: NONE, _: &'a Allocator) -> Self {
+        None
     }
 }

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -8,11 +8,11 @@
 
 use std::cell::Cell;
 
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, IntoIn};
+use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator, IntoIn};
 use oxc_str::{Ident, Str};
 use oxc_syntax::{reference::ReferenceId, scope::ScopeId, symbol::SymbolId};
 
-use crate::{AstBuilder, ast::*};
+use crate::{ast::*, builder::AstBuilder};
 
 impl<'a> AstBuilder<'a> {
     /// Build a [`Program`].
@@ -27,7 +27,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn program(
-        self,
+        &self,
         span: Span,
         source_type: SourceType,
         source_text: &'a str,
@@ -62,7 +62,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn program_with_scope_id(
-        self,
+        &self,
         span: Span,
         source_type: SourceType,
         source_text: &'a str,
@@ -93,7 +93,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The boolean value itself
     #[inline]
-    pub fn expression_boolean_literal(self, span: Span, value: bool) -> Expression<'a> {
+    pub fn expression_boolean_literal(&self, span: Span, value: bool) -> Expression<'a> {
         Expression::BooleanLiteral(self.alloc_boolean_literal(span, value))
     }
 
@@ -104,7 +104,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     #[inline]
-    pub fn expression_null_literal(self, span: Span) -> Expression<'a> {
+    pub fn expression_null_literal(&self, span: Span) -> Expression<'a> {
         Expression::NullLiteral(self.alloc_null_literal(span))
     }
 
@@ -119,7 +119,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn expression_numeric_literal(
-        self,
+        &self,
         span: Span,
         value: f64,
         raw: Option<Str<'a>>,
@@ -139,7 +139,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn expression_big_int_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -161,7 +161,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The regular expression as it appears in source code
     #[inline]
     pub fn expression_reg_exp_literal(
-        self,
+        &self,
         span: Span,
         regex: RegExp<'a>,
         raw: Option<Str<'a>>,
@@ -179,7 +179,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn expression_string_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -201,7 +201,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn expression_string_literal_with_lone_surrogates<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -228,7 +228,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn expression_template_literal(
-        self,
+        &self,
         span: Span,
         quasis: ArenaVec<'a, TemplateElement<'a>>,
         expressions: ArenaVec<'a, Expression<'a>>,
@@ -244,7 +244,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn expression_identifier<S1>(self, span: Span, name: S1) -> Expression<'a>
+    pub fn expression_identifier<S1>(&self, span: Span, name: S1) -> Expression<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -261,7 +261,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn expression_identifier_with_reference_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         reference_id: ReferenceId,
@@ -286,7 +286,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`
     #[inline]
     pub fn expression_meta_property(
-        self,
+        &self,
         span: Span,
         meta: IdentifierName<'a>,
         property: IdentifierName<'a>,
@@ -301,7 +301,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn expression_super(self, span: Span) -> Expression<'a> {
+    pub fn expression_super(&self, span: Span) -> Expression<'a> {
         Expression::Super(self.alloc_super(span))
     }
 
@@ -314,7 +314,7 @@ impl<'a> AstBuilder<'a> {
     /// * `elements`
     #[inline]
     pub fn expression_array(
-        self,
+        &self,
         span: Span,
         elements: ArenaVec<'a, ArrayExpressionElement<'a>>,
     ) -> Expression<'a> {
@@ -335,7 +335,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
     pub fn expression_arrow_function<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -378,7 +378,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
     pub fn expression_arrow_function_with_scope_id_and_pure_and_pife<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -423,7 +423,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn expression_assignment(
-        self,
+        &self,
         span: Span,
         operator: AssignmentOperator,
         left: AssignmentTarget<'a>,
@@ -442,7 +442,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
     #[inline]
-    pub fn expression_await(self, span: Span, argument: Expression<'a>) -> Expression<'a> {
+    pub fn expression_await(&self, span: Span, argument: Expression<'a>) -> Expression<'a> {
         Expression::AwaitExpression(self.alloc_await_expression(span, argument))
     }
 
@@ -457,7 +457,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn expression_binary(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: BinaryOperator,
@@ -478,7 +478,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn expression_call<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -510,7 +510,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn expression_call_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -539,7 +539,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     #[inline]
-    pub fn expression_chain(self, span: Span, expression: ChainElement<'a>) -> Expression<'a> {
+    pub fn expression_chain(&self, span: Span, expression: ChainElement<'a>) -> Expression<'a> {
         Expression::ChainExpression(self.alloc_chain_expression(span, expression))
     }
 
@@ -561,7 +561,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
     pub fn expression_class<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -613,7 +613,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
     pub fn expression_class_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -659,7 +659,7 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn expression_conditional(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Expression<'a>,
@@ -688,7 +688,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The function body.
     #[inline]
     pub fn expression_function<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -744,7 +744,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
     pub fn expression_function_with_scope_id_and_pure_and_pife<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -796,7 +796,7 @@ impl<'a> AstBuilder<'a> {
     /// * `phase`
     #[inline]
     pub fn expression_import(
-        self,
+        &self,
         span: Span,
         source: Expression<'a>,
         options: Option<Expression<'a>>,
@@ -816,7 +816,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn expression_logical(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: LogicalOperator,
@@ -836,7 +836,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn expression_new<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -865,7 +865,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`
     #[inline]
     pub fn expression_new_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -893,7 +893,7 @@ impl<'a> AstBuilder<'a> {
     /// * `properties`: Properties declared in the object
     #[inline]
     pub fn expression_object(
-        self,
+        &self,
         span: Span,
         properties: ArenaVec<'a, ObjectPropertyKind<'a>>,
     ) -> Expression<'a> {
@@ -909,7 +909,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn expression_parenthesized(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> Expression<'a> {
@@ -925,7 +925,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn expression_sequence(
-        self,
+        &self,
         span: Span,
         expressions: ArenaVec<'a, Expression<'a>>,
     ) -> Expression<'a> {
@@ -943,7 +943,7 @@ impl<'a> AstBuilder<'a> {
     /// * `quasi`
     #[inline]
     pub fn expression_tagged_template<T1>(
-        self,
+        &self,
         span: Span,
         tag: Expression<'a>,
         type_arguments: T1,
@@ -967,7 +967,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn expression_this(self, span: Span) -> Expression<'a> {
+    pub fn expression_this(&self, span: Span) -> Expression<'a> {
         Expression::ThisExpression(self.alloc_this_expression(span))
     }
 
@@ -981,7 +981,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn expression_unary(
-        self,
+        &self,
         span: Span,
         operator: UnaryOperator,
         argument: Expression<'a>,
@@ -1000,7 +1000,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn expression_update(
-        self,
+        &self,
         span: Span,
         operator: UpdateOperator,
         prefix: bool,
@@ -1019,7 +1019,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn expression_yield(
-        self,
+        &self,
         span: Span,
         delegate: bool,
         argument: Option<Expression<'a>>,
@@ -1037,7 +1037,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn expression_private_in(
-        self,
+        &self,
         span: Span,
         left: PrivateIdentifier<'a>,
         right: Expression<'a>,
@@ -1056,7 +1056,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn expression_jsx_element<T1, T2>(
-        self,
+        &self,
         span: Span,
         opening_element: T1,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -1085,7 +1085,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     #[inline]
     pub fn expression_jsx_fragment(
-        self,
+        &self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -1109,7 +1109,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn expression_ts_as(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -1127,7 +1127,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type `expression` must satisfy.
     #[inline]
     pub fn expression_ts_satisfies(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -1149,7 +1149,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn expression_ts_type_assertion(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         expression: Expression<'a>,
@@ -1165,7 +1165,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     #[inline]
-    pub fn expression_ts_non_null(self, span: Span, expression: Expression<'a>) -> Expression<'a> {
+    pub fn expression_ts_non_null(&self, span: Span, expression: Expression<'a>) -> Expression<'a> {
         Expression::TSNonNullExpression(self.alloc_ts_non_null_expression(span, expression))
     }
 
@@ -1179,7 +1179,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn expression_ts_instantiation<T1>(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_arguments: T1,
@@ -1204,7 +1204,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`
     #[inline]
     pub fn expression_v8_intrinsic(
-        self,
+        &self,
         span: Span,
         name: IdentifierName<'a>,
         arguments: ArenaVec<'a, Argument<'a>>,
@@ -1221,7 +1221,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn identifier_name<S1>(self, span: Span, name: S1) -> IdentifierName<'a>
+    pub fn identifier_name<S1>(&self, span: Span, name: S1) -> IdentifierName<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -1237,11 +1237,15 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn alloc_identifier_name<S1>(self, span: Span, name: S1) -> ArenaBox<'a, IdentifierName<'a>>
+    pub fn alloc_identifier_name<S1>(
+        &self,
+        span: Span,
+        name: S1,
+    ) -> ArenaBox<'a, IdentifierName<'a>>
     where
         S1: Into<Ident<'a>>,
     {
-        ArenaBox::new_in(self.identifier_name(span, name), &self)
+        ArenaBox::new_in(self.identifier_name(span, name), self)
     }
 
     /// Build an [`IdentifierReference`].
@@ -1253,7 +1257,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn identifier_reference<S1>(self, span: Span, name: S1) -> IdentifierReference<'a>
+    pub fn identifier_reference<S1>(&self, span: Span, name: S1) -> IdentifierReference<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -1275,14 +1279,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn alloc_identifier_reference<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> ArenaBox<'a, IdentifierReference<'a>>
     where
         S1: Into<Ident<'a>>,
     {
-        ArenaBox::new_in(self.identifier_reference(span, name), &self)
+        ArenaBox::new_in(self.identifier_reference(span, name), self)
     }
 
     /// Build an [`IdentifierReference`] with `reference_id`.
@@ -1296,7 +1300,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn identifier_reference_with_reference_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         reference_id: ReferenceId,
@@ -1323,7 +1327,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn alloc_identifier_reference_with_reference_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         reference_id: ReferenceId,
@@ -1333,7 +1337,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.identifier_reference_with_reference_id(span, name, reference_id),
-            &self,
+            self,
         )
     }
 
@@ -1346,7 +1350,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     #[inline]
-    pub fn binding_identifier<S1>(self, span: Span, name: S1) -> BindingIdentifier<'a>
+    pub fn binding_identifier<S1>(&self, span: Span, name: S1) -> BindingIdentifier<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -1368,14 +1372,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The identifier name being bound.
     #[inline]
     pub fn alloc_binding_identifier<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> ArenaBox<'a, BindingIdentifier<'a>>
     where
         S1: Into<Ident<'a>>,
     {
-        ArenaBox::new_in(self.binding_identifier(span, name), &self)
+        ArenaBox::new_in(self.binding_identifier(span, name), self)
     }
 
     /// Build a [`BindingIdentifier`] with `symbol_id`.
@@ -1389,7 +1393,7 @@ impl<'a> AstBuilder<'a> {
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
     pub fn binding_identifier_with_symbol_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         symbol_id: SymbolId,
@@ -1416,7 +1420,7 @@ impl<'a> AstBuilder<'a> {
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
     pub fn alloc_binding_identifier_with_symbol_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         symbol_id: SymbolId,
@@ -1424,7 +1428,7 @@ impl<'a> AstBuilder<'a> {
     where
         S1: Into<Ident<'a>>,
     {
-        ArenaBox::new_in(self.binding_identifier_with_symbol_id(span, name, symbol_id), &self)
+        ArenaBox::new_in(self.binding_identifier_with_symbol_id(span, name, symbol_id), self)
     }
 
     /// Build a [`LabelIdentifier`].
@@ -1433,7 +1437,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn label_identifier<S1>(self, span: Span, name: S1) -> LabelIdentifier<'a>
+    pub fn label_identifier<S1>(&self, span: Span, name: S1) -> LabelIdentifier<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -1448,7 +1452,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn this_expression(self, span: Span) -> ThisExpression {
+    pub fn this_expression(&self, span: Span) -> ThisExpression {
         ThisExpression { node_id: Default::default(), span }
     }
 
@@ -1460,8 +1464,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_this_expression(self, span: Span) -> ArenaBox<'a, ThisExpression> {
-        ArenaBox::new_in(self.this_expression(span), &self)
+    pub fn alloc_this_expression(&self, span: Span) -> ArenaBox<'a, ThisExpression> {
+        ArenaBox::new_in(self.this_expression(span), self)
     }
 
     /// Build an [`ArrayExpression`].
@@ -1474,7 +1478,7 @@ impl<'a> AstBuilder<'a> {
     /// * `elements`
     #[inline]
     pub fn array_expression(
-        self,
+        &self,
         span: Span,
         elements: ArenaVec<'a, ArrayExpressionElement<'a>>,
     ) -> ArrayExpression<'a> {
@@ -1491,11 +1495,11 @@ impl<'a> AstBuilder<'a> {
     /// * `elements`
     #[inline]
     pub fn alloc_array_expression(
-        self,
+        &self,
         span: Span,
         elements: ArenaVec<'a, ArrayExpressionElement<'a>>,
     ) -> ArenaBox<'a, ArrayExpression<'a>> {
-        ArenaBox::new_in(self.array_expression(span, elements), &self)
+        ArenaBox::new_in(self.array_expression(span, elements), self)
     }
 
     /// Build an [`ArrayExpressionElement::SpreadElement`].
@@ -1507,7 +1511,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn array_expression_element_spread_element(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> ArrayExpressionElement<'a> {
@@ -1521,7 +1525,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn array_expression_element_elision(self, span: Span) -> ArrayExpressionElement<'a> {
+    pub fn array_expression_element_elision(&self, span: Span) -> ArrayExpressionElement<'a> {
         ArrayExpressionElement::Elision(self.alloc_elision(span))
     }
 
@@ -1533,7 +1537,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn elision(self, span: Span) -> Elision {
+    pub fn elision(&self, span: Span) -> Elision {
         Elision { node_id: Default::default(), span }
     }
 
@@ -1545,8 +1549,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_elision(self, span: Span) -> ArenaBox<'a, Elision> {
-        ArenaBox::new_in(self.elision(span), &self)
+    pub fn alloc_elision(&self, span: Span) -> ArenaBox<'a, Elision> {
+        ArenaBox::new_in(self.elision(span), self)
     }
 
     /// Build an [`ObjectExpression`].
@@ -1559,7 +1563,7 @@ impl<'a> AstBuilder<'a> {
     /// * `properties`: Properties declared in the object
     #[inline]
     pub fn object_expression(
-        self,
+        &self,
         span: Span,
         properties: ArenaVec<'a, ObjectPropertyKind<'a>>,
     ) -> ObjectExpression<'a> {
@@ -1576,11 +1580,11 @@ impl<'a> AstBuilder<'a> {
     /// * `properties`: Properties declared in the object
     #[inline]
     pub fn alloc_object_expression(
-        self,
+        &self,
         span: Span,
         properties: ArenaVec<'a, ObjectPropertyKind<'a>>,
     ) -> ArenaBox<'a, ObjectExpression<'a>> {
-        ArenaBox::new_in(self.object_expression(span, properties), &self)
+        ArenaBox::new_in(self.object_expression(span, properties), self)
     }
 
     /// Build an [`ObjectPropertyKind::ObjectProperty`].
@@ -1597,7 +1601,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`
     #[inline]
     pub fn object_property_kind_object_property(
-        self,
+        &self,
         span: Span,
         kind: PropertyKind,
         key: PropertyKey<'a>,
@@ -1620,7 +1624,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn object_property_kind_spread_property(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> ObjectPropertyKind<'a> {
@@ -1642,7 +1646,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`
     #[inline]
     pub fn object_property(
-        self,
+        &self,
         span: Span,
         kind: PropertyKind,
         key: PropertyKey<'a>,
@@ -1678,7 +1682,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`
     #[inline]
     pub fn alloc_object_property(
-        self,
+        &self,
         span: Span,
         kind: PropertyKind,
         key: PropertyKey<'a>,
@@ -1689,7 +1693,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, ObjectProperty<'a>> {
         ArenaBox::new_in(
             self.object_property(span, kind, key, value, method, shorthand, computed),
-            &self,
+            self,
         )
     }
 
@@ -1701,7 +1705,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn property_key_static_identifier<S1>(self, span: Span, name: S1) -> PropertyKey<'a>
+    pub fn property_key_static_identifier<S1>(&self, span: Span, name: S1) -> PropertyKey<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -1716,7 +1720,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn property_key_private_identifier<S1>(self, span: Span, name: S1) -> PropertyKey<'a>
+    pub fn property_key_private_identifier<S1>(&self, span: Span, name: S1) -> PropertyKey<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -1734,7 +1738,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn template_literal(
-        self,
+        &self,
         span: Span,
         quasis: ArenaVec<'a, TemplateElement<'a>>,
         expressions: ArenaVec<'a, Expression<'a>>,
@@ -1753,12 +1757,12 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn alloc_template_literal(
-        self,
+        &self,
         span: Span,
         quasis: ArenaVec<'a, TemplateElement<'a>>,
         expressions: ArenaVec<'a, Expression<'a>>,
     ) -> ArenaBox<'a, TemplateLiteral<'a>> {
-        ArenaBox::new_in(self.template_literal(span, quasis, expressions), &self)
+        ArenaBox::new_in(self.template_literal(span, quasis, expressions), self)
     }
 
     /// Build a [`TaggedTemplateExpression`].
@@ -1773,7 +1777,7 @@ impl<'a> AstBuilder<'a> {
     /// * `quasi`
     #[inline]
     pub fn tagged_template_expression<T1>(
-        self,
+        &self,
         span: Span,
         tag: Expression<'a>,
         type_arguments: T1,
@@ -1786,7 +1790,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             tag,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
             quasi,
         }
     }
@@ -1803,7 +1807,7 @@ impl<'a> AstBuilder<'a> {
     /// * `quasi`
     #[inline]
     pub fn alloc_tagged_template_expression<T1>(
-        self,
+        &self,
         span: Span,
         tag: Expression<'a>,
         type_arguments: T1,
@@ -1812,7 +1816,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        ArenaBox::new_in(self.tagged_template_expression(span, tag, type_arguments, quasi), &self)
+        ArenaBox::new_in(self.tagged_template_expression(span, tag, type_arguments, quasi), self)
     }
 
     /// Build a [`TemplateElement`].
@@ -1823,7 +1827,7 @@ impl<'a> AstBuilder<'a> {
     /// * `tail`
     #[inline]
     pub fn template_element(
-        self,
+        &self,
         span: Span,
         value: TemplateElementValue<'a>,
         tail: bool,
@@ -1846,7 +1850,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The template element contains lone surrogates.
     #[inline]
     pub fn template_element_with_lone_surrogates(
-        self,
+        &self,
         span: Span,
         value: TemplateElementValue<'a>,
         tail: bool,
@@ -1866,7 +1870,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn member_expression_computed(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         expression: Expression<'a>,
@@ -1888,7 +1892,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn member_expression_static(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         property: IdentifierName<'a>,
@@ -1910,7 +1914,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn member_expression_private_field_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         field: PrivateIdentifier<'a>,
@@ -1933,7 +1937,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn computed_member_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         expression: Expression<'a>,
@@ -1954,13 +1958,13 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn alloc_computed_member_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         expression: Expression<'a>,
         optional: bool,
     ) -> ArenaBox<'a, ComputedMemberExpression<'a>> {
-        ArenaBox::new_in(self.computed_member_expression(span, object, expression, optional), &self)
+        ArenaBox::new_in(self.computed_member_expression(span, object, expression, optional), self)
     }
 
     /// Build a [`StaticMemberExpression`].
@@ -1975,7 +1979,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn static_member_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         property: IdentifierName<'a>,
@@ -1996,13 +2000,13 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn alloc_static_member_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         property: IdentifierName<'a>,
         optional: bool,
     ) -> ArenaBox<'a, StaticMemberExpression<'a>> {
-        ArenaBox::new_in(self.static_member_expression(span, object, property, optional), &self)
+        ArenaBox::new_in(self.static_member_expression(span, object, property, optional), self)
     }
 
     /// Build a [`PrivateFieldExpression`].
@@ -2017,7 +2021,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn private_field_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         field: PrivateIdentifier<'a>,
@@ -2038,13 +2042,13 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn alloc_private_field_expression(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         field: PrivateIdentifier<'a>,
         optional: bool,
     ) -> ArenaBox<'a, PrivateFieldExpression<'a>> {
-        ArenaBox::new_in(self.private_field_expression(span, object, field, optional), &self)
+        ArenaBox::new_in(self.private_field_expression(span, object, field, optional), self)
     }
 
     /// Build a [`CallExpression`].
@@ -2060,7 +2064,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn call_expression<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2074,7 +2078,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             callee,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
             arguments,
             optional,
             pure: Default::default(),
@@ -2094,7 +2098,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn alloc_call_expression<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2106,7 +2110,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.call_expression(span, callee, type_arguments, arguments, optional),
-            &self,
+            self,
         )
     }
 
@@ -2124,7 +2128,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn call_expression_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2139,7 +2143,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             callee,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
             arguments,
             optional,
             pure,
@@ -2160,7 +2164,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn alloc_call_expression_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2173,7 +2177,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.call_expression_with_pure(span, callee, type_arguments, arguments, optional, pure),
-            &self,
+            self,
         )
     }
 
@@ -2189,7 +2193,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn new_expression<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2202,7 +2206,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             callee,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
             arguments,
             pure: Default::default(),
         }
@@ -2220,7 +2224,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn alloc_new_expression<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2229,7 +2233,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        ArenaBox::new_in(self.new_expression(span, callee, type_arguments, arguments), &self)
+        ArenaBox::new_in(self.new_expression(span, callee, type_arguments, arguments), self)
     }
 
     /// Build a [`NewExpression`] with `pure`.
@@ -2245,7 +2249,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`
     #[inline]
     pub fn new_expression_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2259,7 +2263,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             callee,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
             arguments,
             pure,
         }
@@ -2278,7 +2282,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`
     #[inline]
     pub fn alloc_new_expression_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -2290,7 +2294,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.new_expression_with_pure(span, callee, type_arguments, arguments, pure),
-            &self,
+            self,
         )
     }
 
@@ -2305,7 +2309,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`
     #[inline]
     pub fn meta_property(
-        self,
+        &self,
         span: Span,
         meta: IdentifierName<'a>,
         property: IdentifierName<'a>,
@@ -2324,12 +2328,12 @@ impl<'a> AstBuilder<'a> {
     /// * `property`
     #[inline]
     pub fn alloc_meta_property(
-        self,
+        &self,
         span: Span,
         meta: IdentifierName<'a>,
         property: IdentifierName<'a>,
     ) -> ArenaBox<'a, MetaProperty<'a>> {
-        ArenaBox::new_in(self.meta_property(span, meta, property), &self)
+        ArenaBox::new_in(self.meta_property(span, meta, property), self)
     }
 
     /// Build a [`SpreadElement`].
@@ -2341,7 +2345,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being spread.
     #[inline]
-    pub fn spread_element(self, span: Span, argument: Expression<'a>) -> SpreadElement<'a> {
+    pub fn spread_element(&self, span: Span, argument: Expression<'a>) -> SpreadElement<'a> {
         SpreadElement { node_id: Default::default(), span, argument }
     }
 
@@ -2355,11 +2359,11 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn alloc_spread_element(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> ArenaBox<'a, SpreadElement<'a>> {
-        ArenaBox::new_in(self.spread_element(span, argument), &self)
+        ArenaBox::new_in(self.spread_element(span, argument), self)
     }
 
     /// Build an [`Argument::SpreadElement`].
@@ -2370,7 +2374,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being spread.
     #[inline]
-    pub fn argument_spread_element(self, span: Span, argument: Expression<'a>) -> Argument<'a> {
+    pub fn argument_spread_element(&self, span: Span, argument: Expression<'a>) -> Argument<'a> {
         Argument::SpreadElement(self.alloc_spread_element(span, argument))
     }
 
@@ -2386,7 +2390,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn update_expression(
-        self,
+        &self,
         span: Span,
         operator: UpdateOperator,
         prefix: bool,
@@ -2407,13 +2411,13 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_update_expression(
-        self,
+        &self,
         span: Span,
         operator: UpdateOperator,
         prefix: bool,
         argument: SimpleAssignmentTarget<'a>,
     ) -> ArenaBox<'a, UpdateExpression<'a>> {
-        ArenaBox::new_in(self.update_expression(span, operator, prefix, argument), &self)
+        ArenaBox::new_in(self.update_expression(span, operator, prefix, argument), self)
     }
 
     /// Build an [`UnaryExpression`].
@@ -2427,7 +2431,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn unary_expression(
-        self,
+        &self,
         span: Span,
         operator: UnaryOperator,
         argument: Expression<'a>,
@@ -2446,12 +2450,12 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_unary_expression(
-        self,
+        &self,
         span: Span,
         operator: UnaryOperator,
         argument: Expression<'a>,
     ) -> ArenaBox<'a, UnaryExpression<'a>> {
-        ArenaBox::new_in(self.unary_expression(span, operator, argument), &self)
+        ArenaBox::new_in(self.unary_expression(span, operator, argument), self)
     }
 
     /// Build a [`BinaryExpression`].
@@ -2466,7 +2470,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn binary_expression(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: BinaryOperator,
@@ -2487,13 +2491,13 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_binary_expression(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: BinaryOperator,
         right: Expression<'a>,
     ) -> ArenaBox<'a, BinaryExpression<'a>> {
-        ArenaBox::new_in(self.binary_expression(span, left, operator, right), &self)
+        ArenaBox::new_in(self.binary_expression(span, left, operator, right), self)
     }
 
     /// Build a [`PrivateInExpression`].
@@ -2507,7 +2511,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn private_in_expression(
-        self,
+        &self,
         span: Span,
         left: PrivateIdentifier<'a>,
         right: Expression<'a>,
@@ -2526,12 +2530,12 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_private_in_expression(
-        self,
+        &self,
         span: Span,
         left: PrivateIdentifier<'a>,
         right: Expression<'a>,
     ) -> ArenaBox<'a, PrivateInExpression<'a>> {
-        ArenaBox::new_in(self.private_in_expression(span, left, right), &self)
+        ArenaBox::new_in(self.private_in_expression(span, left, right), self)
     }
 
     /// Build a [`LogicalExpression`].
@@ -2546,7 +2550,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn logical_expression(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: LogicalOperator,
@@ -2567,13 +2571,13 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_logical_expression(
-        self,
+        &self,
         span: Span,
         left: Expression<'a>,
         operator: LogicalOperator,
         right: Expression<'a>,
     ) -> ArenaBox<'a, LogicalExpression<'a>> {
-        ArenaBox::new_in(self.logical_expression(span, left, operator, right), &self)
+        ArenaBox::new_in(self.logical_expression(span, left, operator, right), self)
     }
 
     /// Build a [`ConditionalExpression`].
@@ -2588,7 +2592,7 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn conditional_expression(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Expression<'a>,
@@ -2609,13 +2613,13 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn alloc_conditional_expression(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Expression<'a>,
         alternate: Expression<'a>,
     ) -> ArenaBox<'a, ConditionalExpression<'a>> {
-        ArenaBox::new_in(self.conditional_expression(span, test, consequent, alternate), &self)
+        ArenaBox::new_in(self.conditional_expression(span, test, consequent, alternate), self)
     }
 
     /// Build an [`AssignmentExpression`].
@@ -2630,7 +2634,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn assignment_expression(
-        self,
+        &self,
         span: Span,
         operator: AssignmentOperator,
         left: AssignmentTarget<'a>,
@@ -2651,13 +2655,13 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_assignment_expression(
-        self,
+        &self,
         span: Span,
         operator: AssignmentOperator,
         left: AssignmentTarget<'a>,
         right: Expression<'a>,
     ) -> ArenaBox<'a, AssignmentExpression<'a>> {
-        ArenaBox::new_in(self.assignment_expression(span, operator, left, right), &self)
+        ArenaBox::new_in(self.assignment_expression(span, operator, left, right), self)
     }
 
     /// Build a [`SimpleAssignmentTarget::AssignmentTargetIdentifier`].
@@ -2669,7 +2673,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn simple_assignment_target_assignment_target_identifier<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> SimpleAssignmentTarget<'a>
@@ -2691,7 +2695,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn simple_assignment_target_assignment_target_identifier_with_reference_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         reference_id: ReferenceId,
@@ -2714,7 +2718,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn simple_assignment_target_ts_as_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -2736,7 +2740,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type `expression` must satisfy.
     #[inline]
     pub fn simple_assignment_target_ts_satisfies_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -2757,7 +2761,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn simple_assignment_target_ts_non_null_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> SimpleAssignmentTarget<'a> {
@@ -2776,7 +2780,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn simple_assignment_target_ts_type_assertion(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         expression: Expression<'a>,
@@ -2798,7 +2802,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn assignment_target_pattern_array_assignment_target<T1>(
-        self,
+        &self,
         span: Span,
         elements: ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: T1,
@@ -2821,7 +2825,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn assignment_target_pattern_object_assignment_target<T1>(
-        self,
+        &self,
         span: Span,
         properties: ArenaVec<'a, AssignmentTargetProperty<'a>>,
         rest: T1,
@@ -2845,7 +2849,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn array_assignment_target<T1>(
-        self,
+        &self,
         span: Span,
         elements: ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: T1,
@@ -2857,7 +2861,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             elements,
-            rest: rest.into_in(self.allocator),
+            rest: rest.into_in(self.allocator()),
         }
     }
 
@@ -2872,7 +2876,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn alloc_array_assignment_target<T1>(
-        self,
+        &self,
         span: Span,
         elements: ArenaVec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: T1,
@@ -2880,7 +2884,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
-        ArenaBox::new_in(self.array_assignment_target(span, elements, rest), &self)
+        ArenaBox::new_in(self.array_assignment_target(span, elements, rest), self)
     }
 
     /// Build an [`ObjectAssignmentTarget`].
@@ -2894,7 +2898,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn object_assignment_target<T1>(
-        self,
+        &self,
         span: Span,
         properties: ArenaVec<'a, AssignmentTargetProperty<'a>>,
         rest: T1,
@@ -2906,7 +2910,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             properties,
-            rest: rest.into_in(self.allocator),
+            rest: rest.into_in(self.allocator()),
         }
     }
 
@@ -2921,7 +2925,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn alloc_object_assignment_target<T1>(
-        self,
+        &self,
         span: Span,
         properties: ArenaVec<'a, AssignmentTargetProperty<'a>>,
         rest: T1,
@@ -2929,7 +2933,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, AssignmentTargetRest<'a>>>>,
     {
-        ArenaBox::new_in(self.object_assignment_target(span, properties, rest), &self)
+        ArenaBox::new_in(self.object_assignment_target(span, properties, rest), self)
     }
 
     /// Build an [`AssignmentTargetRest`].
@@ -2942,7 +2946,7 @@ impl<'a> AstBuilder<'a> {
     /// * `target`
     #[inline]
     pub fn assignment_target_rest(
-        self,
+        &self,
         span: Span,
         target: AssignmentTarget<'a>,
     ) -> AssignmentTargetRest<'a> {
@@ -2959,11 +2963,11 @@ impl<'a> AstBuilder<'a> {
     /// * `target`
     #[inline]
     pub fn alloc_assignment_target_rest(
-        self,
+        &self,
         span: Span,
         target: AssignmentTarget<'a>,
     ) -> ArenaBox<'a, AssignmentTargetRest<'a>> {
-        ArenaBox::new_in(self.assignment_target_rest(span, target), &self)
+        ArenaBox::new_in(self.assignment_target_rest(span, target), self)
     }
 
     /// Build an [`AssignmentTargetMaybeDefault::AssignmentTargetWithDefault`].
@@ -2976,7 +2980,7 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn assignment_target_maybe_default_assignment_target_with_default(
-        self,
+        &self,
         span: Span,
         binding: AssignmentTarget<'a>,
         init: Expression<'a>,
@@ -2997,7 +3001,7 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn assignment_target_with_default(
-        self,
+        &self,
         span: Span,
         binding: AssignmentTarget<'a>,
         init: Expression<'a>,
@@ -3016,12 +3020,12 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn alloc_assignment_target_with_default(
-        self,
+        &self,
         span: Span,
         binding: AssignmentTarget<'a>,
         init: Expression<'a>,
     ) -> ArenaBox<'a, AssignmentTargetWithDefault<'a>> {
-        ArenaBox::new_in(self.assignment_target_with_default(span, binding, init), &self)
+        ArenaBox::new_in(self.assignment_target_with_default(span, binding, init), self)
     }
 
     /// Build an [`AssignmentTargetProperty::AssignmentTargetPropertyIdentifier`].
@@ -3034,7 +3038,7 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn assignment_target_property_assignment_target_property_identifier(
-        self,
+        &self,
         span: Span,
         binding: IdentifierReference<'a>,
         init: Option<Expression<'a>>,
@@ -3055,7 +3059,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`: Property was declared with a computed key
     #[inline]
     pub fn assignment_target_property_assignment_target_property_property(
-        self,
+        &self,
         span: Span,
         name: PropertyKey<'a>,
         binding: AssignmentTargetMaybeDefault<'a>,
@@ -3077,7 +3081,7 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn assignment_target_property_identifier(
-        self,
+        &self,
         span: Span,
         binding: IdentifierReference<'a>,
         init: Option<Expression<'a>>,
@@ -3096,12 +3100,12 @@ impl<'a> AstBuilder<'a> {
     /// * `init`
     #[inline]
     pub fn alloc_assignment_target_property_identifier(
-        self,
+        &self,
         span: Span,
         binding: IdentifierReference<'a>,
         init: Option<Expression<'a>>,
     ) -> ArenaBox<'a, AssignmentTargetPropertyIdentifier<'a>> {
-        ArenaBox::new_in(self.assignment_target_property_identifier(span, binding, init), &self)
+        ArenaBox::new_in(self.assignment_target_property_identifier(span, binding, init), self)
     }
 
     /// Build an [`AssignmentTargetPropertyProperty`].
@@ -3116,7 +3120,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`: Property was declared with a computed key
     #[inline]
     pub fn assignment_target_property_property(
-        self,
+        &self,
         span: Span,
         name: PropertyKey<'a>,
         binding: AssignmentTargetMaybeDefault<'a>,
@@ -3143,7 +3147,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`: Property was declared with a computed key
     #[inline]
     pub fn alloc_assignment_target_property_property(
-        self,
+        &self,
         span: Span,
         name: PropertyKey<'a>,
         binding: AssignmentTargetMaybeDefault<'a>,
@@ -3151,7 +3155,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, AssignmentTargetPropertyProperty<'a>> {
         ArenaBox::new_in(
             self.assignment_target_property_property(span, name, binding, computed),
-            &self,
+            self,
         )
     }
 
@@ -3165,7 +3169,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn sequence_expression(
-        self,
+        &self,
         span: Span,
         expressions: ArenaVec<'a, Expression<'a>>,
     ) -> SequenceExpression<'a> {
@@ -3182,11 +3186,11 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn alloc_sequence_expression(
-        self,
+        &self,
         span: Span,
         expressions: ArenaVec<'a, Expression<'a>>,
     ) -> ArenaBox<'a, SequenceExpression<'a>> {
-        ArenaBox::new_in(self.sequence_expression(span, expressions), &self)
+        ArenaBox::new_in(self.sequence_expression(span, expressions), self)
     }
 
     /// Build a [`Super`].
@@ -3197,7 +3201,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn super_(self, span: Span) -> Super {
+    pub fn super_(&self, span: Span) -> Super {
         Super { node_id: Default::default(), span }
     }
 
@@ -3209,8 +3213,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_super(self, span: Span) -> ArenaBox<'a, Super> {
-        ArenaBox::new_in(self.super_(span), &self)
+    pub fn alloc_super(&self, span: Span) -> ArenaBox<'a, Super> {
+        ArenaBox::new_in(self.super_(span), self)
     }
 
     /// Build an [`AwaitExpression`].
@@ -3222,7 +3226,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
     #[inline]
-    pub fn await_expression(self, span: Span, argument: Expression<'a>) -> AwaitExpression<'a> {
+    pub fn await_expression(&self, span: Span, argument: Expression<'a>) -> AwaitExpression<'a> {
         AwaitExpression { node_id: Default::default(), span, argument }
     }
 
@@ -3236,11 +3240,11 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_await_expression(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> ArenaBox<'a, AwaitExpression<'a>> {
-        ArenaBox::new_in(self.await_expression(span, argument), &self)
+        ArenaBox::new_in(self.await_expression(span, argument), self)
     }
 
     /// Build a [`ChainExpression`].
@@ -3252,7 +3256,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     #[inline]
-    pub fn chain_expression(self, span: Span, expression: ChainElement<'a>) -> ChainExpression<'a> {
+    pub fn chain_expression(
+        &self,
+        span: Span,
+        expression: ChainElement<'a>,
+    ) -> ChainExpression<'a> {
         ChainExpression { node_id: Default::default(), span, expression }
     }
 
@@ -3266,11 +3274,11 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_chain_expression(
-        self,
+        &self,
         span: Span,
         expression: ChainElement<'a>,
     ) -> ArenaBox<'a, ChainExpression<'a>> {
-        ArenaBox::new_in(self.chain_expression(span, expression), &self)
+        ArenaBox::new_in(self.chain_expression(span, expression), self)
     }
 
     /// Build a [`ChainElement::CallExpression`].
@@ -3285,7 +3293,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn chain_element_call_expression<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -3317,7 +3325,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn chain_element_call_expression_with_pure<T1>(
-        self,
+        &self,
         span: Span,
         callee: Expression<'a>,
         type_arguments: T1,
@@ -3347,7 +3355,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn chain_element_ts_non_null_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ChainElement<'a> {
@@ -3364,7 +3372,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn parenthesized_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ParenthesizedExpression<'a> {
@@ -3381,11 +3389,11 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_parenthesized_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ArenaBox<'a, ParenthesizedExpression<'a>> {
-        ArenaBox::new_in(self.parenthesized_expression(span, expression), &self)
+        ArenaBox::new_in(self.parenthesized_expression(span, expression), self)
     }
 
     /// Build a [`Statement::BlockStatement`].
@@ -3396,7 +3404,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn statement_block(self, span: Span, body: ArenaVec<'a, Statement<'a>>) -> Statement<'a> {
+    pub fn statement_block(&self, span: Span, body: ArenaVec<'a, Statement<'a>>) -> Statement<'a> {
         Statement::BlockStatement(self.alloc_block_statement(span, body))
     }
 
@@ -3410,7 +3418,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_block_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
@@ -3426,7 +3434,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `label`
     #[inline]
-    pub fn statement_break(self, span: Span, label: Option<LabelIdentifier<'a>>) -> Statement<'a> {
+    pub fn statement_break(&self, span: Span, label: Option<LabelIdentifier<'a>>) -> Statement<'a> {
         Statement::BreakStatement(self.alloc_break_statement(span, label))
     }
 
@@ -3439,7 +3447,7 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     #[inline]
     pub fn statement_continue(
-        self,
+        &self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> Statement<'a> {
@@ -3453,7 +3461,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn statement_debugger(self, span: Span) -> Statement<'a> {
+    pub fn statement_debugger(&self, span: Span) -> Statement<'a> {
         Statement::DebuggerStatement(self.alloc_debugger_statement(span))
     }
 
@@ -3467,7 +3475,7 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     #[inline]
     pub fn statement_do_while(
-        self,
+        &self,
         span: Span,
         body: Statement<'a>,
         test: Expression<'a>,
@@ -3482,7 +3490,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn statement_empty(self, span: Span) -> Statement<'a> {
+    pub fn statement_empty(&self, span: Span) -> Statement<'a> {
         Statement::EmptyStatement(self.alloc_empty_statement(span))
     }
 
@@ -3494,7 +3502,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     #[inline]
-    pub fn statement_expression(self, span: Span, expression: Expression<'a>) -> Statement<'a> {
+    pub fn statement_expression(&self, span: Span, expression: Expression<'a>) -> Statement<'a> {
         Statement::ExpressionStatement(self.alloc_expression_statement(span, expression))
     }
 
@@ -3509,7 +3517,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_for_in(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -3530,7 +3538,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_for_in_with_scope_id(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -3554,7 +3562,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_for_of(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -3577,7 +3585,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_for_of_with_scope_id(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -3602,7 +3610,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_for(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -3625,7 +3633,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_for_with_scope_id(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -3649,7 +3657,7 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn statement_if(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Statement<'a>,
@@ -3668,7 +3676,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_labeled(
-        self,
+        &self,
         span: Span,
         label: LabelIdentifier<'a>,
         body: Statement<'a>,
@@ -3684,7 +3692,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
     #[inline]
-    pub fn statement_return(self, span: Span, argument: Option<Expression<'a>>) -> Statement<'a> {
+    pub fn statement_return(&self, span: Span, argument: Option<Expression<'a>>) -> Statement<'a> {
         Statement::ReturnStatement(self.alloc_return_statement(span, argument))
     }
 
@@ -3698,7 +3706,7 @@ impl<'a> AstBuilder<'a> {
     /// * `cases`
     #[inline]
     pub fn statement_switch(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: ArenaVec<'a, SwitchCase<'a>>,
@@ -3717,7 +3725,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_switch_with_scope_id(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: ArenaVec<'a, SwitchCase<'a>>,
@@ -3739,7 +3747,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being thrown, e.g. `err` in `throw err;`
     #[inline]
-    pub fn statement_throw(self, span: Span, argument: Expression<'a>) -> Statement<'a> {
+    pub fn statement_throw(&self, span: Span, argument: Expression<'a>) -> Statement<'a> {
         Statement::ThrowStatement(self.alloc_throw_statement(span, argument))
     }
 
@@ -3754,7 +3762,7 @@ impl<'a> AstBuilder<'a> {
     /// * `finalizer`: The `finally` clause
     #[inline]
     pub fn statement_try<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         block: T1,
         handler: T2,
@@ -3778,7 +3786,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_while(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         body: Statement<'a>,
@@ -3796,7 +3804,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn statement_with(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         body: Statement<'a>,
@@ -3815,7 +3823,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn statement_with_with_scope_id(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         body: Statement<'a>,
@@ -3834,7 +3842,7 @@ impl<'a> AstBuilder<'a> {
     /// * `directive`: Raw content of directive as it appears in source, any escapes left as is
     #[inline]
     pub fn directive<S1>(
-        self,
+        &self,
         span: Span,
         expression: StringLiteral<'a>,
         directive: S1,
@@ -3851,7 +3859,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `value`
     #[inline]
-    pub fn hashbang<S1>(self, span: Span, value: S1) -> Hashbang<'a>
+    pub fn hashbang<S1>(&self, span: Span, value: S1) -> Hashbang<'a>
     where
         S1: Into<Str<'a>>,
     {
@@ -3868,7 +3876,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn block_statement(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, Statement<'a>>,
     ) -> BlockStatement<'a> {
@@ -3885,11 +3893,11 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_block_statement(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, Statement<'a>>,
     ) -> ArenaBox<'a, BlockStatement<'a>> {
-        ArenaBox::new_in(self.block_statement(span, body), &self)
+        ArenaBox::new_in(self.block_statement(span, body), self)
     }
 
     /// Build a [`BlockStatement`] with `scope_id`.
@@ -3903,7 +3911,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn block_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
@@ -3927,12 +3935,12 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_block_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
     ) -> ArenaBox<'a, BlockStatement<'a>> {
-        ArenaBox::new_in(self.block_statement_with_scope_id(span, body, scope_id), &self)
+        ArenaBox::new_in(self.block_statement_with_scope_id(span, body, scope_id), self)
     }
 
     /// Build a [`Declaration::VariableDeclaration`].
@@ -3946,7 +3954,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn declaration_variable(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         declarations: ArenaVec<'a, VariableDeclarator<'a>>,
@@ -3978,7 +3986,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The function body.
     #[inline]
     pub fn declaration_function<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -4034,7 +4042,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
     pub fn declaration_function_with_scope_id_and_pure_and_pife<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -4093,7 +4101,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
     pub fn declaration_class<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -4145,7 +4153,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
     pub fn declaration_class_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -4192,7 +4200,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn declaration_ts_type_alias<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -4224,7 +4232,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn declaration_ts_type_alias_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -4258,7 +4266,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
     pub fn declaration_ts_interface<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -4294,7 +4302,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn declaration_ts_interface_with_scope_id<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -4330,7 +4338,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn declaration_ts_enum(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         body: TSEnumBody<'a>,
@@ -4354,7 +4362,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn declaration_ts_module(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -4379,7 +4387,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn declaration_ts_module_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -4403,7 +4411,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn declaration_ts_global(
-        self,
+        &self,
         span: Span,
         global_span: Span,
         body: TSModuleBlock<'a>,
@@ -4429,7 +4437,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn declaration_ts_global_with_scope_id(
-        self,
+        &self,
         span: Span,
         global_span: Span,
         body: TSModuleBlock<'a>,
@@ -4456,7 +4464,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`
     #[inline]
     pub fn declaration_ts_import_equals(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         module_reference: TSModuleReference<'a>,
@@ -4482,7 +4490,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn variable_declaration(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         declarations: ArenaVec<'a, VariableDeclarator<'a>>,
@@ -4503,13 +4511,13 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn alloc_variable_declaration(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         declarations: ArenaVec<'a, VariableDeclarator<'a>>,
         declare: bool,
     ) -> ArenaBox<'a, VariableDeclaration<'a>> {
-        ArenaBox::new_in(self.variable_declaration(span, kind, declarations, declare), &self)
+        ArenaBox::new_in(self.variable_declaration(span, kind, declarations, declare), self)
     }
 
     /// Build a [`VariableDeclarator`].
@@ -4523,7 +4531,7 @@ impl<'a> AstBuilder<'a> {
     /// * `definite`
     #[inline]
     pub fn variable_declarator<T1>(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         id: BindingPattern<'a>,
@@ -4539,7 +4547,7 @@ impl<'a> AstBuilder<'a> {
             span,
             kind,
             id,
-            type_annotation: type_annotation.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
             init,
             definite,
         }
@@ -4553,7 +4561,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn empty_statement(self, span: Span) -> EmptyStatement {
+    pub fn empty_statement(&self, span: Span) -> EmptyStatement {
         EmptyStatement { node_id: Default::default(), span }
     }
 
@@ -4565,8 +4573,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_empty_statement(self, span: Span) -> ArenaBox<'a, EmptyStatement> {
-        ArenaBox::new_in(self.empty_statement(span), &self)
+    pub fn alloc_empty_statement(&self, span: Span) -> ArenaBox<'a, EmptyStatement> {
+        ArenaBox::new_in(self.empty_statement(span), self)
     }
 
     /// Build an [`ExpressionStatement`].
@@ -4579,7 +4587,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn expression_statement(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ExpressionStatement<'a> {
@@ -4596,11 +4604,11 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_expression_statement(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ArenaBox<'a, ExpressionStatement<'a>> {
-        ArenaBox::new_in(self.expression_statement(span, expression), &self)
+        ArenaBox::new_in(self.expression_statement(span, expression), self)
     }
 
     /// Build an [`IfStatement`].
@@ -4615,7 +4623,7 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn if_statement(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Statement<'a>,
@@ -4636,13 +4644,13 @@ impl<'a> AstBuilder<'a> {
     /// * `alternate`
     #[inline]
     pub fn alloc_if_statement(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         consequent: Statement<'a>,
         alternate: Option<Statement<'a>>,
     ) -> ArenaBox<'a, IfStatement<'a>> {
-        ArenaBox::new_in(self.if_statement(span, test, consequent, alternate), &self)
+        ArenaBox::new_in(self.if_statement(span, test, consequent, alternate), self)
     }
 
     /// Build a [`DoWhileStatement`].
@@ -4656,7 +4664,7 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     #[inline]
     pub fn do_while_statement(
-        self,
+        &self,
         span: Span,
         body: Statement<'a>,
         test: Expression<'a>,
@@ -4675,12 +4683,12 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     #[inline]
     pub fn alloc_do_while_statement(
-        self,
+        &self,
         span: Span,
         body: Statement<'a>,
         test: Expression<'a>,
     ) -> ArenaBox<'a, DoWhileStatement<'a>> {
-        ArenaBox::new_in(self.do_while_statement(span, body, test), &self)
+        ArenaBox::new_in(self.do_while_statement(span, body, test), self)
     }
 
     /// Build a [`WhileStatement`].
@@ -4694,7 +4702,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn while_statement(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         body: Statement<'a>,
@@ -4713,12 +4721,12 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_while_statement(
-        self,
+        &self,
         span: Span,
         test: Expression<'a>,
         body: Statement<'a>,
     ) -> ArenaBox<'a, WhileStatement<'a>> {
-        ArenaBox::new_in(self.while_statement(span, test, body), &self)
+        ArenaBox::new_in(self.while_statement(span, test, body), self)
     }
 
     /// Build a [`ForStatement`].
@@ -4734,7 +4742,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn for_statement(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -4765,14 +4773,14 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_for_statement(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
         update: Option<Expression<'a>>,
         body: Statement<'a>,
     ) -> ArenaBox<'a, ForStatement<'a>> {
-        ArenaBox::new_in(self.for_statement(span, init, test, update, body), &self)
+        ArenaBox::new_in(self.for_statement(span, init, test, update, body), self)
     }
 
     /// Build a [`ForStatement`] with `scope_id`.
@@ -4789,7 +4797,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn for_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -4822,7 +4830,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_for_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         init: Option<ForStatementInit<'a>>,
         test: Option<Expression<'a>>,
@@ -4832,7 +4840,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, ForStatement<'a>> {
         ArenaBox::new_in(
             self.for_statement_with_scope_id(span, init, test, update, body, scope_id),
-            &self,
+            self,
         )
     }
 
@@ -4847,7 +4855,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn for_statement_init_variable_declaration(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         declarations: ArenaVec<'a, VariableDeclarator<'a>>,
@@ -4873,7 +4881,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn for_in_statement(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -4901,13 +4909,13 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_for_in_statement(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
         body: Statement<'a>,
     ) -> ArenaBox<'a, ForInStatement<'a>> {
-        ArenaBox::new_in(self.for_in_statement(span, left, right, body), &self)
+        ArenaBox::new_in(self.for_in_statement(span, left, right, body), self)
     }
 
     /// Build a [`ForInStatement`] with `scope_id`.
@@ -4923,7 +4931,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn for_in_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -4953,7 +4961,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_for_in_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
@@ -4962,7 +4970,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, ForInStatement<'a>> {
         ArenaBox::new_in(
             self.for_in_statement_with_scope_id(span, left, right, body, scope_id),
-            &self,
+            self,
         )
     }
 
@@ -4977,7 +4985,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn for_statement_left_variable_declaration(
-        self,
+        &self,
         span: Span,
         kind: VariableDeclarationKind,
         declarations: ArenaVec<'a, VariableDeclarator<'a>>,
@@ -5004,7 +5012,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn for_of_statement(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -5035,14 +5043,14 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_for_of_statement(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
         right: Expression<'a>,
         body: Statement<'a>,
     ) -> ArenaBox<'a, ForOfStatement<'a>> {
-        ArenaBox::new_in(self.for_of_statement(span, r#await, left, right, body), &self)
+        ArenaBox::new_in(self.for_of_statement(span, r#await, left, right, body), self)
     }
 
     /// Build a [`ForOfStatement`] with `scope_id`.
@@ -5059,7 +5067,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn for_of_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -5092,7 +5100,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_for_of_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
@@ -5102,7 +5110,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, ForOfStatement<'a>> {
         ArenaBox::new_in(
             self.for_of_statement_with_scope_id(span, r#await, left, right, body, scope_id),
-            &self,
+            self,
         )
     }
 
@@ -5116,7 +5124,7 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     #[inline]
     pub fn continue_statement(
-        self,
+        &self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> ContinueStatement<'a> {
@@ -5133,11 +5141,11 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     #[inline]
     pub fn alloc_continue_statement(
-        self,
+        &self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> ArenaBox<'a, ContinueStatement<'a>> {
-        ArenaBox::new_in(self.continue_statement(span, label), &self)
+        ArenaBox::new_in(self.continue_statement(span, label), self)
     }
 
     /// Build a [`BreakStatement`].
@@ -5150,7 +5158,7 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     #[inline]
     pub fn break_statement(
-        self,
+        &self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> BreakStatement<'a> {
@@ -5167,11 +5175,11 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     #[inline]
     pub fn alloc_break_statement(
-        self,
+        &self,
         span: Span,
         label: Option<LabelIdentifier<'a>>,
     ) -> ArenaBox<'a, BreakStatement<'a>> {
-        ArenaBox::new_in(self.break_statement(span, label), &self)
+        ArenaBox::new_in(self.break_statement(span, label), self)
     }
 
     /// Build a [`ReturnStatement`].
@@ -5184,7 +5192,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn return_statement(
-        self,
+        &self,
         span: Span,
         argument: Option<Expression<'a>>,
     ) -> ReturnStatement<'a> {
@@ -5201,11 +5209,11 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_return_statement(
-        self,
+        &self,
         span: Span,
         argument: Option<Expression<'a>>,
     ) -> ArenaBox<'a, ReturnStatement<'a>> {
-        ArenaBox::new_in(self.return_statement(span, argument), &self)
+        ArenaBox::new_in(self.return_statement(span, argument), self)
     }
 
     /// Build a [`WithStatement`].
@@ -5219,7 +5227,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn with_statement(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         body: Statement<'a>,
@@ -5244,12 +5252,12 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_with_statement(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         body: Statement<'a>,
     ) -> ArenaBox<'a, WithStatement<'a>> {
-        ArenaBox::new_in(self.with_statement(span, object, body), &self)
+        ArenaBox::new_in(self.with_statement(span, object, body), self)
     }
 
     /// Build a [`WithStatement`] with `scope_id`.
@@ -5264,7 +5272,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn with_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         body: Statement<'a>,
@@ -5291,13 +5299,13 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_with_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         object: Expression<'a>,
         body: Statement<'a>,
         scope_id: ScopeId,
     ) -> ArenaBox<'a, WithStatement<'a>> {
-        ArenaBox::new_in(self.with_statement_with_scope_id(span, object, body, scope_id), &self)
+        ArenaBox::new_in(self.with_statement_with_scope_id(span, object, body, scope_id), self)
     }
 
     /// Build a [`SwitchStatement`].
@@ -5311,7 +5319,7 @@ impl<'a> AstBuilder<'a> {
     /// * `cases`
     #[inline]
     pub fn switch_statement(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: ArenaVec<'a, SwitchCase<'a>>,
@@ -5336,12 +5344,12 @@ impl<'a> AstBuilder<'a> {
     /// * `cases`
     #[inline]
     pub fn alloc_switch_statement(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: ArenaVec<'a, SwitchCase<'a>>,
     ) -> ArenaBox<'a, SwitchStatement<'a>> {
-        ArenaBox::new_in(self.switch_statement(span, discriminant, cases), &self)
+        ArenaBox::new_in(self.switch_statement(span, discriminant, cases), self)
     }
 
     /// Build a [`SwitchStatement`] with `scope_id`.
@@ -5356,7 +5364,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn switch_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: ArenaVec<'a, SwitchCase<'a>>,
@@ -5383,7 +5391,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_switch_statement_with_scope_id(
-        self,
+        &self,
         span: Span,
         discriminant: Expression<'a>,
         cases: ArenaVec<'a, SwitchCase<'a>>,
@@ -5391,7 +5399,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, SwitchStatement<'a>> {
         ArenaBox::new_in(
             self.switch_statement_with_scope_id(span, discriminant, cases, scope_id),
-            &self,
+            self,
         )
     }
 
@@ -5403,7 +5411,7 @@ impl<'a> AstBuilder<'a> {
     /// * `consequent`
     #[inline]
     pub fn switch_case(
-        self,
+        &self,
         span: Span,
         test: Option<Expression<'a>>,
         consequent: ArenaVec<'a, Statement<'a>>,
@@ -5422,7 +5430,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn labeled_statement(
-        self,
+        &self,
         span: Span,
         label: LabelIdentifier<'a>,
         body: Statement<'a>,
@@ -5441,12 +5449,12 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_labeled_statement(
-        self,
+        &self,
         span: Span,
         label: LabelIdentifier<'a>,
         body: Statement<'a>,
     ) -> ArenaBox<'a, LabeledStatement<'a>> {
-        ArenaBox::new_in(self.labeled_statement(span, label, body), &self)
+        ArenaBox::new_in(self.labeled_statement(span, label, body), self)
     }
 
     /// Build a [`ThrowStatement`].
@@ -5458,7 +5466,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being thrown, e.g. `err` in `throw err;`
     #[inline]
-    pub fn throw_statement(self, span: Span, argument: Expression<'a>) -> ThrowStatement<'a> {
+    pub fn throw_statement(&self, span: Span, argument: Expression<'a>) -> ThrowStatement<'a> {
         ThrowStatement { node_id: Default::default(), span, argument }
     }
 
@@ -5472,11 +5480,11 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being thrown, e.g. `err` in `throw err;`
     #[inline]
     pub fn alloc_throw_statement(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> ArenaBox<'a, ThrowStatement<'a>> {
-        ArenaBox::new_in(self.throw_statement(span, argument), &self)
+        ArenaBox::new_in(self.throw_statement(span, argument), self)
     }
 
     /// Build a [`TryStatement`].
@@ -5491,7 +5499,7 @@ impl<'a> AstBuilder<'a> {
     /// * `finalizer`: The `finally` clause
     #[inline]
     pub fn try_statement<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         block: T1,
         handler: T2,
@@ -5505,9 +5513,9 @@ impl<'a> AstBuilder<'a> {
         TryStatement {
             node_id: Default::default(),
             span,
-            block: block.into_in(self.allocator),
-            handler: handler.into_in(self.allocator),
-            finalizer: finalizer.into_in(self.allocator),
+            block: block.into_in(self.allocator()),
+            handler: handler.into_in(self.allocator()),
+            finalizer: finalizer.into_in(self.allocator()),
         }
     }
 
@@ -5523,7 +5531,7 @@ impl<'a> AstBuilder<'a> {
     /// * `finalizer`: The `finally` clause
     #[inline]
     pub fn alloc_try_statement<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         block: T1,
         handler: T2,
@@ -5534,7 +5542,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Option<ArenaBox<'a, CatchClause<'a>>>>,
         T3: IntoIn<'a, Option<ArenaBox<'a, BlockStatement<'a>>>>,
     {
-        ArenaBox::new_in(self.try_statement(span, block, handler, finalizer), &self)
+        ArenaBox::new_in(self.try_statement(span, block, handler, finalizer), self)
     }
 
     /// Build a [`CatchClause`].
@@ -5548,7 +5556,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The statements run when an error is caught
     #[inline]
     pub fn catch_clause<T1>(
-        self,
+        &self,
         span: Span,
         param: Option<CatchParameter<'a>>,
         body: T1,
@@ -5560,7 +5568,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             param,
-            body: body.into_in(self.allocator),
+            body: body.into_in(self.allocator()),
             scope_id: Default::default(),
         }
     }
@@ -5576,7 +5584,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The statements run when an error is caught
     #[inline]
     pub fn alloc_catch_clause<T1>(
-        self,
+        &self,
         span: Span,
         param: Option<CatchParameter<'a>>,
         body: T1,
@@ -5584,7 +5592,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
     {
-        ArenaBox::new_in(self.catch_clause(span, param, body), &self)
+        ArenaBox::new_in(self.catch_clause(span, param, body), self)
     }
 
     /// Build a [`CatchClause`] with `scope_id`.
@@ -5599,7 +5607,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn catch_clause_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         param: Option<CatchParameter<'a>>,
         body: T1,
@@ -5612,7 +5620,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             param,
-            body: body.into_in(self.allocator),
+            body: body.into_in(self.allocator()),
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -5629,7 +5637,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_catch_clause_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         param: Option<CatchParameter<'a>>,
         body: T1,
@@ -5638,7 +5646,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, ArenaBox<'a, BlockStatement<'a>>>,
     {
-        ArenaBox::new_in(self.catch_clause_with_scope_id(span, param, body, scope_id), &self)
+        ArenaBox::new_in(self.catch_clause_with_scope_id(span, param, body, scope_id), self)
     }
 
     /// Build a [`CatchParameter`].
@@ -5649,7 +5657,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn catch_parameter<T1>(
-        self,
+        &self,
         span: Span,
         pattern: BindingPattern<'a>,
         type_annotation: T1,
@@ -5661,7 +5669,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             pattern,
-            type_annotation: type_annotation.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
         }
     }
 
@@ -5673,7 +5681,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn debugger_statement(self, span: Span) -> DebuggerStatement {
+    pub fn debugger_statement(&self, span: Span) -> DebuggerStatement {
         DebuggerStatement { node_id: Default::default(), span }
     }
 
@@ -5685,8 +5693,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_debugger_statement(self, span: Span) -> ArenaBox<'a, DebuggerStatement> {
-        ArenaBox::new_in(self.debugger_statement(span), &self)
+    pub fn alloc_debugger_statement(&self, span: Span) -> ArenaBox<'a, DebuggerStatement> {
+        ArenaBox::new_in(self.debugger_statement(span), self)
     }
 
     /// Build a [`BindingPattern::BindingIdentifier`].
@@ -5697,7 +5705,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     #[inline]
-    pub fn binding_pattern_binding_identifier<S1>(self, span: Span, name: S1) -> BindingPattern<'a>
+    pub fn binding_pattern_binding_identifier<S1>(&self, span: Span, name: S1) -> BindingPattern<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -5714,7 +5722,7 @@ impl<'a> AstBuilder<'a> {
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
     pub fn binding_pattern_binding_identifier_with_symbol_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         symbol_id: SymbolId,
@@ -5737,7 +5745,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn binding_pattern_object_pattern<T1>(
-        self,
+        &self,
         span: Span,
         properties: ArenaVec<'a, BindingProperty<'a>>,
         rest: T1,
@@ -5758,7 +5766,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn binding_pattern_array_pattern<T1>(
-        self,
+        &self,
         span: Span,
         elements: ArenaVec<'a, Option<BindingPattern<'a>>>,
         rest: T1,
@@ -5779,7 +5787,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn binding_pattern_assignment_pattern(
-        self,
+        &self,
         span: Span,
         left: BindingPattern<'a>,
         right: Expression<'a>,
@@ -5798,7 +5806,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn assignment_pattern(
-        self,
+        &self,
         span: Span,
         left: BindingPattern<'a>,
         right: Expression<'a>,
@@ -5817,12 +5825,12 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_assignment_pattern(
-        self,
+        &self,
         span: Span,
         left: BindingPattern<'a>,
         right: Expression<'a>,
     ) -> ArenaBox<'a, AssignmentPattern<'a>> {
-        ArenaBox::new_in(self.assignment_pattern(span, left, right), &self)
+        ArenaBox::new_in(self.assignment_pattern(span, left, right), self)
     }
 
     /// Build an [`ObjectPattern`].
@@ -5836,7 +5844,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn object_pattern<T1>(
-        self,
+        &self,
         span: Span,
         properties: ArenaVec<'a, BindingProperty<'a>>,
         rest: T1,
@@ -5848,7 +5856,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             properties,
-            rest: rest.into_in(self.allocator),
+            rest: rest.into_in(self.allocator()),
         }
     }
 
@@ -5863,7 +5871,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn alloc_object_pattern<T1>(
-        self,
+        &self,
         span: Span,
         properties: ArenaVec<'a, BindingProperty<'a>>,
         rest: T1,
@@ -5871,7 +5879,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
-        ArenaBox::new_in(self.object_pattern(span, properties, rest), &self)
+        ArenaBox::new_in(self.object_pattern(span, properties, rest), self)
     }
 
     /// Build a [`BindingProperty`].
@@ -5884,7 +5892,7 @@ impl<'a> AstBuilder<'a> {
     /// * `computed`
     #[inline]
     pub fn binding_property(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         value: BindingPattern<'a>,
@@ -5905,7 +5913,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn array_pattern<T1>(
-        self,
+        &self,
         span: Span,
         elements: ArenaVec<'a, Option<BindingPattern<'a>>>,
         rest: T1,
@@ -5917,7 +5925,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             elements,
-            rest: rest.into_in(self.allocator),
+            rest: rest.into_in(self.allocator()),
         }
     }
 
@@ -5932,7 +5940,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn alloc_array_pattern<T1>(
-        self,
+        &self,
         span: Span,
         elements: ArenaVec<'a, Option<BindingPattern<'a>>>,
         rest: T1,
@@ -5940,7 +5948,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, BindingRestElement<'a>>>>,
     {
-        ArenaBox::new_in(self.array_pattern(span, elements, rest), &self)
+        ArenaBox::new_in(self.array_pattern(span, elements, rest), self)
     }
 
     /// Build a [`BindingRestElement`].
@@ -5953,7 +5961,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn binding_rest_element(
-        self,
+        &self,
         span: Span,
         argument: BindingPattern<'a>,
     ) -> BindingRestElement<'a> {
@@ -5970,11 +5978,11 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_binding_rest_element(
-        self,
+        &self,
         span: Span,
         argument: BindingPattern<'a>,
     ) -> ArenaBox<'a, BindingRestElement<'a>> {
-        ArenaBox::new_in(self.binding_rest_element(span, argument), &self)
+        ArenaBox::new_in(self.binding_rest_element(span, argument), self)
     }
 
     /// Build a [`Function`].
@@ -5996,7 +6004,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The function body.
     #[inline]
     pub fn function<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -6024,11 +6032,11 @@ impl<'a> AstBuilder<'a> {
             generator,
             r#async,
             declare,
-            type_parameters: type_parameters.into_in(self.allocator),
-            this_param: this_param.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
-            body: body.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            this_param: this_param.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
+            body: body.into_in(self.allocator()),
             scope_id: Default::default(),
             pure: Default::default(),
             pife: Default::default(),
@@ -6054,7 +6062,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The function body.
     #[inline]
     pub fn alloc_function<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -6088,7 +6096,7 @@ impl<'a> AstBuilder<'a> {
                 return_type,
                 body,
             ),
-            &self,
+            self,
         )
     }
 
@@ -6114,7 +6122,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
     pub fn function_with_scope_id_and_pure_and_pife<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -6145,11 +6153,11 @@ impl<'a> AstBuilder<'a> {
             generator,
             r#async,
             declare,
-            type_parameters: type_parameters.into_in(self.allocator),
-            this_param: this_param.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
-            body: body.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            this_param: this_param.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
+            body: body.into_in(self.allocator()),
             scope_id: Cell::new(Some(scope_id)),
             pure,
             pife,
@@ -6178,7 +6186,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
     pub fn alloc_function_with_scope_id_and_pure_and_pife<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -6218,7 +6226,7 @@ impl<'a> AstBuilder<'a> {
                 pure,
                 pife,
             ),
-            &self,
+            self,
         )
     }
 
@@ -6234,7 +6242,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn formal_parameters<T1>(
-        self,
+        &self,
         span: Span,
         kind: FormalParameterKind,
         items: ArenaVec<'a, FormalParameter<'a>>,
@@ -6248,7 +6256,7 @@ impl<'a> AstBuilder<'a> {
             span,
             kind,
             items,
-            rest: rest.into_in(self.allocator),
+            rest: rest.into_in(self.allocator()),
         }
     }
 
@@ -6264,7 +6272,7 @@ impl<'a> AstBuilder<'a> {
     /// * `rest`
     #[inline]
     pub fn alloc_formal_parameters<T1>(
-        self,
+        &self,
         span: Span,
         kind: FormalParameterKind,
         items: ArenaVec<'a, FormalParameter<'a>>,
@@ -6273,7 +6281,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, FormalParameterRest<'a>>>>,
     {
-        ArenaBox::new_in(self.formal_parameters(span, kind, items, rest), &self)
+        ArenaBox::new_in(self.formal_parameters(span, kind, items, rest), self)
     }
 
     /// Build a [`FormalParameter`].
@@ -6290,7 +6298,7 @@ impl<'a> AstBuilder<'a> {
     /// * `override`
     #[inline]
     pub fn formal_parameter<T1, T2>(
-        self,
+        &self,
         span: Span,
         decorators: ArenaVec<'a, Decorator<'a>>,
         pattern: BindingPattern<'a>,
@@ -6310,8 +6318,8 @@ impl<'a> AstBuilder<'a> {
             span,
             decorators,
             pattern,
-            type_annotation: type_annotation.into_in(self.allocator),
-            initializer: initializer.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
+            initializer: initializer.into_in(self.allocator()),
             optional,
             accessibility,
             readonly,
@@ -6331,7 +6339,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn formal_parameter_rest<T1>(
-        self,
+        &self,
         span: Span,
         decorators: ArenaVec<'a, Decorator<'a>>,
         rest: BindingRestElement<'a>,
@@ -6345,7 +6353,7 @@ impl<'a> AstBuilder<'a> {
             span,
             decorators,
             rest,
-            type_annotation: type_annotation.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
         }
     }
 
@@ -6361,7 +6369,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_formal_parameter_rest<T1>(
-        self,
+        &self,
         span: Span,
         decorators: ArenaVec<'a, Decorator<'a>>,
         rest: BindingRestElement<'a>,
@@ -6370,7 +6378,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        ArenaBox::new_in(self.formal_parameter_rest(span, decorators, rest, type_annotation), &self)
+        ArenaBox::new_in(self.formal_parameter_rest(span, decorators, rest, type_annotation), self)
     }
 
     /// Build a [`FunctionBody`].
@@ -6384,7 +6392,7 @@ impl<'a> AstBuilder<'a> {
     /// * `statements`
     #[inline]
     pub fn function_body(
-        self,
+        &self,
         span: Span,
         directives: ArenaVec<'a, Directive<'a>>,
         statements: ArenaVec<'a, Statement<'a>>,
@@ -6403,12 +6411,12 @@ impl<'a> AstBuilder<'a> {
     /// * `statements`
     #[inline]
     pub fn alloc_function_body(
-        self,
+        &self,
         span: Span,
         directives: ArenaVec<'a, Directive<'a>>,
         statements: ArenaVec<'a, Statement<'a>>,
     ) -> ArenaBox<'a, FunctionBody<'a>> {
-        ArenaBox::new_in(self.function_body(span, directives, statements), &self)
+        ArenaBox::new_in(self.function_body(span, directives, statements), self)
     }
 
     /// Build an [`ArrowFunctionExpression`].
@@ -6426,7 +6434,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
     pub fn arrow_function_expression<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -6446,10 +6454,10 @@ impl<'a> AstBuilder<'a> {
             span,
             expression,
             r#async,
-            type_parameters: type_parameters.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
-            body: body.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
+            body: body.into_in(self.allocator()),
             scope_id: Default::default(),
             pure: Default::default(),
             pife: Default::default(),
@@ -6471,7 +6479,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
     #[inline]
     pub fn alloc_arrow_function_expression<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -6496,7 +6504,7 @@ impl<'a> AstBuilder<'a> {
                 return_type,
                 body,
             ),
-            &self,
+            self,
         )
     }
 
@@ -6518,7 +6526,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
     pub fn arrow_function_expression_with_scope_id_and_pure_and_pife<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -6541,10 +6549,10 @@ impl<'a> AstBuilder<'a> {
             span,
             expression,
             r#async,
-            type_parameters: type_parameters.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
-            body: body.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
+            body: body.into_in(self.allocator()),
             scope_id: Cell::new(Some(scope_id)),
             pure,
             pife,
@@ -6569,7 +6577,7 @@ impl<'a> AstBuilder<'a> {
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
     #[inline]
     pub fn alloc_arrow_function_expression_with_scope_id_and_pure_and_pife<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         expression: bool,
         r#async: bool,
@@ -6600,7 +6608,7 @@ impl<'a> AstBuilder<'a> {
                 pure,
                 pife,
             ),
-            &self,
+            self,
         )
     }
 
@@ -6615,7 +6623,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn yield_expression(
-        self,
+        &self,
         span: Span,
         delegate: bool,
         argument: Option<Expression<'a>>,
@@ -6634,12 +6642,12 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn alloc_yield_expression(
-        self,
+        &self,
         span: Span,
         delegate: bool,
         argument: Option<Expression<'a>>,
     ) -> ArenaBox<'a, YieldExpression<'a>> {
-        ArenaBox::new_in(self.yield_expression(span, delegate, argument), &self)
+        ArenaBox::new_in(self.yield_expression(span, delegate, argument), self)
     }
 
     /// Build a [`Class`].
@@ -6661,7 +6669,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
     pub fn class<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -6685,11 +6693,11 @@ impl<'a> AstBuilder<'a> {
             r#type,
             decorators,
             id,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
             super_class,
-            super_type_arguments: super_type_arguments.into_in(self.allocator),
+            super_type_arguments: super_type_arguments.into_in(self.allocator()),
             implements,
-            body: body.into_in(self.allocator),
+            body: body.into_in(self.allocator()),
             r#abstract,
             declare,
             scope_id: Default::default(),
@@ -6715,7 +6723,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
     pub fn alloc_class<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -6747,7 +6755,7 @@ impl<'a> AstBuilder<'a> {
                 r#abstract,
                 declare,
             ),
-            &self,
+            self,
         )
     }
 
@@ -6771,7 +6779,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
     pub fn class_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -6796,11 +6804,11 @@ impl<'a> AstBuilder<'a> {
             r#type,
             decorators,
             id,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
             super_class,
-            super_type_arguments: super_type_arguments.into_in(self.allocator),
+            super_type_arguments: super_type_arguments.into_in(self.allocator()),
             implements,
-            body: body.into_in(self.allocator),
+            body: body.into_in(self.allocator()),
             r#abstract,
             declare,
             scope_id: Cell::new(Some(scope_id)),
@@ -6827,7 +6835,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
     pub fn alloc_class_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -6861,7 +6869,7 @@ impl<'a> AstBuilder<'a> {
                 declare,
                 scope_id,
             ),
-            &self,
+            self,
         )
     }
 
@@ -6874,7 +6882,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn class_body(self, span: Span, body: ArenaVec<'a, ClassElement<'a>>) -> ClassBody<'a> {
+    pub fn class_body(&self, span: Span, body: ArenaVec<'a, ClassElement<'a>>) -> ClassBody<'a> {
         ClassBody { node_id: Default::default(), span, body }
     }
 
@@ -6888,11 +6896,11 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_class_body(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, ClassElement<'a>>,
     ) -> ArenaBox<'a, ClassBody<'a>> {
-        ArenaBox::new_in(self.class_body(span, body), &self)
+        ArenaBox::new_in(self.class_body(span, body), self)
     }
 
     /// Build a [`ClassElement::StaticBlock`].
@@ -6904,7 +6912,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn class_element_static_block(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, Statement<'a>>,
     ) -> ClassElement<'a> {
@@ -6921,7 +6929,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn class_element_static_block_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
@@ -6947,7 +6955,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`
     #[inline]
     pub fn class_element_method_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: MethodDefinitionType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -6999,7 +7007,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn class_element_property_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: PropertyDefinitionType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -7054,7 +7062,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn class_element_accessor_property<T1>(
-        self,
+        &self,
         span: Span,
         r#type: AccessorPropertyType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -7097,7 +7105,7 @@ impl<'a> AstBuilder<'a> {
     /// * `static`
     #[inline]
     pub fn class_element_ts_index_signature<T1>(
-        self,
+        &self,
         span: Span,
         parameters: ArenaVec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
@@ -7135,7 +7143,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`
     #[inline]
     pub fn method_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: MethodDefinitionType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -7157,7 +7165,7 @@ impl<'a> AstBuilder<'a> {
             r#type,
             decorators,
             key,
-            value: value.into_in(self.allocator),
+            value: value.into_in(self.allocator()),
             kind,
             computed,
             r#static,
@@ -7186,7 +7194,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`
     #[inline]
     pub fn alloc_method_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: MethodDefinitionType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -7216,7 +7224,7 @@ impl<'a> AstBuilder<'a> {
                 optional,
                 accessibility,
             ),
-            &self,
+            self,
         )
     }
 
@@ -7242,7 +7250,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn property_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: PropertyDefinitionType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -7267,7 +7275,7 @@ impl<'a> AstBuilder<'a> {
             r#type,
             decorators,
             key,
-            type_annotation: type_annotation.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
             value,
             computed,
             r#static,
@@ -7302,7 +7310,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn alloc_property_definition<T1>(
-        self,
+        &self,
         span: Span,
         r#type: PropertyDefinitionType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -7338,7 +7346,7 @@ impl<'a> AstBuilder<'a> {
                 readonly,
                 accessibility,
             ),
-            &self,
+            self,
         )
     }
 
@@ -7351,7 +7359,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn private_identifier<S1>(self, span: Span, name: S1) -> PrivateIdentifier<'a>
+    pub fn private_identifier<S1>(&self, span: Span, name: S1) -> PrivateIdentifier<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -7368,14 +7376,14 @@ impl<'a> AstBuilder<'a> {
     /// * `name`
     #[inline]
     pub fn alloc_private_identifier<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> ArenaBox<'a, PrivateIdentifier<'a>>
     where
         S1: Into<Ident<'a>>,
     {
-        ArenaBox::new_in(self.private_identifier(span, name), &self)
+        ArenaBox::new_in(self.private_identifier(span, name), self)
     }
 
     /// Build a [`StaticBlock`].
@@ -7387,7 +7395,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     #[inline]
-    pub fn static_block(self, span: Span, body: ArenaVec<'a, Statement<'a>>) -> StaticBlock<'a> {
+    pub fn static_block(&self, span: Span, body: ArenaVec<'a, Statement<'a>>) -> StaticBlock<'a> {
         StaticBlock { node_id: Default::default(), span, body, scope_id: Default::default() }
     }
 
@@ -7401,11 +7409,11 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_static_block(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, Statement<'a>>,
     ) -> ArenaBox<'a, StaticBlock<'a>> {
-        ArenaBox::new_in(self.static_block(span, body), &self)
+        ArenaBox::new_in(self.static_block(span, body), self)
     }
 
     /// Build a [`StaticBlock`] with `scope_id`.
@@ -7419,7 +7427,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn static_block_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
@@ -7438,12 +7446,12 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_static_block_with_scope_id(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, Statement<'a>>,
         scope_id: ScopeId,
     ) -> ArenaBox<'a, StaticBlock<'a>> {
-        ArenaBox::new_in(self.static_block_with_scope_id(span, body, scope_id), &self)
+        ArenaBox::new_in(self.static_block_with_scope_id(span, body, scope_id), self)
     }
 
     /// Build a [`ModuleDeclaration::ImportDeclaration`].
@@ -7459,7 +7467,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`: `import type { foo } from 'bar'`
     #[inline]
     pub fn module_declaration_import_declaration<T1>(
-        self,
+        &self,
         span: Span,
         specifiers: Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
@@ -7492,7 +7500,7 @@ impl<'a> AstBuilder<'a> {
     /// * `export_kind`
     #[inline]
     pub fn module_declaration_export_all_declaration<T1>(
-        self,
+        &self,
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
@@ -7520,7 +7528,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declaration`
     #[inline]
     pub fn module_declaration_export_default_declaration(
-        self,
+        &self,
         span: Span,
         declaration: ExportDefaultDeclarationKind<'a>,
     ) -> ModuleDeclaration<'a> {
@@ -7542,7 +7550,7 @@ impl<'a> AstBuilder<'a> {
     /// * `with_clause`: Some(vec![]) for empty assertion
     #[inline]
     pub fn module_declaration_export_named_declaration<T1>(
-        self,
+        &self,
         span: Span,
         declaration: Option<Declaration<'a>>,
         specifiers: ArenaVec<'a, ExportSpecifier<'a>>,
@@ -7572,7 +7580,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn module_declaration_ts_export_assignment(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ModuleDeclaration<'a> {
@@ -7588,7 +7596,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`
     #[inline]
     pub fn module_declaration_ts_namespace_export_declaration(
-        self,
+        &self,
         span: Span,
         id: IdentifierName<'a>,
     ) -> ModuleDeclaration<'a> {
@@ -7616,7 +7624,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn accessor_property<T1>(
-        self,
+        &self,
         span: Span,
         r#type: AccessorPropertyType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -7638,7 +7646,7 @@ impl<'a> AstBuilder<'a> {
             r#type,
             decorators,
             key,
-            type_annotation: type_annotation.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
             value,
             computed,
             r#static,
@@ -7667,7 +7675,7 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`: Accessibility modifier.
     #[inline]
     pub fn alloc_accessor_property<T1>(
-        self,
+        &self,
         span: Span,
         r#type: AccessorPropertyType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -7697,7 +7705,7 @@ impl<'a> AstBuilder<'a> {
                 definite,
                 accessibility,
             ),
-            &self,
+            self,
         )
     }
 
@@ -7713,7 +7721,7 @@ impl<'a> AstBuilder<'a> {
     /// * `phase`
     #[inline]
     pub fn import_expression(
-        self,
+        &self,
         span: Span,
         source: Expression<'a>,
         options: Option<Expression<'a>>,
@@ -7734,13 +7742,13 @@ impl<'a> AstBuilder<'a> {
     /// * `phase`
     #[inline]
     pub fn alloc_import_expression(
-        self,
+        &self,
         span: Span,
         source: Expression<'a>,
         options: Option<Expression<'a>>,
         phase: Option<ImportPhase>,
     ) -> ArenaBox<'a, ImportExpression<'a>> {
-        ArenaBox::new_in(self.import_expression(span, source, options, phase), &self)
+        ArenaBox::new_in(self.import_expression(span, source, options, phase), self)
     }
 
     /// Build an [`ImportDeclaration`].
@@ -7757,7 +7765,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`: `import type { foo } from 'bar'`
     #[inline]
     pub fn import_declaration<T1>(
-        self,
+        &self,
         span: Span,
         specifiers: Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
@@ -7774,7 +7782,7 @@ impl<'a> AstBuilder<'a> {
             specifiers,
             source,
             phase,
-            with_clause: with_clause.into_in(self.allocator),
+            with_clause: with_clause.into_in(self.allocator()),
             import_kind,
         }
     }
@@ -7793,7 +7801,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`: `import type { foo } from 'bar'`
     #[inline]
     pub fn alloc_import_declaration<T1>(
-        self,
+        &self,
         span: Span,
         specifiers: Option<ArenaVec<'a, ImportDeclarationSpecifier<'a>>>,
         source: StringLiteral<'a>,
@@ -7806,7 +7814,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.import_declaration(span, specifiers, source, phase, with_clause, import_kind),
-            &self,
+            self,
         )
     }
 
@@ -7821,7 +7829,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`: Value or type.
     #[inline]
     pub fn import_declaration_specifier_import_specifier(
-        self,
+        &self,
         span: Span,
         imported: ModuleExportName<'a>,
         local: BindingIdentifier<'a>,
@@ -7844,7 +7852,7 @@ impl<'a> AstBuilder<'a> {
     /// * `local`: The name of the imported symbol.
     #[inline]
     pub fn import_declaration_specifier_import_default_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportDeclarationSpecifier<'a> {
@@ -7862,7 +7870,7 @@ impl<'a> AstBuilder<'a> {
     /// * `local`
     #[inline]
     pub fn import_declaration_specifier_import_namespace_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportDeclarationSpecifier<'a> {
@@ -7883,7 +7891,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`: Value or type.
     #[inline]
     pub fn import_specifier(
-        self,
+        &self,
         span: Span,
         imported: ModuleExportName<'a>,
         local: BindingIdentifier<'a>,
@@ -7904,13 +7912,13 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`: Value or type.
     #[inline]
     pub fn alloc_import_specifier(
-        self,
+        &self,
         span: Span,
         imported: ModuleExportName<'a>,
         local: BindingIdentifier<'a>,
         import_kind: ImportOrExportKind,
     ) -> ArenaBox<'a, ImportSpecifier<'a>> {
-        ArenaBox::new_in(self.import_specifier(span, imported, local, import_kind), &self)
+        ArenaBox::new_in(self.import_specifier(span, imported, local, import_kind), self)
     }
 
     /// Build an [`ImportDefaultSpecifier`].
@@ -7923,7 +7931,7 @@ impl<'a> AstBuilder<'a> {
     /// * `local`: The name of the imported symbol.
     #[inline]
     pub fn import_default_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportDefaultSpecifier<'a> {
@@ -7940,11 +7948,11 @@ impl<'a> AstBuilder<'a> {
     /// * `local`: The name of the imported symbol.
     #[inline]
     pub fn alloc_import_default_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ArenaBox<'a, ImportDefaultSpecifier<'a>> {
-        ArenaBox::new_in(self.import_default_specifier(span, local), &self)
+        ArenaBox::new_in(self.import_default_specifier(span, local), self)
     }
 
     /// Build an [`ImportNamespaceSpecifier`].
@@ -7957,7 +7965,7 @@ impl<'a> AstBuilder<'a> {
     /// * `local`
     #[inline]
     pub fn import_namespace_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ImportNamespaceSpecifier<'a> {
@@ -7974,11 +7982,11 @@ impl<'a> AstBuilder<'a> {
     /// * `local`
     #[inline]
     pub fn alloc_import_namespace_specifier(
-        self,
+        &self,
         span: Span,
         local: BindingIdentifier<'a>,
     ) -> ArenaBox<'a, ImportNamespaceSpecifier<'a>> {
-        ArenaBox::new_in(self.import_namespace_specifier(span, local), &self)
+        ArenaBox::new_in(self.import_namespace_specifier(span, local), self)
     }
 
     /// Build a [`WithClause`].
@@ -7992,7 +8000,7 @@ impl<'a> AstBuilder<'a> {
     /// * `with_entries`
     #[inline]
     pub fn with_clause(
-        self,
+        &self,
         span: Span,
         keyword: WithClauseKeyword,
         with_entries: ArenaVec<'a, ImportAttribute<'a>>,
@@ -8011,12 +8019,12 @@ impl<'a> AstBuilder<'a> {
     /// * `with_entries`
     #[inline]
     pub fn alloc_with_clause(
-        self,
+        &self,
         span: Span,
         keyword: WithClauseKeyword,
         with_entries: ArenaVec<'a, ImportAttribute<'a>>,
     ) -> ArenaBox<'a, WithClause<'a>> {
-        ArenaBox::new_in(self.with_clause(span, keyword, with_entries), &self)
+        ArenaBox::new_in(self.with_clause(span, keyword, with_entries), self)
     }
 
     /// Build an [`ImportAttribute`].
@@ -8027,7 +8035,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`
     #[inline]
     pub fn import_attribute(
-        self,
+        &self,
         span: Span,
         key: ImportAttributeKey<'a>,
         value: StringLiteral<'a>,
@@ -8041,7 +8049,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn import_attribute_key_identifier<S1>(self, span: Span, name: S1) -> ImportAttributeKey<'a>
+    pub fn import_attribute_key_identifier<S1>(
+        &self,
+        span: Span,
+        name: S1,
+    ) -> ImportAttributeKey<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -8056,7 +8068,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn import_attribute_key_string_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -8076,7 +8088,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn import_attribute_key_string_literal_with_lone_surrogates<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -8107,7 +8119,7 @@ impl<'a> AstBuilder<'a> {
     /// * `with_clause`: Some(vec![]) for empty assertion
     #[inline]
     pub fn export_named_declaration<T1>(
-        self,
+        &self,
         span: Span,
         declaration: Option<Declaration<'a>>,
         specifiers: ArenaVec<'a, ExportSpecifier<'a>>,
@@ -8125,7 +8137,7 @@ impl<'a> AstBuilder<'a> {
             specifiers,
             source,
             export_kind,
-            with_clause: with_clause.into_in(self.allocator),
+            with_clause: with_clause.into_in(self.allocator()),
         }
     }
 
@@ -8143,7 +8155,7 @@ impl<'a> AstBuilder<'a> {
     /// * `with_clause`: Some(vec![]) for empty assertion
     #[inline]
     pub fn alloc_export_named_declaration<T1>(
-        self,
+        &self,
         span: Span,
         declaration: Option<Declaration<'a>>,
         specifiers: ArenaVec<'a, ExportSpecifier<'a>>,
@@ -8163,7 +8175,7 @@ impl<'a> AstBuilder<'a> {
                 export_kind,
                 with_clause,
             ),
-            &self,
+            self,
         )
     }
 
@@ -8177,7 +8189,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declaration`
     #[inline]
     pub fn export_default_declaration(
-        self,
+        &self,
         span: Span,
         declaration: ExportDefaultDeclarationKind<'a>,
     ) -> ExportDefaultDeclaration<'a> {
@@ -8194,11 +8206,11 @@ impl<'a> AstBuilder<'a> {
     /// * `declaration`
     #[inline]
     pub fn alloc_export_default_declaration(
-        self,
+        &self,
         span: Span,
         declaration: ExportDefaultDeclarationKind<'a>,
     ) -> ArenaBox<'a, ExportDefaultDeclaration<'a>> {
-        ArenaBox::new_in(self.export_default_declaration(span, declaration), &self)
+        ArenaBox::new_in(self.export_default_declaration(span, declaration), self)
     }
 
     /// Build an [`ExportAllDeclaration`].
@@ -8214,7 +8226,7 @@ impl<'a> AstBuilder<'a> {
     /// * `export_kind`
     #[inline]
     pub fn export_all_declaration<T1>(
-        self,
+        &self,
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
@@ -8229,7 +8241,7 @@ impl<'a> AstBuilder<'a> {
             span,
             exported,
             source,
-            with_clause: with_clause.into_in(self.allocator),
+            with_clause: with_clause.into_in(self.allocator()),
             export_kind,
         }
     }
@@ -8247,7 +8259,7 @@ impl<'a> AstBuilder<'a> {
     /// * `export_kind`
     #[inline]
     pub fn alloc_export_all_declaration<T1>(
-        self,
+        &self,
         span: Span,
         exported: Option<ModuleExportName<'a>>,
         source: StringLiteral<'a>,
@@ -8259,7 +8271,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.export_all_declaration(span, exported, source, with_clause, export_kind),
-            &self,
+            self,
         )
     }
 
@@ -8272,7 +8284,7 @@ impl<'a> AstBuilder<'a> {
     /// * `export_kind`
     #[inline]
     pub fn export_specifier(
-        self,
+        &self,
         span: Span,
         local: ModuleExportName<'a>,
         exported: ModuleExportName<'a>,
@@ -8299,7 +8311,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`: The function body.
     #[inline]
     pub fn export_default_declaration_kind_function_declaration<T1, T2, T3, T4, T5>(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -8361,7 +8373,7 @@ impl<'a> AstBuilder<'a> {
         T4,
         T5,
     >(
-        self,
+        &self,
         span: Span,
         r#type: FunctionType,
         id: Option<BindingIdentifier<'a>>,
@@ -8422,7 +8434,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
     pub fn export_default_declaration_kind_class_declaration<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -8474,7 +8486,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
     #[inline]
     pub fn export_default_declaration_kind_class_declaration_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#type: ClassType,
         decorators: ArenaVec<'a, Decorator<'a>>,
@@ -8522,7 +8534,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
     pub fn export_default_declaration_kind_ts_interface_declaration<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -8558,7 +8570,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn export_default_declaration_kind_ts_interface_declaration_with_scope_id<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -8591,7 +8603,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`
     #[inline]
     pub fn module_export_name_identifier_name<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> ModuleExportName<'a>
@@ -8608,7 +8620,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn module_export_name_identifier_reference<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> ModuleExportName<'a>
@@ -8626,7 +8638,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn module_export_name_identifier_reference_with_reference_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         reference_id: ReferenceId,
@@ -8649,7 +8661,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn module_export_name_string_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -8669,7 +8681,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn module_export_name_string_literal_with_lone_surrogates<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -8697,7 +8709,7 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`
     #[inline]
     pub fn v8_intrinsic_expression(
-        self,
+        &self,
         span: Span,
         name: IdentifierName<'a>,
         arguments: ArenaVec<'a, Argument<'a>>,
@@ -8716,12 +8728,12 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`
     #[inline]
     pub fn alloc_v8_intrinsic_expression(
-        self,
+        &self,
         span: Span,
         name: IdentifierName<'a>,
         arguments: ArenaVec<'a, Argument<'a>>,
     ) -> ArenaBox<'a, V8IntrinsicExpression<'a>> {
-        ArenaBox::new_in(self.v8_intrinsic_expression(span, name, arguments), &self)
+        ArenaBox::new_in(self.v8_intrinsic_expression(span, name, arguments), self)
     }
 
     /// Build a [`BooleanLiteral`].
@@ -8733,7 +8745,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The boolean value itself
     #[inline]
-    pub fn boolean_literal(self, span: Span, value: bool) -> BooleanLiteral {
+    pub fn boolean_literal(&self, span: Span, value: bool) -> BooleanLiteral {
         BooleanLiteral { node_id: Default::default(), span, value }
     }
 
@@ -8746,8 +8758,8 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The boolean value itself
     #[inline]
-    pub fn alloc_boolean_literal(self, span: Span, value: bool) -> ArenaBox<'a, BooleanLiteral> {
-        ArenaBox::new_in(self.boolean_literal(span, value), &self)
+    pub fn alloc_boolean_literal(&self, span: Span, value: bool) -> ArenaBox<'a, BooleanLiteral> {
+        ArenaBox::new_in(self.boolean_literal(span, value), self)
     }
 
     /// Build a [`NullLiteral`].
@@ -8758,7 +8770,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     #[inline]
-    pub fn null_literal(self, span: Span) -> NullLiteral {
+    pub fn null_literal(&self, span: Span) -> NullLiteral {
         NullLiteral { node_id: Default::default(), span }
     }
 
@@ -8770,8 +8782,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     #[inline]
-    pub fn alloc_null_literal(self, span: Span) -> ArenaBox<'a, NullLiteral> {
-        ArenaBox::new_in(self.null_literal(span), &self)
+    pub fn alloc_null_literal(&self, span: Span) -> ArenaBox<'a, NullLiteral> {
+        ArenaBox::new_in(self.null_literal(span), self)
     }
 
     /// Build a [`NumericLiteral`].
@@ -8786,7 +8798,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn numeric_literal(
-        self,
+        &self,
         span: Span,
         value: f64,
         raw: Option<Str<'a>>,
@@ -8807,13 +8819,13 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn alloc_numeric_literal(
-        self,
+        &self,
         span: Span,
         value: f64,
         raw: Option<Str<'a>>,
         base: NumberBase,
     ) -> ArenaBox<'a, NumericLiteral<'a>> {
-        ArenaBox::new_in(self.numeric_literal(span, value, raw, base), &self)
+        ArenaBox::new_in(self.numeric_literal(span, value, raw, base), self)
     }
 
     /// Build a [`StringLiteral`].
@@ -8827,7 +8839,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn string_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -8855,7 +8867,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn alloc_string_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -8863,7 +8875,7 @@ impl<'a> AstBuilder<'a> {
     where
         S1: Into<Str<'a>>,
     {
-        ArenaBox::new_in(self.string_literal(span, value, raw), &self)
+        ArenaBox::new_in(self.string_literal(span, value, raw), self)
     }
 
     /// Build a [`StringLiteral`] with `lone_surrogates`.
@@ -8878,7 +8890,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn string_literal_with_lone_surrogates<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -8908,7 +8920,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn alloc_string_literal_with_lone_surrogates<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -8919,7 +8931,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.string_literal_with_lone_surrogates(span, value, raw, lone_surrogates),
-            &self,
+            self,
         )
     }
 
@@ -8935,7 +8947,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn big_int_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -8959,7 +8971,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn alloc_big_int_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -8968,7 +8980,7 @@ impl<'a> AstBuilder<'a> {
     where
         S1: Into<Str<'a>>,
     {
-        ArenaBox::new_in(self.big_int_literal(span, value, raw, base), &self)
+        ArenaBox::new_in(self.big_int_literal(span, value, raw, base), self)
     }
 
     /// Build a [`RegExpLiteral`].
@@ -8982,7 +8994,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The regular expression as it appears in source code
     #[inline]
     pub fn reg_exp_literal(
-        self,
+        &self,
         span: Span,
         regex: RegExp<'a>,
         raw: Option<Str<'a>>,
@@ -9001,12 +9013,12 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The regular expression as it appears in source code
     #[inline]
     pub fn alloc_reg_exp_literal(
-        self,
+        &self,
         span: Span,
         regex: RegExp<'a>,
         raw: Option<Str<'a>>,
     ) -> ArenaBox<'a, RegExpLiteral<'a>> {
-        ArenaBox::new_in(self.reg_exp_literal(span, regex, raw), &self)
+        ArenaBox::new_in(self.reg_exp_literal(span, regex, raw), self)
     }
 
     /// Build a [`JSXElement`].
@@ -9021,7 +9033,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn jsx_element<T1, T2>(
-        self,
+        &self,
         span: Span,
         opening_element: T1,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -9034,9 +9046,9 @@ impl<'a> AstBuilder<'a> {
         JSXElement {
             node_id: Default::default(),
             span,
-            opening_element: opening_element.into_in(self.allocator),
+            opening_element: opening_element.into_in(self.allocator()),
             children,
-            closing_element: closing_element.into_in(self.allocator),
+            closing_element: closing_element.into_in(self.allocator()),
         }
     }
 
@@ -9052,7 +9064,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn alloc_jsx_element<T1, T2>(
-        self,
+        &self,
         span: Span,
         opening_element: T1,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -9062,7 +9074,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, ArenaBox<'a, JSXOpeningElement<'a>>>,
         T2: IntoIn<'a, Option<ArenaBox<'a, JSXClosingElement<'a>>>>,
     {
-        ArenaBox::new_in(self.jsx_element(span, opening_element, children, closing_element), &self)
+        ArenaBox::new_in(self.jsx_element(span, opening_element, children, closing_element), self)
     }
 
     /// Build a [`JSXOpeningElement`].
@@ -9077,7 +9089,7 @@ impl<'a> AstBuilder<'a> {
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     #[inline]
     pub fn jsx_opening_element<T1>(
-        self,
+        &self,
         span: Span,
         name: JSXElementName<'a>,
         type_arguments: T1,
@@ -9090,7 +9102,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             name,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
             attributes,
         }
     }
@@ -9107,7 +9119,7 @@ impl<'a> AstBuilder<'a> {
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     #[inline]
     pub fn alloc_jsx_opening_element<T1>(
-        self,
+        &self,
         span: Span,
         name: JSXElementName<'a>,
         type_arguments: T1,
@@ -9116,7 +9128,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        ArenaBox::new_in(self.jsx_opening_element(span, name, type_arguments, attributes), &self)
+        ArenaBox::new_in(self.jsx_opening_element(span, name, type_arguments, attributes), self)
     }
 
     /// Build a [`JSXClosingElement`].
@@ -9129,7 +9141,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The tag name, e.g. `Foo` in `</Foo>`.
     #[inline]
     pub fn jsx_closing_element(
-        self,
+        &self,
         span: Span,
         name: JSXElementName<'a>,
     ) -> JSXClosingElement<'a> {
@@ -9146,11 +9158,11 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The tag name, e.g. `Foo` in `</Foo>`.
     #[inline]
     pub fn alloc_jsx_closing_element(
-        self,
+        &self,
         span: Span,
         name: JSXElementName<'a>,
     ) -> ArenaBox<'a, JSXClosingElement<'a>> {
-        ArenaBox::new_in(self.jsx_closing_element(span, name), &self)
+        ArenaBox::new_in(self.jsx_closing_element(span, name), self)
     }
 
     /// Build a [`JSXFragment`].
@@ -9165,7 +9177,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     #[inline]
     pub fn jsx_fragment(
-        self,
+        &self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -9192,7 +9204,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     #[inline]
     pub fn alloc_jsx_fragment(
-        self,
+        &self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -9200,7 +9212,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, JSXFragment<'a>> {
         ArenaBox::new_in(
             self.jsx_fragment(span, opening_fragment, children, closing_fragment),
-            &self,
+            self,
         )
     }
 
@@ -9209,7 +9221,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     #[inline]
-    pub fn jsx_opening_fragment(self, span: Span) -> JSXOpeningFragment {
+    pub fn jsx_opening_fragment(&self, span: Span) -> JSXOpeningFragment {
         JSXOpeningFragment { node_id: Default::default(), span }
     }
 
@@ -9218,7 +9230,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     #[inline]
-    pub fn jsx_closing_fragment(self, span: Span) -> JSXClosingFragment {
+    pub fn jsx_closing_fragment(&self, span: Span) -> JSXClosingFragment {
         JSXClosingFragment { node_id: Default::default(), span }
     }
 
@@ -9230,7 +9242,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_element_name_identifier<S1>(self, span: Span, name: S1) -> JSXElementName<'a>
+    pub fn jsx_element_name_identifier<S1>(&self, span: Span, name: S1) -> JSXElementName<'a>
     where
         S1: Into<Str<'a>>,
     {
@@ -9246,7 +9258,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn jsx_element_name_identifier_reference<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> JSXElementName<'a>
@@ -9266,7 +9278,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn jsx_element_name_identifier_reference_with_reference_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         reference_id: ReferenceId,
@@ -9291,7 +9303,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_element_name_namespaced_name(
-        self,
+        &self,
         span: Span,
         namespace: JSXIdentifier<'a>,
         name: JSXIdentifier<'a>,
@@ -9309,7 +9321,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn jsx_element_name_member_expression(
-        self,
+        &self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
@@ -9324,7 +9336,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn jsx_element_name_this_expression(self, span: Span) -> JSXElementName<'a> {
+    pub fn jsx_element_name_this_expression(&self, span: Span) -> JSXElementName<'a> {
         JSXElementName::ThisExpression(self.alloc_this_expression(span))
     }
 
@@ -9339,7 +9351,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_namespaced_name(
-        self,
+        &self,
         span: Span,
         namespace: JSXIdentifier<'a>,
         name: JSXIdentifier<'a>,
@@ -9358,12 +9370,12 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn alloc_jsx_namespaced_name(
-        self,
+        &self,
         span: Span,
         namespace: JSXIdentifier<'a>,
         name: JSXIdentifier<'a>,
     ) -> ArenaBox<'a, JSXNamespacedName<'a>> {
-        ArenaBox::new_in(self.jsx_namespaced_name(span, namespace, name), &self)
+        ArenaBox::new_in(self.jsx_namespaced_name(span, namespace, name), self)
     }
 
     /// Build a [`JSXMemberExpression`].
@@ -9377,7 +9389,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn jsx_member_expression(
-        self,
+        &self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
@@ -9396,12 +9408,12 @@ impl<'a> AstBuilder<'a> {
     /// * `property`: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn alloc_jsx_member_expression(
-        self,
+        &self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
     ) -> ArenaBox<'a, JSXMemberExpression<'a>> {
-        ArenaBox::new_in(self.jsx_member_expression(span, object, property), &self)
+        ArenaBox::new_in(self.jsx_member_expression(span, object, property), self)
     }
 
     /// Build a [`JSXMemberExpressionObject::IdentifierReference`].
@@ -9413,7 +9425,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn jsx_member_expression_object_identifier_reference<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> JSXMemberExpressionObject<'a>
@@ -9433,7 +9445,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn jsx_member_expression_object_identifier_reference_with_reference_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         reference_id: ReferenceId,
@@ -9456,7 +9468,7 @@ impl<'a> AstBuilder<'a> {
     /// * `property`: The property being accessed. This is everything after the last `.`.
     #[inline]
     pub fn jsx_member_expression_object_member_expression(
-        self,
+        &self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
         property: JSXIdentifier<'a>,
@@ -9474,7 +9486,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     #[inline]
     pub fn jsx_member_expression_object_this_expression(
-        self,
+        &self,
         span: Span,
     ) -> JSXMemberExpressionObject<'a> {
         JSXMemberExpressionObject::ThisExpression(self.alloc_this_expression(span))
@@ -9490,7 +9502,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression inside the container.
     #[inline]
     pub fn jsx_expression_container(
-        self,
+        &self,
         span: Span,
         expression: JSXExpression<'a>,
     ) -> JSXExpressionContainer<'a> {
@@ -9507,11 +9519,11 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression inside the container.
     #[inline]
     pub fn alloc_jsx_expression_container(
-        self,
+        &self,
         span: Span,
         expression: JSXExpression<'a>,
     ) -> ArenaBox<'a, JSXExpressionContainer<'a>> {
-        ArenaBox::new_in(self.jsx_expression_container(span, expression), &self)
+        ArenaBox::new_in(self.jsx_expression_container(span, expression), self)
     }
 
     /// Build a [`JSXExpression::EmptyExpression`].
@@ -9521,7 +9533,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     #[inline]
-    pub fn jsx_expression_empty_expression(self, span: Span) -> JSXExpression<'a> {
+    pub fn jsx_expression_empty_expression(&self, span: Span) -> JSXExpression<'a> {
         JSXExpression::EmptyExpression(self.alloc_jsx_empty_expression(span))
     }
 
@@ -9533,7 +9545,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     #[inline]
-    pub fn jsx_empty_expression(self, span: Span) -> JSXEmptyExpression {
+    pub fn jsx_empty_expression(&self, span: Span) -> JSXEmptyExpression {
         JSXEmptyExpression { node_id: Default::default(), span }
     }
 
@@ -9545,8 +9557,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     #[inline]
-    pub fn alloc_jsx_empty_expression(self, span: Span) -> ArenaBox<'a, JSXEmptyExpression> {
-        ArenaBox::new_in(self.jsx_empty_expression(span), &self)
+    pub fn alloc_jsx_empty_expression(&self, span: Span) -> ArenaBox<'a, JSXEmptyExpression> {
+        ArenaBox::new_in(self.jsx_empty_expression(span), self)
     }
 
     /// Build a [`JSXAttributeItem::Attribute`].
@@ -9559,7 +9571,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the attribute. This can be a string literal, an expression,
     #[inline]
     pub fn jsx_attribute_item_attribute(
-        self,
+        &self,
         span: Span,
         name: JSXAttributeName<'a>,
         value: Option<JSXAttributeValue<'a>>,
@@ -9576,7 +9588,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn jsx_attribute_item_spread_attribute(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> JSXAttributeItem<'a> {
@@ -9594,7 +9606,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the attribute. This can be a string literal, an expression,
     #[inline]
     pub fn jsx_attribute(
-        self,
+        &self,
         span: Span,
         name: JSXAttributeName<'a>,
         value: Option<JSXAttributeValue<'a>>,
@@ -9613,12 +9625,12 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the attribute. This can be a string literal, an expression,
     #[inline]
     pub fn alloc_jsx_attribute(
-        self,
+        &self,
         span: Span,
         name: JSXAttributeName<'a>,
         value: Option<JSXAttributeValue<'a>>,
     ) -> ArenaBox<'a, JSXAttribute<'a>> {
-        ArenaBox::new_in(self.jsx_attribute(span, name, value), &self)
+        ArenaBox::new_in(self.jsx_attribute(span, name, value), self)
     }
 
     /// Build a [`JSXSpreadAttribute`].
@@ -9631,7 +9643,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn jsx_spread_attribute(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> JSXSpreadAttribute<'a> {
@@ -9648,11 +9660,11 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`: The expression being spread.
     #[inline]
     pub fn alloc_jsx_spread_attribute(
-        self,
+        &self,
         span: Span,
         argument: Expression<'a>,
     ) -> ArenaBox<'a, JSXSpreadAttribute<'a>> {
-        ArenaBox::new_in(self.jsx_spread_attribute(span, argument), &self)
+        ArenaBox::new_in(self.jsx_spread_attribute(span, argument), self)
     }
 
     /// Build a [`JSXAttributeName::Identifier`].
@@ -9663,7 +9675,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_attribute_name_identifier<S1>(self, span: Span, name: S1) -> JSXAttributeName<'a>
+    pub fn jsx_attribute_name_identifier<S1>(&self, span: Span, name: S1) -> JSXAttributeName<'a>
     where
         S1: Into<Str<'a>>,
     {
@@ -9680,7 +9692,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_attribute_name_namespaced_name(
-        self,
+        &self,
         span: Span,
         namespace: JSXIdentifier<'a>,
         name: JSXIdentifier<'a>,
@@ -9698,7 +9710,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn jsx_attribute_value_string_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -9720,7 +9732,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn jsx_attribute_value_string_literal_with_lone_surrogates<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -9746,7 +9758,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression inside the container.
     #[inline]
     pub fn jsx_attribute_value_expression_container(
-        self,
+        &self,
         span: Span,
         expression: JSXExpression<'a>,
     ) -> JSXAttributeValue<'a> {
@@ -9766,7 +9778,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn jsx_attribute_value_element<T1, T2>(
-        self,
+        &self,
         span: Span,
         opening_element: T1,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -9795,7 +9807,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     #[inline]
     pub fn jsx_attribute_value_fragment(
-        self,
+        &self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -9818,7 +9830,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_identifier<S1>(self, span: Span, name: S1) -> JSXIdentifier<'a>
+    pub fn jsx_identifier<S1>(&self, span: Span, name: S1) -> JSXIdentifier<'a>
     where
         S1: Into<Str<'a>>,
     {
@@ -9834,11 +9846,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn alloc_jsx_identifier<S1>(self, span: Span, name: S1) -> ArenaBox<'a, JSXIdentifier<'a>>
+    pub fn alloc_jsx_identifier<S1>(&self, span: Span, name: S1) -> ArenaBox<'a, JSXIdentifier<'a>>
     where
         S1: Into<Str<'a>>,
     {
-        ArenaBox::new_in(self.jsx_identifier(span, name), &self)
+        ArenaBox::new_in(self.jsx_identifier(span, name), self)
     }
 
     /// Build a [`JSXChild::Text`].
@@ -9850,7 +9862,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn jsx_child_text<S1>(self, span: Span, value: S1, raw: Option<Str<'a>>) -> JSXChild<'a>
+    pub fn jsx_child_text<S1>(&self, span: Span, value: S1, raw: Option<Str<'a>>) -> JSXChild<'a>
     where
         S1: Into<Str<'a>>,
     {
@@ -9868,7 +9880,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element.
     #[inline]
     pub fn jsx_child_element<T1, T2>(
-        self,
+        &self,
         span: Span,
         opening_element: T1,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -9892,7 +9904,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     #[inline]
     pub fn jsx_child_fragment(
-        self,
+        &self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
         children: ArenaVec<'a, JSXChild<'a>>,
@@ -9915,7 +9927,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression inside the container.
     #[inline]
     pub fn jsx_child_expression_container(
-        self,
+        &self,
         span: Span,
         expression: JSXExpression<'a>,
     ) -> JSXChild<'a> {
@@ -9930,7 +9942,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `expression`: The expression being spread.
     #[inline]
-    pub fn jsx_child_spread(self, span: Span, expression: Expression<'a>) -> JSXChild<'a> {
+    pub fn jsx_child_spread(&self, span: Span, expression: Expression<'a>) -> JSXChild<'a> {
         JSXChild::Spread(self.alloc_jsx_spread_child(span, expression))
     }
 
@@ -9943,7 +9955,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `expression`: The expression being spread.
     #[inline]
-    pub fn jsx_spread_child(self, span: Span, expression: Expression<'a>) -> JSXSpreadChild<'a> {
+    pub fn jsx_spread_child(&self, span: Span, expression: Expression<'a>) -> JSXSpreadChild<'a> {
         JSXSpreadChild { node_id: Default::default(), span, expression }
     }
 
@@ -9957,11 +9969,11 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`: The expression being spread.
     #[inline]
     pub fn alloc_jsx_spread_child(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ArenaBox<'a, JSXSpreadChild<'a>> {
-        ArenaBox::new_in(self.jsx_spread_child(span, expression), &self)
+        ArenaBox::new_in(self.jsx_spread_child(span, expression), self)
     }
 
     /// Build a [`JSXText`].
@@ -9974,7 +9986,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn jsx_text<S1>(self, span: Span, value: S1, raw: Option<Str<'a>>) -> JSXText<'a>
+    pub fn jsx_text<S1>(&self, span: Span, value: S1, raw: Option<Str<'a>>) -> JSXText<'a>
     where
         S1: Into<Str<'a>>,
     {
@@ -9992,7 +10004,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn alloc_jsx_text<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -10000,7 +10012,7 @@ impl<'a> AstBuilder<'a> {
     where
         S1: Into<Str<'a>>,
     {
-        ArenaBox::new_in(self.jsx_text(span, value, raw), &self)
+        ArenaBox::new_in(self.jsx_text(span, value, raw), self)
     }
 
     /// Build a [`TSThisParameter`].
@@ -10014,7 +10026,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: Type type the `this` keyword will have in the function
     #[inline]
     pub fn ts_this_parameter<T1>(
-        self,
+        &self,
         span: Span,
         this_span: Span,
         type_annotation: T1,
@@ -10026,7 +10038,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             this_span,
-            type_annotation: type_annotation.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
         }
     }
 
@@ -10041,7 +10053,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: Type type the `this` keyword will have in the function
     #[inline]
     pub fn alloc_ts_this_parameter<T1>(
-        self,
+        &self,
         span: Span,
         this_span: Span,
         type_annotation: T1,
@@ -10049,7 +10061,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeAnnotation<'a>>>>,
     {
-        ArenaBox::new_in(self.ts_this_parameter(span, this_span, type_annotation), &self)
+        ArenaBox::new_in(self.ts_this_parameter(span, this_span, type_annotation), self)
     }
 
     /// Build a [`TSEnumDeclaration`].
@@ -10065,7 +10077,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn ts_enum_declaration(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         body: TSEnumBody<'a>,
@@ -10088,14 +10100,14 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn alloc_ts_enum_declaration(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         body: TSEnumBody<'a>,
         r#const: bool,
         declare: bool,
     ) -> ArenaBox<'a, TSEnumDeclaration<'a>> {
-        ArenaBox::new_in(self.ts_enum_declaration(span, id, body, r#const, declare), &self)
+        ArenaBox::new_in(self.ts_enum_declaration(span, id, body, r#const, declare), self)
     }
 
     /// Build a [`TSEnumBody`].
@@ -10105,7 +10117,7 @@ impl<'a> AstBuilder<'a> {
     /// * `members`
     #[inline]
     pub fn ts_enum_body(
-        self,
+        &self,
         span: Span,
         members: ArenaVec<'a, TSEnumMember<'a>>,
     ) -> TSEnumBody<'a> {
@@ -10120,7 +10132,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_enum_body_with_scope_id(
-        self,
+        &self,
         span: Span,
         members: ArenaVec<'a, TSEnumMember<'a>>,
         scope_id: ScopeId,
@@ -10141,7 +10153,7 @@ impl<'a> AstBuilder<'a> {
     /// * `initializer`
     #[inline]
     pub fn ts_enum_member(
-        self,
+        &self,
         span: Span,
         id: TSEnumMemberName<'a>,
         initializer: Option<Expression<'a>>,
@@ -10157,7 +10169,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn ts_enum_member_name_identifier<S1>(self, span: Span, name: S1) -> TSEnumMemberName<'a>
+    pub fn ts_enum_member_name_identifier<S1>(&self, span: Span, name: S1) -> TSEnumMemberName<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -10174,7 +10186,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn ts_enum_member_name_string<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -10196,7 +10208,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn ts_enum_member_name_string_with_lone_surrogates<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -10223,7 +10235,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn ts_enum_member_name_computed_string<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -10245,7 +10257,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn ts_enum_member_name_computed_string_with_lone_surrogates<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -10272,7 +10284,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn ts_enum_member_name_computed_template_string(
-        self,
+        &self,
         span: Span,
         quasis: ArenaVec<'a, TemplateElement<'a>>,
         expressions: ArenaVec<'a, Expression<'a>>,
@@ -10294,7 +10306,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The actual type in the annotation
     #[inline]
     pub fn ts_type_annotation(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSTypeAnnotation<'a> {
@@ -10311,11 +10323,11 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The actual type in the annotation
     #[inline]
     pub fn alloc_ts_type_annotation(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> ArenaBox<'a, TSTypeAnnotation<'a>> {
-        ArenaBox::new_in(self.ts_type_annotation(span, type_annotation), &self)
+        ArenaBox::new_in(self.ts_type_annotation(span, type_annotation), self)
     }
 
     /// Build a [`TSLiteralType`].
@@ -10327,7 +10339,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `literal`
     #[inline]
-    pub fn ts_literal_type(self, span: Span, literal: TSLiteral<'a>) -> TSLiteralType<'a> {
+    pub fn ts_literal_type(&self, span: Span, literal: TSLiteral<'a>) -> TSLiteralType<'a> {
         TSLiteralType { node_id: Default::default(), span, literal }
     }
 
@@ -10341,11 +10353,11 @@ impl<'a> AstBuilder<'a> {
     /// * `literal`
     #[inline]
     pub fn alloc_ts_literal_type(
-        self,
+        &self,
         span: Span,
         literal: TSLiteral<'a>,
     ) -> ArenaBox<'a, TSLiteralType<'a>> {
-        ArenaBox::new_in(self.ts_literal_type(span, literal), &self)
+        ArenaBox::new_in(self.ts_literal_type(span, literal), self)
     }
 
     /// Build a [`TSLiteral::BooleanLiteral`].
@@ -10356,7 +10368,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The boolean value itself
     #[inline]
-    pub fn ts_literal_boolean_literal(self, span: Span, value: bool) -> TSLiteral<'a> {
+    pub fn ts_literal_boolean_literal(&self, span: Span, value: bool) -> TSLiteral<'a> {
         TSLiteral::BooleanLiteral(self.alloc_boolean_literal(span, value))
     }
 
@@ -10371,7 +10383,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn ts_literal_numeric_literal(
-        self,
+        &self,
         span: Span,
         value: f64,
         raw: Option<Str<'a>>,
@@ -10391,7 +10403,7 @@ impl<'a> AstBuilder<'a> {
     /// * `base`: The base representation used by the literal in source code
     #[inline]
     pub fn ts_literal_big_int_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -10413,7 +10425,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn ts_literal_string_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -10435,7 +10447,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn ts_literal_string_literal_with_lone_surrogates<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -10462,7 +10474,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expressions`
     #[inline]
     pub fn ts_literal_template_literal(
-        self,
+        &self,
         span: Span,
         quasis: ArenaVec<'a, TemplateElement<'a>>,
         expressions: ArenaVec<'a, Expression<'a>>,
@@ -10480,7 +10492,7 @@ impl<'a> AstBuilder<'a> {
     /// * `argument`
     #[inline]
     pub fn ts_literal_unary_expression(
-        self,
+        &self,
         span: Span,
         operator: UnaryOperator,
         argument: Expression<'a>,
@@ -10495,7 +10507,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_any_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_any_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSAnyKeyword(self.alloc_ts_any_keyword(span))
     }
 
@@ -10506,7 +10518,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_big_int_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_big_int_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSBigIntKeyword(self.alloc_ts_big_int_keyword(span))
     }
 
@@ -10517,7 +10529,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_boolean_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_boolean_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSBooleanKeyword(self.alloc_ts_boolean_keyword(span))
     }
 
@@ -10528,7 +10540,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_intrinsic_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_intrinsic_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSIntrinsicKeyword(self.alloc_ts_intrinsic_keyword(span))
     }
 
@@ -10539,7 +10551,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_never_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_never_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSNeverKeyword(self.alloc_ts_never_keyword(span))
     }
 
@@ -10550,7 +10562,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_null_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_null_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSNullKeyword(self.alloc_ts_null_keyword(span))
     }
 
@@ -10561,7 +10573,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_number_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_number_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSNumberKeyword(self.alloc_ts_number_keyword(span))
     }
 
@@ -10572,7 +10584,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_object_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_object_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSObjectKeyword(self.alloc_ts_object_keyword(span))
     }
 
@@ -10583,7 +10595,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_string_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_string_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSStringKeyword(self.alloc_ts_string_keyword(span))
     }
 
@@ -10594,7 +10606,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_symbol_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_symbol_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSSymbolKeyword(self.alloc_ts_symbol_keyword(span))
     }
 
@@ -10605,7 +10617,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_undefined_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_undefined_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSUndefinedKeyword(self.alloc_ts_undefined_keyword(span))
     }
 
@@ -10616,7 +10628,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_unknown_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_unknown_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSUnknownKeyword(self.alloc_ts_unknown_keyword(span))
     }
 
@@ -10627,7 +10639,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_void_keyword(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_void_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSVoidKeyword(self.alloc_ts_void_keyword(span))
     }
 
@@ -10639,7 +10651,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `element_type`
     #[inline]
-    pub fn ts_type_array_type(self, span: Span, element_type: TSType<'a>) -> TSType<'a> {
+    pub fn ts_type_array_type(&self, span: Span, element_type: TSType<'a>) -> TSType<'a> {
         TSType::TSArrayType(self.alloc_ts_array_type(span, element_type))
     }
 
@@ -10655,7 +10667,7 @@ impl<'a> AstBuilder<'a> {
     /// * `false_type`: The type evaluated to if the test is false.
     #[inline]
     pub fn ts_type_conditional_type(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -10684,7 +10696,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_type_conditional_type_with_scope_id(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -10714,7 +10726,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_type_constructor_type<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#abstract: bool,
         type_parameters: T1,
@@ -10748,7 +10760,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_type_constructor_type_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#abstract: bool,
         type_parameters: T1,
@@ -10783,7 +10795,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`: Return type of the function.
     #[inline]
     pub fn ts_type_function_type<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -10818,7 +10830,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_type_function_type_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -10854,7 +10866,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_import_type<T1, T2>(
-        self,
+        &self,
         span: Span,
         source: StringLiteral<'a>,
         options: T1,
@@ -10884,7 +10896,7 @@ impl<'a> AstBuilder<'a> {
     /// * `index_type`
     #[inline]
     pub fn ts_type_indexed_access_type(
-        self,
+        &self,
         span: Span,
         object_type: TSType<'a>,
         index_type: TSType<'a>,
@@ -10904,7 +10916,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
     #[inline]
-    pub fn ts_type_infer_type<T1>(self, span: Span, type_parameter: T1) -> TSType<'a>
+    pub fn ts_type_infer_type<T1>(&self, span: Span, type_parameter: T1) -> TSType<'a>
     where
         T1: IntoIn<'a, ArenaBox<'a, TSTypeParameter<'a>>>,
     {
@@ -10920,7 +10932,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`
     #[inline]
     pub fn ts_type_intersection_type(
-        self,
+        &self,
         span: Span,
         types: ArenaVec<'a, TSType<'a>>,
     ) -> TSType<'a> {
@@ -10935,7 +10947,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `literal`
     #[inline]
-    pub fn ts_type_literal_type(self, span: Span, literal: TSLiteral<'a>) -> TSType<'a> {
+    pub fn ts_type_literal_type(&self, span: Span, literal: TSLiteral<'a>) -> TSType<'a> {
         TSType::TSLiteralType(self.alloc_ts_literal_type(span, literal))
     }
 
@@ -10953,7 +10965,7 @@ impl<'a> AstBuilder<'a> {
     /// * `readonly`: Readonly modifier before keyed index signature
     #[inline]
     pub fn ts_type_mapped_type(
-        self,
+        &self,
         span: Span,
         key: BindingIdentifier<'a>,
         constraint: TSType<'a>,
@@ -10988,7 +11000,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_type_mapped_type_with_scope_id(
-        self,
+        &self,
         span: Span,
         key: BindingIdentifier<'a>,
         constraint: TSType<'a>,
@@ -11021,7 +11033,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn ts_type_named_tuple_member(
-        self,
+        &self,
         span: Span,
         label: IdentifierName<'a>,
         element_type: TSTupleElement<'a>,
@@ -11045,7 +11057,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`: The interpolated expressions in the template literal.
     #[inline]
     pub fn ts_type_template_literal_type(
-        self,
+        &self,
         span: Span,
         quasis: ArenaVec<'a, TemplateElement<'a>>,
         types: ArenaVec<'a, TSType<'a>>,
@@ -11060,7 +11072,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_this_type(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_this_type(&self, span: Span) -> TSType<'a> {
         TSType::TSThisType(self.alloc_ts_this_type(span))
     }
 
@@ -11073,7 +11085,7 @@ impl<'a> AstBuilder<'a> {
     /// * `element_types`
     #[inline]
     pub fn ts_type_tuple_type(
-        self,
+        &self,
         span: Span,
         element_types: ArenaVec<'a, TSTupleElement<'a>>,
     ) -> TSType<'a> {
@@ -11089,7 +11101,7 @@ impl<'a> AstBuilder<'a> {
     /// * `members`
     #[inline]
     pub fn ts_type_type_literal(
-        self,
+        &self,
         span: Span,
         members: ArenaVec<'a, TSSignature<'a>>,
     ) -> TSType<'a> {
@@ -11106,7 +11118,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type being operated on
     #[inline]
     pub fn ts_type_type_operator_type(
-        self,
+        &self,
         span: Span,
         operator: TSTypeOperatorOperator,
         type_annotation: TSType<'a>,
@@ -11125,7 +11137,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_type_type_predicate<T1>(
-        self,
+        &self,
         span: Span,
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
@@ -11152,7 +11164,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_type_query<T1>(
-        self,
+        &self,
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
         type_arguments: T1,
@@ -11173,7 +11185,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_type_reference<T1>(
-        self,
+        &self,
         span: Span,
         type_name: TSTypeName<'a>,
         type_arguments: T1,
@@ -11192,7 +11204,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `types`: The types in the union.
     #[inline]
-    pub fn ts_type_union_type(self, span: Span, types: ArenaVec<'a, TSType<'a>>) -> TSType<'a> {
+    pub fn ts_type_union_type(&self, span: Span, types: ArenaVec<'a, TSType<'a>>) -> TSType<'a> {
         TSType::TSUnionType(self.alloc_ts_union_type(span, types))
     }
 
@@ -11204,7 +11216,11 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     #[inline]
-    pub fn ts_type_parenthesized_type(self, span: Span, type_annotation: TSType<'a>) -> TSType<'a> {
+    pub fn ts_type_parenthesized_type(
+        &self,
+        span: Span,
+        type_annotation: TSType<'a>,
+    ) -> TSType<'a> {
         TSType::TSParenthesizedType(self.alloc_ts_parenthesized_type(span, type_annotation))
     }
 
@@ -11218,7 +11234,7 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`: Was `?` after the type annotation?
     #[inline]
     pub fn ts_type_js_doc_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
@@ -11236,7 +11252,7 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`
     #[inline]
     pub fn ts_type_js_doc_non_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
@@ -11255,7 +11271,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_js_doc_unknown_type(self, span: Span) -> TSType<'a> {
+    pub fn ts_type_js_doc_unknown_type(&self, span: Span) -> TSType<'a> {
         TSType::JSDocUnknownType(self.alloc_js_doc_unknown_type(span))
     }
 
@@ -11272,7 +11288,7 @@ impl<'a> AstBuilder<'a> {
     /// * `false_type`: The type evaluated to if the test is false.
     #[inline]
     pub fn ts_conditional_type(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -11303,7 +11319,7 @@ impl<'a> AstBuilder<'a> {
     /// * `false_type`: The type evaluated to if the test is false.
     #[inline]
     pub fn alloc_ts_conditional_type(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -11312,7 +11328,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, TSConditionalType<'a>> {
         ArenaBox::new_in(
             self.ts_conditional_type(span, check_type, extends_type, true_type, false_type),
-            &self,
+            self,
         )
     }
 
@@ -11330,7 +11346,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_conditional_type_with_scope_id(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -11363,7 +11379,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_conditional_type_with_scope_id(
-        self,
+        &self,
         span: Span,
         check_type: TSType<'a>,
         extends_type: TSType<'a>,
@@ -11380,7 +11396,7 @@ impl<'a> AstBuilder<'a> {
                 false_type,
                 scope_id,
             ),
-            &self,
+            self,
         )
     }
 
@@ -11393,7 +11409,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `types`: The types in the union.
     #[inline]
-    pub fn ts_union_type(self, span: Span, types: ArenaVec<'a, TSType<'a>>) -> TSUnionType<'a> {
+    pub fn ts_union_type(&self, span: Span, types: ArenaVec<'a, TSType<'a>>) -> TSUnionType<'a> {
         TSUnionType { node_id: Default::default(), span, types }
     }
 
@@ -11407,11 +11423,11 @@ impl<'a> AstBuilder<'a> {
     /// * `types`: The types in the union.
     #[inline]
     pub fn alloc_ts_union_type(
-        self,
+        &self,
         span: Span,
         types: ArenaVec<'a, TSType<'a>>,
     ) -> ArenaBox<'a, TSUnionType<'a>> {
-        ArenaBox::new_in(self.ts_union_type(span, types), &self)
+        ArenaBox::new_in(self.ts_union_type(span, types), self)
     }
 
     /// Build a [`TSIntersectionType`].
@@ -11424,7 +11440,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`
     #[inline]
     pub fn ts_intersection_type(
-        self,
+        &self,
         span: Span,
         types: ArenaVec<'a, TSType<'a>>,
     ) -> TSIntersectionType<'a> {
@@ -11441,11 +11457,11 @@ impl<'a> AstBuilder<'a> {
     /// * `types`
     #[inline]
     pub fn alloc_ts_intersection_type(
-        self,
+        &self,
         span: Span,
         types: ArenaVec<'a, TSType<'a>>,
     ) -> ArenaBox<'a, TSIntersectionType<'a>> {
-        ArenaBox::new_in(self.ts_intersection_type(span, types), &self)
+        ArenaBox::new_in(self.ts_intersection_type(span, types), self)
     }
 
     /// Build a [`TSParenthesizedType`].
@@ -11458,7 +11474,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_parenthesized_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSParenthesizedType<'a> {
@@ -11475,11 +11491,11 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_parenthesized_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> ArenaBox<'a, TSParenthesizedType<'a>> {
-        ArenaBox::new_in(self.ts_parenthesized_type(span, type_annotation), &self)
+        ArenaBox::new_in(self.ts_parenthesized_type(span, type_annotation), self)
     }
 
     /// Build a [`TSTypeOperator`].
@@ -11493,7 +11509,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type being operated on
     #[inline]
     pub fn ts_type_operator(
-        self,
+        &self,
         span: Span,
         operator: TSTypeOperatorOperator,
         type_annotation: TSType<'a>,
@@ -11512,12 +11528,12 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type being operated on
     #[inline]
     pub fn alloc_ts_type_operator(
-        self,
+        &self,
         span: Span,
         operator: TSTypeOperatorOperator,
         type_annotation: TSType<'a>,
     ) -> ArenaBox<'a, TSTypeOperator<'a>> {
-        ArenaBox::new_in(self.ts_type_operator(span, operator, type_annotation), &self)
+        ArenaBox::new_in(self.ts_type_operator(span, operator, type_annotation), self)
     }
 
     /// Build a [`TSArrayType`].
@@ -11529,7 +11545,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `element_type`
     #[inline]
-    pub fn ts_array_type(self, span: Span, element_type: TSType<'a>) -> TSArrayType<'a> {
+    pub fn ts_array_type(&self, span: Span, element_type: TSType<'a>) -> TSArrayType<'a> {
         TSArrayType { node_id: Default::default(), span, element_type }
     }
 
@@ -11543,11 +11559,11 @@ impl<'a> AstBuilder<'a> {
     /// * `element_type`
     #[inline]
     pub fn alloc_ts_array_type(
-        self,
+        &self,
         span: Span,
         element_type: TSType<'a>,
     ) -> ArenaBox<'a, TSArrayType<'a>> {
-        ArenaBox::new_in(self.ts_array_type(span, element_type), &self)
+        ArenaBox::new_in(self.ts_array_type(span, element_type), self)
     }
 
     /// Build a [`TSIndexedAccessType`].
@@ -11561,7 +11577,7 @@ impl<'a> AstBuilder<'a> {
     /// * `index_type`
     #[inline]
     pub fn ts_indexed_access_type(
-        self,
+        &self,
         span: Span,
         object_type: TSType<'a>,
         index_type: TSType<'a>,
@@ -11580,12 +11596,12 @@ impl<'a> AstBuilder<'a> {
     /// * `index_type`
     #[inline]
     pub fn alloc_ts_indexed_access_type(
-        self,
+        &self,
         span: Span,
         object_type: TSType<'a>,
         index_type: TSType<'a>,
     ) -> ArenaBox<'a, TSIndexedAccessType<'a>> {
-        ArenaBox::new_in(self.ts_indexed_access_type(span, object_type, index_type), &self)
+        ArenaBox::new_in(self.ts_indexed_access_type(span, object_type, index_type), self)
     }
 
     /// Build a [`TSTupleType`].
@@ -11598,7 +11614,7 @@ impl<'a> AstBuilder<'a> {
     /// * `element_types`
     #[inline]
     pub fn ts_tuple_type(
-        self,
+        &self,
         span: Span,
         element_types: ArenaVec<'a, TSTupleElement<'a>>,
     ) -> TSTupleType<'a> {
@@ -11615,11 +11631,11 @@ impl<'a> AstBuilder<'a> {
     /// * `element_types`
     #[inline]
     pub fn alloc_ts_tuple_type(
-        self,
+        &self,
         span: Span,
         element_types: ArenaVec<'a, TSTupleElement<'a>>,
     ) -> ArenaBox<'a, TSTupleType<'a>> {
-        ArenaBox::new_in(self.ts_tuple_type(span, element_types), &self)
+        ArenaBox::new_in(self.ts_tuple_type(span, element_types), self)
     }
 
     /// Build a [`TSNamedTupleMember`].
@@ -11634,7 +11650,7 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn ts_named_tuple_member(
-        self,
+        &self,
         span: Span,
         label: IdentifierName<'a>,
         element_type: TSTupleElement<'a>,
@@ -11655,13 +11671,13 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`
     #[inline]
     pub fn alloc_ts_named_tuple_member(
-        self,
+        &self,
         span: Span,
         label: IdentifierName<'a>,
         element_type: TSTupleElement<'a>,
         optional: bool,
     ) -> ArenaBox<'a, TSNamedTupleMember<'a>> {
-        ArenaBox::new_in(self.ts_named_tuple_member(span, label, element_type, optional), &self)
+        ArenaBox::new_in(self.ts_named_tuple_member(span, label, element_type, optional), self)
     }
 
     /// Build a [`TSOptionalType`].
@@ -11673,7 +11689,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     #[inline]
-    pub fn ts_optional_type(self, span: Span, type_annotation: TSType<'a>) -> TSOptionalType<'a> {
+    pub fn ts_optional_type(&self, span: Span, type_annotation: TSType<'a>) -> TSOptionalType<'a> {
         TSOptionalType { node_id: Default::default(), span, type_annotation }
     }
 
@@ -11687,11 +11703,11 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_optional_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> ArenaBox<'a, TSOptionalType<'a>> {
-        ArenaBox::new_in(self.ts_optional_type(span, type_annotation), &self)
+        ArenaBox::new_in(self.ts_optional_type(span, type_annotation), self)
     }
 
     /// Build a [`TSRestType`].
@@ -11703,7 +11719,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     #[inline]
-    pub fn ts_rest_type(self, span: Span, type_annotation: TSType<'a>) -> TSRestType<'a> {
+    pub fn ts_rest_type(&self, span: Span, type_annotation: TSType<'a>) -> TSRestType<'a> {
         TSRestType { node_id: Default::default(), span, type_annotation }
     }
 
@@ -11717,11 +11733,11 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_rest_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> ArenaBox<'a, TSRestType<'a>> {
-        ArenaBox::new_in(self.ts_rest_type(span, type_annotation), &self)
+        ArenaBox::new_in(self.ts_rest_type(span, type_annotation), self)
     }
 
     /// Build a [`TSTupleElement::TSOptionalType`].
@@ -11733,7 +11749,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_tuple_element_optional_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSTupleElement<'a> {
@@ -11749,7 +11765,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_tuple_element_rest_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
     ) -> TSTupleElement<'a> {
@@ -11764,7 +11780,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_any_keyword(self, span: Span) -> TSAnyKeyword {
+    pub fn ts_any_keyword(&self, span: Span) -> TSAnyKeyword {
         TSAnyKeyword { node_id: Default::default(), span }
     }
 
@@ -11776,8 +11792,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_any_keyword(self, span: Span) -> ArenaBox<'a, TSAnyKeyword> {
-        ArenaBox::new_in(self.ts_any_keyword(span), &self)
+    pub fn alloc_ts_any_keyword(&self, span: Span) -> ArenaBox<'a, TSAnyKeyword> {
+        ArenaBox::new_in(self.ts_any_keyword(span), self)
     }
 
     /// Build a [`TSStringKeyword`].
@@ -11788,7 +11804,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_string_keyword(self, span: Span) -> TSStringKeyword {
+    pub fn ts_string_keyword(&self, span: Span) -> TSStringKeyword {
         TSStringKeyword { node_id: Default::default(), span }
     }
 
@@ -11800,8 +11816,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_string_keyword(self, span: Span) -> ArenaBox<'a, TSStringKeyword> {
-        ArenaBox::new_in(self.ts_string_keyword(span), &self)
+    pub fn alloc_ts_string_keyword(&self, span: Span) -> ArenaBox<'a, TSStringKeyword> {
+        ArenaBox::new_in(self.ts_string_keyword(span), self)
     }
 
     /// Build a [`TSBooleanKeyword`].
@@ -11812,7 +11828,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_boolean_keyword(self, span: Span) -> TSBooleanKeyword {
+    pub fn ts_boolean_keyword(&self, span: Span) -> TSBooleanKeyword {
         TSBooleanKeyword { node_id: Default::default(), span }
     }
 
@@ -11824,8 +11840,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_boolean_keyword(self, span: Span) -> ArenaBox<'a, TSBooleanKeyword> {
-        ArenaBox::new_in(self.ts_boolean_keyword(span), &self)
+    pub fn alloc_ts_boolean_keyword(&self, span: Span) -> ArenaBox<'a, TSBooleanKeyword> {
+        ArenaBox::new_in(self.ts_boolean_keyword(span), self)
     }
 
     /// Build a [`TSNumberKeyword`].
@@ -11836,7 +11852,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_number_keyword(self, span: Span) -> TSNumberKeyword {
+    pub fn ts_number_keyword(&self, span: Span) -> TSNumberKeyword {
         TSNumberKeyword { node_id: Default::default(), span }
     }
 
@@ -11848,8 +11864,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_number_keyword(self, span: Span) -> ArenaBox<'a, TSNumberKeyword> {
-        ArenaBox::new_in(self.ts_number_keyword(span), &self)
+    pub fn alloc_ts_number_keyword(&self, span: Span) -> ArenaBox<'a, TSNumberKeyword> {
+        ArenaBox::new_in(self.ts_number_keyword(span), self)
     }
 
     /// Build a [`TSNeverKeyword`].
@@ -11860,7 +11876,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_never_keyword(self, span: Span) -> TSNeverKeyword {
+    pub fn ts_never_keyword(&self, span: Span) -> TSNeverKeyword {
         TSNeverKeyword { node_id: Default::default(), span }
     }
 
@@ -11872,8 +11888,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_never_keyword(self, span: Span) -> ArenaBox<'a, TSNeverKeyword> {
-        ArenaBox::new_in(self.ts_never_keyword(span), &self)
+    pub fn alloc_ts_never_keyword(&self, span: Span) -> ArenaBox<'a, TSNeverKeyword> {
+        ArenaBox::new_in(self.ts_never_keyword(span), self)
     }
 
     /// Build a [`TSIntrinsicKeyword`].
@@ -11884,7 +11900,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_intrinsic_keyword(self, span: Span) -> TSIntrinsicKeyword {
+    pub fn ts_intrinsic_keyword(&self, span: Span) -> TSIntrinsicKeyword {
         TSIntrinsicKeyword { node_id: Default::default(), span }
     }
 
@@ -11896,8 +11912,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_intrinsic_keyword(self, span: Span) -> ArenaBox<'a, TSIntrinsicKeyword> {
-        ArenaBox::new_in(self.ts_intrinsic_keyword(span), &self)
+    pub fn alloc_ts_intrinsic_keyword(&self, span: Span) -> ArenaBox<'a, TSIntrinsicKeyword> {
+        ArenaBox::new_in(self.ts_intrinsic_keyword(span), self)
     }
 
     /// Build a [`TSUnknownKeyword`].
@@ -11908,7 +11924,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_unknown_keyword(self, span: Span) -> TSUnknownKeyword {
+    pub fn ts_unknown_keyword(&self, span: Span) -> TSUnknownKeyword {
         TSUnknownKeyword { node_id: Default::default(), span }
     }
 
@@ -11920,8 +11936,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_unknown_keyword(self, span: Span) -> ArenaBox<'a, TSUnknownKeyword> {
-        ArenaBox::new_in(self.ts_unknown_keyword(span), &self)
+    pub fn alloc_ts_unknown_keyword(&self, span: Span) -> ArenaBox<'a, TSUnknownKeyword> {
+        ArenaBox::new_in(self.ts_unknown_keyword(span), self)
     }
 
     /// Build a [`TSNullKeyword`].
@@ -11932,7 +11948,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_null_keyword(self, span: Span) -> TSNullKeyword {
+    pub fn ts_null_keyword(&self, span: Span) -> TSNullKeyword {
         TSNullKeyword { node_id: Default::default(), span }
     }
 
@@ -11944,8 +11960,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_null_keyword(self, span: Span) -> ArenaBox<'a, TSNullKeyword> {
-        ArenaBox::new_in(self.ts_null_keyword(span), &self)
+    pub fn alloc_ts_null_keyword(&self, span: Span) -> ArenaBox<'a, TSNullKeyword> {
+        ArenaBox::new_in(self.ts_null_keyword(span), self)
     }
 
     /// Build a [`TSUndefinedKeyword`].
@@ -11956,7 +11972,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_undefined_keyword(self, span: Span) -> TSUndefinedKeyword {
+    pub fn ts_undefined_keyword(&self, span: Span) -> TSUndefinedKeyword {
         TSUndefinedKeyword { node_id: Default::default(), span }
     }
 
@@ -11968,8 +11984,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_undefined_keyword(self, span: Span) -> ArenaBox<'a, TSUndefinedKeyword> {
-        ArenaBox::new_in(self.ts_undefined_keyword(span), &self)
+    pub fn alloc_ts_undefined_keyword(&self, span: Span) -> ArenaBox<'a, TSUndefinedKeyword> {
+        ArenaBox::new_in(self.ts_undefined_keyword(span), self)
     }
 
     /// Build a [`TSVoidKeyword`].
@@ -11980,7 +11996,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_void_keyword(self, span: Span) -> TSVoidKeyword {
+    pub fn ts_void_keyword(&self, span: Span) -> TSVoidKeyword {
         TSVoidKeyword { node_id: Default::default(), span }
     }
 
@@ -11992,8 +12008,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_void_keyword(self, span: Span) -> ArenaBox<'a, TSVoidKeyword> {
-        ArenaBox::new_in(self.ts_void_keyword(span), &self)
+    pub fn alloc_ts_void_keyword(&self, span: Span) -> ArenaBox<'a, TSVoidKeyword> {
+        ArenaBox::new_in(self.ts_void_keyword(span), self)
     }
 
     /// Build a [`TSSymbolKeyword`].
@@ -12004,7 +12020,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_symbol_keyword(self, span: Span) -> TSSymbolKeyword {
+    pub fn ts_symbol_keyword(&self, span: Span) -> TSSymbolKeyword {
         TSSymbolKeyword { node_id: Default::default(), span }
     }
 
@@ -12016,8 +12032,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_symbol_keyword(self, span: Span) -> ArenaBox<'a, TSSymbolKeyword> {
-        ArenaBox::new_in(self.ts_symbol_keyword(span), &self)
+    pub fn alloc_ts_symbol_keyword(&self, span: Span) -> ArenaBox<'a, TSSymbolKeyword> {
+        ArenaBox::new_in(self.ts_symbol_keyword(span), self)
     }
 
     /// Build a [`TSThisType`].
@@ -12028,7 +12044,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_this_type(self, span: Span) -> TSThisType {
+    pub fn ts_this_type(&self, span: Span) -> TSThisType {
         TSThisType { node_id: Default::default(), span }
     }
 
@@ -12040,8 +12056,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_this_type(self, span: Span) -> ArenaBox<'a, TSThisType> {
-        ArenaBox::new_in(self.ts_this_type(span), &self)
+    pub fn alloc_ts_this_type(&self, span: Span) -> ArenaBox<'a, TSThisType> {
+        ArenaBox::new_in(self.ts_this_type(span), self)
     }
 
     /// Build a [`TSObjectKeyword`].
@@ -12052,7 +12068,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_object_keyword(self, span: Span) -> TSObjectKeyword {
+    pub fn ts_object_keyword(&self, span: Span) -> TSObjectKeyword {
         TSObjectKeyword { node_id: Default::default(), span }
     }
 
@@ -12064,8 +12080,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_object_keyword(self, span: Span) -> ArenaBox<'a, TSObjectKeyword> {
-        ArenaBox::new_in(self.ts_object_keyword(span), &self)
+    pub fn alloc_ts_object_keyword(&self, span: Span) -> ArenaBox<'a, TSObjectKeyword> {
+        ArenaBox::new_in(self.ts_object_keyword(span), self)
     }
 
     /// Build a [`TSBigIntKeyword`].
@@ -12076,7 +12092,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_big_int_keyword(self, span: Span) -> TSBigIntKeyword {
+    pub fn ts_big_int_keyword(&self, span: Span) -> TSBigIntKeyword {
         TSBigIntKeyword { node_id: Default::default(), span }
     }
 
@@ -12088,8 +12104,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_ts_big_int_keyword(self, span: Span) -> ArenaBox<'a, TSBigIntKeyword> {
-        ArenaBox::new_in(self.ts_big_int_keyword(span), &self)
+    pub fn alloc_ts_big_int_keyword(&self, span: Span) -> ArenaBox<'a, TSBigIntKeyword> {
+        ArenaBox::new_in(self.ts_big_int_keyword(span), self)
     }
 
     /// Build a [`TSTypeReference`].
@@ -12103,7 +12119,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_reference<T1>(
-        self,
+        &self,
         span: Span,
         type_name: TSTypeName<'a>,
         type_arguments: T1,
@@ -12115,7 +12131,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             type_name,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
         }
     }
 
@@ -12130,7 +12146,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_type_reference<T1>(
-        self,
+        &self,
         span: Span,
         type_name: TSTypeName<'a>,
         type_arguments: T1,
@@ -12138,7 +12154,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        ArenaBox::new_in(self.ts_type_reference(span, type_name, type_arguments), &self)
+        ArenaBox::new_in(self.ts_type_reference(span, type_name, type_arguments), self)
     }
 
     /// Build a [`TSTypeName::IdentifierReference`].
@@ -12149,7 +12165,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn ts_type_name_identifier_reference<S1>(self, span: Span, name: S1) -> TSTypeName<'a>
+    pub fn ts_type_name_identifier_reference<S1>(&self, span: Span, name: S1) -> TSTypeName<'a>
     where
         S1: Into<Ident<'a>>,
     {
@@ -12166,7 +12182,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn ts_type_name_identifier_reference_with_reference_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         reference_id: ReferenceId,
@@ -12191,7 +12207,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn ts_type_name_qualified_name(
-        self,
+        &self,
         span: Span,
         left: TSTypeName<'a>,
         right: IdentifierName<'a>,
@@ -12206,7 +12222,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_name_this_expression(self, span: Span) -> TSTypeName<'a> {
+    pub fn ts_type_name_this_expression(&self, span: Span) -> TSTypeName<'a> {
         TSTypeName::ThisExpression(self.alloc_this_expression(span))
     }
 
@@ -12221,7 +12237,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn ts_qualified_name(
-        self,
+        &self,
         span: Span,
         left: TSTypeName<'a>,
         right: IdentifierName<'a>,
@@ -12240,12 +12256,12 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_ts_qualified_name(
-        self,
+        &self,
         span: Span,
         left: TSTypeName<'a>,
         right: IdentifierName<'a>,
     ) -> ArenaBox<'a, TSQualifiedName<'a>> {
-        ArenaBox::new_in(self.ts_qualified_name(span, left, right), &self)
+        ArenaBox::new_in(self.ts_qualified_name(span, left, right), self)
     }
 
     /// Build a [`TSTypeParameterInstantiation`].
@@ -12258,7 +12274,7 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     #[inline]
     pub fn ts_type_parameter_instantiation(
-        self,
+        &self,
         span: Span,
         params: ArenaVec<'a, TSType<'a>>,
     ) -> TSTypeParameterInstantiation<'a> {
@@ -12275,11 +12291,11 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     #[inline]
     pub fn alloc_ts_type_parameter_instantiation(
-        self,
+        &self,
         span: Span,
         params: ArenaVec<'a, TSType<'a>>,
     ) -> ArenaBox<'a, TSTypeParameterInstantiation<'a>> {
-        ArenaBox::new_in(self.ts_type_parameter_instantiation(span, params), &self)
+        ArenaBox::new_in(self.ts_type_parameter_instantiation(span, params), self)
     }
 
     /// Build a [`TSTypeParameter`].
@@ -12297,7 +12313,7 @@ impl<'a> AstBuilder<'a> {
     /// * `const`: Was a `const` modifier keyword present?
     #[inline]
     pub fn ts_type_parameter(
-        self,
+        &self,
         span: Span,
         name: BindingIdentifier<'a>,
         constraint: Option<TSType<'a>>,
@@ -12333,7 +12349,7 @@ impl<'a> AstBuilder<'a> {
     /// * `const`: Was a `const` modifier keyword present?
     #[inline]
     pub fn alloc_ts_type_parameter(
-        self,
+        &self,
         span: Span,
         name: BindingIdentifier<'a>,
         constraint: Option<TSType<'a>>,
@@ -12344,7 +12360,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, TSTypeParameter<'a>> {
         ArenaBox::new_in(
             self.ts_type_parameter(span, name, constraint, default, r#in, out, r#const),
-            &self,
+            self,
         )
     }
 
@@ -12358,7 +12374,7 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     #[inline]
     pub fn ts_type_parameter_declaration(
-        self,
+        &self,
         span: Span,
         params: ArenaVec<'a, TSTypeParameter<'a>>,
     ) -> TSTypeParameterDeclaration<'a> {
@@ -12375,11 +12391,11 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     #[inline]
     pub fn alloc_ts_type_parameter_declaration(
-        self,
+        &self,
         span: Span,
         params: ArenaVec<'a, TSTypeParameter<'a>>,
     ) -> ArenaBox<'a, TSTypeParameterDeclaration<'a>> {
-        ArenaBox::new_in(self.ts_type_parameter_declaration(span, params), &self)
+        ArenaBox::new_in(self.ts_type_parameter_declaration(span, params), self)
     }
 
     /// Build a [`TSTypeAliasDeclaration`].
@@ -12395,7 +12411,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn ts_type_alias_declaration<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12409,7 +12425,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             id,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
             type_annotation,
             declare,
             scope_id: Default::default(),
@@ -12429,7 +12445,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn alloc_ts_type_alias_declaration<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12441,7 +12457,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.ts_type_alias_declaration(span, id, type_parameters, type_annotation, declare),
-            &self,
+            self,
         )
     }
 
@@ -12459,7 +12475,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_type_alias_declaration_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12474,7 +12490,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             id,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
             type_annotation,
             declare,
             scope_id: Cell::new(Some(scope_id)),
@@ -12495,7 +12511,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_type_alias_declaration_with_scope_id<T1>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12515,7 +12531,7 @@ impl<'a> AstBuilder<'a> {
                 declare,
                 scope_id,
             ),
-            &self,
+            self,
         )
     }
 
@@ -12527,7 +12543,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_class_implements<T1>(
-        self,
+        &self,
         span: Span,
         expression: TSTypeName<'a>,
         type_arguments: T1,
@@ -12539,7 +12555,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             expression,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
         }
     }
 
@@ -12557,7 +12573,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
     pub fn ts_interface_declaration<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12573,9 +12589,9 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             id,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
             extends,
-            body: body.into_in(self.allocator),
+            body: body.into_in(self.allocator()),
             declare,
             scope_id: Default::default(),
         }
@@ -12595,7 +12611,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
     pub fn alloc_ts_interface_declaration<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12609,7 +12625,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.ts_interface_declaration(span, id, type_parameters, extends, body, declare),
-            &self,
+            self,
         )
     }
 
@@ -12628,7 +12644,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_interface_declaration_with_scope_id<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12645,9 +12661,9 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             id,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
             extends,
-            body: body.into_in(self.allocator),
+            body: body.into_in(self.allocator()),
             declare,
             scope_id: Cell::new(Some(scope_id)),
         }
@@ -12668,7 +12684,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_interface_declaration_with_scope_id<T1, T2>(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         type_parameters: T1,
@@ -12691,7 +12707,7 @@ impl<'a> AstBuilder<'a> {
                 declare,
                 scope_id,
             ),
-            &self,
+            self,
         )
     }
 
@@ -12705,7 +12721,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn ts_interface_body(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, TSSignature<'a>>,
     ) -> TSInterfaceBody<'a> {
@@ -12722,11 +12738,11 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_ts_interface_body(
-        self,
+        &self,
         span: Span,
         body: ArenaVec<'a, TSSignature<'a>>,
     ) -> ArenaBox<'a, TSInterfaceBody<'a>> {
-        ArenaBox::new_in(self.ts_interface_body(span, body), &self)
+        ArenaBox::new_in(self.ts_interface_body(span, body), self)
     }
 
     /// Build a [`TSPropertySignature`].
@@ -12743,7 +12759,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_property_signature<T1>(
-        self,
+        &self,
         span: Span,
         computed: bool,
         optional: bool,
@@ -12761,7 +12777,7 @@ impl<'a> AstBuilder<'a> {
             optional,
             readonly,
             key,
-            type_annotation: type_annotation.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
         }
     }
 
@@ -12779,7 +12795,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_property_signature<T1>(
-        self,
+        &self,
         span: Span,
         computed: bool,
         optional: bool,
@@ -12792,7 +12808,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.ts_property_signature(span, computed, optional, readonly, key, type_annotation),
-            &self,
+            self,
         )
     }
 
@@ -12808,7 +12824,7 @@ impl<'a> AstBuilder<'a> {
     /// * `static`
     #[inline]
     pub fn ts_signature_index_signature<T1>(
-        self,
+        &self,
         span: Span,
         parameters: ArenaVec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
@@ -12840,7 +12856,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_signature_property_signature<T1>(
-        self,
+        &self,
         span: Span,
         computed: bool,
         optional: bool,
@@ -12873,7 +12889,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_signature_call_signature_declaration<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -12908,7 +12924,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_signature_call_signature_declaration_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -12945,7 +12961,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_signature_construct_signature_declaration<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -12976,7 +12992,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_signature_construct_signature_declaration_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -13015,7 +13031,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_signature_method_signature<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -13062,7 +13078,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_signature_method_signature_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -13107,7 +13123,7 @@ impl<'a> AstBuilder<'a> {
     /// * `static`
     #[inline]
     pub fn ts_index_signature<T1>(
-        self,
+        &self,
         span: Span,
         parameters: ArenaVec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
@@ -13121,7 +13137,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             parameters,
-            type_annotation: type_annotation.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
             readonly,
             r#static,
         }
@@ -13140,7 +13156,7 @@ impl<'a> AstBuilder<'a> {
     /// * `static`
     #[inline]
     pub fn alloc_ts_index_signature<T1>(
-        self,
+        &self,
         span: Span,
         parameters: ArenaVec<'a, TSIndexSignatureName<'a>>,
         type_annotation: T1,
@@ -13152,7 +13168,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.ts_index_signature(span, parameters, type_annotation, readonly, r#static),
-            &self,
+            self,
         )
     }
 
@@ -13169,7 +13185,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_call_signature_declaration<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -13185,10 +13201,10 @@ impl<'a> AstBuilder<'a> {
         TSCallSignatureDeclaration {
             node_id: Default::default(),
             span,
-            type_parameters: type_parameters.into_in(self.allocator),
-            this_param: this_param.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            this_param: this_param.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
             scope_id: Default::default(),
         }
     }
@@ -13206,7 +13222,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn alloc_ts_call_signature_declaration<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -13227,7 +13243,7 @@ impl<'a> AstBuilder<'a> {
                 params,
                 return_type,
             ),
-            &self,
+            self,
         )
     }
 
@@ -13245,7 +13261,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_call_signature_declaration_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -13262,10 +13278,10 @@ impl<'a> AstBuilder<'a> {
         TSCallSignatureDeclaration {
             node_id: Default::default(),
             span,
-            type_parameters: type_parameters.into_in(self.allocator),
-            this_param: this_param.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            this_param: this_param.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -13284,7 +13300,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_call_signature_declaration_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -13307,7 +13323,7 @@ impl<'a> AstBuilder<'a> {
                 return_type,
                 scope_id,
             ),
-            &self,
+            self,
         )
     }
 
@@ -13328,7 +13344,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_method_signature<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -13352,10 +13368,10 @@ impl<'a> AstBuilder<'a> {
             computed,
             optional,
             kind,
-            type_parameters: type_parameters.into_in(self.allocator),
-            this_param: this_param.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            this_param: this_param.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
             scope_id: Default::default(),
         }
     }
@@ -13377,7 +13393,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn alloc_ts_method_signature<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -13406,7 +13422,7 @@ impl<'a> AstBuilder<'a> {
                 params,
                 return_type,
             ),
-            &self,
+            self,
         )
     }
 
@@ -13428,7 +13444,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_method_signature_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -13453,10 +13469,10 @@ impl<'a> AstBuilder<'a> {
             computed,
             optional,
             kind,
-            type_parameters: type_parameters.into_in(self.allocator),
-            this_param: this_param.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            this_param: this_param.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -13479,7 +13495,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_method_signature_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         key: PropertyKey<'a>,
         computed: bool,
@@ -13510,7 +13526,7 @@ impl<'a> AstBuilder<'a> {
                 return_type,
                 scope_id,
             ),
-            &self,
+            self,
         )
     }
 
@@ -13526,7 +13542,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_construct_signature_declaration<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -13540,9 +13556,9 @@ impl<'a> AstBuilder<'a> {
         TSConstructSignatureDeclaration {
             node_id: Default::default(),
             span,
-            type_parameters: type_parameters.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
             scope_id: Default::default(),
         }
     }
@@ -13559,7 +13575,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn alloc_ts_construct_signature_declaration<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -13572,7 +13588,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.ts_construct_signature_declaration(span, type_parameters, params, return_type),
-            &self,
+            self,
         )
     }
 
@@ -13589,7 +13605,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_construct_signature_declaration_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -13604,9 +13620,9 @@ impl<'a> AstBuilder<'a> {
         TSConstructSignatureDeclaration {
             node_id: Default::default(),
             span,
-            type_parameters: type_parameters.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -13624,7 +13640,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_construct_signature_declaration_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         params: T2,
@@ -13644,7 +13660,7 @@ impl<'a> AstBuilder<'a> {
                 return_type,
                 scope_id,
             ),
-            &self,
+            self,
         )
     }
 
@@ -13656,7 +13672,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_index_signature_name<S1, T1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         type_annotation: T1,
@@ -13669,7 +13685,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             name: name.into(),
-            type_annotation: type_annotation.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
         }
     }
 
@@ -13681,7 +13697,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_interface_heritage<T1>(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_arguments: T1,
@@ -13693,7 +13709,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             expression,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
         }
     }
 
@@ -13709,7 +13725,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_type_predicate<T1>(
-        self,
+        &self,
         span: Span,
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
@@ -13723,7 +13739,7 @@ impl<'a> AstBuilder<'a> {
             span,
             parameter_name,
             asserts,
-            type_annotation: type_annotation.into_in(self.allocator),
+            type_annotation: type_annotation.into_in(self.allocator()),
         }
     }
 
@@ -13739,7 +13755,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_type_predicate<T1>(
-        self,
+        &self,
         span: Span,
         parameter_name: TSTypePredicateName<'a>,
         asserts: bool,
@@ -13750,7 +13766,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.ts_type_predicate(span, parameter_name, asserts, type_annotation),
-            &self,
+            self,
         )
     }
 
@@ -13763,7 +13779,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`
     #[inline]
     pub fn ts_type_predicate_name_identifier<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> TSTypePredicateName<'a>
@@ -13780,7 +13796,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_predicate_name_this(self, span: Span) -> TSTypePredicateName<'a> {
+    pub fn ts_type_predicate_name_this(&self, span: Span) -> TSTypePredicateName<'a> {
         TSTypePredicateName::This(self.alloc_ts_this_type(span))
     }
 
@@ -13797,7 +13813,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn ts_module_declaration(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -13828,14 +13844,14 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn alloc_ts_module_declaration(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
         kind: TSModuleDeclarationKind,
         declare: bool,
     ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
-        ArenaBox::new_in(self.ts_module_declaration(span, id, body, kind, declare), &self)
+        ArenaBox::new_in(self.ts_module_declaration(span, id, body, kind, declare), self)
     }
 
     /// Build a [`TSModuleDeclaration`] with `scope_id`.
@@ -13852,7 +13868,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_module_declaration_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -13885,7 +13901,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_module_declaration_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -13895,7 +13911,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, TSModuleDeclaration<'a>> {
         ArenaBox::new_in(
             self.ts_module_declaration_with_scope_id(span, id, body, kind, declare, scope_id),
-            &self,
+            self,
         )
     }
 
@@ -13906,7 +13922,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The identifier name being bound.
     #[inline]
     pub fn ts_module_declaration_name_identifier<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> TSModuleDeclarationName<'a>
@@ -13924,7 +13940,7 @@ impl<'a> AstBuilder<'a> {
     /// * `symbol_id`: Unique identifier for this binding.
     #[inline]
     pub fn ts_module_declaration_name_identifier_with_symbol_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         symbol_id: SymbolId,
@@ -13945,7 +13961,7 @@ impl<'a> AstBuilder<'a> {
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
     pub fn ts_module_declaration_name_string_literal<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -13965,7 +13981,7 @@ impl<'a> AstBuilder<'a> {
     /// * `lone_surrogates`: The string value contains lone surrogates.
     #[inline]
     pub fn ts_module_declaration_name_string_literal_with_lone_surrogates<S1>(
-        self,
+        &self,
         span: Span,
         value: S1,
         raw: Option<Str<'a>>,
@@ -13994,7 +14010,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn ts_module_declaration_body_module_declaration(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -14019,7 +14035,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_module_declaration_body_module_declaration_with_scope_id(
-        self,
+        &self,
         span: Span,
         id: TSModuleDeclarationName<'a>,
         body: Option<TSModuleDeclarationBody<'a>>,
@@ -14042,7 +14058,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn ts_module_declaration_body_module_block(
-        self,
+        &self,
         span: Span,
         directives: ArenaVec<'a, Directive<'a>>,
         body: ArenaVec<'a, Statement<'a>>,
@@ -14062,7 +14078,7 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn ts_global_declaration(
-        self,
+        &self,
         span: Span,
         global_span: Span,
         body: TSModuleBlock<'a>,
@@ -14090,13 +14106,13 @@ impl<'a> AstBuilder<'a> {
     /// * `declare`
     #[inline]
     pub fn alloc_ts_global_declaration(
-        self,
+        &self,
         span: Span,
         global_span: Span,
         body: TSModuleBlock<'a>,
         declare: bool,
     ) -> ArenaBox<'a, TSGlobalDeclaration<'a>> {
-        ArenaBox::new_in(self.ts_global_declaration(span, global_span, body, declare), &self)
+        ArenaBox::new_in(self.ts_global_declaration(span, global_span, body, declare), self)
     }
 
     /// Build a [`TSGlobalDeclaration`] with `scope_id`.
@@ -14112,7 +14128,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_global_declaration_with_scope_id(
-        self,
+        &self,
         span: Span,
         global_span: Span,
         body: TSModuleBlock<'a>,
@@ -14142,7 +14158,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_global_declaration_with_scope_id(
-        self,
+        &self,
         span: Span,
         global_span: Span,
         body: TSModuleBlock<'a>,
@@ -14151,7 +14167,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, TSGlobalDeclaration<'a>> {
         ArenaBox::new_in(
             self.ts_global_declaration_with_scope_id(span, global_span, body, declare, scope_id),
-            &self,
+            self,
         )
     }
 
@@ -14166,7 +14182,7 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn ts_module_block(
-        self,
+        &self,
         span: Span,
         directives: ArenaVec<'a, Directive<'a>>,
         body: ArenaVec<'a, Statement<'a>>,
@@ -14185,12 +14201,12 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     #[inline]
     pub fn alloc_ts_module_block(
-        self,
+        &self,
         span: Span,
         directives: ArenaVec<'a, Directive<'a>>,
         body: ArenaVec<'a, Statement<'a>>,
     ) -> ArenaBox<'a, TSModuleBlock<'a>> {
-        ArenaBox::new_in(self.ts_module_block(span, directives, body), &self)
+        ArenaBox::new_in(self.ts_module_block(span, directives, body), self)
     }
 
     /// Build a [`TSTypeLiteral`].
@@ -14203,7 +14219,7 @@ impl<'a> AstBuilder<'a> {
     /// * `members`
     #[inline]
     pub fn ts_type_literal(
-        self,
+        &self,
         span: Span,
         members: ArenaVec<'a, TSSignature<'a>>,
     ) -> TSTypeLiteral<'a> {
@@ -14220,11 +14236,11 @@ impl<'a> AstBuilder<'a> {
     /// * `members`
     #[inline]
     pub fn alloc_ts_type_literal(
-        self,
+        &self,
         span: Span,
         members: ArenaVec<'a, TSSignature<'a>>,
     ) -> ArenaBox<'a, TSTypeLiteral<'a>> {
-        ArenaBox::new_in(self.ts_type_literal(span, members), &self)
+        ArenaBox::new_in(self.ts_type_literal(span, members), self)
     }
 
     /// Build a [`TSInferType`].
@@ -14236,14 +14252,14 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
     #[inline]
-    pub fn ts_infer_type<T1>(self, span: Span, type_parameter: T1) -> TSInferType<'a>
+    pub fn ts_infer_type<T1>(&self, span: Span, type_parameter: T1) -> TSInferType<'a>
     where
         T1: IntoIn<'a, ArenaBox<'a, TSTypeParameter<'a>>>,
     {
         TSInferType {
             node_id: Default::default(),
             span,
-            type_parameter: type_parameter.into_in(self.allocator),
+            type_parameter: type_parameter.into_in(self.allocator()),
         }
     }
 
@@ -14257,14 +14273,14 @@ impl<'a> AstBuilder<'a> {
     /// * `type_parameter`: The type bound when the
     #[inline]
     pub fn alloc_ts_infer_type<T1>(
-        self,
+        &self,
         span: Span,
         type_parameter: T1,
     ) -> ArenaBox<'a, TSInferType<'a>>
     where
         T1: IntoIn<'a, ArenaBox<'a, TSTypeParameter<'a>>>,
     {
-        ArenaBox::new_in(self.ts_infer_type(span, type_parameter), &self)
+        ArenaBox::new_in(self.ts_infer_type(span, type_parameter), self)
     }
 
     /// Build a [`TSTypeQuery`].
@@ -14278,7 +14294,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_query<T1>(
-        self,
+        &self,
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
         type_arguments: T1,
@@ -14290,7 +14306,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             expr_name,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
         }
     }
 
@@ -14305,7 +14321,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_type_query<T1>(
-        self,
+        &self,
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
         type_arguments: T1,
@@ -14313,7 +14329,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        ArenaBox::new_in(self.ts_type_query(span, expr_name, type_arguments), &self)
+        ArenaBox::new_in(self.ts_type_query(span, expr_name, type_arguments), self)
     }
 
     /// Build a [`TSTypeQueryExprName::TSImportType`].
@@ -14328,7 +14344,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_type_query_expr_name_import_type<T1, T2>(
-        self,
+        &self,
         span: Span,
         source: StringLiteral<'a>,
         options: T1,
@@ -14361,7 +14377,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_import_type<T1, T2>(
-        self,
+        &self,
         span: Span,
         source: StringLiteral<'a>,
         options: T1,
@@ -14376,9 +14392,9 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             source,
-            options: options.into_in(self.allocator),
+            options: options.into_in(self.allocator()),
             qualifier,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
         }
     }
 
@@ -14395,7 +14411,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_import_type<T1, T2>(
-        self,
+        &self,
         span: Span,
         source: StringLiteral<'a>,
         options: T1,
@@ -14408,7 +14424,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.ts_import_type(span, source, options, qualifier, type_arguments),
-            &self,
+            self,
         )
     }
 
@@ -14421,7 +14437,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`
     #[inline]
     pub fn ts_import_type_qualifier_identifier<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> TSImportTypeQualifier<'a>
@@ -14441,7 +14457,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn ts_import_type_qualifier_qualified_name(
-        self,
+        &self,
         span: Span,
         left: TSImportTypeQualifier<'a>,
         right: IdentifierName<'a>,
@@ -14462,7 +14478,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn ts_import_type_qualified_name(
-        self,
+        &self,
         span: Span,
         left: TSImportTypeQualifier<'a>,
         right: IdentifierName<'a>,
@@ -14481,12 +14497,12 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn alloc_ts_import_type_qualified_name(
-        self,
+        &self,
         span: Span,
         left: TSImportTypeQualifier<'a>,
         right: IdentifierName<'a>,
     ) -> ArenaBox<'a, TSImportTypeQualifiedName<'a>> {
-        ArenaBox::new_in(self.ts_import_type_qualified_name(span, left, right), &self)
+        ArenaBox::new_in(self.ts_import_type_qualified_name(span, left, right), self)
     }
 
     /// Build a [`TSFunctionType`].
@@ -14502,7 +14518,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`: Return type of the function.
     #[inline]
     pub fn ts_function_type<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -14518,10 +14534,10 @@ impl<'a> AstBuilder<'a> {
         TSFunctionType {
             node_id: Default::default(),
             span,
-            type_parameters: type_parameters.into_in(self.allocator),
-            this_param: this_param.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            this_param: this_param.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
             scope_id: Default::default(),
         }
     }
@@ -14539,7 +14555,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`: Return type of the function.
     #[inline]
     pub fn alloc_ts_function_type<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -14554,7 +14570,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.ts_function_type(span, type_parameters, this_param, params, return_type),
-            &self,
+            self,
         )
     }
 
@@ -14572,7 +14588,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_function_type_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -14589,10 +14605,10 @@ impl<'a> AstBuilder<'a> {
         TSFunctionType {
             node_id: Default::default(),
             span,
-            type_parameters: type_parameters.into_in(self.allocator),
-            this_param: this_param.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            this_param: this_param.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -14611,7 +14627,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_function_type_with_scope_id<T1, T2, T3, T4>(
-        self,
+        &self,
         span: Span,
         type_parameters: T1,
         this_param: T2,
@@ -14634,7 +14650,7 @@ impl<'a> AstBuilder<'a> {
                 return_type,
                 scope_id,
             ),
-            &self,
+            self,
         )
     }
 
@@ -14651,7 +14667,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn ts_constructor_type<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#abstract: bool,
         type_parameters: T1,
@@ -14667,9 +14683,9 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             r#abstract,
-            type_parameters: type_parameters.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
             scope_id: Default::default(),
         }
     }
@@ -14687,7 +14703,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`
     #[inline]
     pub fn alloc_ts_constructor_type<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#abstract: bool,
         type_parameters: T1,
@@ -14701,7 +14717,7 @@ impl<'a> AstBuilder<'a> {
     {
         ArenaBox::new_in(
             self.ts_constructor_type(span, r#abstract, type_parameters, params, return_type),
-            &self,
+            self,
         )
     }
 
@@ -14719,7 +14735,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_constructor_type_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#abstract: bool,
         type_parameters: T1,
@@ -14736,9 +14752,9 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             r#abstract,
-            type_parameters: type_parameters.into_in(self.allocator),
-            params: params.into_in(self.allocator),
-            return_type: return_type.into_in(self.allocator),
+            type_parameters: type_parameters.into_in(self.allocator()),
+            params: params.into_in(self.allocator()),
+            return_type: return_type.into_in(self.allocator()),
             scope_id: Cell::new(Some(scope_id)),
         }
     }
@@ -14757,7 +14773,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_constructor_type_with_scope_id<T1, T2, T3>(
-        self,
+        &self,
         span: Span,
         r#abstract: bool,
         type_parameters: T1,
@@ -14779,7 +14795,7 @@ impl<'a> AstBuilder<'a> {
                 return_type,
                 scope_id,
             ),
-            &self,
+            self,
         )
     }
 
@@ -14798,7 +14814,7 @@ impl<'a> AstBuilder<'a> {
     /// * `readonly`: Readonly modifier before keyed index signature
     #[inline]
     pub fn ts_mapped_type(
-        self,
+        &self,
         span: Span,
         key: BindingIdentifier<'a>,
         constraint: TSType<'a>,
@@ -14835,7 +14851,7 @@ impl<'a> AstBuilder<'a> {
     /// * `readonly`: Readonly modifier before keyed index signature
     #[inline]
     pub fn alloc_ts_mapped_type(
-        self,
+        &self,
         span: Span,
         key: BindingIdentifier<'a>,
         constraint: TSType<'a>,
@@ -14854,7 +14870,7 @@ impl<'a> AstBuilder<'a> {
                 optional,
                 readonly,
             ),
-            &self,
+            self,
         )
     }
 
@@ -14874,7 +14890,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn ts_mapped_type_with_scope_id(
-        self,
+        &self,
         span: Span,
         key: BindingIdentifier<'a>,
         constraint: TSType<'a>,
@@ -14913,7 +14929,7 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     #[inline]
     pub fn alloc_ts_mapped_type_with_scope_id(
-        self,
+        &self,
         span: Span,
         key: BindingIdentifier<'a>,
         constraint: TSType<'a>,
@@ -14934,7 +14950,7 @@ impl<'a> AstBuilder<'a> {
                 readonly,
                 scope_id,
             ),
-            &self,
+            self,
         )
     }
 
@@ -14949,7 +14965,7 @@ impl<'a> AstBuilder<'a> {
     /// * `types`: The interpolated expressions in the template literal.
     #[inline]
     pub fn ts_template_literal_type(
-        self,
+        &self,
         span: Span,
         quasis: ArenaVec<'a, TemplateElement<'a>>,
         types: ArenaVec<'a, TSType<'a>>,
@@ -14968,12 +14984,12 @@ impl<'a> AstBuilder<'a> {
     /// * `types`: The interpolated expressions in the template literal.
     #[inline]
     pub fn alloc_ts_template_literal_type(
-        self,
+        &self,
         span: Span,
         quasis: ArenaVec<'a, TemplateElement<'a>>,
         types: ArenaVec<'a, TSType<'a>>,
     ) -> ArenaBox<'a, TSTemplateLiteralType<'a>> {
-        ArenaBox::new_in(self.ts_template_literal_type(span, quasis, types), &self)
+        ArenaBox::new_in(self.ts_template_literal_type(span, quasis, types), self)
     }
 
     /// Build a [`TSAsExpression`].
@@ -14987,7 +15003,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn ts_as_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -15006,12 +15022,12 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     #[inline]
     pub fn alloc_ts_as_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
     ) -> ArenaBox<'a, TSAsExpression<'a>> {
-        ArenaBox::new_in(self.ts_as_expression(span, expression, type_annotation), &self)
+        ArenaBox::new_in(self.ts_as_expression(span, expression, type_annotation), self)
     }
 
     /// Build a [`TSSatisfiesExpression`].
@@ -15025,7 +15041,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type `expression` must satisfy.
     #[inline]
     pub fn ts_satisfies_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
@@ -15044,12 +15060,12 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`: The type `expression` must satisfy.
     #[inline]
     pub fn alloc_ts_satisfies_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_annotation: TSType<'a>,
     ) -> ArenaBox<'a, TSSatisfiesExpression<'a>> {
-        ArenaBox::new_in(self.ts_satisfies_expression(span, expression, type_annotation), &self)
+        ArenaBox::new_in(self.ts_satisfies_expression(span, expression, type_annotation), self)
     }
 
     /// Build a [`TSTypeAssertion`].
@@ -15063,7 +15079,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn ts_type_assertion(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         expression: Expression<'a>,
@@ -15082,12 +15098,12 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_ts_type_assertion(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         expression: Expression<'a>,
     ) -> ArenaBox<'a, TSTypeAssertion<'a>> {
-        ArenaBox::new_in(self.ts_type_assertion(span, type_annotation, expression), &self)
+        ArenaBox::new_in(self.ts_type_assertion(span, type_annotation, expression), self)
     }
 
     /// Build a [`TSImportEqualsDeclaration`].
@@ -15102,7 +15118,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`
     #[inline]
     pub fn ts_import_equals_declaration(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         module_reference: TSModuleReference<'a>,
@@ -15129,7 +15145,7 @@ impl<'a> AstBuilder<'a> {
     /// * `import_kind`
     #[inline]
     pub fn alloc_ts_import_equals_declaration(
-        self,
+        &self,
         span: Span,
         id: BindingIdentifier<'a>,
         module_reference: TSModuleReference<'a>,
@@ -15137,7 +15153,7 @@ impl<'a> AstBuilder<'a> {
     ) -> ArenaBox<'a, TSImportEqualsDeclaration<'a>> {
         ArenaBox::new_in(
             self.ts_import_equals_declaration(span, id, module_reference, import_kind),
-            &self,
+            self,
         )
     }
 
@@ -15150,7 +15166,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn ts_module_reference_external_module_reference(
-        self,
+        &self,
         span: Span,
         expression: StringLiteral<'a>,
     ) -> TSModuleReference<'a> {
@@ -15168,7 +15184,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the identifier being referenced.
     #[inline]
     pub fn ts_module_reference_identifier_reference<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
     ) -> TSModuleReference<'a>
@@ -15188,7 +15204,7 @@ impl<'a> AstBuilder<'a> {
     /// * `reference_id`: Reference ID
     #[inline]
     pub fn ts_module_reference_identifier_reference_with_reference_id<S1>(
-        self,
+        &self,
         span: Span,
         name: S1,
         reference_id: ReferenceId,
@@ -15213,7 +15229,7 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     #[inline]
     pub fn ts_module_reference_qualified_name(
-        self,
+        &self,
         span: Span,
         left: TSTypeName<'a>,
         right: IdentifierName<'a>,
@@ -15231,7 +15247,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn ts_external_module_reference(
-        self,
+        &self,
         span: Span,
         expression: StringLiteral<'a>,
     ) -> TSExternalModuleReference<'a> {
@@ -15248,11 +15264,11 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_ts_external_module_reference(
-        self,
+        &self,
         span: Span,
         expression: StringLiteral<'a>,
     ) -> ArenaBox<'a, TSExternalModuleReference<'a>> {
-        ArenaBox::new_in(self.ts_external_module_reference(span, expression), &self)
+        ArenaBox::new_in(self.ts_external_module_reference(span, expression), self)
     }
 
     /// Build a [`TSNonNullExpression`].
@@ -15265,7 +15281,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn ts_non_null_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> TSNonNullExpression<'a> {
@@ -15282,11 +15298,11 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_ts_non_null_expression(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ArenaBox<'a, TSNonNullExpression<'a>> {
-        ArenaBox::new_in(self.ts_non_null_expression(span, expression), &self)
+        ArenaBox::new_in(self.ts_non_null_expression(span, expression), self)
     }
 
     /// Build a [`Decorator`].
@@ -15295,7 +15311,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     #[inline]
-    pub fn decorator(self, span: Span, expression: Expression<'a>) -> Decorator<'a> {
+    pub fn decorator(&self, span: Span, expression: Expression<'a>) -> Decorator<'a> {
         Decorator { node_id: Default::default(), span, expression }
     }
 
@@ -15309,7 +15325,7 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn ts_export_assignment(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> TSExportAssignment<'a> {
@@ -15326,11 +15342,11 @@ impl<'a> AstBuilder<'a> {
     /// * `expression`
     #[inline]
     pub fn alloc_ts_export_assignment(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
     ) -> ArenaBox<'a, TSExportAssignment<'a>> {
-        ArenaBox::new_in(self.ts_export_assignment(span, expression), &self)
+        ArenaBox::new_in(self.ts_export_assignment(span, expression), self)
     }
 
     /// Build a [`TSNamespaceExportDeclaration`].
@@ -15343,7 +15359,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`
     #[inline]
     pub fn ts_namespace_export_declaration(
-        self,
+        &self,
         span: Span,
         id: IdentifierName<'a>,
     ) -> TSNamespaceExportDeclaration<'a> {
@@ -15360,11 +15376,11 @@ impl<'a> AstBuilder<'a> {
     /// * `id`
     #[inline]
     pub fn alloc_ts_namespace_export_declaration(
-        self,
+        &self,
         span: Span,
         id: IdentifierName<'a>,
     ) -> ArenaBox<'a, TSNamespaceExportDeclaration<'a>> {
-        ArenaBox::new_in(self.ts_namespace_export_declaration(span, id), &self)
+        ArenaBox::new_in(self.ts_namespace_export_declaration(span, id), self)
     }
 
     /// Build a [`TSInstantiationExpression`].
@@ -15378,7 +15394,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn ts_instantiation_expression<T1>(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_arguments: T1,
@@ -15390,7 +15406,7 @@ impl<'a> AstBuilder<'a> {
             node_id: Default::default(),
             span,
             expression,
-            type_arguments: type_arguments.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator()),
         }
     }
 
@@ -15405,7 +15421,7 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_instantiation_expression<T1>(
-        self,
+        &self,
         span: Span,
         expression: Expression<'a>,
         type_arguments: T1,
@@ -15413,7 +15429,7 @@ impl<'a> AstBuilder<'a> {
     where
         T1: IntoIn<'a, ArenaBox<'a, TSTypeParameterInstantiation<'a>>>,
     {
-        ArenaBox::new_in(self.ts_instantiation_expression(span, expression, type_arguments), &self)
+        ArenaBox::new_in(self.ts_instantiation_expression(span, expression, type_arguments), self)
     }
 
     /// Build a [`JSDocNullableType`].
@@ -15427,7 +15443,7 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`: Was `?` after the type annotation?
     #[inline]
     pub fn js_doc_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
@@ -15446,12 +15462,12 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`: Was `?` after the type annotation?
     #[inline]
     pub fn alloc_js_doc_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
     ) -> ArenaBox<'a, JSDocNullableType<'a>> {
-        ArenaBox::new_in(self.js_doc_nullable_type(span, type_annotation, postfix), &self)
+        ArenaBox::new_in(self.js_doc_nullable_type(span, type_annotation, postfix), self)
     }
 
     /// Build a [`JSDocNonNullableType`].
@@ -15465,7 +15481,7 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`
     #[inline]
     pub fn js_doc_non_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
@@ -15484,12 +15500,12 @@ impl<'a> AstBuilder<'a> {
     /// * `postfix`
     #[inline]
     pub fn alloc_js_doc_non_nullable_type(
-        self,
+        &self,
         span: Span,
         type_annotation: TSType<'a>,
         postfix: bool,
     ) -> ArenaBox<'a, JSDocNonNullableType<'a>> {
-        ArenaBox::new_in(self.js_doc_non_nullable_type(span, type_annotation, postfix), &self)
+        ArenaBox::new_in(self.js_doc_non_nullable_type(span, type_annotation, postfix), self)
     }
 
     /// Build a [`JSDocUnknownType`].
@@ -15500,7 +15516,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn js_doc_unknown_type(self, span: Span) -> JSDocUnknownType {
+    pub fn js_doc_unknown_type(&self, span: Span) -> JSDocUnknownType {
         JSDocUnknownType { node_id: Default::default(), span }
     }
 
@@ -15512,7 +15528,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn alloc_js_doc_unknown_type(self, span: Span) -> ArenaBox<'a, JSDocUnknownType> {
-        ArenaBox::new_in(self.js_doc_unknown_type(span), &self)
+    pub fn alloc_js_doc_unknown_type(&self, span: Span) -> ArenaBox<'a, JSDocUnknownType> {
+        ArenaBox::new_in(self.js_doc_unknown_type(span), self)
     }
 }

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -44,36 +44,21 @@
 pub mod ast;
 mod ast_impl;
 mod ast_kind_impl;
+pub mod builder;
 pub mod precedence;
 mod trivia;
 
 #[cfg(feature = "serialize")]
 mod serialize;
 
-// AST builder.
-//
-// We intend to migrate from the old `AstBuilder` struct which has methods defined on it directly,
-// to new methods defined on AST types themselves, which take a param that implements `GetAstBuilder` trait.
-//
-// During transition period, we support both, with new `AstBuilder` gated behind `builder_new` Cargo feature.
-// After all Oxc crates and all major downstream consumers have migrated, we will remove the old `AstBuilder`,
-// and make the new one the default.
-//
-// * Old AST builder is exposed as crate-level item, to avoid breaking changes.
-// * New AST builder is exposed via `builder` module.
-//
-// See https://github.com/oxc-project/oxc/issues/23043 for more details.
-mod ast_builder_impl;
-pub use ast_builder_impl::{AstBuilder, NONE};
-#[cfg(feature = "builder_new")]
-pub mod builder;
-
 mod generated {
     pub mod ast_kind;
 
     #[cfg(debug_assertions)]
     mod assert_layouts;
+    #[cfg(not(feature = "disable_old_builder"))]
     mod ast_builder;
+    mod builder_methods;
     mod derive_clone_in;
     mod derive_content_eq;
     mod derive_dummy;
@@ -85,15 +70,13 @@ mod generated {
     mod derive_take_in;
     mod derive_unstable_address;
     mod get_id;
-
-    #[cfg(feature = "builder_new")]
-    mod builder_methods;
 }
 pub use generated::ast_kind;
 
 pub use ast::comment::{Comment, CommentContent, CommentKind, CommentPosition};
 pub use ast_kind::{AstKind, AstType};
 pub use ast_kind_impl::{MemberExpressionKind, ModuleDeclarationKind};
+pub use builder::{AstBuilder, NONE};
 pub use trivia::{
     CommentsRange, comments_range, get_comment_at, has_comments_between, is_inside_comment,
 };

--- a/crates/oxc_ast_visit/Cargo.toml
+++ b/crates/oxc_ast_visit/Cargo.toml
@@ -26,8 +26,10 @@ oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 
 [dev-dependencies]
-# `AstBuilder` is only used in tests
-oxc_ast = { workspace = true, features = ["builder_new"] }
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 
 [features]
 default = []

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -37,8 +37,10 @@ itoa = { workspace = true }
 rustc-hash = { workspace = true }
 
 [dev-dependencies]
-# `AstBuilder` is only used in tests
-oxc_ast = { workspace = true, features = ["builder_new"] }
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 
 insta = { workspace = true }
 oxc_parser = { workspace = true }

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true, features = ["builder_new"] }
+oxc_ast = { workspace = true }
 oxc_regular_expression = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true, features = ["to_js_string"] }
@@ -30,3 +30,9 @@ oxc_syntax = { workspace = true, features = ["to_js_string"] }
 cow-utils = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
+
+[dev-dependencies]
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }

--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -22,7 +22,7 @@ test = false
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true, features = ["builder_new"] }
+oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
@@ -37,3 +37,9 @@ rustc-hash = { workspace = true }
 insta = { workspace = true, features = ["glob"] }
 oxc_codegen = { workspace = true, features = ["sourcemap"] }
 oxc_parser = { workspace = true }
+
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
+

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -26,7 +26,7 @@ doctest = true
 
 [dependencies]
 oxc_allocator = { workspace = true, features = ["fixed_size", "bitset"] }
-oxc_ast = { workspace = true, features = ["builder_new"] }
+oxc_ast = { workspace = true }
 oxc_ast_macros = { workspace = true }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_cfg = { workspace = true }
@@ -81,3 +81,8 @@ url = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 markdown = { workspace = true }
+
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -21,7 +21,7 @@ test = true
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true, features = ["builder_new"] }
+oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_compat = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["stack"] }
@@ -44,6 +44,11 @@ rustc-hash = { workspace = true }
 oxc_codegen = { workspace = true, features = ["sourcemap"] }
 oxc_parser = { workspace = true }
 oxc_sourcemap = { workspace = true }
+
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 
 insta = { workspace = true }
 javascript-globals = { workspace = true }

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true, features = ["builder_new"] }
+oxc_ast = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["assert_unchecked", "fieldless_enum"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
@@ -39,7 +39,11 @@ seq-macro = { workspace = true }
 memchr = { workspace = true }
 
 [dev-dependencies]
-oxc_ast = { workspace = true, features = ["serialize"] }
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder", "serialize"] }
+
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
 pico-args = { workspace = true }
 

--- a/crates/oxc_react_compiler/Cargo.toml
+++ b/crates/oxc_react_compiler/Cargo.toml
@@ -28,7 +28,7 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true, features = ["builder_new"] }
+oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_codegen = { workspace = true }
 oxc_diagnostics = { workspace = true }
@@ -47,6 +47,12 @@ react_compiler_hir = { package = "forked_react_compiler_hir", version = "0.2.0" 
 indexmap = { workspace = true, features = ["serde"] }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
+
+[dev-dependencies]
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 
 # The `src/` conversion modules are vendored close to upstream `react_compiler_oxc`
 # (kept near byte-for-byte to ease re-syncing), so relax the handful of lints they

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true, features = ["builder_new"] }
+oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_compat = { workspace = true }
 oxc_data_structures = { workspace = true, features = [
@@ -57,6 +57,11 @@ insta = { workspace = true }
 oxc_codegen = { workspace = true, features = ["sourcemap"] }
 oxc_parser = { workspace = true }
 pico-args = { workspace = true }
+
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 
 [features]
 # Run the experimental React Compiler as the first transform pass.

--- a/crates/oxc_transformer_plugins/Cargo.toml
+++ b/crates/oxc_transformer_plugins/Cargo.toml
@@ -24,7 +24,7 @@ doctest = false
 cow-utils = { workspace = true }
 itoa = { workspace = true }
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true, features = ["builder_new"] }
+oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
@@ -48,3 +48,8 @@ oxc_semantic = { workspace = true }
 oxc_sourcemap = { workspace = true }
 oxc_tasks_common = { workspace = true }
 oxc_transformer = { workspace = true }
+
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -24,7 +24,7 @@ doctest = true
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_ast = { workspace = true, features = ["builder_new"] }
+oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_data_structures = { workspace = true, features = ["stack"] }
 oxc_ecmascript = { workspace = true }
@@ -35,3 +35,9 @@ oxc_syntax = { workspace = true }
 
 itoa = { workspace = true }
 rustc-hash = { workspace = true }
+
+[dev-dependencies]
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# if we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }

--- a/tasks/ast_tools/Cargo.toml
+++ b/tasks/ast_tools/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 #
 # `features = ["serialize"]` on `oxc_span` and `oxc_syntax` is needed to work around a bug in `oxc_index`.
 oxc_allocator = { workspace = true, optional = true }
-oxc_ast = { workspace = true, optional = true, features = ["builder_new"] }
+oxc_ast = { workspace = true, optional = true, features = ["disable_old_builder"] }
 oxc_ast_visit = { workspace = true, optional = true }
 oxc_codegen = { workspace = true, optional = true, features = ["sourcemap"] }
 oxc_minifier = { workspace = true, optional = true }

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -84,12 +84,12 @@ impl Generator for AstBuilderGenerator {
             use std::cell::Cell;
 
             ///@@line_break
-            use oxc_allocator::{Allocator, ArenaBox, ArenaVec, IntoIn};
+            use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator, IntoIn};
             use oxc_str::{Ident, Str};
             use oxc_syntax::{scope::ScopeId, symbol::SymbolId, reference::ReferenceId};
 
             ///@@line_break
-            use crate::{AstBuilder, ast::*};
+            use crate::{ast::*, builder::AstBuilder};
 
             ///@@line_break
             impl<'a> AstBuilder<'a> {
@@ -265,7 +265,7 @@ fn generate_builder_methods_for_struct_impl(
         #fn_docs
         #params_docs
         #[inline]
-        pub fn #fn_name #generic_params (self, #fn_params) -> #struct_ty #where_clause {
+        pub fn #fn_name #generic_params (&self, #fn_params) -> #struct_ty #where_clause {
             #struct_ident { #fields }
         }
     };
@@ -289,8 +289,8 @@ fn generate_builder_methods_for_struct_impl(
         #[doc = #alloc_doc2]
         #params_docs
         #[inline]
-        pub fn #alloc_fn_name #generic_params (self, #fn_params) -> ArenaBox<'a, #struct_ty> #where_clause {
-            ArenaBox::new_in(self.#fn_name(#(#args),*), &self)
+        pub fn #alloc_fn_name #generic_params (&self, #fn_params) -> ArenaBox<'a, #struct_ty> #where_clause {
+            ArenaBox::new_in(self.#fn_name(#(#args),*), self)
         }
     }
 }
@@ -301,7 +301,7 @@ fn generate_builder_methods_for_struct_impl(
 ///
 /// ```
 /// //        ↓↓↓↓ generic params
-/// pub fn foo<T1>(self, span: Span, type_parameters: T1) -> Foo<'a>
+/// pub fn foo<T1>(&self, span: Span, type_parameters: T1) -> Foo<'a>
 ///     where T1: IntoIn<'a, Option<ArenaBox<'a, TSTypeParameterInstantiation<'a>>>> {}
 /// //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ where clause
 /// ```
@@ -436,7 +436,7 @@ fn get_struct_fn_params_and_fields(
         let field = match param.generic_type {
             Some(GenericType::Into) => quote!( #param_ident: #param_ident.into() ),
             Some(GenericType::IntoIn) => {
-                quote!( #param_ident: #param_ident.into_in(self.allocator) )
+                quote!( #param_ident: #param_ident.into_in(self.allocator()) )
             }
             None => quote!( #param_ident ),
         };
@@ -582,7 +582,7 @@ fn generate_builder_method_for_enum_variant_impl(
         #fn_docs
         #params_docs
         #[inline]
-        pub fn #fn_name #generic_params(self, #(#fn_params),*) -> #enum_ty #where_clause {
+        pub fn #fn_name #generic_params(&self, #(#fn_params),*) -> #enum_ty #where_clause {
             #enum_ident::#variant_ident(self.#inner_builder_name(#(#args),*))
         }
     }


### PR DESCRIPTION
Part of #23043.

Recent PRs have introduced a new `AstBuilder` type, and migrated all Oxc's crates over to it.

To allow downstream consumers to incrementally migrate from old `AstBuilder` to new one, unify the two implementations into a single `AstBuilder` type.

Remove the `builder_new` Cargo feature and instead add a new feature `disable_old_builder`. When enabled, this feature removes all the methods from `AstBuilder`, and makes `AstBuilder` non-`Copy`. Consumers should migrate, and then enable this feature to ensure later changes don't use the methods which are slated for removal.

Enable the `disable_old_builder` feature in all Oxc crates which use `AstBuilder` _in tests_. This ensures we don't go back to using the deprecated methods, while not forcing the feature on consumers (e.g. Rolldown) who use e.g. `oxc_transformer` but also use `AstBuilder` directly.