### PR TITLE
docs(linter/typescript): clarify consistent-type-imports behavior

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -101,7 +101,14 @@ enum Prefer {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce consistent usage of type imports.
+    /// Enforce consistent usage of type imports by adding or removing the
+    /// `type` keyword from imports.
+    ///
+    /// The `fixStyle` option controls where newly added `type` keywords are
+    /// placed when this rule auto-fixes imports. It does not enforce the
+    /// placement of `type` keywords that are already present in the code. To
+    /// enforce consistent placement, use
+    /// [`import/consistent-type-specifier-style`](https://oxc.rs/docs/guide/usage/linter/rules/import/consistent-type-specifier-style.html).
     ///
     /// #### Ignored Files
     /// This rule ignores `.astro`, `.svelte` and `.vue` files entirely. Since Oxlint does


### PR DESCRIPTION
## Summary

- Clarify that `typescript/consistent-type-imports` adds or removes `type` keywords.
- Explain that `fixStyle` only controls placement for newly added `type` keywords during autofix.
- Point users to `import/consistent-type-specifier-style` for enforcing placement of existing `type` keywords.

References #23971 and https://github.com/oxc-project/oxc/issues/23971#issuecomment-4841540665.
