### PR TITLE
docs(linter/unicorn): update prefer-dom-node-text-content rationale

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_dom_node_text_content.rs
@@ -21,10 +21,10 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// There are some disadvantages of using .innerText.
-    /// - `.innerText` is much more performance-heavy as it requires layout information to return the result.
+    /// There are some disadvantages of using `.innerText`.
+    /// - `.innerText` returns rendered text and ignores hidden content, while `.textContent` returns the node's full text content.
+    /// - `.innerText` can trigger reflow because it takes CSS styles into account.
     /// - `.innerText` is defined only for HTMLElement objects, while `.textContent` is defined for all Node objects.
-    /// - `.innerText` is not standard, for example, it is not present in Firefox.
     ///
     /// ### Examples
     ///


### PR DESCRIPTION
  Fixes #23921.

 Uses the differences documented by [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext)