### PR TITLE
docs(ast): correct doc comment

### DIFF
--- a/crates/oxc_ast/src/ast/macros.rs
+++ b/crates/oxc_ast/src/ast/macros.rs
@@ -21,13 +21,12 @@
 /// ```ignore
 /// inherit_variants! {
 ///     #[ast]
-///     enum Statement<'a> {
-///         pub enum Statement<'a> {
-///             BlockStatement(Box<'a, BlockStatement<'a>>) = 0,
-///             BreakStatement(Box<'a, BreakStatement<'a>>) = 1,
-///             @inherit Declaration
-///             @inherit ModuleDeclaration
-///         }
+///     pub enum Statement<'a> {
+///         BlockStatement(Box<'a, BlockStatement<'a>>) = 0,
+///         BreakStatement(Box<'a, BreakStatement<'a>>) = 1,
+///
+///         @inherit Declaration
+///         @inherit ModuleDeclaration
 ///     }
 /// }
 /// ```
@@ -36,21 +35,19 @@
 ///
 /// ```ignore
 /// #[ast]
-/// enum Statement<'a> {
-///     pub enum Statement<'a> {
-///         BlockStatement(Box<'a, BlockStatement<'a>>) = 0,
-///         BreakStatement(Box<'a, BreakStatement<'a>>) = 1,
+/// pub enum Statement<'a> {
+///     BlockStatement(Box<'a, BlockStatement<'a>>) = 0,
+///     BreakStatement(Box<'a, BreakStatement<'a>>) = 1,
 ///
-///         // Inherited from `Declaration`
-///         VariableDeclaration(Box<'a, VariableDeclaration<'a>>) = 32,
-///         FunctionDeclaration(Box<'a, Function<'a>>) = 33,
-///         // ...and many more
+///     // Inherited from `Declaration`
+///     VariableDeclaration(Box<'a, VariableDeclaration<'a>>) = 32,
+///     FunctionDeclaration(Box<'a, Function<'a>>) = 33,
+///     // ...and many more
 ///
-///         // Inherited from `ModuleDeclaration`
-///         ImportDeclaration(Box<'a, ImportDeclaration<'a>>) = 64,
-///         ExportAllDeclaration(Box<'a, ExportAllDeclaration<'a>>) = 65,
-///         // ...and many more
-///     }
+///     // Inherited from `ModuleDeclaration`
+///     ImportDeclaration(Box<'a, ImportDeclaration<'a>>) = 64,
+///     ExportAllDeclaration(Box<'a, ExportAllDeclaration<'a>>) = 65,
+///     // ...and many more
 /// }
 ///
 /// shared_enum_variants!(

--- a/crates/oxc_ast/src/ast/mod.rs
+++ b/crates/oxc_ast/src/ast/mod.rs
@@ -15,6 +15,7 @@
 //! Instead of nested enums:
 //!
 //! ```ignore
+//! #[ast]
 //! pub enum Expression<'a> {
 //!     BooleanLiteral(Box<'a, BooleanLiteral>),
 //!     NullLiteral(Box<'a, NullLiteral>),
@@ -22,6 +23,7 @@
 //!     MemberExpression(MemberExpression<'a>),
 //! }
 //!
+//! #[ast]
 //! pub enum MemberExpression<'a> {
 //!     ComputedMemberExpression(Box<'a, ComputedMemberExpression<'a>>),
 //!     StaticMemberExpression(Box<'a, StaticMemberExpression<'a>>),
@@ -33,7 +35,7 @@
 //!
 //! ```ignore
 //! inherit_variants! {
-//! #[repr(C, u8)]
+//! #[ast]
 //! pub enum Expression<'a> {
 //!     BooleanLiteral(Box<'a, BooleanLiteral>) = 0,
 //!     NullLiteral(Box<'a, NullLiteral>) = 1,
@@ -42,7 +44,7 @@
 //! }
 //! }
 //!
-//! #[repr(C, u8)]
+//! #[ast]
 //! pub enum MemberExpression<'a> {
 //!     ComputedMemberExpression(Box<'a, ComputedMemberExpression<'a>>) = 48,
 //!     StaticMemberExpression(Box<'a, StaticMemberExpression<'a>>) = 49,
@@ -53,7 +55,7 @@
 //! `inherit_variants!` macro expands `Expression` to:
 //!
 //! ```ignore
-//! #[repr(C, u8)]
+//! #[ast]
 //! pub enum Expression<'a> {
 //!     BooleanLiteral(Box<'a, BooleanLiteral>) = 0,
 //!     NullLiteral(Box<'a, NullLiteral>) = 1,


### PR DESCRIPTION
Docs only change. Correct doc comments related to enum inheritance in AST.