### PR TITLE
refactor(parser): track cover grammar state for arrow heads

### DIFF
--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -403,7 +403,11 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let type_annotation = if self.is_ts { self.parse_ts_type_annotation() } else { None };
         // `new.target` is allowed in a class accessor field initializer.
         let value = self.eat(Kind::Eq).then(|| {
-            self.context_add(Context::NewTarget, Self::parse_assignment_expression_or_higher)
+            let cover_paren_depth = std::mem::replace(&mut self.state.cover_paren_depth, 0);
+            let value =
+                self.context_add(Context::NewTarget, Self::parse_assignment_expression_or_higher);
+            self.state.cover_paren_depth = cover_paren_depth;
+            value
         });
         self.asi();
         let r#type = if modifiers.contains(ModifierKind::Abstract) {
@@ -670,11 +674,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // Initializer[+In, ?Yield, ?Await]opt
         // `new.target` is allowed in a class field initializer.
         let initializer = self.eat(Kind::Eq).then(|| {
-            self.context(
+            // A field initializer re-establishes its own `await`/`yield` contexts; it is not
+            // part of any enclosing cover paren frame.
+            let cover_paren_depth = std::mem::replace(&mut self.state.cover_paren_depth, 0);
+            let initializer = self.context(
                 Context::In | Context::NewTarget,
                 Context::Yield | Context::Await,
                 Self::parse_expr,
-            )
+            );
+            self.state.cover_paren_depth = cover_paren_depth;
+            initializer
         });
 
         // Handle trailing `;` or newline

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -33,10 +33,16 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         let opening_span = self.cur_token().span();
         self.expect(Kind::LCurly);
 
+        // A function body re-establishes its own `await`/`yield` contexts; it is not part of
+        // any enclosing cover paren frame.
+        let cover_paren_depth = std::mem::replace(&mut self.state.cover_paren_depth, 0);
+
         // Add Return context, remove TopLevel context
         let (directives, statements) = self.context(Context::Return, Context::TopLevel, |p| {
             p.parse_directives_and_statements(/* in_ts_namespace_body */ false)
         });
+
+        self.state.cover_paren_depth = cover_paren_depth;
 
         self.expect_closing(Kind::RCurly, opening_span);
         FunctionBody::boxed(self.end_span(span), directives, statements, self)
@@ -257,6 +263,9 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         // functions, which are parsed via `parse_function_body` directly).
         self.ctx =
             self.ctx.and_in(true).and_await(r#async).and_yield(generator).and_new_target(true);
+        // A function re-establishes its own `await`/`yield` contexts for both parameters and
+        // body; none of it is part of any enclosing cover paren frame.
+        let cover_paren_depth = std::mem::replace(&mut self.state.cover_paren_depth, 0);
         let type_parameters = self.parse_ts_type_parameters();
         let (this_param, params) = self.parse_formal_parameters(func_kind, param_kind);
         let return_type = if self.is_ts { self.parse_ts_return_type_annotation() } else { None };
@@ -265,6 +274,7 @@ impl<'a, C: Config> ParserImpl<'a, C> {
         } else {
             None
         };
+        self.state.cover_paren_depth = cover_paren_depth;
         self.ctx = self
             .ctx
             .and_in(ctx.has_in())

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -8,6 +8,12 @@ use crate::cursor::ParserCheckpoint;
 pub struct ParserState<'a> {
     pub not_parenthesized_arrow: FxHashSet<u32>,
 
+    /// Number of `CoverParenthesizedExpressionAndArrowParameterList` frames currently
+    /// being parsed. Non-zero while parsing the items of a `( ... )` that may turn out
+    /// to be arrow function parameters. Reset to 0 while parsing nested function bodies,
+    /// which re-establish their own `await`/`yield` contexts.
+    pub cover_paren_depth: u32,
+
     /// Temporary storage for `CoverInitializedName` `({ foo = bar })`.
     /// Keyed by `ObjectProperty`'s span.start.
     pub cover_initialized_name: FxHashMap<u32, AssignmentExpression<'a>>,
@@ -37,6 +43,7 @@ impl ParserState<'_> {
     pub fn new() -> Self {
         Self {
             not_parenthesized_arrow: FxHashSet::default(),
+            cover_paren_depth: 0,
             cover_initialized_name: FxHashMap::default(),
             trailing_commas: FxHashMap::default(),
             potential_await_reparse: Vec::new(),


### PR DESCRIPTION
Track cover-parenthesized parsing depth and clear it when nested function/class parsing re-establishes parser contexts.

AI-assisted.