### PR TITLE
perf(linter/unicorn/prefer-number-properties): speed up global checks

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -3652,11 +3652,10 @@ impl RuleRunner for crate::rules::unicorn::prefer_number_properties::PreferNumbe
     const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
         AstType::CallExpression,
         AstType::ComputedMemberExpression,
-        AstType::IdentifierReference,
         AstType::PrivateFieldExpression,
         AstType::StaticMemberExpression,
     ]));
-    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
+    const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Unknown;
 }
 
 impl RuleRunner for crate::rules::unicorn::prefer_object_from_entries::PreferObjectFromEntries {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_number_properties.rs
@@ -103,71 +103,18 @@ impl Rule for PreferNumberProperties {
                     return;
                 };
 
-                if GLOBAL_OBJECT_NAMES.contains(&ident_name.name.as_str()) {
-                    let Some(name) = member_expr.static_property_name() else {
-                        return;
-                    };
-                    if (name == "NaN" && self.check_nan)
-                        || (name == "Infinity" && self.check_infinity)
-                    {
-                        ctx.diagnostic_with_fix(
-                            prefer_number_properties_diagnostic(member_expr.span(), name.as_str()),
-                            |fixer| fixer.replace(ident_name.span, "Number"),
-                        );
-                    }
+                if !GLOBAL_OBJECT_NAMES.contains(&ident_name.name.as_str()) {
+                    return;
                 }
-            }
-            AstKind::IdentifierReference(ident_ref)
-                if ctx.is_reference_to_global_variable(ident_ref) =>
-            {
-                let ident_name = ident_ref.name.as_str();
-                if (ident_name == "NaN" && self.check_nan)
-                    || (ident_name == "Infinity" && self.check_infinity)
-                    || (matches!(ident_name, "isNaN" | "isFinite" | "parseFloat" | "parseInt")
-                        && matches!(ctx.nodes().parent_kind(node.id()), AstKind::ObjectProperty(_)))
+                let Some(name) = member_expr.static_property_name() else {
+                    return;
+                };
+                if (name == "NaN" && self.check_nan) || (name == "Infinity" && self.check_infinity)
                 {
-                    let (replacement_span, replacement_text) = if ident_name == "Infinity" {
-                        if let Some(unary) = find_ancestor_unary(node, ctx) {
-                            match unary.operator {
-                                UnaryOperator::UnaryNegation => {
-                                    (unary.span, "Number.NEGATIVE_INFINITY")
-                                }
-                                _ => (ident_ref.span, "Number.POSITIVE_INFINITY"),
-                            }
-                        } else {
-                            (ident_ref.span, "Number.POSITIVE_INFINITY")
-                        }
-                    } else {
-                        (ident_ref.span, "")
-                    };
-
-                    let fixer = |fixer: RuleFixer<'_, 'a>| match ctx.nodes().parent_kind(node.id())
-                    {
-                        AstKind::ObjectProperty(prop)
-                            if prop.shorthand && ident_name == "Infinity" =>
-                        {
-                            fixer
-                                .insert_text_after(&ident_ref.span, format!(": {replacement_text}"))
-                        }
-                        AstKind::ObjectProperty(prop) if prop.shorthand => fixer
-                            .insert_text_before(&ident_ref.span, format!("{ident_name}: Number.")),
-                        _ if ident_name == "Infinity" => {
-                            fixer.replace(replacement_span, replacement_text)
-                        }
-                        _ => fixer.insert_text_before(&ident_ref.span, "Number."),
-                    };
-
-                    if ident_name == "isNaN" || ident_name == "isFinite" {
-                        ctx.diagnostic_with_dangerous_fix(
-                            prefer_number_properties_diagnostic(ident_ref.span, &ident_ref.name),
-                            fixer,
-                        );
-                    } else {
-                        ctx.diagnostic_with_fix(
-                            prefer_number_properties_diagnostic(ident_ref.span, &ident_ref.name),
-                            fixer,
-                        );
-                    }
+                    ctx.diagnostic_with_fix(
+                        prefer_number_properties_diagnostic(member_expr.span(), name.as_str()),
+                        |fixer| fixer.replace(ident_name.span, "Number"),
+                    );
                 }
             }
             AstKind::CallExpression(call_expr) => {
@@ -175,57 +122,135 @@ impl Rule for PreferNumberProperties {
                     return;
                 };
 
-                if matches!(ident_name, "isNaN" | "isFinite" | "parseFloat" | "parseInt") {
-                    if let Expression::Identifier(ident) = &call_expr.callee
-                        && !ctx.is_reference_to_global_variable(ident)
-                    {
-                        return;
+                if !matches!(ident_name, "isNaN" | "isFinite" | "parseFloat" | "parseInt") {
+                    return;
+                }
+                if let Expression::Identifier(ident) = &call_expr.callee
+                    && !ctx.is_reference_to_global_variable(ident)
+                {
+                    return;
+                }
+
+                let fixer = |fixer: RuleFixer<'_, 'a>| match &call_expr.callee {
+                    Expression::Identifier(ident) => {
+                        // Use replace on the full call expression span instead of insert_text_before.
+                        // This ensures the fix span overlaps with prefer_numeric_literals fixes,
+                        // so the fixer's conflict resolution will skip one of them instead of
+                        // applying both and producing invalid code like `Number.0o111`.
+                        let args_span = Span::new(ident.span.end, call_expr.span.end);
+                        let args_text = ctx.source_range(args_span);
+                        fixer.replace(call_expr.span, format!("Number.{ident_name}{args_text}"))
                     }
-
-                    let fixer = |fixer: RuleFixer<'_, 'a>| match &call_expr.callee {
-                        Expression::Identifier(ident) => {
-                            // Use replace on the full call expression span instead of insert_text_before.
-                            // This ensures the fix span overlaps with prefer_numeric_literals fixes,
-                            // so the fixer's conflict resolution will skip one of them instead of
-                            // applying both and producing invalid code like `Number.0o111`.
-                            let args_span = Span::new(ident.span.end, call_expr.span.end);
-                            let args_text = ctx.source_range(args_span);
-                            fixer.replace(call_expr.span, format!("Number.{ident_name}{args_text}"))
+                    match_member_expression!(Expression) => {
+                        let member_expr = call_expr.callee.to_member_expression();
+                        let mut args_span = Span::new(member_expr.span().end, call_expr.span.end);
+                        if let Some(s) = &call_expr.type_arguments {
+                            args_span = args_span.merge(s.span());
                         }
-                        match_member_expression!(Expression) => {
-                            let member_expr = call_expr.callee.to_member_expression();
-                            let mut args_span =
-                                Span::new(member_expr.span().end, call_expr.span.end);
-                            if let Some(s) = &call_expr.type_arguments {
-                                args_span = args_span.merge(s.span());
-                            }
-                            let args_text = ctx.source_range(args_span);
+                        let args_text = ctx.source_range(args_span);
 
-                            fixer.replace(call_expr.span, format!("Number.{ident_name}{args_text}"))
-                        }
-                        _ => unreachable!(),
-                    };
-
-                    if ident_name == "isFinite" || ident_name == "isNaN" {
-                        ctx.diagnostic_with_dangerous_fix(
-                            prefer_number_properties_diagnostic(
-                                call_expr.callee.span(),
-                                ident_name,
-                            ),
-                            fixer,
-                        );
-                    } else {
-                        ctx.diagnostic_with_fix(
-                            prefer_number_properties_diagnostic(
-                                call_expr.callee.span(),
-                                ident_name,
-                            ),
-                            fixer,
-                        );
+                        fixer.replace(call_expr.span, format!("Number.{ident_name}{args_text}"))
                     }
+                    _ => unreachable!(),
+                };
+
+                if ident_name == "isFinite" || ident_name == "isNaN" {
+                    ctx.diagnostic_with_dangerous_fix(
+                        prefer_number_properties_diagnostic(call_expr.callee.span(), ident_name),
+                        fixer,
+                    );
+                } else {
+                    ctx.diagnostic_with_fix(
+                        prefer_number_properties_diagnostic(call_expr.callee.span(), ident_name),
+                        fixer,
+                    );
                 }
             }
             _ => {}
+        }
+    }
+
+    /// Handle bare global identifiers (`NaN`, `Infinity`, method shorthand) without
+    /// visiting every `IdentifierReference` in the file (hundreds of thousands of calls).
+    fn run_once(&self, ctx: &LintContext) {
+        let unresolved = ctx.scoping().root_unresolved_references();
+        let names: &[&str] = if self.check_nan && self.check_infinity {
+            &["NaN", "Infinity", "isNaN", "isFinite", "parseFloat", "parseInt"]
+        } else if self.check_nan {
+            &["NaN", "isNaN", "isFinite", "parseFloat", "parseInt"]
+        } else if self.check_infinity {
+            &["Infinity", "isNaN", "isFinite", "parseFloat", "parseInt"]
+        } else {
+            &["isNaN", "isFinite", "parseFloat", "parseInt"]
+        };
+
+        for &name in names {
+            let Some(ref_ids) = unresolved.get(name) else {
+                continue;
+            };
+            for &ref_id in ref_ids {
+                let reference = ctx.scoping().get_reference(ref_id);
+                let node = ctx.nodes().get_node(reference.node_id());
+                let AstKind::IdentifierReference(ident_ref) = node.kind() else {
+                    continue;
+                };
+                // Skip identifiers that are call callees — handled in `run` on CallExpression.
+                if matches!(ctx.nodes().parent_kind(node.id()), AstKind::CallExpression(_))
+                    && matches!(name, "isNaN" | "isFinite" | "parseFloat" | "parseInt")
+                {
+                    continue;
+                }
+                let is_method_shorthand =
+                    matches!(name, "isNaN" | "isFinite" | "parseFloat" | "parseInt");
+                if is_method_shorthand
+                    && !matches!(ctx.nodes().parent_kind(node.id()), AstKind::ObjectProperty(_))
+                {
+                    continue;
+                }
+                // Globals are off? is_reference_to_global_variable also checks globals table.
+                if !ctx.is_reference_to_global_variable(ident_ref) {
+                    continue;
+                }
+
+                let is_infinity = name == "Infinity";
+                let (replacement_span, replacement_text) = if is_infinity {
+                    if let Some(unary) = find_ancestor_unary(node, ctx) {
+                        match unary.operator {
+                            UnaryOperator::UnaryNegation => {
+                                (unary.span, "Number.NEGATIVE_INFINITY")
+                            }
+                            _ => (ident_ref.span, "Number.POSITIVE_INFINITY"),
+                        }
+                    } else {
+                        (ident_ref.span, "Number.POSITIVE_INFINITY")
+                    }
+                } else {
+                    (ident_ref.span, "")
+                };
+
+                let fixer = |fixer: RuleFixer<'_, '_>| match ctx.nodes().parent_kind(node.id()) {
+                    AstKind::ObjectProperty(prop) if prop.shorthand && is_infinity => {
+                        fixer.insert_text_after(&ident_ref.span, format!(": {replacement_text}"))
+                    }
+                    AstKind::ObjectProperty(prop) if prop.shorthand => {
+                        fixer.insert_text_before(&ident_ref.span, format!("{name}: Number."))
+                    }
+                    _ if is_infinity => fixer.replace(replacement_span, replacement_text),
+                    _ => fixer.insert_text_before(&ident_ref.span, "Number."),
+                };
+
+                if name == "isNaN" || name == "isFinite" {
+                    ctx.diagnostic_with_dangerous_fix(
+                        prefer_number_properties_diagnostic(ident_ref.span, name),
+                        fixer,
+                    );
+                } else {
+                    ctx.diagnostic_with_fix(
+                        prefer_number_properties_diagnostic(ident_ref.span, name),
+                        fixer,
+                    );
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Split from #23829.

Move bare `NaN`/`Infinity` and method shorthand handling to `run_once` over root unresolved references, leaving call expressions and global-object member replacements in `run`.

This reduces identifier-reference visits on large files while preserving behavior.

Co-authored-by: Yagiz Nizipli <yagiz@nizipli.com>