### PR TITLE
perf(semantic): store class private-name element ids inline (SmallVec)

### DIFF
--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 
 use oxc_index::IndexVec;
 use oxc_span::Span;
@@ -36,14 +37,21 @@ pub struct PrivateIdentifierReference<'a> {
     pub id: NodeId,
     pub name: Ident<'a>,
     pub span: Span,
-    pub element_ids: Vec<ElementId>,
+    /// At most 2 ids (a property/accessor resolves to 1, a method to 2 for
+    /// get/set), so kept inline to avoid a heap allocation per private reference.
+    pub element_ids: ElementIds,
 }
 
 impl<'a> PrivateIdentifierReference<'a> {
-    pub fn new(id: NodeId, name: Ident<'a>, span: Span, element_ids: Vec<ElementId>) -> Self {
+    pub fn new(id: NodeId, name: Ident<'a>, span: Span, element_ids: ElementIds) -> Self {
         Self { id, name, span, element_ids }
     }
 }
+
+/// Element ids a (private) name resolves to within a class. Bounded to 2 (a
+/// property/accessor is a single element; a method can have a getter + setter),
+/// so stored inline via `SmallVec` — no heap allocation in the common case.
+pub type ElementIds = SmallVec<[ElementId; 2]>;
 
 /// Class Table
 ///
@@ -85,8 +93,8 @@ impl<'a> ClassTable<'a> {
         class_id: ClassId,
         name: Ident<'_>,
         is_private: bool,
-    ) -> Vec<ElementId> {
-        let mut element_ids = vec![];
+    ) -> ElementIds {
+        let mut element_ids = ElementIds::new();
         for (element_id, element) in self.elements[class_id].iter_enumerated() {
             if element.name == name && element.is_private == is_private {
                 element_ids.push(element_id);

--- a/tasks/track_memory_allocations/allocs_minifier.snap
+++ b/tasks/track_memory_allocations/allocs_minifier.snap
@@ -6,11 +6,11 @@ App.tsx                    | 415.34 kB      ||             78 |              8 |
 
 RadixUIAdoptionSection.jsx | 2.52 kB        ||             24 |              0 ||             32 |              6
 
-pdf.mjs                    | 567.30 kB      ||           2569 |            205 ||          47484 |           7742
+pdf.mjs                    | 567.30 kB      ||           1417 |            205 ||          47484 |           7742
 
 antd.js                    | 6.69 MB        ||           1040 |             56 ||         337232 |          69333
 
 binder.ts                  | 193.08 kB      ||             41 |              1 ||           7083 |            824
 
-kitchen-sink.tsx           | 732.90 kB      ||           2576 |            174 ||          90546 |          15840
+kitchen-sink.tsx           | 732.90 kB      ||           2534 |            174 ||          90546 |          15840
 


### PR DESCRIPTION
## Summary

`ClassTable::get_element_ids` returns the element ids a private name resolves to within
a class, and the result is stored on every `PrivateIdentifierReference`. It is bounded to
**at most 2** — a property/accessor is a single element, and a method is at most two (for a
getter + setter); the loop `break`s accordingly. Yet it heap-allocated a fresh `Vec` on
every call, so class-private-member-heavy files pay a lot of tiny allocations.

Store the ids inline with `SmallVec<[ElementId; 2]>` (the new `ElementIds` alias), so the
common (≤2) case never touches the heap. Behaviour is unchanged — the only cross-crate
consumer (`no_unused_private_class_members`) reads them via `.contains()`, which works on
`SmallVec` via deref.

## Results — `cargo allocs` (minifier system allocations)

| fixture | before | after |
| --- | ---: | ---: |
| pdf.mjs | 2569 | **1417** (−1152, −45%) |

These allocations are eliminated (the ids live inline now). The win scales with how many
private-member references a file has; the semantic snapshot is unchanged.

## Tests

- `cargo test -p oxc_semantic --lib --tests` — pass
- `cargo test -p oxc_linter no_unused_private_class_members` — pass (the `.element_ids` consumer)

## AI disclosure

Prepared with AI assistance (Claude). I located the hotspot with a per-call-site allocation
profile (it was the largest minifier sys-alloc source on the class-heavy pdf.mjs), verified
the result is bounded to ≤2 and that the consumer is `SmallVec`-compatible, and measured the
reduction with `cargo allocs`.
