### PR TITLE
refactor(ast_tools): `EnumDef::inherits_enums` return iterator of `&EnumDef`s

### DIFF
--- a/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
+++ b/tasks/ast_tools/src/generators/formatter/ast_nodes.rs
@@ -567,8 +567,7 @@ fn generate_enum_impls(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
         quote! { #enum_ident::#variant_name(s) => { #implementation }, }
     });
 
-    let inherits_match_arms = enum_def.inherits_types(schema).map(|inherited_type| {
-        let inherited_enum_def = inherited_type.as_enum().unwrap();
+    let inherits_match_arms = enum_def.inherits_enums(schema).map(|inherited_enum_def| {
         let inherits_snake_name = inherited_enum_def.snake_name();
         let match_ident = format_ident!("match_{inherits_snake_name}");
         let to_fn_ident = format_ident!("to_{inherits_snake_name}");

--- a/tasks/ast_tools/src/generators/formatter/format.rs
+++ b/tasks/ast_tools/src/generators/formatter/format.rs
@@ -283,12 +283,8 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
         })
     });
 
-    let inherits_match_arms = enum_def.inherits_types(schema).map(|inherits_type| {
-        let inherits_type = inherits_type.as_enum().unwrap();
-        let inherits_inner_type = inherits_type
-            .maybe_inner_type(schema)
-            .map_or_else(|| inherits_type.ident(), TypeDef::ident);
-
+    let inherits_match_arms = enum_def.inherits_enums(schema).map(|inherits_type| {
+        let inherits_ident = inherits_type.ident();
         let inherits_snake_name = inherits_type.snake_name();
         let match_ident = format_ident!("match_{inherits_snake_name}");
 
@@ -296,7 +292,7 @@ fn generate_enum_implementation(enum_def: &EnumDef, schema: &Schema) -> TokenStr
         let match_arm = quote! {
             it @ #match_ident!(#enum_ident) => {
                 let inner = it.#to_fn_ident();
-                allocator.alloc(AstNode::<'a, #inherits_inner_type> {
+                allocator.alloc(AstNode::<'a, #inherits_ident> {
                     inner,
                     parent,
                     allocator,

--- a/tasks/ast_tools/src/generators/traverse/walk.rs
+++ b/tasks/ast_tools/src/generators/traverse/walk.rs
@@ -566,8 +566,7 @@ fn generate_walk_for_enum(enum_def: &EnumDef, schema: &Schema, config: &WalkConf
     }
 
     // Inherited variants
-    for inherits_type in enum_def.inherits_types(schema) {
-        let inherited_enum = inherits_type.as_enum().unwrap();
+    for inherited_enum in enum_def.inherits_enums(schema) {
         let inherited_snake = inherited_enum.snake_name();
         let walk_inherited_fn = format_ident!("walk_{inherited_snake}");
 
@@ -613,8 +612,7 @@ fn collect_inherited_patterns(
                 let variant_ident = variant.ident();
                 patterns.push(quote!(#parent_ident::#variant_ident(_)));
             }
-            for inherits_type in enum_def.inherits_types(schema) {
-                let nested_enum = inherits_type.as_enum().unwrap();
+            for nested_enum in enum_def.inherits_enums(schema) {
                 next_queue.push(nested_enum);
             }
         }

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -358,7 +358,9 @@ fn generate_ts_type_def_for_enum(enum_def: &EnumDef, schema: &Schema) -> Option<
         .collect::<FxIndexSet<_>>();
 
     variant_type_names.extend(
-        enum_def.inherits_types(schema).map(|inherited_type| ts_type_name(inherited_type, schema)),
+        enum_def
+            .inherits_enums(schema)
+            .map(|inherited_enum_def| enum_ts_type_name(inherited_enum_def, schema)),
     );
 
     let union = variant_type_names.iter().join(" | ");
@@ -381,17 +383,7 @@ fn ts_type_name<'s>(type_def: &'s TypeDef, schema: &'s Schema) -> Cow<'s, str> {
                 Cow::Borrowed(struct_def.name())
             }
         }
-        TypeDef::Enum(enum_def) => {
-            if let Some(ts_alias) = &enum_def.estree.ts_alias {
-                Cow::Borrowed(ts_alias)
-            } else if let Some(converter_name) = &enum_def.estree.via
-                && let Some(type_name) = get_ts_type_for_converter(converter_name, schema)
-            {
-                Cow::Borrowed(type_name)
-            } else {
-                Cow::Borrowed(enum_def.name())
-            }
-        }
+        TypeDef::Enum(enum_def) => enum_ts_type_name(enum_def, schema),
         TypeDef::Primitive(primitive_def) => Cow::Borrowed(match primitive_def.name() {
             #[rustfmt::skip]
             "u8" | "u16" | "u32" | "u64" | "u128" | "usize"
@@ -410,6 +402,19 @@ fn ts_type_name<'s>(type_def: &'s TypeDef, schema: &'s Schema) -> Cow<'s, str> {
         TypeDef::Box(box_def) => ts_type_name(box_def.inner_type(schema), schema),
         TypeDef::Cell(cell_def) => ts_type_name(cell_def.inner_type(schema), schema),
         TypeDef::Pointer(pointer_def) => ts_type_name(pointer_def.inner_type(schema), schema),
+    }
+}
+
+/// Get TS type name for an enum.
+fn enum_ts_type_name<'s>(enum_def: &'s EnumDef, schema: &'s Schema) -> Cow<'s, str> {
+    if let Some(ts_alias) = &enum_def.estree.ts_alias {
+        Cow::Borrowed(ts_alias)
+    } else if let Some(converter_name) = &enum_def.estree.via
+        && let Some(type_name) = get_ts_type_for_converter(converter_name, schema)
+    {
+        Cow::Borrowed(type_name)
+    } else {
+        Cow::Borrowed(enum_def.name())
     }
 }
 

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -567,9 +567,8 @@ impl VisitBuilder<'_> {
             .unzip();
 
         let (inherits_match_arms, inherits_match_arms_mut): (TokenStream, TokenStream) = enum_def
-            .inherits_types(self.schema)
+            .inherits_enums(self.schema)
             .map(|inherits_type| {
-                let inherits_type = inherits_type.as_enum().unwrap();
                 let inner_visit_fn_ident = inherits_type.visit.visitor_ident();
                 let Some(inner_visit_fn_ident) = inner_visit_fn_ident else {
                     panic!(

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -103,9 +103,9 @@ impl EnumDef {
         AllVariantsIter::new(self, schema)
     }
 
-    /// Get own enum variants (not including inherited).
-    pub fn inherits_types<'s>(&'s self, schema: &'s Schema) -> impl Iterator<Item = &'s TypeDef> {
-        self.inherits.iter().map(|&type_id| &schema.types[type_id])
+    /// Get iterator over enums this enum inherits from directly.
+    pub fn inherits_enums<'s>(&'s self, schema: &'s Schema) -> impl Iterator<Item = &'s EnumDef> {
+        self.inherits.iter().map(|&type_id| schema.enum_def(type_id))
     }
 
     /// Get whether all variants are fieldless.


### PR DESCRIPTION
`EnumDef::inherits_enums` returns an iterator of enums that an enum inherits variants from. Inheritance only operates on enums, so make it yield `&EnumDef`s not `&TypeDef`s.