### PR TITLE
perf(transformer/nullish_coalescing): move cold path into separate function

### DIFF
--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -46,24 +46,26 @@ impl NullishCoalescingOperator {
 }
 
 impl<'a> Traverse<'a, TransformState<'a>> for NullishCoalescingOperator {
+    #[inline]
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         // left ?? right
-        if !matches!(expr, Expression::LogicalExpression(logical_expr) if logical_expr.operator == LogicalOperator::Coalesce)
+        if matches!(expr, Expression::LogicalExpression(logical_expr) if logical_expr.operator == LogicalOperator::Coalesce)
         {
-            return;
+            Self::transform_logical_expression(expr, ctx);
         }
-
-        // Take ownership of the `LogicalExpression`
-        let Expression::LogicalExpression(logical_expr) = expr.take_in(ctx) else { unreachable!() };
-
-        *expr = self.transform_logical_expression(logical_expr, ctx);
     }
 }
 
 impl<'a> NullishCoalescingOperator {
-    #[expect(clippy::unused_self)]
-    fn transform_logical_expression(
-        &self,
+    #[cold] // Most `Expression`s are not `??` `LogicalExpression`s
+    fn transform_logical_expression(expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
+        // Take ownership of the `LogicalExpression`
+        let Expression::LogicalExpression(logical_expr) = expr.take_in(ctx) else { unreachable!() };
+
+        *expr = Self::transform_logical_expression_impl(logical_expr, ctx);
+    }
+
+    fn transform_logical_expression_impl(
         logical_expr: ArenaBox<'a, LogicalExpression<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {


### PR DESCRIPTION
Small optimization to nullish coalescing transform.

Move the logic for transforming `??` into a separate `#[cold]` function. The vast majority of `Expression`s are not `??` `LogicalExpression`s. This allows us to inline `enter_expression`, which becomes just a cheap "Is it `??`. No. Exit." check on the common path.