### PR TITLE
fix(linter/unicorn/custom-error-definition): handle non-ascii class names

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/custom_error_definition.rs
+++ b/crates/oxc_linter/src/rules/unicorn/custom_error_definition.rs
@@ -303,7 +303,8 @@ fn get_class_name(name: &str) -> String {
 
 fn strip_suffix_case_insensitive<'a>(value: &'a str, suffix: &str) -> Option<&'a str> {
     let start = value.len().checked_sub(suffix.len())?;
-    value[start..].eq_ignore_ascii_case(suffix).then_some(&value[..start])
+    let (prefix, value_suffix) = value.split_at_checked(start)?;
+    value_suffix.eq_ignore_ascii_case(suffix).then_some(prefix)
 }
 
 fn is_name_property_definition(prop: &PropertyDefinition) -> bool {
@@ -534,6 +535,7 @@ fn test() {
                 this.name = 'fooerror';
             }
         }",
+        r"class ºrror extends Error {}",
         r"class FooError extends Error {
             constructor() { }
         }",

--- a/crates/oxc_linter/src/snapshots/unicorn_custom_error_definition.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_custom_error_definition.snap
@@ -66,6 +66,18 @@ source: crates/oxc_linter/src/tester.rs
  2 │             constructor(message) {
    ╰────
 
+  ⚠ unicorn(custom-error-definition): Invalid class name, use `ºrrorError`.
+   ╭─[custom_error_definition.tsx:1:7]
+ 1 │ class ºrror extends Error {}
+   ·       ─────
+   ╰────
+
+  ⚠ unicorn(custom-error-definition): The `name` property should be set to `ºrror`.
+   ╭─[custom_error_definition.tsx:1:1]
+ 1 │ class ºrror extends Error {}
+   · ────────────────────────────
+   ╰────
+
   ⚠ unicorn(custom-error-definition): Missing call to `super()` in constructor.
    ╭─[custom_error_definition.tsx:2:27]
  1 │ class FooError extends Error {


### PR DESCRIPTION
- avoid slicing at invalid UTF-8 boundaries in custom-error-definition class name normalization
- add a regression case for a non-ASCII class name from #23937

Fixes #23937.
