### PR TITLE
feat(ast)!: only export `AstBuilder` and `NONE` in `builder` module

### DIFF
--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -76,6 +76,7 @@ pub use generated::ast_kind;
 pub use ast::comment::{Comment, CommentContent, CommentKind, CommentPosition};
 pub use ast_kind::{AstKind, AstType};
 pub use ast_kind_impl::{MemberExpressionKind, ModuleDeclarationKind};
+#[cfg(not(feature = "disable_old_builder"))]
 pub use builder::{AstBuilder, NONE};
 pub use trivia::{
     CommentsRange, comments_range, get_comment_at, has_comments_between, is_inside_comment,

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, CloneIn, GetAllocator};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::{ContentEq, GetSpan, SPAN};
 
 use crate::{

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec, CloneIn, GetAllocator};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::{SPAN, Span};
 
 use crate::{

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -11,9 +11,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::{Allocator, ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::{
-    NONE,
     ast::*,
-    builder::{AstBuilder, GetAstBuilder},
+    builder::{AstBuilder, GetAstBuilder, NONE},
 };
 use oxc_ast_visit::Visit;
 use oxc_diagnostics::{Diagnostics, OxcDiagnostic};

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec, CloneIn, GetAllocator, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::{GetSpan, SPAN};
 use oxc_str::Str;
 

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -1,12 +1,12 @@
 use oxc_allocator::{ArenaVec, CloneIn, GetAllocator};
 use oxc_ast::{
-    NONE,
     ast::{
         ArrayExpression, ArrayExpressionElement, ArrowFunctionExpression, Expression, Function,
         ObjectExpression, ObjectPropertyKind, PropertyKey, PropertyKind, TSLiteral,
         TSMethodSignatureKind, TSSignature, TSTupleElement, TSType, TSTypeAnnotation,
         TSTypeOperatorOperator,
     },
+    builder::NONE,
 };
 use oxc_span::{ContentEq, GetSpan, SPAN, Span};
 use oxc_syntax::identifier::is_identifier_name;

--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -1,5 +1,8 @@
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::{NONE, ast::*, builder::AstBuilder};
+use oxc_ast::{
+    ast::*,
+    builder::{AstBuilder, NONE},
+};
 use oxc_ast_visit::Visit;
 use oxc_ecmascript::BoundNames;
 use oxc_span::{SPAN, Span};

--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -1,6 +1,6 @@
 use crate::TraverseCtx;
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_compat::ESFeature;
 use oxc_ecmascript::{
     constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType},

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use cow_utils::CowUtils;
 
 use oxc_allocator::{ArenaBox, ArenaVec, GetAllocator, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_compat::ESFeature;
 use oxc_ecmascript::{
     StringCharAt, StringCharAtResult, ToBigInt, ToIntegerIndex,

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -2,7 +2,7 @@ use std::iter::repeat_with;
 
 use crate::generated::ancestor::Ancestor;
 use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_compat::ESFeature;
 use oxc_ecmascript::side_effects::MayHaveSideEffectsContext;
 use oxc_ecmascript::{

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::FileExtension;
 use oxc_syntax::precedence::Precedence;
 

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::GetSpan;
 use rustc_hash::FxHashMap;
 

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::GetSpan;
 use oxc_syntax::operator::UnaryOperator;
 

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -92,7 +92,7 @@ use indexmap::IndexMap;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_ast_visit::{VisitMut, walk_mut::walk_expression};
 use oxc_data_structures::stack::{NonEmptyStack, SparseStack};
 use oxc_semantic::{ReferenceFlags, SymbolId};

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -72,8 +72,8 @@ use serde::Deserialize;
 
 use oxc_allocator::{ArenaBox, ArenaVec};
 use oxc_ast::{
-    NONE,
     ast::{Argument, CallExpression, Expression, IdentifierName},
+    builder::NONE,
 };
 use oxc_semantic::{ReferenceFlags, SymbolFlags};
 use oxc_span::SPAN;

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -33,7 +33,7 @@
 use indexmap::{IndexMap, map::Entry as IndexMapEntry};
 
 use oxc_allocator::ArenaVec;
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::ReferenceFlags;
 use oxc_span::SPAN;
 use oxc_str::{Str, static_ident};

--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -15,7 +15,10 @@
 //! ```
 
 use oxc_allocator::ArenaVec;
-use oxc_ast::{NONE, ast::*, builder::AstBuilder};
+use oxc_ast::{
+    ast::*,
+    builder::{AstBuilder, NONE},
+};
 use oxc_data_structures::stack::SparseStack;
 use oxc_span::SPAN;
 use oxc_traverse::{BoundIdentifier, ast_operations::GatherNodeParts};

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -51,7 +51,7 @@ use std::mem;
 use oxc_allocator::{
     Address, ArenaBox, ArenaVec, CloneIn, GetAddress, GetAllocator, TakeIn, UnstableAddress,
 };
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_ast_visit::{Visit, VisitMut};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -33,7 +33,7 @@
 //! * Exponentiation operator specification: <https://tc39.es/ecma262/#sec-exp-operator>
 
 use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::ReferenceFlags;
 use oxc_span::{SPAN, Span};
 use oxc_str::static_ident;

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -54,7 +54,7 @@
 use std::{borrow::Cow, mem};
 
 use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_ast_visit::Visit;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{GetSpan, SPAN};

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -1,7 +1,7 @@
 //! This module is responsible for transforming `for await` to `for` statement
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{SPAN, Span};
 use oxc_str::static_ident;

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -32,7 +32,7 @@ use std::mem;
 use serde::Deserialize;
 
 use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, GetAllocator, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{BoundNames, ToJsString, WithoutGlobalReferenceInformation};
 use oxc_semantic::{ScopeFlags, ScopeId, SymbolFlags};

--- a/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
+++ b/crates/oxc_transformer/src/es2019/optional_catch_binding.rs
@@ -33,7 +33,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-optional-catch-binding>
 //! * Optional catch binding TC39 proposal: <https://github.com/tc39/proposal-optional-catch-binding>
 
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::SymbolFlags;
 use oxc_span::SPAN;
 use oxc_traverse::Traverse;

--- a/crates/oxc_transformer/src/es2020/export_namespace_from.rs
+++ b/crates/oxc_transformer/src/es2020/export_namespace_from.rs
@@ -26,7 +26,7 @@
 //! * "export ns from" TC39 proposal: <https://github.com/tc39/proposal-export-ns-from>
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::SymbolFlags;
 use oxc_span::SPAN;
 use oxc_traverse::Traverse;

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -29,7 +29,7 @@
 //! * Nullish coalescing TC39 proposal: <https://github.com/tc39-transfer/proposal-nullish-coalescing>
 
 use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::{ScopeFlags, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator, LogicalOperator};

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -50,7 +50,7 @@
 use std::mem;
 
 use oxc_allocator::{ArenaVec, CloneIn, GetAllocator, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::{GetSpan, SPAN, Span};
 use oxc_traverse::{Ancestor, BoundIdentifier, MaybeBoundIdentifier, Traverse};
 

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -2,7 +2,7 @@
 //! Transform of class itself.
 
 use oxc_allocator::{Address, ArenaVec, GetAddress, TakeIn, UnstableAddress};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::SPAN;
 use oxc_str::{Ident, static_ident};
 use oxc_syntax::{

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -104,7 +104,7 @@ use std::iter;
 use oxc_allocator::{ArenaVec, TakeIn};
 use rustc_hash::FxHashMap;
 
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_span::SPAN;
 use oxc_str::Ident;

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -4,7 +4,7 @@
 use std::mem;
 
 use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::SPAN;
 use oxc_str::static_ident;
 use oxc_syntax::{reference::ReferenceId, symbol::SymbolId};

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -2,7 +2,7 @@
 //! Transform of class property declarations (instance or static properties).
 
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::{SPAN, Span};
 use oxc_str::static_ident;
 use oxc_syntax::reference::ReferenceFlags;

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -4,7 +4,7 @@
 use std::path::Path;
 
 use oxc_allocator::ArenaVec;
-use oxc_ast::{NONE, ast::*, builder::AstBuilder};
+use oxc_ast::{ast::*, builder::AstBuilder, builder::NONE};
 use oxc_span::SPAN;
 use oxc_traverse::BoundIdentifier;
 

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -42,7 +42,7 @@
 use itoa::Buffer as ItoaBuffer;
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_span::SPAN;
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 use oxc_traverse::Traverse;

--- a/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/es2026/explicit_resource_management.rs
@@ -38,7 +38,7 @@ use std::mem;
 use rustc_hash::FxHashMap;
 
 use oxc_allocator::{Address, ArenaBox, ArenaVec, GetAddress, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{NodeId, ScopeFlags, ScopeId, SymbolFlags, SymbolId};
 use oxc_span::{SPAN, Span};

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -89,7 +89,10 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-helper-builder-react-jsx>
 
 use oxc_allocator::{ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator, TakeIn};
-use oxc_ast::{NONE, ast::*, builder::AstBuilder};
+use oxc_ast::{
+    ast::*,
+    builder::{AstBuilder, NONE},
+};
 use oxc_ecmascript::PropName;
 use oxc_span::{SPAN, Span};
 use oxc_str::{Ident, Str};

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -34,7 +34,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/blob/v7.26.2/packages/babel-plugin-transform-react-jsx-source/src/index.ts>
 
 use oxc_allocator::ArenaVec;
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_data_structures::rope::{Rope, get_line_column};
 use oxc_span::SPAN;
 use oxc_syntax::{number::NumberBase, symbol::SymbolFlags};

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -10,7 +10,11 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use oxc_allocator::{
     ArenaStringBuilder, ArenaVec, CloneIn, GetAddress, GetAllocator, TakeIn, UnstableAddress,
 };
-use oxc_ast::{NONE, ast::*, builder::AstBuilder, match_expression};
+use oxc_ast::{
+    ast::*,
+    builder::{AstBuilder, NONE},
+    match_expression,
+};
 use oxc_ast_visit::{
     Visit,
     walk::{walk_call_expression, walk_declaration},

--- a/crates/oxc_transformer/src/plugins/styled_components.rs
+++ b/crates/oxc_transformer/src/plugins/styled_components.rs
@@ -64,7 +64,10 @@ use rustc_hash::FxHasher;
 use serde::Deserialize;
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*, builder::AstBuilder};
+use oxc_ast::{
+    ast::*,
+    builder::{AstBuilder, NONE},
+};
 use oxc_data_structures::{inline_string::InlineString, slice_iter::SliceIter};
 use oxc_semantic::SymbolId;
 use oxc_span::SPAN;

--- a/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
+++ b/crates/oxc_transformer/src/plugins/tagged_template_transform.rs
@@ -41,7 +41,7 @@
 use std::iter;
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::SymbolFlags;
 use oxc_span::SPAN;
 use oxc_traverse::{BoundIdentifier, Traverse};

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -45,7 +45,7 @@
 //! (actually these would be improvements on ESBuild, not Babel)
 
 use oxc_allocator::{ArenaVec, GetAllocator};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_regular_expression::{
     RegexUnsupportedPatterns, has_unsupported_regular_expression_pattern,
 };

--- a/crates/oxc_transformer/src/typescript/class.rs
+++ b/crates/oxc_transformer/src/typescript/class.rs
@@ -1,7 +1,7 @@
 use rustc_hash::FxHashSet;
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::{ScopeFlags, ScopeId};
 use oxc_span::SPAN;
 use oxc_str::Ident;

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 
 use oxc_allocator::{ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_ast_visit::{VisitMut, walk_mut};
 use oxc_data_structures::stack::NonEmptyStack;
 use oxc_semantic::{ScopeFlags, ScopeId};

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::{Reference, SymbolFlags};
 use oxc_span::SPAN;
 use oxc_str::static_ident;

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::{ArenaBox, ArenaVec, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_ecmascript::BoundNames;
 use oxc_span::{SPAN, Span};
 use oxc_syntax::{

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -1,7 +1,7 @@
 use std::iter;
 
 use oxc_allocator::{ArenaBox, ArenaVec};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_semantic::{ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{GetSpan, SPAN};
 use oxc_str::{Ident, static_ident};

--- a/crates/oxc_transformer_plugins/src/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/src/inject_global_variables.rs
@@ -4,9 +4,8 @@ use cow_utils::CowUtils;
 
 use oxc_allocator::{Allocator, ArenaVec, GetAllocator};
 use oxc_ast::{
-    NONE,
     ast::*,
-    builder::{AstBuilder, GetAstBuilder},
+    builder::{AstBuilder, GetAstBuilder, NONE},
 };
 use oxc_semantic::Scoping;
 use oxc_span::SPAN;

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -51,7 +51,7 @@ use itoa::Buffer as ItoaBuffer;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator, TakeIn};
-use oxc_ast::{NONE, ast::*};
+use oxc_ast::{ast::*, builder::NONE};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::{ReferenceFlags, ScopeFlags, Scoping, SymbolFlags, SymbolId};
 use oxc_span::SPAN;


### PR DESCRIPTION
Part of #23043.

Do not export `AstBuilder` and `NONE` from root of `oxc_ast` crate. They are available via `builder` module e.g. `use oxc_ast::builder::NONE;`.

We're going to be adding more AST builder types, and I don't think we should throw them all into the crate's top-level exports.

This change is behind the `disable_old_builder` Cargo feature (see #23875) so is not an immediate breaking change - consumers would need to make this change while migrating to new `AstBuilder`.