### PR TITLE
perf(minifier): bail member-expr folding before the side-effect walk

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -39,23 +39,30 @@ impl<'a> PeepholeOptimizations {
     pub fn fold_static_member_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::StaticMemberExpression(e) = expr else { return };
         // TODO: tryFoldObjectPropAccess(n, left, name)
+        // `evaluate_value` only folds a narrow set of member accesses (currently
+        // `.length` on constant strings/arrays) and bails cheaply otherwise.
+        // Evaluate it first so the overwhelmingly common non-foldable access
+        // (e.g. `a.b.c.prop`) skips the recursive `may_have_side_effects` walk
+        // over the object's member chain.
+        let Some(value) = e.evaluate_value(ctx) else { return };
         if e.object.may_have_side_effects(ctx) {
             return;
         }
-        if let Some(changed) = e.evaluate_value(ctx).map(|value| ctx.value_to_expr(e.span, value)) {
-            ctx.replace_expression(expr, changed);
-        }
+        let changed = ctx.value_to_expr(e.span, value);
+        ctx.replace_expression(expr, changed);
     }
 
     pub fn fold_computed_member_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::ComputedMemberExpression(e) = expr else { return };
         // TODO: tryFoldObjectPropAccess(n, left, name)
+        // See `fold_static_member_expr`: bail via the cheap `evaluate_value`
+        // check before walking the object and key for side effects.
+        let Some(value) = e.evaluate_value(ctx) else { return };
         if e.object.may_have_side_effects(ctx) || e.expression.may_have_side_effects(ctx) {
             return;
         }
-        if let Some(changed) = e.evaluate_value(ctx).map(|value| ctx.value_to_expr(e.span, value)) {
-            ctx.replace_expression(expr, changed);
-        }
+        let changed = ctx.value_to_expr(e.span, value);
+        ctx.replace_expression(expr, changed);
     }
 
     pub fn fold_logical_expr(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {


### PR DESCRIPTION
## What

`fold_static_member_expr` and `fold_computed_member_expr` ran the recursive `may_have_side_effects(object)` check on **every** member access, before calling `evaluate_value`. But `evaluate_value` can only fold a narrow set of member accesses — currently `.length` on a constant string / non-spread array literal — and bails cheaply otherwise.

This reorders the two functions so the cheap `evaluate_value` gates the side-effect walk:

```rust
let Some(value) = e.evaluate_value(ctx) else { return };
if e.object.may_have_side_effects(ctx) { return; }
let changed = ctx.value_to_expr(e.span, value);
ctx.replace_expression(expr, changed);
```

Using `evaluate_value` itself as the gate (rather than hard-coding the `.length` check) keeps it in sync if more foldable member patterns are added later.

## Why it's behavior-preserving

Folding happens iff `evaluate_value` is `Some` **and** the object has no side effects — true in both the old and new ordering. `evaluate_value` is a pure read-only query (no mutation, no diagnostics), so evaluating it before the side-effect check changes nothing observable. All 538 `oxc_minifier` tests pass; `cargo fmt --check` clean; no new clippy warnings.

## Impact

In real code, `.length` folding on a constant is virtually nonexistent, so almost every member-fold attempt previously paid for a wasted `may_have_side_effects(object)` walk. Measured deterministically (temporary instrumentation counting calls) on cached benchmark files, the share of fold attempts that now skip the object side-effect walk:

| file | fold attempts | skipped side-effect walks | of which member-chain (recursive) |
|---|---|---|---|
| react.development.js | 1,078 | 1,078 (100%) | 65 |
| App.tsx | 19,272 | 19,271 | 5,566 |
| kitchen-sink.tsx | 59,431 | 59,426 | 8,954 |
| antd.js | 173,257 | 173,257 (100%) | 12,952 |

The biggest savings are on member-expression chains (e.g. `a.b.c.prop`), where the skipped `may_have_side_effects` walk recurses over the whole chain. I'm relying on CodSpeed CI for the wall-clock delta — my local machine is too noisy for a trustworthy criterion measurement.

## AI usage disclosure

This change was developed with assistance from an AI tool (Claude). I (the contributor) reviewed, tested, and validated it: I verified the behavior-equivalence argument, confirmed the full `oxc_minifier` test suite passes, and produced the work-reduction measurements above.