### PR TITLE
perf(isolated_declarations): remove redundant clone of formal parameter pattern

### DIFF
--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -115,7 +115,9 @@ impl<'a> IsolatedDeclarations<'a> {
             return Some(FormalParameter::new(
                 param.span,
                 ArenaVec::new_in(self),
-                pattern.clone_in(self.allocator()),
+                // `pattern` is already an owned, freshly-cloned binding (see above) and is
+                // not used afterwards, so move it in directly instead of cloning again.
+                pattern,
                 type_annotation,
                 NONE,
                 optional,


### PR DESCRIPTION
## What

`transform_formal_parameter` first builds an **owned** `pattern` (a deep `clone_in` of the source binding pattern) and mutates it in place:

```rust
let mut pattern = if let BindingPattern::AssignmentPattern(pattern) = &param.pattern {
    pattern.left.clone_in(self.allocator())
} else {
    param.pattern.clone_in(self.allocator())
};
FormalParameterBindingPattern::remove_assignments_from_kind(self, &mut pattern);
```

In the inferred-type / optional branch it then cloned that already-owned `pattern` a **second** time into the arena and returned, dropping the original:

```rust
return Some(FormalParameter::new(
    param.span,
    ArenaVec::new_in(self),
    pattern.clone_in(self.allocator()), // <- redundant: `pattern` is owned and dropped right after
    ...
));
```

The sibling branch just below already moves `pattern` directly into the identical `FormalParameter::new`, so the second clone is redundant. This PR moves the owned `pattern` in instead.

## Behaviour

Unchanged. The output is a freshly-built AST that is codegen'd to a `.d.ts` string (no symbol identity involved), so moving the already-cloned, already-mutated pattern is equivalent to cloning it again. `cargo test -p oxc_isolated_declarations` passes with no `.d.ts` snapshot changes.

## Evidence

Removing the redundant clone is a deterministic reduction in arena allocation. Measured over `vue-id.ts` (the `bench_isolated_declarations` corpus), the output `Allocator::used_bytes()` after `IsolatedDeclarations::build` drops:

```
19,594,584 -> 19,530,256 bytes  (-64,328)
```

This is reproducible (it depends only on the code path taken, not on machine state). It removes genuine work — fewer arena allocations, node copies and drops — rather than reordering existing work. CodSpeed cycle counts may read flat, as this is a small fraction (~0.3%) of the build.

---

*Disclosure: this change was prepared with AI assistance (Claude). I reviewed, tested and verified it myself — behaviour is byte-identical (insta snapshots unchanged) and the `used_bytes` reduction above was measured locally before/after.*