### PR TITLE
fix(linter/jsdoc): avoid param root underflow

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_description.rs
@@ -108,7 +108,7 @@ impl Rule for RequireParamDescription {
         let settings = &ctx.settings().jsdoc;
         let resolved_param_tag_name = settings.resolve_tag_name("param");
 
-        let mut root_count = 0;
+        let mut root_names = Vec::new();
         for jsdoc in jsdocs
             .iter()
             .filter(|jsdoc| !should_ignore_as_internal(jsdoc, settings))
@@ -121,14 +121,28 @@ impl Rule for RequireParamDescription {
 
                 let (_, name_part, comment_part) = tag.type_name_comment();
 
-                if name_part.is_some_and(|name_part| !name_part.parsed().contains('.')) {
-                    root_count += 1;
-                }
-                if settings.exempt_destructured_roots_from_checks {
-                    // -1 for count to idx conversion
-                    if let Some(ParamKind::Nested(_)) = params_to_check.get(root_count - 1) {
-                        continue;
-                    }
+                let (current_param, is_current_root_tag) =
+                    name_part.map_or((None, false), |name_part| {
+                        let name = name_part.parsed();
+                        let root_name = name
+                            .split_once('.')
+                            .map_or(name, |(root_name, _)| root_name)
+                            .trim_end_matches("[]");
+                        let is_current_root_tag = name == root_name;
+                        let root_index = root_names
+                            .iter()
+                            .position(|&name| name == root_name)
+                            .unwrap_or_else(|| {
+                                root_names.push(root_name);
+                                root_names.len() - 1
+                            });
+                        (params_to_check.get(root_index), is_current_root_tag)
+                    });
+
+                if settings.exempt_destructured_roots_from_checks
+                    && matches!(current_param, Some(ParamKind::Nested(_)))
+                {
+                    continue;
                 }
 
                 // If description exists, skip
@@ -137,7 +151,7 @@ impl Rule for RequireParamDescription {
                 }
 
                 let is_destructured_root =
-                    matches!(params_to_check.get(root_count - 1), Some(ParamKind::Nested(_)));
+                    is_current_root_tag && matches!(current_param, Some(ParamKind::Nested(_)));
 
                 if self.0.set_default_destructured_root_description
                     && is_destructured_root
@@ -276,6 +290,22 @@ fn test() {
             Some(
                 serde_json::json!({ "settings": {        "jsdoc": {          "tagNamePreference": {            "param": "arg",          },        },      } }),
             ),
+        ),
+        ("/** @param input.userId */\nfunction quux (input) {}", None, None),
+        (
+            "/** @param input.userId User ID.\n * @param options */\nfunction quux (input, {flag}) {}",
+            Some(serde_json::json!([{ "setDefaultDestructuredRootDescription": true }])),
+            None,
+        ),
+        (
+            "/** @param employees Employees.\n * @param employees[].name Employee name.\n * @param options */\nfunction quux (employees, {flag}) {}",
+            Some(serde_json::json!([{ "setDefaultDestructuredRootDescription": true }])),
+            None,
+        ),
+        (
+            "/** @param root.foo */\nfunction quux ({foo}) {}",
+            Some(serde_json::json!([{ "setDefaultDestructuredRootDescription": true }])),
+            None,
         ),
         (
             "

--- a/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_param_type.rs
@@ -106,7 +106,7 @@ impl Rule for RequireParamType {
         let settings = &ctx.settings().jsdoc;
         let resolved_param_tag_name = settings.resolve_tag_name("param");
 
-        let mut root_count = 0;
+        let mut root_names = Vec::new();
         for jsdoc in jsdocs
             .iter()
             .filter(|jsdoc| !should_ignore_as_internal(jsdoc, settings))
@@ -119,14 +119,28 @@ impl Rule for RequireParamType {
 
                 let (type_part, name_part, _) = tag.type_name_comment();
 
-                if name_part.is_some_and(|name_part| !name_part.parsed().contains('.')) {
-                    root_count += 1;
-                }
-                if settings.exempt_destructured_roots_from_checks {
-                    // -1 for count to idx conversion
-                    if let Some(ParamKind::Nested(_)) = params_to_check.get(root_count - 1) {
-                        continue;
-                    }
+                let (current_param, is_current_root_tag) =
+                    name_part.map_or((None, false), |name_part| {
+                        let name = name_part.parsed();
+                        let root_name = name
+                            .split_once('.')
+                            .map_or(name, |(root_name, _)| root_name)
+                            .trim_end_matches("[]");
+                        let is_current_root_tag = name == root_name;
+                        let root_index = root_names
+                            .iter()
+                            .position(|&name| name == root_name)
+                            .unwrap_or_else(|| {
+                                root_names.push(root_name);
+                                root_names.len() - 1
+                            });
+                        (params_to_check.get(root_index), is_current_root_tag)
+                    });
+
+                if settings.exempt_destructured_roots_from_checks
+                    && matches!(current_param, Some(ParamKind::Nested(_)))
+                {
+                    continue;
                 }
 
                 // If type exists, skip
@@ -135,7 +149,7 @@ impl Rule for RequireParamType {
                 }
 
                 let is_destructured_root =
-                    matches!(params_to_check.get(root_count - 1), Some(ParamKind::Nested(_)));
+                    is_current_root_tag && matches!(current_param, Some(ParamKind::Nested(_)));
 
                 if self.0.set_default_destructured_root_type
                     && is_destructured_root
@@ -281,6 +295,26 @@ fn test() {
             Some(
                 serde_json::json!({ "settings": { "jsdoc": { "tagNamePreference": { "param": "arg" } } } }),
             ),
+        ),
+        (
+            "/** @param input.userId - The ID of the user to update. */\nfunction quux (input) {}",
+            None,
+            None,
+        ),
+        (
+            "/** @param input.userId - The ID of the user to update.\n * @param options */\nfunction quux (input, {flag}) {}",
+            Some(serde_json::json!([{ "setDefaultDestructuredRootType": true }])),
+            None,
+        ),
+        (
+            "/** @param {object[]} employees\n * @param {string} employees[].name\n * @param options */\nfunction quux (employees, {flag}) {}",
+            Some(serde_json::json!([{ "setDefaultDestructuredRootType": true }])),
+            None,
+        ),
+        (
+            "/** @param root.foo */\nfunction quux ({foo}) {}",
+            Some(serde_json::json!([{ "setDefaultDestructuredRootType": true }])),
+            None,
         ),
         (
             "

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_param_description.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_param_description.snap
@@ -21,6 +21,40 @@ source: crates/oxc_linter/src/tester.rs
   help: Add description to `@param` tag.
 
   ⚠ jsdoc(require-param-description): Missing JSDoc `@param` description.
+   ╭─[require_param_description.tsx:1:5]
+ 1 │ /** @param input.userId */
+   ·     ──────
+ 2 │ function quux (input) {}
+   ╰────
+  help: Add description to `@param` tag.
+
+  ⚠ jsdoc(require-param-description): Missing root description for @param.
+   ╭─[require_param_description.tsx:2:4]
+ 1 │ /** @param input.userId User ID.
+ 2 │  * @param options */
+   ·    ──────
+ 3 │ function quux (input, {flag}) {}
+   ╰────
+  help: Add root description to `@param`.
+
+  ⚠ jsdoc(require-param-description): Missing root description for @param.
+   ╭─[require_param_description.tsx:3:4]
+ 2 │  * @param employees[].name Employee name.
+ 3 │  * @param options */
+   ·    ──────
+ 4 │ function quux (employees, {flag}) {}
+   ╰────
+  help: Add root description to `@param`.
+
+  ⚠ jsdoc(require-param-description): Missing JSDoc `@param` description.
+   ╭─[require_param_description.tsx:1:5]
+ 1 │ /** @param root.foo */
+   ·     ──────
+ 2 │ function quux ({foo}) {}
+   ╰────
+  help: Add description to `@param` tag.
+
+  ⚠ jsdoc(require-param-description): Missing JSDoc `@param` description.
    ╭─[require_param_description.tsx:4:17]
  3 │                        * @param {number} foo Foo description
  4 │                        * @param {object} root

--- a/crates/oxc_linter/src/snapshots/jsdoc_require_param_type.snap
+++ b/crates/oxc_linter/src/snapshots/jsdoc_require_param_type.snap
@@ -29,6 +29,48 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Add {type} to `@param` tag.
 
+  ⚠ jsdoc(require-param-type): Missing JSDoc `@param` type.
+   ╭─[require_param_type.tsx:1:5]
+ 1 │ /** @param input.userId - The ID of the user to update. */
+   ·     ──────
+ 2 │ function quux (input) {}
+   ╰────
+  help: Add {type} to `@param` tag.
+
+  ⚠ jsdoc(require-param-type): Missing JSDoc `@param` type.
+   ╭─[require_param_type.tsx:1:5]
+ 1 │ /** @param input.userId - The ID of the user to update.
+   ·     ──────
+ 2 │  * @param options */
+   ╰────
+  help: Add {type} to `@param` tag.
+
+  ⚠ jsdoc(require-param-type): Missing root type for @param.
+   ╭─[require_param_type.tsx:2:4]
+ 1 │ /** @param input.userId - The ID of the user to update.
+ 2 │  * @param options */
+   ·    ──────
+ 3 │ function quux (input, {flag}) {}
+   ╰────
+  help: Add {object} to `@param` tag.
+
+  ⚠ jsdoc(require-param-type): Missing root type for @param.
+   ╭─[require_param_type.tsx:3:4]
+ 2 │  * @param {string} employees[].name
+ 3 │  * @param options */
+   ·    ──────
+ 4 │ function quux (employees, {flag}) {}
+   ╰────
+  help: Add {object} to `@param` tag.
+
+  ⚠ jsdoc(require-param-type): Missing JSDoc `@param` type.
+   ╭─[require_param_type.tsx:1:5]
+ 1 │ /** @param root.foo */
+   ·     ──────
+ 2 │ function quux ({foo}) {}
+   ╰────
+  help: Add {type} to `@param` tag.
+
   ⚠ jsdoc(require-param-type): Missing root type for @param.
    ╭─[require_param_type.tsx:4:17]
  3 │                        * @param {number} foo


### PR DESCRIPTION
- avoid subtracting from `root_count` before any root `@param` has been seen
- apply the guarded lookup to both `jsdoc/require-param-type` and the sibling `jsdoc/require-param-description` rule
- add regression snapshots for dotted child params like `@param input.userId` without a preceding `@param input`

## Reproduction

Found from oxc-ecosystem-ci calcom/cal.com failure:

```js
/** @param input.userId - The ID of the user to update. */
function quux(input) {}
```

Before this change, `jsdoc/require-param-type` panicked with `attempt to subtract with overflow`.
