### PR TITLE
perf(formatter): inline fits element dispatcher

### DIFF
--- a/crates/oxc_formatter_core/src/printer/mod.rs
+++ b/crates/oxc_formatter_core/src/printer/mod.rs
@@ -1028,6 +1028,9 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
     }
 
     /// Tests if the passed element fits on the current line or not.
+    // LLVM considers this dispatcher too large to inline heuristically, but the fitting loop calls
+    // it for every visited format element.
+    #[inline(always)]
     fn fits_element(&mut self, element: &'a FormatElement) -> PrintResult<Fits> {
         use Tag::{
             EndAlign, EndConditionalContent, EndDedent, EndEntry, EndFill, EndGroup, EndIndent,


### PR DESCRIPTION
## Summary

- inline the formatter-core `FitsMeasurer::fits_element` dispatcher
- mirrors the applicable hot-loop optimization from astral-sh/ruff#26429

## Local benchmark

Command:

```sh
cargo bench -p oxc_benchmark --bench formatter --no-default-features --features compiler -- --sample-size 20 --warm-up-time 1 --measurement-time 3
```

Compared `main` (`d05773604f`) against this branch (`356e65db1c`) with Criterion saved baselines. Median times from a single local run:

| fixture | main median | PR median | delta |
| --- | ---: | ---: | ---: |
| `RadixUIAdoptionSection.jsx` | 41.82 us | 39.69 us | -5.09% |
| `errors.ts` | 60.51 us | 56.20 us | -7.12% |
| `Search.tsx` | 249.52 us | 239.56 us | -3.99% |
| `core.js` | 230.19 us | 221.52 us | -3.77% |
| `next.ts` | 360.07 us | 348.98 us | -3.08% |
| `index.tsx` | 712.25 us | 673.43 us | -5.45% |
| `handle-comments.js` | 394.35 us | 376.84 us | -4.44% |
| `types.ts` | 1.393 ms | 1.304 ms | -6.42% |
| `App.tsx` | 8.928 ms | 8.156 ms | -8.64% |

Geomean across these formatter fixtures: -5.35% median runtime. Treat as directional local data; CI/CodSpeed is the source of truth.
