### PR TITLE
perf(linter/eslint/no-unused-vars): precompute exported bindings

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
@@ -73,7 +73,7 @@ impl NoUnusedVars {
                 Symbol::new(ctx, ctx.module_record(), specifier.local().symbol_id());
             !Self::should_skip_symbol(&specifier_symbol)
                 && self.is_ignored(&specifier_symbol).is_none()
-                && !specifier_symbol.is_exported()
+                && !specifier_symbol.is_exported_binding()
                 && !specifier_symbol.has_usages(self)
         })
     }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -224,13 +224,15 @@ impl Rule for NoUnusedVars {
     }
 
     fn run_once(&self, ctx: &LintContext) {
+        let precomputed_exported_names = Symbol::collect_exported_local_names(ctx.module_record());
+
         for symbol in ctx.scoping().symbol_ids() {
             let symbol = Symbol::new(ctx, ctx.module_record(), symbol);
             if Self::should_skip_symbol(&symbol) {
                 continue;
             }
 
-            self.run_on_symbol_internal(&symbol, ctx);
+            self.run_on_symbol_internal(&symbol, ctx, &precomputed_exported_names);
         }
     }
 
@@ -247,15 +249,19 @@ impl Rule for NoUnusedVars {
 }
 
 impl NoUnusedVars {
-    fn run_on_symbol_internal<'a>(&self, symbol: &Symbol<'_, 'a>, ctx: &LintContext<'a>) {
+    fn run_on_symbol_internal<'a>(
+        &self,
+        symbol: &Symbol<'_, 'a>,
+        ctx: &LintContext<'a>,
+        exported_names: &rustc_hash::FxHashSet<&str>,
+    ) {
         let is_ignored = self.is_ignored(symbol);
 
         if is_ignored.is_some() && !self.report_used_ignore_pattern {
             return;
         }
 
-        // Order matters. We want to call cheap/high "yield" functions first.
-        let is_used = symbol.is_exported() || symbol.has_usages(self);
+        let is_used = symbol.is_exported(exported_names) || symbol.has_usages(self);
 
         match (is_used, *is_ignored) {
             // used, ignored because variable name matches one of several

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -1,5 +1,7 @@
 use std::{cell::OnceCell, fmt, iter};
 
+use rustc_hash::FxHashSet;
+
 use oxc_ast::{
     AstKind,
     ast::{
@@ -172,21 +174,32 @@ impl<'s, 'a> Symbol<'s, 'a> {
 }
 
 impl<'a> Symbol<'_, 'a> {
+    /// Collect local names that are re-exported, for O(1) export checks per symbol.
+    pub fn collect_exported_local_names(module_record: &ModuleRecord) -> FxHashSet<&str> {
+        let mut names = FxHashSet::default();
+        for entry in &module_record.local_export_entries {
+            match &entry.local_name {
+                ExportLocalName::Name(name) | ExportLocalName::Default(name) => {
+                    names.insert(name.name());
+                }
+                ExportLocalName::Null => {}
+            }
+        }
+        names
+    }
+
     /// Is this [`Symbol`] exported?
     ///
     /// NOTE: does not support CJS right now.
-    pub fn is_exported(&self) -> bool {
+    pub fn is_exported(&self, exported_names: &FxHashSet<&str>) -> bool {
         let is_in_exportable_scope = self.is_root() || self.is_in_ts_namespace();
-        is_in_exportable_scope && (self.is_local_exported_binding() || self.in_export_node())
+        is_in_exportable_scope && (exported_names.contains(self.name()) || self.in_export_node())
     }
 
-    fn is_local_exported_binding(&self) -> bool {
-        self.module_record.local_export_entries.iter().any(|entry| match &entry.local_name {
-            ExportLocalName::Name(name) | ExportLocalName::Default(name) => {
-                name.name() == self.name()
-            }
-            ExportLocalName::Null => false,
-        })
+    /// Convenience wrapper that builds the export set (for call sites that check one symbol).
+    pub fn is_exported_binding(&self) -> bool {
+        let names = Self::collect_exported_local_names(self.module_record);
+        self.is_exported(&names)
     }
 
     #[inline]


### PR DESCRIPTION
Split from #23829.

Precompute exported local names once per file so `eslint/no-unused-vars` can check exported bindings in O(1) instead of repeatedly scanning export entries.

Skip usage walks for exported symbols and adapt the single-symbol import-fixer call site to preserve behavior.

AI-assisted with Codex.

Co-authored-by: Yagiz Nizipli <yagiz@nizipli.com>