### PR TITLE
perf(linter/promise/always-return): narrow to function node types

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -4469,7 +4469,8 @@ impl RuleRunner for crate::rules::jsdoc::require_yields_type::RequireYieldsType 
 }
 
 impl RuleRunner for crate::rules::promise::always_return::AlwaysReturn {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> =
+        Some(&AstTypesBitset::from_types(&[AstType::ArrowFunctionExpression, AstType::Function]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -740,6 +740,10 @@ mod test {
             &unicorn::consistent_assert::ConsistentAssert,
             &[ImportDeclaration],
         );
+        assert_rule_runs_on_node_types(
+            &promise::always_return::AlwaysReturn::default(),
+            &[Function, ArrowFunctionExpression],
+        );
     }
 
     #[test]

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -196,8 +196,6 @@ impl Rule for AlwaysReturn {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // Narrow to function nodes so the linter codegen can generate `NODE_TYPES`
-        // and skip dispatching this rule on other node kinds.
         match node.kind() {
             AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {}
             _ => return,

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -542,12 +542,12 @@ fn test() {
         ),
         // A `then()` callback with a loop, ending in `return <nested then-chain>`
         (
-            r#"hey.then(function (x) { while (x.next()) { collect(x); } return load().then(function (y) { return y; }); })"#,
+            r"hey.then(function (x) { while (x.next()) { collect(x); } return load().then(function (y) { return y; }); })",
             None,
         ),
         // `if`/`else` where the `else` branch loops, then `return <object>`.
         (
-            r#"hey.then(x => { let n = 0; if (a) { n = 1; } else { while (cond(n)) { n++; } } return { items: x.map(i => i) }; })"#,
+            r"hey.then(x => { let n = 0; if (a) { n = 1; } else { while (cond(n)) { n++; } } return { items: x.map(i => i) }; })",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/rules/promise/always_return.rs
+++ b/crates/oxc_linter/src/rules/promise/always_return.rs
@@ -196,6 +196,13 @@ impl Rule for AlwaysReturn {
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // Narrow to function nodes so the linter codegen can generate `NODE_TYPES`
+        // and skip dispatching this rule on other node kinds.
+        match node.kind() {
+            AstKind::Function(_) | AstKind::ArrowFunctionExpression(_) => {}
+            _ => return,
+        }
+
         if !is_inline_then_function_expression(node, ctx) {
             return;
         }
@@ -532,6 +539,16 @@ fn test() {
         (
             "hey.then(x => { window['x'] = x })",
             Some(serde_json::json!([{ "ignoreAssignmentVariable": ["globalThis", "window"] }])),
+        ),
+        // A `then()` callback with a loop, ending in `return <nested then-chain>`
+        (
+            r#"hey.then(function (x) { while (x.next()) { collect(x); } return load().then(function (y) { return y; }); })"#,
+            None,
+        ),
+        // `if`/`else` where the `else` branch loops, then `return <object>`.
+        (
+            r#"hey.then(x => { let n = 0; if (a) { n = 1; } else { while (cond(n)) { n++; } } return { items: x.map(i => i) }; })"#,
+            None,
         ),
     ];
 


### PR DESCRIPTION
## What

`promise/always-return` had `NODE_TYPES = None`, so the linter dispatched its `run` method on **every** AST node and relied on an early-return inside a helper to filter out non-functions. Because the node-kind check lived inside `is_inline_then_function_expression`, the linter codegen couldn't infer the rule's node types.

This PR leads `run` with a `match node.kind()` that returns early for non-function nodes so codegen picks it up.

This results in a behavior change (which is covered by the new tests), and that behavior change is a match for the original rule from eslint-plugin-promise and is therefore correct (assuming we did not diverge intentionally from the original rule).

This was generated with Claude Code, reviewed and tested by me.

## Perf

Measured on VS Code (11674 files) with only this rule enabled:

| | Calls | Time |
|---|---|---|
| Before | 15,251,059 | ~238ms |
| After | 236,173 | ~13ms |

## Behavior

The warning count shifts slightly (1189 → 1187). This is an **intentional** consequence of the change and actually brings the rule closer to the original ESLint rule's behavior.

## Verification

- `cargo test -p oxc_linter always_return` — rule pass/fail snapshot suite passes
- `test_rule_runner_impls` passes (added a manual `assert_rule_runs_on_node_types` entry locking the bitset in both directions)
- Built `target/release/oxlint` and smoke-tested the rule fires/stays-silent correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)