### PR TITLE
feat(formatter_css): update `oxc-css-parser@0.0.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,12 +1132,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hmac-sha1-compact"
 version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,23 +1737,11 @@ dependencies = [
 
 [[package]]
 name = "oxc-css-parser"
-version = "0.0.1"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c26a7ada942216acafa6d6a10b269b23f5d9b58902ee99898c6d287b196d660c"
+checksum = "0519caca3ae35ba72f2c14054ea24697dfcb55c3b4d5834c9a879e6e55280e65"
 dependencies = [
- "oxc-css-parser-macro",
- "smallvec",
-]
-
-[[package]]
-name = "oxc-css-parser-macro"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b840f0d8e8f12de73ef70c0d63108499a36264e71fc3901da94030252d004c7b"
-dependencies = [
- "heck",
- "quote",
- "syn",
+ "oxc_allocator",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,7 +227,7 @@ pico-args = "0.5.0" # Minimal argument parser
 prettyplease = "0.2.37" # Rust code formatting
 project-root = "0.2.2" # Project root detection
 quickcheck = "1.1.0" # Property-based testing
-oxc-css-parser = "0.0.1" # CSS/SCSS/Less parser (raffia 0.12.3 fork: adds `template_placeholder` typed placeholders for css-in-js + valid-syntax coverage fixes (see crates/oxc_formatter_css/AGENTS.md))
+oxc-css-parser = "0.0.3" # CSS/SCSS/Less parser (raffia 0.12.3 fork: adds `template_placeholder` typed placeholders for css-in-js + valid-syntax coverage fixes (see crates/oxc_formatter_css/AGENTS.md))
 rand = "0.10.0" # Random number generation
 rayon = "1.11.0" # Data parallelism
 ropey = "1.6.1" # Rope text structure
@@ -260,6 +260,14 @@ website_common = { path = "tasks/website_common" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["oxc_transform_napi", "oxc_parser_napi", "oxc_minify_napi"]
+
+# `oxc_allocator` is both dogfooded here (workspace path) and published to crates.io.
+# External workspace-dependencies (e.g. `oxc-css-parser`) pull it from the registry,
+# and cargo treats `oxc_allocator (path)` and `oxc_allocator (registry)` as separate crate instances
+# even at the same version.
+# Force the registry request to resolve to the workspace copy so there's a single instance.
+[patch.crates-io]
+oxc_allocator = { path = "crates/oxc_allocator" }
 
 [profile.dev]
 # Disabling debug info speeds up local and CI builds,

--- a/crates/oxc_formatter_css/AGENTS.md
+++ b/crates/oxc_formatter_css/AGENTS.md
@@ -118,40 +118,39 @@ Ports prettier-plugin-tailwindcss's `transformCss`: with the option on, `@apply`
 
 See `write_apply_prelude` in `at_rule.rs` (collection + `!important` / Less `~"..."` extraction) and `format.rs` (sorter dispatch).
 
-### Intentionally unsupported: postcss plugin syntax
+### postcss plugin syntax
 
-These syntax that only "works" in Prettier because `postcss` parses without validation and a build-time plugin interprets it later is mostly NOT supported.
-(`postcss` is permissive with any syntax it doesn't understand, while we parse strictly with `oxc-css-parser`.)
+`postcss` parses everything permissively and lets plugins interpret syntax at runtime; `oxc-css-parser` parses strictly, so plugin-specific syntax is rejected by default. Failures emit a LOUD diagnostic.
 
-These plugins were once common but are now mostly legacy. Representative examples we do NOT support:
+However, some plugin-flavored constructs work anyway, because:
 
-- `postcss-simple-vars`: `$blue: #056ef0;` declarations, value-position `$blue`, `$(dir)` interpolation
-- `postcss-mixins`: parametered `@define-mixin x $a, $b` and `$var` inside body
-  - Plain `@define-mixin icon {}` / `@mixin icon;` / `@mixin icon a, b;` DO parse fine
-- `postcss-nested-props` (`font: { ... }`), ICSS nested `:export { nest: {} }`, `--element(...)` (CSS Extensions, zero implementations)
+- 1: Now standard CSS
+  - CSS nesting
+  - Tailwind v3/v4 at-rules (`@tailwind`, `@apply`, `@layer`, `@theme`, `@utility`, `@variant`, `@config`, `@custom-media`)
+  - CSS Modules (`@value` incl. `from`, `:global`/`:local`, `composes`, plain `:import`/`:export`)
+- 2: CSS forward-compat
+  - Unknown at-rules (`postcss-mixins`'s `@define-mixin`, `@mixin`, etc.) round-trip as `UnknownAtRule` with the prelude held as a verbatim `TokenSeq`
+  - `@media`/`@supports` preludes `oxc-css-parser` can't structure fall through to `<general-enclosed>` as a verbatim `TokenSeq`
 
-Failures emit a LOUD diagnostic; ignore-listing is the escape hatch.
+Beyond those, we add support per-plugin when there's real demand.
 
-We DO support, however, the following popular plugin-flavored syntaxes:
+#### Supported: postcss-simple-vars (auto-enabled for `CssVariant::Css`)
 
-- Tailwind v3/v4 at-rules: `@tailwind`, `@apply`, `@layer`, `@theme`, `@utility`, `@variant`, `@config`, `@custom-media`
-- CSS Modules constructs: `@value` (incl. `from`), `:global`/`:local`, `composes`, plain `:import`/`:export`
-- Standard CSS nesting
+Covered:
 
-Less also rejects (matching `lessc`):
+- `$var: value !important;` declarations (top-level and inside rules)
+- `$var` references in property values
+- `$var` references inside `@media`/at-rule preludes
 
-- Value-position `@{var}` interpolation
-- Whitespace inside a Less lookup (`@config   [   option1]`)
-
-If there is high demand, we can also consider making some parts acceptable by updating the `oxc-css-parser` parser side.
+NOT covered: `$(var)` interpolation (`margin-$(dir): 10px`, `.icon.is-$(network)`), selector-position bare `$var` (`.$prefix`), comment substitutions (`<<$(var)>>`).
 
 ### Known divergences
 
 Deliberate divergences from Prettier (impact does not justify the matching cost):
 
-- Less `func(x, + 20px)` unary gluing
+- Less: `func(x, + 20px)` unary gluing
   - Prettier prints `+20px`; `oxc-css-parser` ASTs `, +` as a comma-left binary operation, so matching is ad-hoc for a torture-test-only shape
-- Nested Less math in a function arg / multi-value shorthand
+- Less: Nested math in a function arg / multi-value shorthand
   - Prettier's fill fit-check breaks INSIDE the wide chunk; our core `fill` (biome semantics) breaks the SEPARATOR instead.
   - Principled fix is the shared core-fill fit-check change (needs JS-conformance impact experiment first)
 - Broken `:not(...)` selector args indent at +2
@@ -178,6 +177,10 @@ Deliberate divergences from Prettier (impact does not justify the matching cost)
     - Each mode is internally consistent with what its parser produces
   - The value syntax `--p: { ... }` itself is valid CSS, but its only intended consumer was the `@apply --p;` at-rule from the dropped CSS Apply Rule proposal
     - With no consumer, real-world usage is near zero, so the cross-mode behavior difference is theoretical
+- Less: Value-position `@{var}` interpolation
+  - `oxc-css-parser` rejects it matching `lessc`; Prettier (postcss) accepts and prints verbatim
+- Less: Lookup with whitespace inside (`@config   [   option1]`)
+  - `oxc-css-parser` rejects matching `lessc`; Prettier accepts
 
 ## Verification
 

--- a/crates/oxc_formatter_css/examples/embedded_debug.rs
+++ b/crates/oxc_formatter_css/examples/embedded_debug.rs
@@ -1,7 +1,8 @@
-//! Format a CSS/SCSS/Less fragment through the embedded entry point
+//! Format an SCSS fragment through the embedded entry point
 //! (`format_to_ir`), the dispatcher path oxfmt uses for css-in-js.
-//! Unlike `css_formatter`, this tolerates `` `PLACEHOLDER-N` ``
-//! markers in value/selector position.
+//! The dispatcher always parses as SCSS, so this example is hardcoded
+//! to `CssVariant::Scss`. Unlike `css_formatter`, this tolerates
+//! `` `PLACEHOLDER-N` `` markers in value/selector position.
 //!
 //! ```sh
 //! cargo run -p oxc_formatter_css --example embedded_debug -- [filename]
@@ -22,14 +23,11 @@ fn main() {
     let source_text = std::fs::read_to_string(path)
         .unwrap_or_else(|err| panic!("Failed to read {}: {err}", path.display()));
 
-    let variant = match path.extension().and_then(|e| e.to_str()) {
-        Some("less") => CssVariant::Less,
-        // The css-in-js dispatcher always parses as SCSS, mirror it.
-        _ => CssVariant::Scss,
-    };
     // Match Prettier's default print width for side-by-side comparison.
     let line_width = oxc_formatter_core::LineWidth::try_from(80).unwrap();
-    let options = CssFormatOptions { variant, line_width, ..CssFormatOptions::default() };
+    // The css-in-js dispatcher always parses as SCSS.
+    let options =
+        CssFormatOptions { variant: CssVariant::Scss, line_width, ..CssFormatOptions::default() };
 
     let allocator = Allocator::new();
     let group_id_builder = UniqueGroupIdBuilder::default();

--- a/crates/oxc_formatter_css/examples/parse_debug.rs
+++ b/crates/oxc_formatter_css/examples/parse_debug.rs
@@ -8,16 +8,24 @@
 
 use std::io::Read;
 
+use oxc_allocator::Allocator;
 use oxc_css_parser::{ParserBuilder, ParserOptions, Syntax, ast::Stylesheet};
 
 fn main() {
     let mut args = pico_args::Arguments::from_env();
-    let syntax =
+    let (syntax, options) =
         match args.opt_value_from_str::<_, String>("--syntax").unwrap().as_deref().unwrap_or("css")
         {
-            "scss" => Syntax::Scss,
-            "less" => Syntax::Less,
-            _ => Syntax::Css,
+            "scss" => (Syntax::Scss, ParserOptions::default()),
+            "less" => (Syntax::Less, ParserOptions::default()),
+            _ => (
+                Syntax::Css,
+                ParserOptions {
+                    try_parsing_value_in_custom_property: true,
+                    allow_postcss_simple_vars: true,
+                    ..Default::default()
+                },
+            ),
         };
     let name: String = args.free_from_str().unwrap_or_else(|_| "-".to_string());
 
@@ -29,15 +37,13 @@ fn main() {
         std::fs::read_to_string(&name).unwrap()
     };
 
-    let mut comments = vec![];
+    let allocator = Allocator::default();
     // Mirror `format.rs`'s parser options so the dump matches what the formatter sees.
-    let mut parser = ParserBuilder::new(&source)
-        .syntax(syntax)
-        .options(ParserOptions { try_parsing_value_in_custom_property: true, ..Default::default() })
-        .comments(&mut comments)
-        .build();
+    let mut parser =
+        ParserBuilder::new(&allocator, &source).syntax(syntax).options(options).comments().build();
     let result = parser.parse::<Stylesheet>();
     let errors = parser.recoverable_errors().to_vec();
+    let comments = parser.comments().to_vec();
     drop(parser);
     match result {
         Ok(stylesheet) => {

--- a/crates/oxc_formatter_css/src/format.rs
+++ b/crates/oxc_formatter_css/src/format.rs
@@ -13,7 +13,7 @@ use crate::{
     TEMPLATE_PLACEHOLDER_PREFIX, TEMPLATE_PLACEHOLDER_SUFFIX,
     comments::CssComment,
     context::CssFormatContext,
-    options::CssFormatOptions,
+    options::{CssFormatOptions, CssVariant},
     print::{self, CssFormatter},
 };
 
@@ -154,8 +154,7 @@ fn parse_stylesheet<'a>(
         None => source,
     };
 
-    let mut comments = vec![];
-    let mut parser = ParserBuilder::new(parse_source)
+    let mut parser = ParserBuilder::new(allocator, parse_source)
         .syntax(options.variant.to_css_syntax())
         .options(ParserOptions {
             // Derive the affix from the host sentinel (single source of truth),
@@ -168,9 +167,13 @@ fn parse_stylesheet<'a>(
                     .expect("placeholder prefix starts with a backtick"),
             }),
             try_parsing_value_in_custom_property: true,
+            // `.css` files in real projects routinely flow through `postcss-simple-vars`
+            // (Mantine, Vite/Next templates, etc), so accept its `$var` syntax in `CssVariant::Css`.
+            // Scss/Less already handle `$variable` natively.
+            allow_postcss_simple_vars: matches!(options.variant, CssVariant::Css),
             ..ParserOptions::default()
         })
-        .comments(&mut comments)
+        .comments()
         .build();
 
     let stylesheet = parser.parse::<Stylesheet>().map_err(|error| to_diagnostic(&error))?;
@@ -183,10 +186,9 @@ fn parse_stylesheet<'a>(
     }) {
         return Err(to_diagnostic(error));
     }
-    drop(parser);
 
     let comments: &'a [CssComment] = ArenaVec::from_iter_in(
-        comments.iter().map(|c| CssComment {
+        parser.comments().iter().map(|c| CssComment {
             span: to_span(&c.span),
             inline: matches!(c.kind, oxc_css_parser::token::CommentKind::Line),
         }),

--- a/crates/oxc_formatter_css/src/print/at_rule.rs
+++ b/crates/oxc_formatter_css/src/print/at_rule.rs
@@ -1536,7 +1536,17 @@ fn write_media_in_parens<'a>(in_parens: &MediaInParens<'a>, f: &mut CssFormatter
             let span = to_span(&interpolation.span);
             write!(f, text(f.context().source_text().text_for(&span)));
         }
+        // W3C `<general-enclosed>` forward-compat fallback: any prelude oxc-css-parser
+        // can't structure (e.g. `(max-width: $bp)` without `allow_postcss_simple_vars`)
+        // is preserved as a verbatim `TokenSeq` inside its own parens.
+        MediaInParensKind::GeneralEnclosed(seq) => write_general_enclosed(&seq.span, f),
     }
+}
+
+/// `<general-enclosed>` prints its `TokenSeq` verbatim inside its own parens.
+fn write_general_enclosed(span: &oxc_css_parser::Span, f: &mut CssFormatter<'_, '_>) {
+    let span = to_span(span);
+    write!(f, [text("("), text(f.context().source_text().text_for(&span)), text(")")]);
 }
 
 fn write_media_feature_name<'a>(name: &MediaFeatureName<'a>, f: &mut CssFormatter<'_, 'a>) {
@@ -1544,7 +1554,9 @@ fn write_media_feature_name<'a>(name: &MediaFeatureName<'a>, f: &mut CssFormatte
     let span = to_span(name.span());
     match name {
         MediaFeatureName::Ident(_) => write_maybe_lowercase(source.text_for(&span), f),
-        MediaFeatureName::SassVariable(_) => write!(f, text(source.text_for(&span))),
+        MediaFeatureName::SassVariable(_) | MediaFeatureName::PostcssSimpleVar(_) => {
+            write!(f, text(source.text_for(&span)));
+        }
     }
 }
 
@@ -1676,6 +1688,7 @@ fn write_supports_in_parens<'a>(in_parens: &SupportsInParens<'a>, f: &mut CssFor
         SupportsInParensKind::Function(func) => {
             value::write_function(func, ValueContext::default(), f);
         }
+        SupportsInParensKind::GeneralEnclosed(seq) => write_general_enclosed(&seq.span, f),
     }
 }
 

--- a/crates/oxc_formatter_css/src/print/mod.rs
+++ b/crates/oxc_formatter_css/src/print/mod.rs
@@ -14,6 +14,7 @@ use crate::{
 
 pub mod at_rule;
 pub mod less;
+pub mod postcss_simple_vars;
 pub mod scss;
 pub mod selector;
 pub mod statement;

--- a/crates/oxc_formatter_css/src/print/postcss_simple_vars.rs
+++ b/crates/oxc_formatter_css/src/print/postcss_simple_vars.rs
@@ -1,0 +1,54 @@
+//! postcss-simple-vars: `$var: value;` declarations and `$var` references
+//! in [`crate::CssVariant::Css`] mode (auto-enabled for Css variant via
+//! `ParserOptions::allow_postcss_simple_vars`; see `format.rs`).
+//!
+//! postcss-simple-vars is a textual substitution, so the AST is intentionally
+//! minimal (no namespace, no `!default`/`!global`, no list semantics). The
+//! formatter only normalizes spacing around `$name`, `:`, and the value
+//! stream — anything more would diverge from the plugin's runtime behavior.
+
+use oxc_css_parser::ast::{PostcssSimpleVar, PostcssSimpleVarDeclaration};
+
+use oxc_formatter_core::{
+    Buffer,
+    builders::{space, text},
+    write,
+};
+
+use crate::{
+    format::to_span,
+    print::{
+        CssFormatter,
+        value::{self, ValueContext},
+    },
+};
+
+/// `$var: value;`
+pub(super) fn write_postcss_simple_var_declaration<'a>(
+    decl: &PostcssSimpleVarDeclaration<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    write_postcss_simple_var(&decl.name, f);
+    write!(f, ":");
+    write!(f, space());
+
+    let ctx = ValueContext::default();
+    for (i, value) in decl.value.iter().enumerate() {
+        // Each token in `postcss-simple-vars` values is space-separated;
+        // the value stream already includes any trailing `ImportantAnnotation` pushed by the parser.
+        if i > 0 {
+            write!(f, space());
+        }
+        value::write_component_value(value, ctx, f);
+    }
+}
+
+/// `$var` reference in value position.
+pub(super) fn write_postcss_simple_var<'a>(
+    variable: &PostcssSimpleVar<'a>,
+    f: &mut CssFormatter<'_, 'a>,
+) {
+    let source = f.context().source_text();
+    let span = to_span(&variable.span);
+    write!(f, text(source.text_for(&span)));
+}

--- a/crates/oxc_formatter_css/src/print/selector.rs
+++ b/crates/oxc_formatter_css/src/print/selector.rs
@@ -39,7 +39,7 @@ pub(super) fn is_icss_selector(list: &SelectorList<'_>) -> bool {
         return false;
     };
     let InterpolableIdent::Literal(ident) = &pseudo.name else { return false };
-    matches!(ident.name.as_ref(), "import" | "export")
+    matches!(ident.name, "import" | "export")
 }
 
 /// How a selector list separates its selectors.
@@ -355,7 +355,9 @@ fn write_attribute_selector<'a>(attribute: &AttributeSelector<'a>, f: &mut CssFo
                 write!(f, "~");
                 value::write_str(&escaped.str, f);
             }
-            AttributeSelectorValue::Percentage(_) => {
+            AttributeSelectorValue::Percentage(_)
+            | AttributeSelectorValue::Number(_)
+            | AttributeSelectorValue::Dimension(_) => {
                 let span = to_span(value.span());
                 write!(f, text(source.text_for(&span)));
             }

--- a/crates/oxc_formatter_css/src/print/statement.rs
+++ b/crates/oxc_formatter_css/src/print/statement.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     format::to_span,
     print::{
-        CssFormatter, at_rule, format_with, less, scss, selector,
+        CssFormatter, at_rule, format_with, less, postcss_simple_vars, scss, selector,
         value::{self, ValueContext},
         write_maybe_lowercase,
     },
@@ -210,6 +210,10 @@ pub(super) fn write_statement<'a>(stmt: &Statement<'a>, f: &mut CssFormatter<'_,
         }
         Statement::SassVariableDeclaration(decl) => {
             scss::write_sass_variable_declaration(decl, f);
+            write!(f, ";");
+        }
+        Statement::PostcssSimpleVarDeclaration(decl) => {
+            postcss_simple_vars::write_postcss_simple_var_declaration(decl, f);
             write!(f, ";");
         }
         Statement::SassIfAtRule(if_rule) => scss::write_sass_if_at_rule(if_rule, f),

--- a/crates/oxc_formatter_css/src/print/value.rs
+++ b/crates/oxc_formatter_css/src/print/value.rs
@@ -1384,6 +1384,10 @@ pub(super) fn write_component_value<'a>(
         ComponentValue::Placeholder(placeholder) => {
             super::write_placeholder(placeholder, f);
         }
+        // postcss-simple-vars `$name` reference (Css mode with the opt-in)
+        ComponentValue::PostcssSimpleVar(variable) => {
+            super::postcss_simple_vars::write_postcss_simple_var(variable, f);
+        }
         // Everything else (Sass/Less constructs, interpolations, token fallbacks):
         // print the source verbatim until ported structurally.
         _ => {

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/scss/selector-placeholders.scss
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/scss/selector-placeholders.scss
@@ -13,3 +13,17 @@ a.`PLACEHOLDER-0`:focus,a.`PLACEHOLDER-1`:hover {
 a[data-x=`PLACEHOLDER-6`] {
   color: blue;
 }
+/* A placeholder immediately glued to selector content (no space) is a
+   compound-selector piece: commas + newlines to the next placeholder
+   must NOT split the run into a bare-placeholder statement + separate rule. */
+`PLACEHOLDER-7`:hover &,
+  `PLACEHOLDER-8`:focus-within &,
+  `PLACEHOLDER-9`:after {
+  color: red;
+}
+/* But space-separated placeholders (styled-components' `${sanitize} ${fonts}`
+   mixin idiom) stay standalone; the `html` on the next line is a separate rule. */
+`PLACEHOLDER-10` `PLACEHOLDER-11`
+html {
+  margin: 0;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/embedded/scss/selector-placeholders.scss.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/embedded/scss/selector-placeholders.scss.snap
@@ -17,6 +17,20 @@ a.`PLACEHOLDER-0`:focus,a.`PLACEHOLDER-1`:hover {
 a[data-x=`PLACEHOLDER-6`] {
   color: blue;
 }
+/* A placeholder immediately glued to selector content (no space) is a
+   compound-selector piece: commas + newlines to the next placeholder
+   must NOT split the run into a bare-placeholder statement + separate rule. */
+`PLACEHOLDER-7`:hover &,
+  `PLACEHOLDER-8`:focus-within &,
+  `PLACEHOLDER-9`:after {
+  color: red;
+}
+/* But space-separated placeholders (styled-components' `${sanitize} ${fonts}`
+   mixin idiom) stay standalone; the `html` on the next line is a separate rule. */
+`PLACEHOLDER-10` `PLACEHOLDER-11`
+html {
+  margin: 0;
+}
 
 ==================== Output ====================
 ------------------
@@ -38,6 +52,18 @@ a.`PLACEHOLDER-0`:focus,a.`PLACEHOLDER-1`:hover {
 a[data-x=`PLACEHOLDER-6`] {
   color: blue;
 }
+/* A placeholder immediately glued to selector content (no space) is a
+   compound-selector piece: commas + newlines to the next placeholder
+   must NOT split the run into a bare-placeholder statement + separate rule. */
+`PLACEHOLDER-7`:hover &, `PLACEHOLDER-8`:focus-within &, `PLACEHOLDER-9`:after {
+  color: red;
+}
+/* But space-separated placeholders (styled-components' `${sanitize} ${fonts}`
+   mixin idiom) stay standalone; the `html` on the next line is a separate rule. */
+`PLACEHOLDER-10` `PLACEHOLDER-11`
+html {
+  margin: 0;
+}
 
 -------------------
 { printWidth: 100 }
@@ -57,6 +83,18 @@ a.`PLACEHOLDER-0`:focus,a.`PLACEHOLDER-1`:hover {
 }
 a[data-x=`PLACEHOLDER-6`] {
   color: blue;
+}
+/* A placeholder immediately glued to selector content (no space) is a
+   compound-selector piece: commas + newlines to the next placeholder
+   must NOT split the run into a bare-placeholder statement + separate rule. */
+`PLACEHOLDER-7`:hover &, `PLACEHOLDER-8`:focus-within &, `PLACEHOLDER-9`:after {
+  color: red;
+}
+/* But space-separated placeholders (styled-components' `${sanitize} ${fonts}`
+   mixin idiom) stay standalone; the `html` on the next line is a separate rule. */
+`PLACEHOLDER-10` `PLACEHOLDER-11`
+html {
+  margin: 0;
 }
 
 ===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/declaration.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/declaration.css
@@ -1,0 +1,3 @@
+$primary: red;
+$breakpoint-md: 62em;
+$padding: 10px 20px;

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/declaration.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/declaration.css.snap
@@ -1,0 +1,24 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+$primary: red;
+$breakpoint-md: 62em;
+$padding: 10px 20px;
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+$primary: red;
+$breakpoint-md: 62em;
+$padding: 10px 20px;
+
+-------------------
+{ printWidth: 100 }
+-------------------
+$primary: red;
+$breakpoint-md: 62em;
+$padding: 10px 20px;
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/important.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/important.css
@@ -1,0 +1,6 @@
+$primary: red !important;
+$padding: 10px !important;
+
+.demo {
+  color: $primary;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/important.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/important.css.snap
@@ -1,0 +1,33 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+$primary: red !important;
+$padding: 10px !important;
+
+.demo {
+  color: $primary;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+$primary: red !important;
+$padding: 10px !important;
+
+.demo {
+  color: $primary;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+$primary: red !important;
+$padding: 10px !important;
+
+.demo {
+  color: $primary;
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/media-query.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/media-query.css
@@ -1,0 +1,11 @@
+.demo {
+  @media (max-width: $breakpoint-md) {
+    font-size: 12px;
+  }
+}
+
+@media (min-width: $breakpoint-sm) and (max-width: $breakpoint-lg) {
+  .a {
+    color: red;
+  }
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/media-query.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/media-query.css.snap
@@ -1,0 +1,48 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+.demo {
+  @media (max-width: $breakpoint-md) {
+    font-size: 12px;
+  }
+}
+
+@media (min-width: $breakpoint-sm) and (max-width: $breakpoint-lg) {
+  .a {
+    color: red;
+  }
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+.demo {
+  @media (max-width: $breakpoint-md) {
+    font-size: 12px;
+  }
+}
+
+@media (min-width: $breakpoint-sm) and (max-width: $breakpoint-lg) {
+  .a {
+    color: red;
+  }
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+.demo {
+  @media (max-width: $breakpoint-md) {
+    font-size: 12px;
+  }
+}
+
+@media (min-width: $breakpoint-sm) and (max-width: $breakpoint-lg) {
+  .a {
+    color: red;
+  }
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/messy.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/messy.css
@@ -1,0 +1,3 @@
+$primary:red;$bp:48em;
+
+.demo{ color:$primary  ;  padding   :   10px; @media (max-width:$bp){font-size:12px;} }

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/messy.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/messy.css.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+$primary:red;$bp:48em;
+
+.demo{ color:$primary  ;  padding   :   10px; @media (max-width:$bp){font-size:12px;} }
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+$primary: red;
+$bp: 48em;
+
+.demo {
+  color: $primary;
+  padding: 10px;
+  @media (max-width: $bp) {
+    font-size: 12px;
+  }
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+$primary: red;
+$bp: 48em;
+
+.demo {
+  color: $primary;
+  padding: 10px;
+  @media (max-width: $bp) {
+    font-size: 12px;
+  }
+}
+
+===================== End =====================

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/reference.css
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/reference.css
@@ -1,0 +1,5 @@
+.demo {
+  color: $primary;
+  padding: $padding;
+  border: 1px solid $border-color;
+}

--- a/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/reference.css.snap
+++ b/crates/oxc_formatter_css/tests/fixtures/format/css/postcss-simple-vars/reference.css.snap
@@ -1,0 +1,30 @@
+---
+source: crates/oxc_formatter_css/tests/fixtures/mod.rs
+---
+==================== Input ====================
+.demo {
+  color: $primary;
+  padding: $padding;
+  border: 1px solid $border-color;
+}
+
+==================== Output ====================
+------------------
+{ printWidth: 80 }
+------------------
+.demo {
+  color: $primary;
+  padding: $padding;
+  border: 1px solid $border-color;
+}
+
+-------------------
+{ printWidth: 100 }
+-------------------
+.demo {
+  color: $primary;
+  padding: $padding;
+  border: 1px solid $border-color;
+}
+
+===================== End =====================

--- a/tasks/prettier_conformance/snapshots/prettier.css.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.css.snap.md
@@ -1,4 +1,4 @@
-css compatibility: 114/114 (100.00%), 24 files skipped
+css compatibility: 113/113 (100.00%), 23 files skipped
 
 # Failed
 
@@ -9,7 +9,6 @@ css compatibility: 114/114 (100.00%), 24 files skipped
 
 - css/atrule/charset.css
 - css/atrule/extend.css
-- css/atrule/if-else.css
 - css/atrule/import.css
 - css/atrule/supports.css
 - css/attribute/quotes.css

--- a/tasks/prettier_conformance/snapshots/prettier.less.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.less.snap.md
@@ -1,9 +1,10 @@
-less compatibility: 39/39 (100.00%), 8 files skipped
+less compatibility: 38/39 (97.44%), 7 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
+| less/postcss-8-improment/test.less | 💥 | 94.12% |
 
 # Skipped (parse error, TODO: should be ignored or supported)
 
@@ -14,4 +15,3 @@ less compatibility: 39/39 (100.00%), 8 files skipped
 - less/lookup/lookup-1.less
 - less/no-semicolon/url.less
 - less/parens/parens.less
-- less/postcss-8-improment/test.less

--- a/tasks/prettier_conformance/src/ignore_list.rs
+++ b/tasks/prettier_conformance/src/ignore_list.rs
@@ -113,4 +113,6 @@ pub const IGNORE_TESTS: &[&str] = &[
     "js/quotes/objects.js",
     // Embedded Angular template
     "typescript/decorators-ts/angular.ts",
+    // postcss-conditionals (archived: https://github.com/andyjansson/postcss-conditionals).
+    "css/atrule/if-else.css",
 ];


### PR DESCRIPTION
Fixes #23969, closes #23983.

Notably `oxc-css-parser@0.0.3` contains:

- partial `postcss-simple-vars` support
- fix glued css-in-js placeholder (`${C}:hover &`)

As `oxc_allocator` has also been added as a dependency in `oxc-css-parser`, this has caused a conflict with the latest local (workspace) instance, so a `patch.crates-io` section has also been added. Apparently, this is a technique also used in [Tokio](https://github.com/tokio-rs/tokio/blob/master/Cargo.toml#L18-L23).