### PR TITLE
refactor(ast_tools): move `phf::Map` generation into a utility function

### DIFF
--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -12,11 +12,10 @@ use std::{
 };
 
 use itertools::Itertools;
-use phf_codegen::Map as PhfMapGen;
 use proc_macro2::TokenStream;
 use quote::quote;
 use rustc_hash::FxHashMap;
-use syn::{Expr, Ident, parse_str};
+use syn::Ident;
 
 use crate::{
     AST_MACROS_CRATE_PATH, Codegen, Generator,
@@ -26,7 +25,7 @@ use crate::{
         StructOrEnum, TypeDef, TypeId, Visibility,
         extensions::layout::{GetLayout, GetOffset, Layout, Niche, Offset, PlatformLayout},
     },
-    utils::{format_cow, number_lit},
+    utils::{format_cow, generate_phf_map, number_lit},
 };
 
 use super::define_generator;
@@ -793,8 +792,7 @@ fn template(krate: &str, assertions_64: &TokenStream, assertions_32: &TokenStrea
 ///
 /// `#[ast]` macro will re-order struct fields in order we provide here.
 fn generate_struct_details(schema: &Schema) -> Output {
-    let mut map = PhfMapGen::new();
-    for struct_def in schema.structs() {
+    let map = generate_phf_map(schema.structs().map(|struct_def| {
         // Get layout indexes of fields in source order.
         // If struct as written already has fields in layout order, then no-reordering is required,
         // in which case output `None`.
@@ -817,12 +815,10 @@ fn generate_struct_details(schema: &Schema) -> Output {
         };
 
         let is_node = struct_def.kind.has_kind;
+        let details = quote!( StructDetails { field_order: #field_order, is_node: #is_node });
 
-        let details = quote!( StructDetails { field_order: #field_order, is_node: #is_node } );
-
-        map.entry(struct_def.name(), details.to_string());
-    }
-    let map = parse_str::<Expr>(&map.build().to_string()).unwrap();
+        (struct_def.name(), details)
+    }));
 
     let code = quote! {
         use crate::ast::StructDetails;

--- a/tasks/ast_tools/src/utils.rs
+++ b/tasks/ast_tools/src/utils.rs
@@ -3,10 +3,11 @@ use std::borrow::Cow;
 use convert_case::{Case, Casing};
 use indexmap::{IndexMap, IndexSet};
 use phf::{Set as PhfSet, phf_set};
+use phf_codegen::Map as PhfMapGen;
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use rustc_hash::FxBuildHasher;
-use syn::{Ident, LitInt};
+use syn::{Expr, Ident, LitInt, parse_str};
 
 pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 pub type FxIndexSet<K> = IndexSet<K, FxBuildHasher>;
@@ -136,6 +137,18 @@ pub fn article_for(word: &str) -> &'static str {
         Some(b'A' | b'E' | b'I' | b'O' | b'U') => "an",
         _ => "a",
     }
+}
+
+/// Generate code to create a `phf::Map` from an iterator of entries.
+pub fn generate_phf_map<'e>(entries: impl Iterator<Item = (&'e str, TokenStream)>) -> TokenStream {
+    let mut map = PhfMapGen::new();
+
+    for (entry_name, tokens) in entries {
+        map.entry(entry_name, tokens.to_string());
+    }
+
+    let map = parse_str::<Expr>(&map.build().to_string()).unwrap();
+    quote!( #map )
 }
 
 /// Macro to `format!` arguments, and wrap the formatted string in a `Cow::Owned`.


### PR DESCRIPTION
Pure refactor.

Move logic for codegenning a `phf::Map` into a utility function that takes an iterator of `(name, content)` entries.