### PR TITLE
fix(oxlint, oxfmt): enable `disable_old_builder` Cargo feature for `oxc_ast` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2827,6 +2827,7 @@ dependencies = [
  "oxc-schemars",
  "oxc-toml",
  "oxc_allocator",
+ "oxc_ast",
  "oxc_config",
  "oxc_diagnostics",
  "oxc_formatter",

--- a/apps/oxfmt/Cargo.toml
+++ b/apps/oxfmt/Cargo.toml
@@ -28,6 +28,7 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true, features = ["pool"] }
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 oxc_config = { workspace = true }
 oxc_diagnostics = { workspace = true }
 oxc_formatter = { workspace = true }
@@ -89,3 +90,7 @@ default = ["napi"]
 napi = ["dep:napi", "dep:napi-derive"]
 allocator = ["dep:mimalloc-safe"]
 detect_code_removal = ["oxc_formatter/detect_code_removal"]
+
+[package.metadata.cargo-shear]
+# `oxc_ast` is a feature-only dependency, to enable its `disable_old_builder` feature
+ignored = ["oxc_ast"]

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -28,7 +28,7 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true, features = ["fixed_size"] }
-oxc_ast = { workspace = true }
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
 oxc_ast_visit = { workspace = true, features = ["serialize"] }
 oxc_config = { workspace = true }
 oxc_diagnostics = { workspace = true }


### PR DESCRIPTION
Part of #23043.

We don't enable `oxc_ast`'s `disable_old_builder` Cargo feature in any of our published crates, or crates that are depended on by published crates.

`apps/oxlint` and `apps/oxfmt` are not published, so enable the feature on them, to ensure no usage of legacy `AstBuilder` methods sneak in during the transition period before we delete these methods.