### PR TITLE
fix(all): enable `disable_old_builder` Cargo feature for `oxc_ast` crate in tests

### DIFF
--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -43,6 +43,12 @@ oxc_syntax = { workspace = true }
 oxc_transformer = { workspace = true, optional = true }
 oxc_transformer_plugins = { workspace = true, optional = true }
 
+[dev-dependencies]
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# If we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
+
 [features]
 default = ["regular_expression"]
 

--- a/crates/oxc_estree_tokens/Cargo.toml
+++ b/crates/oxc_estree_tokens/Cargo.toml
@@ -28,3 +28,9 @@ oxc_estree = { workspace = true, features = ["serialize"] }
 oxc_parser = { workspace = true, features = ["mutate_tokens"] }
 oxc_span = { workspace = true, features = ["serialize"] }
 itoa = { workspace = true }
+
+[dev-dependencies]
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# If we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }

--- a/crates/oxc_formatter/Cargo.toml
+++ b/crates/oxc_formatter/Cargo.toml
@@ -47,6 +47,11 @@ pico-args = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# If we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
+
 [build-dependencies]
 oxc_formatter_core = { workspace = true, features = ["test_harness"] }
 

--- a/crates/oxc_formatter_json/Cargo.toml
+++ b/crates/oxc_formatter_json/Cargo.toml
@@ -32,6 +32,11 @@ oxc_formatter_core = { workspace = true, features = ["test_harness"] }
 oxc_tasks_common = { workspace = true }
 pico-args = { workspace = true }
 
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# If we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
+
 [build-dependencies]
 oxc_formatter_core = { workspace = true, features = ["test_harness"] }
 

--- a/crates/oxc_jsdoc/Cargo.toml
+++ b/crates/oxc_jsdoc/Cargo.toml
@@ -25,3 +25,9 @@ oxc_span = { workspace = true }
 
 rustc-hash = { workspace = true }
 
+[dev-dependencies]
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# If we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
+

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -34,3 +34,8 @@ rustc-hash = { workspace = true }
 
 [dev-dependencies]
 oxc_parser = { workspace = true }
+
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# If we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -31,6 +31,12 @@ oxc_syntax = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 
+[dev-dependencies]
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# If we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
+
 [build-dependencies]
 napi-build = { workspace = true }
 

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -45,6 +45,11 @@ oxc_parser = { workspace = true }
 rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 
+# Catch usage of old `AstBuilder` APIs in tests, without affecting downstream consumers.
+# If we enabled `disable_old_builder` feature in main dependency, feature unification would
+# cause it to be activated for `oxc_ast` for the user too.
+oxc_ast = { workspace = true, features = ["disable_old_builder"] }
+
 [features]
 default = []
 cfg = ["dep:oxc_cfg"]


### PR DESCRIPTION
Part of #23043.

We don't enable `oxc_ast`'s `disable_old_builder` Cargo feature in any of our published crates, or crates that are depended on by published crates.

However, we want to ensure no usage of legacy `AstBuilder` methods sneak in during the transition period before we delete these methods. Enable the feature in tests in all crates which depend on `oxc_ast`, to make sure any usage of legacy methods gets caught.