### PR TITLE
fix(ast): silence deprecation warnings within files defining deprecated `AstBuilder` methods

### DIFF
--- a/crates/oxc_ast/src/builder/methods.rs
+++ b/crates/oxc_ast/src/builder/methods.rs
@@ -1,3 +1,6 @@
+// These methods are all deprecated, but they call each other internally
+#![expect(deprecated)]
+
 use std::{alloc::Layout, borrow::Cow, mem::MaybeUninit, slice, str};
 
 use oxc_allocator::{ArenaBox, ArenaVec, FromIn, IntoIn};

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -4,7 +4,7 @@
 //! AST node factories
 
 #![allow(unused_imports)]
-#![expect(clippy::default_trait_access, clippy::unused_self)]
+#![expect(deprecated, clippy::default_trait_access, clippy::unused_self)]
 
 use std::cell::Cell;
 

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -75,10 +75,7 @@ impl Generator for AstBuilderGenerator {
 
             //!@@line_break
             #![allow(unused_imports)]
-            #![expect(
-                clippy::default_trait_access,
-                clippy::unused_self,
-            )]
+            #![expect(deprecated, clippy::default_trait_access, clippy::unused_self)]
 
             ///@@line_break
             use std::cell::Cell;


### PR DESCRIPTION
Part of #23043.

#23877 added `#[deprecated]` to all legacy `AstBuilder` methods. However, deprecation warnings are firing inside the files which define the legacy methods, because they call each other.

Silence these warnings, so users only get warnings for their own code.