### PR TITLE
perf(formatter): inline fits element dispatcher

### DIFF
--- a/crates/oxc_formatter_core/src/printer/mod.rs
+++ b/crates/oxc_formatter_core/src/printer/mod.rs
@@ -1028,6 +1028,9 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
     }
 
     /// Tests if the passed element fits on the current line or not.
+    // LLVM considers this dispatcher too large to inline heuristically, but the fitting loop calls
+    // it for every visited format element.
+    #[inline(always)]
     fn fits_element(&mut self, element: &'a FormatElement) -> PrintResult<Fits> {
         use Tag::{
             EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,


### PR DESCRIPTION
## Summary

- inline the formatter-core `FitsMeasurer::fits_element` dispatcher
- mirrors the applicable hot-loop optimization from astral-sh/ruff#26429

## Validation

- `cargo fmt --check -p oxc_formatter_core`
- `cargo test -p oxc_formatter_core`
- `cargo clippy -p oxc_formatter_core --all-targets -- -D warnings`

AI-assisted change: drafted with Codex and reviewed locally before publication.