### PR TITLE
refactor(ast_tools): move `article_for` to utils module

### DIFF
--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -11,7 +11,7 @@ use crate::{
     schema::{
         Def, EnumDef, FieldDef, Schema, StructDef, StructOrEnum, TypeDef, TypeId, VariantDef,
     },
-    utils::{create_safe_ident, is_reserved_name},
+    utils::{article_for, create_safe_ident, is_reserved_name},
 };
 
 use super::{AttrLocation, AttrPart, AttrPositions, attr_positions, define_generator};
@@ -668,13 +668,5 @@ fn generate_doc_comment_for_params(params: &[Param]) -> TokenStream {
         ///
         /// ## Parameters
         #(#lines)*
-    }
-}
-
-/// Get the correct article ("a" / "an") that should precede a word in a doc comment.
-fn article_for(word: &str) -> &'static str {
-    match word.as_bytes().first().map(u8::to_ascii_uppercase) {
-        Some(b'A' | b'E' | b'I' | b'O' | b'U') => "an",
-        _ => "a",
     }
 }

--- a/tasks/ast_tools/src/generators/builder_methods.rs
+++ b/tasks/ast_tools/src/generators/builder_methods.rs
@@ -15,6 +15,7 @@ use crate::{
     schema::{
         Def, EnumDef, FieldDef, Schema, StructDef, StructOrEnum, TypeDef, TypeId, VariantDef,
     },
+    utils::article_for,
 };
 
 use super::define_generator;
@@ -617,13 +618,5 @@ fn generate_doc_comment_for_params(params: &[Param]) -> TokenStream {
         ///
         /// ## Parameters
         #(#lines)*
-    }
-}
-
-/// Get the correct article ("a" / "an") that should precede a word in a doc comment.
-fn article_for(word: &str) -> &'static str {
-    match word.as_bytes().first().map(u8::to_ascii_uppercase) {
-        Some(b'A' | b'E' | b'I' | b'O' | b'U') => "an",
-        _ => "a",
     }
 }

--- a/tasks/ast_tools/src/utils.rs
+++ b/tasks/ast_tools/src/utils.rs
@@ -130,6 +130,14 @@ pub fn snake_case(s: &str) -> String {
     result
 }
 
+/// Get the correct article ("a" / "an") that should precede a word in a doc comment.
+pub fn article_for(word: &str) -> &'static str {
+    match word.as_bytes().first().map(u8::to_ascii_uppercase) {
+        Some(b'A' | b'E' | b'I' | b'O' | b'U') => "an",
+        _ => "a",
+    }
+}
+
 /// Macro to `format!` arguments, and wrap the formatted string in a `Cow::Owned`.
 macro_rules! format_cow {
     ($($tokens:tt)+) => {


### PR DESCRIPTION
Pure refactor.

`article_for` was duplicated in 2 places. Move it into `utils` module and share the implementation.