### PR TITLE
perf(linter/eslint/max-depth): derive node types

### DIFF
--- a/crates/oxc_linter/src/generated/rule_runner_impls.rs
+++ b/crates/oxc_linter/src/generated/rule_runner_impls.rs
@@ -399,7 +399,17 @@ impl RuleRunner for crate::rules::eslint::max_classes_per_file::MaxClassesPerFil
 }
 
 impl RuleRunner for crate::rules::eslint::max_depth::MaxDepth {
-    const NODE_TYPES: Option<&AstTypesBitset> = None;
+    const NODE_TYPES: Option<&AstTypesBitset> = Some(&AstTypesBitset::from_types(&[
+        AstType::DoWhileStatement,
+        AstType::ForInStatement,
+        AstType::ForOfStatement,
+        AstType::ForStatement,
+        AstType::IfStatement,
+        AstType::SwitchStatement,
+        AstType::TryStatement,
+        AstType::WhileStatement,
+        AstType::WithStatement,
+    ]));
     const RUN_FUNCTIONS: RuleRunFunctionsImplemented = RuleRunFunctionsImplemented::Run;
 }
 

--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -123,6 +123,12 @@ impl Rule for MaxDepth {
     #[expect(clippy::cast_possible_truncation)] // the length of ancestors can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
+            // An `else if`'s `IfStatement` continues its parent's chain, so it isn't a new level.
+            AstKind::IfStatement(_)
+                if matches!(ctx.nodes().parent_kind(node.id()), AstKind::IfStatement(_)) =>
+            {
+                return;
+            }
             AstKind::IfStatement(_)
             | AstKind::SwitchStatement(_)
             | AstKind::TryStatement(_)
@@ -134,20 +140,21 @@ impl Rule for MaxDepth {
             | AstKind::ForOfStatement(_) => {}
             _ => return,
         }
-        if should_count(node, ctx.nodes()) {
-            let depth = 1 + ctx
-                .nodes()
-                .ancestors(node.id())
-                .take_while(|node| !should_stop(node))
-                .filter(|node| should_count(node, ctx.nodes()))
-                .count() as u32;
-            if depth > self.max {
-                ctx.diagnostic(max_depth_diagnostic(depth, self.max, node.span()));
-            }
+
+        let depth = 1 + ctx
+            .nodes()
+            .ancestors(node.id())
+            .take_while(|node| !should_stop(node))
+            .filter(|node| should_count(node, ctx.nodes()))
+            .count() as u32;
+        if depth > self.max {
+            ctx.diagnostic(max_depth_diagnostic(depth, self.max, node.span()));
         }
     }
 }
 
+/// Whether an ancestor node counts as a nesting level. Mirrors the kinds matched in `run`;
+/// kept as a predicate because the ancestor walk needs to test arbitrary nodes.
 fn should_count(node: &AstNode<'_>, nodes: &AstNodes<'_>) -> bool {
     matches!(node.kind(), AstKind::IfStatement(_) if !matches!(nodes.parent_kind(node.id()), AstKind::IfStatement(_)))
         || matches!(node.kind(), |AstKind::SwitchStatement(_)| AstKind::TryStatement(_)

--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -122,9 +122,6 @@ impl Rule for MaxDepth {
 
     #[expect(clippy::cast_possible_truncation)] // the length of ancestors can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        // Narrow to the node kinds this rule acts on so the linter codegen can derive a
-        // `NODE_TYPES` bitset and only dispatch `run` for these kinds, rather than every node.
-        // Must mirror the kinds matched in `should_count`.
         match node.kind() {
             AstKind::IfStatement(_)
             | AstKind::SwitchStatement(_)

--- a/crates/oxc_linter/src/rules/eslint/max_depth.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_depth.rs
@@ -122,6 +122,21 @@ impl Rule for MaxDepth {
 
     #[expect(clippy::cast_possible_truncation)] // the length of ancestors can't be over u32::MAX, because the source code is already limited by u32::MAX.
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        // Narrow to the node kinds this rule acts on so the linter codegen can derive a
+        // `NODE_TYPES` bitset and only dispatch `run` for these kinds, rather than every node.
+        // Must mirror the kinds matched in `should_count`.
+        match node.kind() {
+            AstKind::IfStatement(_)
+            | AstKind::SwitchStatement(_)
+            | AstKind::TryStatement(_)
+            | AstKind::DoWhileStatement(_)
+            | AstKind::WhileStatement(_)
+            | AstKind::WithStatement(_)
+            | AstKind::ForStatement(_)
+            | AstKind::ForInStatement(_)
+            | AstKind::ForOfStatement(_) => {}
+            _ => return,
+        }
         if should_count(node, ctx.nodes()) {
             let depth = 1 + ctx
                 .nodes()


### PR DESCRIPTION
Run on VS Code before and after to compare call #s and also to ensure that the number of violations were identical (which they are). Generated with Claude Code, tested and reviewed by me.

This rule is the last rule (after the other open PR is also merged) in the Rust set that runs on every node in a given codebase. All other rules had less than 15.2M calls when run on the vscode codebase. `--debug=timings` doesn't include type-aware rules, so I haven't looked at those at all, and I'm not sure we can limit AST Nodes like this for those rules anyway.

## What

`eslint/max-depth` matched on AST kinds inside its `should_count` helper rather than inline in `run`, so the linter codegen couldn't derive a `NODE_TYPES` bitset and emitted `None`. That placed the rule in the `any_type` bucket, dispatching `run` on **every** AST node.

This restructures `run` to lead with a narrowing `match node.kind()` that the codegen's `EarlyDivergeDetector` recognizes, so codegen now emits a bitset of the 9 statement kinds the rule actually acts on. `should_count`/`should_stop` are unchanged, so the `IfStatement` parent-guard and ancestor-counting logic — and thus the rule's behavior — are identical.

## Results

Measured on 11,674 files with only this rule enabled:

| | Calls | Rule time |
|---|---|---|
| Before | 15,251,059 | 223.1 ms |
| After | 157,335 | 5.5 ms |

~97× fewer `run` calls, ~40× faster.

## Test plan

- `cargo test -p oxc_linter max_depth` passes (behavior unchanged)
- `cargo lintgen` regenerates the bitset; generated impl now carries the 9 node types

🤖 Generated with [Claude Code](https://claude.com/claude-code)