### PR TITLE
fix(minifier): treat Object.isExtensible/isFrozen/isSealed as pure

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -614,19 +614,15 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
             // except that a `Proxy` target makes them fire observable traps, and a
             // `null`/`undefined` target makes them throw. They introspect their first
             // argument via internal methods a Proxy can trap (`[[OwnPropertyKeys]]`,
-            // `[[GetOwnProperty]]`, `[[GetPrototypeOf]]`, `[[IsExtensible]]`) but,
-            // unlike `Object.values`/`entries`, never invoke `[[Get]]`, so they run no
-            // getter on a plain object. Side-effect-free only when the target is
-            // provably neither a Proxy nor nullish.
+            // `[[GetOwnProperty]]`, `[[GetPrototypeOf]]`) but, unlike `Object.values`/
+            // `entries`, never invoke `[[Get]]`, so they run no getter on a plain object.
+            // Side-effect-free only when the target is provably neither a Proxy nor nullish.
             "getOwnPropertyDescriptor"
             | "getOwnPropertyDescriptors"
             | "getOwnPropertyNames"
             | "getOwnPropertySymbols"
             | "getPrototypeOf"
             | "hasOwn"
-            | "isExtensible"
-            | "isFrozen"
-            | "isSealed"
             | "keys" => {
                 // An argument with its own side effects (e.g. inline `new Proxy(...)`) — keep.
                 if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
@@ -649,6 +645,32 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
                 // literal object/array, or a primitive `ToObject` wraps without user code).
                 // An undetermined value could be a Proxy whose trap is observable.
                 value_type.is_undetermined()
+            }
+            // `isExtensible`/`isFrozen`/`isSealed` differ from the introspection methods
+            // above: they never `ToObject` their target, so a non-object receiver (missing,
+            // `null`, `undefined`, or any primitive) returns a primitive (`false`/`true`)
+            // without throwing. They still fire `[[IsExtensible]]` (and, for `isFrozen`/
+            // `isSealed`, `[[OwnPropertyKeys]]`/`[[GetOwnProperty]]`) on an object target,
+            // so a Proxy target stays observable; `[[Get]]` is never invoked.
+            "isExtensible" | "isFrozen" | "isSealed" => {
+                // An argument with its own side effects (e.g. inline `new Proxy(...)`) — keep.
+                if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
+                    return true;
+                }
+                // No first expression argument: either no arguments (`undefined` receiver →
+                // a primitive result, pure) or a leading spread that could place a Proxy
+                // here (keep).
+                let Some(arg) = self.arguments.first().and_then(Argument::as_expression) else {
+                    return !self.arguments.is_empty();
+                };
+                // With property reads assumed pure, the Proxy-trap concern is waived.
+                if ctx.property_read_side_effects() == PropertyReadSideEffects::None {
+                    return false;
+                }
+                // Pure for a determined target: a non-object primitive returns without a
+                // trap, and a literal object/array cannot be a Proxy. An undetermined value
+                // could be a Proxy whose trap is observable.
+                arg.value_type(ctx).is_undetermined()
             }
             // `Object.create(proto)` allocates an object with prototype `proto`; it runs
             // no user code and is pure when `proto` is provably an object or `null`

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -1187,10 +1187,12 @@ fn test_call_expressions() {
     test("Object.getPrototypeOf()", true);
     test("Object.hasOwn()", true);
     test("Object.is()", false);
-    test("Object.isExtensible()", true);
-    test("Object.isFrozen()", true);
-    test("Object.isSealed()", true);
     test("Object.keys()", true);
+    // `isExtensible`/`isFrozen`/`isSealed` return a primitive for a non-object receiver
+    // (`Object.isExtensible(undefined)` -> `false`) instead of throwing, so they are pure.
+    test("Object.isExtensible()", false);
+    test("Object.isFrozen()", false);
+    test("Object.isSealed()", false);
 
     test("String.fromCharCode()", false);
     test("String.fromCodePoint()", false);
@@ -1239,6 +1241,18 @@ fn test_proxy_sensitive_object_methods() {
     test("Object.isExtensible({})", false);
     test("Object.isFrozen({})", false);
     test("Object.isSealed({})", false);
+
+    // `isExtensible`/`isFrozen`/`isSealed` never `ToObject` their target: a non-object
+    // (missing/null/undefined/primitive) yields a primitive result without throwing, so
+    // they stay pure where `keys`/`getOwnPropertyDescriptor`/... must be kept.
+    test("Object.isExtensible(null)", false);
+    test("Object.isFrozen(undefined)", false);
+    test("Object.isSealed(42)", false);
+    // A Proxy target still fires the `[[IsExtensible]]`/`[[OwnPropertyKeys]]` traps, so an
+    // undetermined target (could be a Proxy) or an inline Proxy is kept.
+    test("Object.isExtensible(x)", true);
+    test("Object.isFrozen(new Proxy({}, {}))", true);
+    test("Object.isSealed(...x)", true);
 
     // Kept when the target could be a Proxy (undetermined) or would throw (null/undefined).
     test("Object.keys(x)", true);


### PR DESCRIPTION
## What

`Object.isExtensible`, `Object.isFrozen`, and `Object.isSealed` were grouped with the throwing introspection methods (`Object.keys`, `getOwnPropertyDescriptor`, …) in `CallExpression::may_have_side_effects`, so a call with a missing / `null` / `undefined` argument was conservatively kept.

Unlike those methods, the three `is*` methods never `ToObject` their target — per [spec](https://tc39.es/ecma262/#sec-object.isextensible) a non-object receiver returns a primitive (`false` / `true`) instead of throwing, so the call is side-effect-free and an unused one can be dropped.

```js
// in
Object.isExtensible();
Object.isFrozen(x);
Object.isSealed();
Object.keys();

// out
Object.isFrozen(x), Object.keys();
```

`isExtensible()` / `isSealed()` drop (pure); `isFrozen(x)` stays — an undetermined target could be a `Proxy`, whose `[[IsExtensible]]` / `[[OwnPropertyKeys]]` traps are observable — and `keys()` stays (it throws on the `undefined` receiver).

Covered by new cases in `crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs`; `minsize` unchanged.

Closes #23779
