### PR TITLE
fix(formatter_graphql): break `implements` list by print-width

### DIFF
--- a/crates/oxc_formatter_graphql/AGENTS.md
+++ b/crates/oxc_formatter_graphql/AGENTS.md
@@ -88,20 +88,20 @@ Run `clippy` and resolve all warnings.
 
 ### Fixtures tests
 
-Snapshot tests driven by fixture files under `tests/fixtures/graphql/`,
-covering what the Prettier conformance suite does not:
-`# oxfmt-ignore` suppression, blank-line runs inside block strings,
-string escape re-encoding (incl. the `\r` divergence), empty `[]` / `{}` values,
-the full set of type-system extensions, insignificant-comma trivia,
-trailing comments at various positions,
-width-overflowing `implements` lists (which never break),
-and executable descriptions + legacy fragment variables
-(comment / blank-line / width edges beyond the conformance fixtures).
+Snapshot tests driven by fixture files under `tests/fixtures/graphql/`, covering what the Prettier conformance suite does not:
 
-`build.rs` auto-generates a test case from every `.graphql` file using the core
-`test_support` harness. Unit tests in `tests/fixtures/mod.rs` cover parse-error
-`Err` semantics and BOM preservation; `src/comments.rs` has `classify_gap` tests
-(CR / CRLF endings, which `.gitattributes` keeps out of fixture files).
+- `# oxfmt-ignore` suppression
+- blank-line runs inside block strings
+- string escape re-encoding (incl. the `\r` divergence)
+- empty `[]` / `{}` values
+- the full set of type-system extensions
+- insignificant-comma trivia
+- trailing comments at various positions
+- etc
+
+`build.rs` auto-generates a test case from every `.graphql` file using the core `test_support` harness.
+Unit tests in `tests/fixtures/mod.rs` cover parse-error `Err` semantics and BOM preservation;
+`src/comments.rs` has `classify_gap` tests (CR / CRLF endings, which `.gitattributes` keeps out of fixture files).
 
 ```sh
 cargo test -p oxc_formatter_graphql
@@ -162,10 +162,6 @@ Directive applications like `@oneOf` / `@defer` need no work. `oxc-graphql-parse
 
 These are in Prettier's unreleased changelog (main has them, next stable will).
 
-- [#18582](https://github.com/prettier/prettier/blob/main/changelog_unreleased/graphql/18582.md):
-  allow `implements` lists to break. We currently implement never break
-  (see `tests/fixtures/graphql/implements-width.graphql`),
-  so this is a layout divergence that will become incompatible, not a new-syntax item, lands sooner.
 - [#19171](https://github.com/prettier/prettier/blob/main/changelog_unreleased/graphql/19171.md):
   directives on directive definitions (`directive @a @b on QUERY`) + `extend directive`.
   graphql-js 17 graduated this to default (no option).

--- a/crates/oxc_formatter_graphql/src/print/common.rs
+++ b/crates/oxc_formatter_graphql/src/print/common.rs
@@ -243,13 +243,11 @@ pub(super) fn write_input_value_definition<'a>(
     write_directives(&input_value.directives, DirectivesStyle::Attached, f);
 }
 
-/// ` implements A & B`, mirroring Prettier 3.8.4's `printInterfaces`:
-/// names joined by plain `" & "` — the list NEVER breaks on line width (no group, no indent).
-/// TODO: We will revisit this once Prettier 3.9.x released, as it changed the behavior.
+/// ` implements A & B`, mirroring Prettier's  `printInterfaces`:
+/// `indent(group(join([" &", line], names)))`.
 ///
-/// A `line` replaces the space only when a comment sits between two names;
-/// outside any group it always prints as a newline,
-/// so the list breaks exactly at the comment position (at zero extra indentation).
+/// The whole list is one group so it breaks together on width overflow.
+/// A leading comment between two names emits a `hard_line_break` which forces the group to expand.
 pub(super) fn write_implements_interfaces<'a>(
     interfaces: &'a [NamedType<'a>],
     f: &mut GraphqlFormatter<'_, 'a>,
@@ -258,20 +256,15 @@ pub(super) fn write_implements_interfaces<'a>(
         return;
     }
     write!(f, " implements ");
-    for (i, named) in interfaces.iter().enumerate() {
-        let start = to_span(named.name.span).start;
-        if i > 0 {
-            write!(f, " &");
-            // Pending comments before this name = comments between the two names
-            // (Prettier checks `textBetween.includes("#")`).
-            let has_comment = f.context().comments().iter_before(start).next().is_some();
-            if has_comment {
-                write!(f, soft_line_break_or_space());
-            } else {
-                write!(f, space());
+    let joined = format_with(move |f: &mut GraphqlFormatter<'_, 'a>| {
+        for (i, named) in interfaces.iter().enumerate() {
+            let start = to_span(named.name.span).start;
+            if i > 0 {
+                write!(f, [" &", soft_line_break_or_space()]);
             }
+            flush_leading_comments(start, f);
+            write_named_type(named, f);
         }
-        flush_leading_comments(start, f);
-        write_named_type(named, f);
-    }
+    });
+    write!(f, group(&indent(&joined)));
 }

--- a/crates/oxc_formatter_graphql/tests/fixtures/graphql/implements-width.graphql.snap
+++ b/crates/oxc_formatter_graphql/tests/fixtures/graphql/implements-width.graphql.snap
@@ -22,17 +22,27 @@ type Short implements Node & Other @docsCategory(name: "checks") {
 ------------------
 { printWidth: 80 }
 ------------------
-type CheckRun implements Node & RequirableByPullRequest & UniformResourceLocatable
-  @docsCategory(name: "checks") {
+type CheckRun implements Node &
+  RequirableByPullRequest &
+  UniformResourceLocatable @docsCategory(name: "checks") {
   id: ID!
 }
 
-type CommitComment implements Comment & Deletable & Minimizable & Node & Reactable & RepositoryNode & Updatable & UpdatableComment
-  @docsCategory(name: "commits") {
+type CommitComment implements Comment &
+  Deletable &
+  Minimizable &
+  Node &
+  Reactable &
+  RepositoryNode &
+  Updatable &
+  UpdatableComment @docsCategory(name: "commits") {
   id: ID!
 }
 
-type LongNoDirective implements Node & RequirableByPullRequest & UniformResourceLocatable & ExtraLongInterface {
+type LongNoDirective implements Node &
+  RequirableByPullRequest &
+  UniformResourceLocatable &
+  ExtraLongInterface {
   id: ID!
 }
 
@@ -48,12 +58,21 @@ type CheckRun implements Node & RequirableByPullRequest & UniformResourceLocatab
   id: ID!
 }
 
-type CommitComment implements Comment & Deletable & Minimizable & Node & Reactable & RepositoryNode & Updatable & UpdatableComment
-  @docsCategory(name: "commits") {
+type CommitComment implements Comment &
+  Deletable &
+  Minimizable &
+  Node &
+  Reactable &
+  RepositoryNode &
+  Updatable &
+  UpdatableComment @docsCategory(name: "commits") {
   id: ID!
 }
 
-type LongNoDirective implements Node & RequirableByPullRequest & UniformResourceLocatable & ExtraLongInterface {
+type LongNoDirective implements Node &
+  RequirableByPullRequest &
+  UniformResourceLocatable &
+  ExtraLongInterface {
   id: ID!
 }
 

--- a/tasks/prettier_conformance/snapshots/prettier.graphql.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.graphql.snap.md
@@ -1,12 +1,9 @@
-graphql compatibility: 54/57 (94.74%), 2 files skipped
+graphql compatibility: 57/57 (100.00%), 2 files skipped
 
 # Failed
 
 | Spec path | Failed or Passed | Match ratio |
 | :-------- | :--------------: | :---------: |
-| graphql/comments/interfaces.graphql | 💥 | 25.00% |
-| graphql/interface/many-interfaces.graphql | 💥 | 36.36% |
-| graphql/interface/separator-detection.graphql | 💥 | 67.57% |
 
 # Skipped (parse error, TODO: should be ignored or supported)
 


### PR DESCRIPTION
Part of #23923

Now `implements` long list are broken on print-width.

```gql
type LongNoDirective implements Node &
  RequirableByPullRequest &
  UniformResourceLocatable &
  ExtraLongInterface {
  id: ID!
}
```