### PR TITLE
perf(linter/jest-vitest): speed up no-standalone-expect

### DIFF
--- a/crates/oxc_linter/src/rules/shared/jest_vitest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/shared/jest_vitest/no_standalone_expect.rs
@@ -1,11 +1,12 @@
+use rustc_hash::FxHashMap;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_semantic::NodeId;
 use oxc_span::Span;
 use oxc_str::CompactStr;
-use rustc_hash::FxHashMap;
-use schemars::JsonSchema;
-use serde::Deserialize;
 
 use crate::{
     AstNode,
@@ -64,11 +65,11 @@ impl NoStandaloneExpectConfig {
 
     pub fn run_once(&self, ctx: &LintContext<'_>) {
         let possible_jest_nodes = collect_possible_jest_call_node(ctx);
-        let id_nodes_mapping =
-            possible_jest_nodes.iter().fold(FxHashMap::default(), |mut acc, cur| {
-                acc.entry(cur.node.id()).or_insert(cur);
-                acc
-            });
+        let mut id_nodes_mapping = FxHashMap::default();
+        id_nodes_mapping.reserve(possible_jest_nodes.len());
+        for cur in &possible_jest_nodes {
+            id_nodes_mapping.entry(cur.node.id()).or_insert(cur);
+        }
 
         for possible_jest_node in &possible_jest_nodes {
             self.run(possible_jest_node, &id_nodes_mapping, ctx);


### PR DESCRIPTION
Split from #23829.

Ports the shared no-standalone-expect collection optimization from #23829 to avoid extra sorting work.

Co-authored-by: Yagiz Nizipli <yagiz@nizipli.com>