### PR TITLE
refactor(ast_tools): rename `AssertLayoutsGenerator`

### DIFF
--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -31,11 +31,11 @@ use crate::{
 use super::define_generator;
 
 /// Generator for memory layout assertions.
-pub struct AssertLayouts;
+pub struct AssertLayoutsGenerator;
 
-define_generator!(AssertLayouts);
+define_generator!(AssertLayoutsGenerator);
 
-impl Generator for AssertLayouts {
+impl Generator for AssertLayoutsGenerator {
     /// Calculate layouts of all types.
     fn prepare(&self, schema: &mut Schema, _codegen: &Codegen) {
         LayoutCalculator::calculate(schema);

--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -27,7 +27,7 @@ mod typescript;
 mod utf8_to_utf16;
 mod visit;
 
-pub use assert_layouts::AssertLayouts;
+pub use assert_layouts::AssertLayoutsGenerator;
 pub use ast_builder::AstBuilderGenerator;
 pub use ast_kind::AstKindGenerator;
 pub use builder_methods::BuilderMethodsGenerator;
@@ -147,8 +147,8 @@ pub trait Generator: Runner {
 ///
 /// # Example
 /// ```
-/// struct AssertLayouts;
-/// define_generator!(AssertLayouts);
+/// struct AssertLayoutsGenerator;
+/// define_generator!(AssertLayoutsGenerator);
 /// ```
 macro_rules! define_generator {
     ($ident:ident $($lifetime:lifetime)?) => {

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -93,7 +93,7 @@
 //! Now, in the prepare phase, generators can perform any modifications to the `Schema` that require
 //! access to more than 1 [`TypeDef`] at the same time. They do this by implementing the
 //! [`Generator::prepare`] or [`Derive::prepare`] method.
-//! A good example of this is the [`AssertLayouts`] generator.
+//! A good example of this is [`AssertLayoutsGenerator`].
 //!
 //! At the end of this phase, the [`Schema`] is locked as read-only.
 //!
@@ -179,7 +179,7 @@
 //! [`FieldDef`]: schema::FieldDef
 //! [`VariantDef`]: schema::VariantDef
 //! [`MetaType`]: schema::MetaType
-//! [`AssertLayouts`]: generators::AssertLayouts
+//! [`AssertLayoutsGenerator`]: generators::AssertLayoutsGenerator
 //! [`TokenStream`]: proc_macro2::TokenStream
 //! [`AttrLocation`]: parse::attr::AttrLocation
 //! [`AttrPart`]: parse::attr::AttrPart
@@ -258,7 +258,7 @@ const DERIVES: &[&(dyn Derive + Sync)] = &[
 
 /// Code generators
 const GENERATORS: &[&(dyn Generator + Sync)] = &[
-    &generators::AssertLayouts,
+    &generators::AssertLayoutsGenerator,
     &generators::AstKindGenerator,
     &generators::AstBuilderGenerator,
     &generators::BuilderMethodsGenerator,


### PR DESCRIPTION
Pure refactor. Rename this generator to match the others.