### PR TITLE
fix(oxfmt): update `--migrate prettier`

### DIFF
--- a/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
+++ b/apps/oxfmt/src-js/cli/migration/migrate-prettier.ts
@@ -20,9 +20,8 @@ export async function runMigratePrettier() {
   // completely unsure why, but Prettier hangs forever when run via `napi`...
   const { resolveConfigFile, resolveConfig } = await import("prettier");
 
-  // NOTE: Prettier's config resolving is based on each file,
-  // but ours is based on the project root, typically `cwd`.
-  // So we assume the config for a dummy file at the `cwd`.
+  // TODO: Support nested config?
+  // For now, we assume the config for a dummy file at the `cwd`.
   const prettierConfigPath = await resolveConfigFile(join(cwd, "dummy.js"));
 
   // No Prettier config found, fallback with `--init` behavior
@@ -56,26 +55,36 @@ export async function runMigratePrettier() {
   }
 
   // Start with blank, then fill in from `prettierConfig`.
-  // NOTE: Some options unsupported by Oxfmt may still be valid when invoking Prettier.
-  // However, to avoid inconsistency, we do not enable options that affect Oxfmt.
   const oxfmtrc = await createBlankOxfmtrcFile(cwd);
 
+  let hasTailwindcssPlugin = false;
   let hasSortPackageJsonPlugin = false;
+  let hasSveltePlugin = false;
   for (const [key, value] of Object.entries(prettierConfig ?? {})) {
-    // Handle plugins - check for prettier-plugin-tailwindcss and warn about others
+    // Handle plugins - check for known plugins and warn about others
     if (key === "plugins" && Array.isArray(value)) {
       for (const plugin of (value as Options["plugins"])!) {
         if (plugin === "prettier-plugin-tailwindcss") {
-          // Migrate `prettier-plugin-tailwindcss` options
-          migrateTailwindOptions(prettierConfig!, oxfmtrc);
+          hasTailwindcssPlugin = true;
         } else if (plugin === "prettier-plugin-packagejson") {
           hasSortPackageJsonPlugin = true;
+        } else if (plugin === "prettier-plugin-svelte") {
+          hasSveltePlugin = true;
         } else if (typeof plugin === "string") {
           console.error(`  - plugins: "${plugin}" is not supported, skipping...`);
         } else {
           console.error(`  - plugins: custom plugin module is not supported, skipping...`);
         }
       }
+      continue;
+    }
+    // Per-file options that should not appear in a shared config; drop if leaked in
+    if (key === "parser" || key === "filepath") {
+      continue;
+    }
+    // Prettier-only options without an Oxfmt equivalent
+    if (key === "requirePragma" || key === "insertPragma") {
+      console.error(`  - "${key}" is not supported, skipping...`);
       continue;
     }
     // Oxfmt does not support this, fallback to default
@@ -85,12 +94,12 @@ export async function runMigratePrettier() {
     }
     // Oxfmt does not support these experimental options yet
     if (key === "experimentalTernaries" || key === "experimentalOperatorPosition") {
-      console.error(`  - "${key}" is not supported in JS/TS files yet`);
+      console.error(`  - "${key}" is not supported yet`);
       continue;
     }
 
-    // Skip Tailwind options - handled separately by migrateTailwindOptions
-    if (key.startsWith("tailwind")) {
+    // Skip plugin-specific options - handled separately
+    if (key.startsWith("tailwind") || key.startsWith("svelte")) {
       continue;
     }
 
@@ -115,9 +124,19 @@ export async function runMigratePrettier() {
   } else {
     oxfmtrc.sortPackageJson = false;
   }
-  // `embeddedLanguageFormatting` is not fully supported for JS-in-XXX yet.
-  if (oxfmtrc.embeddedLanguageFormatting !== "off") {
-    console.error(`  - "embeddedLanguageFormatting" in JS/TS files is not fully supported yet`);
+  // Plugin options: only enable when the corresponding Prettier plugin is used.
+  // Empty object means "enabled with defaults"; both Tailwind and Svelte are disabled by default.
+  if (hasTailwindcssPlugin) {
+    oxfmtrc.sortTailwindcss = migrateMappedOptions(
+      prettierConfig!,
+      TAILWIND_OPTION_MAPPING,
+      filterTailwindRegex,
+    );
+    console.log("Migrated prettier-plugin-tailwindcss options to sortTailwindcss");
+  }
+  if (hasSveltePlugin) {
+    oxfmtrc.svelte = migrateMappedOptions(prettierConfig!, SVELTE_OPTION_MAPPING);
+    console.log("Migrated prettier-plugin-svelte options to svelte");
   }
 
   // Migrate `ignorePatterns` from `.prettierignore`
@@ -130,10 +149,11 @@ export async function runMigratePrettier() {
   oxfmtrc.ignorePatterns = ignores;
 
   // TODO: Oxfmt now supports `overrides`,
-  // but `overrides` field is not included in `resolveConfig()` result.
-  // Automatic migration requires manual config file parsing.
+  // but `overrides` field is stripped from `resolveConfig()` result.
+  // Automatic migration requires reading the raw config file and handling each format
+  // (JSON, JSONC, YAML, JS/CJS/MJS, TOML, package.json).
   // See: https://github.com/oxc-project/oxc/issues/18215
-  if ("overrides" in oxfmtrc) {
+  if (await rawConfigHasOverrides(prettierConfigPath)) {
     console.warn(
       `  - "overrides" cannot be migrated automatically. See: https://github.com/oxc-project/oxc/issues/18215`,
     );
@@ -172,8 +192,26 @@ async function resolvePrettierIgnore(cwd: string) {
   return ignores;
 }
 
+// Best-effort detection of a top-level `overrides` key in the raw config file.
+// Uses string matching to cover all config formats (JSON/JSONC/JSON5/YAML/JS/TOML)
+// Matches:
+// - JSON/JSONC/JSON5/JS: `"overrides":` / `overrides:`
+// - YAML: `overrides:`
+// - TOML: `[[overrides]]` / `overrides =`
+async function rawConfigHasOverrides(configPath: string): Promise<boolean> {
+  try {
+    const content = await readFile(configPath, "utf8");
+    return /^\s*(?:\[\[\s*overrides\s*\]\]|["']?overrides["']?\s*[:=])/mv.test(content);
+  } catch {
+    return false;
+  }
+}
+
 // ---
 
+// Map Oxfmt's namespaced option keys (left) to Prettier's flat option keys (right).
+// Used by `migrateMappedOptions` to copy values from Prettier's flat config
+// into a single Oxfmt namespace (e.g. `sortTailwindcss`, `svelte`).
 const TAILWIND_OPTION_MAPPING: Record<string, string> = {
   config: "tailwindConfig",
   stylesheet: "tailwindStylesheet",
@@ -183,55 +221,41 @@ const TAILWIND_OPTION_MAPPING: Record<string, string> = {
   preserveDuplicates: "tailwindPreserveDuplicates",
 };
 
-/**
- * Migrate prettier-plugin-tailwindcss options to Oxfmt's sortTailwindcss format.
- *
- * Prettier format:
- * ```json
- * {
- *   "plugins": ["prettier-plugin-tailwindcss"],
- *   "tailwindConfig": "./tailwind.config.js",
- *   "tailwindFunctions": ["clsx", "cn"]
- * }
- * ```
- *
- * Oxfmt format:
- * ```json
- * {
- *   "sortTailwindcss": {
- *     "config": "./tailwind.config.js",
- *     "functions": ["clsx", "cn"]
- *   }
- * }
- * ```
- */
-function migrateTailwindOptions(
-  prettierConfig: Record<string, unknown>,
-  oxfmtrc: Record<string, unknown>,
-): void {
-  // Collect Tailwind options from Prettier config
-  const tailwindOptions: Record<string, unknown> = {};
-  for (const [oxfmtKey, prettierKey] of Object.entries(TAILWIND_OPTION_MAPPING)) {
-    const value = prettierConfig[prettierKey];
-    if (value !== undefined) {
-      if (
-        (prettierKey == "tailwindFunctions" || prettierKey == "tailwindAttributes") &&
-        Array.isArray(value)
-      ) {
-        for (const item of value as string[]) {
-          if (typeof item === "string" && item.startsWith("/") && item.endsWith("/")) {
-            console.warn(
-              `  - Do not support regex in "${prettierKey}" option yet, skipping: ${item}`,
-            );
-            continue;
-          }
-        }
-      }
-      tailwindOptions[oxfmtKey] = value;
-    }
-  }
+const SVELTE_OPTION_MAPPING: Record<string, string> = {
+  allowShorthand: "svelteAllowShorthand",
+  indentScriptAndStyle: "svelteIndentScriptAndStyle",
+  sortOrder: "svelteSortOrder",
+};
 
-  // Only add sortTailwindcss if plugin is used or options are present
-  oxfmtrc.sortTailwindcss = tailwindOptions;
-  console.log("Migrated prettier-plugin-tailwindcss options to sortTailwindcss");
+function migrateMappedOptions(
+  prettierConfig: Record<string, unknown>,
+  mapping: Record<string, string>,
+  transform?: (prettierKey: string, value: unknown) => unknown,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [oxfmtKey, prettierKey] of Object.entries(mapping)) {
+    const value = prettierConfig[prettierKey];
+    if (value === undefined) continue;
+    result[oxfmtKey] = transform ? transform(prettierKey, value) : value;
+  }
+  return result;
+}
+
+// `tailwindFunctions` / `tailwindAttributes` accept regex strings (e.g. `/^tw-/`)
+// which Oxfmt does not support. Drop them and warn.
+function filterTailwindRegex(prettierKey: string, value: unknown): unknown {
+  if (
+    (prettierKey !== "tailwindFunctions" && prettierKey !== "tailwindAttributes") ||
+    !Array.isArray(value)
+  ) {
+    return value;
+  }
+  return (value as unknown[]).filter((item): item is string => {
+    if (typeof item !== "string") return false;
+    const isRegex = item.startsWith("/") && item.endsWith("/");
+    if (isRegex) {
+      console.warn(`  - Regexp in "${prettierKey}" option is not supported, skipping: ${item}`);
+    }
+    return !isRegex;
+  });
 }

--- a/apps/oxfmt/test/cli/migrate_prettier/0.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/0.snap.md
@@ -16,15 +16,25 @@ oxfmt --migrate prettier
     - .prettierrc
   - no_config/ <CWD>
     - .gitkeep
+  - overrides_json/
+    - .prettierrc.json
+  - overrides_jsonc/
+    - .prettierrc.json5
+  - overrides_yaml/
+    - .prettierrc.yaml
   - sort_pkg_disabled/
     - .prettierrc
   - sort_pkg_enabled/
+    - .prettierrc
+  - svelte_plugin/
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
   - tailwind_options/
     - .prettierrc
   - tailwind_regex/
+    - .prettierrc
+  - unsupported_opts/
     - .prettierrc
   - with_ignore/
     - .prettierignore

--- a/apps/oxfmt/test/cli/migrate_prettier/1.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/1.snap.md
@@ -16,15 +16,25 @@ oxfmt --migrate prettier
     - .prettierrc
   - no_config/
     - .gitkeep
+  - overrides_json/
+    - .prettierrc.json
+  - overrides_jsonc/
+    - .prettierrc.json5
+  - overrides_yaml/
+    - .prettierrc.yaml
   - sort_pkg_disabled/
     - .prettierrc
   - sort_pkg_enabled/
+    - .prettierrc
+  - svelte_plugin/
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
   - tailwind_options/
     - .prettierrc
   - tailwind_regex/
+    - .prettierrc
+  - unsupported_opts/
     - .prettierrc
   - with_ignore/
     - .prettierignore

--- a/apps/oxfmt/test/cli/migrate_prettier/10.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/10.snap.md
@@ -26,11 +26,11 @@ oxfmt --migrate prettier
     - .prettierrc
   - sort_pkg_enabled/
     - .prettierrc
-  - svelte_plugin/
+  - svelte_plugin/ <CWD>
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
-  - tailwind_options/ <CWD>
+  - tailwind_options/
     - .prettierrc
   - tailwind_regex/
     - .prettierrc
@@ -49,7 +49,7 @@ oxfmt --migrate prettier
 ## stdout
 ```
 Found Prettier configuration at: <cwd>/.prettierrc
-Migrated prettier-plugin-tailwindcss options to sortTailwindcss
+Migrated prettier-plugin-svelte options to svelte
 Created `.oxfmtrc.json`.
 ```
 
@@ -60,21 +60,15 @@ Created `.oxfmtrc.json`.
 
 ## File changes
 
-### tailwind_options/.oxfmtrc.json (created)
+### svelte_plugin/.oxfmtrc.json (created)
 ```
 {
   "printWidth": 80,
   "sortPackageJson": false,
-  "sortTailwindcss": {
-    "config": "./tailwind.config.js",
-    "functions": [
-      "clsx",
-      "cn"
-    ],
-    "attributes": [
-      "myClass"
-    ],
-    "preserveWhitespace": true
+  "svelte": {
+    "allowShorthand": false,
+    "indentScriptAndStyle": false,
+    "sortOrder": "options-scripts-markup-styles"
   },
   "ignorePatterns": []
 }

--- a/apps/oxfmt/test/cli/migrate_prettier/11.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/11.snap.md
@@ -30,11 +30,11 @@ oxfmt --migrate prettier
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
-  - tailwind_options/ <CWD>
+  - tailwind_options/
     - .prettierrc
   - tailwind_regex/
     - .prettierrc
-  - unsupported_opts/
+  - unsupported_opts/ <CWD>
     - .prettierrc
   - with_ignore/
     - .prettierignore
@@ -49,33 +49,24 @@ oxfmt --migrate prettier
 ## stdout
 ```
 Found Prettier configuration at: <cwd>/.prettierrc
-Migrated prettier-plugin-tailwindcss options to sortTailwindcss
 Created `.oxfmtrc.json`.
 ```
 
 ## stderr
 ```
+  - "requirePragma" is not supported, skipping...
+  - "insertPragma" is not supported, skipping...
   - "printWidth" is not set in Prettier config, defaulting to 80 (Oxfmt default: 100)
 ```
 
 ## File changes
 
-### tailwind_options/.oxfmtrc.json (created)
+### unsupported_opts/.oxfmtrc.json (created)
 ```
 {
+  "embeddedLanguageFormatting": "auto",
   "printWidth": 80,
   "sortPackageJson": false,
-  "sortTailwindcss": {
-    "config": "./tailwind.config.js",
-    "functions": [
-      "clsx",
-      "cn"
-    ],
-    "attributes": [
-      "myClass"
-    ],
-    "preserveWhitespace": true
-  },
   "ignorePatterns": []
 }
 

--- a/apps/oxfmt/test/cli/migrate_prettier/12.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/12.snap.md
@@ -16,7 +16,7 @@ oxfmt --migrate prettier
     - .prettierrc
   - no_config/
     - .gitkeep
-  - overrides_json/
+  - overrides_json/ <CWD>
     - .prettierrc.json
   - overrides_jsonc/
     - .prettierrc.json5
@@ -30,7 +30,7 @@ oxfmt --migrate prettier
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
-  - tailwind_options/ <CWD>
+  - tailwind_options/
     - .prettierrc
   - tailwind_regex/
     - .prettierrc
@@ -48,34 +48,24 @@ oxfmt --migrate prettier
 
 ## stdout
 ```
-Found Prettier configuration at: <cwd>/.prettierrc
-Migrated prettier-plugin-tailwindcss options to sortTailwindcss
+Found Prettier configuration at: <cwd>/.prettierrc.json
 Created `.oxfmtrc.json`.
 ```
 
 ## stderr
 ```
   - "printWidth" is not set in Prettier config, defaulting to 80 (Oxfmt default: 100)
+  - "overrides" cannot be migrated automatically. See: https://github.com/oxc-project/oxc/issues/18215
 ```
 
 ## File changes
 
-### tailwind_options/.oxfmtrc.json (created)
+### overrides_json/.oxfmtrc.json (created)
 ```
 {
+  "semi": false,
   "printWidth": 80,
   "sortPackageJson": false,
-  "sortTailwindcss": {
-    "config": "./tailwind.config.js",
-    "functions": [
-      "clsx",
-      "cn"
-    ],
-    "attributes": [
-      "myClass"
-    ],
-    "preserveWhitespace": true
-  },
   "ignorePatterns": []
 }
 

--- a/apps/oxfmt/test/cli/migrate_prettier/13.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/13.snap.md
@@ -18,7 +18,7 @@ oxfmt --migrate prettier
     - .gitkeep
   - overrides_json/
     - .prettierrc.json
-  - overrides_jsonc/
+  - overrides_jsonc/ <CWD>
     - .prettierrc.json5
   - overrides_yaml/
     - .prettierrc.yaml
@@ -30,7 +30,7 @@ oxfmt --migrate prettier
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
-  - tailwind_options/ <CWD>
+  - tailwind_options/
     - .prettierrc
   - tailwind_regex/
     - .prettierrc
@@ -48,34 +48,24 @@ oxfmt --migrate prettier
 
 ## stdout
 ```
-Found Prettier configuration at: <cwd>/.prettierrc
-Migrated prettier-plugin-tailwindcss options to sortTailwindcss
+Found Prettier configuration at: <cwd>/.prettierrc.json5
 Created `.oxfmtrc.json`.
 ```
 
 ## stderr
 ```
   - "printWidth" is not set in Prettier config, defaulting to 80 (Oxfmt default: 100)
+  - "overrides" cannot be migrated automatically. See: https://github.com/oxc-project/oxc/issues/18215
 ```
 
 ## File changes
 
-### tailwind_options/.oxfmtrc.json (created)
+### overrides_jsonc/.oxfmtrc.json (created)
 ```
 {
+  "semi": true,
   "printWidth": 80,
   "sortPackageJson": false,
-  "sortTailwindcss": {
-    "config": "./tailwind.config.js",
-    "functions": [
-      "clsx",
-      "cn"
-    ],
-    "attributes": [
-      "myClass"
-    ],
-    "preserveWhitespace": true
-  },
   "ignorePatterns": []
 }
 

--- a/apps/oxfmt/test/cli/migrate_prettier/14.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/14.snap.md
@@ -20,7 +20,7 @@ oxfmt --migrate prettier
     - .prettierrc.json
   - overrides_jsonc/
     - .prettierrc.json5
-  - overrides_yaml/
+  - overrides_yaml/ <CWD>
     - .prettierrc.yaml
   - sort_pkg_disabled/
     - .prettierrc
@@ -30,7 +30,7 @@ oxfmt --migrate prettier
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
-  - tailwind_options/ <CWD>
+  - tailwind_options/
     - .prettierrc
   - tailwind_regex/
     - .prettierrc
@@ -48,34 +48,24 @@ oxfmt --migrate prettier
 
 ## stdout
 ```
-Found Prettier configuration at: <cwd>/.prettierrc
-Migrated prettier-plugin-tailwindcss options to sortTailwindcss
+Found Prettier configuration at: <cwd>/.prettierrc.yaml
 Created `.oxfmtrc.json`.
 ```
 
 ## stderr
 ```
   - "printWidth" is not set in Prettier config, defaulting to 80 (Oxfmt default: 100)
+  - "overrides" cannot be migrated automatically. See: https://github.com/oxc-project/oxc/issues/18215
 ```
 
 ## File changes
 
-### tailwind_options/.oxfmtrc.json (created)
+### overrides_yaml/.oxfmtrc.json (created)
 ```
 {
+  "semi": true,
   "printWidth": 80,
   "sortPackageJson": false,
-  "sortTailwindcss": {
-    "config": "./tailwind.config.js",
-    "functions": [
-      "clsx",
-      "cn"
-    ],
-    "attributes": [
-      "myClass"
-    ],
-    "preserveWhitespace": true
-  },
   "ignorePatterns": []
 }
 

--- a/apps/oxfmt/test/cli/migrate_prettier/2.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/2.snap.md
@@ -16,15 +16,25 @@ oxfmt --migrate prettier
     - .prettierrc
   - no_config/
     - .gitkeep
+  - overrides_json/
+    - .prettierrc.json
+  - overrides_jsonc/
+    - .prettierrc.json5
+  - overrides_yaml/
+    - .prettierrc.yaml
   - sort_pkg_disabled/
     - .prettierrc
   - sort_pkg_enabled/
+    - .prettierrc
+  - svelte_plugin/
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
   - tailwind_options/
     - .prettierrc
   - tailwind_regex/
+    - .prettierrc
+  - unsupported_opts/
     - .prettierrc
   - with_ignore/
     - .prettierignore
@@ -44,7 +54,7 @@ Created `.oxfmtrc.json`.
 
 ## stderr
 ```
-  - "embeddedLanguageFormatting" in JS/TS files is not fully supported yet
+
 ```
 
 ## File changes

--- a/apps/oxfmt/test/cli/migrate_prettier/3.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/3.snap.md
@@ -16,15 +16,25 @@ oxfmt --migrate prettier
     - .prettierrc
   - no_config/
     - .gitkeep
+  - overrides_json/
+    - .prettierrc.json
+  - overrides_jsonc/
+    - .prettierrc.json5
+  - overrides_yaml/
+    - .prettierrc.yaml
   - sort_pkg_disabled/
     - .prettierrc
   - sort_pkg_enabled/
+    - .prettierrc
+  - svelte_plugin/
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
   - tailwind_options/
     - .prettierrc
   - tailwind_regex/
+    - .prettierrc
+  - unsupported_opts/
     - .prettierrc
   - with_ignore/
     - .prettierignore
@@ -45,7 +55,6 @@ Created `.oxfmtrc.json`.
 ## stderr
 ```
   - "printWidth" is not set in Prettier config, defaulting to 80 (Oxfmt default: 100)
-  - "embeddedLanguageFormatting" in JS/TS files is not fully supported yet
 ```
 
 ## File changes

--- a/apps/oxfmt/test/cli/migrate_prettier/4.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/4.snap.md
@@ -16,15 +16,25 @@ oxfmt --migrate prettier
     - .prettierrc
   - no_config/
     - .gitkeep
+  - overrides_json/
+    - .prettierrc.json
+  - overrides_jsonc/
+    - .prettierrc.json5
+  - overrides_yaml/
+    - .prettierrc.yaml
   - sort_pkg_disabled/
     - .prettierrc
   - sort_pkg_enabled/
+    - .prettierrc
+  - svelte_plugin/
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
   - tailwind_options/
     - .prettierrc
   - tailwind_regex/
+    - .prettierrc
+  - unsupported_opts/
     - .prettierrc
   - with_ignore/ <CWD>
     - .prettierignore
@@ -46,7 +56,6 @@ Created `.oxfmtrc.json`.
 ## stderr
 ```
   - "printWidth" is not set in Prettier config, defaulting to 80 (Oxfmt default: 100)
-  - "embeddedLanguageFormatting" in JS/TS files is not fully supported yet
 ```
 
 ## File changes

--- a/apps/oxfmt/test/cli/migrate_prettier/6.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/6.snap.md
@@ -16,15 +16,25 @@ oxfmt --migrate prettier
     - .prettierrc
   - no_config/
     - .gitkeep
+  - overrides_json/
+    - .prettierrc.json
+  - overrides_jsonc/
+    - .prettierrc.json5
+  - overrides_yaml/
+    - .prettierrc.yaml
   - sort_pkg_disabled/
     - .prettierrc
   - sort_pkg_enabled/
+    - .prettierrc
+  - svelte_plugin/
     - .prettierrc
   - tailwind_empty/ <CWD>
     - .prettierrc
   - tailwind_options/
     - .prettierrc
   - tailwind_regex/
+    - .prettierrc
+  - unsupported_opts/
     - .prettierrc
   - with_ignore/
     - .prettierignore
@@ -46,7 +56,6 @@ Created `.oxfmtrc.json`.
 ## stderr
 ```
   - "printWidth" is not set in Prettier config, defaulting to 80 (Oxfmt default: 100)
-  - "embeddedLanguageFormatting" in JS/TS files is not fully supported yet
 ```
 
 ## File changes
@@ -54,9 +63,9 @@ Created `.oxfmtrc.json`.
 ### tailwind_empty/.oxfmtrc.json (created)
 ```
 {
-  "sortTailwindcss": {},
   "printWidth": 80,
   "sortPackageJson": false,
+  "sortTailwindcss": {},
   "ignorePatterns": []
 }
 

--- a/apps/oxfmt/test/cli/migrate_prettier/7.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/7.snap.md
@@ -16,15 +16,25 @@ oxfmt --migrate prettier
     - .prettierrc
   - no_config/
     - .gitkeep
+  - overrides_json/
+    - .prettierrc.json
+  - overrides_jsonc/
+    - .prettierrc.json5
+  - overrides_yaml/
+    - .prettierrc.yaml
   - sort_pkg_disabled/
     - .prettierrc
   - sort_pkg_enabled/
+    - .prettierrc
+  - svelte_plugin/
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
   - tailwind_options/
     - .prettierrc
   - tailwind_regex/ <CWD>
+    - .prettierrc
+  - unsupported_opts/
     - .prettierrc
   - with_ignore/
     - .prettierignore
@@ -45,10 +55,9 @@ Created `.oxfmtrc.json`.
 
 ## stderr
 ```
-  - Do not support regex in "tailwindFunctions" option yet, skipping: /^tw-/
-  - Do not support regex in "tailwindAttributes" option yet, skipping: /^data-tw-/
   - "printWidth" is not set in Prettier config, defaulting to 80 (Oxfmt default: 100)
-  - "embeddedLanguageFormatting" in JS/TS files is not fully supported yet
+  - Regexp in "tailwindFunctions" option is not supported, skipping: /^tw-/
+  - Regexp in "tailwindAttributes" option is not supported, skipping: /^data-tw-/
 ```
 
 ## File changes
@@ -56,18 +65,16 @@ Created `.oxfmtrc.json`.
 ### tailwind_regex/.oxfmtrc.json (created)
 ```
 {
-  "sortTailwindcss": {
-    "functions": [
-      "clsx",
-      "/^tw-/"
-    ],
-    "attributes": [
-      "className",
-      "/^data-tw-/"
-    ]
-  },
   "printWidth": 80,
   "sortPackageJson": false,
+  "sortTailwindcss": {
+    "functions": [
+      "clsx"
+    ],
+    "attributes": [
+      "className"
+    ]
+  },
   "ignorePatterns": []
 }
 

--- a/apps/oxfmt/test/cli/migrate_prettier/8.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/8.snap.md
@@ -16,15 +16,25 @@ oxfmt --migrate prettier
     - .prettierrc
   - no_config/
     - .gitkeep
+  - overrides_json/
+    - .prettierrc.json
+  - overrides_jsonc/
+    - .prettierrc.json5
+  - overrides_yaml/
+    - .prettierrc.yaml
   - sort_pkg_disabled/ <CWD>
     - .prettierrc
   - sort_pkg_enabled/
+    - .prettierrc
+  - svelte_plugin/
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
   - tailwind_options/
     - .prettierrc
   - tailwind_regex/
+    - .prettierrc
+  - unsupported_opts/
     - .prettierrc
   - with_ignore/
     - .prettierignore
@@ -45,7 +55,6 @@ Created `.oxfmtrc.json`.
 ## stderr
 ```
   - "printWidth" is not set in Prettier config, defaulting to 80 (Oxfmt default: 100)
-  - "embeddedLanguageFormatting" in JS/TS files is not fully supported yet
 ```
 
 ## File changes

--- a/apps/oxfmt/test/cli/migrate_prettier/9.snap.md
+++ b/apps/oxfmt/test/cli/migrate_prettier/9.snap.md
@@ -16,15 +16,25 @@ oxfmt --migrate prettier
     - .prettierrc
   - no_config/
     - .gitkeep
+  - overrides_json/
+    - .prettierrc.json
+  - overrides_jsonc/
+    - .prettierrc.json5
+  - overrides_yaml/
+    - .prettierrc.yaml
   - sort_pkg_disabled/
     - .prettierrc
   - sort_pkg_enabled/ <CWD>
+    - .prettierrc
+  - svelte_plugin/
     - .prettierrc
   - tailwind_empty/
     - .prettierrc
   - tailwind_options/
     - .prettierrc
   - tailwind_regex/
+    - .prettierrc
+  - unsupported_opts/
     - .prettierrc
   - with_ignore/
     - .prettierignore
@@ -46,7 +56,6 @@ Created `.oxfmtrc.json`.
 ```
   - "printWidth" is not set in Prettier config, defaulting to 80 (Oxfmt default: 100)
   - Migrated "prettier-plugin-packagejson" to "sortPackageJson"
-  - "embeddedLanguageFormatting" in JS/TS files is not fully supported yet
 ```
 
 ## File changes

--- a/apps/oxfmt/test/cli/migrate_prettier/fixtures/overrides_json/.prettierrc.json
+++ b/apps/oxfmt/test/cli/migrate_prettier/fixtures/overrides_json/.prettierrc.json
@@ -1,0 +1,11 @@
+{
+  "semi": false,
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "tabWidth": 4
+      }
+    }
+  ]
+}

--- a/apps/oxfmt/test/cli/migrate_prettier/fixtures/overrides_jsonc/.prettierrc.json5
+++ b/apps/oxfmt/test/cli/migrate_prettier/fixtures/overrides_jsonc/.prettierrc.json5
@@ -1,0 +1,12 @@
+{
+  // Some comment that breaks pure JSON.parse
+  "semi": true,
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "tabWidth": 4
+      }
+    }
+  ]
+}

--- a/apps/oxfmt/test/cli/migrate_prettier/fixtures/overrides_yaml/.prettierrc.yaml
+++ b/apps/oxfmt/test/cli/migrate_prettier/fixtures/overrides_yaml/.prettierrc.yaml
@@ -1,0 +1,5 @@
+semi: true
+overrides:
+  - files: "*.md"
+    options:
+      tabWidth: 4

--- a/apps/oxfmt/test/cli/migrate_prettier/fixtures/svelte_plugin/.prettierrc
+++ b/apps/oxfmt/test/cli/migrate_prettier/fixtures/svelte_plugin/.prettierrc
@@ -1,0 +1,1 @@
+{"plugins":["prettier-plugin-svelte"],"svelteSortOrder":"options-scripts-markup-styles","svelteAllowShorthand":false,"svelteIndentScriptAndStyle":false}

--- a/apps/oxfmt/test/cli/migrate_prettier/fixtures/unsupported_opts/.prettierrc
+++ b/apps/oxfmt/test/cli/migrate_prettier/fixtures/unsupported_opts/.prettierrc
@@ -1,0 +1,1 @@
+{"requirePragma":true,"insertPragma":true,"parser":"typescript","filepath":"src/index.ts","embeddedLanguageFormatting":"auto"}

--- a/apps/oxfmt/test/cli/migrate_prettier/options.json
+++ b/apps/oxfmt/test/cli/migrate_prettier/options.json
@@ -8,5 +8,10 @@
   { "cwd": "tailwind_empty", "args": ["--migrate", "prettier"] },
   { "cwd": "tailwind_regex", "args": ["--migrate", "prettier"] },
   { "cwd": "sort_pkg_disabled", "args": ["--migrate", "prettier"] },
-  { "cwd": "sort_pkg_enabled", "args": ["--migrate", "prettier"] }
+  { "cwd": "sort_pkg_enabled", "args": ["--migrate", "prettier"] },
+  { "cwd": "svelte_plugin", "args": ["--migrate", "prettier"] },
+  { "cwd": "unsupported_opts", "args": ["--migrate", "prettier"] },
+  { "cwd": "overrides_json", "args": ["--migrate", "prettier"] },
+  { "cwd": "overrides_jsonc", "args": ["--migrate", "prettier"] },
+  { "cwd": "overrides_yaml", "args": ["--migrate", "prettier"] }
 ]


### PR DESCRIPTION
A bit outdated, updated it to reflect the latest situation.

- Support `svelte` migration
- Better (but not yet complete) `overrides` detection
- Remove warning about `embeddedLanguageFormatting` (already supported)
- etc