### PR TITLE
perf(transformer/object_rest_spread): pre-allocate capacity in `Vec`

### DIFF
--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -27,7 +27,7 @@
 //! * Babel plugin implementation: <https://github.com/babel/babel/tree/v7.26.2/packages/babel-plugin-transform-object-rest-spread>
 //! * Object rest/spread TC39 proposal: <https://github.com/tc39/proposal-object-rest-spread>
 
-use std::mem;
+use std::{iter, mem};
 
 use serde::Deserialize;
 
@@ -384,8 +384,7 @@ impl<'a> ObjectRestSpread<'a> {
         let mut exprs = vec![];
         Self::recursive_walk_assignment_target(&mut assign_expr.left, &mut decls, &mut exprs, ctx);
         Self::insert_var_declaration_before_containing_statement(decls, ctx);
-        let mut expressions = ArenaVec::from_value_in(expr.take_in(ctx), ctx);
-        expressions.extend(exprs);
+        let expressions = ArenaVec::from_iter_in(iter::chain([expr.take_in(ctx)], exprs), ctx);
         *expr = Expression::new_sequence_expression(SPAN, expressions, ctx);
     }
 


### PR DESCRIPTION
Small optimization to object rest/spread transform.

Allocate sufficient capacity in `Vec` for its elements. Previously we created a `Vec` with length 1 (with `Vec::from_value_in`) and then extended the `Vec` with `extend` which would cause it to reallocate. Instead create the `Vec` with `Vec::from_iter_in(iter::chain(...))` which allocates the `Vec` with the right capacity upfront.