### PR TITLE
fix(minifier): don't drop global calls that throw despite pure arguments

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/expressions.rs
+++ b/crates/oxc_ecmascript/src/side_effects/expressions.rs
@@ -618,7 +618,18 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
                 || is_pure_callable_constructor(name)
                 || (name == "RegExp" && is_valid_regexp(&self.arguments))
             {
-                return self.arguments.iter().any(|e| e.may_have_side_effects(ctx));
+                if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
+                    return true;
+                }
+                // `isNaN`/`isFinite` coerce their argument via `ToNumber`, which throws a
+                // TypeError on a BigInt. (The other pure globals — `parseInt`, `decodeURI`,
+                // `String()`, ... — `ToString`, which accepts BigInt.)
+                if matches!(name, "isNaN" | "isFinite")
+                    && any_arg_throws_to_number(&self.arguments, ctx)
+                {
+                    return true;
+                }
+                return false;
             }
         }
 
@@ -643,7 +654,36 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
         }
 
         if is_pure_global_method_call(object.name.as_str(), name) {
-            return self.arguments.iter().any(|e| e.may_have_side_effects(ctx));
+            if self.arguments.iter().any(|e| e.may_have_side_effects(ctx)) {
+                return true;
+            }
+            let object = object.name.as_str();
+            // `ToNumber`-coercing methods throw a TypeError on a BigInt argument.
+            let coerces_to_number = match object {
+                "Math" => true,
+                "Date" => name == "UTC",
+                "String" => matches!(name, "fromCharCode" | "fromCodePoint"),
+                _ => false,
+            };
+            if coerces_to_number && any_arg_throws_to_number(&self.arguments, ctx) {
+                return true;
+            }
+            // `String.fromCodePoint(cp)` additionally throws a RangeError unless every
+            // `cp` is an integer in `[0, 0x10FFFF]`.
+            if object == "String"
+                && name == "fromCodePoint"
+                && self
+                    .arguments
+                    .iter()
+                    .any(|arg| arg.as_expression().is_some_and(is_invalid_code_point_literal))
+            {
+                return true;
+            }
+            // `URL.canParse(url)` has a required first argument; with none it throws.
+            if object == "URL" && name == "canParse" && self.arguments.is_empty() {
+                return true;
+            }
+            return false;
         }
 
         if object.name != "Object" {
@@ -734,6 +774,38 @@ impl<'a> MayHaveSideEffects<'a> for CallExpression<'a> {
             _ => true,
         }
     }
+}
+
+/// Whether any argument is provably a BigInt, for which `ToNumber` throws a `TypeError`.
+///
+/// A Symbol argument also throws, but oxc can never prove a value is a Symbol (there is
+/// no `ValueType::Symbol`), so — like esbuild — that case is left droppable to avoid
+/// keeping every `Math.abs(x)` / `isNaN(x)` on an undetermined argument.
+fn any_arg_throws_to_number<'a>(
+    args: &[Argument<'a>],
+    ctx: &impl MayHaveSideEffectsContext<'a>,
+) -> bool {
+    args.iter().any(|arg| arg.as_expression().is_some_and(|e| e.value_type(ctx).is_bigint()))
+}
+
+/// Whether `expr` is a numeric literal (optionally negated) that is not a valid Unicode
+/// code point — i.e. not an integer in `[0, 0x10FFFF]` — for which
+/// `String.fromCodePoint` throws a `RangeError`.
+///
+/// Non-literal arguments return `false` (left droppable, matching how other undetermined
+/// coercions are treated); a BigInt literal is handled by [`any_arg_throws_to_number`].
+fn is_invalid_code_point_literal(expr: &Expression) -> bool {
+    let value = match expr {
+        Expression::NumericLiteral(n) => n.value,
+        Expression::UnaryExpression(u) if u.operator == UnaryOperator::UnaryNegation => {
+            match &u.argument {
+                Expression::NumericLiteral(n) => -n.value,
+                _ => return false,
+            }
+        }
+        _ => return false,
+    };
+    !(value.fract() == 0.0 && (0.0..=1_114_111.0).contains(&value))
 }
 
 /// Check that the first argument won't produce a Symbol from `ToPrimitive`.

--- a/crates/oxc_ecmascript/src/side_effects/known_globals.rs
+++ b/crates/oxc_ecmascript/src/side_effects/known_globals.rs
@@ -405,8 +405,16 @@ pub(super) fn is_pure_global_method_call(object: &str, method: &str) -> bool {
         // target, and `Object.create` reads its `properties` argument; both are
         // handled in `CallExpression::may_have_side_effects`.
         "Object" => method == "is",
-        "String" => matches!(method, "fromCharCode" | "fromCodePoint" | "raw"),
-        "Symbol" => matches!(method, "for" | "keyFor"),
+        // `String.raw(template)` reads `template.raw` and throws a TypeError on a
+        // missing/non-template argument, which is never provably safe — kept as not-pure.
+        // `fromCharCode`/`fromCodePoint` coerce via `ToNumber` (throw-checked in
+        // `CallExpression::may_have_side_effects`).
+        "String" => matches!(method, "fromCharCode" | "fromCodePoint"),
+        // `Symbol.keyFor(sym)` requires a Symbol argument and throws otherwise, which is
+        // never provable — kept as not-pure.
+        "Symbol" => method == "for",
+        // `URL.canParse(url)` has a required first argument (throws with none); the
+        // arg-count check lives in `CallExpression::may_have_side_effects`.
         "URL" => method == "canParse",
         _ if is_typed_array_constructor(object) => method == "of",
         _ => false,

--- a/crates/oxc_minifier/docs/ASSUMPTIONS.md
+++ b/crates/oxc_minifier/docs/ASSUMPTIONS.md
@@ -81,6 +81,21 @@ try {
 
 This also lets an unused `new Int8Array(n)` (or any TypedArray) with a numeric-literal `n` be dropped: a valid length allocates a zeroed buffer with no observable effect, and a too-large literal only throws a maximum-length `RangeError`. A non-literal, negative (`new Int8Array(-1)`), `BigInt` (`new Int8Array(0n)`), or object argument is kept.
 
+### Coercion to a primitive does not throw for non-Symbol arguments
+
+Pure global functions and methods that coerce their arguments (`parseInt`, `isNaN`, `Math.*`, `Date.UTC`, `String.fromCharCode`, …) are treated as side-effect-free, so an unused call is dropped. A Symbol argument would make `ToString` / `ToNumber` throw a `TypeError`, but the minifier assumes a non-Symbol argument when it cannot prove the type — so `Math.abs(x)` / `parseInt(x)` stay droppable.
+
+```javascript
+// The minifier assumes this never happens:
+Math.abs(Symbol.iterator); // TypeError: Cannot convert a Symbol value to a number
+```
+
+A call is still kept when an argument _provably_ throws:
+
+- `ToNumber` on a `BigInt` (`Math.abs(10n)`, `isNaN(10n)`, `Date.UTC(10n)`).
+- `String.fromCodePoint(cp)` with a code point outside `[0, 0x10FFFF]` (`String.fromCodePoint(-1)`) — an "invalid code point" `RangeError`, distinct from the droppable maximum-length errors above.
+- A missing or invalid required argument (`String.raw()`, `Symbol.keyFor()`, `URL.canParse()`).
+
 ### No side effects from extending a class
 
 Extending a class does not have a side effect.

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -1196,12 +1196,15 @@ fn test_call_expressions() {
 
     test("String.fromCharCode()", false);
     test("String.fromCodePoint()", false);
-    test("String.raw()", false);
+    // `String.raw(undefined)` reads `undefined.raw` -> throws TypeError.
+    test("String.raw()", true);
 
     test("Symbol.for()", false);
-    test("Symbol.keyFor()", false);
+    // `Symbol.keyFor(undefined)` requires a Symbol argument -> throws TypeError.
+    test("Symbol.keyFor()", true);
 
-    test("URL.canParse()", false);
+    // `URL.canParse()` has a required first argument -> throws TypeError with none.
+    test("URL.canParse()", true);
 
     test("BigInt64Array.of()", false);
     test("BigUint64Array.of()", false);
@@ -1284,6 +1287,64 @@ fn test_proxy_sensitive_object_methods() {
     test("Object.create(undefined)", true); // throws
     test("Object.create({}, x)", true); // properties read via [[OwnPropertyKeys]]/[[Get]]
     test("Object.create({}, {})", true);
+}
+
+/// Known-pure global functions/methods that nonetheless *throw* for some arguments,
+/// so the call is not side-effect-free and must not be dropped. Cross-checked against
+/// terser and esbuild, which both keep these.
+#[test]
+fn test_throwing_global_calls() {
+    // Tier 1: missing/invalid required argument always throws a TypeError.
+    // `String.raw(template)` reads `template.raw`; `undefined`/non-template throws.
+    test("String.raw()", true);
+    test("String.raw({})", true);
+    test("String.raw(x)", true);
+    // `Symbol.keyFor(sym)` requires a Symbol argument; anything else throws.
+    test("Symbol.keyFor()", true);
+    test("Symbol.keyFor(42)", true);
+    test("Symbol.keyFor(x)", true);
+    // `URL.canParse(url)` has a required first argument; with none it throws.
+    test("URL.canParse()", true);
+    test("URL.canParse('x')", false); // a string argument is fine
+    test("URL.canParse(x)", false);
+
+    // Tier 2: `String.fromCodePoint(cp)` throws RangeError unless every `cp` is an
+    // integer in [0, 0x10FFFF]. `fromCharCode` truncates via ToUint16 and never
+    // RangeErrors.
+    test("String.fromCodePoint(-1)", true);
+    test("String.fromCodePoint(1.5)", true);
+    test("String.fromCodePoint(0x110000)", true);
+    test("String.fromCodePoint(65)", false);
+    test("String.fromCodePoint(0, 0x10FFFF)", false);
+    test("String.fromCodePoint(0, -1)", true);
+    test("String.fromCodePoint(x)", false); // undetermined -> stay droppable
+    test("String.fromCharCode(-1)", false);
+    test("String.fromCharCode(1.5)", false);
+
+    // Tier 3: `ToNumber` coercion throws a TypeError on a BigInt argument (provable).
+    // A Symbol also throws, but oxc can never prove a value is a Symbol, so — like
+    // esbuild — those stay droppable; only the BigInt cases are guarded.
+    test("Math.abs(10n)", true);
+    test("Math.floor(10n)", true);
+    test("Math.max(1, 10n)", true);
+    test("Date.UTC(10n)", true);
+    test("String.fromCharCode(10n)", true);
+    test("String.fromCodePoint(10n)", true);
+    test("isNaN(10n)", true);
+    test("isFinite(10n)", true);
+    // Non-BigInt arguments remain pure/droppable.
+    test("Math.abs(1)", false);
+    test("Math.floor(1.5)", false);
+    test("Math.max(1, 2)", false);
+    test("Date.UTC(2020, 0)", false);
+    // `ToString` coercers (parseInt/parseFloat/decodeURI/.../Date.parse/Symbol.for)
+    // accept BigInt (`ToString(10n)` -> "10"); only a Symbol throws (not provable).
+    test("parseInt(10n)", false);
+    test("parseFloat(10n)", false);
+    test("decodeURI(10n)", false);
+    test("Number.parseInt(10n)", false);
+    test("Date.parse(10n)", false);
+    test("Symbol.for(10n)", false);
 }
 
 #[test]


### PR DESCRIPTION
## What

`is_pure_global_method_call` (and the bare-global path) in `CallExpression::may_have_side_effects` treated a call as side-effect-free whenever its arguments were, ignoring that several of these functions **throw** at runtime. Unused calls that throw were therefore dropped as dead code. terser and esbuild both keep them.

Guard the cases oxc can prove:

| Call | Throws | Before | After |
| --- | --- | --- | --- |
| `String.raw()`, `Symbol.keyFor()`, `Symbol.keyFor(42)` | `TypeError` (missing/invalid required arg) | dropped | kept |
| `URL.canParse()` | `TypeError` (required first arg) | dropped | kept |
| `String.fromCodePoint(-1 / 1.5 / 0x110000)` | `RangeError` (code point outside `[0, 0x10FFFF]`) | dropped | kept |
| `Math.abs(10n)`, `Date.UTC(10n)`, `String.fromCharCode(10n)`, `isNaN(10n)`, … | `TypeError` (`ToNumber(BigInt)`) | dropped | kept |

Safe optimizations are preserved — `URL.canParse("x")`, `String.fromCodePoint(65)`, `String.fromCharCode(65)`, `Math.abs(1)` still drop. `String.raw` / `Symbol.keyFor` are removed from the pure-method list (never provably safe); the rest get argument guards.

### A Symbol argument is left droppable, on purpose

A Symbol argument also throws (`ToString` / `ToNumber` on a Symbol), but oxc has no `ValueType::Symbol` and `to_primitive` never resolves a pure expression to `Symbol`, so a Symbol throw is **never provable**. Guarding it would mean keeping every `Math.abs(x)` / `parseInt(x)` on an undetermined argument — a large minification regression. esbuild makes the same trade-off (it drops `Math.abs(Symbol.iterator)` too), so only the provable cases are guarded.

oxc already guards exactly this for the `Number` / `Symbol` / `BigInt` / `Error` constructors; this brings the method-call path in line. The assumption (including the non-provable-Symbol carve-out) is documented in `crates/oxc_minifier/docs/ASSUMPTIONS.md`.

Covered by `test_throwing_global_calls` in `crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs`; cross-checked against terser and esbuild; `minsize` unchanged.

---

Stacked on #23916.
