### PR TITLE
docs(ast): add `#[deprecated]` to legacy `AstBuilder` methods

### DIFF
--- a/crates/oxc_ast/src/builder/methods.rs
+++ b/crates/oxc_ast/src/builder/methods.rs
@@ -11,6 +11,7 @@ use super::{AstBuilder, NONE};
 
 impl<'a> AstBuilder<'a> {
     /// Move a value into the memory arena.
+    #[deprecated(note = "Use `ArenaBox::new_in` instead")]
     #[inline]
     pub fn alloc<T>(self, value: T) -> ArenaBox<'a, T> {
         ArenaBox::new_in(value, &self)
@@ -19,6 +20,7 @@ impl<'a> AstBuilder<'a> {
     /// Create a new empty [`Vec`] that stores its elements in the memory arena.
     ///
     /// [`Vec`]: ArenaVec
+    #[deprecated(note = "Use `ArenaVec::new_in` instead")]
     #[inline]
     pub fn vec<T>(self) -> ArenaVec<'a, T> {
         ArenaVec::new_in(&self)
@@ -29,6 +31,7 @@ impl<'a> AstBuilder<'a> {
     /// elements.
     ///
     /// [`Vec`]: ArenaVec
+    #[deprecated(note = "Use `ArenaVec::with_capacity_in` instead")]
     #[inline]
     pub fn vec_with_capacity<T>(self, capacity: usize) -> ArenaVec<'a, T> {
         ArenaVec::with_capacity_in(capacity, &self)
@@ -37,6 +40,7 @@ impl<'a> AstBuilder<'a> {
     /// Create a new arena-allocated [`Vec`] initialized with a single element.
     ///
     /// [`Vec`]: ArenaVec
+    #[deprecated(note = "Use `ArenaVec::from_value_in` instead")]
     #[inline]
     pub fn vec1<T>(self, value: T) -> ArenaVec<'a, T> {
         ArenaVec::from_value_in(value, &self)
@@ -45,6 +49,7 @@ impl<'a> AstBuilder<'a> {
     /// Collect an iterator into a new arena-allocated [`Vec`].
     ///
     /// [`Vec`]: ArenaVec
+    #[deprecated(note = "Use `ArenaVec::from_iter_in` instead")]
     #[inline]
     pub fn vec_from_iter<T, I: IntoIterator<Item = T>>(self, iter: I) -> ArenaVec<'a, T> {
         ArenaVec::from_iter_in(iter, &self)
@@ -57,18 +62,21 @@ impl<'a> AstBuilder<'a> {
     /// on stack and then copying to arena.
     ///
     /// [`Vec`]: ArenaVec
+    #[deprecated(note = "Use `ArenaVec::from_array_in` instead")]
     #[inline]
     pub fn vec_from_array<T, const N: usize>(self, array: [T; N]) -> ArenaVec<'a, T> {
         ArenaVec::from_array_in(array, &self)
     }
 
     /// Allocate an [`Ident`] from a string slice.
+    #[deprecated(note = "Use `Ident::from_in` instead")]
     #[inline]
     pub fn ident(self, value: &str) -> Ident<'a> {
         Ident::from_in(value, self.allocator)
     }
 
     /// Allocate an [`Ident`] from an array of string slices.
+    #[deprecated(note = "Use `Ident::from_strs_array_in` instead")]
     #[inline]
     pub fn ident_from_strs_array<const N: usize>(self, strings: [&str; N]) -> Ident<'a> {
         Ident::from_strs_array_in(strings, &self)
@@ -80,18 +88,21 @@ impl<'a> AstBuilder<'a> {
     /// without allocating a new one.
     ///
     /// If the `Cow` is owned, allocates the string into arena to generate a new `Ident`.
+    #[deprecated(note = "Use `Ident::from_cow_in` instead")]
     #[inline]
     pub fn ident_from_cow(self, value: &Cow<'a, str>) -> Ident<'a> {
         Ident::from_cow_in(value, &self)
     }
 
     /// Allocate a [`Str`] from a string slice.
+    #[deprecated(note = "Use `Str::from_in` instead")]
     #[inline]
     pub fn str(self, value: &str) -> Str<'a> {
         Str::from_in(value, self.allocator)
     }
 
     /// Allocate a [`Str`] from an array of string slices.
+    #[deprecated(note = "Use `Str::from_strs_array_in` instead")]
     #[inline]
     pub fn str_from_strs_array<const N: usize>(self, strings: [&str; N]) -> Str<'a> {
         Str::from_strs_array_in(strings, &self)
@@ -103,18 +114,21 @@ impl<'a> AstBuilder<'a> {
     /// without allocating a new one.
     ///
     /// If the `Cow` is owned, allocates the string into arena to generate a new `Str`.
+    #[deprecated(note = "Use `Str::from_cow_in` instead")]
     #[inline]
     pub fn str_from_cow(self, value: &Cow<'a, str>) -> Str<'a> {
         Str::from_cow_in(value, &self)
     }
 
     /// `0`
+    #[deprecated(note = "Use `Expression::new_number_0` instead")]
     #[inline]
     pub fn number_0(self) -> Expression<'a> {
         self.expression_numeric_literal(SPAN, 0.0, None, NumberBase::Decimal)
     }
 
     /// `void 0`
+    #[deprecated(note = "Use `Expression::new_void_0` instead")]
     #[inline]
     pub fn void_0(self, span: Span) -> Expression<'a> {
         let num = self.number_0();
@@ -122,12 +136,14 @@ impl<'a> AstBuilder<'a> {
     }
 
     /// `NaN`
+    #[deprecated(note = "Use `Expression::new_nan` instead")]
     #[inline]
     pub fn nan(self, span: Span) -> Expression<'a> {
         self.expression_numeric_literal(span, f64::NAN, None, NumberBase::Decimal)
     }
 
     /// `"use strict"` directive
+    #[deprecated(note = "Use `Directive::new_use_strict` instead")]
     #[inline]
     pub fn use_strict_directive(self) -> Directive<'a> {
         let use_strict = Str::from("use strict");
@@ -138,6 +154,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Create a [`FormalParameter`] with no type annotations, modifiers,
     /// decorators, or initializer.
+    #[deprecated(note = "Use `FormalParameter::new_plain` instead")]
     #[inline]
     pub fn plain_formal_parameter(
         self,
@@ -149,6 +166,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Create a [`Function`] with no "extras".
     /// i.e. no decorators, type annotations, accessibility modifiers, etc.
+    #[deprecated(note = "Use `Function::boxed_plain_with_scope_id` instead")]
     #[inline]
     pub fn alloc_plain_function_with_scope_id(
         self,
@@ -178,6 +196,7 @@ impl<'a> AstBuilder<'a> {
     }
 
     /// Build a [`Function`] with `scope_id`.
+    #[deprecated(note = "Use `Function::boxed_with_scope_id` instead")]
     #[inline]
     pub fn alloc_function_with_scope_id<T1, T2, T3, T4, T5>(
         self,
@@ -222,6 +241,7 @@ impl<'a> AstBuilder<'a> {
     /* ---------- Modules ---------- */
 
     /// Create an empty [`ExportNamedDeclaration`] with no modifiers
+    #[deprecated(note = "Use `ExportNamedDeclaration::boxed_plain_declaration` instead")]
     #[inline]
     pub fn plain_export_named_declaration_declaration(
         self,
@@ -240,6 +260,7 @@ impl<'a> AstBuilder<'a> {
 
     /// Create an [`ExportNamedDeclaration`] with no modifiers that contains a
     /// set of [exported symbol names](ExportSpecifier).
+    #[deprecated(note = "Use `ExportNamedDeclaration::boxed_plain` instead")]
     #[inline]
     pub fn plain_export_named_declaration(
         self,
@@ -263,6 +284,7 @@ impl<'a> AstBuilder<'a> {
     ///
     /// Like [`AstBuilder::template_element`], but escapes backticks, `${`, backslashes, and carriage
     /// returns in `value.raw` first.
+    #[deprecated(note = "Use `TemplateElement::new_escape_raw` instead")]
     #[inline]
     pub fn template_element_escape_raw(
         self,
@@ -278,6 +300,7 @@ impl<'a> AstBuilder<'a> {
     ///
     /// Like [`AstBuilder::template_element_with_lone_surrogates`], but escapes backticks, `${`,
     /// backslashes, and carriage returns in `value.raw` first.
+    #[deprecated(note = "Use `TemplateElement::new_escape_raw_with_lone_surrogates` instead")]
     #[inline]
     pub fn template_element_escape_raw_with_lone_surrogates(
         self,

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -25,6 +25,9 @@ impl<'a> AstBuilder<'a> {
     /// * `hashbang`
     /// * `directives`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn program(
         &self,
@@ -60,6 +63,9 @@ impl<'a> AstBuilder<'a> {
     /// * `directives`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn program_with_scope_id(
         &self,
@@ -92,6 +98,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `value`: The boolean value itself
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_boolean_literal(&self, span: Span, value: bool) -> Expression<'a> {
         Expression::BooleanLiteral(self.alloc_boolean_literal(span, value))
@@ -103,6 +112,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_null_literal(&self, span: Span) -> Expression<'a> {
         Expression::NullLiteral(self.alloc_null_literal(span))
@@ -117,6 +129,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the number, converted into base 10
     /// * `raw`: The number as it appears in source code
     /// * `base`: The base representation used by the literal in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_numeric_literal(
         &self,
@@ -137,6 +152,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: Bigint value in base 10 with no underscores
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_big_int_literal<S1>(
         &self,
@@ -159,6 +177,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `regex`: The parsed regular expression. See [`oxc_regular_expression`] for more
     /// * `raw`: The regular expression as it appears in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_reg_exp_literal(
         &self,
@@ -177,6 +198,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_string_literal<S1>(
         &self,
@@ -199,6 +223,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_string_literal_with_lone_surrogates<S1>(
         &self,
@@ -226,6 +253,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `quasis`
     /// * `expressions`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_template_literal(
         &self,
@@ -243,6 +273,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_identifier<S1>(&self, span: Span, name: S1) -> Expression<'a>
     where
@@ -259,6 +292,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_identifier_with_reference_id<S1>(
         &self,
@@ -284,6 +320,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `meta`
     /// * `property`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_meta_property(
         &self,
@@ -300,6 +339,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_super(&self, span: Span) -> Expression<'a> {
         Expression::Super(self.alloc_super(span))
@@ -312,6 +354,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_array(
         &self,
@@ -333,6 +378,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_arrow_function<T1, T2, T3, T4>(
         &self,
@@ -376,6 +424,9 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_arrow_function_with_scope_id_and_pure_and_pife<T1, T2, T3, T4>(
         &self,
@@ -421,6 +472,9 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_assignment(
         &self,
@@ -441,6 +495,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_await(&self, span: Span, argument: Expression<'a>) -> Expression<'a> {
         Expression::AwaitExpression(self.alloc_await_expression(span, argument))
@@ -455,6 +512,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `operator`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_binary(
         &self,
@@ -476,6 +536,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_call<T1>(
         &self,
@@ -508,6 +571,9 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_call_with_pure<T1>(
         &self,
@@ -538,6 +604,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_chain(&self, span: Span, expression: ChainElement<'a>) -> Expression<'a> {
         Expression::ChainExpression(self.alloc_chain_expression(span, expression))
@@ -559,6 +628,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_class<T1, T2, T3>(
         &self,
@@ -611,6 +683,9 @@ impl<'a> AstBuilder<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_class_with_scope_id<T1, T2, T3>(
         &self,
@@ -657,6 +732,9 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     /// * `consequent`
     /// * `alternate`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_conditional(
         &self,
@@ -686,6 +764,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`: Function parameters.
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_function<T1, T2, T3, T4, T5>(
         &self,
@@ -742,6 +823,9 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_function_with_scope_id_and_pure_and_pife<T1, T2, T3, T4, T5>(
         &self,
@@ -794,6 +878,9 @@ impl<'a> AstBuilder<'a> {
     /// * `source`
     /// * `options`
     /// * `phase`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_import(
         &self,
@@ -814,6 +901,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `operator`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_logical(
         &self,
@@ -834,6 +924,9 @@ impl<'a> AstBuilder<'a> {
     /// * `callee`
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_new<T1>(
         &self,
@@ -863,6 +956,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_new_with_pure<T1>(
         &self,
@@ -891,6 +987,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `properties`: Properties declared in the object
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_object(
         &self,
@@ -907,6 +1006,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_parenthesized(
         &self,
@@ -923,6 +1025,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expressions`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_sequence(
         &self,
@@ -941,6 +1046,9 @@ impl<'a> AstBuilder<'a> {
     /// * `tag`
     /// * `type_arguments`
     /// * `quasi`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_tagged_template<T1>(
         &self,
@@ -966,6 +1074,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_this(&self, span: Span) -> Expression<'a> {
         Expression::ThisExpression(self.alloc_this_expression(span))
@@ -979,6 +1090,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `operator`
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_unary(
         &self,
@@ -998,6 +1112,9 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `prefix`
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_update(
         &self,
@@ -1017,6 +1134,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `delegate`
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_yield(
         &self,
@@ -1035,6 +1155,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_private_in(
         &self,
@@ -1054,6 +1177,9 @@ impl<'a> AstBuilder<'a> {
     /// * `opening_element`: Opening tag of the element.
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_jsx_element<T1, T2>(
         &self,
@@ -1083,6 +1209,9 @@ impl<'a> AstBuilder<'a> {
     /// * `opening_fragment`: `<>`
     /// * `children`: Elements inside the fragment.
     /// * `closing_fragment`: `</>`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_jsx_fragment(
         &self,
@@ -1107,6 +1236,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_ts_as(
         &self,
@@ -1125,6 +1257,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`: The value expression being constrained.
     /// * `type_annotation`: The type `expression` must satisfy.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_ts_satisfies(
         &self,
@@ -1147,6 +1282,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_ts_type_assertion(
         &self,
@@ -1164,6 +1302,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_ts_non_null(&self, span: Span, expression: Expression<'a>) -> Expression<'a> {
         Expression::TSNonNullExpression(self.alloc_ts_non_null_expression(span, expression))
@@ -1177,6 +1318,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_ts_instantiation<T1>(
         &self,
@@ -1202,6 +1346,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     /// * `arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_v8_intrinsic(
         &self,
@@ -1220,6 +1367,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn identifier_name<S1>(&self, span: Span, name: S1) -> IdentifierName<'a>
     where
@@ -1236,6 +1386,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_identifier_name<S1>(
         &self,
@@ -1256,6 +1409,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn identifier_reference<S1>(&self, span: Span, name: S1) -> IdentifierReference<'a>
     where
@@ -1277,6 +1433,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_identifier_reference<S1>(
         &self,
@@ -1298,6 +1457,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn identifier_reference_with_reference_id<S1>(
         &self,
@@ -1325,6 +1487,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_identifier_reference_with_reference_id<S1>(
         &self,
@@ -1349,6 +1514,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn binding_identifier<S1>(&self, span: Span, name: S1) -> BindingIdentifier<'a>
     where
@@ -1370,6 +1538,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_binding_identifier<S1>(
         &self,
@@ -1391,6 +1562,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     /// * `symbol_id`: Unique identifier for this binding.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn binding_identifier_with_symbol_id<S1>(
         &self,
@@ -1418,6 +1592,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     /// * `symbol_id`: Unique identifier for this binding.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_binding_identifier_with_symbol_id<S1>(
         &self,
@@ -1436,6 +1613,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn label_identifier<S1>(&self, span: Span, name: S1) -> LabelIdentifier<'a>
     where
@@ -1451,6 +1631,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn this_expression(&self, span: Span) -> ThisExpression {
         ThisExpression { node_id: Default::default(), span }
@@ -1463,6 +1646,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_this_expression(&self, span: Span) -> ArenaBox<'a, ThisExpression> {
         ArenaBox::new_in(self.this_expression(span), self)
@@ -1476,6 +1662,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn array_expression(
         &self,
@@ -1493,6 +1682,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_array_expression(
         &self,
@@ -1509,6 +1701,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn array_expression_element_spread_element(
         &self,
@@ -1524,6 +1719,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn array_expression_element_elision(&self, span: Span) -> ArrayExpressionElement<'a> {
         ArrayExpressionElement::Elision(self.alloc_elision(span))
@@ -1536,6 +1734,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn elision(&self, span: Span) -> Elision {
         Elision { node_id: Default::default(), span }
@@ -1548,6 +1749,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_elision(&self, span: Span) -> ArenaBox<'a, Elision> {
         ArenaBox::new_in(self.elision(span), self)
@@ -1561,6 +1765,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `properties`: Properties declared in the object
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn object_expression(
         &self,
@@ -1578,6 +1785,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `properties`: Properties declared in the object
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_object_expression(
         &self,
@@ -1599,6 +1809,9 @@ impl<'a> AstBuilder<'a> {
     /// * `method`
     /// * `shorthand`
     /// * `computed`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn object_property_kind_object_property(
         &self,
@@ -1622,6 +1835,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn object_property_kind_spread_property(
         &self,
@@ -1644,6 +1860,9 @@ impl<'a> AstBuilder<'a> {
     /// * `method`
     /// * `shorthand`
     /// * `computed`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn object_property(
         &self,
@@ -1680,6 +1899,9 @@ impl<'a> AstBuilder<'a> {
     /// * `method`
     /// * `shorthand`
     /// * `computed`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_object_property(
         &self,
@@ -1704,6 +1926,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn property_key_static_identifier<S1>(&self, span: Span, name: S1) -> PropertyKey<'a>
     where
@@ -1719,6 +1944,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn property_key_private_identifier<S1>(&self, span: Span, name: S1) -> PropertyKey<'a>
     where
@@ -1736,6 +1964,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `quasis`
     /// * `expressions`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn template_literal(
         &self,
@@ -1755,6 +1986,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `quasis`
     /// * `expressions`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_template_literal(
         &self,
@@ -1775,6 +2009,9 @@ impl<'a> AstBuilder<'a> {
     /// * `tag`
     /// * `type_arguments`
     /// * `quasi`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn tagged_template_expression<T1>(
         &self,
@@ -1805,6 +2042,9 @@ impl<'a> AstBuilder<'a> {
     /// * `tag`
     /// * `type_arguments`
     /// * `quasi`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_tagged_template_expression<T1>(
         &self,
@@ -1825,6 +2065,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `value`
     /// * `tail`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn template_element(
         &self,
@@ -1848,6 +2091,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`
     /// * `tail`
     /// * `lone_surrogates`: The template element contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn template_element_with_lone_surrogates(
         &self,
@@ -1868,6 +2114,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `expression`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn member_expression_computed(
         &self,
@@ -1890,6 +2139,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `property`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn member_expression_static(
         &self,
@@ -1912,6 +2164,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `field`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn member_expression_private_field_expression(
         &self,
@@ -1935,6 +2190,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `expression`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn computed_member_expression(
         &self,
@@ -1956,6 +2214,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `expression`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_computed_member_expression(
         &self,
@@ -1977,6 +2238,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `property`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn static_member_expression(
         &self,
@@ -1998,6 +2262,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `property`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_static_member_expression(
         &self,
@@ -2019,6 +2286,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `field`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn private_field_expression(
         &self,
@@ -2040,6 +2310,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `field`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_private_field_expression(
         &self,
@@ -2062,6 +2335,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn call_expression<T1>(
         &self,
@@ -2096,6 +2372,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_call_expression<T1>(
         &self,
@@ -2126,6 +2405,9 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn call_expression_with_pure<T1>(
         &self,
@@ -2162,6 +2444,9 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_call_expression_with_pure<T1>(
         &self,
@@ -2191,6 +2476,9 @@ impl<'a> AstBuilder<'a> {
     /// * `callee`
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn new_expression<T1>(
         &self,
@@ -2222,6 +2510,9 @@ impl<'a> AstBuilder<'a> {
     /// * `callee`
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_new_expression<T1>(
         &self,
@@ -2247,6 +2538,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn new_expression_with_pure<T1>(
         &self,
@@ -2280,6 +2574,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     /// * `arguments`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     /// * `pure`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_new_expression_with_pure<T1>(
         &self,
@@ -2307,6 +2604,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `meta`
     /// * `property`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn meta_property(
         &self,
@@ -2326,6 +2626,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `meta`
     /// * `property`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_meta_property(
         &self,
@@ -2344,6 +2647,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn spread_element(&self, span: Span, argument: Expression<'a>) -> SpreadElement<'a> {
         SpreadElement { node_id: Default::default(), span, argument }
@@ -2357,6 +2663,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_spread_element(
         &self,
@@ -2373,6 +2682,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn argument_spread_element(&self, span: Span, argument: Expression<'a>) -> Argument<'a> {
         Argument::SpreadElement(self.alloc_spread_element(span, argument))
@@ -2388,6 +2700,9 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `prefix`
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn update_expression(
         &self,
@@ -2409,6 +2724,9 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `prefix`
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_update_expression(
         &self,
@@ -2429,6 +2747,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `operator`
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn unary_expression(
         &self,
@@ -2448,6 +2769,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `operator`
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_unary_expression(
         &self,
@@ -2468,6 +2792,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `operator`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn binary_expression(
         &self,
@@ -2489,6 +2816,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `operator`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_binary_expression(
         &self,
@@ -2509,6 +2839,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn private_in_expression(
         &self,
@@ -2528,6 +2861,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_private_in_expression(
         &self,
@@ -2548,6 +2884,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `operator`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn logical_expression(
         &self,
@@ -2569,6 +2908,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `operator`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_logical_expression(
         &self,
@@ -2590,6 +2932,9 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     /// * `consequent`
     /// * `alternate`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn conditional_expression(
         &self,
@@ -2611,6 +2956,9 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     /// * `consequent`
     /// * `alternate`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_conditional_expression(
         &self,
@@ -2632,6 +2980,9 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_expression(
         &self,
@@ -2653,6 +3004,9 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_assignment_expression(
         &self,
@@ -2671,6 +3025,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn simple_assignment_target_assignment_target_identifier<S1>(
         &self,
@@ -2693,6 +3050,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn simple_assignment_target_assignment_target_identifier_with_reference_id<S1>(
         &self,
@@ -2716,6 +3076,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn simple_assignment_target_ts_as_expression(
         &self,
@@ -2738,6 +3101,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`: The value expression being constrained.
     /// * `type_annotation`: The type `expression` must satisfy.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn simple_assignment_target_ts_satisfies_expression(
         &self,
@@ -2759,6 +3125,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn simple_assignment_target_ts_non_null_expression(
         &self,
@@ -2778,6 +3147,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn simple_assignment_target_ts_type_assertion(
         &self,
@@ -2800,6 +3172,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_target_pattern_array_assignment_target<T1>(
         &self,
@@ -2823,6 +3198,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `properties`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_target_pattern_object_assignment_target<T1>(
         &self,
@@ -2847,6 +3225,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn array_assignment_target<T1>(
         &self,
@@ -2874,6 +3255,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_array_assignment_target<T1>(
         &self,
@@ -2896,6 +3280,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `properties`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn object_assignment_target<T1>(
         &self,
@@ -2923,6 +3310,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `properties`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_object_assignment_target<T1>(
         &self,
@@ -2944,6 +3334,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `target`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_target_rest(
         &self,
@@ -2961,6 +3354,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `target`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_assignment_target_rest(
         &self,
@@ -2978,6 +3374,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `binding`
     /// * `init`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_target_maybe_default_assignment_target_with_default(
         &self,
@@ -2999,6 +3398,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `binding`
     /// * `init`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_target_with_default(
         &self,
@@ -3018,6 +3420,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `binding`
     /// * `init`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_assignment_target_with_default(
         &self,
@@ -3036,6 +3441,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `binding`
     /// * `init`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_target_property_assignment_target_property_identifier(
         &self,
@@ -3057,6 +3465,9 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The property key
     /// * `binding`: The binding part of the property
     /// * `computed`: Property was declared with a computed key
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_target_property_assignment_target_property_property(
         &self,
@@ -3079,6 +3490,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `binding`
     /// * `init`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_target_property_identifier(
         &self,
@@ -3098,6 +3512,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `binding`
     /// * `init`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_assignment_target_property_identifier(
         &self,
@@ -3118,6 +3535,9 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The property key
     /// * `binding`: The binding part of the property
     /// * `computed`: Property was declared with a computed key
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_target_property_property(
         &self,
@@ -3145,6 +3565,9 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The property key
     /// * `binding`: The binding part of the property
     /// * `computed`: Property was declared with a computed key
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_assignment_target_property_property(
         &self,
@@ -3167,6 +3590,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expressions`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn sequence_expression(
         &self,
@@ -3184,6 +3610,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expressions`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_sequence_expression(
         &self,
@@ -3200,6 +3629,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn super_(&self, span: Span) -> Super {
         Super { node_id: Default::default(), span }
@@ -3212,6 +3644,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_super(&self, span: Span) -> ArenaBox<'a, Super> {
         ArenaBox::new_in(self.super_(span), self)
@@ -3225,6 +3660,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn await_expression(&self, span: Span, argument: Expression<'a>) -> AwaitExpression<'a> {
         AwaitExpression { node_id: Default::default(), span, argument }
@@ -3238,6 +3676,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_await_expression(
         &self,
@@ -3255,6 +3696,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn chain_expression(
         &self,
@@ -3272,6 +3716,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_chain_expression(
         &self,
@@ -3291,6 +3738,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn chain_element_call_expression<T1>(
         &self,
@@ -3323,6 +3773,9 @@ impl<'a> AstBuilder<'a> {
     /// * `arguments`
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn chain_element_call_expression_with_pure<T1>(
         &self,
@@ -3353,6 +3806,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn chain_element_ts_non_null_expression(
         &self,
@@ -3370,6 +3826,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn parenthesized_expression(
         &self,
@@ -3387,6 +3846,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_parenthesized_expression(
         &self,
@@ -3403,6 +3865,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_block(&self, span: Span, body: ArenaVec<'a, Statement<'a>>) -> Statement<'a> {
         Statement::BlockStatement(self.alloc_block_statement(span, body))
@@ -3416,6 +3881,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_block_with_scope_id(
         &self,
@@ -3433,6 +3901,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `label`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_break(&self, span: Span, label: Option<LabelIdentifier<'a>>) -> Statement<'a> {
         Statement::BreakStatement(self.alloc_break_statement(span, label))
@@ -3445,6 +3916,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `label`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_continue(
         &self,
@@ -3460,6 +3934,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_debugger(&self, span: Span) -> Statement<'a> {
         Statement::DebuggerStatement(self.alloc_debugger_statement(span))
@@ -3473,6 +3950,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     /// * `test`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_do_while(
         &self,
@@ -3489,6 +3969,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_empty(&self, span: Span) -> Statement<'a> {
         Statement::EmptyStatement(self.alloc_empty_statement(span))
@@ -3501,6 +3984,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_expression(&self, span: Span, expression: Expression<'a>) -> Statement<'a> {
         Statement::ExpressionStatement(self.alloc_expression_statement(span, expression))
@@ -3515,6 +4001,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `right`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_for_in(
         &self,
@@ -3536,6 +4025,9 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_for_in_with_scope_id(
         &self,
@@ -3560,6 +4052,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `right`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_for_of(
         &self,
@@ -3583,6 +4078,9 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_for_of_with_scope_id(
         &self,
@@ -3608,6 +4106,9 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     /// * `update`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_for(
         &self,
@@ -3631,6 +4132,9 @@ impl<'a> AstBuilder<'a> {
     /// * `update`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_for_with_scope_id(
         &self,
@@ -3655,6 +4159,9 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     /// * `consequent`
     /// * `alternate`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_if(
         &self,
@@ -3674,6 +4181,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `label`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_labeled(
         &self,
@@ -3691,6 +4201,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_return(&self, span: Span, argument: Option<Expression<'a>>) -> Statement<'a> {
         Statement::ReturnStatement(self.alloc_return_statement(span, argument))
@@ -3704,6 +4217,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `discriminant`
     /// * `cases`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_switch(
         &self,
@@ -3723,6 +4239,9 @@ impl<'a> AstBuilder<'a> {
     /// * `discriminant`
     /// * `cases`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_switch_with_scope_id(
         &self,
@@ -3746,6 +4265,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being thrown, e.g. `err` in `throw err;`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_throw(&self, span: Span, argument: Expression<'a>) -> Statement<'a> {
         Statement::ThrowStatement(self.alloc_throw_statement(span, argument))
@@ -3760,6 +4282,9 @@ impl<'a> AstBuilder<'a> {
     /// * `block`: Statements in the `try` block
     /// * `handler`: The `catch` clause, including the parameter and the block statement
     /// * `finalizer`: The `finally` clause
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_try<T1, T2, T3>(
         &self,
@@ -3784,6 +4309,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `test`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_while(
         &self,
@@ -3802,6 +4330,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `object`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_with(
         &self,
@@ -3821,6 +4352,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn statement_with_with_scope_id(
         &self,
@@ -3840,6 +4374,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`: Directive with any escapes unescaped
     /// * `directive`: Raw content of directive as it appears in source, any escapes left as is
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn directive<S1>(
         &self,
@@ -3858,6 +4395,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `value`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn hashbang<S1>(&self, span: Span, value: S1) -> Hashbang<'a>
     where
@@ -3874,6 +4414,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn block_statement(
         &self,
@@ -3891,6 +4434,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_block_statement(
         &self,
@@ -3909,6 +4455,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn block_statement_with_scope_id(
         &self,
@@ -3933,6 +4482,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_block_statement_with_scope_id(
         &self,
@@ -3952,6 +4504,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`
     /// * `declarations`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_variable(
         &self,
@@ -3984,6 +4539,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`: Function parameters.
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_function<T1, T2, T3, T4, T5>(
         &self,
@@ -4040,6 +4598,9 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_function_with_scope_id_and_pure_and_pife<T1, T2, T3, T4, T5>(
         &self,
@@ -4099,6 +4660,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_class<T1, T2, T3>(
         &self,
@@ -4151,6 +4715,9 @@ impl<'a> AstBuilder<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_class_with_scope_id<T1, T2, T3>(
         &self,
@@ -4198,6 +4765,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_parameters`
     /// * `type_annotation`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_ts_type_alias<T1>(
         &self,
@@ -4230,6 +4800,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `declare`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_ts_type_alias_with_scope_id<T1>(
         &self,
@@ -4264,6 +4837,9 @@ impl<'a> AstBuilder<'a> {
     /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_ts_interface<T1, T2>(
         &self,
@@ -4300,6 +4876,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_ts_interface_with_scope_id<T1, T2>(
         &self,
@@ -4336,6 +4915,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `const`: `true` for const enums
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_ts_enum(
         &self,
@@ -4360,6 +4942,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `kind`: The keyword used to define this module declaration.
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_ts_module(
         &self,
@@ -4385,6 +4970,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`: The keyword used to define this module declaration.
     /// * `declare`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_ts_module_with_scope_id(
         &self,
@@ -4409,6 +4997,9 @@ impl<'a> AstBuilder<'a> {
     /// * `global_span`: Span of `global` keyword
     /// * `body`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_ts_global(
         &self,
@@ -4435,6 +5026,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `declare`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_ts_global_with_scope_id(
         &self,
@@ -4462,6 +5056,9 @@ impl<'a> AstBuilder<'a> {
     /// * `id`
     /// * `module_reference`
     /// * `import_kind`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn declaration_ts_import_equals(
         &self,
@@ -4488,6 +5085,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`
     /// * `declarations`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn variable_declaration(
         &self,
@@ -4509,6 +5109,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`
     /// * `declarations`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_variable_declaration(
         &self,
@@ -4529,6 +5132,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `init`
     /// * `definite`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn variable_declarator<T1>(
         &self,
@@ -4560,6 +5166,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn empty_statement(&self, span: Span) -> EmptyStatement {
         EmptyStatement { node_id: Default::default(), span }
@@ -4572,6 +5181,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_empty_statement(&self, span: Span) -> ArenaBox<'a, EmptyStatement> {
         ArenaBox::new_in(self.empty_statement(span), self)
@@ -4585,6 +5197,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn expression_statement(
         &self,
@@ -4602,6 +5217,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_expression_statement(
         &self,
@@ -4621,6 +5239,9 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     /// * `consequent`
     /// * `alternate`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn if_statement(
         &self,
@@ -4642,6 +5263,9 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     /// * `consequent`
     /// * `alternate`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_if_statement(
         &self,
@@ -4662,6 +5286,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     /// * `test`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn do_while_statement(
         &self,
@@ -4681,6 +5308,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     /// * `test`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_do_while_statement(
         &self,
@@ -4700,6 +5330,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `test`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn while_statement(
         &self,
@@ -4719,6 +5352,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `test`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_while_statement(
         &self,
@@ -4740,6 +5376,9 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     /// * `update`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn for_statement(
         &self,
@@ -4771,6 +5410,9 @@ impl<'a> AstBuilder<'a> {
     /// * `test`
     /// * `update`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_for_statement(
         &self,
@@ -4795,6 +5437,9 @@ impl<'a> AstBuilder<'a> {
     /// * `update`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn for_statement_with_scope_id(
         &self,
@@ -4828,6 +5473,9 @@ impl<'a> AstBuilder<'a> {
     /// * `update`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_for_statement_with_scope_id(
         &self,
@@ -4853,6 +5501,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`
     /// * `declarations`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn for_statement_init_variable_declaration(
         &self,
@@ -4879,6 +5530,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `right`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn for_in_statement(
         &self,
@@ -4907,6 +5561,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `right`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_for_in_statement(
         &self,
@@ -4929,6 +5586,9 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn for_in_statement_with_scope_id(
         &self,
@@ -4959,6 +5619,9 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_for_in_statement_with_scope_id(
         &self,
@@ -4983,6 +5646,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`
     /// * `declarations`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn for_statement_left_variable_declaration(
         &self,
@@ -5010,6 +5676,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `right`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn for_of_statement(
         &self,
@@ -5041,6 +5710,9 @@ impl<'a> AstBuilder<'a> {
     /// * `left`
     /// * `right`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_for_of_statement(
         &self,
@@ -5065,6 +5737,9 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn for_of_statement_with_scope_id(
         &self,
@@ -5098,6 +5773,9 @@ impl<'a> AstBuilder<'a> {
     /// * `right`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_for_of_statement_with_scope_id(
         &self,
@@ -5122,6 +5800,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `label`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn continue_statement(
         &self,
@@ -5139,6 +5820,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `label`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_continue_statement(
         &self,
@@ -5156,6 +5840,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `label`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn break_statement(
         &self,
@@ -5173,6 +5860,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `label`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_break_statement(
         &self,
@@ -5190,6 +5880,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn return_statement(
         &self,
@@ -5207,6 +5900,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_return_statement(
         &self,
@@ -5225,6 +5921,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `object`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn with_statement(
         &self,
@@ -5250,6 +5949,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `object`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_with_statement(
         &self,
@@ -5270,6 +5972,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn with_statement_with_scope_id(
         &self,
@@ -5297,6 +6002,9 @@ impl<'a> AstBuilder<'a> {
     /// * `object`
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_with_statement_with_scope_id(
         &self,
@@ -5317,6 +6025,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `discriminant`
     /// * `cases`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn switch_statement(
         &self,
@@ -5342,6 +6053,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `discriminant`
     /// * `cases`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_switch_statement(
         &self,
@@ -5362,6 +6076,9 @@ impl<'a> AstBuilder<'a> {
     /// * `discriminant`
     /// * `cases`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn switch_statement_with_scope_id(
         &self,
@@ -5389,6 +6106,9 @@ impl<'a> AstBuilder<'a> {
     /// * `discriminant`
     /// * `cases`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_switch_statement_with_scope_id(
         &self,
@@ -5409,6 +6129,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `test`
     /// * `consequent`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn switch_case(
         &self,
@@ -5428,6 +6151,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `label`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn labeled_statement(
         &self,
@@ -5447,6 +6173,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `label`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_labeled_statement(
         &self,
@@ -5465,6 +6194,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being thrown, e.g. `err` in `throw err;`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn throw_statement(&self, span: Span, argument: Expression<'a>) -> ThrowStatement<'a> {
         ThrowStatement { node_id: Default::default(), span, argument }
@@ -5478,6 +6210,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being thrown, e.g. `err` in `throw err;`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_throw_statement(
         &self,
@@ -5497,6 +6232,9 @@ impl<'a> AstBuilder<'a> {
     /// * `block`: Statements in the `try` block
     /// * `handler`: The `catch` clause, including the parameter and the block statement
     /// * `finalizer`: The `finally` clause
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn try_statement<T1, T2, T3>(
         &self,
@@ -5529,6 +6267,9 @@ impl<'a> AstBuilder<'a> {
     /// * `block`: Statements in the `try` block
     /// * `handler`: The `catch` clause, including the parameter and the block statement
     /// * `finalizer`: The `finally` clause
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_try_statement<T1, T2, T3>(
         &self,
@@ -5554,6 +6295,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `param`: The caught error parameter, e.g. `e` in `catch (e) {}`
     /// * `body`: The statements run when an error is caught
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn catch_clause<T1>(
         &self,
@@ -5582,6 +6326,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `param`: The caught error parameter, e.g. `e` in `catch (e) {}`
     /// * `body`: The statements run when an error is caught
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_catch_clause<T1>(
         &self,
@@ -5605,6 +6352,9 @@ impl<'a> AstBuilder<'a> {
     /// * `param`: The caught error parameter, e.g. `e` in `catch (e) {}`
     /// * `body`: The statements run when an error is caught
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn catch_clause_with_scope_id<T1>(
         &self,
@@ -5635,6 +6385,9 @@ impl<'a> AstBuilder<'a> {
     /// * `param`: The caught error parameter, e.g. `e` in `catch (e) {}`
     /// * `body`: The statements run when an error is caught
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_catch_clause_with_scope_id<T1>(
         &self,
@@ -5655,6 +6408,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `pattern`: The bound error
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn catch_parameter<T1>(
         &self,
@@ -5680,6 +6436,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn debugger_statement(&self, span: Span) -> DebuggerStatement {
         DebuggerStatement { node_id: Default::default(), span }
@@ -5692,6 +6451,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_debugger_statement(&self, span: Span) -> ArenaBox<'a, DebuggerStatement> {
         ArenaBox::new_in(self.debugger_statement(span), self)
@@ -5704,6 +6466,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn binding_pattern_binding_identifier<S1>(&self, span: Span, name: S1) -> BindingPattern<'a>
     where
@@ -5720,6 +6485,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     /// * `symbol_id`: Unique identifier for this binding.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn binding_pattern_binding_identifier_with_symbol_id<S1>(
         &self,
@@ -5743,6 +6511,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `properties`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn binding_pattern_object_pattern<T1>(
         &self,
@@ -5764,6 +6535,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn binding_pattern_array_pattern<T1>(
         &self,
@@ -5785,6 +6559,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn binding_pattern_assignment_pattern(
         &self,
@@ -5804,6 +6581,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn assignment_pattern(
         &self,
@@ -5823,6 +6603,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_assignment_pattern(
         &self,
@@ -5842,6 +6625,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `properties`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn object_pattern<T1>(
         &self,
@@ -5869,6 +6655,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `properties`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_object_pattern<T1>(
         &self,
@@ -5890,6 +6679,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`
     /// * `shorthand`
     /// * `computed`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn binding_property(
         &self,
@@ -5911,6 +6703,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn array_pattern<T1>(
         &self,
@@ -5938,6 +6733,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_array_pattern<T1>(
         &self,
@@ -5959,6 +6757,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn binding_rest_element(
         &self,
@@ -5976,6 +6777,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_binding_rest_element(
         &self,
@@ -6002,6 +6806,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`: Function parameters.
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn function<T1, T2, T3, T4, T5>(
         &self,
@@ -6060,6 +6867,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`: Function parameters.
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_function<T1, T2, T3, T4, T5>(
         &self,
@@ -6120,6 +6930,9 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn function_with_scope_id_and_pure_and_pife<T1, T2, T3, T4, T5>(
         &self,
@@ -6184,6 +6997,9 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_function_with_scope_id_and_pure_and_pife<T1, T2, T3, T4, T5>(
         &self,
@@ -6240,6 +7056,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`
     /// * `items`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn formal_parameters<T1>(
         &self,
@@ -6270,6 +7089,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`
     /// * `items`
     /// * `rest`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_formal_parameters<T1>(
         &self,
@@ -6296,6 +7118,9 @@ impl<'a> AstBuilder<'a> {
     /// * `accessibility`
     /// * `readonly`
     /// * `override`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn formal_parameter<T1, T2>(
         &self,
@@ -6337,6 +7162,9 @@ impl<'a> AstBuilder<'a> {
     /// * `decorators`
     /// * `rest`
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn formal_parameter_rest<T1>(
         &self,
@@ -6367,6 +7195,9 @@ impl<'a> AstBuilder<'a> {
     /// * `decorators`
     /// * `rest`
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_formal_parameter_rest<T1>(
         &self,
@@ -6390,6 +7221,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `directives`
     /// * `statements`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn function_body(
         &self,
@@ -6409,6 +7243,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `directives`
     /// * `statements`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_function_body(
         &self,
@@ -6432,6 +7269,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn arrow_function_expression<T1, T2, T3, T4>(
         &self,
@@ -6477,6 +7317,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `body`: See `expression` for whether this arrow expression returns an expression.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_arrow_function_expression<T1, T2, T3, T4>(
         &self,
@@ -6524,6 +7367,9 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn arrow_function_expression_with_scope_id_and_pure_and_pife<T1, T2, T3, T4>(
         &self,
@@ -6575,6 +7421,9 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_arrow_function_expression_with_scope_id_and_pure_and_pife<T1, T2, T3, T4>(
         &self,
@@ -6621,6 +7470,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `delegate`
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn yield_expression(
         &self,
@@ -6640,6 +7492,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `delegate`
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_yield_expression(
         &self,
@@ -6667,6 +7522,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn class<T1, T2, T3>(
         &self,
@@ -6721,6 +7579,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_class<T1, T2, T3>(
         &self,
@@ -6777,6 +7638,9 @@ impl<'a> AstBuilder<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn class_with_scope_id<T1, T2, T3>(
         &self,
@@ -6833,6 +7697,9 @@ impl<'a> AstBuilder<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_class_with_scope_id<T1, T2, T3>(
         &self,
@@ -6881,6 +7748,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn class_body(&self, span: Span, body: ArenaVec<'a, ClassElement<'a>>) -> ClassBody<'a> {
         ClassBody { node_id: Default::default(), span, body }
@@ -6894,6 +7764,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_class_body(
         &self,
@@ -6910,6 +7783,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn class_element_static_block(
         &self,
@@ -6927,6 +7803,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn class_element_static_block_with_scope_id(
         &self,
@@ -6953,6 +7832,9 @@ impl<'a> AstBuilder<'a> {
     /// * `override`
     /// * `optional`
     /// * `accessibility`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn class_element_method_definition<T1>(
         &self,
@@ -7005,6 +7887,9 @@ impl<'a> AstBuilder<'a> {
     /// * `definite`
     /// * `readonly`: `true` when declared with a `readonly` modifier
     /// * `accessibility`: Accessibility modifier.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn class_element_property_definition<T1>(
         &self,
@@ -7060,6 +7945,9 @@ impl<'a> AstBuilder<'a> {
     /// * `override`: Property was declared with a `override` modifier
     /// * `definite`: Property has a `!` after its key.
     /// * `accessibility`: Accessibility modifier.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn class_element_accessor_property<T1>(
         &self,
@@ -7103,6 +7991,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `readonly`
     /// * `static`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn class_element_ts_index_signature<T1>(
         &self,
@@ -7141,6 +8032,9 @@ impl<'a> AstBuilder<'a> {
     /// * `override`
     /// * `optional`
     /// * `accessibility`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn method_definition<T1>(
         &self,
@@ -7192,6 +8086,9 @@ impl<'a> AstBuilder<'a> {
     /// * `override`
     /// * `optional`
     /// * `accessibility`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_method_definition<T1>(
         &self,
@@ -7248,6 +8145,9 @@ impl<'a> AstBuilder<'a> {
     /// * `definite`
     /// * `readonly`: `true` when declared with a `readonly` modifier
     /// * `accessibility`: Accessibility modifier.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn property_definition<T1>(
         &self,
@@ -7308,6 +8208,9 @@ impl<'a> AstBuilder<'a> {
     /// * `definite`
     /// * `readonly`: `true` when declared with a `readonly` modifier
     /// * `accessibility`: Accessibility modifier.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_property_definition<T1>(
         &self,
@@ -7358,6 +8261,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn private_identifier<S1>(&self, span: Span, name: S1) -> PrivateIdentifier<'a>
     where
@@ -7374,6 +8280,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_private_identifier<S1>(
         &self,
@@ -7394,6 +8303,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn static_block(&self, span: Span, body: ArenaVec<'a, Statement<'a>>) -> StaticBlock<'a> {
         StaticBlock { node_id: Default::default(), span, body, scope_id: Default::default() }
@@ -7407,6 +8319,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_static_block(
         &self,
@@ -7425,6 +8340,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn static_block_with_scope_id(
         &self,
@@ -7444,6 +8362,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `body`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_static_block_with_scope_id(
         &self,
@@ -7465,6 +8386,9 @@ impl<'a> AstBuilder<'a> {
     /// * `phase`
     /// * `with_clause`: Some(vec![]) for empty assertion
     /// * `import_kind`: `import type { foo } from 'bar'`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_declaration_import_declaration<T1>(
         &self,
@@ -7498,6 +8422,9 @@ impl<'a> AstBuilder<'a> {
     /// * `source`
     /// * `with_clause`: Will be `Some(vec![])` for empty assertion
     /// * `export_kind`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_declaration_export_all_declaration<T1>(
         &self,
@@ -7526,6 +8453,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `declaration`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_declaration_export_default_declaration(
         &self,
@@ -7548,6 +8478,9 @@ impl<'a> AstBuilder<'a> {
     /// * `source`
     /// * `export_kind`: `export type { foo }`
     /// * `with_clause`: Some(vec![]) for empty assertion
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_declaration_export_named_declaration<T1>(
         &self,
@@ -7578,6 +8511,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_declaration_ts_export_assignment(
         &self,
@@ -7594,6 +8530,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_declaration_ts_namespace_export_declaration(
         &self,
@@ -7622,6 +8561,9 @@ impl<'a> AstBuilder<'a> {
     /// * `override`: Property was declared with a `override` modifier
     /// * `definite`: Property has a `!` after its key.
     /// * `accessibility`: Accessibility modifier.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn accessor_property<T1>(
         &self,
@@ -7673,6 +8615,9 @@ impl<'a> AstBuilder<'a> {
     /// * `override`: Property was declared with a `override` modifier
     /// * `definite`: Property has a `!` after its key.
     /// * `accessibility`: Accessibility modifier.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_accessor_property<T1>(
         &self,
@@ -7719,6 +8664,9 @@ impl<'a> AstBuilder<'a> {
     /// * `source`
     /// * `options`
     /// * `phase`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_expression(
         &self,
@@ -7740,6 +8688,9 @@ impl<'a> AstBuilder<'a> {
     /// * `source`
     /// * `options`
     /// * `phase`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_import_expression(
         &self,
@@ -7763,6 +8714,9 @@ impl<'a> AstBuilder<'a> {
     /// * `phase`
     /// * `with_clause`: Some(vec![]) for empty assertion
     /// * `import_kind`: `import type { foo } from 'bar'`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_declaration<T1>(
         &self,
@@ -7799,6 +8753,9 @@ impl<'a> AstBuilder<'a> {
     /// * `phase`
     /// * `with_clause`: Some(vec![]) for empty assertion
     /// * `import_kind`: `import type { foo } from 'bar'`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_import_declaration<T1>(
         &self,
@@ -7827,6 +8784,9 @@ impl<'a> AstBuilder<'a> {
     /// * `imported`: Imported symbol.
     /// * `local`: Binding for local symbol.
     /// * `import_kind`: Value or type.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_declaration_specifier_import_specifier(
         &self,
@@ -7850,6 +8810,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `local`: The name of the imported symbol.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_declaration_specifier_import_default_specifier(
         &self,
@@ -7868,6 +8831,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `local`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_declaration_specifier_import_namespace_specifier(
         &self,
@@ -7889,6 +8855,9 @@ impl<'a> AstBuilder<'a> {
     /// * `imported`: Imported symbol.
     /// * `local`: Binding for local symbol.
     /// * `import_kind`: Value or type.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_specifier(
         &self,
@@ -7910,6 +8879,9 @@ impl<'a> AstBuilder<'a> {
     /// * `imported`: Imported symbol.
     /// * `local`: Binding for local symbol.
     /// * `import_kind`: Value or type.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_import_specifier(
         &self,
@@ -7929,6 +8901,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `local`: The name of the imported symbol.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_default_specifier(
         &self,
@@ -7946,6 +8921,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `local`: The name of the imported symbol.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_import_default_specifier(
         &self,
@@ -7963,6 +8941,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `local`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_namespace_specifier(
         &self,
@@ -7980,6 +8961,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `local`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_import_namespace_specifier(
         &self,
@@ -7998,6 +8982,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `keyword`
     /// * `with_entries`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn with_clause(
         &self,
@@ -8017,6 +9004,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `keyword`
     /// * `with_entries`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_with_clause(
         &self,
@@ -8033,6 +9023,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `key`
     /// * `value`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_attribute(
         &self,
@@ -8048,6 +9041,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_attribute_key_identifier<S1>(
         &self,
@@ -8066,6 +9062,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_attribute_key_string_literal<S1>(
         &self,
@@ -8086,6 +9085,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn import_attribute_key_string_literal_with_lone_surrogates<S1>(
         &self,
@@ -8117,6 +9119,9 @@ impl<'a> AstBuilder<'a> {
     /// * `source`
     /// * `export_kind`: `export type { foo }`
     /// * `with_clause`: Some(vec![]) for empty assertion
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn export_named_declaration<T1>(
         &self,
@@ -8153,6 +9158,9 @@ impl<'a> AstBuilder<'a> {
     /// * `source`
     /// * `export_kind`: `export type { foo }`
     /// * `with_clause`: Some(vec![]) for empty assertion
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_export_named_declaration<T1>(
         &self,
@@ -8187,6 +9195,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `declaration`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn export_default_declaration(
         &self,
@@ -8204,6 +9215,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `declaration`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_export_default_declaration(
         &self,
@@ -8224,6 +9238,9 @@ impl<'a> AstBuilder<'a> {
     /// * `source`
     /// * `with_clause`: Will be `Some(vec![])` for empty assertion
     /// * `export_kind`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn export_all_declaration<T1>(
         &self,
@@ -8257,6 +9274,9 @@ impl<'a> AstBuilder<'a> {
     /// * `source`
     /// * `with_clause`: Will be `Some(vec![])` for empty assertion
     /// * `export_kind`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_export_all_declaration<T1>(
         &self,
@@ -8282,6 +9302,9 @@ impl<'a> AstBuilder<'a> {
     /// * `local`
     /// * `exported`
     /// * `export_kind`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn export_specifier(
         &self,
@@ -8309,6 +9332,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`: Function parameters.
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn export_default_declaration_kind_function_declaration<T1, T2, T3, T4, T5>(
         &self,
@@ -8365,6 +9391,9 @@ impl<'a> AstBuilder<'a> {
     /// * `scope_id`
     /// * `pure`: `true` if the function is marked with a `/*#__NO_SIDE_EFFECTS__*/` comment
     /// * `pife`: `true` if the function should be marked as "Possibly-Invoked Function Expression" (PIFE).
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn export_default_declaration_kind_function_declaration_with_scope_id_and_pure_and_pife<
         T1,
@@ -8432,6 +9461,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn export_default_declaration_kind_class_declaration<T1, T2, T3>(
         &self,
@@ -8484,6 +9516,9 @@ impl<'a> AstBuilder<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     /// * `scope_id`: Id of the scope created by the [`Class`], including type parameters and
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn export_default_declaration_kind_class_declaration_with_scope_id<T1, T2, T3>(
         &self,
@@ -8532,6 +9567,9 @@ impl<'a> AstBuilder<'a> {
     /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn export_default_declaration_kind_ts_interface_declaration<T1, T2>(
         &self,
@@ -8568,6 +9606,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn export_default_declaration_kind_ts_interface_declaration_with_scope_id<T1, T2>(
         &self,
@@ -8601,6 +9642,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_export_name_identifier_name<S1>(
         &self,
@@ -8618,6 +9662,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_export_name_identifier_reference<S1>(
         &self,
@@ -8636,6 +9683,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_export_name_identifier_reference_with_reference_id<S1>(
         &self,
@@ -8659,6 +9709,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_export_name_string_literal<S1>(
         &self,
@@ -8679,6 +9732,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn module_export_name_string_literal_with_lone_surrogates<S1>(
         &self,
@@ -8707,6 +9763,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     /// * `arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn v8_intrinsic_expression(
         &self,
@@ -8726,6 +9785,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     /// * `arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_v8_intrinsic_expression(
         &self,
@@ -8744,6 +9806,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `value`: The boolean value itself
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn boolean_literal(&self, span: Span, value: bool) -> BooleanLiteral {
         BooleanLiteral { node_id: Default::default(), span, value }
@@ -8757,6 +9822,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `value`: The boolean value itself
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_boolean_literal(&self, span: Span, value: bool) -> ArenaBox<'a, BooleanLiteral> {
         ArenaBox::new_in(self.boolean_literal(span, value), self)
@@ -8769,6 +9837,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn null_literal(&self, span: Span) -> NullLiteral {
         NullLiteral { node_id: Default::default(), span }
@@ -8781,6 +9852,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_null_literal(&self, span: Span) -> ArenaBox<'a, NullLiteral> {
         ArenaBox::new_in(self.null_literal(span), self)
@@ -8796,6 +9870,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the number, converted into base 10
     /// * `raw`: The number as it appears in source code
     /// * `base`: The base representation used by the literal in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn numeric_literal(
         &self,
@@ -8817,6 +9894,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the number, converted into base 10
     /// * `raw`: The number as it appears in source code
     /// * `base`: The base representation used by the literal in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_numeric_literal(
         &self,
@@ -8837,6 +9917,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn string_literal<S1>(
         &self,
@@ -8865,6 +9948,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_string_literal<S1>(
         &self,
@@ -8888,6 +9974,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn string_literal_with_lone_surrogates<S1>(
         &self,
@@ -8918,6 +10007,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_string_literal_with_lone_surrogates<S1>(
         &self,
@@ -8945,6 +10037,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: Bigint value in base 10 with no underscores
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn big_int_literal<S1>(
         &self,
@@ -8969,6 +10064,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: Bigint value in base 10 with no underscores
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_big_int_literal<S1>(
         &self,
@@ -8992,6 +10090,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `regex`: The parsed regular expression. See [`oxc_regular_expression`] for more
     /// * `raw`: The regular expression as it appears in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn reg_exp_literal(
         &self,
@@ -9011,6 +10112,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `regex`: The parsed regular expression. See [`oxc_regular_expression`] for more
     /// * `raw`: The regular expression as it appears in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_reg_exp_literal(
         &self,
@@ -9031,6 +10135,9 @@ impl<'a> AstBuilder<'a> {
     /// * `opening_element`: Opening tag of the element.
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_element<T1, T2>(
         &self,
@@ -9062,6 +10169,9 @@ impl<'a> AstBuilder<'a> {
     /// * `opening_element`: Opening tag of the element.
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_element<T1, T2>(
         &self,
@@ -9087,6 +10197,9 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
     /// * `type_arguments`: Type parameters for generic JSX elements.
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_opening_element<T1>(
         &self,
@@ -9117,6 +10230,9 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
     /// * `type_arguments`: Type parameters for generic JSX elements.
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_opening_element<T1>(
         &self,
@@ -9139,6 +10255,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `name`: The tag name, e.g. `Foo` in `</Foo>`.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_closing_element(
         &self,
@@ -9156,6 +10275,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `name`: The tag name, e.g. `Foo` in `</Foo>`.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_closing_element(
         &self,
@@ -9175,6 +10297,9 @@ impl<'a> AstBuilder<'a> {
     /// * `opening_fragment`: `<>`
     /// * `children`: Elements inside the fragment.
     /// * `closing_fragment`: `</>`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_fragment(
         &self,
@@ -9202,6 +10327,9 @@ impl<'a> AstBuilder<'a> {
     /// * `opening_fragment`: `<>`
     /// * `children`: Elements inside the fragment.
     /// * `closing_fragment`: `</>`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_fragment(
         &self,
@@ -9220,6 +10348,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_opening_fragment(&self, span: Span) -> JSXOpeningFragment {
         JSXOpeningFragment { node_id: Default::default(), span }
@@ -9229,6 +10360,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_closing_fragment(&self, span: Span) -> JSXClosingFragment {
         JSXClosingFragment { node_id: Default::default(), span }
@@ -9241,6 +10375,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_element_name_identifier<S1>(&self, span: Span, name: S1) -> JSXElementName<'a>
     where
@@ -9256,6 +10393,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_element_name_identifier_reference<S1>(
         &self,
@@ -9276,6 +10416,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_element_name_identifier_reference_with_reference_id<S1>(
         &self,
@@ -9301,6 +10444,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_element_name_namespaced_name(
         &self,
@@ -9319,6 +10465,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `object`: The object being accessed. This is everything before the last `.`.
     /// * `property`: The property being accessed. This is everything after the last `.`.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_element_name_member_expression(
         &self,
@@ -9335,6 +10484,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_element_name_this_expression(&self, span: Span) -> JSXElementName<'a> {
         JSXElementName::ThisExpression(self.alloc_this_expression(span))
@@ -9349,6 +10501,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_namespaced_name(
         &self,
@@ -9368,6 +10523,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_namespaced_name(
         &self,
@@ -9387,6 +10545,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `object`: The object being accessed. This is everything before the last `.`.
     /// * `property`: The property being accessed. This is everything after the last `.`.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_member_expression(
         &self,
@@ -9406,6 +10567,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `object`: The object being accessed. This is everything before the last `.`.
     /// * `property`: The property being accessed. This is everything after the last `.`.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_member_expression(
         &self,
@@ -9423,6 +10587,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_member_expression_object_identifier_reference<S1>(
         &self,
@@ -9443,6 +10610,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_member_expression_object_identifier_reference_with_reference_id<S1>(
         &self,
@@ -9466,6 +10636,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `object`: The object being accessed. This is everything before the last `.`.
     /// * `property`: The property being accessed. This is everything after the last `.`.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_member_expression_object_member_expression(
         &self,
@@ -9484,6 +10657,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_member_expression_object_this_expression(
         &self,
@@ -9500,6 +10676,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `expression`: The expression inside the container.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_expression_container(
         &self,
@@ -9517,6 +10696,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `expression`: The expression inside the container.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_expression_container(
         &self,
@@ -9532,6 +10714,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_expression_empty_expression(&self, span: Span) -> JSXExpression<'a> {
         JSXExpression::EmptyExpression(self.alloc_jsx_empty_expression(span))
@@ -9544,6 +10729,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_empty_expression(&self, span: Span) -> JSXEmptyExpression {
         JSXEmptyExpression { node_id: Default::default(), span }
@@ -9556,6 +10744,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_empty_expression(&self, span: Span) -> ArenaBox<'a, JSXEmptyExpression> {
         ArenaBox::new_in(self.jsx_empty_expression(span), self)
@@ -9569,6 +10760,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the attribute. This is a prop in React-like applications.
     /// * `value`: The value of the attribute. This can be a string literal, an expression,
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_attribute_item_attribute(
         &self,
@@ -9586,6 +10780,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `argument`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_attribute_item_spread_attribute(
         &self,
@@ -9604,6 +10801,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the attribute. This is a prop in React-like applications.
     /// * `value`: The value of the attribute. This can be a string literal, an expression,
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_attribute(
         &self,
@@ -9623,6 +10823,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `name`: The name of the attribute. This is a prop in React-like applications.
     /// * `value`: The value of the attribute. This can be a string literal, an expression,
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_attribute(
         &self,
@@ -9641,6 +10844,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `argument`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_spread_attribute(
         &self,
@@ -9658,6 +10864,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `argument`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_spread_attribute(
         &self,
@@ -9674,6 +10883,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_attribute_name_identifier<S1>(&self, span: Span, name: S1) -> JSXAttributeName<'a>
     where
@@ -9690,6 +10902,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
     /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_attribute_name_namespaced_name(
         &self,
@@ -9708,6 +10923,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_attribute_value_string_literal<S1>(
         &self,
@@ -9730,6 +10948,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_attribute_value_string_literal_with_lone_surrogates<S1>(
         &self,
@@ -9756,6 +10977,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `expression`: The expression inside the container.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_attribute_value_expression_container(
         &self,
@@ -9776,6 +11000,9 @@ impl<'a> AstBuilder<'a> {
     /// * `opening_element`: Opening tag of the element.
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_attribute_value_element<T1, T2>(
         &self,
@@ -9805,6 +11032,9 @@ impl<'a> AstBuilder<'a> {
     /// * `opening_fragment`: `<>`
     /// * `children`: Elements inside the fragment.
     /// * `closing_fragment`: `</>`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_attribute_value_fragment(
         &self,
@@ -9829,6 +11059,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_identifier<S1>(&self, span: Span, name: S1) -> JSXIdentifier<'a>
     where
@@ -9845,6 +11078,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `name`: The name of the identifier.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_identifier<S1>(&self, span: Span, name: S1) -> ArenaBox<'a, JSXIdentifier<'a>>
     where
@@ -9861,6 +11097,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_child_text<S1>(&self, span: Span, value: S1, raw: Option<Str<'a>>) -> JSXChild<'a>
     where
@@ -9878,6 +11117,9 @@ impl<'a> AstBuilder<'a> {
     /// * `opening_element`: Opening tag of the element.
     /// * `children`: Children of the element.
     /// * `closing_element`: Closing tag of the element.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_child_element<T1, T2>(
         &self,
@@ -9902,6 +11144,9 @@ impl<'a> AstBuilder<'a> {
     /// * `opening_fragment`: `<>`
     /// * `children`: Elements inside the fragment.
     /// * `closing_fragment`: `</>`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_child_fragment(
         &self,
@@ -9925,6 +11170,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `expression`: The expression inside the container.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_child_expression_container(
         &self,
@@ -9941,6 +11189,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `expression`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_child_spread(&self, span: Span, expression: Expression<'a>) -> JSXChild<'a> {
         JSXChild::Spread(self.alloc_jsx_spread_child(span, expression))
@@ -9954,6 +11205,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `expression`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_spread_child(&self, span: Span, expression: Expression<'a>) -> JSXSpreadChild<'a> {
         JSXSpreadChild { node_id: Default::default(), span, expression }
@@ -9967,6 +11221,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `expression`: The expression being spread.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_spread_child(
         &self,
@@ -9985,6 +11242,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn jsx_text<S1>(&self, span: Span, value: S1, raw: Option<Str<'a>>) -> JSXText<'a>
     where
@@ -10002,6 +11262,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The text content.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_jsx_text<S1>(
         &self,
@@ -10024,6 +11287,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `this_span`
     /// * `type_annotation`: Type type the `this` keyword will have in the function
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_this_parameter<T1>(
         &self,
@@ -10051,6 +11317,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `this_span`
     /// * `type_annotation`: Type type the `this` keyword will have in the function
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_this_parameter<T1>(
         &self,
@@ -10075,6 +11344,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `const`: `true` for const enums
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_enum_declaration(
         &self,
@@ -10098,6 +11370,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `const`: `true` for const enums
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_enum_declaration(
         &self,
@@ -10115,6 +11390,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `members`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_enum_body(
         &self,
@@ -10130,6 +11408,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `members`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_enum_body_with_scope_id(
         &self,
@@ -10151,6 +11432,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `id`
     /// * `initializer`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_enum_member(
         &self,
@@ -10168,6 +11452,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_enum_member_name_identifier<S1>(&self, span: Span, name: S1) -> TSEnumMemberName<'a>
     where
@@ -10184,6 +11471,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_enum_member_name_string<S1>(
         &self,
@@ -10206,6 +11496,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_enum_member_name_string_with_lone_surrogates<S1>(
         &self,
@@ -10233,6 +11526,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_enum_member_name_computed_string<S1>(
         &self,
@@ -10255,6 +11551,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_enum_member_name_computed_string_with_lone_surrogates<S1>(
         &self,
@@ -10282,6 +11581,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `quasis`
     /// * `expressions`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_enum_member_name_computed_template_string(
         &self,
@@ -10304,6 +11606,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`: The actual type in the annotation
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_annotation(
         &self,
@@ -10321,6 +11626,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`: The actual type in the annotation
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_annotation(
         &self,
@@ -10338,6 +11646,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `literal`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_literal_type(&self, span: Span, literal: TSLiteral<'a>) -> TSLiteralType<'a> {
         TSLiteralType { node_id: Default::default(), span, literal }
@@ -10351,6 +11662,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `literal`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_literal_type(
         &self,
@@ -10367,6 +11681,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code.
     /// * `value`: The boolean value itself
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_literal_boolean_literal(&self, span: Span, value: bool) -> TSLiteral<'a> {
         TSLiteral::BooleanLiteral(self.alloc_boolean_literal(span, value))
@@ -10381,6 +11698,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the number, converted into base 10
     /// * `raw`: The number as it appears in source code
     /// * `base`: The base representation used by the literal in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_literal_numeric_literal(
         &self,
@@ -10401,6 +11721,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: Bigint value in base 10 with no underscores
     /// * `raw`: The bigint as it appears in source code
     /// * `base`: The base representation used by the literal in source code
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_literal_big_int_literal<S1>(
         &self,
@@ -10423,6 +11746,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_literal_string_literal<S1>(
         &self,
@@ -10445,6 +11771,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_literal_string_literal_with_lone_surrogates<S1>(
         &self,
@@ -10472,6 +11801,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `quasis`
     /// * `expressions`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_literal_template_literal(
         &self,
@@ -10490,6 +11822,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `operator`
     /// * `argument`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_literal_unary_expression(
         &self,
@@ -10506,6 +11841,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_any_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSAnyKeyword(self.alloc_ts_any_keyword(span))
@@ -10517,6 +11855,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_big_int_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSBigIntKeyword(self.alloc_ts_big_int_keyword(span))
@@ -10528,6 +11869,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_boolean_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSBooleanKeyword(self.alloc_ts_boolean_keyword(span))
@@ -10539,6 +11883,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_intrinsic_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSIntrinsicKeyword(self.alloc_ts_intrinsic_keyword(span))
@@ -10550,6 +11897,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_never_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSNeverKeyword(self.alloc_ts_never_keyword(span))
@@ -10561,6 +11911,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_null_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSNullKeyword(self.alloc_ts_null_keyword(span))
@@ -10572,6 +11925,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_number_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSNumberKeyword(self.alloc_ts_number_keyword(span))
@@ -10583,6 +11939,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_object_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSObjectKeyword(self.alloc_ts_object_keyword(span))
@@ -10594,6 +11953,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_string_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSStringKeyword(self.alloc_ts_string_keyword(span))
@@ -10605,6 +11967,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_symbol_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSSymbolKeyword(self.alloc_ts_symbol_keyword(span))
@@ -10616,6 +11981,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_undefined_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSUndefinedKeyword(self.alloc_ts_undefined_keyword(span))
@@ -10627,6 +11995,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_unknown_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSUnknownKeyword(self.alloc_ts_unknown_keyword(span))
@@ -10638,6 +12009,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_void_keyword(&self, span: Span) -> TSType<'a> {
         TSType::TSVoidKeyword(self.alloc_ts_void_keyword(span))
@@ -10650,6 +12024,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `element_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_array_type(&self, span: Span, element_type: TSType<'a>) -> TSType<'a> {
         TSType::TSArrayType(self.alloc_ts_array_type(span, element_type))
@@ -10665,6 +12042,9 @@ impl<'a> AstBuilder<'a> {
     /// * `extends_type`: The type `check_type` is being tested against.
     /// * `true_type`: The type evaluated to if the test is true.
     /// * `false_type`: The type evaluated to if the test is false.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_conditional_type(
         &self,
@@ -10694,6 +12074,9 @@ impl<'a> AstBuilder<'a> {
     /// * `true_type`: The type evaluated to if the test is true.
     /// * `false_type`: The type evaluated to if the test is false.
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_conditional_type_with_scope_id(
         &self,
@@ -10724,6 +12107,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_parameters`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_constructor_type<T1, T2, T3>(
         &self,
@@ -10758,6 +12144,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_constructor_type_with_scope_id<T1, T2, T3>(
         &self,
@@ -10793,6 +12182,9 @@ impl<'a> AstBuilder<'a> {
     /// * `this_param`: `this` parameter
     /// * `params`: Function parameters. Akin to [`Function::params`].
     /// * `return_type`: Return type of the function.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_function_type<T1, T2, T3, T4>(
         &self,
@@ -10828,6 +12220,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`: Function parameters. Akin to [`Function::params`].
     /// * `return_type`: Return type of the function.
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_function_type_with_scope_id<T1, T2, T3, T4>(
         &self,
@@ -10864,6 +12259,9 @@ impl<'a> AstBuilder<'a> {
     /// * `options`
     /// * `qualifier`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_import_type<T1, T2>(
         &self,
@@ -10894,6 +12292,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `object_type`
     /// * `index_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_indexed_access_type(
         &self,
@@ -10915,6 +12316,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_infer_type<T1>(&self, span: Span, type_parameter: T1) -> TSType<'a>
     where
@@ -10930,6 +12334,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `types`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_intersection_type(
         &self,
@@ -10946,6 +12353,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `literal`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_literal_type(&self, span: Span, literal: TSLiteral<'a>) -> TSType<'a> {
         TSType::TSLiteralType(self.alloc_ts_literal_type(span, literal))
@@ -10963,6 +12373,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_mapped_type(
         &self,
@@ -10998,6 +12411,9 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_mapped_type_with_scope_id(
         &self,
@@ -11031,6 +12447,9 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     /// * `element_type`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_named_tuple_member(
         &self,
@@ -11055,6 +12474,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `quasis`: The string parts of the template literal.
     /// * `types`: The interpolated expressions in the template literal.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_template_literal_type(
         &self,
@@ -11071,6 +12493,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_this_type(&self, span: Span) -> TSType<'a> {
         TSType::TSThisType(self.alloc_ts_this_type(span))
@@ -11083,6 +12508,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `element_types`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_tuple_type(
         &self,
@@ -11099,6 +12527,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `members`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_type_literal(
         &self,
@@ -11116,6 +12547,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `operator`
     /// * `type_annotation`: The type being operated on
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_type_operator_type(
         &self,
@@ -11135,6 +12569,9 @@ impl<'a> AstBuilder<'a> {
     /// * `parameter_name`: The identifier the predicate operates on
     /// * `asserts`: Does this predicate include an `asserts` modifier?
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_type_predicate<T1>(
         &self,
@@ -11162,6 +12599,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expr_name`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_type_query<T1>(
         &self,
@@ -11183,6 +12623,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_name`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_type_reference<T1>(
         &self,
@@ -11203,6 +12646,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `types`: The types in the union.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_union_type(&self, span: Span, types: ArenaVec<'a, TSType<'a>>) -> TSType<'a> {
         TSType::TSUnionType(self.alloc_ts_union_type(span, types))
@@ -11215,6 +12661,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_parenthesized_type(
         &self,
@@ -11232,6 +12681,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     /// * `postfix`: Was `?` after the type annotation?
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_js_doc_nullable_type(
         &self,
@@ -11250,6 +12702,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     /// * `postfix`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_js_doc_non_nullable_type(
         &self,
@@ -11270,6 +12725,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_js_doc_unknown_type(&self, span: Span) -> TSType<'a> {
         TSType::JSDocUnknownType(self.alloc_js_doc_unknown_type(span))
@@ -11286,6 +12744,9 @@ impl<'a> AstBuilder<'a> {
     /// * `extends_type`: The type `check_type` is being tested against.
     /// * `true_type`: The type evaluated to if the test is true.
     /// * `false_type`: The type evaluated to if the test is false.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_conditional_type(
         &self,
@@ -11317,6 +12778,9 @@ impl<'a> AstBuilder<'a> {
     /// * `extends_type`: The type `check_type` is being tested against.
     /// * `true_type`: The type evaluated to if the test is true.
     /// * `false_type`: The type evaluated to if the test is false.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_conditional_type(
         &self,
@@ -11344,6 +12808,9 @@ impl<'a> AstBuilder<'a> {
     /// * `true_type`: The type evaluated to if the test is true.
     /// * `false_type`: The type evaluated to if the test is false.
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_conditional_type_with_scope_id(
         &self,
@@ -11377,6 +12844,9 @@ impl<'a> AstBuilder<'a> {
     /// * `true_type`: The type evaluated to if the test is true.
     /// * `false_type`: The type evaluated to if the test is false.
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_conditional_type_with_scope_id(
         &self,
@@ -11408,6 +12878,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `types`: The types in the union.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_union_type(&self, span: Span, types: ArenaVec<'a, TSType<'a>>) -> TSUnionType<'a> {
         TSUnionType { node_id: Default::default(), span, types }
@@ -11421,6 +12894,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `types`: The types in the union.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_union_type(
         &self,
@@ -11438,6 +12914,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `types`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_intersection_type(
         &self,
@@ -11455,6 +12934,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `types`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_intersection_type(
         &self,
@@ -11472,6 +12954,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_parenthesized_type(
         &self,
@@ -11489,6 +12974,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_parenthesized_type(
         &self,
@@ -11507,6 +12995,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `operator`
     /// * `type_annotation`: The type being operated on
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_operator(
         &self,
@@ -11526,6 +13017,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `operator`
     /// * `type_annotation`: The type being operated on
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_operator(
         &self,
@@ -11544,6 +13038,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `element_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_array_type(&self, span: Span, element_type: TSType<'a>) -> TSArrayType<'a> {
         TSArrayType { node_id: Default::default(), span, element_type }
@@ -11557,6 +13054,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `element_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_array_type(
         &self,
@@ -11575,6 +13075,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `object_type`
     /// * `index_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_indexed_access_type(
         &self,
@@ -11594,6 +13097,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `object_type`
     /// * `index_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_indexed_access_type(
         &self,
@@ -11612,6 +13118,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `element_types`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_tuple_type(
         &self,
@@ -11629,6 +13138,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `element_types`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_tuple_type(
         &self,
@@ -11648,6 +13160,9 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     /// * `element_type`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_named_tuple_member(
         &self,
@@ -11669,6 +13184,9 @@ impl<'a> AstBuilder<'a> {
     /// * `label`
     /// * `element_type`
     /// * `optional`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_named_tuple_member(
         &self,
@@ -11688,6 +13206,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_optional_type(&self, span: Span, type_annotation: TSType<'a>) -> TSOptionalType<'a> {
         TSOptionalType { node_id: Default::default(), span, type_annotation }
@@ -11701,6 +13222,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_optional_type(
         &self,
@@ -11718,6 +13242,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_rest_type(&self, span: Span, type_annotation: TSType<'a>) -> TSRestType<'a> {
         TSRestType { node_id: Default::default(), span, type_annotation }
@@ -11731,6 +13258,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_rest_type(
         &self,
@@ -11747,6 +13277,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_tuple_element_optional_type(
         &self,
@@ -11763,6 +13296,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_tuple_element_rest_type(
         &self,
@@ -11779,6 +13315,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_any_keyword(&self, span: Span) -> TSAnyKeyword {
         TSAnyKeyword { node_id: Default::default(), span }
@@ -11791,6 +13330,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_any_keyword(&self, span: Span) -> ArenaBox<'a, TSAnyKeyword> {
         ArenaBox::new_in(self.ts_any_keyword(span), self)
@@ -11803,6 +13345,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_string_keyword(&self, span: Span) -> TSStringKeyword {
         TSStringKeyword { node_id: Default::default(), span }
@@ -11815,6 +13360,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_string_keyword(&self, span: Span) -> ArenaBox<'a, TSStringKeyword> {
         ArenaBox::new_in(self.ts_string_keyword(span), self)
@@ -11827,6 +13375,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_boolean_keyword(&self, span: Span) -> TSBooleanKeyword {
         TSBooleanKeyword { node_id: Default::default(), span }
@@ -11839,6 +13390,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_boolean_keyword(&self, span: Span) -> ArenaBox<'a, TSBooleanKeyword> {
         ArenaBox::new_in(self.ts_boolean_keyword(span), self)
@@ -11851,6 +13405,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_number_keyword(&self, span: Span) -> TSNumberKeyword {
         TSNumberKeyword { node_id: Default::default(), span }
@@ -11863,6 +13420,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_number_keyword(&self, span: Span) -> ArenaBox<'a, TSNumberKeyword> {
         ArenaBox::new_in(self.ts_number_keyword(span), self)
@@ -11875,6 +13435,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_never_keyword(&self, span: Span) -> TSNeverKeyword {
         TSNeverKeyword { node_id: Default::default(), span }
@@ -11887,6 +13450,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_never_keyword(&self, span: Span) -> ArenaBox<'a, TSNeverKeyword> {
         ArenaBox::new_in(self.ts_never_keyword(span), self)
@@ -11899,6 +13465,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_intrinsic_keyword(&self, span: Span) -> TSIntrinsicKeyword {
         TSIntrinsicKeyword { node_id: Default::default(), span }
@@ -11911,6 +13480,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_intrinsic_keyword(&self, span: Span) -> ArenaBox<'a, TSIntrinsicKeyword> {
         ArenaBox::new_in(self.ts_intrinsic_keyword(span), self)
@@ -11923,6 +13495,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_unknown_keyword(&self, span: Span) -> TSUnknownKeyword {
         TSUnknownKeyword { node_id: Default::default(), span }
@@ -11935,6 +13510,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_unknown_keyword(&self, span: Span) -> ArenaBox<'a, TSUnknownKeyword> {
         ArenaBox::new_in(self.ts_unknown_keyword(span), self)
@@ -11947,6 +13525,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_null_keyword(&self, span: Span) -> TSNullKeyword {
         TSNullKeyword { node_id: Default::default(), span }
@@ -11959,6 +13540,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_null_keyword(&self, span: Span) -> ArenaBox<'a, TSNullKeyword> {
         ArenaBox::new_in(self.ts_null_keyword(span), self)
@@ -11971,6 +13555,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_undefined_keyword(&self, span: Span) -> TSUndefinedKeyword {
         TSUndefinedKeyword { node_id: Default::default(), span }
@@ -11983,6 +13570,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_undefined_keyword(&self, span: Span) -> ArenaBox<'a, TSUndefinedKeyword> {
         ArenaBox::new_in(self.ts_undefined_keyword(span), self)
@@ -11995,6 +13585,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_void_keyword(&self, span: Span) -> TSVoidKeyword {
         TSVoidKeyword { node_id: Default::default(), span }
@@ -12007,6 +13600,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_void_keyword(&self, span: Span) -> ArenaBox<'a, TSVoidKeyword> {
         ArenaBox::new_in(self.ts_void_keyword(span), self)
@@ -12019,6 +13615,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_symbol_keyword(&self, span: Span) -> TSSymbolKeyword {
         TSSymbolKeyword { node_id: Default::default(), span }
@@ -12031,6 +13630,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_symbol_keyword(&self, span: Span) -> ArenaBox<'a, TSSymbolKeyword> {
         ArenaBox::new_in(self.ts_symbol_keyword(span), self)
@@ -12043,6 +13645,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_this_type(&self, span: Span) -> TSThisType {
         TSThisType { node_id: Default::default(), span }
@@ -12055,6 +13660,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_this_type(&self, span: Span) -> ArenaBox<'a, TSThisType> {
         ArenaBox::new_in(self.ts_this_type(span), self)
@@ -12067,6 +13675,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_object_keyword(&self, span: Span) -> TSObjectKeyword {
         TSObjectKeyword { node_id: Default::default(), span }
@@ -12079,6 +13690,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_object_keyword(&self, span: Span) -> ArenaBox<'a, TSObjectKeyword> {
         ArenaBox::new_in(self.ts_object_keyword(span), self)
@@ -12091,6 +13705,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_big_int_keyword(&self, span: Span) -> TSBigIntKeyword {
         TSBigIntKeyword { node_id: Default::default(), span }
@@ -12103,6 +13720,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_big_int_keyword(&self, span: Span) -> ArenaBox<'a, TSBigIntKeyword> {
         ArenaBox::new_in(self.ts_big_int_keyword(span), self)
@@ -12117,6 +13737,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_name`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_reference<T1>(
         &self,
@@ -12144,6 +13767,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_name`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_reference<T1>(
         &self,
@@ -12164,6 +13790,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_name_identifier_reference<S1>(&self, span: Span, name: S1) -> TSTypeName<'a>
     where
@@ -12180,6 +13809,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_name_identifier_reference_with_reference_id<S1>(
         &self,
@@ -12205,6 +13837,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_name_qualified_name(
         &self,
@@ -12221,6 +13856,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_name_this_expression(&self, span: Span) -> TSTypeName<'a> {
         TSTypeName::ThisExpression(self.alloc_this_expression(span))
@@ -12235,6 +13873,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_qualified_name(
         &self,
@@ -12254,6 +13895,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_qualified_name(
         &self,
@@ -12272,6 +13916,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `params`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_parameter_instantiation(
         &self,
@@ -12289,6 +13936,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `params`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_parameter_instantiation(
         &self,
@@ -12311,6 +13961,9 @@ impl<'a> AstBuilder<'a> {
     /// * `in`: Was an `in` modifier keyword present?
     /// * `out`: Was an `out` modifier keyword present?
     /// * `const`: Was a `const` modifier keyword present?
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_parameter(
         &self,
@@ -12347,6 +14000,9 @@ impl<'a> AstBuilder<'a> {
     /// * `in`: Was an `in` modifier keyword present?
     /// * `out`: Was an `out` modifier keyword present?
     /// * `const`: Was a `const` modifier keyword present?
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_parameter(
         &self,
@@ -12372,6 +14028,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `params`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_parameter_declaration(
         &self,
@@ -12389,6 +14048,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `params`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_parameter_declaration(
         &self,
@@ -12409,6 +14071,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_parameters`
     /// * `type_annotation`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_alias_declaration<T1>(
         &self,
@@ -12443,6 +14108,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_parameters`
     /// * `type_annotation`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_alias_declaration<T1>(
         &self,
@@ -12473,6 +14141,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `declare`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_alias_declaration_with_scope_id<T1>(
         &self,
@@ -12509,6 +14180,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `declare`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_alias_declaration_with_scope_id<T1>(
         &self,
@@ -12541,6 +14215,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_class_implements<T1>(
         &self,
@@ -12571,6 +14248,9 @@ impl<'a> AstBuilder<'a> {
     /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_interface_declaration<T1, T2>(
         &self,
@@ -12609,6 +14289,9 @@ impl<'a> AstBuilder<'a> {
     /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_interface_declaration<T1, T2>(
         &self,
@@ -12642,6 +14325,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_interface_declaration_with_scope_id<T1, T2>(
         &self,
@@ -12682,6 +14368,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_interface_declaration_with_scope_id<T1, T2>(
         &self,
@@ -12719,6 +14408,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_interface_body(
         &self,
@@ -12736,6 +14428,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_interface_body(
         &self,
@@ -12757,6 +14452,9 @@ impl<'a> AstBuilder<'a> {
     /// * `readonly`
     /// * `key`
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_property_signature<T1>(
         &self,
@@ -12793,6 +14491,9 @@ impl<'a> AstBuilder<'a> {
     /// * `readonly`
     /// * `key`
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_property_signature<T1>(
         &self,
@@ -12822,6 +14523,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `readonly`
     /// * `static`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_signature_index_signature<T1>(
         &self,
@@ -12854,6 +14558,9 @@ impl<'a> AstBuilder<'a> {
     /// * `readonly`
     /// * `key`
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_signature_property_signature<T1>(
         &self,
@@ -12887,6 +14594,9 @@ impl<'a> AstBuilder<'a> {
     /// * `this_param`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_signature_call_signature_declaration<T1, T2, T3, T4>(
         &self,
@@ -12922,6 +14632,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_signature_call_signature_declaration_with_scope_id<T1, T2, T3, T4>(
         &self,
@@ -12959,6 +14672,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_parameters`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_signature_construct_signature_declaration<T1, T2, T3>(
         &self,
@@ -12990,6 +14706,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_signature_construct_signature_declaration_with_scope_id<T1, T2, T3>(
         &self,
@@ -13029,6 +14748,9 @@ impl<'a> AstBuilder<'a> {
     /// * `this_param`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_signature_method_signature<T1, T2, T3, T4>(
         &self,
@@ -13076,6 +14798,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_signature_method_signature_with_scope_id<T1, T2, T3, T4>(
         &self,
@@ -13121,6 +14846,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `readonly`
     /// * `static`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_index_signature<T1>(
         &self,
@@ -13154,6 +14882,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `readonly`
     /// * `static`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_index_signature<T1>(
         &self,
@@ -13183,6 +14914,9 @@ impl<'a> AstBuilder<'a> {
     /// * `this_param`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_call_signature_declaration<T1, T2, T3, T4>(
         &self,
@@ -13220,6 +14954,9 @@ impl<'a> AstBuilder<'a> {
     /// * `this_param`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_call_signature_declaration<T1, T2, T3, T4>(
         &self,
@@ -13259,6 +14996,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_call_signature_declaration_with_scope_id<T1, T2, T3, T4>(
         &self,
@@ -13298,6 +15038,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_call_signature_declaration_with_scope_id<T1, T2, T3, T4>(
         &self,
@@ -13342,6 +15085,9 @@ impl<'a> AstBuilder<'a> {
     /// * `this_param`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_method_signature<T1, T2, T3, T4>(
         &self,
@@ -13391,6 +15137,9 @@ impl<'a> AstBuilder<'a> {
     /// * `this_param`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_method_signature<T1, T2, T3, T4>(
         &self,
@@ -13442,6 +15191,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_method_signature_with_scope_id<T1, T2, T3, T4>(
         &self,
@@ -13493,6 +15245,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_method_signature_with_scope_id<T1, T2, T3, T4>(
         &self,
@@ -13540,6 +15295,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_parameters`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_construct_signature_declaration<T1, T2, T3>(
         &self,
@@ -13573,6 +15331,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_parameters`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_construct_signature_declaration<T1, T2, T3>(
         &self,
@@ -13603,6 +15364,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_construct_signature_declaration_with_scope_id<T1, T2, T3>(
         &self,
@@ -13638,6 +15402,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_construct_signature_declaration_with_scope_id<T1, T2, T3>(
         &self,
@@ -13670,6 +15437,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_index_signature_name<S1, T1>(
         &self,
@@ -13695,6 +15465,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_interface_heritage<T1>(
         &self,
@@ -13723,6 +15496,9 @@ impl<'a> AstBuilder<'a> {
     /// * `parameter_name`: The identifier the predicate operates on
     /// * `asserts`: Does this predicate include an `asserts` modifier?
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_predicate<T1>(
         &self,
@@ -13753,6 +15529,9 @@ impl<'a> AstBuilder<'a> {
     /// * `parameter_name`: The identifier the predicate operates on
     /// * `asserts`: Does this predicate include an `asserts` modifier?
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_predicate<T1>(
         &self,
@@ -13777,6 +15556,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_predicate_name_identifier<S1>(
         &self,
@@ -13795,6 +15577,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_predicate_name_this(&self, span: Span) -> TSTypePredicateName<'a> {
         TSTypePredicateName::This(self.alloc_ts_this_type(span))
@@ -13811,6 +15596,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `kind`: The keyword used to define this module declaration.
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_declaration(
         &self,
@@ -13842,6 +15630,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `kind`: The keyword used to define this module declaration.
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_module_declaration(
         &self,
@@ -13866,6 +15657,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`: The keyword used to define this module declaration.
     /// * `declare`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_declaration_with_scope_id(
         &self,
@@ -13899,6 +15693,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`: The keyword used to define this module declaration.
     /// * `declare`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_module_declaration_with_scope_id(
         &self,
@@ -13920,6 +15717,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_declaration_name_identifier<S1>(
         &self,
@@ -13938,6 +15738,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     /// * `symbol_id`: Unique identifier for this binding.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_declaration_name_identifier_with_symbol_id<S1>(
         &self,
@@ -13959,6 +15762,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code.
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_declaration_name_string_literal<S1>(
         &self,
@@ -13979,6 +15785,9 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     /// * `lone_surrogates`: The string value contains lone surrogates.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_declaration_name_string_literal_with_lone_surrogates<S1>(
         &self,
@@ -14008,6 +15817,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `kind`: The keyword used to define this module declaration.
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_declaration_body_module_declaration(
         &self,
@@ -14033,6 +15845,9 @@ impl<'a> AstBuilder<'a> {
     /// * `kind`: The keyword used to define this module declaration.
     /// * `declare`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_declaration_body_module_declaration_with_scope_id(
         &self,
@@ -14056,6 +15871,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `directives`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_declaration_body_module_block(
         &self,
@@ -14076,6 +15894,9 @@ impl<'a> AstBuilder<'a> {
     /// * `global_span`: Span of `global` keyword
     /// * `body`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_global_declaration(
         &self,
@@ -14104,6 +15925,9 @@ impl<'a> AstBuilder<'a> {
     /// * `global_span`: Span of `global` keyword
     /// * `body`
     /// * `declare`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_global_declaration(
         &self,
@@ -14126,6 +15950,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `declare`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_global_declaration_with_scope_id(
         &self,
@@ -14156,6 +15983,9 @@ impl<'a> AstBuilder<'a> {
     /// * `body`
     /// * `declare`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_global_declaration_with_scope_id(
         &self,
@@ -14180,6 +16010,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `directives`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_block(
         &self,
@@ -14199,6 +16032,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `directives`
     /// * `body`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_module_block(
         &self,
@@ -14217,6 +16053,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `members`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_literal(
         &self,
@@ -14234,6 +16073,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `members`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_literal(
         &self,
@@ -14251,6 +16093,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_infer_type<T1>(&self, span: Span, type_parameter: T1) -> TSInferType<'a>
     where
@@ -14271,6 +16116,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_parameter`: The type bound when the
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_infer_type<T1>(
         &self,
@@ -14292,6 +16140,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expr_name`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_query<T1>(
         &self,
@@ -14319,6 +16170,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expr_name`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_query<T1>(
         &self,
@@ -14342,6 +16196,9 @@ impl<'a> AstBuilder<'a> {
     /// * `options`
     /// * `qualifier`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_query_expr_name_import_type<T1, T2>(
         &self,
@@ -14375,6 +16232,9 @@ impl<'a> AstBuilder<'a> {
     /// * `options`
     /// * `qualifier`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_import_type<T1, T2>(
         &self,
@@ -14409,6 +16269,9 @@ impl<'a> AstBuilder<'a> {
     /// * `options`
     /// * `qualifier`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_import_type<T1, T2>(
         &self,
@@ -14435,6 +16298,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_import_type_qualifier_identifier<S1>(
         &self,
@@ -14455,6 +16321,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_import_type_qualifier_qualified_name(
         &self,
@@ -14476,6 +16345,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_import_type_qualified_name(
         &self,
@@ -14495,6 +16367,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_import_type_qualified_name(
         &self,
@@ -14516,6 +16391,9 @@ impl<'a> AstBuilder<'a> {
     /// * `this_param`: `this` parameter
     /// * `params`: Function parameters. Akin to [`Function::params`].
     /// * `return_type`: Return type of the function.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_function_type<T1, T2, T3, T4>(
         &self,
@@ -14553,6 +16431,9 @@ impl<'a> AstBuilder<'a> {
     /// * `this_param`: `this` parameter
     /// * `params`: Function parameters. Akin to [`Function::params`].
     /// * `return_type`: Return type of the function.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_function_type<T1, T2, T3, T4>(
         &self,
@@ -14586,6 +16467,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`: Function parameters. Akin to [`Function::params`].
     /// * `return_type`: Return type of the function.
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_function_type_with_scope_id<T1, T2, T3, T4>(
         &self,
@@ -14625,6 +16509,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`: Function parameters. Akin to [`Function::params`].
     /// * `return_type`: Return type of the function.
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_function_type_with_scope_id<T1, T2, T3, T4>(
         &self,
@@ -14665,6 +16552,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_parameters`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_constructor_type<T1, T2, T3>(
         &self,
@@ -14701,6 +16591,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_parameters`
     /// * `params`
     /// * `return_type`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_constructor_type<T1, T2, T3>(
         &self,
@@ -14733,6 +16626,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_constructor_type_with_scope_id<T1, T2, T3>(
         &self,
@@ -14771,6 +16667,9 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_constructor_type_with_scope_id<T1, T2, T3>(
         &self,
@@ -14812,6 +16711,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_mapped_type(
         &self,
@@ -14849,6 +16751,9 @@ impl<'a> AstBuilder<'a> {
     /// * `type_annotation`
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_mapped_type(
         &self,
@@ -14888,6 +16793,9 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_mapped_type_with_scope_id(
         &self,
@@ -14927,6 +16835,9 @@ impl<'a> AstBuilder<'a> {
     /// * `optional`: Optional modifier on type annotation
     /// * `readonly`: Readonly modifier before keyed index signature
     /// * `scope_id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_mapped_type_with_scope_id(
         &self,
@@ -14963,6 +16874,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `quasis`: The string parts of the template literal.
     /// * `types`: The interpolated expressions in the template literal.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_template_literal_type(
         &self,
@@ -14982,6 +16896,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `quasis`: The string parts of the template literal.
     /// * `types`: The interpolated expressions in the template literal.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_template_literal_type(
         &self,
@@ -15001,6 +16918,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_as_expression(
         &self,
@@ -15020,6 +16940,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     /// * `type_annotation`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_as_expression(
         &self,
@@ -15039,6 +16962,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`: The value expression being constrained.
     /// * `type_annotation`: The type `expression` must satisfy.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_satisfies_expression(
         &self,
@@ -15058,6 +16984,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`: The value expression being constrained.
     /// * `type_annotation`: The type `expression` must satisfy.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_satisfies_expression(
         &self,
@@ -15077,6 +17006,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_type_assertion(
         &self,
@@ -15096,6 +17028,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_type_assertion(
         &self,
@@ -15116,6 +17051,9 @@ impl<'a> AstBuilder<'a> {
     /// * `id`
     /// * `module_reference`
     /// * `import_kind`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_import_equals_declaration(
         &self,
@@ -15143,6 +17081,9 @@ impl<'a> AstBuilder<'a> {
     /// * `id`
     /// * `module_reference`
     /// * `import_kind`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_import_equals_declaration(
         &self,
@@ -15164,6 +17105,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_reference_external_module_reference(
         &self,
@@ -15182,6 +17126,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_reference_identifier_reference<S1>(
         &self,
@@ -15202,6 +17149,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     /// * `reference_id`: Reference ID
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_reference_identifier_reference_with_reference_id<S1>(
         &self,
@@ -15227,6 +17177,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `left`
     /// * `right`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_module_reference_qualified_name(
         &self,
@@ -15245,6 +17198,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_external_module_reference(
         &self,
@@ -15262,6 +17218,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_external_module_reference(
         &self,
@@ -15279,6 +17238,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_non_null_expression(
         &self,
@@ -15296,6 +17258,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_non_null_expression(
         &self,
@@ -15310,6 +17275,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn decorator(&self, span: Span, expression: Expression<'a>) -> Decorator<'a> {
         Decorator { node_id: Default::default(), span, expression }
@@ -15323,6 +17291,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_export_assignment(
         &self,
@@ -15340,6 +17311,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_export_assignment(
         &self,
@@ -15357,6 +17331,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_namespace_export_declaration(
         &self,
@@ -15374,6 +17351,9 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_namespace_export_declaration(
         &self,
@@ -15392,6 +17372,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn ts_instantiation_expression<T1>(
         &self,
@@ -15419,6 +17402,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
     /// * `type_arguments`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_ts_instantiation_expression<T1>(
         &self,
@@ -15441,6 +17427,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     /// * `postfix`: Was `?` after the type annotation?
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn js_doc_nullable_type(
         &self,
@@ -15460,6 +17449,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     /// * `postfix`: Was `?` after the type annotation?
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_js_doc_nullable_type(
         &self,
@@ -15479,6 +17471,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     /// * `postfix`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn js_doc_non_nullable_type(
         &self,
@@ -15498,6 +17493,9 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `type_annotation`
     /// * `postfix`
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_js_doc_non_nullable_type(
         &self,
@@ -15515,6 +17513,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn js_doc_unknown_type(&self, span: Span) -> JSDocUnknownType {
         JSDocUnknownType { node_id: Default::default(), span }
@@ -15527,6 +17528,9 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
+    #[deprecated(
+        note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043"
+    )]
     #[inline]
     pub fn alloc_js_doc_unknown_type(&self, span: Span) -> ArenaBox<'a, JSDocUnknownType> {
         ArenaBox::new_in(self.js_doc_unknown_type(span), self)

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -264,6 +264,7 @@ fn generate_builder_methods_for_struct_impl(
         ///@@line_break
         #fn_docs
         #params_docs
+        #[deprecated(note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043")]
         #[inline]
         pub fn #fn_name #generic_params (&self, #fn_params) -> #struct_ty #where_clause {
             #struct_ident { #fields }
@@ -288,6 +289,7 @@ fn generate_builder_methods_for_struct_impl(
         #[doc = " Returns a [`Box`](ArenaBox) containing the newly-allocated node."]
         #[doc = #alloc_doc2]
         #params_docs
+        #[deprecated(note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043")]
         #[inline]
         pub fn #alloc_fn_name #generic_params (&self, #fn_params) -> ArenaBox<'a, #struct_ty> #where_clause {
             ArenaBox::new_in(self.#fn_name(#(#args),*), self)
@@ -581,6 +583,7 @@ fn generate_builder_method_for_enum_variant_impl(
         ///@@line_break
         #fn_docs
         #params_docs
+        #[deprecated(note = "Migrate to new `AstBuilder` interface. See https://github.com/oxc-project/oxc/issues/23043")]
         #[inline]
         pub fn #fn_name #generic_params(&self, #(#fn_params),*) -> #enum_ty #where_clause {
             #enum_ident::#variant_ident(self.#inner_builder_name(#(#args),*))


### PR DESCRIPTION
Closes #23043. 

Add `#[deprecated]` attributes to all legacy `AstBuilder` methods, prompting consumers to migrate to the new interface.