### PR TITLE
refactor(formatter_css): use `try_parsing_value_in_custom_property` option

### DIFF
--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -167,6 +167,7 @@ fn parse_stylesheet<'a>(
                     .strip_prefix(TEMPLATE_PLACEHOLDER_SUFFIX)
                     .expect("placeholder prefix starts with a backtick"),
             }),
+            try_parsing_value_in_custom_property: true,
             ..ParserOptions::default()
         })
         .comments(&mut comments)

--- a/crates/oxc_formatter_css/src/print/statement.rs
+++ b/crates/oxc_formatter_css/src/print/statement.rs
@@ -1,6 +1,6 @@
 use cow_utils::CowUtils;
 use oxc_css_parser::{
-    ParserBuilder, Spanned,
+    Spanned,
     ast::{ComponentValue, Declaration, InterpolableIdent, QualifiedRule, SimpleBlock, Statement},
 };
 
@@ -346,7 +346,6 @@ pub(super) fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter
             write!(f, text(trimmed_between));
         }
     }
-    let mut reparsed_important_start: Option<u32> = None;
     if decl.value.is_empty() {
         // Custom properties with a whitespace-only value keep it verbatim
         // (`--one-space: ;` stays as-is). Scan up to the `;` in the source.
@@ -409,26 +408,7 @@ pub(super) fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter
             // The raw text includes any comments; drop them from the cursor.
             let _ = f.context().comments().take_before(value_end);
         } else {
-            // Custom property values come back from `oxc-css-parser` as a raw token stream
-            // (per spec, `<declaration-value>` is any token soup),
-            // but Prettier (postcss) value-parses them like any other declaration,
-            // so `var(...)` etc. get the normal group/break layout.
-            let reparsed = if prop.starts_with("--")
-                && decl.value.iter().all(|v| matches!(v, ComponentValue::TokenWithSpan(_)))
-            {
-                reparse_custom_property_value(decl, f)
-            } else {
-                None
-            };
-            let values: &[ComponentValue<'a>] = reparsed.as_ref().map_or(&decl.value, |d| &d.value);
-            // A custom property's `!important` lands in the REPARSED declaration
-            // (the original token-soup decl has `important: None`);
-            // remember its source offset so the tail printing below doesn't drop it.
-            // The padded copy keeps original offsets.
-            reparsed_important_start = reparsed
-                .as_ref()
-                .and_then(|d| d.important.as_ref())
-                .map(|important| to_span(important.span()).start);
+            let values = &*decl.value;
 
             let ctx = ValueContext {
                 decl_prop: Some(prop_lower),
@@ -448,7 +428,6 @@ pub(super) fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter
             // A single interpolated component is exempt,
             // its fill-chunk fit ignores the line tail (see `is_single_sass_interpolation`).
             let has_tail = decl.important.is_none()
-                && reparsed_important_start.is_none()
                 && !value::is_single_sass_interpolation(values)
                 && f.context().comments().iter_before(bound).any(|c| c.span.start >= value_end);
             let ctx = ValueContext { tail_bound: has_tail.then_some(bound), ..ctx };
@@ -481,9 +460,6 @@ pub(super) fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter
     if let Some(important) = &decl.important {
         value::flush_trailing_value_comments(to_span(important.span()).start, f);
         write!(f, [space(), "!important"]);
-    } else if let Some(start) = reparsed_important_start {
-        value::flush_trailing_value_comments(start, f);
-        write!(f, [space(), "!important"]);
     }
     // Comments between the value and the `;`.
     // NOTE: the `;` position is the flush bound, so a comment after `;` stays for the trailing-comment pass.
@@ -496,51 +472,6 @@ pub(super) fn write_declaration<'a>(decl: &Declaration<'a>, f: &mut CssFormatter
             write!(f, space());
         }
     }
-}
-
-/// Re-parse a custom property's raw token-stream value as a normal declaration,
-/// so the value gets the standard group/break layout.
-///
-/// The declaration is rebuilt at the same source offsets,
-/// (the prefix is blanked out and the `--name` prop replaced by a same-length plain ident)
-/// so every span in the re-parsed value stays valid against the original source.
-/// (Prettier pulls the same offset-preserving trick for custom-property rule blocks in `parser-postcss.js`)
-///
-/// Returns `None` (caller keeps the token stream) when the value does not parse as a plain declaration value.
-fn reparse_custom_property_value<'a>(
-    decl: &Declaration<'a>,
-    f: &CssFormatter<'_, 'a>,
-) -> Option<Declaration<'a>> {
-    let source = f.context().source_text();
-    let decl_span = to_span(decl.span());
-    let name_span = to_span(decl.name.span());
-
-    let mut padded = String::with_capacity(decl_span.end as usize);
-    for c in source.slice_range(0, name_span.start).chars() {
-        if c == '\n' || c == '\r' {
-            padded.push(c);
-        } else {
-            // One space per BYTE (not per char): spans are byte offsets,
-            // so a multi-byte char (e.g. `º` in a comment) must keep its width.
-            for _ in 0..c.len_utf8() {
-                padded.push(' ');
-            }
-        }
-    }
-    for _ in name_span.start..name_span.end {
-        padded.push('a');
-    }
-    padded.push_str(source.slice_range(name_span.end, decl_span.end));
-
-    let allocator = f.allocator();
-    let padded: &'a str = allocator.alloc_str(&padded);
-    let syntax = f.options().variant.to_css_syntax();
-    let mut parser = ParserBuilder::new(padded).syntax(syntax).build();
-    let reparsed = parser.parse::<Declaration>().ok()?;
-    if !parser.recoverable_errors().is_empty() {
-        return None;
-    }
-    Some(reparsed)
 }
 
 /// Prints a `--prop: { a: b; c: d }` rule-block value by re-flowing the raw text:

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/custom-property-important.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/custom-property-important.css
@@ -1,6 +1,6 @@
-/* A custom property's `!important` lives in the re-parsed declaration
-   (the original is a raw token soup with `important: None`) — it must
-   survive printing. */
+/* `!important` on a custom property must survive printing
+   (the value parses as a normal `<declaration-value>` so the trailing
+   `!important` lands on the declaration itself). */
 html {
   margin-right: 0px !important;
   --removed-body-scroll-bar-size: 0px !important;

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/custom-property-important.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/custom-property-important.css.snap
@@ -2,9 +2,9 @@
 source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 ---
 ==================== Input ====================
-/* A custom property's `!important` lives in the re-parsed declaration
-   (the original is a raw token soup with `important: None`) — it must
-   survive printing. */
+/* `!important` on a custom property must survive printing
+   (the value parses as a normal `<declaration-value>` so the trailing
+   `!important` lands on the declaration itself). */
 html {
   margin-right: 0px !important;
   --removed-body-scroll-bar-size: 0px !important;
@@ -18,9 +18,9 @@ html {
 ------------------
 { printWidth: 80 }
 ------------------
-/* A custom property's `!important` lives in the re-parsed declaration
-   (the original is a raw token soup with `important: None`) — it must
-   survive printing. */
+/* `!important` on a custom property must survive printing
+   (the value parses as a normal `<declaration-value>` so the trailing
+   `!important` lands on the declaration itself). */
 html {
   margin-right: 0px !important;
   --removed-body-scroll-bar-size: 0px !important;
@@ -33,9 +33,9 @@ html {
 -------------------
 { printWidth: 100 }
 -------------------
-/* A custom property's `!important` lives in the re-parsed declaration
-   (the original is a raw token soup with `important: None`) — it must
-   survive printing. */
+/* `!important` on a custom property must survive printing
+   (the value parses as a normal `<declaration-value>` so the trailing
+   `!important` lands on the declaration itself). */
 html {
   margin-right: 0px !important;
   --removed-body-scroll-bar-size: 0px !important;

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/custom-property-value-break.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/custom-property-value-break.css
@@ -1,6 +1,6 @@
 :host {
   /* 80 columns exactly: stays flat (so does Prettier) */
   --pulse-color: var(--wa-color-border-loud, var(--wa-color-brand-border-loud));
-  /* re-parsed as a normal value: breaks like any declaration */
+  /* parsed as a normal value: breaks like any declaration */
   --slide-size: calc((100% - (var(--slides-per-page) - 1) * var(--slide-gap)) / var(--slides-per-page));
 }

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/custom-property-value-break.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/custom-property-value-break.css.snap
@@ -5,7 +5,7 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 :host {
   /* 80 columns exactly: stays flat (so does Prettier) */
   --pulse-color: var(--wa-color-border-loud, var(--wa-color-brand-border-loud));
-  /* re-parsed as a normal value: breaks like any declaration */
+  /* parsed as a normal value: breaks like any declaration */
   --slide-size: calc((100% - (var(--slides-per-page) - 1) * var(--slide-gap)) / var(--slides-per-page));
 }
 
@@ -16,7 +16,7 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 :host {
   /* 80 columns exactly: stays flat (so does Prettier) */
   --pulse-color: var(--wa-color-border-loud, var(--wa-color-brand-border-loud));
-  /* re-parsed as a normal value: breaks like any declaration */
+  /* parsed as a normal value: breaks like any declaration */
   --slide-size: calc(
     (100% - (var(--slides-per-page) - 1) * var(--slide-gap)) /
       var(--slides-per-page)
@@ -29,7 +29,7 @@ source: crates/oxc_formatter_css/tests/fixtures/mod.rs
 :host {
   /* 80 columns exactly: stays flat (so does Prettier) */
   --pulse-color: var(--wa-color-border-loud, var(--wa-color-brand-border-loud));
-  /* re-parsed as a normal value: breaks like any declaration */
+  /* parsed as a normal value: breaks like any declaration */
   --slide-size: calc(
     (100% - (var(--slides-per-page) - 1) * var(--slide-gap)) / var(--slides-per-page)
   );


### PR DESCRIPTION
Use parser option instead of manual reparsing.