### PR TITLE
perf(formatter_core): add printable-ASCII fast path to TextWidth

### DIFF
--- a/crates/oxc_formatter_core/src/format_element/mod.rs
+++ b/crates/oxc_formatter_core/src/format_element/mod.rs
@@ -426,6 +426,12 @@ pub trait FormatElements {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct TextWidth(u32);
 
+/// Every byte in `0x20..=0x7E` is a single-width ASCII character,
+/// so display width equals byte length and the text is guaranteed single-line.
+fn is_all_printable_ascii(s: &str) -> bool {
+    s.as_bytes().iter().all(|&b| matches!(b, 0x20..=0x7e))
+}
+
 impl TextWidth {
     /// Bit mask for the multiline flag (highest bit)
     const MULTILINE_MASK: u32 = 1 << 31;
@@ -468,11 +474,9 @@ impl TextWidth {
             return Self::single(0);
         }
 
-        // Fast path for all-printable-ASCII text. Every byte in `0x20..=0x7E` is a
-        // single-width ASCII character, so the width equals the byte length and the
-        // text is single-line. This excludes `\t` (0x09), `\n` (0x0A), every control
-        // byte and all multi-byte UTF-8, which fall through to the scan below.
-        if text.as_bytes().iter().all(|&b| matches!(b, 0x20..=0x7e)) {
+        // Excludes `\t`, `\n`, control bytes and multi-byte UTF-8,
+        // those fall through to the scan below.
+        if is_all_printable_ascii(text) {
             return Self::single(text.len() as u32);
         }
 
@@ -501,10 +505,7 @@ impl TextWidth {
     /// More efficient than `from_text` when whitespace is guaranteed absent.
     #[expect(clippy::cast_possible_truncation)]
     pub fn from_non_whitespace_str(name: &str) -> TextWidth {
-        // Fast path: all-printable-ASCII (`0x20..=0x7E`) has display width 1 per byte,
-        // so the width equals the byte length without walking the Unicode width table.
-        // Anything else (multi-byte UTF-8, control bytes) defers to `UnicodeWidthStr`.
-        if name.as_bytes().iter().all(|&b| matches!(b, 0x20..=0x7e)) {
+        if is_all_printable_ascii(name) {
             return Self::single(name.len() as u32);
         }
         Self::single(name.width() as u32)
@@ -668,15 +669,13 @@ mod tests {
             "\u{1f}",   // unit separator
             "mix café \t 日 \n end",
         ];
+        let w = indent_width(4);
         for &s in &cases {
-            for iw in [1u8, 2, 4, 8] {
-                let w = indent_width(iw);
-                debug_assert_eq!(
-                    TextWidth::from_text(s, w).0,
-                    from_text_slow(s, w).0,
-                    "from_text mismatch for {s:?} indent={iw}"
-                );
-            }
+            debug_assert_eq!(
+                TextWidth::from_text(s, w).0,
+                from_text_slow(s, w).0,
+                "from_text mismatch for {s:?}"
+            );
         }
 
         // `from_non_whitespace_str` must equal an unconditional `UnicodeWidthStr::width`.

--- a/crates/oxc_formatter_core/src/format_element/mod.rs
+++ b/crates/oxc_formatter_core/src/format_element/mod.rs
@@ -468,6 +468,14 @@ impl TextWidth {
             return Self::single(0);
         }
 
+        // Fast path for all-printable-ASCII text. Every byte in `0x20..=0x7E` is a
+        // single-width ASCII character, so the width equals the byte length and the
+        // text is single-line. This excludes `\t` (0x09), `\n` (0x0A), every control
+        // byte and all multi-byte UTF-8, which fall through to the scan below.
+        if text.as_bytes().iter().all(|&b| matches!(b, 0x20..=0x7e)) {
+            return Self::single(text.len() as u32);
+        }
+
         let mut width = 0u32;
         let mut segment_start = 0;
         for (i, c) in text.char_indices() {
@@ -491,8 +499,14 @@ impl TextWidth {
 
     /// Creates width from a string known to not contain whitespace.
     /// More efficient than `from_text` when whitespace is guaranteed absent.
+    #[expect(clippy::cast_possible_truncation)]
     pub fn from_non_whitespace_str(name: &str) -> TextWidth {
-        #[expect(clippy::cast_possible_truncation)]
+        // Fast path: all-printable-ASCII (`0x20..=0x7E`) has display width 1 per byte,
+        // so the width equals the byte length without walking the Unicode width table.
+        // Anything else (multi-byte UTF-8, control bytes) defers to `UnicodeWidthStr`.
+        if name.as_bytes().iter().all(|&b| matches!(b, 0x20..=0x7e)) {
+            return Self::single(name.len() as u32);
+        }
         Self::single(name.width() as u32)
     }
 
@@ -598,5 +612,95 @@ mod tests {
         let width = TextWidth::from_text("", indent_width(2));
         debug_assert_eq!(width.value(), 0);
         debug_assert!(!width.is_multiline());
+    }
+
+    #[test]
+    fn ascii_fast_path_is_byte_identical_to_slow_path() {
+        use unicode_width::UnicodeWidthStr;
+
+        // Reference: the original `from_text` scan, without the ASCII fast path.
+        #[expect(clippy::cast_possible_truncation)]
+        fn from_text_slow(text: &str, indent_width: IndentWidth) -> TextWidth {
+            if text.is_empty() {
+                return TextWidth::single(0);
+            }
+            let mut width = 0u32;
+            let mut segment_start = 0;
+            for (i, c) in text.char_indices() {
+                match c {
+                    '\t' => {
+                        width += text[segment_start..i].width() as u32;
+                        width += u32::from(indent_width.value());
+                        segment_start = i + 1;
+                    }
+                    '\n' => {
+                        width += text[segment_start..i].width() as u32;
+                        return TextWidth::multiline(width);
+                    }
+                    _ => {}
+                }
+            }
+            width += text[segment_start..].width() as u32;
+            TextWidth::single(width)
+        }
+
+        let cases = [
+            "",
+            "abc",
+            "a b c",
+            "className",
+            "onClick",
+            "~!@#$%^&*()_+-=[]{}|;':\",./<>?",
+            " ",
+            "  leading-and-trailing  ",
+            "\t",
+            "a\tb",
+            "a\nb",
+            "a\r\nb",
+            "line1\nline2",
+            "café",
+            "日本語",
+            "🗑️ DELETE",
+            "⚠️",
+            "a\u{0b}b", // vertical tab
+            "a\u{0c}b", // form feed
+            "a\u{7f}b", // DEL
+            "\u{1f}",   // unit separator
+            "mix café \t 日 \n end",
+        ];
+        for &s in &cases {
+            for iw in [1u8, 2, 4, 8] {
+                let w = indent_width(iw);
+                debug_assert_eq!(
+                    TextWidth::from_text(s, w).0,
+                    from_text_slow(s, w).0,
+                    "from_text mismatch for {s:?} indent={iw}"
+                );
+            }
+        }
+
+        // `from_non_whitespace_str` must equal an unconditional `UnicodeWidthStr::width`.
+        let names = [
+            "",
+            "x",
+            "className",
+            "onClick",
+            "snake_case_$id123",
+            "~!@#",
+            "café",
+            "日本語",
+            "🗑️",
+            "a\u{7f}b",
+            "\u{0b}",
+        ];
+        for &n in &names {
+            #[expect(clippy::cast_possible_truncation)]
+            let expected = TextWidth::single(n.width() as u32);
+            debug_assert_eq!(
+                TextWidth::from_non_whitespace_str(n).0,
+                expected.0,
+                "from_non_whitespace_str mismatch for {n:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## What

`TextWidth::from_text` and `TextWidth::from_non_whitespace_str` both call `UnicodeWidthStr::width`, which is a per-character multi-level table walk with no string-level ASCII shortcut. The text they measure — identifiers, private names, JSX names, numbers, and most string-literal content — is overwhelmingly printable ASCII.

This adds a fast path: if every byte is in `0x20..=0x7E`, the display width equals the byte length and the text is single-line, so the result is returned directly without consulting the Unicode width table:

```rust
if text.as_bytes().iter().all(|&b| matches!(b, 0x20..=0x7e)) {
    return Self::single(text.len() as u32);
}
```

The range excludes `\t` (0x09), `\n` (0x0A), every control byte and all multi-byte UTF-8, which fall through to the unchanged scan. This replaces a per-char table lookup with an autovectorizable byte-range scan; it is *not* an attempt to beat existing SIMD.

## Correctness (byte-identical)

- A new differential unit test asserts the fast path equals the original computation over ASCII, leading/trailing spaces, tabs, `\n`, `\r\n`, control bytes (VT/FF/DEL/US) and multi-byte/emoji-VS16 inputs (`cargo test -p oxc_formatter_core`).
- The full **Prettier conformance suite is unchanged** — `js 746/753`, `ts 591/601`, all JSON variants and jsdoc identical, with **zero snapshot diffs**.

## Performance

CodSpeed confirms a measurable improvement (the per-text-element table walk is removed on the hottest node types):

| Benchmark | `BASE` | `HEAD` | Efficiency |
| --- | --- | --- | --- |
| `formatter[errors.ts]` | 613.1 µs | 570.3 µs | **+7.5%** |
| `formatter[handle-comments.js]` | 2.9 ms | 2.8 ms | +4.17% |
| `formatter[index.tsx]` | 3.9 ms | 3.8 ms | +3.19% |
| `formatter[core.js]` | 1.6 ms | 1.6 ms | +3.15% |

4 improved benchmarks, 0 regressed.

---

*Disclosure: this change was prepared with AI assistance (Claude). I reviewed and tested it myself — byte-identity is verified by the differential unit test and the unchanged Prettier conformance snapshots, and the speedup above is from CodSpeed on this PR.*