### PR TITLE
refactor(ast): calculate which structs are transparent in `ast_tools`

### DIFF
--- a/crates/oxc_ast_macros/src/ast.rs
+++ b/crates/oxc_ast_macros/src/ast.rs
@@ -64,6 +64,7 @@ fn modify_enum_impl(item: &ItemEnum) -> Result<TokenStream, &'static str> {
 pub struct StructDetails {
     pub field_order: Option<&'static [u8]>,
     pub is_node: bool,
+    pub is_transparent: bool,
 }
 
 /// Add `#[repr(C)]` / `#[repr(transparent)]`, and `#[derive(::oxc_ast_macros::Ast)]` to struct,
@@ -105,10 +106,12 @@ fn modify_struct_impl(
 
     reorder_struct_fields(item, struct_details)?;
 
-    // `#[repr(transparent)]` for structs with only one field.
-    // `#[repr(C)]` otherwise.
-    let field_count = item.fields.len();
-    let repr = if field_count == 1 { quote!(#[repr(transparent)]) } else { quote!(#[repr(C)]) };
+    // `#[repr(transparent)]` for structs with at most 1 non-zero-sized field, `#[repr(C)]` otherwise
+    let repr = if struct_details.is_transparent {
+        quote!(#[repr(transparent)])
+    } else {
+        quote!(#[repr(C)])
+    };
 
     // `#[non_exhaustive]` on AST node types
     let non_exhaustive =

--- a/crates/oxc_ast_macros/src/generated/structs.rs
+++ b/crates/oxc_ast_macros/src/generated/structs.rs
@@ -89,441 +89,1391 @@ pub static STRUCTS: phf::Map<&'static str, StructDetails> = ::phf::Map {
         (0, 1),
     ],
     entries: &[
-        ("LabelIdentifier", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("TSQualifiedName", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("TSNullKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("IndexedReference", StructDetails { field_order: None, is_node: false }),
-        ("I32Dummy", StructDetails { field_order: None, is_node: false }),
-        ("ImportExpression", StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true }),
+        (
+            "LabelIdentifier",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSQualifiedName",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSNullKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "IndexedReference",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        ("I32Dummy", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "ImportExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "AssignmentTargetPropertyIdentifier",
-            StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("IfStatement", StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true }),
-        ("SwitchStatement", StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true }),
+        (
+            "IfStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "SwitchStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "TSTypeParameter",
-            StructDetails { field_order: Some(&[1, 0, 5, 6, 7, 2, 3, 4]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 5, 6, 7, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("Comment", StructDetails { field_order: None, is_node: false }),
-        ("DebuggerStatement", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("JSDocNullableType", StructDetails { field_order: Some(&[1, 0, 3, 2]), is_node: true }),
-        ("ImportSpecifier", StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true }),
-        ("BindingRestElement", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("StaticBlock", StructDetails { field_order: Some(&[1, 0, 3, 2]), is_node: true }),
-        ("LogicalExpression", StructDetails { field_order: Some(&[1, 0, 3, 2, 4]), is_node: true }),
-        ("AssignmentPattern", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        ("Comment", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "DebuggerStatement",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSDocNullableType",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ImportSpecifier",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "BindingRestElement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "StaticBlock",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "LogicalExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "AssignmentPattern",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "PropertyDefinition",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 6, 7, 8, 9, 3, 4, 5, 10, 11, 12, 13, 14]),
                 is_node: true,
+                is_transparent: false,
             },
         ),
-        ("Character", StructDetails { field_order: Some(&[0, 2, 1]), is_node: false }),
+        (
+            "Character",
+            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
+        ),
         (
             "AccessorProperty",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 6, 7, 8, 9, 3, 4, 5, 10, 11]),
                 is_node: true,
+                is_transparent: false,
             },
         ),
         (
             "Program",
-            StructDetails { field_order: Some(&[1, 0, 8, 3, 4, 5, 6, 7, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 8, 3, 4, 5, 6, 7, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("ErrorLabel", StructDetails { field_order: Some(&[1, 0]), is_node: false }),
-        ("ImportAttribute", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("TSInterfaceBody", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("JSXSpreadAttribute", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("TemplateElementValue", StructDetails { field_order: None, is_node: false }),
+        (
+            "ErrorLabel",
+            StructDetails { field_order: Some(&[1, 0]), is_node: false, is_transparent: false },
+        ),
+        (
+            "ImportAttribute",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSInterfaceBody",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXSpreadAttribute",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TemplateElementValue",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
         (
             "TSTypeAliasDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 6, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("Elision", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
+        (
+            "Elision",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
         (
             "ObjectProperty",
-            StructDetails { field_order: Some(&[1, 0, 2, 6, 7, 3, 4, 5]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 6, 7, 3, 4, 5]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TSTypeLiteral", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("TSVoidKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("NewExpression", StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 2]), is_node: true }),
+        (
+            "TSTypeLiteral",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSVoidKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "NewExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "TSEnumDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 4, 5, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 5, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "ExportDefaultDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true },
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
-        ("RegExpPattern", StructDetails { field_order: None, is_node: false }),
-        ("CatchParameter", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        (
+            "RegExpPattern",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "CatchParameter",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "StaticMemberExpression",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("Hashbang", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("ScopeId", StructDetails { field_order: None, is_node: false }),
-        ("TryStatement", StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true }),
-        ("TSUndefinedKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("IgnoreGroup", StructDetails { field_order: None, is_node: false }),
-        ("TSIndexedAccessType", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("YieldExpression", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        (
+            "Hashbang",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        ("ScopeId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "TryStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSUndefinedKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        ("IgnoreGroup", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "TSIndexedAccessType",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "YieldExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "V8IntrinsicExpression",
-            StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "TaggedTemplateExpression",
-            StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("IdentifierReference", StructDetails { field_order: Some(&[1, 0, 3, 2]), is_node: true }),
-        ("JSXNamespacedName", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("FormalParameters", StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true }),
-        ("JSXAttribute", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("AwaitExpression", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "IdentifierReference",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSXNamespacedName",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "FormalParameters",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSXAttribute",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "AwaitExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "VariableDeclarator",
-            StructDetails { field_order: Some(&[1, 0, 2, 4, 5, 6, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 4, 5, 6, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("CharacterClassRange", StructDetails { field_order: None, is_node: false }),
-        ("CapturingGroup", StructDetails { field_order: None, is_node: false }),
-        ("TSTupleType", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("Span", StructDetails { field_order: Some(&[1, 2, 0]), is_node: false }),
-        ("ContinueStatement", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("SwitchCase", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        (
+            "CharacterClassRange",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "CapturingGroup",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "TSTupleType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "Span",
+            StructDetails { field_order: Some(&[1, 2, 0]), is_node: false, is_transparent: false },
+        ),
+        (
+            "ContinueStatement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "SwitchCase",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "TSExternalModuleReference",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true },
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
-        ("SpreadElement", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("TSTypeAnnotation", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "SpreadElement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSTypeAnnotation",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "Function",
             StructDetails {
                 field_order: Some(&[1, 0, 9, 3, 10, 11, 12, 4, 5, 6, 7, 8, 2, 13, 14]),
                 is_node: true,
+                is_transparent: false,
             },
         ),
-        ("UpdateExpression", StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true }),
-        ("Alternative", StructDetails { field_order: None, is_node: false }),
-        ("JSXExpressionContainer", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "UpdateExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        ("Alternative", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "JSXExpressionContainer",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "AssignmentExpression",
-            StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("StaticImport", StructDetails { field_order: None, is_node: false }),
-        ("JSXSpreadChild", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("BigIntLiteral", StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true }),
+        (
+            "StaticImport",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "JSXSpreadChild",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "BigIntLiteral",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "MethodDefinition",
             StructDetails {
                 field_order: Some(&[1, 0, 2, 6, 7, 8, 3, 4, 5, 9, 10, 11]),
                 is_node: true,
+                is_transparent: false,
             },
         ),
         (
             "TSTypeParameterDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true },
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
-        ("Error", StructDetails { field_order: Some(&[4, 0, 1, 2, 3]), is_node: false }),
-        ("JSXClosingFragment", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("ClassStringDisjunction", StructDetails { field_order: Some(&[0, 2, 1]), is_node: false }),
-        ("StaticExport", StructDetails { field_order: None, is_node: false }),
+        (
+            "Error",
+            StructDetails {
+                field_order: Some(&[4, 0, 1, 2, 3]),
+                is_node: false,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSXClosingFragment",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ClassStringDisjunction",
+            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
+        ),
+        (
+            "StaticExport",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
         (
             "ForStatement",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 6, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TemplateLiteral", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("TSImportType", StructDetails { field_order: Some(&[1, 0, 2, 3, 4, 5]), is_node: true }),
-        ("TSBooleanKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("TSStringKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
+        (
+            "TemplateLiteral",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSImportType",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4, 5]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSBooleanKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSStringKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
         (
             "ImportDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 4, 5, 2, 6, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 5, 2, 6, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "VariableDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 2, 4, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 4, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TSInterfaceHeritage", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("AssignmentTargetRest", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("Pattern", StructDetails { field_order: None, is_node: false }),
-        ("TSThisType", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("SequenceExpression", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("TSNumberKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("TSAsExpression", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        (
+            "TSInterfaceHeritage",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "AssignmentTargetRest",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        ("Pattern", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "TSThisType",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "SequenceExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSNumberKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSAsExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "ArrowFunctionExpression",
-            StructDetails { field_order: Some(&[1, 0, 7, 8, 3, 4, 5, 6, 2, 9, 10]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 7, 8, 3, 4, 5, 6, 2, 9, 10]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "PrivateFieldExpression",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("ObjectPattern", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("TSOptionalType", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "ObjectPattern",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSOptionalType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "ConditionalExpression",
-            StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("WithStatement", StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true }),
-        ("JSXMemberExpression", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("TSUnknownKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("TSParenthesizedType", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("Directive", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("NameSpan", StructDetails { field_order: Some(&[1, 0]), is_node: false }),
-        ("TSThisParameter", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        (
+            "WithStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSXMemberExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSUnknownKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSParenthesizedType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "Directive",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "NameSpan",
+            StructDetails { field_order: Some(&[1, 0]), is_node: false, is_transparent: false },
+        ),
+        (
+            "TSThisParameter",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "TSGlobalDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "TSNamespaceExportDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true },
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
-        ("CharacterClass", StructDetails { field_order: Some(&[0, 2, 3, 4, 1]), is_node: false }),
-        ("TSEnumBody", StructDetails { field_order: Some(&[1, 0, 3, 2]), is_node: true }),
-        ("LookAroundAssertion", StructDetails { field_order: Some(&[0, 2, 1]), is_node: false }),
-        ("TSTypeReference", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("ThrowStatement", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "CharacterClass",
+            StructDetails {
+                field_order: Some(&[0, 2, 3, 4, 1]),
+                is_node: false,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSEnumBody",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "LookAroundAssertion",
+            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
+        ),
+        (
+            "TSTypeReference",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ThrowStatement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "ExportNamedDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 2, 6]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 2, 6]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("Modifiers", StructDetails { field_order: None, is_node: false }),
-        ("DynamicImport", StructDetails { field_order: None, is_node: false }),
-        ("UnaryExpression", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("BoundaryAssertion", StructDetails { field_order: None, is_node: false }),
-        ("TSBigIntKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("StringLiteral", StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true }),
-        ("Quantifier", StructDetails { field_order: Some(&[0, 1, 2, 4, 3]), is_node: false }),
+        ("Modifiers", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "DynamicImport",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "UnaryExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "BoundaryAssertion",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "TSBigIntKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "StringLiteral",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "Quantifier",
+            StructDetails {
+                field_order: Some(&[0, 1, 2, 4, 3]),
+                is_node: false,
+                is_transparent: false,
+            },
+        ),
         (
             "ImportNamespaceSpecifier",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true },
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
-        ("Disjunction", StructDetails { field_order: None, is_node: false }),
+        ("Disjunction", StructDetails { field_order: None, is_node: false, is_transparent: false }),
         (
             "TSTemplateLiteralType",
-            StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("PrivateInExpression", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("Modifier", StructDetails { field_order: None, is_node: false }),
-        ("ExpressionStatement", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("NumericLiteral", StructDetails { field_order: Some(&[1, 0, 4, 3, 2]), is_node: true }),
+        (
+            "PrivateInExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        ("Modifier", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "ExpressionStatement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "NumericLiteral",
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "TSCallSignatureDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 6, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "TSMethodSignature",
-            StructDetails { field_order: Some(&[1, 0, 3, 8, 9, 10, 4, 5, 6, 7, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 8, 9, 10, 4, 5, 6, 7, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("NullLiteral", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("BreakStatement", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("ParenthesizedExpression", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "NullLiteral",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "BreakStatement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ParenthesizedExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "ComputedMemberExpression",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "TSIndexSignature",
-            StructDetails { field_order: Some(&[1, 0, 4, 5, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 5, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "ObjectAssignmentTarget",
-            StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "TSImportTypeQualifiedName",
-            StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("Decorator", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("JSDocNonNullableType", StructDetails { field_order: Some(&[1, 0, 3, 2]), is_node: true }),
-        ("TSObjectKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
+        (
+            "Decorator",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSDocNonNullableType",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSObjectKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
         (
             "TSNamedTupleMember",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "AssignmentTargetWithDefault",
-            StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TSClassImplements", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("ImportDefaultSpecifier", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("JSXOpeningFragment", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("ThisExpression", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("CatchClause", StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true }),
+        (
+            "TSClassImplements",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ImportDefaultSpecifier",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXOpeningFragment",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ThisExpression",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "CatchClause",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "CallExpression",
-            StructDetails { field_order: Some(&[1, 0, 4, 5, 6, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 5, 6, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TSSymbolKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("LabeledStatement", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("ReturnStatement", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("TemplateElement", StructDetails { field_order: Some(&[1, 0, 4, 2, 3]), is_node: true }),
-        ("ClassBody", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("BindingIdentifier", StructDetails { field_order: Some(&[1, 0, 3, 2]), is_node: true }),
-        ("WhileStatement", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        (
+            "TSSymbolKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "LabeledStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ReturnStatement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TemplateElement",
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ClassBody",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "BindingIdentifier",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "WhileStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "TSFunctionType",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 6, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("EcmaScriptModule", StructDetails { field_order: Some(&[4, 0, 1, 2, 3]), is_node: false }),
-        ("DoWhileStatement", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("SourceType", StructDetails { field_order: None, is_node: false }),
-        ("ArrayPattern", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        (
+            "EcmaScriptModule",
+            StructDetails {
+                field_order: Some(&[4, 0, 1, 2, 3]),
+                is_node: false,
+                is_transparent: false,
+            },
+        ),
+        (
+            "DoWhileStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        ("SourceType", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "ArrayPattern",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "TSConstructorType",
-            StructDetails { field_order: Some(&[1, 0, 6, 3, 4, 5, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 6, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("ExportSpecifier", StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true }),
+        (
+            "ExportSpecifier",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "UnicodePropertyEscape",
-            StructDetails { field_order: Some(&[0, 3, 4, 1, 2]), is_node: false },
+            StructDetails {
+                field_order: Some(&[0, 3, 4, 1, 2]),
+                is_node: false,
+                is_transparent: false,
+            },
         ),
-        ("CharacterClassEscape", StructDetails { field_order: None, is_node: false }),
-        ("EmptyStatement", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("ReferenceId", StructDetails { field_order: None, is_node: false }),
-        ("JSXOpeningElement", StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true }),
-        ("TSTypeOperator", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("JSXFragment", StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true }),
-        ("Super", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("TSArrayType", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("ObjectExpression", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("BooleanLiteral", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("TSTypeQuery", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        (
+            "CharacterClassEscape",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "EmptyStatement",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        ("ReferenceId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "JSXOpeningElement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSTypeOperator",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSXFragment",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "Super",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSArrayType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ObjectExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "BooleanLiteral",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSTypeQuery",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "TSImportEqualsDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "TSModuleDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 6, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("BinaryExpression", StructDetails { field_order: Some(&[1, 0, 3, 2, 4]), is_node: true }),
-        ("RegExp", StructDetails { field_order: None, is_node: false }),
+        (
+            "BinaryExpression",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        ("RegExp", StructDetails { field_order: None, is_node: false, is_transparent: false }),
         (
             "RawTransferMetadata2",
-            StructDetails { field_order: Some(&[0, 3, 4, 5, 1, 2]), is_node: false },
+            StructDetails {
+                field_order: Some(&[0, 3, 4, 5, 1, 2]),
+                is_node: false,
+                is_transparent: false,
+            },
         ),
-        ("PrivateIdentifier", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "PrivateIdentifier",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "TSTypeParameterInstantiation",
-            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true },
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
         ),
-        ("WithClause", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("RawTransferData", StructDetails { field_order: None, is_node: false }),
+        (
+            "WithClause",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "RawTransferData",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
         (
             "ArrayAssignmentTarget",
-            StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TSIndexSignatureName", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("TSNeverKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("NonMaxU32", StructDetails { field_order: None, is_node: false }),
-        ("JSXElement", StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true }),
+        (
+            "TSIndexSignatureName",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSNeverKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        ("NonMaxU32", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "JSXElement",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "ForOfStatement",
-            StructDetails { field_order: Some(&[1, 0, 6, 3, 4, 5, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 6, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TSTypeAssertion", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        (
+            "TSTypeAssertion",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "TSConstructSignatureDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "TSSatisfiesExpression",
-            StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("Dot", StructDetails { field_order: None, is_node: false }),
-        ("TSEnumMember", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("FunctionBody", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
+        ("Dot", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "TSEnumMember",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "FunctionBody",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
         (
             "ExportAllDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("ClassString", StructDetails { field_order: Some(&[0, 2, 1]), is_node: false }),
-        ("TSInferType", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "ClassString",
+            StructDetails { field_order: Some(&[0, 2, 1]), is_node: false, is_transparent: false },
+        ),
+        (
+            "TSInferType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "AssignmentTargetPropertyProperty",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "FormalParameter",
-            StructDetails { field_order: Some(&[1, 0, 6, 7, 8, 9, 2, 3, 4, 5]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 6, 7, 8, 9, 2, 3, 4, 5]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TSLiteralType", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("TSRestType", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("ArrayExpression", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "TSLiteralType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSRestType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "ArrayExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "Class",
             StructDetails {
                 field_order: Some(&[1, 0, 10, 3, 4, 5, 6, 7, 8, 9, 11, 12, 2]),
                 is_node: true,
+                is_transparent: false,
             },
         ),
-        ("NodeId", StructDetails { field_order: None, is_node: false }),
-        ("RegExpFlags", StructDetails { field_order: None, is_node: false }),
+        ("NodeId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        ("RegExpFlags", StructDetails { field_order: None, is_node: false, is_transparent: true }),
         (
             "TSPropertySignature",
-            StructDetails { field_order: Some(&[1, 0, 2, 3, 4, 5, 6]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4, 5, 6]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("BlockStatement", StructDetails { field_order: Some(&[1, 0, 3, 2]), is_node: true }),
-        ("RegExpLiteral", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("TSUnionType", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "BlockStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "RegExpLiteral",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSUnionType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "RawTransferMetadata",
-            StructDetails { field_order: Some(&[0, 3, 4, 5, 1, 2]), is_node: false },
+            StructDetails {
+                field_order: Some(&[0, 3, 4, 5, 1, 2]),
+                is_node: false,
+                is_transparent: false,
+            },
         ),
-        ("IdentifierName", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "IdentifierName",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "TSInterfaceDeclaration",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 6, 7, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 7, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("ImportEntry", StructDetails { field_order: None, is_node: false }),
-        ("TSIntersectionType", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        ("ImportEntry", StructDetails { field_order: None, is_node: false, is_transparent: false }),
+        (
+            "TSIntersectionType",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "TSMappedType",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 6, 7, 8, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 7, 8, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
         (
             "FormalParameterRest",
-            StructDetails { field_order: Some(&[1, 0, 2, 3, 4]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("NamedReference", StructDetails { field_order: None, is_node: false }),
+        (
+            "NamedReference",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
         (
             "TSInstantiationExpression",
-            StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TSNonNullExpression", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("JSXClosingElement", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("SymbolId", StructDetails { field_order: None, is_node: false }),
-        ("JSXEmptyExpression", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("CommentNewlines", StructDetails { field_order: None, is_node: false }),
+        (
+            "TSNonNullExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXClosingElement",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        ("SymbolId", StructDetails { field_order: None, is_node: false, is_transparent: true }),
+        (
+            "JSXEmptyExpression",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "CommentNewlines",
+            StructDetails { field_order: None, is_node: false, is_transparent: true },
+        ),
         (
             "ExportEntry",
-            StructDetails { field_order: Some(&[1, 0, 2, 3, 4, 5, 6]), is_node: false },
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3, 4, 5, 6]),
+                is_node: false,
+                is_transparent: false,
+            },
         ),
-        ("FixedSizeAllocatorMetadata", StructDetails { field_order: None, is_node: false }),
-        ("ForInStatement", StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 2]), is_node: true }),
-        ("ChainExpression", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
-        ("TSModuleBlock", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("JSDocUnknownType", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("JSXIdentifier", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "FixedSizeAllocatorMetadata",
+            StructDetails { field_order: None, is_node: false, is_transparent: false },
+        ),
+        (
+            "ForInStatement",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "ChainExpression",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
+        (
+            "TSModuleBlock",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "JSDocUnknownType",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXIdentifier",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "BindingProperty",
-            StructDetails { field_order: Some(&[1, 0, 4, 5, 2, 3]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 4, 5, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TSAnyKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("JSXText", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("TSExportAssignment", StructDetails { field_order: Some(&[1, 0, 2]), is_node: true }),
+        (
+            "TSAnyKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "JSXText",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSExportAssignment",
+            StructDetails { field_order: Some(&[1, 0, 2]), is_node: true, is_transparent: false },
+        ),
         (
             "TSConditionalType",
-            StructDetails { field_order: Some(&[1, 0, 3, 4, 5, 6, 2]), is_node: true },
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 4, 5, 6, 2]),
+                is_node: true,
+                is_transparent: false,
+            },
         ),
-        ("TSIntrinsicKeyword", StructDetails { field_order: Some(&[1, 0]), is_node: true }),
-        ("MetaProperty", StructDetails { field_order: Some(&[1, 0, 2, 3]), is_node: true }),
-        ("TSTypePredicate", StructDetails { field_order: Some(&[1, 0, 3, 2, 4]), is_node: true }),
+        (
+            "TSIntrinsicKeyword",
+            StructDetails { field_order: Some(&[1, 0]), is_node: true, is_transparent: false },
+        ),
+        (
+            "MetaProperty",
+            StructDetails {
+                field_order: Some(&[1, 0, 2, 3]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
+        (
+            "TSTypePredicate",
+            StructDetails {
+                field_order: Some(&[1, 0, 3, 2, 4]),
+                is_node: true,
+                is_transparent: false,
+            },
+        ),
     ],
 };

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -815,7 +815,26 @@ fn generate_struct_details(schema: &Schema) -> Output {
         };
 
         let is_node = struct_def.kind.has_kind;
-        let details = quote!( StructDetails { field_order: #field_order, is_node: #is_node });
+
+        // Struct can be `#[repr(transparent)]` if it has at most 1 field with non-zero size or non-trivial alignment.
+        // Zero-sized fields (e.g. `PhantomData`) don't affect layout, so don't count them.
+        let mut is_transparent = true;
+        let mut seen_non_trivial_field = false;
+
+        for field in &struct_def.fields {
+            let layout64 = field.type_def(schema).layout_64();
+            if layout64.size > 0 || layout64.align > 1 {
+                if seen_non_trivial_field {
+                    is_transparent = false;
+                    break;
+                }
+                seen_non_trivial_field = true;
+            }
+        }
+
+        let details = quote! {
+            StructDetails { field_order: #field_order, is_node: #is_node, is_transparent: #is_transparent }
+        };
 
         (struct_def.name(), details)
     }));


### PR DESCRIPTION
Similar to #23957.

Move work from `#[ast]` macro into `ast_tools`. Calculate whether a struct can be marked `#[repr(transparent)]` or not in `ast_tools` and pass that info to `#[ast]` macro via the `StructDetails` struct. This has 2 advantages:

1. Avoids having to iterate over all fields of each struct in the macro.
2. It's more accurate. `ast_tools` knows the size of fields, so it can exclude ZST fields from the count.

A struct like this will now be marked `#[repr(transparent)]` despite having more than 1 field, because 2 of the fields contain ZSTs:

```rust
struct Foo<'a> {
    num: u32,
    _empty: [u8; 0],
    _marker: PhantomData<&'a ()>,
}   
```

Moving work from macro into `ast_tools` is preferable because `ast_tools` runs only after changes to AST, whereas the macro code runs every time `oxc_ast` crate is compiled.