### PR TITLE
feat(ast_tools): store reverse-mapping of enum inheritance in schema

### DIFF
--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -108,6 +108,9 @@ impl<'c> Parser<'c> {
         // Set container IDs on type defs
         self.set_container_ids(&mut types);
 
+        // Populate `inherited_by` on enums (reverse of `inherits`)
+        Self::set_inherited_by(&mut types);
+
         // Generate `HashMap` mapping name of `#[ast_meta]` type to its `MetaId`
         let meta_names = self
             .meta_names
@@ -197,6 +200,28 @@ impl<'c> Parser<'c> {
                 TypeDef::Cell(def) => def.containers.non_null_id = Some(non_null_id),
                 TypeDef::Pointer(def) => def.containers.non_null_id = Some(non_null_id),
             }
+        }
+    }
+
+    /// Populate `inherited_by` on enums - the reverse mapping of `inherits`.
+    ///
+    /// For each enum which inherits from other enums, add it to the `inherited_by` list of each
+    /// enum it inherits from. e.g. `AssignmentTarget` inherits `SimpleAssignmentTarget`, so
+    /// `AssignmentTarget` is added to `SimpleAssignmentTarget`'s `inherited_by`.
+    fn set_inherited_by(types: &mut IndexVec<TypeId, TypeDef>) {
+        // Collect (inherited enum, inheritor enum) pairs first,
+        // to avoid borrowing `types` both immutably and mutably at the same time
+        let mut pairs = vec![];
+        for type_def in types.iter() {
+            if let TypeDef::Enum(enum_def) = type_def {
+                for &inherited_id in &enum_def.inherits {
+                    pairs.push((inherited_id, enum_def.id));
+                }
+            }
+        }
+
+        for (inherited_id, inheritor_id) in pairs {
+            types[inherited_id].as_enum_mut().unwrap().inherited_by.push(inheritor_id);
         }
     }
 

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -41,6 +41,16 @@ pub struct EnumDef {
     pub variants: Vec<VariantDef>,
     /// Enums whose variants this enum inherits (declared with `INHERIT(EnumName<'a>)` marker variants)
     pub inherits: Vec<TypeId>,
+    /// Enums which inherit this enum's variants. This is the reverse of [`inherits`].
+    ///
+    /// e.g. `Expression` is inherited by `ArrayExpressionElement`, `Argument`, and others, so all of
+    /// those appear in `Expression`'s `inherited_by`.
+    ///
+    /// Populated after all types are parsed (see `Parser::set_inherited_by`), so is empty during
+    /// parsing of attributes.
+    ///
+    /// [`inherits`]: EnumDef::inherits
+    pub inherited_by: Vec<TypeId>,
     pub builder: AstBuilderType,
     pub visit: VisitEnum,
     pub layout: Layout,
@@ -78,6 +88,7 @@ impl EnumDef {
             generated_derives,
             variants,
             inherits,
+            inherited_by: vec![],
             builder: AstBuilderType::default(),
             visit: VisitEnum::default(),
             layout: Layout::default(),


### PR DESCRIPTION
Make the AST schema in `ast_tools` contain a 2-way graph of enum inheritance. Given any enum, you can now answer both questions "what other enums does this enum inherit the variants of?" and "what other enums inherit _this_ enum's variants?".