### PR TITLE
refactor(ast): codegen `match_*!` macros

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -169,58 +169,6 @@ pub enum Expression<'a> {
 }
 }
 
-/// Macro for matching `Expression`'s variants.
-/// Includes `MemberExpression`'s variants.
-#[macro_export]
-macro_rules! match_expression {
-    ($ty:ident) => {
-        $ty::BooleanLiteral(_)
-            | $ty::NullLiteral(_)
-            | $ty::NumericLiteral(_)
-            | $ty::BigIntLiteral(_)
-            | $ty::RegExpLiteral(_)
-            | $ty::StringLiteral(_)
-            | $ty::TemplateLiteral(_)
-            | $ty::Identifier(_)
-            | $ty::MetaProperty(_)
-            | $ty::Super(_)
-            | $ty::ArrayExpression(_)
-            | $ty::ArrowFunctionExpression(_)
-            | $ty::AssignmentExpression(_)
-            | $ty::AwaitExpression(_)
-            | $ty::BinaryExpression(_)
-            | $ty::CallExpression(_)
-            | $ty::ChainExpression(_)
-            | $ty::ClassExpression(_)
-            | $ty::ConditionalExpression(_)
-            | $ty::FunctionExpression(_)
-            | $ty::ImportExpression(_)
-            | $ty::LogicalExpression(_)
-            | $ty::NewExpression(_)
-            | $ty::ObjectExpression(_)
-            | $ty::ParenthesizedExpression(_)
-            | $ty::SequenceExpression(_)
-            | $ty::TaggedTemplateExpression(_)
-            | $ty::ThisExpression(_)
-            | $ty::UnaryExpression(_)
-            | $ty::UpdateExpression(_)
-            | $ty::YieldExpression(_)
-            | $ty::PrivateInExpression(_)
-            | $ty::JSXElement(_)
-            | $ty::JSXFragment(_)
-            | $ty::TSAsExpression(_)
-            | $ty::TSSatisfiesExpression(_)
-            | $ty::TSTypeAssertion(_)
-            | $ty::TSNonNullExpression(_)
-            | $ty::TSInstantiationExpression(_)
-            | $ty::ComputedMemberExpression(_)
-            | $ty::StaticMemberExpression(_)
-            | $ty::PrivateFieldExpression(_)
-            | $ty::V8IntrinsicExpression(_)
-    };
-}
-pub use match_expression;
-
 /// `foo` in `let foo = 1;`
 ///
 /// Fundamental syntactic structure used for naming variables, functions, and properties.
@@ -535,17 +483,6 @@ pub enum MemberExpression<'a> {
     PrivateFieldExpression(Box<'a, PrivateFieldExpression<'a>>) = 50,
 }
 
-/// Macro for matching `MemberExpression`'s variants.
-#[macro_export]
-macro_rules! match_member_expression {
-    ($ty:ident) => {
-        $ty::ComputedMemberExpression(_)
-            | $ty::StaticMemberExpression(_)
-            | $ty::PrivateFieldExpression(_)
-    };
-}
-pub use match_member_expression;
-
 /// `ar[0]` in `const ar = [1, 2]; ar[0];`
 ///
 /// Represents a computed member access expression, which can include an object and an expression.
@@ -835,42 +772,6 @@ pub enum SimpleAssignmentTarget<'a> {
 }
 }
 
-/// Macro for matching `AssignmentTarget`'s variants.
-/// Includes `SimpleAssignmentTarget`'s and `AssignmentTargetPattern`'s variants.
-#[macro_export]
-macro_rules! match_assignment_target {
-    ($ty:ident) => {
-        $ty::AssignmentTargetIdentifier(_)
-            | $ty::ComputedMemberExpression(_)
-            | $ty::StaticMemberExpression(_)
-            | $ty::PrivateFieldExpression(_)
-            | $ty::TSAsExpression(_)
-            | $ty::TSSatisfiesExpression(_)
-            | $ty::TSNonNullExpression(_)
-            | $ty::TSTypeAssertion(_)
-            | $ty::ArrayAssignmentTarget(_)
-            | $ty::ObjectAssignmentTarget(_)
-    };
-}
-pub use match_assignment_target;
-
-/// Macro for matching `SimpleAssignmentTarget`'s variants.
-/// Includes `MemberExpression`'s variants
-#[macro_export]
-macro_rules! match_simple_assignment_target {
-    ($ty:ident) => {
-        $ty::AssignmentTargetIdentifier(_)
-            | $ty::ComputedMemberExpression(_)
-            | $ty::StaticMemberExpression(_)
-            | $ty::PrivateFieldExpression(_)
-            | $ty::TSAsExpression(_)
-            | $ty::TSSatisfiesExpression(_)
-            | $ty::TSNonNullExpression(_)
-            | $ty::TSTypeAssertion(_)
-    };
-}
-pub use match_simple_assignment_target;
-
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
@@ -878,15 +779,6 @@ pub enum AssignmentTargetPattern<'a> {
     ArrayAssignmentTarget(Box<'a, ArrayAssignmentTarget<'a>>) = 8,
     ObjectAssignmentTarget(Box<'a, ObjectAssignmentTarget<'a>>) = 9,
 }
-
-/// Macro for matching `AssignmentTargetPattern`'s variants.
-#[macro_export]
-macro_rules! match_assignment_target_pattern {
-    ($ty:ident) => {
-        $ty::ArrayAssignmentTarget(_) | $ty::ObjectAssignmentTarget(_)
-    };
-}
-pub use match_assignment_target_pattern;
 
 /// `[a, b]` in `[a, b] = arr;`
 ///
@@ -1214,23 +1106,6 @@ pub enum Declaration<'a> {
     TSGlobalDeclaration(Box<'a, TSGlobalDeclaration<'a>>) = 39,
     TSImportEqualsDeclaration(Box<'a, TSImportEqualsDeclaration<'a>>) = 40,
 }
-
-/// Macro for matching `Declaration`'s variants.
-#[macro_export]
-macro_rules! match_declaration {
-    ($ty:ident) => {
-        $ty::VariableDeclaration(_)
-            | $ty::FunctionDeclaration(_)
-            | $ty::ClassDeclaration(_)
-            | $ty::TSTypeAliasDeclaration(_)
-            | $ty::TSInterfaceDeclaration(_)
-            | $ty::TSEnumDeclaration(_)
-            | $ty::TSModuleDeclaration(_)
-            | $ty::TSGlobalDeclaration(_)
-            | $ty::TSImportEqualsDeclaration(_)
-    };
-}
-pub use match_declaration;
 
 /// `let a;` in `let a; a = 1;`
 ///
@@ -2436,20 +2311,6 @@ pub enum ModuleDeclaration<'a> {
     /// `export as namespace React;`
     TSNamespaceExportDeclaration(Box<'a, TSNamespaceExportDeclaration<'a>>) = 69,
 }
-
-/// Macro for matching `ModuleDeclaration`'s variants.
-#[macro_export]
-macro_rules! match_module_declaration {
-    ($ty:ident) => {
-        $ty::ImportDeclaration(_)
-            | $ty::ExportAllDeclaration(_)
-            | $ty::ExportDefaultDeclaration(_)
-            | $ty::ExportNamedDeclaration(_)
-            | $ty::TSExportAssignment(_)
-            | $ty::TSNamespaceExportDeclaration(_)
-    };
-}
-pub use match_module_declaration;
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/oxc_ast/src/ast/mod.rs
+++ b/crates/oxc_ast/src/ast/mod.rs
@@ -192,4 +192,8 @@ pub use jsx::*;
 pub use literal::*;
 pub use ts::*;
 
+// `match_*!` macros are `#[macro_export]`ed at the crate root.
+// Re-export them here so they're also available via `crate::ast` (e.g. `use crate::ast::*`).
+pub use crate::generated::inherit_variants::*;
+
 use macros::inherit_variants;

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -281,51 +281,6 @@ pub enum TSType<'a> {
     JSDocUnknownType(Box<'a, JSDocUnknownType>) = 37,
 }
 
-/// Macro for matching `TSType`'s variants.
-#[macro_export]
-macro_rules! match_ts_type {
-    ($ty:ident) => {
-        $ty::TSAnyKeyword(_)
-            | $ty::TSBigIntKeyword(_)
-            | $ty::TSBooleanKeyword(_)
-            | $ty::TSIntrinsicKeyword(_)
-            | $ty::TSNeverKeyword(_)
-            | $ty::TSNullKeyword(_)
-            | $ty::TSNumberKeyword(_)
-            | $ty::TSObjectKeyword(_)
-            | $ty::TSStringKeyword(_)
-            | $ty::TSSymbolKeyword(_)
-            | $ty::TSThisType(_)
-            | $ty::TSUndefinedKeyword(_)
-            | $ty::TSUnknownKeyword(_)
-            | $ty::TSVoidKeyword(_)
-            | $ty::TSArrayType(_)
-            | $ty::TSConditionalType(_)
-            | $ty::TSConstructorType(_)
-            | $ty::TSFunctionType(_)
-            | $ty::TSImportType(_)
-            | $ty::TSIndexedAccessType(_)
-            | $ty::TSInferType(_)
-            | $ty::TSIntersectionType(_)
-            | $ty::TSLiteralType(_)
-            | $ty::TSMappedType(_)
-            | $ty::TSNamedTupleMember(_)
-            | $ty::TSTemplateLiteralType(_)
-            | $ty::TSTupleType(_)
-            | $ty::TSTypeLiteral(_)
-            | $ty::TSTypeOperatorType(_)
-            | $ty::TSTypePredicate(_)
-            | $ty::TSTypeQuery(_)
-            | $ty::TSTypeReference(_)
-            | $ty::TSUnionType(_)
-            | $ty::TSParenthesizedType(_)
-            | $ty::JSDocNullableType(_)
-            | $ty::JSDocNonNullableType(_)
-            | $ty::JSDocUnknownType(_)
-    };
-}
-pub use match_ts_type;
-
 /// TypeScript Conditional Type
 ///
 /// ## Example
@@ -821,15 +776,6 @@ pub enum TSTypeName<'a> {
     QualifiedName(Box<'a, TSQualifiedName<'a>>) = 1,
     ThisExpression(Box<'a, ThisExpression>) = 2,
 }
-
-/// Macro for matching `TSTypeName`'s variants.
-#[macro_export]
-macro_rules! match_ts_type_name {
-    ($ty:ident) => {
-        $ty::IdentifierReference(_) | $ty::QualifiedName(_) | $ty::ThisExpression(_)
-    };
-}
-pub use match_ts_type_name;
 
 /// TypeScript Qualified Name
 ///

--- a/crates/oxc_ast/src/generated/inherit_variants.rs
+++ b/crates/oxc_ast/src/generated/inherit_variants.rs
@@ -6650,3 +6650,199 @@ impl<'a> From<TSTypeName<'a>> for TSTypeQueryExprName<'a> {
         }
     }
 }
+
+/// Macro for matching [`Expression`]'s variants.
+///
+/// Includes variants inherited from [`MemberExpression`].
+#[macro_export]
+macro_rules! match_expression {
+    ($ty:ident) => {
+        $ty::BooleanLiteral(_)
+            | $ty::NullLiteral(_)
+            | $ty::NumericLiteral(_)
+            | $ty::BigIntLiteral(_)
+            | $ty::RegExpLiteral(_)
+            | $ty::StringLiteral(_)
+            | $ty::TemplateLiteral(_)
+            | $ty::Identifier(_)
+            | $ty::MetaProperty(_)
+            | $ty::Super(_)
+            | $ty::ArrayExpression(_)
+            | $ty::ArrowFunctionExpression(_)
+            | $ty::AssignmentExpression(_)
+            | $ty::AwaitExpression(_)
+            | $ty::BinaryExpression(_)
+            | $ty::CallExpression(_)
+            | $ty::ChainExpression(_)
+            | $ty::ClassExpression(_)
+            | $ty::ConditionalExpression(_)
+            | $ty::FunctionExpression(_)
+            | $ty::ImportExpression(_)
+            | $ty::LogicalExpression(_)
+            | $ty::NewExpression(_)
+            | $ty::ObjectExpression(_)
+            | $ty::ParenthesizedExpression(_)
+            | $ty::SequenceExpression(_)
+            | $ty::TaggedTemplateExpression(_)
+            | $ty::ThisExpression(_)
+            | $ty::UnaryExpression(_)
+            | $ty::UpdateExpression(_)
+            | $ty::YieldExpression(_)
+            | $ty::PrivateInExpression(_)
+            | $ty::JSXElement(_)
+            | $ty::JSXFragment(_)
+            | $ty::TSAsExpression(_)
+            | $ty::TSSatisfiesExpression(_)
+            | $ty::TSTypeAssertion(_)
+            | $ty::TSNonNullExpression(_)
+            | $ty::TSInstantiationExpression(_)
+            | $ty::V8IntrinsicExpression(_)
+            | $ty::ComputedMemberExpression(_)
+            | $ty::StaticMemberExpression(_)
+            | $ty::PrivateFieldExpression(_)
+    };
+}
+pub use match_expression;
+
+/// Macro for matching [`MemberExpression`]'s variants.
+#[macro_export]
+macro_rules! match_member_expression {
+    ($ty:ident) => {
+        $ty::ComputedMemberExpression(_)
+            | $ty::StaticMemberExpression(_)
+            | $ty::PrivateFieldExpression(_)
+    };
+}
+pub use match_member_expression;
+
+/// Macro for matching [`AssignmentTarget`]'s variants.
+///
+/// Includes variants inherited from [`SimpleAssignmentTarget`], [`MemberExpression`], [`AssignmentTargetPattern`].
+#[macro_export]
+macro_rules! match_assignment_target {
+    ($ty:ident) => {
+        $ty::AssignmentTargetIdentifier(_)
+            | $ty::TSAsExpression(_)
+            | $ty::TSSatisfiesExpression(_)
+            | $ty::TSNonNullExpression(_)
+            | $ty::TSTypeAssertion(_)
+            | $ty::ComputedMemberExpression(_)
+            | $ty::StaticMemberExpression(_)
+            | $ty::PrivateFieldExpression(_)
+            | $ty::ArrayAssignmentTarget(_)
+            | $ty::ObjectAssignmentTarget(_)
+    };
+}
+pub use match_assignment_target;
+
+/// Macro for matching [`SimpleAssignmentTarget`]'s variants.
+///
+/// Includes variants inherited from [`MemberExpression`].
+#[macro_export]
+macro_rules! match_simple_assignment_target {
+    ($ty:ident) => {
+        $ty::AssignmentTargetIdentifier(_)
+            | $ty::TSAsExpression(_)
+            | $ty::TSSatisfiesExpression(_)
+            | $ty::TSNonNullExpression(_)
+            | $ty::TSTypeAssertion(_)
+            | $ty::ComputedMemberExpression(_)
+            | $ty::StaticMemberExpression(_)
+            | $ty::PrivateFieldExpression(_)
+    };
+}
+pub use match_simple_assignment_target;
+
+/// Macro for matching [`AssignmentTargetPattern`]'s variants.
+#[macro_export]
+macro_rules! match_assignment_target_pattern {
+    ($ty:ident) => {
+        $ty::ArrayAssignmentTarget(_) | $ty::ObjectAssignmentTarget(_)
+    };
+}
+pub use match_assignment_target_pattern;
+
+/// Macro for matching [`Declaration`]'s variants.
+#[macro_export]
+macro_rules! match_declaration {
+    ($ty:ident) => {
+        $ty::VariableDeclaration(_)
+            | $ty::FunctionDeclaration(_)
+            | $ty::ClassDeclaration(_)
+            | $ty::TSTypeAliasDeclaration(_)
+            | $ty::TSInterfaceDeclaration(_)
+            | $ty::TSEnumDeclaration(_)
+            | $ty::TSModuleDeclaration(_)
+            | $ty::TSGlobalDeclaration(_)
+            | $ty::TSImportEqualsDeclaration(_)
+    };
+}
+pub use match_declaration;
+
+/// Macro for matching [`ModuleDeclaration`]'s variants.
+#[macro_export]
+macro_rules! match_module_declaration {
+    ($ty:ident) => {
+        $ty::ImportDeclaration(_)
+            | $ty::ExportAllDeclaration(_)
+            | $ty::ExportDefaultDeclaration(_)
+            | $ty::ExportNamedDeclaration(_)
+            | $ty::TSExportAssignment(_)
+            | $ty::TSNamespaceExportDeclaration(_)
+    };
+}
+pub use match_module_declaration;
+
+/// Macro for matching [`TSType`]'s variants.
+#[macro_export]
+macro_rules! match_ts_type {
+    ($ty:ident) => {
+        $ty::TSAnyKeyword(_)
+            | $ty::TSBigIntKeyword(_)
+            | $ty::TSBooleanKeyword(_)
+            | $ty::TSIntrinsicKeyword(_)
+            | $ty::TSNeverKeyword(_)
+            | $ty::TSNullKeyword(_)
+            | $ty::TSNumberKeyword(_)
+            | $ty::TSObjectKeyword(_)
+            | $ty::TSStringKeyword(_)
+            | $ty::TSSymbolKeyword(_)
+            | $ty::TSUndefinedKeyword(_)
+            | $ty::TSUnknownKeyword(_)
+            | $ty::TSVoidKeyword(_)
+            | $ty::TSArrayType(_)
+            | $ty::TSConditionalType(_)
+            | $ty::TSConstructorType(_)
+            | $ty::TSFunctionType(_)
+            | $ty::TSImportType(_)
+            | $ty::TSIndexedAccessType(_)
+            | $ty::TSInferType(_)
+            | $ty::TSIntersectionType(_)
+            | $ty::TSLiteralType(_)
+            | $ty::TSMappedType(_)
+            | $ty::TSNamedTupleMember(_)
+            | $ty::TSTemplateLiteralType(_)
+            | $ty::TSThisType(_)
+            | $ty::TSTupleType(_)
+            | $ty::TSTypeLiteral(_)
+            | $ty::TSTypeOperatorType(_)
+            | $ty::TSTypePredicate(_)
+            | $ty::TSTypeQuery(_)
+            | $ty::TSTypeReference(_)
+            | $ty::TSUnionType(_)
+            | $ty::TSParenthesizedType(_)
+            | $ty::JSDocNullableType(_)
+            | $ty::JSDocNonNullableType(_)
+            | $ty::JSDocUnknownType(_)
+    };
+}
+pub use match_ts_type;
+
+/// Macro for matching [`TSTypeName`]'s variants.
+#[macro_export]
+macro_rules! match_ts_type_name {
+    ($ty:ident) => {
+        $ty::IdentifierReference(_) | $ty::QualifiedName(_) | $ty::ThisExpression(_)
+    };
+}
+pub use match_ts_type_name;

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -70,7 +70,7 @@ mod generated {
     mod derive_take_in;
     mod derive_unstable_address;
     mod get_id;
-    mod inherit_variants;
+    pub mod inherit_variants;
 }
 pub use generated::ast_kind;
 

--- a/tasks/ast_tools/src/generators/inherit_variants.rs
+++ b/tasks/ast_tools/src/generators/inherit_variants.rs
@@ -15,10 +15,15 @@
 //! * `impl From<Child> for Parent`
 //! * Compile-time assertions that the discriminants of shared variants match between the 2 enums
 //!
+//! It also generates a `match_child!` macro for each enum which is inherited by another enum.
+//! e.g. `match_expression!(ty)` expands to a match pattern covering all of `Expression`'s variants
+//! (`ty::BooleanLiteral(_) | ty::NullLiteral(_) | ...`), for use in `match` arms and `matches!`.
+//!
 //! Note: The actual insertion of inherited variants into enum definitions, and calculation of variant
 //! discriminants, is (currently) still handled by the `inherit_variants!` declarative macro.
 //! This generator is intended to grow to take over those responsibilities too.
 
+use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
@@ -39,6 +44,7 @@ define_generator!(InheritVariantsGenerator);
 impl Generator for InheritVariantsGenerator {
     fn generate(&self, schema: &Schema, _codegen: &Codegen) -> Output {
         let impls = generate_impls(schema);
+        let match_macros = generate_match_macros(schema);
 
         let output = quote! {
             //!@ Some `TryFrom` impls have a single non-shared variant left for the catch-all arm
@@ -55,6 +61,8 @@ impl Generator for InheritVariantsGenerator {
 
             ///@@line_break
             #impls
+
+            #match_macros
         };
 
         Output::Rust { path: output_path(AST_CRATE_PATH, "inherit_variants.rs"), tokens: output }
@@ -84,6 +92,64 @@ fn generate_impls(schema: &Schema) -> TokenStream {
         }
 
         #(#impls)*
+    }
+}
+
+/// Generate a `match_child!` macro for every enum which is inherited by another enum.
+fn generate_match_macros(schema: &Schema) -> TokenStream {
+    let mut output = TokenStream::new();
+
+    for enum_def in schema.enums() {
+        if !enum_def.inherited_by.is_empty() {
+            output.extend(generate_match_macro(enum_def, schema));
+        }
+    }
+
+    output
+}
+
+/// Generate a `match_child!` macro for an enum.
+///
+/// e.g. for `Expression`:
+///
+/// ```ignore
+/// macro_rules! match_expression {
+///     ($ty:ident) => {
+///         $ty::BooleanLiteral(_) | $ty::NullLiteral(_) | /* ...all other variants... */
+///     };
+/// }
+/// ```
+fn generate_match_macro(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
+    let macro_ident = format_ident!("match_{}", enum_def.snake_name());
+
+    let patterns = enum_def.all_variants(schema).map(|variant| {
+        let variant_ident = variant.ident();
+        quote!( $ty::#variant_ident(_) )
+    });
+
+    let doc = format!(" Macro for matching [`{}`]'s variants.", enum_def.name());
+    let mut inherited = enum_def.all_inherits(schema).map(EnumDef::name).peekable();
+    let inherited_doc = inherited.peek().is_some().then(|| {
+        let line = format!(" Includes variants inherited from [`{}`].", inherited.join("`], [`"));
+        quote! {
+            ///
+            #[doc = #line]
+        }
+    });
+
+    // `#[macro_export]` exports the macro at the crate root.
+    // The `pub use` makes it an item of this module too, so `crate::ast` can glob re-export it too.
+    quote! {
+        ///@@line_break
+        #[doc = #doc]
+        #inherited_doc
+        #[macro_export]
+        macro_rules! #macro_ident {
+            ($ty:ident) => {
+                #(#patterns)|*
+            };
+        }
+        pub use #macro_ident;
     }
 }
 


### PR DESCRIPTION
Pure refactor.

`oxc_ast` contained 9 hand-written macros e.g. `match_expression!`. Codegen these macros instead.

The macros are exactly the same as they were before, just they're now codegenned, so will reflect any changes made to AST automatically.