### PR TITLE
feat(linter/react): add `disallowedValues` option for `forbid-dom-props` rule

### DIFF
--- a/apps/oxlint/src-js/package/config.generated.ts
+++ b/apps/oxlint/src-js/package/config.generated.ts
@@ -4408,7 +4408,7 @@ export interface ForbidDomPropsConfig {
    * An array of prop names or objects that are forbidden on DOM elements.
    *
    * Each array element can be a string with the property name, or an object
-   * with `propName`, an optional `disallowedFor` array of DOM node names,
+   * with `propName`, optional `disallowedFor` and `disallowedValues` arrays,
    * and an optional custom `message`.
    *
    * Examples:
@@ -4416,11 +4416,13 @@ export interface ForbidDomPropsConfig {
    * - `["error", { "forbid": ["id", "style"] }]`
    * - `["error", { "forbid": [{ "propName": "className", "message": "Use class instead" }] }]`
    * - `["error", { "forbid": [{ "propName": "style", "disallowedFor": ["div", "span"] }] }]`
+   * - `["error", { "forbid": [{ "propName": "type", "disallowedValues": ["button"] }] }]`
    */
   forbid?: ForbidDomPropsItem[];
 }
 /**
- * A prop with optional `disallowedFor` DOM node list and custom `message`.
+ * A prop with optional `disallowedFor` DOM node list, optional `disallowedValues`
+ * value list, and custom `message`.
  */
 export interface PropWithOptions {
   /**
@@ -4429,6 +4431,11 @@ export interface PropWithOptions {
    * DOM elements.
    */
   disallowedFor?: string[];
+  /**
+   * A list of string literal values for which this prop is forbidden. If
+   * omitted, the prop is forbidden for all values.
+   */
+  disallowedValues?: string[];
   /**
    * A custom message to display when this prop is used.
    */

--- a/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
@@ -359,11 +359,11 @@ fn test() {
             ),
         ),
         (
-            r#"
+            "
                     const First = (props) => (
                       <div someProp={`some${value}`} />
                     );
-                  "#,
+                  ",
             Some(
                 serde_json::json!([ { "forbid": [ { "propName": "someProp", "disallowedValues": ["someValue"], }, ], }, ]),
             ),
@@ -451,11 +451,11 @@ fn test() {
             ),
         ),
         (
-            r#"
+            "
                     const First = (props) => (
                       <div someProp={`someValue`} />
                     );
-                  "#,
+                  ",
             Some(
                 serde_json::json!([ { "forbid": [ { "propName": "someProp", "disallowedValues": ["someValue"], }, ], }, ]),
             ),

--- a/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
@@ -1,4 +1,7 @@
-use oxc_ast::{AstKind, ast::JSXAttributeValue};
+use oxc_ast::{
+    AstKind,
+    ast::{JSXAttributeValue, JSXExpression},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -197,11 +200,7 @@ impl Rule for ForbidDomProps {
 
                     let mut prop_value = None;
                     if let Some(disallowed_values) = &options.disallowed_values {
-                        prop_value = attr
-                            .value
-                            .as_ref()
-                            .and_then(JSXAttributeValue::as_string_literal)
-                            .map(|str_lit| str_lit.value.as_str());
+                        prop_value = attr.value.as_ref().and_then(static_jsx_string_value);
 
                         if prop_value
                             .is_none_or(|prop_value| !disallowed_values.contains(prop_value))
@@ -223,6 +222,20 @@ impl Rule for ForbidDomProps {
 
     fn should_run(&self, ctx: &ContextHost) -> bool {
         ctx.source_type().is_jsx() && !self.forbid.is_empty()
+    }
+}
+
+fn static_jsx_string_value<'a>(value: &'a JSXAttributeValue<'a>) -> Option<&'a str> {
+    match value {
+        JSXAttributeValue::StringLiteral(str_lit) => Some(str_lit.value.as_str()),
+        JSXAttributeValue::ExpressionContainer(container) => match &container.expression {
+            JSXExpression::StringLiteral(str_lit) => Some(str_lit.value.as_str()),
+            JSXExpression::TemplateLiteral(template_lit) => {
+                template_lit.single_quasi().map(|quasi| quasi.as_str())
+            }
+            _ => None,
+        },
+        _ => None,
     }
 }
 
@@ -348,6 +361,16 @@ fn test() {
         (
             r#"
                     const First = (props) => (
+                      <div someProp={`some${value}`} />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([ { "forbid": [ { "propName": "someProp", "disallowedValues": ["someValue"], }, ], }, ]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
                       <div someProp="someValue" />
                     );
                   "#,
@@ -411,6 +434,26 @@ fn test() {
             r#"
                     const First = (props) => (
                       <div someProp="someValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([ { "forbid": [ { "propName": "someProp", "disallowedValues": ["someValue"], }, ], }, ]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div someProp={"someValue"} />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([ { "forbid": [ { "propName": "someProp", "disallowedValues": ["someValue"], }, ], }, ]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div someProp={`someValue`} />
                     );
                   "#,
             Some(

--- a/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
+++ b/crates/oxc_linter/src/rules/react/forbid_dom_props.rs
@@ -1,4 +1,4 @@
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, ast::JSXAttributeValue};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -17,17 +17,25 @@ use crate::{
 fn forbid_dom_props_diagnostic(
     span: Span,
     property: &str,
+    property_value: Option<&str>,
     message: Option<&String>,
 ) -> OxcDiagnostic {
     if let Some(message) = message {
         return OxcDiagnostic::warn(message.clone()).with_label(span);
     }
-    OxcDiagnostic::warn(format!("Prop \"{property}\" is forbidden on DOM Nodes")).with_label(span)
+    if let Some(property_value) = property_value {
+        return OxcDiagnostic::warn(format!(
+            r#"Prop "{property}" with value "{property_value}" is forbidden on DOM Nodes"#
+        ))
+        .with_label(span);
+    }
+    OxcDiagnostic::warn(format!(r#"Prop "{property}" is forbidden on DOM Nodes"#)).with_label(span)
 }
 
 #[derive(Debug, Default, Clone)]
 struct ForbidPropOptions {
     disallowed_for: FxHashSet<CompactStr>,
+    disallowed_values: Option<FxHashSet<CompactStr>>,
     message: Option<String>,
 }
 
@@ -49,6 +57,7 @@ impl From<ForbidDomPropsConfig> for ForbidDomProps {
                 ForbidDomPropsItem::PropWithOptions(PropWithOptions {
                     prop_name,
                     disallowed_for,
+                    disallowed_values,
                     message,
                 }) => {
                     forbid.insert(
@@ -58,6 +67,8 @@ impl From<ForbidDomPropsConfig> for ForbidDomProps {
                                 .unwrap_or_default()
                                 .into_iter()
                                 .collect(),
+                            disallowed_values: disallowed_values
+                                .map(|values| values.into_iter().collect()),
                             message,
                         },
                     );
@@ -74,11 +85,13 @@ impl From<ForbidDomPropsConfig> for ForbidDomProps {
 pub enum ForbidDomPropsItem {
     /// A prop name to forbid on all DOM elements.
     PropName(CompactStr),
-    /// A prop with optional `disallowedFor` DOM node list and custom `message`.
+    /// A prop with optional `disallowedFor` DOM node list, optional
+    /// `disallowedValues` value list, and custom `message`.
     PropWithOptions(PropWithOptions),
 }
 
-/// A prop with optional `disallowedFor` DOM node list and custom `message`.
+/// A prop with optional `disallowedFor` DOM node list, optional `disallowedValues`
+/// value list, and custom `message`.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PropWithOptions {
@@ -88,6 +101,9 @@ pub struct PropWithOptions {
     /// prop is forbidden. If empty or omitted, the prop is forbidden on all
     /// DOM elements.
     disallowed_for: Option<Vec<CompactStr>>,
+    /// A list of string literal values for which this prop is forbidden. If
+    /// omitted, the prop is forbidden for all values.
+    disallowed_values: Option<Vec<CompactStr>>,
     /// A custom message to display when this prop is used.
     message: Option<String>,
 }
@@ -99,7 +115,7 @@ pub struct ForbidDomPropsConfig {
     /// An array of prop names or objects that are forbidden on DOM elements.
     ///
     /// Each array element can be a string with the property name, or an object
-    /// with `propName`, an optional `disallowedFor` array of DOM node names,
+    /// with `propName`, optional `disallowedFor` and `disallowedValues` arrays,
     /// and an optional custom `message`.
     ///
     /// Examples:
@@ -107,6 +123,7 @@ pub struct ForbidDomPropsConfig {
     /// - `["error", { "forbid": ["id", "style"] }]`
     /// - `["error", { "forbid": [{ "propName": "className", "message": "Use class instead" }] }]`
     /// - `["error", { "forbid": [{ "propName": "style", "disallowedFor": ["div", "span"] }] }]`
+    /// - `["error", { "forbid": [{ "propName": "type", "disallowedValues": ["button"] }] }]`
     forbid: Vec<ForbidDomPropsItem>,
 }
 
@@ -177,9 +194,26 @@ impl Rule for ForbidDomProps {
                     {
                         continue;
                     }
+
+                    let mut prop_value = None;
+                    if let Some(disallowed_values) = &options.disallowed_values {
+                        prop_value = attr
+                            .value
+                            .as_ref()
+                            .and_then(JSXAttributeValue::as_string_literal)
+                            .map(|str_lit| str_lit.value.as_str());
+
+                        if prop_value
+                            .is_none_or(|prop_value| !disallowed_values.contains(prop_value))
+                        {
+                            continue;
+                        }
+                    }
+
                     ctx.diagnostic(forbid_dom_props_diagnostic(
                         attr_ident.span,
                         prop_name,
+                        prop_value,
                         options.message.as_ref(),
                     ));
                 }
@@ -278,7 +312,47 @@ fn test() {
                     );
                   "#,
             Some(
-                serde_json::json!([{ "forbid": [{"propName": "otherProp","disallowedFor": ["span"],},],},]),
+                serde_json::json!([ { "forbid": [ { "propName": "otherProp", "disallowedFor": ["span"], }, ], }, ]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div someProp="someValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([ { "forbid": [ { "propName": "someProp", "disallowedValues": [], }, ], }, ]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <Foo someProp="someValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([ { "forbid": [ { "propName": "someProp", "disallowedValues": ["someValue"], }, ], }, ]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div someProp="value" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([ { "forbid": [ { "propName": "someProp", "disallowedValues": ["someValue"], }, ], }, ]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div someProp="someValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([ { "forbid": [ { "propName": "someProp", "disallowedValues": ["someValue"], "disallowedFor": ["span"], }, ], }, ]),
             ),
         ),
     ];
@@ -320,7 +394,27 @@ fn test() {
                     );
                   "#,
             Some(
-                serde_json::json!([{"forbid": [{ "propName": "className", "message": "Please use class instead of ClassName" }],},]),
+                serde_json::json!([ { "forbid": [{ "propName": "className", "message": "Please use class instead of ClassName" }], }, ]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <span otherProp="bar" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([ { "forbid": [ { "propName": "otherProp", "disallowedFor": ["span"], }, ], }, ]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div someProp="someValue" />
+                    );
+                  "#,
+            Some(
+                serde_json::json!([ { "forbid": [ { "propName": "someProp", "disallowedValues": ["someValue"], }, ], }, ]),
             ),
         ),
         (
@@ -332,7 +426,7 @@ fn test() {
                     );
                   "#,
             Some(
-                serde_json::json!([{"forbid": [{ "propName": "className", "message": "Please use class instead of ClassName" },{ "propName": "otherProp", "message": "Avoid using otherProp" },],},]),
+                serde_json::json!([ { "forbid": [ { "propName": "className", "message": "Please use class instead of ClassName" }, { "propName": "otherProp", "message": "Avoid using otherProp" }, ], }, ]),
             ),
         ),
         (
@@ -344,7 +438,7 @@ fn test() {
                     );
                   "#,
             Some(
-                serde_json::json!([{"forbid": [{ "propName": "className" },{ "propName": "otherProp", "message": "Avoid using otherProp" },],},]),
+                serde_json::json!([ { "forbid": [ { "propName": "className" }, { "propName": "otherProp", "message": "Avoid using otherProp" }, ], }, ]),
             ),
         ),
         (
@@ -357,7 +451,7 @@ fn test() {
                     );
                   "#,
             Some(
-                serde_json::json!([{"forbid": [{"propName": "accept", "disallowedFor": ["form"],"message": "Avoid using the accept attribute on <form>",}],},]),
+                serde_json::json!([ { "forbid": [{ "propName": "accept", "disallowedFor": ["form"], "message": "Avoid using the accept attribute on <form>", }], }, ]),
             ),
         ),
         (
@@ -366,12 +460,30 @@ fn test() {
                       <div className="foo">
                         <input className="boo" />
                         <span className="foobar">Foobar</span>
-                        <div otherProp="bar" className="forbiddenClassname" />
+                        <div otherProp="bar" />
                       </div>
                     );
                   "#,
             Some(
-                serde_json::json!([{"forbid": [{"propName": "className","disallowedFor": ["div", "span"],"message": "Please use class instead of ClassName",},{ "propName": "otherProp", "message": "Avoid using otherProp" },],},]),
+                serde_json::json!([ { "forbid": [ { "propName": "className", "disallowedFor": ["div", "span"], "message": "Please use class instead of ClassName", }, { "propName": "otherProp", "message": "Avoid using otherProp" }, ], }, ]),
+            ),
+        ),
+        (
+            r#"
+                    const First = (props) => (
+                      <div className="foo">
+                        <input className="boo" />
+                        <span className="foobar">Foobar</span>
+                        <div otherProp="bar" />
+                        <p thirdProp="foo" />
+                        <div thirdProp="baz" />
+                        <p thirdProp="bar" />
+                        <p thirdProp="baz" />
+                      </div>
+                    );
+                  "#,
+            Some(
+                serde_json::json!([ { "forbid": [ { "propName": "className", "disallowedFor": ["div", "span"], "message": "Please use class instead of ClassName", }, { "propName": "otherProp", "message": "Avoid using otherProp" }, { "propName": "thirdProp", "disallowedFor": ["p"], "disallowedValues": ["bar", "baz"], "message": "Do not use thirdProp with values bar and baz on p", }, ], }, ]),
             ),
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/react_forbid_dom_props.snap
+++ b/crates/oxc_linter/src/snapshots/react_forbid_dom_props.snap
@@ -34,6 +34,22 @@ source: crates/oxc_linter/src/tester.rs
  4 │                     );
    ╰────
 
+  ⚠ react(forbid-dom-props): Prop "otherProp" is forbidden on DOM Nodes
+   ╭─[forbid_dom_props.tsx:3:29]
+ 2 │                     const First = (props) => (
+ 3 │                       <span otherProp="bar" />
+   ·                             ─────────
+ 4 │                     );
+   ╰────
+
+  ⚠ react(forbid-dom-props): Prop "someProp" with value "someValue" is forbidden on DOM Nodes
+   ╭─[forbid_dom_props.tsx:3:28]
+ 2 │                     const First = (props) => (
+ 3 │                       <div someProp="someValue" />
+   ·                            ────────
+ 4 │                     );
+   ╰────
+
   ⚠ react(forbid-dom-props): Please use class instead of ClassName
    ╭─[forbid_dom_props.tsx:3:28]
  2 │                     const First = (props) => (
@@ -87,21 +103,53 @@ source: crates/oxc_linter/src/tester.rs
  4 │                         <input className="boo" />
  5 │                         <span className="foobar">Foobar</span>
    ·                               ─────────
- 6 │                         <div otherProp="bar" className="forbiddenClassname" />
+ 6 │                         <div otherProp="bar" />
    ╰────
 
   ⚠ react(forbid-dom-props): Avoid using otherProp
    ╭─[forbid_dom_props.tsx:6:30]
  5 │                         <span className="foobar">Foobar</span>
- 6 │                         <div otherProp="bar" className="forbiddenClassname" />
+ 6 │                         <div otherProp="bar" />
    ·                              ─────────
  7 │                       </div>
    ╰────
 
   ⚠ react(forbid-dom-props): Please use class instead of ClassName
-   ╭─[forbid_dom_props.tsx:6:46]
- 5 │                         <span className="foobar">Foobar</span>
- 6 │                         <div otherProp="bar" className="forbiddenClassname" />
-   ·                                              ─────────
- 7 │                       </div>
+   ╭─[forbid_dom_props.tsx:3:28]
+ 2 │                     const First = (props) => (
+ 3 │                       <div className="foo">
+   ·                            ─────────
+ 4 │                         <input className="boo" />
    ╰────
+
+  ⚠ react(forbid-dom-props): Please use class instead of ClassName
+   ╭─[forbid_dom_props.tsx:5:31]
+ 4 │                         <input className="boo" />
+ 5 │                         <span className="foobar">Foobar</span>
+   ·                               ─────────
+ 6 │                         <div otherProp="bar" />
+   ╰────
+
+  ⚠ react(forbid-dom-props): Avoid using otherProp
+   ╭─[forbid_dom_props.tsx:6:30]
+ 5 │                         <span className="foobar">Foobar</span>
+ 6 │                         <div otherProp="bar" />
+   ·                              ─────────
+ 7 │                         <p thirdProp="foo" />
+   ╰────
+
+  ⚠ react(forbid-dom-props): Do not use thirdProp with values bar and baz on p
+    ╭─[forbid_dom_props.tsx:9:28]
+  8 │                         <div thirdProp="baz" />
+  9 │                         <p thirdProp="bar" />
+    ·                            ─────────
+ 10 │                         <p thirdProp="baz" />
+    ╰────
+
+  ⚠ react(forbid-dom-props): Do not use thirdProp with values bar and baz on p
+    ╭─[forbid_dom_props.tsx:10:28]
+  9 │                         <p thirdProp="bar" />
+ 10 │                         <p thirdProp="baz" />
+    ·                            ─────────
+ 11 │                       </div>
+    ╰────

--- a/crates/oxc_linter/src/snapshots/react_forbid_dom_props.snap
+++ b/crates/oxc_linter/src/snapshots/react_forbid_dom_props.snap
@@ -50,6 +50,22 @@ source: crates/oxc_linter/src/tester.rs
  4 │                     );
    ╰────
 
+  ⚠ react(forbid-dom-props): Prop "someProp" with value "someValue" is forbidden on DOM Nodes
+   ╭─[forbid_dom_props.tsx:3:28]
+ 2 │                     const First = (props) => (
+ 3 │                       <div someProp={"someValue"} />
+   ·                            ────────
+ 4 │                     );
+   ╰────
+
+  ⚠ react(forbid-dom-props): Prop "someProp" with value "someValue" is forbidden on DOM Nodes
+   ╭─[forbid_dom_props.tsx:3:28]
+ 2 │                     const First = (props) => (
+ 3 │                       <div someProp={`someValue`} />
+   ·                            ────────
+ 4 │                     );
+   ╰────
+
   ⚠ react(forbid-dom-props): Please use class instead of ClassName
    ╭─[forbid_dom_props.tsx:3:28]
  2 │                     const First = (props) => (

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -10819,12 +10819,12 @@
       "type": "object",
       "properties": {
         "forbid": {
-          "description": "An array of prop names or objects that are forbidden on DOM elements.\n\nEach array element can be a string with the property name, or an object\nwith `propName`, an optional `disallowedFor` array of DOM node names,\nand an optional custom `message`.\n\nExamples:\n\n- `[\"error\", { \"forbid\": [\"id\", \"style\"] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"className\", \"message\": \"Use class instead\" }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"style\", \"disallowedFor\": [\"div\", \"span\"] }] }]`",
+          "description": "An array of prop names or objects that are forbidden on DOM elements.\n\nEach array element can be a string with the property name, or an object\nwith `propName`, optional `disallowedFor` and `disallowedValues` arrays,\nand an optional custom `message`.\n\nExamples:\n\n- `[\"error\", { \"forbid\": [\"id\", \"style\"] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"className\", \"message\": \"Use class instead\" }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"style\", \"disallowedFor\": [\"div\", \"span\"] }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"type\", \"disallowedValues\": [\"button\"] }] }]`",
           "type": "array",
           "items": {
             "$ref": "#/definitions/ForbidDomPropsItem"
           },
-          "markdownDescription": "An array of prop names or objects that are forbidden on DOM elements.\n\nEach array element can be a string with the property name, or an object\nwith `propName`, an optional `disallowedFor` array of DOM node names,\nand an optional custom `message`.\n\nExamples:\n\n- `[\"error\", { \"forbid\": [\"id\", \"style\"] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"className\", \"message\": \"Use class instead\" }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"style\", \"disallowedFor\": [\"div\", \"span\"] }] }]`"
+          "markdownDescription": "An array of prop names or objects that are forbidden on DOM elements.\n\nEach array element can be a string with the property name, or an object\nwith `propName`, optional `disallowedFor` and `disallowedValues` arrays,\nand an optional custom `message`.\n\nExamples:\n\n- `[\"error\", { \"forbid\": [\"id\", \"style\"] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"className\", \"message\": \"Use class instead\" }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"style\", \"disallowedFor\": [\"div\", \"span\"] }] }]`\n- `[\"error\", { \"forbid\": [{ \"propName\": \"type\", \"disallowedValues\": [\"button\"] }] }]`"
         }
       },
       "additionalProperties": false,
@@ -10839,13 +10839,13 @@
           "markdownDescription": "A prop name to forbid on all DOM elements."
         },
         {
-          "description": "A prop with optional `disallowedFor` DOM node list and custom `message`.",
+          "description": "A prop with optional `disallowedFor` DOM node list, optional\n`disallowedValues` value list, and custom `message`.",
           "allOf": [
             {
               "$ref": "#/definitions/PropWithOptions"
             }
           ],
-          "markdownDescription": "A prop with optional `disallowedFor` DOM node list and custom `message`."
+          "markdownDescription": "A prop with optional `disallowedFor` DOM node list, optional\n`disallowedValues` value list, and custom `message`."
         }
       ],
       "markdownDescription": "A forbidden prop, either as a plain prop name string or with options."
@@ -17321,7 +17321,7 @@
       "additionalProperties": false
     },
     "PropWithOptions": {
-      "description": "A prop with optional `disallowedFor` DOM node list and custom `message`.",
+      "description": "A prop with optional `disallowedFor` DOM node list, optional `disallowedValues`\nvalue list, and custom `message`.",
       "type": "object",
       "required": [
         "propName"
@@ -17335,6 +17335,14 @@
           },
           "markdownDescription": "A list of DOM element names (e.g. `[\"div\", \"span\"]`) on which this\nprop is forbidden. If empty or omitted, the prop is forbidden on all\nDOM elements."
         },
+        "disallowedValues": {
+          "description": "A list of string literal values for which this prop is forbidden. If\nomitted, the prop is forbidden for all values.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "markdownDescription": "A list of string literal values for which this prop is forbidden. If\nomitted, the prop is forbidden for all values."
+        },
         "message": {
           "description": "A custom message to display when this prop is used.",
           "type": "string",
@@ -17347,7 +17355,7 @@
         }
       },
       "additionalProperties": false,
-      "markdownDescription": "A prop with optional `disallowedFor` DOM node list and custom `message`."
+      "markdownDescription": "A prop with optional `disallowedFor` DOM node list, optional `disallowedValues`\nvalue list, and custom `message`."
     },
     "PropertyDetails": {
       "type": "object",

--- a/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
+++ b/tasks/website_linter/src/rules/snapshots/docs_rule_pages.snap
@@ -1617,7 +1617,7 @@ type: `array`
 An array of prop names or objects that are forbidden on DOM elements.
 
 Each array element can be a string with the property name, or an object
-with `propName`, an optional `disallowedFor` array of DOM node names,
+with `propName`, optional `disallowedFor` and `disallowedValues` arrays,
 and an optional custom `message`.
 
 Examples:
@@ -1625,6 +1625,7 @@ Examples:
 - `["error", { "forbid": ["id", "style"] }]`
 - `["error", { "forbid": [{ "propName": "className", "message": "Use class instead" }] }]`
 - `["error", { "forbid": [{ "propName": "style", "disallowedFor": ["div", "span"] }] }]`
+- `["error", { "forbid": [{ "propName": "type", "disallowedValues": ["button"] }] }]`
 
 
 #### forbid[n]
@@ -1643,6 +1644,15 @@ type: `string[]`
 A list of DOM element names (e.g. `["div", "span"]`) on which this
 prop is forbidden. If empty or omitted, the prop is forbidden on all
 DOM elements.
+
+
+##### forbid[n].disallowedValues
+
+type: `string[]`
+
+
+A list of string literal values for which this prop is forbidden. If
+omitted, the prop is forbidden for all values.
 
 
 ##### forbid[n].message


### PR DESCRIPTION
fixes #23049. Tests regenerated from upstream