### PR TITLE
fix(parser): fix clippy warnings

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -35,6 +35,7 @@ mod typescript;
 mod unicode;
 mod whitespace;
 
+#[cfg_attr(not(feature = "benchmarking"), expect(clippy::redundant_pub_crate))]
 pub(crate) use byte_handlers::{ByteHandler, ByteHandlers, byte_handler_tables};
 pub use kind::Kind;
 pub use number::{parse_big_int, parse_float, parse_int};


### PR DESCRIPTION
Fix clippy warnings which arise sometimes when compiling `oxc_parser` crate in isolation. They don't arise when running `just lint` as feature unification ensures that `benchmarking` feature is enabled.