### PR TITLE
refactor(react_compiler): move all imports to top, trim module allows

### DIFF
--- a/crates/oxc_react_compiler/src/convert_ast.rs
+++ b/crates/oxc_react_compiler/src/convert_ast.rs
@@ -24,6 +24,7 @@ use crate::react_compiler_ast::statements::*;
 use oxc_ast::ast as oxc;
 use oxc_span::GetSpan;
 use oxc_span::Span;
+use oxc_syntax::xml_entities::XML_ENTITIES;
 
 /// Decode XML/HTML entities in JSX text (`&amp;` → `&`, `&gt;` → `>`, `&#123;`
 /// → `{`, `&#x1F600;` → emoji, …) so the Babel `JSXText.value` is the decoded
@@ -62,7 +63,7 @@ fn decode_jsx_entities(s: &str) -> String {
                 num.parse::<u32>().ok().and_then(char::from_u32)
             }
         } else {
-            oxc_syntax::xml_entities::XML_ENTITIES.get(word).copied()
+            XML_ENTITIES.get(word).copied()
         };
         match decoded {
             Some(c) => out.push(c),

--- a/crates/oxc_react_compiler/src/convert_ast_reverse.rs
+++ b/crates/oxc_react_compiler/src/convert_ast_reverse.rs
@@ -9,6 +9,9 @@
 //! (which represents the compiler's Babel-compatible output) and produces OXC AST
 //! nodes allocated in an OXC arena, suitable for code generation via `oxc_codegen`.
 
+use crate::react_compiler_ast::File;
+use crate::react_compiler_ast::Program;
+use crate::react_compiler_ast::SourceType as AstSourceType;
 use crate::react_compiler_ast::common::BaseNode;
 use crate::react_compiler_ast::declarations::*;
 use crate::react_compiler_ast::expressions::*;
@@ -16,12 +19,14 @@ use crate::react_compiler_ast::jsx::*;
 use crate::react_compiler_ast::operators::*;
 use crate::react_compiler_ast::patterns::*;
 use crate::react_compiler_ast::statements::*;
-use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator};
+use oxc_allocator::{Allocator, ArenaBox, ArenaStringBuilder, ArenaVec, GetAllocator};
 use oxc_ast::ast as oxc;
 use oxc_ast::builder::{AstBuilder, GetAstBuilder};
 use oxc_ast_visit::VisitMut;
+use oxc_parser::Parser;
 use oxc_span::GetSpanMut;
 use oxc_span::SPAN;
+use oxc_span::SourceType;
 use oxc_span::Span;
 use oxc_str::Str;
 use oxc_syntax::identifier::is_identifier_name;
@@ -29,6 +34,8 @@ use oxc_syntax::operator::{
     AssignmentOperator as OxcAssOp, BinaryOperator as OxcBinOp, LogicalOperator as OxcLogOp,
     UnaryOperator as OxcUnOp, UpdateOperator as OxcUpOp,
 };
+use serde_json::Value;
+use std::iter::once;
 
 fn set_statement_span(stmt: &mut oxc::Statement<'_>, span: Span) {
     match stmt {
@@ -87,17 +94,14 @@ impl VisitMut<'_> for SpanShift {
 }
 
 /// Convert a `crate::react_compiler_ast::File` into an OXC `Program` allocated in the given arena.
-pub fn convert_program_to_oxc<'a>(
-    file: &crate::react_compiler_ast::File,
-    allocator: &'a Allocator,
-) -> oxc::Program<'a> {
+pub fn convert_program_to_oxc<'a>(file: &File, allocator: &'a Allocator) -> oxc::Program<'a> {
     let ctx = ReverseCtx::new(allocator, None);
     ctx.convert_program(&file.program)
 }
 
 /// Convert with source text available for extracting TS declarations.
 pub fn convert_program_to_oxc_with_source<'a>(
-    file: &crate::react_compiler_ast::File,
+    file: &File,
     allocator: &'a Allocator,
     source_text: &str,
 ) -> oxc::Program<'a> {
@@ -129,8 +133,7 @@ impl<'a> ReverseCtx<'a> {
         original_start: usize,
     ) -> Option<oxc::Statement<'a>> {
         let text_ref = self.copy_source_text_to_allocator(text);
-        let parsed =
-            oxc_parser::Parser::new(self.allocator, text_ref, oxc_span::SourceType::tsx()).parse();
+        let parsed = Parser::new(self.allocator, text_ref, SourceType::tsx()).parse();
         if parsed.panicked || parsed.program.body.is_empty() {
             return None;
         }
@@ -156,9 +159,7 @@ impl<'a> ReverseCtx<'a> {
     ) -> Option<oxc::Expression<'a>> {
         let text_ref = self.copy_source_text_to_allocator(text);
         let mut expr =
-            oxc_parser::Parser::new(self.allocator, text_ref, oxc_span::SourceType::tsx())
-                .parse_expression()
-                .ok()?;
+            Parser::new(self.allocator, text_ref, SourceType::tsx()).parse_expression().ok()?;
         if original_start > 0 {
             let mut shifter = SpanShift { offset: original_start as u32 };
             shifter.visit_expression(&mut expr);
@@ -183,12 +184,12 @@ impl<'a> ReverseCtx<'a> {
     }
 
     fn copy_source_text_to_allocator(&self, text: &str) -> &'a str {
-        oxc_allocator::ArenaStringBuilder::from_str_in(text, self.allocator).into_str()
+        ArenaStringBuilder::from_str_in(text, self.allocator).into_str()
     }
 
     fn extract_source_class_expression(
         &self,
-        class: &crate::react_compiler_ast::expressions::ClassExpression,
+        class: &ClassExpression,
     ) -> Option<oxc::Expression<'a>> {
         let expr = self.extract_source_expr(&class.base)?;
         if matches!(expr, oxc::Expression::ClassExpression(_)) { Some(expr) } else { None }
@@ -271,16 +272,12 @@ impl<'a> ReverseCtx<'a> {
         }
     }
 
-    fn extract_source_ts_type_from_json(
-        &self,
-        value: &serde_json::Value,
-    ) -> Option<oxc::TSType<'a>> {
-        let value =
-            if value.get("type").and_then(serde_json::Value::as_str) == Some("TSTypeAnnotation") {
-                value.get("typeAnnotation")?
-            } else {
-                value
-            };
+    fn extract_source_ts_type_from_json(&self, value: &Value) -> Option<oxc::TSType<'a>> {
+        let value = if value.get("type").and_then(Value::as_str) == Some("TSTypeAnnotation") {
+            value.get("typeAnnotation")?
+        } else {
+            value
+        };
         let source = self.source_text.as_deref()?;
         let start = value.get("start")?.as_u64()? as usize;
         let end = value.get("end")?.as_u64()? as usize;
@@ -290,9 +287,9 @@ impl<'a> ReverseCtx<'a> {
         self.parse_source_ts_type_text_at(&source[start..end], start)
     }
 
-    fn span_from_json_value(&self, value: &serde_json::Value) -> Span {
-        let start = value.get("start").and_then(serde_json::Value::as_u64);
-        let end = value.get("end").and_then(serde_json::Value::as_u64);
+    fn span_from_json_value(&self, value: &Value) -> Span {
+        let start = value.get("start").and_then(Value::as_u64);
+        let end = value.get("end").and_then(Value::as_u64);
         match (start, end) {
             (Some(start), Some(end)) => Span::new(start as u32, end as u32),
             (Some(start), None) => Span::new(start as u32, start as u32),
@@ -302,25 +299,24 @@ impl<'a> ReverseCtx<'a> {
 
     fn convert_ts_type_annotation_from_json(
         &self,
-        value: &serde_json::Value,
+        value: &Value,
     ) -> Option<ArenaBox<'a, oxc::TSTypeAnnotation<'a>>> {
-        let ty =
-            if value.get("type").and_then(serde_json::Value::as_str) == Some("TSTypeAnnotation") {
-                let type_annotation = value.get("typeAnnotation")?;
-                self.convert_ts_type_from_json(type_annotation).or_else(|| {
-                    if Self::ts_type_json_contains_type_query(type_annotation) {
-                        None
-                    } else {
-                        self.extract_source_ts_type_from_json(value)
-                    }
-                })?
-            } else {
-                self.convert_ts_type_from_json(value)?
-            };
+        let ty = if value.get("type").and_then(Value::as_str) == Some("TSTypeAnnotation") {
+            let type_annotation = value.get("typeAnnotation")?;
+            self.convert_ts_type_from_json(type_annotation).or_else(|| {
+                if Self::ts_type_json_contains_type_query(type_annotation) {
+                    None
+                } else {
+                    self.extract_source_ts_type_from_json(value)
+                }
+            })?
+        } else {
+            self.convert_ts_type_from_json(value)?
+        };
         Some(oxc::TSTypeAnnotation::boxed(SPAN, ty, self))
     }
 
-    fn convert_ts_type_from_json(&self, value: &serde_json::Value) -> Option<oxc::TSType<'a>> {
+    fn convert_ts_type_from_json(&self, value: &Value) -> Option<oxc::TSType<'a>> {
         if !Self::ts_type_json_contains_type_query(value)
             && let Some(ty) = self.extract_source_ts_type_from_json(value)
         {
@@ -410,10 +406,7 @@ impl<'a> ReverseCtx<'a> {
         }
     }
 
-    fn convert_ts_type_name_from_json(
-        &self,
-        value: &serde_json::Value,
-    ) -> Option<oxc::TSTypeName<'a>> {
+    fn convert_ts_type_name_from_json(&self, value: &Value) -> Option<oxc::TSTypeName<'a>> {
         match value.get("type")?.as_str()? {
             "Identifier" => Some(oxc::TSTypeName::new_identifier_reference(
                 self.span_from_json_value(value),
@@ -444,7 +437,7 @@ impl<'a> ReverseCtx<'a> {
 
     fn convert_ts_type_query_expr_name_from_json(
         &self,
-        value: &serde_json::Value,
+        value: &Value,
     ) -> Option<oxc::TSTypeQueryExprName<'a>> {
         match self.convert_ts_type_name_from_json(value)? {
             oxc::TSTypeName::IdentifierReference(identifier) => {
@@ -461,7 +454,7 @@ impl<'a> ReverseCtx<'a> {
 
     fn convert_ts_type_parameter_instantiation_from_json(
         &self,
-        value: &serde_json::Value,
+        value: &Value,
     ) -> Option<ArenaBox<'a, oxc::TSTypeParameterInstantiation<'a>>> {
         let params = value.get("params")?.as_array()?;
         let params = ArenaVec::from_iter_in(
@@ -471,10 +464,7 @@ impl<'a> ReverseCtx<'a> {
         Some(oxc::TSTypeParameterInstantiation::boxed(SPAN, params, self))
     }
 
-    fn convert_ts_literal_from_json(
-        &self,
-        value: &serde_json::Value,
-    ) -> Option<oxc::TSLiteral<'a>> {
+    fn convert_ts_literal_from_json(&self, value: &Value) -> Option<oxc::TSLiteral<'a>> {
         match value.get("type")?.as_str()? {
             "BooleanLiteral" => Some(oxc::TSLiteral::new_boolean_literal(
                 SPAN,
@@ -505,22 +495,20 @@ impl<'a> ReverseCtx<'a> {
         }
     }
 
-    fn ts_type_json_contains_type_query(value: &serde_json::Value) -> bool {
+    fn ts_type_json_contains_type_query(value: &Value) -> bool {
         match value {
-            serde_json::Value::Object(obj) => {
-                let is_rename_sensitive_type_query =
-                    obj.get("type").and_then(serde_json::Value::as_str) == Some("TSTypeQuery")
-                        && obj
-                            .get("exprName")
-                            .and_then(|expr| expr.get("type"))
-                            .and_then(serde_json::Value::as_str)
-                            != Some("TSImportType");
+            Value::Object(obj) => {
+                let is_rename_sensitive_type_query = obj.get("type").and_then(Value::as_str)
+                    == Some("TSTypeQuery")
+                    && obj
+                        .get("exprName")
+                        .and_then(|expr| expr.get("type"))
+                        .and_then(Value::as_str)
+                        != Some("TSImportType");
                 is_rename_sensitive_type_query
                     || obj.values().any(Self::ts_type_json_contains_type_query)
             }
-            serde_json::Value::Array(values) => {
-                values.iter().any(Self::ts_type_json_contains_type_query)
-            }
+            Value::Array(values) => values.iter().any(Self::ts_type_json_contains_type_query),
             _ => false,
         }
     }
@@ -1010,10 +998,10 @@ impl<'a> ReverseCtx<'a> {
 
     // ===== Program =====
 
-    fn convert_program(&self, program: &crate::react_compiler_ast::Program) -> oxc::Program<'a> {
+    fn convert_program(&self, program: &Program) -> oxc::Program<'a> {
         let source_type = match program.source_type {
-            crate::react_compiler_ast::SourceType::Module => oxc_span::SourceType::mjs(),
-            crate::react_compiler_ast::SourceType::Script => oxc_span::SourceType::cjs(),
+            AstSourceType::Module => SourceType::mjs(),
+            AstSourceType::Script => SourceType::cjs(),
         };
 
         // Use convert_statements_with_spans for the top-level body so that
@@ -1735,7 +1723,7 @@ impl<'a> ReverseCtx<'a> {
                 let left = self.convert_pattern_to_assignment_target(&p.left);
                 oxc::Expression::new_assignment_expression(
                     SPAN,
-                    oxc_syntax::operator::AssignmentOperator::Assign,
+                    OxcAssOp::Assign,
                     left,
                     self.convert_expression(&p.right),
                     self,
@@ -2005,10 +1993,7 @@ impl<'a> ReverseCtx<'a> {
         }
     }
 
-    fn convert_template_literal(
-        &self,
-        tl: &crate::react_compiler_ast::expressions::TemplateLiteral,
-    ) -> oxc::TemplateLiteral<'a> {
+    fn convert_template_literal(&self, tl: &TemplateLiteral) -> oxc::TemplateLiteral<'a> {
         let quasis = ArenaVec::from_iter_in(
             tl.quasis.iter().map(|q| {
                 let raw = self.str(&q.value.raw);
@@ -2083,7 +2068,7 @@ impl<'a> ReverseCtx<'a> {
 
     fn convert_class_to_oxc(
         &self,
-        c: &crate::react_compiler_ast::expressions::ClassExpression,
+        c: &ClassExpression,
         class_type: oxc::ClassType,
     ) -> oxc::Class<'a> {
         let id =
@@ -2187,7 +2172,7 @@ impl<'a> ReverseCtx<'a> {
             ArrowFunctionBody::Expression(expr) => {
                 let oxc_expr = self.convert_expression(expr);
                 let stmt = oxc::Statement::new_expression_statement(SPAN, oxc_expr, self);
-                let stmts = ArenaVec::from_iter_in(std::iter::once(stmt), self);
+                let stmts = ArenaVec::from_iter_in(once(stmt), self);
                 oxc::FunctionBody::new(SPAN, ArenaVec::new_in(self), stmts, self)
             }
         };
@@ -2971,10 +2956,10 @@ impl<'a> ReverseCtx<'a> {
 
     fn convert_import_specifier(
         &self,
-        spec: &crate::react_compiler_ast::declarations::ImportSpecifier,
+        spec: &ImportSpecifier,
     ) -> oxc::ImportDeclarationSpecifier<'a> {
         match spec {
-            crate::react_compiler_ast::declarations::ImportSpecifier::ImportSpecifier(s) => {
+            ImportSpecifier::ImportSpecifier(s) => {
                 let local = oxc::BindingIdentifier::new(SPAN, self.str(&s.local.name), self);
                 let imported = self.convert_module_export_name(&s.imported);
                 let import_kind = match s.import_kind.as_ref() {
@@ -2984,14 +2969,12 @@ impl<'a> ReverseCtx<'a> {
                 let is = oxc::ImportSpecifier::new(SPAN, imported, local, import_kind, self);
                 oxc::ImportDeclarationSpecifier::ImportSpecifier(ArenaBox::new_in(is, self))
             }
-            crate::react_compiler_ast::declarations::ImportSpecifier::ImportDefaultSpecifier(s) => {
+            ImportSpecifier::ImportDefaultSpecifier(s) => {
                 let local = oxc::BindingIdentifier::new(SPAN, self.str(&s.local.name), self);
                 let ids = oxc::ImportDefaultSpecifier::new(SPAN, local, self);
                 oxc::ImportDeclarationSpecifier::ImportDefaultSpecifier(ArenaBox::new_in(ids, self))
             }
-            crate::react_compiler_ast::declarations::ImportSpecifier::ImportNamespaceSpecifier(
-                s,
-            ) => {
+            ImportSpecifier::ImportNamespaceSpecifier(s) => {
                 let local = oxc::BindingIdentifier::new(SPAN, self.str(&s.local.name), self);
                 let ins = oxc::ImportNamespaceSpecifier::new(SPAN, local, self);
                 oxc::ImportDeclarationSpecifier::ImportNamespaceSpecifier(ArenaBox::new_in(
@@ -3001,22 +2984,17 @@ impl<'a> ReverseCtx<'a> {
         }
     }
 
-    fn convert_module_export_name(
-        &self,
-        name: &crate::react_compiler_ast::declarations::ModuleExportName,
-    ) -> oxc::ModuleExportName<'a> {
+    fn convert_module_export_name(&self, name: &ModuleExportName) -> oxc::ModuleExportName<'a> {
         match name {
-            crate::react_compiler_ast::declarations::ModuleExportName::Identifier(id) => {
+            ModuleExportName::Identifier(id) => {
                 oxc::ModuleExportName::new_identifier_name(SPAN, self.str(&id.name), self)
             }
-            crate::react_compiler_ast::declarations::ModuleExportName::StringLiteral(s) => {
-                oxc::ModuleExportName::new_string_literal(
-                    SPAN,
-                    self.str(&s.value.to_string_lossy()),
-                    None,
-                    self,
-                )
-            }
+            ModuleExportName::StringLiteral(s) => oxc::ModuleExportName::new_string_literal(
+                SPAN,
+                self.str(&s.value.to_string_lossy()),
+                None,
+                self,
+            ),
         }
     }
 
@@ -3027,15 +3005,13 @@ impl<'a> ReverseCtx<'a> {
     /// plain name.
     fn convert_module_export_name_local_ref(
         &self,
-        name: &crate::react_compiler_ast::declarations::ModuleExportName,
+        name: &ModuleExportName,
     ) -> oxc::ModuleExportName<'a> {
         match name {
-            crate::react_compiler_ast::declarations::ModuleExportName::Identifier(id) => {
+            ModuleExportName::Identifier(id) => {
                 oxc::ModuleExportName::new_identifier_reference(SPAN, self.str(&id.name), self)
             }
-            crate::react_compiler_ast::declarations::ModuleExportName::StringLiteral(_) => {
-                self.convert_module_export_name(name)
-            }
+            ModuleExportName::StringLiteral(_) => self.convert_module_export_name(name),
         }
     }
 
@@ -3104,11 +3080,11 @@ impl<'a> ReverseCtx<'a> {
 
     fn convert_export_specifier(
         &self,
-        spec: &crate::react_compiler_ast::declarations::ExportSpecifier,
+        spec: &ExportSpecifier,
         local_is_reference: bool,
     ) -> oxc::ExportSpecifier<'a> {
         match spec {
-            crate::react_compiler_ast::declarations::ExportSpecifier::ExportSpecifier(s) => {
+            ExportSpecifier::ExportSpecifier(s) => {
                 let local = if local_is_reference {
                     self.convert_module_export_name_local_ref(&s.local)
                 } else {
@@ -3121,7 +3097,7 @@ impl<'a> ReverseCtx<'a> {
                 };
                 oxc::ExportSpecifier::new(SPAN, local, exported, export_kind, self)
             }
-            crate::react_compiler_ast::declarations::ExportSpecifier::ExportDefaultSpecifier(s) => {
+            ExportSpecifier::ExportDefaultSpecifier(s) => {
                 let name = oxc::ModuleExportName::new_identifier_name(
                     SPAN,
                     self.str(&s.exported.name),
@@ -3137,9 +3113,7 @@ impl<'a> ReverseCtx<'a> {
                     self,
                 )
             }
-            crate::react_compiler_ast::declarations::ExportSpecifier::ExportNamespaceSpecifier(
-                s,
-            ) => {
+            ExportSpecifier::ExportNamespaceSpecifier(s) => {
                 let exported = self.convert_module_export_name(&s.exported);
                 let star = oxc::ModuleExportName::new_identifier_name(SPAN, self.str("*"), self);
                 oxc::ExportSpecifier::new(
@@ -3213,7 +3187,7 @@ impl<'a> ReverseCtx<'a> {
 
     // ===== Operators =====
 
-    fn convert_binary_operator(&self, op: &BinaryOperator) -> oxc_syntax::operator::BinaryOperator {
+    fn convert_binary_operator(&self, op: &BinaryOperator) -> OxcBinOp {
         match op {
             BinaryOperator::Add => OxcBinOp::Addition,
             BinaryOperator::Sub => OxcBinOp::Subtraction,
@@ -3241,10 +3215,7 @@ impl<'a> ReverseCtx<'a> {
         }
     }
 
-    fn convert_logical_operator(
-        &self,
-        op: &LogicalOperator,
-    ) -> oxc_syntax::operator::LogicalOperator {
+    fn convert_logical_operator(&self, op: &LogicalOperator) -> OxcLogOp {
         match op {
             LogicalOperator::Or => OxcLogOp::Or,
             LogicalOperator::And => OxcLogOp::And,
@@ -3252,7 +3223,7 @@ impl<'a> ReverseCtx<'a> {
         }
     }
 
-    fn convert_unary_operator(&self, op: &UnaryOperator) -> oxc_syntax::operator::UnaryOperator {
+    fn convert_unary_operator(&self, op: &UnaryOperator) -> OxcUnOp {
         match op {
             UnaryOperator::Neg => OxcUnOp::UnaryNegation,
             UnaryOperator::Plus => OxcUnOp::UnaryPlus,
@@ -3265,17 +3236,14 @@ impl<'a> ReverseCtx<'a> {
         }
     }
 
-    fn convert_update_operator(&self, op: &UpdateOperator) -> oxc_syntax::operator::UpdateOperator {
+    fn convert_update_operator(&self, op: &UpdateOperator) -> OxcUpOp {
         match op {
             UpdateOperator::Increment => OxcUpOp::Increment,
             UpdateOperator::Decrement => OxcUpOp::Decrement,
         }
     }
 
-    fn convert_assignment_operator(
-        &self,
-        op: &AssignmentOperator,
-    ) -> oxc_syntax::operator::AssignmentOperator {
+    fn convert_assignment_operator(&self, op: &AssignmentOperator) -> OxcAssOp {
         match op {
             AssignmentOperator::Assign => OxcAssOp::Assign,
             AssignmentOperator::AddAssign => OxcAssOp::Addition,

--- a/crates/oxc_react_compiler/src/convert_ast_reverse.rs
+++ b/crates/oxc_react_compiler/src/convert_ast_reverse.rs
@@ -20,13 +20,17 @@ use oxc_allocator::{Allocator, ArenaBox, ArenaVec, GetAllocator};
 use oxc_ast::ast as oxc;
 use oxc_ast::builder::{AstBuilder, GetAstBuilder};
 use oxc_ast_visit::VisitMut;
+use oxc_span::GetSpanMut;
 use oxc_span::SPAN;
 use oxc_span::Span;
 use oxc_str::Str;
 use oxc_syntax::identifier::is_identifier_name;
+use oxc_syntax::operator::{
+    AssignmentOperator as OxcAssOp, BinaryOperator as OxcBinOp, LogicalOperator as OxcLogOp,
+    UnaryOperator as OxcUnOp, UpdateOperator as OxcUpOp,
+};
 
 fn set_statement_span(stmt: &mut oxc::Statement<'_>, span: Span) {
-    use oxc_span::GetSpanMut;
     match stmt {
         oxc::Statement::ImportDeclaration(d) => *d.span_mut() = span,
         oxc::Statement::VariableDeclaration(d) => *d.span_mut() = span,
@@ -3210,7 +3214,6 @@ impl<'a> ReverseCtx<'a> {
     // ===== Operators =====
 
     fn convert_binary_operator(&self, op: &BinaryOperator) -> oxc_syntax::operator::BinaryOperator {
-        use oxc_syntax::operator::BinaryOperator as OxcBinOp;
         match op {
             BinaryOperator::Add => OxcBinOp::Addition,
             BinaryOperator::Sub => OxcBinOp::Subtraction,
@@ -3242,7 +3245,6 @@ impl<'a> ReverseCtx<'a> {
         &self,
         op: &LogicalOperator,
     ) -> oxc_syntax::operator::LogicalOperator {
-        use oxc_syntax::operator::LogicalOperator as OxcLogOp;
         match op {
             LogicalOperator::Or => OxcLogOp::Or,
             LogicalOperator::And => OxcLogOp::And,
@@ -3251,7 +3253,6 @@ impl<'a> ReverseCtx<'a> {
     }
 
     fn convert_unary_operator(&self, op: &UnaryOperator) -> oxc_syntax::operator::UnaryOperator {
-        use oxc_syntax::operator::UnaryOperator as OxcUnOp;
         match op {
             UnaryOperator::Neg => OxcUnOp::UnaryNegation,
             UnaryOperator::Plus => OxcUnOp::UnaryPlus,
@@ -3265,7 +3266,6 @@ impl<'a> ReverseCtx<'a> {
     }
 
     fn convert_update_operator(&self, op: &UpdateOperator) -> oxc_syntax::operator::UpdateOperator {
-        use oxc_syntax::operator::UpdateOperator as OxcUpOp;
         match op {
             UpdateOperator::Increment => OxcUpOp::Increment,
             UpdateOperator::Decrement => OxcUpOp::Decrement,
@@ -3276,7 +3276,6 @@ impl<'a> ReverseCtx<'a> {
         &self,
         op: &AssignmentOperator,
     ) -> oxc_syntax::operator::AssignmentOperator {
-        use oxc_syntax::operator::AssignmentOperator as OxcAssOp;
         match op {
             AssignmentOperator::Assign => OxcAssOp::Assign,
             AssignmentOperator::AddAssign => OxcAssOp::Addition,

--- a/crates/oxc_react_compiler/src/convert_scope.rs
+++ b/crates/oxc_react_compiler/src/convert_scope.rs
@@ -7,9 +7,17 @@ use crate::react_compiler_ast::scope::*;
 use indexmap::IndexMap;
 use oxc_ast::AstKind;
 use oxc_ast::ast::{BindingPattern, Program};
+use oxc_ast::ast::{
+    ExportDefaultDeclarationKind, ImportDeclaration, ModuleExportName, PropertyKind, Statement,
+    TSModuleDeclarationName,
+};
+use oxc_semantic::NodeId;
 use oxc_semantic::Semantic;
 use oxc_span::GetSpan;
+use oxc_syntax::scope::ScopeFlags;
+use oxc_syntax::scope::ScopeId as OxcScopeId;
 use oxc_syntax::symbol::SymbolFlags;
+use oxc_syntax::symbol::SymbolId;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 
 /// `IndexMap` keyed with the deterministic Fx hasher, matching the `FxIndexMap`
@@ -29,8 +37,7 @@ pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo 
     let mut node_id_to_scope: FxHashMap<u32, ScopeId> = FxHashMap::default();
     let mut ref_node_id_to_binding: FxIndexMap<u32, BindingId> = FxIndexMap::default();
 
-    let mut symbol_to_binding: FxHashMap<oxc_syntax::symbol::SymbolId, BindingId> =
-        FxHashMap::default();
+    let mut symbol_to_binding: FxHashMap<SymbolId, BindingId> = FxHashMap::default();
 
     // First pass: Create all bindings from symbols
     for symbol_id in scoping.symbol_ids() {
@@ -96,10 +103,7 @@ pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo 
                 match parent_node.kind() {
                     AstKind::ObjectProperty(prop)
                         if prop.method
-                            || matches!(
-                                prop.kind,
-                                oxc_ast::ast::PropertyKind::Get | oxc_ast::ast::PropertyKind::Set
-                            ) =>
+                            || matches!(prop.kind, PropertyKind::Get | PropertyKind::Set) =>
                     {
                         let prop_start = parent_node.kind().span().start;
                         if prop_start != start {
@@ -154,10 +158,8 @@ pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo 
     // as a reference to the function's binding. OXC doesn't create a reference for
     // the export itself, so we add one at the export statement's start position.
     for stmt in &_program.body {
-        if let oxc_ast::ast::Statement::ExportDefaultDeclaration(export) = stmt {
-            if let oxc_ast::ast::ExportDefaultDeclarationKind::FunctionDeclaration(func) =
-                &export.declaration
-            {
+        if let Statement::ExportDefaultDeclaration(export) = stmt {
+            if let ExportDefaultDeclarationKind::FunctionDeclaration(func) = &export.declaration {
                 if let Some(id) = &func.id {
                     let name = id.name.as_str();
                     if let Some(symbol_id) = id.symbol_id.get() {
@@ -184,10 +186,8 @@ pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo 
     // as a reference to the function's binding. OXC doesn't create a reference for
     // the export itself, so we add one at the export statement's start position.
     for stmt in &_program.body {
-        if let oxc_ast::ast::Statement::ExportDefaultDeclaration(export) = stmt {
-            if let oxc_ast::ast::ExportDefaultDeclarationKind::FunctionDeclaration(func) =
-                &export.declaration
-            {
+        if let Statement::ExportDefaultDeclaration(export) = stmt {
+            if let ExportDefaultDeclarationKind::FunctionDeclaration(func) = &export.declaration {
                 if let Some(id) = &func.id {
                     let name = id.name.as_str();
                     if let Some(symbol_id) = id.symbol_id.get() {
@@ -225,24 +225,20 @@ pub fn convert_scope_info(semantic: &Semantic, _program: &Program) -> ScopeInfo 
 }
 
 /// Map OXC ScopeFlags to our ScopeKind.
-fn get_scope_kind(
-    flags: oxc_syntax::scope::ScopeFlags,
-    semantic: &Semantic,
-    scope_id: oxc_syntax::scope::ScopeId,
-) -> ScopeKind {
-    if flags.contains(oxc_syntax::scope::ScopeFlags::Top) {
+fn get_scope_kind(flags: ScopeFlags, semantic: &Semantic, scope_id: OxcScopeId) -> ScopeKind {
+    if flags.contains(ScopeFlags::Top) {
         return ScopeKind::Program;
     }
 
-    if flags.intersects(oxc_syntax::scope::ScopeFlags::Function) {
+    if flags.intersects(ScopeFlags::Function) {
         return ScopeKind::Function;
     }
 
-    if flags.contains(oxc_syntax::scope::ScopeFlags::CatchClause) {
+    if flags.contains(ScopeFlags::CatchClause) {
         return ScopeKind::Catch;
     }
 
-    if flags.contains(oxc_syntax::scope::ScopeFlags::ClassStaticBlock) {
+    if flags.contains(ScopeFlags::ClassStaticBlock) {
         return ScopeKind::Class;
     }
 
@@ -260,11 +256,7 @@ fn get_scope_kind(
 }
 
 /// Map OXC SymbolFlags to our BindingKind.
-fn get_binding_kind(
-    flags: SymbolFlags,
-    semantic: &Semantic,
-    symbol_id: oxc_syntax::symbol::SymbolId,
-) -> BindingKind {
+fn get_binding_kind(flags: SymbolFlags, semantic: &Semantic, symbol_id: SymbolId) -> BindingKind {
     if flags.contains(SymbolFlags::Import) {
         return BindingKind::Module;
     }
@@ -314,7 +306,7 @@ fn get_binding_kind(
 /// Get the declaration type string and start position for a binding.
 fn get_declaration_info(
     semantic: &Semantic,
-    symbol_id: oxc_syntax::symbol::SymbolId,
+    symbol_id: SymbolId,
     name: &str,
 ) -> (String, Option<u32>) {
     let decl_node = semantic.symbol_declaration(symbol_id);
@@ -399,14 +391,16 @@ fn find_binding_identifier_start(kind: AstKind, name: &str) -> Option<u32> {
                 None
             }
         }
-        AstKind::TSModuleDeclaration(decl) => {
-            match &decl.id {
-                oxc_ast::ast::TSModuleDeclarationName::Identifier(id) => {
-                    if id.name.as_str() == name { Some(id.span.start) } else { None }
+        AstKind::TSModuleDeclaration(decl) => match &decl.id {
+            TSModuleDeclarationName::Identifier(id) => {
+                if id.name.as_str() == name {
+                    Some(id.span.start)
+                } else {
+                    None
                 }
-                _ => None,
             }
-        }
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -452,10 +446,7 @@ fn find_identifier_in_pattern(pattern: &BindingPattern, name: &str) -> Option<u3
 }
 
 /// Extract import data for a module binding.
-fn get_import_data(
-    semantic: &Semantic,
-    symbol_id: oxc_syntax::symbol::SymbolId,
-) -> Option<ImportBindingData> {
+fn get_import_data(semantic: &Semantic, symbol_id: SymbolId) -> Option<ImportBindingData> {
     let decl_node = semantic.symbol_declaration(symbol_id);
 
     match decl_node.kind() {
@@ -478,11 +469,9 @@ fn get_import_data(
         AstKind::ImportSpecifier(spec) => {
             let import_decl = find_import_declaration(semantic, decl_node.id())?;
             let imported_name = match &spec.imported {
-                oxc_ast::ast::ModuleExportName::IdentifierName(ident) => ident.name.to_string(),
-                oxc_ast::ast::ModuleExportName::IdentifierReference(ident) => {
-                    ident.name.to_string()
-                }
-                oxc_ast::ast::ModuleExportName::StringLiteral(lit) => lit.value.to_string(),
+                ModuleExportName::IdentifierName(ident) => ident.name.to_string(),
+                ModuleExportName::IdentifierReference(ident) => ident.name.to_string(),
+                ModuleExportName::StringLiteral(lit) => lit.value.to_string(),
             };
             Some(ImportBindingData {
                 source: import_decl.source.value.to_string(),
@@ -497,8 +486,8 @@ fn get_import_data(
 /// Find the ImportDeclaration node that contains the given import specifier.
 fn find_import_declaration<'a>(
     semantic: &'a Semantic,
-    specifier_node_id: oxc_semantic::NodeId,
-) -> Option<&'a oxc_ast::ast::ImportDeclaration<'a>> {
+    specifier_node_id: NodeId,
+) -> Option<&'a ImportDeclaration<'a>> {
     let mut current_id = specifier_node_id;
     // Walk up the parent chain (max 10 levels to avoid infinite loop)
     for _ in 0..10 {

--- a/crates/oxc_react_compiler/src/convert_scope.rs
+++ b/crates/oxc_react_compiler/src/convert_scope.rs
@@ -6,7 +6,7 @@
 use crate::react_compiler_ast::scope::*;
 use indexmap::IndexMap;
 use oxc_ast::AstKind;
-use oxc_ast::ast::Program;
+use oxc_ast::ast::{BindingPattern, Program};
 use oxc_semantic::Semantic;
 use oxc_span::GetSpan;
 use oxc_syntax::symbol::SymbolFlags;
@@ -412,9 +412,7 @@ fn find_binding_identifier_start(kind: AstKind, name: &str) -> Option<u32> {
 }
 
 /// Recursively find a binding identifier within a binding pattern.
-fn find_identifier_in_pattern(pattern: &oxc_ast::ast::BindingPattern, name: &str) -> Option<u32> {
-    use oxc_ast::ast::BindingPattern;
-
+fn find_identifier_in_pattern(pattern: &BindingPattern, name: &str) -> Option<u32> {
     match pattern {
         BindingPattern::BindingIdentifier(ident) => {
             if ident.name.as_str() == name {

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::ArenaVec;
+use oxc_allocator::{Allocator, ArenaVec};
 
 pub mod convert_ast;
 pub mod convert_ast_reverse;
@@ -38,8 +38,11 @@ pub mod react_compiler_utils;
 #[allow(clippy::all)]
 pub mod react_compiler_validation;
 
-use crate::react_compiler::entrypoint::compile_result::LoggerEvent;
+use crate::react_compiler::entrypoint::compile_result::{CompileResult, LoggerEvent};
+use crate::react_compiler::entrypoint::program::compile_program;
+use crate::react_compiler_ast::File;
 use convert_ast::convert_program;
+use convert_ast_reverse::convert_program_to_oxc_with_source;
 use convert_scope::convert_scope_info;
 use diagnostics::compile_result_to_diagnostics;
 use prefilter::{has_react_like_functions, has_resource_management_declarations};
@@ -50,7 +53,11 @@ pub use crate::react_compiler::entrypoint::plugin_options::{
 };
 pub use crate::react_compiler_hir::environment_config::EnvironmentConfig;
 
-use oxc_span::GetSpan;
+use oxc_ast::ast::Program;
+use oxc_diagnostics::Diagnostics;
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+use oxc_span::{GetSpan, SourceType};
 use rustc_hash::FxHashSet;
 
 /// [`PluginOptions`] with the compiler's standard defaults (it has no `Default`).
@@ -87,7 +94,7 @@ pub struct TransformResult {
     /// Errors and warnings produced by the compile. Errors (e.g. Rules of Hooks
     /// violations) are hard problems in the source; the program is still left
     /// valid. Warnings include bail-outs where the compiler declined to optimize.
-    pub diagnostics: oxc_diagnostics::Diagnostics,
+    pub diagnostics: Diagnostics,
     /// Raw structured logger events from the upstream compiler (compile
     /// success/skip/error with memoization stats), for tooling and profiling.
     /// Unlike `diagnostics`, these are not meant for user-facing reporting.
@@ -96,7 +103,7 @@ pub struct TransformResult {
 
 pub struct LintResult {
     /// Errors and warnings produced by the compile.
-    pub diagnostics: oxc_diagnostics::Diagnostics,
+    pub diagnostics: Diagnostics,
 }
 
 /// Run the React Compiler on a pre-parsed program, rewriting `program` in place
@@ -104,8 +111,8 @@ pub struct LintResult {
 ///
 /// Must run **first**, on the pristine AST, before any other transform.
 pub fn transform<'a>(
-    program: &mut oxc_ast::ast::Program<'a>,
-    allocator: &'a oxc_allocator::Allocator,
+    program: &mut Program<'a>,
+    allocator: &'a Allocator,
     options: PluginOptions,
 ) -> TransformResult {
     let (compiled, diagnostics, events) = compile(program, allocator, options);
@@ -122,47 +129,38 @@ pub fn transform<'a>(
 /// Containing the semantic borrow inside this call is what lets `transform`
 /// write the result back into its `&mut program` afterwards.
 fn compile<'a>(
-    program: &oxc_ast::ast::Program<'a>,
-    allocator: &'a oxc_allocator::Allocator,
+    program: &Program<'a>,
+    allocator: &'a Allocator,
     options: PluginOptions,
-) -> (Option<oxc_ast::ast::Program<'a>>, oxc_diagnostics::Diagnostics, Vec<LoggerEvent>) {
+) -> (Option<Program<'a>>, Diagnostics, Vec<LoggerEvent>) {
     let source_text = program.source_text;
 
     // Skip files with no React-like functions, unless the mode compiles everything.
     if !matches!(options.compilation_mode.as_str(), "all" | "annotation")
         && !has_react_like_functions(program)
     {
-        return (None, oxc_diagnostics::Diagnostics::default(), Vec::new());
+        return (None, Diagnostics::default(), Vec::new());
     }
 
     // `using`/`await using` disposal semantics aren't preserved yet — skip the file.
     if has_resource_management_declarations(program) {
-        return (None, oxc_diagnostics::Diagnostics::default(), Vec::new());
+        return (None, Diagnostics::default(), Vec::new());
     }
 
-    let semantic =
-        oxc_semantic::SemanticBuilder::new().with_build_nodes(true).build(program).semantic;
+    let semantic = SemanticBuilder::new().with_build_nodes(true).build(program).semantic;
 
     let file = convert_program(program, source_text);
     let scope_info = convert_scope_info(&semantic, program);
-    let result =
-        crate::react_compiler::entrypoint::program::compile_program(file, scope_info, options);
+    let result = compile_program(file, scope_info, options);
 
     let diagnostics = compile_result_to_diagnostics(&result);
     let (program_ast, events) = match result {
-        crate::react_compiler::entrypoint::compile_result::CompileResult::Success {
-            ast,
-            events,
-            ..
-        } => (ast, events),
-        crate::react_compiler::entrypoint::compile_result::CompileResult::Error {
-            events, ..
-        } => (None, events),
+        CompileResult::Success { ast, events, .. } => (ast, events),
+        CompileResult::Error { events, .. } => (None, events),
     };
 
-    let compiled = program_ast.map(|file: crate::react_compiler_ast::File| {
-        let mut compiled =
-            convert_ast_reverse::convert_program_to_oxc_with_source(&file, allocator, source_text);
+    let compiled = program_ast.map(|file: File| {
+        let mut compiled = convert_program_to_oxc_with_source(&file, allocator, source_text);
         compiled.source_type = program.source_type;
         preserve_comments(&mut compiled, program, allocator);
         compiled
@@ -176,9 +174,9 @@ fn compile<'a>(
 /// drops comments, so we reuse the ones from the original `source` program
 /// (already parsed) rather than re-parsing the source.
 fn preserve_comments<'a>(
-    compiled: &mut oxc_ast::ast::Program<'a>,
-    source: &oxc_ast::ast::Program<'a>,
-    allocator: &'a oxc_allocator::Allocator,
+    compiled: &mut Program<'a>,
+    source: &Program<'a>,
+    allocator: &'a Allocator,
 ) {
     // Keep only comments attached to a top-level statement; inner comments have
     // `attached_to` positions that match no top-level statement.
@@ -209,23 +207,23 @@ fn preserve_comments<'a>(
 /// the (possibly rewritten) program together with the result.
 pub fn transform_source<'a>(
     source_text: &'a str,
-    source_type: oxc_span::SourceType,
-    allocator: &'a oxc_allocator::Allocator,
+    source_type: SourceType,
+    allocator: &'a Allocator,
     options: PluginOptions,
-) -> (oxc_ast::ast::Program<'a>, TransformResult) {
-    let mut program = oxc_parser::Parser::new(allocator, source_text, source_type).parse().program;
+) -> (Program<'a>, TransformResult) {
+    let mut program = Parser::new(allocator, source_text, source_type).parse().program;
     let result = transform(&mut program, allocator, options);
     (program, result)
 }
 
 /// Lint a pre-parsed program — like [`transform`] but read-only: it collects
 /// diagnostics without rewriting the program.
-pub fn lint(program: &oxc_ast::ast::Program, options: PluginOptions) -> LintResult {
+pub fn lint(program: &Program, options: PluginOptions) -> LintResult {
     let mut options = options;
     options.no_emit = true;
 
     // `no_emit` produces no program; a local arena for the conversion suffices.
-    let allocator = oxc_allocator::Allocator::default();
+    let allocator = Allocator::default();
     let (_program, diagnostics, _events) = compile(program, &allocator, options);
     LintResult { diagnostics }
 }
@@ -233,11 +231,11 @@ pub fn lint(program: &oxc_ast::ast::Program, options: PluginOptions) -> LintResu
 /// Convenience wrapper — parses source text, runs semantic analysis, then lints.
 pub fn lint_source(
     source_text: &str,
-    source_type: oxc_span::SourceType,
+    source_type: SourceType,
     options: PluginOptions,
 ) -> LintResult {
-    let allocator = oxc_allocator::Allocator::default();
-    let parsed = oxc_parser::Parser::new(&allocator, source_text, source_type).parse();
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source_text, source_type).parse();
     lint(&parsed.program, options)
 }
 
@@ -245,10 +243,14 @@ pub fn lint_source(
 // back -> codegen.
 #[cfg(test)]
 mod tests {
-    use crate::react_compiler::entrypoint::plugin_options::PluginOptions;
+    use oxc_allocator::Allocator;
     use oxc_ast::ast::{ModuleExportName, Statement};
+    use oxc_codegen::Codegen;
+    use oxc_semantic::SemanticBuilder;
+    use oxc_span::SourceType;
 
     use super::transform_source;
+    use crate::react_compiler::entrypoint::plugin_options::PluginOptions;
 
     fn options() -> PluginOptions {
         // The upstream options type is constructed typed (it has no `Deserialize`);
@@ -264,9 +266,8 @@ mod tests {
         let source = "function Component(props) {\n  \
             return <div onClick={() => props.onClick()}>{props.text}</div>;\n}\n";
 
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
 
         assert!(!result.diagnostics.has_errors(), "unexpected errors: {:?}", result.diagnostics);
         assert!(
@@ -276,7 +277,7 @@ mod tests {
         );
         assert!(result.changed, "React Compiler should have transformed the component");
 
-        let output = oxc_codegen::Codegen::new().build(&program).code;
+        let output = Codegen::new().build(&program).code;
 
         assert!(
             output.contains("react/compiler-runtime"),
@@ -291,9 +292,8 @@ mod tests {
     #[test]
     fn skips_non_react_code() {
         let source = "function add(a, b) {\n  return a + b;\n}\n";
-        let allocator = oxc_allocator::Allocator::default();
-        let (_program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (_program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(!result.changed, "non-React code must not be transformed");
     }
 
@@ -313,15 +313,14 @@ class Brand {\n  #brand = 1;\n  static isBrand(obj: object) { return #brand in o
 function Component(props) {\n  return <div>{props.text}</div>;\n}\n\
 export = legacy;\n";
 
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(
             result.changed,
             "component should be compiled; diagnostics: {:?}",
             result.diagnostics
         );
-        let output = oxc_codegen::Codegen::new().build(&program).code;
+        let output = Codegen::new().build(&program).code;
         assert!(
             output.contains("react/compiler-runtime"),
             "expected compiler-runtime import in output:\n{output}"
@@ -352,8 +351,8 @@ export = legacy;\n";
         ];
         let opts = options();
         for source in cases {
-            let allocator = oxc_allocator::Allocator::default();
-            let _ = transform_source(source, oxc_span::SourceType::tsx(), &allocator, opts.clone());
+            let allocator = Allocator::default();
+            let _ = transform_source(source, SourceType::tsx(), &allocator, opts.clone());
         }
     }
 
@@ -364,11 +363,10 @@ export = legacy;\n";
         let source = "\
 class Store {\n  count = 0;\n  increment() {\n    this.count++;\n  }\n}\n\
 function Component(props) {\n  return <div>{props.text}</div>;\n}\n";
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(result.changed, "component should be compiled");
-        let output = oxc_codegen::Codegen::new().build(&program).code;
+        let output = Codegen::new().build(&program).code;
         assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
         assert!(output.contains("count = 0"), "class field lost:\n{output}");
         assert!(output.contains("increment("), "class method lost:\n{output}");
@@ -390,11 +388,10 @@ function helper() {\n\
 function Component(props) {\n\
   return <div>{props.text}</div>;\n\
 }\n";
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(result.changed, "component should be compiled");
-        let output = oxc_codegen::Codegen::new().build(&program).code;
+        let output = Codegen::new().build(&program).code;
 
         assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
         assert!(output.contains("import \"./style.css\";"), "bare import changed:\n{output}");
@@ -444,11 +441,10 @@ function Component(props: Props): JSX.Element {\n\
   </Context.Provider>;\n\
 }\n";
 
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(result.changed, "component should compile; diagnostics: {:?}", result.diagnostics);
-        let output = oxc_codegen::Codegen::new().build(&program).code;
+        let output = Codegen::new().build(&program).code;
 
         assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
         assert!(output.contains("as const"), "`as const` lost:\n{output}");
@@ -492,11 +488,10 @@ function Component({ fields }: { fields: Field[] }) {\n\
   return <>{nodes}{field.value}</>;\n\
 }\n";
 
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(result.changed, "component should be compiled");
-        let output = oxc_codegen::Codegen::new().build(&program).code;
+        let output = Codegen::new().build(&program).code;
 
         assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
         assert!(
@@ -516,11 +511,10 @@ function Component(props) {\n\
   return <TemplateLinkSection label={props.label} piiWarning='Use the iframe&apos;s payload.' />;\n\
 }\n";
 
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(result.changed, "component should be compiled");
-        let output = oxc_codegen::Codegen::new().build(&program).code;
+        let output = Codegen::new().build(&program).code;
 
         assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
         assert!(
@@ -543,9 +537,9 @@ async function Component(props) {\n  await using x = sideEffect();\n  return <di
         ];
 
         for source in cases {
-            let allocator = oxc_allocator::Allocator::default();
+            let allocator = Allocator::default();
             let (_program, result) =
-                transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+                transform_source(source, SourceType::tsx(), &allocator, options());
 
             assert!(!result.changed, "resource management should skip React Compiler");
             assert!(
@@ -562,11 +556,10 @@ async function Component(props) {\n  await using x = sideEffect();\n  return <di
 export enum E { A }\n\
 export namespace N {\n  export const value = E.A;\n}\n\
 function Component(props) {\n  return <div>{E.A}{N.value}{props.text}</div>;\n}\n";
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(result.changed, "component should be compiled");
-        let output = oxc_codegen::Codegen::new().build(&program).code;
+        let output = Codegen::new().build(&program).code;
 
         assert!(output.contains("export enum E"), "exported enum lost:\n{output}");
         assert!(output.contains("A"), "enum member lost:\n{output}");
@@ -588,9 +581,8 @@ function Component(props) {\n  return <div>{E.A}{N.value}{props.text}</div>;\n}\
 import { Foo } from './foo';\n\
 export { Foo };\n\
 function Component(props) {\n  return <div>{props.text}</div>;\n}\n";
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(result.changed, "component should be compiled");
 
         let export = program
@@ -609,7 +601,7 @@ function Component(props) {\n  return <div>{props.text}</div>;\n}\n";
 
         // The freshly-built scoping for the compiled program must record the
         // export's reference to the import, or import elision would drop it.
-        let semantic = oxc_semantic::SemanticBuilder::new().build(&program).semantic;
+        let semantic = SemanticBuilder::new().build(&program).semantic;
         let scoping = semantic.scoping();
         let foo = scoping
             .symbol_ids()
@@ -625,11 +617,10 @@ function Component(props) {\n  return <div>{props.text}</div>;\n}\n";
     #[test]
     fn memo_wrapped_component_compiles() {
         let source = "React.memo((props) => {\n  return <div>{props.text}</div>;\n});\n";
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(result.changed, "memo-wrapped component should compile");
-        let output = oxc_codegen::Codegen::new().build(&program).code;
+        let output = Codegen::new().build(&program).code;
         assert!(output.contains("react/compiler-runtime"), "should memoize:\n{output}");
         assert!(output.contains("_c("), "expected memo cache reads:\n{output}");
     }
@@ -639,9 +630,8 @@ function Component(props) {\n  return <div>{props.text}</div>;\n}\n";
     fn diagnostics_preserve_compiler_severity() {
         // A Rules of Hooks violation is an `Error`-severity diagnostic.
         let source = "function Component(props) {\n  if (props.cond) {\n    useState(0);\n  }\n  return <div>{props.text}</div>;\n}\n";
-        let allocator = oxc_allocator::Allocator::default();
-        let (_program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (_program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(
             result.diagnostics.has_errors(),
             "Rules of Hooks violation should be reported as an error: {:?}",
@@ -650,9 +640,8 @@ function Component(props) {\n  return <div>{props.text}</div>;\n}\n";
 
         // A local named `fbt` is an unsupported-syntax bail-out — a warning, not an error.
         let source = "function Component() {\n  const fbt = \"span\";\n  return <fbt desc=\"label\">Hello</fbt>;\n}\n";
-        let allocator = oxc_allocator::Allocator::default();
-        let (_program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (_program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(
             result.diagnostics.has_warnings(),
             "fbt bail-out should be reported as a warning: {:?}",
@@ -681,11 +670,10 @@ function Component(props) {\n\
 // keep: trailing\n\
 export default Component;\n";
 
-        let allocator = oxc_allocator::Allocator::default();
-        let (program, result) =
-            transform_source(source, oxc_span::SourceType::tsx(), &allocator, options());
+        let allocator = Allocator::default();
+        let (program, result) = transform_source(source, SourceType::tsx(), &allocator, options());
         assert!(result.changed, "component should be compiled");
-        let output = oxc_codegen::Codegen::new().build(&program).code;
+        let output = Codegen::new().build(&program).code;
 
         assert!(output.contains("react/compiler-runtime"), "component should memoize:\n{output}");
         assert!(output.contains("// keep: leading"), "leading comment lost:\n{output}");

--- a/crates/oxc_react_compiler/src/lib.rs
+++ b/crates/oxc_react_compiler/src/lib.rs
@@ -8,33 +8,34 @@ pub mod prefilter;
 
 // Vendored React Compiler core crates (from oxc-project/forked-react-compiler),
 // each crate flattened to a module. Kept near byte-for-byte with upstream for easy
-// re-syncing, so lints are relaxed here rather than editing the vendored code. They
-// are `pub` so the public API may name types that originate inside them (e.g.
-// `TransformResult::events`), which also keeps `dead_code` quiet on the parts the
-// conversion layer doesn't reach.
-#[allow(clippy::all, dead_code, unused)]
+// re-syncing, so `clippy::all` is relaxed here rather than editing the vendored code.
+// They are `pub` so the public API may name types that originate inside them (e.g.
+// `TransformResult::events`); being `pub` also keeps `dead_code` quiet on the parts
+// the conversion layer doesn't reach, so only the few genuinely-dead private items
+// carry their own targeted `#[allow(dead_code)]`.
+#[allow(clippy::all)]
 pub mod react_compiler;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_ast;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_diagnostics;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_hir;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_inference;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_lowering;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_optimization;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_reactive_scopes;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_ssa;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_typeinference;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_utils;
-#[allow(clippy::all, dead_code, unused)]
+#[allow(clippy::all)]
 pub mod react_compiler_validation;
 
 use crate::react_compiler::entrypoint::compile_result::LoggerEvent;
@@ -49,6 +50,7 @@ pub use crate::react_compiler::entrypoint::plugin_options::{
 };
 pub use crate::react_compiler_hir::environment_config::EnvironmentConfig;
 
+use oxc_span::GetSpan;
 use rustc_hash::FxHashSet;
 
 /// [`PluginOptions`] with the compiler's standard defaults (it has no `Default`).
@@ -183,7 +185,6 @@ fn preserve_comments<'a>(
     let mut top_level_starts = FxHashSet::default();
     top_level_starts.insert(0u32);
     for stmt in &compiled.body {
-        use oxc_span::GetSpan;
         let start = stmt.span().start;
         if start > 0 {
             top_level_starts.insert(start);
@@ -245,6 +246,7 @@ pub fn lint_source(
 #[cfg(test)]
 mod tests {
     use crate::react_compiler::entrypoint::plugin_options::PluginOptions;
+    use oxc_ast::ast::{ModuleExportName, Statement};
 
     use super::transform_source;
 
@@ -582,8 +584,6 @@ function Component(props) {\n  return <div>{E.A}{N.value}{props.text}</div>;\n}\
     /// keeps the import alive instead of leaving a dangling export.
     #[test]
     fn local_reexport_keeps_its_import_binding() {
-        use oxc_ast::ast::{ModuleExportName, Statement};
-
         let source = "\
 import { Foo } from './foo';\n\
 export { Foo };\n\

--- a/crates/oxc_react_compiler/src/prefilter.rs
+++ b/crates/oxc_react_compiler/src/prefilter.rs
@@ -4,9 +4,11 @@
 // LICENSE file in the root directory of this source tree.
 
 use oxc_ast::ast::{
-    AssignmentTarget, CallExpression, Expression, Function, Program, VariableDeclarator,
+    ArrowFunctionExpression, AssignmentExpression, AssignmentTarget, BindingPattern,
+    CallExpression, Class, Expression, Function, Program, VariableDeclaration, VariableDeclarator,
 };
 use oxc_ast_visit::{Visit, walk};
+use oxc_semantic::ScopeFlags;
 
 /// Whether the program contains a component (Uppercase name) or hook (`use[A-Z0-9]`).
 pub fn has_react_like_functions(program: &Program) -> bool {
@@ -44,7 +46,7 @@ struct ResourceManagementVisitor {
 }
 
 impl<'a> Visit<'a> for ResourceManagementVisitor {
-    fn visit_variable_declaration(&mut self, decl: &oxc_ast::ast::VariableDeclaration<'a>) {
+    fn visit_variable_declaration(&mut self, decl: &VariableDeclaration<'a>) {
         if self.found {
             return;
         }
@@ -63,7 +65,7 @@ impl<'a> Visit<'a> for ReactLikeVisitor<'a> {
         }
 
         let name = match &decl.id {
-            oxc_ast::ast::BindingPattern::BindingIdentifier(ident) => Some(ident.name.as_str()),
+            BindingPattern::BindingIdentifier(ident) => Some(ident.name.as_str()),
             _ => None,
         };
 
@@ -77,7 +79,7 @@ impl<'a> Visit<'a> for ReactLikeVisitor<'a> {
         self.current_name = prev_name;
     }
 
-    fn visit_assignment_expression(&mut self, expr: &oxc_ast::ast::AssignmentExpression<'a>) {
+    fn visit_assignment_expression(&mut self, expr: &AssignmentExpression<'a>) {
         if self.found {
             return;
         }
@@ -95,7 +97,7 @@ impl<'a> Visit<'a> for ReactLikeVisitor<'a> {
         self.current_name = prev_name;
     }
 
-    fn visit_function(&mut self, func: &Function<'a>, _flags: oxc_semantic::ScopeFlags) {
+    fn visit_function(&mut self, func: &Function<'a>, _flags: ScopeFlags) {
         if self.found {
             return;
         }
@@ -119,10 +121,7 @@ impl<'a> Visit<'a> for ReactLikeVisitor<'a> {
         // Don't traverse into the function body
     }
 
-    fn visit_arrow_function_expression(
-        &mut self,
-        _expr: &oxc_ast::ast::ArrowFunctionExpression<'a>,
-    ) {
+    fn visit_arrow_function_expression(&mut self, _expr: &ArrowFunctionExpression<'a>) {
         if self.found {
             return;
         }
@@ -159,7 +158,7 @@ impl<'a> Visit<'a> for ReactLikeVisitor<'a> {
         walk::walk_call_expression(self, call);
     }
 
-    fn visit_class(&mut self, _class: &oxc_ast::ast::Class<'a>) {
+    fn visit_class(&mut self, _class: &Class<'a>) {
         // Skip class bodies entirely
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler/debug_print.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/debug_print.rs
@@ -1,8 +1,10 @@
+use std::mem::take;
+
 use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::print::{self, PrintFormatter};
 use crate::react_compiler_hir::{
-    BasicBlock, BlockId, HirFunction, Instruction, ParamPattern, Place, Terminal,
+    BasicBlock, BlockId, HirFunction, Instruction, ParamPattern, Phi, Place, Terminal,
 };
 
 // =============================================================================
@@ -162,7 +164,7 @@ impl<'a> DebugPrinter<'a> {
     // Phi
     // =========================================================================
 
-    fn format_phi(&mut self, phi: &crate::react_compiler_hir::Phi) {
+    fn format_phi(&mut self, phi: &Phi) {
         self.fmt.line("Phi {");
         self.fmt.indent();
         self.fmt.format_place_field("place", &phi.place);
@@ -199,8 +201,8 @@ impl<'a> DebugPrinter<'a> {
                 let mut inner = DebugPrinter {
                     fmt: PrintFormatter {
                         env: fmt.env,
-                        seen_identifiers: std::mem::take(&mut fmt.seen_identifiers),
-                        seen_scopes: std::mem::take(&mut fmt.seen_scopes),
+                        seen_identifiers: take(&mut fmt.seen_identifiers),
+                        seen_scopes: take(&mut fmt.seen_scopes),
                         output: Vec::new(),
                         indent_level: fmt.indent_level,
                     },
@@ -571,8 +573,8 @@ pub fn format_hir_function_into(reactive_fmt: &mut PrintFormatter, func: &HirFun
     let mut printer = DebugPrinter {
         fmt: PrintFormatter {
             env: reactive_fmt.env,
-            seen_identifiers: std::mem::take(&mut reactive_fmt.seen_identifiers),
-            seen_scopes: std::mem::take(&mut reactive_fmt.seen_scopes),
+            seen_identifiers: take(&mut reactive_fmt.seen_identifiers),
+            seen_scopes: take(&mut reactive_fmt.seen_scopes),
             output: Vec::new(),
             indent_level: reactive_fmt.indent_level,
         },

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/gating.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/gating.rs
@@ -8,9 +8,13 @@
 //
 // Ported from `Entrypoint/Gating.ts`.
 
+use crate::react_compiler_ast::Program;
 use crate::react_compiler_ast::common::BaseNode;
+use crate::react_compiler_ast::declarations::{
+    Declaration, ExportDefaultDecl, ExportDefaultDeclaration,
+};
 use crate::react_compiler_ast::expressions::*;
-use crate::react_compiler_ast::patterns::PatternLike;
+use crate::react_compiler_ast::patterns::{PatternLike, RestElement};
 use crate::react_compiler_ast::statements::*;
 use crate::react_compiler_diagnostics::CompilerDiagnostic;
 use crate::react_compiler_diagnostics::ErrorCategory;
@@ -49,7 +53,7 @@ pub struct GatingRewrite {
 /// but batched: all rewrites are collected first, then applied in reverse
 /// index order to maintain validity of earlier indices.
 pub fn apply_gating_rewrites(
-    program: &mut crate::react_compiler_ast::Program,
+    program: &mut Program,
     mut rewrites: Vec<GatingRewrite>,
     context: &mut ProgramContext,
 ) -> Result<(), CompilerDiagnostic> {
@@ -133,34 +137,27 @@ pub fn apply_gating_rewrites(
                         kind: VariableDeclarationKind::Const,
                         declare: None,
                     });
-                    let re_export = Statement::ExportDefaultDeclaration(
-                        crate::react_compiler_ast::declarations::ExportDefaultDeclaration {
-                            base: BaseNode::default(),
-                            declaration: Box::new(
-                                crate::react_compiler_ast::declarations::ExportDefaultDecl::Expression(
-                                    Box::new(Expression::Identifier(make_identifier(&fn_name))),
-                                ),
-                            ),
-                            export_kind: None,
-                        },
-                    );
+                    let re_export = Statement::ExportDefaultDeclaration(ExportDefaultDeclaration {
+                        base: BaseNode::default(),
+                        declaration: Box::new(ExportDefaultDecl::Expression(Box::new(
+                            Expression::Identifier(make_identifier(&fn_name)),
+                        ))),
+                        export_kind: None,
+                    });
                     // Replace the original statement with the var decl, then insert re-export after
                     program.body[rewrite.original_index] = var_decl;
                     program.body.insert(rewrite.original_index + 1, re_export);
                 } else {
                     // Anonymous export default or arrow: replace the declaration content
                     // with the conditional expression
-                    let export_default = Statement::ExportDefaultDeclaration(
-                        crate::react_compiler_ast::declarations::ExportDefaultDeclaration {
+                    let export_default =
+                        Statement::ExportDefaultDeclaration(ExportDefaultDeclaration {
                             base: BaseNode::default(),
-                            declaration: Box::new(
-                                crate::react_compiler_ast::declarations::ExportDefaultDecl::Expression(
-                                    Box::new(gating_expression),
-                                ),
-                            ),
+                            declaration: Box::new(ExportDefaultDecl::Expression(Box::new(
+                                gating_expression,
+                            ))),
                             export_kind: None,
-                        },
-                    );
+                        });
                     program.body[rewrite.original_index] = export_default;
                 }
             }
@@ -200,10 +197,7 @@ fn insert_additional_function_declaration(
         Statement::FunctionDeclaration(fd) => fd.clone(),
         Statement::ExportNamedDeclaration(end) => {
             if let Some(decl) = &end.declaration {
-                if let crate::react_compiler_ast::declarations::Declaration::FunctionDeclaration(
-                    fd,
-                ) = decl.as_ref()
-                {
+                if let Declaration::FunctionDeclaration(fd) = decl.as_ref() {
                     fd.clone()
                 } else {
                     return Err(CompilerDiagnostic::new(
@@ -266,14 +260,12 @@ fn insert_additional_function_declaration(
         let arg_name = format!("arg{}", i);
         match param {
             PatternLike::RestElement(_) => {
-                new_params.push(PatternLike::RestElement(
-                    crate::react_compiler_ast::patterns::RestElement {
-                        base: BaseNode::default(),
-                        argument: Box::new(PatternLike::Identifier(make_identifier(&arg_name))),
-                        type_annotation: None,
-                        decorators: None,
-                    },
-                ));
+                new_params.push(PatternLike::RestElement(RestElement {
+                    base: BaseNode::default(),
+                    argument: Box::new(PatternLike::Identifier(make_identifier(&arg_name))),
+                    type_annotation: None,
+                    decorators: None,
+                }));
                 new_args_optimized.push(Expression::SpreadElement(SpreadElement {
                     base: BaseNode::default(),
                     argument: Box::new(Expression::Identifier(make_identifier(&arg_name))),
@@ -465,9 +457,7 @@ fn get_fn_decl_name(stmt: &Statement) -> Option<String> {
 fn get_fn_decl_name_from_export_default(stmt: &Statement) -> Option<String> {
     match stmt {
         Statement::ExportDefaultDeclaration(ed) => match ed.declaration.as_ref() {
-            crate::react_compiler_ast::declarations::ExportDefaultDecl::FunctionDeclaration(fd) => {
-                fd.id.as_ref().map(|id| id.name.clone())
-            }
+            ExportDefaultDecl::FunctionDeclaration(fd) => fd.id.as_ref().map(|id| id.name.clone()),
             _ => None,
         },
         _ => None,
@@ -497,24 +487,22 @@ fn extract_function_node_from_stmt(
             )),
         },
         Statement::ExportDefaultDeclaration(ed) => match ed.declaration.as_ref() {
-            crate::react_compiler_ast::declarations::ExportDefaultDecl::FunctionDeclaration(fd) => {
+            ExportDefaultDecl::FunctionDeclaration(fd) => {
                 Ok(CompiledFunctionNode::FunctionDeclaration(fd.clone()))
             }
-            crate::react_compiler_ast::declarations::ExportDefaultDecl::Expression(expr) => {
-                match expr.as_ref() {
-                    Expression::ArrowFunctionExpression(arrow) => {
-                        Ok(CompiledFunctionNode::ArrowFunctionExpression(arrow.clone()))
-                    }
-                    Expression::FunctionExpression(fe) => {
-                        Ok(CompiledFunctionNode::FunctionExpression(fe.clone()))
-                    }
-                    _ => Err(CompilerDiagnostic::new(
-                        ErrorCategory::Invariant,
-                        "Expected function expression in export default for gating",
-                        None,
-                    )),
+            ExportDefaultDecl::Expression(expr) => match expr.as_ref() {
+                Expression::ArrowFunctionExpression(arrow) => {
+                    Ok(CompiledFunctionNode::ArrowFunctionExpression(arrow.clone()))
                 }
-            }
+                Expression::FunctionExpression(fe) => {
+                    Ok(CompiledFunctionNode::FunctionExpression(fe.clone()))
+                }
+                _ => Err(CompilerDiagnostic::new(
+                    ErrorCategory::Invariant,
+                    "Expected function expression in export default for gating",
+                    None,
+                )),
+            },
             _ => Err(CompilerDiagnostic::new(
                 ErrorCategory::Invariant,
                 "Expected function in export default declaration for gating",
@@ -561,10 +549,7 @@ fn rename_fn_decl_at(
         }
         Statement::ExportNamedDeclaration(end) => {
             if let Some(decl) = &mut end.declaration {
-                if let crate::react_compiler_ast::declarations::Declaration::FunctionDeclaration(
-                    fd,
-                ) = decl.as_mut()
-                {
+                if let Declaration::FunctionDeclaration(fd) = decl.as_mut() {
                     fd.id = Some(make_identifier(new_name));
                 }
             }

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/imports.rs
@@ -23,6 +23,7 @@ use crate::react_compiler_ast::{Program, SourceType};
 use crate::react_compiler_diagnostics::{
     CompilerError, CompilerErrorDetail, ErrorCategory, Position, SourceLocation,
 };
+use crate::react_compiler_hir::environment::BindingRename;
 
 use super::compile_result::{DebugLogEntry, LoggerEvent, OrderedLogItem};
 use super::plugin_options::{CompilerTarget, PluginOptions};
@@ -63,7 +64,7 @@ pub struct ProgramContext {
     pub hook_guard_name: Option<String>,
 
     // Variable renames from lowering, to be applied back to the Babel AST
-    pub renames: Vec<crate::react_compiler_hir::environment::BindingRename>,
+    pub renames: Vec<BindingRename>,
 
     /// Timing data for profiling. Accumulates across all function compilations.
     pub timing: TimingData,

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -10,17 +10,100 @@
 
 use rustc_hash::FxHashMap;
 
+use crate::react_compiler_ast::common::BaseNode;
 use crate::react_compiler_ast::expressions::*;
+use crate::react_compiler_ast::jsx::JSXAttributeItem;
+use crate::react_compiler_ast::jsx::JSXAttributeValue;
+use crate::react_compiler_ast::jsx::JSXChild;
+use crate::react_compiler_ast::jsx::JSXElementName;
+use crate::react_compiler_ast::jsx::JSXExpressionContainerExpr;
+use crate::react_compiler_ast::jsx::JSXMemberExprObject;
+use crate::react_compiler_ast::jsx::JSXMemberExpression;
+use crate::react_compiler_ast::patterns::ObjectPatternProperty;
 use crate::react_compiler_ast::patterns::PatternLike;
 use crate::react_compiler_ast::scope::*;
+use crate::react_compiler_ast::statements::BlockStatement;
+use crate::react_compiler_ast::statements::FunctionDeclaration;
 use crate::react_compiler_ast::statements::Statement;
+use crate::react_compiler_diagnostics::CompilerDiagnosticDetail;
 use crate::react_compiler_diagnostics::CompilerError;
+use crate::react_compiler_diagnostics::CompilerErrorDetail;
+use crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic;
+use crate::react_compiler_diagnostics::ErrorCategory;
+use crate::react_compiler_hir::HirFunction;
 use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::environment::OutputMode;
 use crate::react_compiler_hir::environment_config::EnvironmentConfig;
+use crate::react_compiler_hir::print::PrintFormatter;
+use crate::react_compiler_inference::align_method_call_scopes;
+use crate::react_compiler_inference::align_object_method_scopes;
+use crate::react_compiler_inference::align_reactive_scopes_to_block_scopes_hir;
+use crate::react_compiler_inference::analyse_functions;
+use crate::react_compiler_inference::build_reactive_scope_terminals_hir;
+use crate::react_compiler_inference::flatten_reactive_loops_hir;
+use crate::react_compiler_inference::flatten_scopes_with_hooks_or_use_hir;
+use crate::react_compiler_inference::infer_mutation_aliasing_effects;
+use crate::react_compiler_inference::infer_mutation_aliasing_ranges;
+use crate::react_compiler_inference::infer_reactive_places;
+use crate::react_compiler_inference::infer_reactive_scope_variables;
+use crate::react_compiler_inference::memoize_fbt_and_macro_operands_in_same_scope;
+use crate::react_compiler_inference::merge_overlapping_reactive_scopes_hir;
+use crate::react_compiler_inference::propagate_scope_dependencies_hir;
 use crate::react_compiler_lowering::FunctionNode;
+use crate::react_compiler_lowering::lower;
+use crate::react_compiler_optimization::constant_propagation;
+use crate::react_compiler_optimization::dead_code_elimination;
+use crate::react_compiler_optimization::drop_manual_memoization;
+use crate::react_compiler_optimization::inline_immediately_invoked_function_expressions;
+use crate::react_compiler_optimization::merge_consecutive_blocks::merge_consecutive_blocks;
+use crate::react_compiler_optimization::name_anonymous_functions;
+use crate::react_compiler_optimization::optimize_for_ssr;
+use crate::react_compiler_optimization::optimize_props_method_calls;
+use crate::react_compiler_optimization::outline_functions;
+use crate::react_compiler_optimization::outline_jsx;
+use crate::react_compiler_optimization::prune_maybe_throws;
+use crate::react_compiler_optimization::prune_unused_labels_hir;
+use crate::react_compiler_reactive_scopes::assert_scope_instructions_within_scopes;
+use crate::react_compiler_reactive_scopes::assert_well_formed_break_targets;
+use crate::react_compiler_reactive_scopes::build_reactive_function;
+use crate::react_compiler_reactive_scopes::codegen_function;
+use crate::react_compiler_reactive_scopes::extract_scope_declarations_from_destructuring;
+use crate::react_compiler_reactive_scopes::merge_reactive_scopes_that_invalidate_together;
+use crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter;
+use crate::react_compiler_reactive_scopes::promote_used_temporaries;
+use crate::react_compiler_reactive_scopes::propagate_early_returns;
+use crate::react_compiler_reactive_scopes::prune_always_invalidating_scopes;
+use crate::react_compiler_reactive_scopes::prune_hoisted_contexts;
+use crate::react_compiler_reactive_scopes::prune_non_escaping_scopes;
+use crate::react_compiler_reactive_scopes::prune_non_reactive_dependencies;
+use crate::react_compiler_reactive_scopes::prune_unused_labels;
+use crate::react_compiler_reactive_scopes::prune_unused_lvalues;
+use crate::react_compiler_reactive_scopes::prune_unused_scopes;
+use crate::react_compiler_reactive_scopes::rename_variables;
+use crate::react_compiler_reactive_scopes::stabilize_block_ids;
+use crate::react_compiler_ssa::eliminate_redundant_phi;
+use crate::react_compiler_ssa::enter_ssa;
+use crate::react_compiler_ssa::rewrite_instruction_kinds_based_on_reassignment;
+use crate::react_compiler_typeinference::infer_types;
 use crate::react_compiler_utils::FxIndexMap;
+use crate::react_compiler_validation::validate_context_variable_lvalues;
+use crate::react_compiler_validation::validate_exhaustive_dependencies;
+use crate::react_compiler_validation::validate_hooks_usage;
+use crate::react_compiler_validation::validate_locals_not_reassigned_after_render;
+use crate::react_compiler_validation::validate_no_capitalized_calls;
+use crate::react_compiler_validation::validate_no_derived_computations_in_effects;
+use crate::react_compiler_validation::validate_no_derived_computations_in_effects_exp;
+use crate::react_compiler_validation::validate_no_freezing_known_mutable_functions;
+use crate::react_compiler_validation::validate_no_jsx_in_try_statement;
+use crate::react_compiler_validation::validate_no_ref_access_in_render;
+use crate::react_compiler_validation::validate_no_set_state_in_effects;
+use crate::react_compiler_validation::validate_no_set_state_in_render;
+use crate::react_compiler_validation::validate_preserved_manual_memoization;
+use crate::react_compiler_validation::validate_static_components;
+use crate::react_compiler_validation::validate_use_memo;
+use std::mem::replace;
+use std::mem::take;
 
 use super::compile_result::CodegenFunction;
 use super::compile_result::CompilerErrorDetailInfo;
@@ -64,7 +147,7 @@ pub fn compile_fn(
     env.reference_node_ids = scope_info.ref_node_id_to_binding.keys().copied().collect();
 
     context.timing.start("lower");
-    let mut hir = crate::react_compiler_lowering::lower(func, fn_name, scope_info, &mut env)?;
+    let mut hir = lower(func, fn_name, scope_info, &mut env)?;
     context.timing.stop();
 
     // Copy renames from lowering to context (keep on env for codegen to apply to type annotations)
@@ -88,7 +171,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("PruneMaybeThrows");
-    crate::react_compiler_optimization::prune_maybe_throws(&mut hir, &mut env.functions)?;
+    prune_maybe_throws(&mut hir, &mut env.functions)?;
     context.timing.stop();
 
     if context.debug_enabled {
@@ -99,14 +182,14 @@ pub fn compile_fn(
     }
 
     context.timing.start("ValidateContextVariableLValues");
-    crate::react_compiler_validation::validate_context_variable_lvalues(&hir, &mut env)?;
+    validate_context_variable_lvalues(&hir, &mut env)?;
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new("ValidateContextVariableLValues", "ok".to_string()));
     }
     context.timing.stop();
 
     context.timing.start("ValidateUseMemo");
-    let void_memo_errors = crate::react_compiler_validation::validate_use_memo(&hir, &mut env);
+    let void_memo_errors = validate_use_memo(&hir, &mut env);
     log_errors_as_events(&void_memo_errors, context);
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new("ValidateUseMemo", "ok".to_string()));
@@ -114,7 +197,7 @@ pub fn compile_fn(
     context.timing.stop();
 
     context.timing.start("DropManualMemoization");
-    crate::react_compiler_optimization::drop_manual_memoization(&mut hir, &mut env)?;
+    drop_manual_memoization(&mut hir, &mut env)?;
     context.timing.stop();
 
     if context.debug_enabled {
@@ -125,9 +208,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("InlineImmediatelyInvokedFunctionExpressions");
-    crate::react_compiler_optimization::inline_immediately_invoked_function_expressions(
-        &mut hir, &mut env,
-    );
+    inline_immediately_invoked_function_expressions(&mut hir, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -141,10 +222,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("MergeConsecutiveBlocks");
-    crate::react_compiler_optimization::merge_consecutive_blocks::merge_consecutive_blocks(
-        &mut hir,
-        &mut env.functions,
-    );
+    merge_consecutive_blocks(&mut hir, &mut env.functions);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -164,10 +242,10 @@ pub fn compile_fn(
     }
 
     context.timing.start("EnterSSA");
-    crate::react_compiler_ssa::enter_ssa(&mut hir, &mut env).map_err(|diag| {
+    enter_ssa(&mut hir, &mut env).map_err(|diag| {
         let loc = diag.primary_location().cloned();
         let mut err = CompilerError::new();
-        err.push_error_detail(crate::react_compiler_diagnostics::CompilerErrorDetail {
+        err.push_error_detail(CompilerErrorDetail {
             category: diag.category,
             reason: diag.reason,
             description: diag.description,
@@ -186,7 +264,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("EliminateRedundantPhi");
-    crate::react_compiler_ssa::eliminate_redundant_phi(&mut hir, &mut env);
+    eliminate_redundant_phi(&mut hir, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -202,7 +280,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("ConstantPropagation");
-    crate::react_compiler_optimization::constant_propagation(&mut hir, &mut env);
+    constant_propagation(&mut hir, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -213,7 +291,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("InferTypes");
-    crate::react_compiler_typeinference::infer_types(&mut hir, &mut env)?;
+    infer_types(&mut hir, &mut env)?;
     context.timing.stop();
 
     if context.debug_enabled {
@@ -226,7 +304,7 @@ pub fn compile_fn(
     if env.enable_validations() {
         if env.config.validate_hooks_usage {
             context.timing.start("ValidateHooksUsage");
-            crate::react_compiler_validation::validate_hooks_usage(&hir, &mut env)?;
+            validate_hooks_usage(&hir, &mut env)?;
             if context.debug_enabled {
                 context.log_debug(DebugLogEntry::new("ValidateHooksUsage", "ok".to_string()));
             }
@@ -235,7 +313,7 @@ pub fn compile_fn(
 
         if env.config.validate_no_capitalized_calls.is_some() {
             context.timing.start("ValidateNoCapitalizedCalls");
-            crate::react_compiler_validation::validate_no_capitalized_calls(&hir, &mut env)?;
+            validate_no_capitalized_calls(&hir, &mut env)?;
             if context.debug_enabled {
                 context
                     .log_debug(DebugLogEntry::new("ValidateNoCapitalizedCalls", "ok".to_string()));
@@ -245,7 +323,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("OptimizePropsMethodCalls");
-    crate::react_compiler_optimization::optimize_props_method_calls(&mut hir, &env);
+    optimize_props_method_calls(&mut hir, &env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -258,15 +336,11 @@ pub fn compile_fn(
     context.timing.start("AnalyseFunctions");
     let mut inner_logs: Vec<String> = Vec::new();
     let debug_inner = context.debug_enabled;
-    let analyse_result = crate::react_compiler_inference::analyse_functions(
-        &mut hir,
-        &mut env,
-        &mut |inner_func, inner_env| {
-            if debug_inner {
-                inner_logs.push(debug_print::debug_hir(inner_func, inner_env));
-            }
-        },
-    );
+    let analyse_result = analyse_functions(&mut hir, &mut env, &mut |inner_func, inner_env| {
+        if debug_inner {
+            inner_logs.push(debug_print::debug_hir(inner_func, inner_env));
+        }
+    });
     context.timing.stop();
 
     // Always flush inner logs before propagating errors
@@ -290,7 +364,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("InferMutationAliasingEffects");
-    crate::react_compiler_inference::infer_mutation_aliasing_effects(&mut hir, &mut env, false)?;
+    infer_mutation_aliasing_effects(&mut hir, &mut env, false)?;
     context.timing.stop();
 
     if context.debug_enabled {
@@ -302,7 +376,7 @@ pub fn compile_fn(
 
     if env.output_mode == OutputMode::Ssr {
         context.timing.start("OptimizeForSSR");
-        crate::react_compiler_optimization::optimize_for_ssr(&mut hir, &env);
+        optimize_for_ssr(&mut hir, &env);
         context.timing.stop();
 
         if context.debug_enabled {
@@ -314,7 +388,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("DeadCodeElimination");
-    crate::react_compiler_optimization::dead_code_elimination(&mut hir, &env);
+    dead_code_elimination(&mut hir, &env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -325,7 +399,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("PruneMaybeThrows2");
-    crate::react_compiler_optimization::prune_maybe_throws(&mut hir, &mut env.functions)?;
+    prune_maybe_throws(&mut hir, &mut env.functions)?;
     context.timing.stop();
 
     if context.debug_enabled {
@@ -336,7 +410,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("InferMutationAliasingRanges");
-    crate::react_compiler_inference::infer_mutation_aliasing_ranges(&mut hir, &mut env, false)?;
+    infer_mutation_aliasing_ranges(&mut hir, &mut env, false)?;
     context.timing.stop();
 
     if context.debug_enabled {
@@ -348,9 +422,7 @@ pub fn compile_fn(
 
     if env.enable_validations() {
         context.timing.start("ValidateLocalsNotReassignedAfterRender");
-        crate::react_compiler_validation::validate_locals_not_reassigned_after_render(
-            &hir, &mut env,
-        );
+        validate_locals_not_reassigned_after_render(&hir, &mut env);
         if context.debug_enabled {
             context.log_debug(DebugLogEntry::new(
                 "ValidateLocalsNotReassignedAfterRender",
@@ -361,7 +433,7 @@ pub fn compile_fn(
 
         if env.config.validate_ref_access_during_render {
             context.timing.start("ValidateNoRefAccessInRender");
-            crate::react_compiler_validation::validate_no_ref_access_in_render(&hir, &mut env);
+            validate_no_ref_access_in_render(&hir, &mut env);
             if context.debug_enabled {
                 context
                     .log_debug(DebugLogEntry::new("ValidateNoRefAccessInRender", "ok".to_string()));
@@ -371,7 +443,7 @@ pub fn compile_fn(
 
         if env.config.validate_no_set_state_in_render {
             context.timing.start("ValidateNoSetStateInRender");
-            crate::react_compiler_validation::validate_no_set_state_in_render(&hir, &mut env)?;
+            validate_no_set_state_in_render(&hir, &mut env)?;
             if context.debug_enabled {
                 context
                     .log_debug(DebugLogEntry::new("ValidateNoSetStateInRender", "ok".to_string()));
@@ -383,10 +455,7 @@ pub fn compile_fn(
             && env.output_mode == OutputMode::Lint
         {
             context.timing.start("ValidateNoDerivedComputationsInEffects");
-            let errors =
-                crate::react_compiler_validation::validate_no_derived_computations_in_effects_exp(
-                    &hir, &env,
-                )?;
+            let errors = validate_no_derived_computations_in_effects_exp(&hir, &env)?;
             log_errors_as_events(&errors, context);
             if context.debug_enabled {
                 context.log_debug(DebugLogEntry::new(
@@ -397,9 +466,7 @@ pub fn compile_fn(
             context.timing.stop();
         } else if env.config.validate_no_derived_computations_in_effects {
             context.timing.start("ValidateNoDerivedComputationsInEffects");
-            crate::react_compiler_validation::validate_no_derived_computations_in_effects(
-                &hir, &mut env,
-            )?;
+            validate_no_derived_computations_in_effects(&hir, &mut env)?;
             if context.debug_enabled {
                 context.log_debug(DebugLogEntry::new(
                     "ValidateNoDerivedComputationsInEffects",
@@ -411,8 +478,7 @@ pub fn compile_fn(
 
         if env.config.validate_no_set_state_in_effects && env.output_mode == OutputMode::Lint {
             context.timing.start("ValidateNoSetStateInEffects");
-            let errors =
-                crate::react_compiler_validation::validate_no_set_state_in_effects(&hir, &env)?;
+            let errors = validate_no_set_state_in_effects(&hir, &env)?;
             log_errors_as_events(&errors, context);
             if context.debug_enabled {
                 context
@@ -423,7 +489,7 @@ pub fn compile_fn(
 
         if env.config.validate_no_jsx_in_try_statements && env.output_mode == OutputMode::Lint {
             context.timing.start("ValidateNoJSXInTryStatement");
-            let errors = crate::react_compiler_validation::validate_no_jsx_in_try_statement(&hir);
+            let errors = validate_no_jsx_in_try_statement(&hir);
             log_errors_as_events(&errors, context);
             if context.debug_enabled {
                 context
@@ -433,9 +499,7 @@ pub fn compile_fn(
         }
 
         context.timing.start("ValidateNoFreezingKnownMutableFunctions");
-        crate::react_compiler_validation::validate_no_freezing_known_mutable_functions(
-            &hir, &mut env,
-        );
+        validate_no_freezing_known_mutable_functions(&hir, &mut env);
         if context.debug_enabled {
             context.log_debug(DebugLogEntry::new(
                 "ValidateNoFreezingKnownMutableFunctions",
@@ -446,7 +510,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("InferReactivePlaces");
-    crate::react_compiler_inference::infer_reactive_places(&mut hir, &mut env)?;
+    infer_reactive_places(&mut hir, &mut env)?;
     context.timing.stop();
 
     if context.debug_enabled {
@@ -458,7 +522,7 @@ pub fn compile_fn(
 
     if env.enable_validations() {
         context.timing.start("ValidateExhaustiveDependencies");
-        crate::react_compiler_validation::validate_exhaustive_dependencies(&mut hir, &mut env)?;
+        validate_exhaustive_dependencies(&mut hir, &mut env)?;
         if context.debug_enabled {
             context
                 .log_debug(DebugLogEntry::new("ValidateExhaustiveDependencies", "ok".to_string()));
@@ -467,7 +531,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("RewriteInstructionKindsBasedOnReassignment");
-    crate::react_compiler_ssa::rewrite_instruction_kinds_based_on_reassignment(&mut hir, &env)?;
+    rewrite_instruction_kinds_based_on_reassignment(&mut hir, &env)?;
     context.timing.stop();
 
     if context.debug_enabled {
@@ -485,7 +549,7 @@ pub fn compile_fn(
         && env.output_mode == OutputMode::Lint
     {
         context.timing.start("ValidateStaticComponents");
-        let errors = crate::react_compiler_validation::validate_static_components(&hir);
+        let errors = validate_static_components(&hir);
         log_errors_as_events(&errors, context);
         if context.debug_enabled {
             context.log_debug(DebugLogEntry::new("ValidateStaticComponents", "ok".to_string()));
@@ -495,7 +559,7 @@ pub fn compile_fn(
 
     if env.enable_memoization() {
         context.timing.start("InferReactiveScopeVariables");
-        crate::react_compiler_inference::infer_reactive_scope_variables(&mut hir, &mut env)?;
+        infer_reactive_scope_variables(&mut hir, &mut env)?;
         context.timing.stop();
 
         if context.debug_enabled {
@@ -508,10 +572,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("MemoizeFbtAndMacroOperandsInSameScope");
-    let fbt_operands =
-        crate::react_compiler_inference::memoize_fbt_and_macro_operands_in_same_scope(
-            &hir, &mut env,
-        );
+    let fbt_operands = memoize_fbt_and_macro_operands_in_same_scope(&hir, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -523,13 +584,13 @@ pub fn compile_fn(
 
     if env.config.enable_jsx_outlining {
         context.timing.start("OutlineJsx");
-        crate::react_compiler_optimization::outline_jsx(&mut hir, &mut env);
+        outline_jsx(&mut hir, &mut env);
         context.timing.stop();
     }
 
     if env.config.enable_name_anonymous_functions {
         context.timing.start("NameAnonymousFunctions");
-        crate::react_compiler_optimization::name_anonymous_functions(&mut hir, &mut env);
+        name_anonymous_functions(&mut hir, &mut env);
         context.timing.stop();
 
         if context.debug_enabled {
@@ -542,7 +603,7 @@ pub fn compile_fn(
 
     if env.config.enable_function_outlining {
         context.timing.start("OutlineFunctions");
-        crate::react_compiler_optimization::outline_functions(&mut hir, &mut env, &fbt_operands);
+        outline_functions(&mut hir, &mut env, &fbt_operands);
         context.timing.stop();
 
         if context.debug_enabled {
@@ -554,7 +615,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("AlignMethodCallScopes");
-    crate::react_compiler_inference::align_method_call_scopes(&mut hir, &mut env);
+    align_method_call_scopes(&mut hir, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -565,7 +626,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("AlignObjectMethodScopes");
-    crate::react_compiler_inference::align_object_method_scopes(&mut hir, &mut env);
+    align_object_method_scopes(&mut hir, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -576,7 +637,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("PruneUnusedLabelsHIR");
-    crate::react_compiler_optimization::prune_unused_labels_hir(&mut hir);
+    prune_unused_labels_hir(&mut hir);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -587,7 +648,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("AlignReactiveScopesToBlockScopesHIR");
-    crate::react_compiler_inference::align_reactive_scopes_to_block_scopes_hir(&mut hir, &mut env);
+    align_reactive_scopes_to_block_scopes_hir(&mut hir, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -601,7 +662,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("MergeOverlappingReactiveScopesHIR");
-    crate::react_compiler_inference::merge_overlapping_reactive_scopes_hir(&mut hir, &mut env);
+    merge_overlapping_reactive_scopes_hir(&mut hir, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -620,7 +681,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("BuildReactiveScopeTerminalsHIR");
-    crate::react_compiler_inference::build_reactive_scope_terminals_hir(&mut hir, &mut env);
+    build_reactive_scope_terminals_hir(&mut hir, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -639,7 +700,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("FlattenReactiveLoopsHIR");
-    crate::react_compiler_inference::flatten_reactive_loops_hir(&mut hir);
+    flatten_reactive_loops_hir(&mut hir);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -650,7 +711,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("FlattenScopesWithHooksOrUseHIR");
-    crate::react_compiler_inference::flatten_scopes_with_hooks_or_use_hir(&mut hir, &env)?;
+    flatten_scopes_with_hooks_or_use_hir(&mut hir, &env)?;
     context.timing.stop();
 
     if context.debug_enabled {
@@ -671,7 +732,7 @@ pub fn compile_fn(
     }
 
     context.timing.start("PropagateScopeDependenciesHIR");
-    crate::react_compiler_inference::propagate_scope_dependencies_hir(&mut hir, &mut env);
+    propagate_scope_dependencies_hir(&mut hir, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
@@ -683,49 +744,42 @@ pub fn compile_fn(
     }
 
     context.timing.start("BuildReactiveFunction");
-    let mut reactive_fn =
-        crate::react_compiler_reactive_scopes::build_reactive_function(&hir, &env)?;
+    let mut reactive_fn = build_reactive_function(&hir, &env)?;
     context.timing.stop();
 
-    let hir_formatter = |fmt: &mut crate::react_compiler_hir::print::PrintFormatter,
-                         func: &crate::react_compiler_hir::HirFunction| {
+    let hir_formatter = |fmt: &mut PrintFormatter, func: &HirFunction| {
         debug_print::format_hir_function_into(fmt, func);
     };
 
     if context.debug_enabled {
         context.timing.start("debug_print:BuildReactiveFunction");
-        let debug_reactive = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug_reactive =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("BuildReactiveFunction", debug_reactive));
         context.timing.stop();
     }
 
     context.timing.start("AssertWellFormedBreakTargets");
-    crate::react_compiler_reactive_scopes::assert_well_formed_break_targets(&reactive_fn, &env);
+    assert_well_formed_break_targets(&reactive_fn, &env);
     if context.debug_enabled {
         context.log_debug(DebugLogEntry::new("AssertWellFormedBreakTargets", "ok".to_string()));
     }
     context.timing.stop();
 
     context.timing.start("PruneUnusedLabels");
-    crate::react_compiler_reactive_scopes::prune_unused_labels(&mut reactive_fn, &env)?;
+    prune_unused_labels(&mut reactive_fn, &env)?;
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:PruneUnusedLabels");
-        let debug_prune_labels_reactive = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug_prune_labels_reactive =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("PruneUnusedLabels", debug_prune_labels_reactive));
         context.timing.stop();
     }
 
     context.timing.start("AssertScopeInstructionsWithinScopes");
-    crate::react_compiler_reactive_scopes::assert_scope_instructions_within_scopes(
-        &reactive_fn,
-        &env,
-    )?;
+    assert_scope_instructions_within_scopes(&reactive_fn, &env)?;
     if context.debug_enabled {
         context
             .log_debug(DebugLogEntry::new("AssertScopeInstructionsWithinScopes", "ok".to_string()));
@@ -733,30 +787,25 @@ pub fn compile_fn(
     context.timing.stop();
 
     context.timing.start("PruneNonEscapingScopes");
-    crate::react_compiler_reactive_scopes::prune_non_escaping_scopes(&mut reactive_fn, &mut env)?;
+    prune_non_escaping_scopes(&mut reactive_fn, &mut env)?;
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:PruneNonEscapingScopes");
-        let debug = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("PruneNonEscapingScopes", debug));
         context.timing.stop();
     }
 
     context.timing.start("PruneNonReactiveDependencies");
-    crate::react_compiler_reactive_scopes::prune_non_reactive_dependencies(
-        &mut reactive_fn,
-        &mut env,
-    );
+    prune_non_reactive_dependencies(&mut reactive_fn, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:PruneNonReactiveDependencies");
-        let debug_prune_non_reactive = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug_prune_non_reactive =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new(
             "PruneNonReactiveDependencies",
             debug_prune_non_reactive,
@@ -765,122 +814,104 @@ pub fn compile_fn(
     }
 
     context.timing.start("PruneUnusedScopes");
-    crate::react_compiler_reactive_scopes::prune_unused_scopes(&mut reactive_fn, &env)?;
+    prune_unused_scopes(&mut reactive_fn, &env)?;
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:PruneUnusedScopes");
-        let debug_prune_unused_scopes = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug_prune_unused_scopes =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("PruneUnusedScopes", debug_prune_unused_scopes));
         context.timing.stop();
     }
 
     context.timing.start("MergeReactiveScopesThatInvalidateTogether");
-    crate::react_compiler_reactive_scopes::merge_reactive_scopes_that_invalidate_together(
-        &mut reactive_fn,
-        &mut env,
-    )?;
+    merge_reactive_scopes_that_invalidate_together(&mut reactive_fn, &mut env)?;
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:MergeReactiveScopesThatInvalidateTogether");
-        let debug = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("MergeReactiveScopesThatInvalidateTogether", debug));
         context.timing.stop();
     }
 
     context.timing.start("PruneAlwaysInvalidatingScopes");
-    crate::react_compiler_reactive_scopes::prune_always_invalidating_scopes(
-        &mut reactive_fn,
-        &env,
-    )?;
+    prune_always_invalidating_scopes(&mut reactive_fn, &env)?;
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:PruneAlwaysInvalidatingScopes");
-        let debug_prune_always_inv = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug_prune_always_inv =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context
             .log_debug(DebugLogEntry::new("PruneAlwaysInvalidatingScopes", debug_prune_always_inv));
         context.timing.stop();
     }
 
     context.timing.start("PropagateEarlyReturns");
-    crate::react_compiler_reactive_scopes::propagate_early_returns(&mut reactive_fn, &mut env);
+    propagate_early_returns(&mut reactive_fn, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:PropagateEarlyReturns");
-        let debug = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("PropagateEarlyReturns", debug));
         context.timing.stop();
     }
 
     context.timing.start("PruneUnusedLValues");
-    crate::react_compiler_reactive_scopes::prune_unused_lvalues(&mut reactive_fn, &env);
+    prune_unused_lvalues(&mut reactive_fn, &env);
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:PruneUnusedLValues");
-        let debug_prune_lvalues = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug_prune_lvalues =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("PruneUnusedLValues", debug_prune_lvalues));
         context.timing.stop();
     }
 
     context.timing.start("PromoteUsedTemporaries");
-    crate::react_compiler_reactive_scopes::promote_used_temporaries(&mut reactive_fn, &mut env);
+    promote_used_temporaries(&mut reactive_fn, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:PromoteUsedTemporaries");
-        let debug = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("PromoteUsedTemporaries", debug));
         context.timing.stop();
     }
 
     context.timing.start("ExtractScopeDeclarationsFromDestructuring");
-    crate::react_compiler_reactive_scopes::extract_scope_declarations_from_destructuring(
-        &mut reactive_fn,
-        &mut env,
-    )?;
+    extract_scope_declarations_from_destructuring(&mut reactive_fn, &mut env)?;
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:ExtractScopeDeclarationsFromDestructuring");
-        let debug = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("ExtractScopeDeclarationsFromDestructuring", debug));
         context.timing.stop();
     }
 
     context.timing.start("StabilizeBlockIds");
-    crate::react_compiler_reactive_scopes::stabilize_block_ids(&mut reactive_fn, &mut env);
+    stabilize_block_ids(&mut reactive_fn, &mut env);
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:StabilizeBlockIds");
-        let debug_stabilize = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug_stabilize =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("StabilizeBlockIds", debug_stabilize));
         context.timing.stop();
     }
 
     context.timing.start("RenameVariables");
-    let unique_identifiers =
-        crate::react_compiler_reactive_scopes::rename_variables(&mut reactive_fn, &mut env);
+    let unique_identifiers = rename_variables(&mut reactive_fn, &mut env);
     context.timing.stop();
 
     for name in &unique_identifiers {
@@ -889,22 +920,20 @@ pub fn compile_fn(
 
     if context.debug_enabled {
         context.timing.start("debug_print:RenameVariables");
-        let debug = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("RenameVariables", debug));
         context.timing.stop();
     }
 
     context.timing.start("PruneHoistedContexts");
-    crate::react_compiler_reactive_scopes::prune_hoisted_contexts(&mut reactive_fn, &mut env)?;
+    prune_hoisted_contexts(&mut reactive_fn, &mut env)?;
     context.timing.stop();
 
     if context.debug_enabled {
         context.timing.start("debug_print:PruneHoistedContexts");
-        let debug = crate::react_compiler_reactive_scopes::print_reactive_function::debug_reactive_function_with_formatter(
-            &reactive_fn, &env, Some(&hir_formatter),
-        );
+        let debug =
+            debug_reactive_function_with_formatter(&reactive_fn, &env, Some(&hir_formatter));
         context.log_debug(DebugLogEntry::new("PruneHoistedContexts", debug));
         context.timing.stop();
     }
@@ -913,10 +942,7 @@ pub fn compile_fn(
         || env.config.validate_preserve_existing_memoization_guarantees
     {
         context.timing.start("ValidatePreservedManualMemoization");
-        crate::react_compiler_validation::validate_preserved_manual_memoization(
-            &reactive_fn,
-            &mut env,
-        );
+        validate_preserved_manual_memoization(&reactive_fn, &mut env);
         if context.debug_enabled {
             context.log_debug(DebugLogEntry::new(
                 "ValidatePreservedManualMemoization",
@@ -927,12 +953,8 @@ pub fn compile_fn(
     }
 
     context.timing.start("codegen");
-    let codegen_result = crate::react_compiler_reactive_scopes::codegen_function(
-        &reactive_fn,
-        &mut env,
-        unique_identifiers,
-        fbt_operands,
-    )?;
+    let codegen_result =
+        codegen_function(&reactive_fn, &mut env, unique_identifiers, fbt_operands)?;
     context.timing.stop();
 
     // NOTE: we intentionally do NOT register the memo cache import here.
@@ -953,8 +975,8 @@ pub fn compile_fn(
     // Simulate unexpected exception for testing (matches TS Pipeline.ts)
     if env.config.throw_unknown_exception_testonly {
         let mut err = CompilerError::new();
-        err.push_error_detail(crate::react_compiler_diagnostics::CompilerErrorDetail {
-            category: crate::react_compiler_diagnostics::ErrorCategory::Invariant,
+        err.push_error_detail(CompilerErrorDetail {
+            category: ErrorCategory::Invariant,
             reason: "unexpected error".to_string(),
             description: None,
             loc: None,
@@ -1064,14 +1086,14 @@ pub fn compile_outlined_fn(
     };
 
     // Build a FunctionDeclaration from the codegen output
-    let mut outlined_decl = crate::react_compiler_ast::statements::FunctionDeclaration {
-        base: crate::react_compiler_ast::common::BaseNode::typed("FunctionDeclaration"),
+    let mut outlined_decl = FunctionDeclaration {
+        base: BaseNode::typed("FunctionDeclaration"),
         id: codegen_fn.id.take(),
-        params: std::mem::take(&mut codegen_fn.params),
-        body: std::mem::replace(
+        params: take(&mut codegen_fn.params),
+        body: replace(
             &mut codegen_fn.body,
-            crate::react_compiler_ast::statements::BlockStatement {
-                base: crate::react_compiler_ast::common::BaseNode::typed("BlockStatement"),
+            BlockStatement {
+                base: BaseNode::typed("BlockStatement"),
                 body: Vec::new(),
                 directives: Vec::new(),
             },
@@ -1089,10 +1111,8 @@ pub fn compile_outlined_fn(
     // Build scope info by assigning fake positions to all identifiers
     let scope_info = build_outlined_scope_info(&mut outlined_decl);
 
-    let func_node =
-        crate::react_compiler_lowering::FunctionNode::FunctionDeclaration(&outlined_decl);
-    let mut hir =
-        crate::react_compiler_lowering::lower(&func_node, fn_name, &scope_info, &mut env)?;
+    let func_node = FunctionNode::FunctionDeclaration(&outlined_decl);
+    let mut hir = lower(&func_node, fn_name, &scope_info, &mut env)?;
 
     if env.has_invariant_errors() {
         return Err(env.take_invariant_errors());
@@ -1103,9 +1123,7 @@ pub fn compile_outlined_fn(
 
 /// Build a ScopeInfo for an outlined function declaration by assigning unique
 /// fake positions to all Identifier nodes and building the binding/reference maps.
-fn build_outlined_scope_info(
-    func: &mut crate::react_compiler_ast::statements::FunctionDeclaration,
-) -> crate::react_compiler_ast::scope::ScopeInfo {
+fn build_outlined_scope_info(func: &mut FunctionDeclaration) -> ScopeInfo {
     let mut pos: u32 = 1; // reserve 0 for the function itself
     func.base.start = Some(0);
 
@@ -1200,12 +1218,12 @@ fn build_outlined_scope_info(
 
 /// Assign positions to identifiers in a pattern and register as bindings.
 fn outlined_assign_pattern_positions(
-    pattern: &mut crate::react_compiler_ast::patterns::PatternLike,
+    pattern: &mut PatternLike,
     pos: &mut u32,
-    kind: crate::react_compiler_ast::scope::BindingKind,
-    fn_bindings: &mut rustc_hash::FxHashMap<String, crate::react_compiler_ast::scope::BindingId>,
-    bindings_list: &mut Vec<crate::react_compiler_ast::scope::BindingData>,
-    ref_to_binding: &mut FxIndexMap<u32, crate::react_compiler_ast::scope::BindingId>,
+    kind: BindingKind,
+    fn_bindings: &mut FxHashMap<String, BindingId>,
+    bindings_list: &mut Vec<BindingData>,
+    ref_to_binding: &mut FxIndexMap<u32, BindingId>,
 ) {
     match pattern {
         PatternLike::Identifier(id) => {
@@ -1236,9 +1254,7 @@ fn outlined_assign_pattern_positions(
         PatternLike::ObjectPattern(obj) => {
             for prop in &mut obj.properties {
                 match prop {
-                    crate::react_compiler_ast::patterns::ObjectPatternProperty::ObjectProperty(
-                        p_inner,
-                    ) => {
+                    ObjectPatternProperty::ObjectProperty(p_inner) => {
                         outlined_assign_pattern_positions(
                             &mut p_inner.value,
                             pos,
@@ -1248,7 +1264,7 @@ fn outlined_assign_pattern_positions(
                             ref_to_binding,
                         );
                     }
-                    crate::react_compiler_ast::patterns::ObjectPatternProperty::RestElement(r) => {
+                    ObjectPatternProperty::RestElement(r) => {
                         outlined_assign_pattern_positions(
                             &mut r.argument,
                             pos,
@@ -1299,11 +1315,11 @@ fn outlined_assign_pattern_positions(
 
 /// Assign positions to identifiers in a statement body.
 fn outlined_assign_stmt_positions(
-    stmt: &mut crate::react_compiler_ast::statements::Statement,
+    stmt: &mut Statement,
     pos: &mut u32,
-    fn_bindings: &mut rustc_hash::FxHashMap<String, crate::react_compiler_ast::scope::BindingId>,
-    bindings_list: &mut Vec<crate::react_compiler_ast::scope::BindingData>,
-    ref_to_binding: &mut FxIndexMap<u32, crate::react_compiler_ast::scope::BindingId>,
+    fn_bindings: &mut FxHashMap<String, BindingId>,
+    bindings_list: &mut Vec<BindingData>,
+    ref_to_binding: &mut FxIndexMap<u32, BindingId>,
 ) {
     match stmt {
         Statement::VariableDeclaration(decl) => {
@@ -1316,7 +1332,7 @@ fn outlined_assign_stmt_positions(
                 outlined_assign_pattern_positions(
                     &mut declarator.id,
                     pos,
-                    crate::react_compiler_ast::scope::BindingKind::Let,
+                    BindingKind::Let,
                     fn_bindings,
                     bindings_list,
                     ref_to_binding,
@@ -1342,10 +1358,10 @@ fn outlined_assign_stmt_positions(
 
 /// Assign positions to identifiers in an expression.
 fn outlined_assign_expr_positions(
-    expr: &mut crate::react_compiler_ast::expressions::Expression,
+    expr: &mut Expression,
     pos: &mut u32,
-    fn_bindings: &rustc_hash::FxHashMap<String, crate::react_compiler_ast::scope::BindingId>,
-    ref_to_binding: &mut FxIndexMap<u32, crate::react_compiler_ast::scope::BindingId>,
+    fn_bindings: &FxHashMap<String, BindingId>,
+    ref_to_binding: &mut FxIndexMap<u32, BindingId>,
 ) {
     match expr {
         Expression::Identifier(id) => {
@@ -1367,7 +1383,7 @@ fn outlined_assign_expr_positions(
             );
             for attr in &mut jsx.opening_element.attributes {
                 match attr {
-                    crate::react_compiler_ast::jsx::JSXAttributeItem::JSXAttribute(a) => {
+                    JSXAttributeItem::JSXAttribute(a) => {
                         if let Some(val) = &mut a.value {
                             outlined_assign_jsx_val_positions(
                                 val,
@@ -1377,7 +1393,7 @@ fn outlined_assign_expr_positions(
                             );
                         }
                     }
-                    crate::react_compiler_ast::jsx::JSXAttributeItem::JSXSpreadAttribute(s) => {
+                    JSXAttributeItem::JSXSpreadAttribute(s) => {
                         outlined_assign_expr_positions(
                             &mut s.argument,
                             pos,
@@ -1401,13 +1417,13 @@ fn outlined_assign_expr_positions(
 }
 
 fn outlined_assign_jsx_name_positions(
-    name: &mut crate::react_compiler_ast::jsx::JSXElementName,
+    name: &mut JSXElementName,
     pos: &mut u32,
-    fn_bindings: &rustc_hash::FxHashMap<String, crate::react_compiler_ast::scope::BindingId>,
-    ref_to_binding: &mut FxIndexMap<u32, crate::react_compiler_ast::scope::BindingId>,
+    fn_bindings: &FxHashMap<String, BindingId>,
+    ref_to_binding: &mut FxIndexMap<u32, BindingId>,
 ) {
     match name {
-        crate::react_compiler_ast::jsx::JSXElementName::JSXIdentifier(id) => {
+        JSXElementName::JSXIdentifier(id) => {
             let p = *pos;
             *pos += 1;
             id.base.start = Some(p);
@@ -1416,7 +1432,7 @@ fn outlined_assign_jsx_name_positions(
                 ref_to_binding.insert(p, bid);
             }
         }
-        crate::react_compiler_ast::jsx::JSXElementName::JSXMemberExpression(m) => {
+        JSXElementName::JSXMemberExpression(m) => {
             outlined_assign_jsx_member_positions(m, pos, fn_bindings, ref_to_binding);
         }
         _ => {}
@@ -1424,13 +1440,13 @@ fn outlined_assign_jsx_name_positions(
 }
 
 fn outlined_assign_jsx_member_positions(
-    member: &mut crate::react_compiler_ast::jsx::JSXMemberExpression,
+    member: &mut JSXMemberExpression,
     pos: &mut u32,
-    fn_bindings: &rustc_hash::FxHashMap<String, crate::react_compiler_ast::scope::BindingId>,
-    ref_to_binding: &mut FxIndexMap<u32, crate::react_compiler_ast::scope::BindingId>,
+    fn_bindings: &FxHashMap<String, BindingId>,
+    ref_to_binding: &mut FxIndexMap<u32, BindingId>,
 ) {
     match &mut *member.object {
-        crate::react_compiler_ast::jsx::JSXMemberExprObject::JSXIdentifier(id) => {
+        JSXMemberExprObject::JSXIdentifier(id) => {
             let p = *pos;
             *pos += 1;
             id.base.start = Some(p);
@@ -1439,31 +1455,28 @@ fn outlined_assign_jsx_member_positions(
                 ref_to_binding.insert(p, bid);
             }
         }
-        crate::react_compiler_ast::jsx::JSXMemberExprObject::JSXMemberExpression(inner) => {
+        JSXMemberExprObject::JSXMemberExpression(inner) => {
             outlined_assign_jsx_member_positions(inner, pos, fn_bindings, ref_to_binding);
         }
     }
 }
 
 fn outlined_assign_jsx_val_positions(
-    val: &mut crate::react_compiler_ast::jsx::JSXAttributeValue,
+    val: &mut JSXAttributeValue,
     pos: &mut u32,
-    fn_bindings: &rustc_hash::FxHashMap<String, crate::react_compiler_ast::scope::BindingId>,
-    ref_to_binding: &mut FxIndexMap<u32, crate::react_compiler_ast::scope::BindingId>,
+    fn_bindings: &FxHashMap<String, BindingId>,
+    ref_to_binding: &mut FxIndexMap<u32, BindingId>,
 ) {
     match val {
-        crate::react_compiler_ast::jsx::JSXAttributeValue::JSXExpressionContainer(c) => {
-            if let crate::react_compiler_ast::jsx::JSXExpressionContainerExpr::Expression(e) =
-                &mut c.expression
-            {
+        JSXAttributeValue::JSXExpressionContainer(c) => {
+            if let JSXExpressionContainerExpr::Expression(e) = &mut c.expression {
                 outlined_assign_expr_positions(e, pos, fn_bindings, ref_to_binding);
             }
         }
-        crate::react_compiler_ast::jsx::JSXAttributeValue::JSXElement(el) => {
-            let mut expr =
-                crate::react_compiler_ast::expressions::Expression::JSXElement(el.clone());
+        JSXAttributeValue::JSXElement(el) => {
+            let mut expr = Expression::JSXElement(el.clone());
             outlined_assign_expr_positions(&mut expr, pos, fn_bindings, ref_to_binding);
-            if let crate::react_compiler_ast::expressions::Expression::JSXElement(new_el) = expr {
+            if let Expression::JSXElement(new_el) = expr {
                 **el = *new_el;
             }
         }
@@ -1472,29 +1485,25 @@ fn outlined_assign_jsx_val_positions(
 }
 
 fn outlined_assign_jsx_child_positions(
-    child: &mut crate::react_compiler_ast::jsx::JSXChild,
+    child: &mut JSXChild,
     pos: &mut u32,
-    fn_bindings: &rustc_hash::FxHashMap<String, crate::react_compiler_ast::scope::BindingId>,
-    ref_to_binding: &mut FxIndexMap<u32, crate::react_compiler_ast::scope::BindingId>,
+    fn_bindings: &FxHashMap<String, BindingId>,
+    ref_to_binding: &mut FxIndexMap<u32, BindingId>,
 ) {
     match child {
-        crate::react_compiler_ast::jsx::JSXChild::JSXExpressionContainer(c) => {
-            if let crate::react_compiler_ast::jsx::JSXExpressionContainerExpr::Expression(e) =
-                &mut c.expression
-            {
+        JSXChild::JSXExpressionContainer(c) => {
+            if let JSXExpressionContainerExpr::Expression(e) = &mut c.expression {
                 outlined_assign_expr_positions(e, pos, fn_bindings, ref_to_binding);
             }
         }
-        crate::react_compiler_ast::jsx::JSXChild::JSXElement(el) => {
-            let mut expr = crate::react_compiler_ast::expressions::Expression::JSXElement(
-                Box::new(*el.clone()),
-            );
+        JSXChild::JSXElement(el) => {
+            let mut expr = Expression::JSXElement(Box::new(*el.clone()));
             outlined_assign_expr_positions(&mut expr, pos, fn_bindings, ref_to_binding);
-            if let crate::react_compiler_ast::expressions::Expression::JSXElement(new_el) = expr {
+            if let Expression::JSXElement(new_el) = expr {
                 **el = *new_el;
             }
         }
-        crate::react_compiler_ast::jsx::JSXChild::JSXFragment(frag) => {
+        JSXChild::JSXFragment(frag) => {
             for inner in &mut frag.children {
                 outlined_assign_jsx_child_positions(inner, pos, fn_bindings, ref_to_binding);
             }
@@ -1509,25 +1518,22 @@ fn outlined_assign_jsx_child_positions(
 /// This is extracted from `compile_fn` to allow reuse for outlined functions.
 /// Returns the compiled CodegenFunction on success.
 fn run_pipeline_passes(
-    hir: &mut crate::react_compiler_hir::HirFunction,
+    hir: &mut HirFunction,
     env: &mut Environment,
     context: &mut ProgramContext,
 ) -> Result<CodegenFunction, CompilerError> {
-    crate::react_compiler_optimization::prune_maybe_throws(hir, &mut env.functions)?;
+    prune_maybe_throws(hir, &mut env.functions)?;
 
-    crate::react_compiler_optimization::drop_manual_memoization(hir, env)?;
+    drop_manual_memoization(hir, env)?;
 
-    crate::react_compiler_optimization::inline_immediately_invoked_function_expressions(hir, env);
+    inline_immediately_invoked_function_expressions(hir, env);
 
-    crate::react_compiler_optimization::merge_consecutive_blocks::merge_consecutive_blocks(
-        hir,
-        &mut env.functions,
-    );
+    merge_consecutive_blocks(hir, &mut env.functions);
 
-    crate::react_compiler_ssa::enter_ssa(hir, env).map_err(|diag| {
+    enter_ssa(hir, env).map_err(|diag| {
         let loc = diag.primary_location().cloned();
         let mut err = CompilerError::new();
-        err.push_error_detail(crate::react_compiler_diagnostics::CompilerErrorDetail {
+        err.push_error_detail(CompilerErrorDetail {
             category: diag.category,
             reason: diag.reason,
             description: diag.description,
@@ -1537,141 +1543,121 @@ fn run_pipeline_passes(
         err
     })?;
 
-    crate::react_compiler_ssa::eliminate_redundant_phi(hir, env);
+    eliminate_redundant_phi(hir, env);
 
-    crate::react_compiler_optimization::constant_propagation(hir, env);
+    constant_propagation(hir, env);
 
-    crate::react_compiler_typeinference::infer_types(hir, env)?;
+    infer_types(hir, env)?;
 
     if env.enable_validations() {
         if env.config.validate_hooks_usage {
-            crate::react_compiler_validation::validate_hooks_usage(hir, env)?;
+            validate_hooks_usage(hir, env)?;
         }
     }
 
-    crate::react_compiler_optimization::optimize_props_method_calls(hir, env);
+    optimize_props_method_calls(hir, env);
 
-    crate::react_compiler_inference::analyse_functions(
-        hir,
-        env,
-        &mut |_inner_func, _inner_env| {},
-    )?;
+    analyse_functions(hir, env, &mut |_inner_func, _inner_env| {})?;
 
     if env.has_invariant_errors() {
         return Err(env.take_invariant_errors());
     }
 
-    crate::react_compiler_inference::infer_mutation_aliasing_effects(hir, env, false)?;
+    infer_mutation_aliasing_effects(hir, env, false)?;
 
     if env.output_mode == OutputMode::Ssr {
-        crate::react_compiler_optimization::optimize_for_ssr(hir, env);
+        optimize_for_ssr(hir, env);
     }
 
-    crate::react_compiler_optimization::dead_code_elimination(hir, env);
+    dead_code_elimination(hir, env);
 
-    crate::react_compiler_optimization::prune_maybe_throws(hir, &mut env.functions)?;
+    prune_maybe_throws(hir, &mut env.functions)?;
 
-    crate::react_compiler_inference::infer_mutation_aliasing_ranges(hir, env, false)?;
+    infer_mutation_aliasing_ranges(hir, env, false)?;
 
     if env.enable_validations() {
-        crate::react_compiler_validation::validate_locals_not_reassigned_after_render(hir, env);
+        validate_locals_not_reassigned_after_render(hir, env);
 
         if env.config.validate_ref_access_during_render {
-            crate::react_compiler_validation::validate_no_ref_access_in_render(hir, env);
+            validate_no_ref_access_in_render(hir, env);
         }
 
         if env.config.validate_no_set_state_in_render {
-            crate::react_compiler_validation::validate_no_set_state_in_render(hir, env)?;
+            validate_no_set_state_in_render(hir, env)?;
         }
 
-        crate::react_compiler_validation::validate_no_freezing_known_mutable_functions(hir, env);
+        validate_no_freezing_known_mutable_functions(hir, env);
     }
 
-    crate::react_compiler_inference::infer_reactive_places(hir, env)?;
+    infer_reactive_places(hir, env)?;
 
     if env.enable_validations() {
-        crate::react_compiler_validation::validate_exhaustive_dependencies(hir, env)?;
+        validate_exhaustive_dependencies(hir, env)?;
     }
 
-    crate::react_compiler_ssa::rewrite_instruction_kinds_based_on_reassignment(hir, env)?;
+    rewrite_instruction_kinds_based_on_reassignment(hir, env)?;
 
     if env.enable_memoization() {
-        crate::react_compiler_inference::infer_reactive_scope_variables(hir, env)?;
+        infer_reactive_scope_variables(hir, env)?;
     }
 
-    let fbt_operands =
-        crate::react_compiler_inference::memoize_fbt_and_macro_operands_in_same_scope(hir, env);
+    let fbt_operands = memoize_fbt_and_macro_operands_in_same_scope(hir, env);
 
     // Don't run outline_jsx on outlined functions (they're already outlined)
 
     if env.config.enable_name_anonymous_functions {
-        crate::react_compiler_optimization::name_anonymous_functions(hir, env);
+        name_anonymous_functions(hir, env);
     }
 
     if env.config.enable_function_outlining {
-        crate::react_compiler_optimization::outline_functions(hir, env, &fbt_operands);
+        outline_functions(hir, env, &fbt_operands);
     }
 
-    crate::react_compiler_inference::align_method_call_scopes(hir, env);
-    crate::react_compiler_inference::align_object_method_scopes(hir, env);
+    align_method_call_scopes(hir, env);
+    align_object_method_scopes(hir, env);
 
-    crate::react_compiler_optimization::prune_unused_labels_hir(hir);
+    prune_unused_labels_hir(hir);
 
-    crate::react_compiler_inference::align_reactive_scopes_to_block_scopes_hir(hir, env);
-    crate::react_compiler_inference::merge_overlapping_reactive_scopes_hir(hir, env);
+    align_reactive_scopes_to_block_scopes_hir(hir, env);
+    merge_overlapping_reactive_scopes_hir(hir, env);
 
-    crate::react_compiler_inference::build_reactive_scope_terminals_hir(hir, env);
-    crate::react_compiler_inference::flatten_reactive_loops_hir(hir);
-    crate::react_compiler_inference::flatten_scopes_with_hooks_or_use_hir(hir, env)?;
-    crate::react_compiler_inference::propagate_scope_dependencies_hir(hir, env);
-    let mut reactive_fn = crate::react_compiler_reactive_scopes::build_reactive_function(hir, env)?;
+    build_reactive_scope_terminals_hir(hir, env);
+    flatten_reactive_loops_hir(hir);
+    flatten_scopes_with_hooks_or_use_hir(hir, env)?;
+    propagate_scope_dependencies_hir(hir, env);
+    let mut reactive_fn = build_reactive_function(hir, env)?;
 
-    crate::react_compiler_reactive_scopes::assert_well_formed_break_targets(&reactive_fn, env);
+    assert_well_formed_break_targets(&reactive_fn, env);
 
-    crate::react_compiler_reactive_scopes::prune_unused_labels(&mut reactive_fn, env)?;
+    prune_unused_labels(&mut reactive_fn, env)?;
 
-    crate::react_compiler_reactive_scopes::assert_scope_instructions_within_scopes(
-        &reactive_fn,
-        env,
-    )?;
+    assert_scope_instructions_within_scopes(&reactive_fn, env)?;
 
-    crate::react_compiler_reactive_scopes::prune_non_escaping_scopes(&mut reactive_fn, env)?;
-    crate::react_compiler_reactive_scopes::prune_non_reactive_dependencies(&mut reactive_fn, env);
-    crate::react_compiler_reactive_scopes::prune_unused_scopes(&mut reactive_fn, env)?;
-    crate::react_compiler_reactive_scopes::merge_reactive_scopes_that_invalidate_together(
-        &mut reactive_fn,
-        env,
-    )?;
-    crate::react_compiler_reactive_scopes::prune_always_invalidating_scopes(&mut reactive_fn, env)?;
-    crate::react_compiler_reactive_scopes::propagate_early_returns(&mut reactive_fn, env);
-    crate::react_compiler_reactive_scopes::prune_unused_lvalues(&mut reactive_fn, env);
-    crate::react_compiler_reactive_scopes::promote_used_temporaries(&mut reactive_fn, env);
-    crate::react_compiler_reactive_scopes::extract_scope_declarations_from_destructuring(
-        &mut reactive_fn,
-        env,
-    )?;
-    crate::react_compiler_reactive_scopes::stabilize_block_ids(&mut reactive_fn, env);
+    prune_non_escaping_scopes(&mut reactive_fn, env)?;
+    prune_non_reactive_dependencies(&mut reactive_fn, env);
+    prune_unused_scopes(&mut reactive_fn, env)?;
+    merge_reactive_scopes_that_invalidate_together(&mut reactive_fn, env)?;
+    prune_always_invalidating_scopes(&mut reactive_fn, env)?;
+    propagate_early_returns(&mut reactive_fn, env);
+    prune_unused_lvalues(&mut reactive_fn, env);
+    promote_used_temporaries(&mut reactive_fn, env);
+    extract_scope_declarations_from_destructuring(&mut reactive_fn, env)?;
+    stabilize_block_ids(&mut reactive_fn, env);
 
-    let unique_identifiers =
-        crate::react_compiler_reactive_scopes::rename_variables(&mut reactive_fn, env);
+    let unique_identifiers = rename_variables(&mut reactive_fn, env);
     for name in &unique_identifiers {
         context.add_new_reference(name.clone());
     }
 
-    crate::react_compiler_reactive_scopes::prune_hoisted_contexts(&mut reactive_fn, env)?;
+    prune_hoisted_contexts(&mut reactive_fn, env)?;
 
     if env.config.enable_preserve_existing_memoization_guarantees
         || env.config.validate_preserve_existing_memoization_guarantees
     {
-        crate::react_compiler_validation::validate_preserved_manual_memoization(&reactive_fn, env);
+        validate_preserved_manual_memoization(&reactive_fn, env);
     }
 
-    let codegen_result = crate::react_compiler_reactive_scopes::codegen_function(
-        &reactive_fn,
-        env,
-        unique_identifiers,
-        fbt_operands,
-    )?;
+    let codegen_result = codegen_function(&reactive_fn, env, unique_identifiers, fbt_operands)?;
 
     Ok(CodegenFunction {
         loc: codegen_result.loc,
@@ -1719,43 +1705,37 @@ fn log_errors_as_events(errors: &CompilerError, context: &mut ProgramContext) {
     let source_filename = context.source_filename();
     for detail in &errors.details {
         let detail_info = match detail {
-            crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic::Diagnostic(d) => {
+            CompilerErrorOrDiagnostic::Diagnostic(d) => {
                 let items: Option<Vec<CompilerErrorItemInfo>> = {
                     let v: Vec<CompilerErrorItemInfo> = d
                         .details
                         .iter()
-                        .map(|item| {
-                            match item {
-                            crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Error {
-                                loc,
-                                message,
-                                identifier_name,
-                            } => CompilerErrorItemInfo {
-                                kind: "error".to_string(),
-                                loc: loc.as_ref().map(|l| LoggerSourceLocation {
-                                    start: LoggerPosition {
-                                        line: l.start.line,
-                                        column: l.start.column,
-                                        index: l.start.index,
-                                    },
-                                    end: LoggerPosition {
-                                        line: l.end.line,
-                                        column: l.end.column,
-                                        index: l.end.index,
-                                    },
-                                    filename: source_filename.clone(),
-                                    identifier_name: identifier_name.clone(),
-                                }),
-                                message: message.clone(),
-                            },
-                            crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Hint {
-                                message,
-                            } => CompilerErrorItemInfo {
+                        .map(|item| match item {
+                            CompilerDiagnosticDetail::Error { loc, message, identifier_name } => {
+                                CompilerErrorItemInfo {
+                                    kind: "error".to_string(),
+                                    loc: loc.as_ref().map(|l| LoggerSourceLocation {
+                                        start: LoggerPosition {
+                                            line: l.start.line,
+                                            column: l.start.column,
+                                            index: l.start.index,
+                                        },
+                                        end: LoggerPosition {
+                                            line: l.end.line,
+                                            column: l.end.column,
+                                            index: l.end.index,
+                                        },
+                                        filename: source_filename.clone(),
+                                        identifier_name: identifier_name.clone(),
+                                    }),
+                                    message: message.clone(),
+                                }
+                            }
+                            CompilerDiagnosticDetail::Hint { message } => CompilerErrorItemInfo {
                                 kind: "hint".to_string(),
                                 loc: None,
                                 message: Some(message.clone()),
                             },
-                        }
                         })
                         .collect();
                     if v.is_empty() { None } else { Some(v) }
@@ -1770,17 +1750,15 @@ fn log_errors_as_events(errors: &CompilerError, context: &mut ProgramContext) {
                     loc: None,
                 }
             }
-            crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic::ErrorDetail(d) => {
-                CompilerErrorDetailInfo {
-                    category: format!("{:?}", d.category),
-                    reason: d.reason.clone(),
-                    description: d.description.clone(),
-                    severity: format!("{:?}", d.logged_severity()),
-                    suggestions: None,
-                    details: None,
-                    loc: None,
-                }
-            }
+            CompilerErrorOrDiagnostic::ErrorDetail(d) => CompilerErrorDetailInfo {
+                category: format!("{:?}", d.category),
+                reason: d.reason.clone(),
+                description: d.description.clone(),
+                severity: format!("{:?}", d.logged_severity()),
+                suggestions: None,
+                details: None,
+                loc: None,
+            },
         };
         context.log_event(super::compile_result::LoggerEvent::CompileError {
             fn_loc: None,

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/pipeline.rs
@@ -8,7 +8,12 @@
 //! Analogous to TS `Pipeline.ts` (`compileFn` → `run` → `runWithEnvironment`).
 //! Currently runs BuildHIR (lowering) and PruneMaybeThrows.
 
-use crate::react_compiler_ast::scope::ScopeInfo;
+use rustc_hash::FxHashMap;
+
+use crate::react_compiler_ast::expressions::*;
+use crate::react_compiler_ast::patterns::PatternLike;
+use crate::react_compiler_ast::scope::*;
+use crate::react_compiler_ast::statements::Statement;
 use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::environment::Environment;
@@ -1101,10 +1106,6 @@ pub fn compile_outlined_fn(
 fn build_outlined_scope_info(
     func: &mut crate::react_compiler_ast::statements::FunctionDeclaration,
 ) -> crate::react_compiler_ast::scope::ScopeInfo {
-    use rustc_hash::FxHashMap;
-
-    use crate::react_compiler_ast::scope::*;
-
     let mut pos: u32 = 1; // reserve 0 for the function itself
     func.base.start = Some(0);
 
@@ -1206,9 +1207,6 @@ fn outlined_assign_pattern_positions(
     bindings_list: &mut Vec<crate::react_compiler_ast::scope::BindingData>,
     ref_to_binding: &mut FxIndexMap<u32, crate::react_compiler_ast::scope::BindingId>,
 ) {
-    use crate::react_compiler_ast::patterns::PatternLike;
-    use crate::react_compiler_ast::scope::*;
-
     match pattern {
         PatternLike::Identifier(id) => {
             let p = *pos;
@@ -1307,8 +1305,6 @@ fn outlined_assign_stmt_positions(
     bindings_list: &mut Vec<crate::react_compiler_ast::scope::BindingData>,
     ref_to_binding: &mut FxIndexMap<u32, crate::react_compiler_ast::scope::BindingId>,
 ) {
-    use crate::react_compiler_ast::statements::Statement;
-
     match stmt {
         Statement::VariableDeclaration(decl) => {
             for declarator in &mut decl.declarations {
@@ -1351,8 +1347,6 @@ fn outlined_assign_expr_positions(
     fn_bindings: &rustc_hash::FxHashMap<String, crate::react_compiler_ast::scope::BindingId>,
     ref_to_binding: &mut FxIndexMap<u32, crate::react_compiler_ast::scope::BindingId>,
 ) {
-    use crate::react_compiler_ast::expressions::*;
-
     match expr {
         Expression::Identifier(id) => {
             let p = *pos;

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -3295,12 +3295,7 @@ fn insert_after_fn_in_block(
     false
 }
 
-fn insert_after_fn_in_expr(
-    expr: &mut crate::react_compiler_ast::expressions::Expression,
-    node_id: u32,
-    new_stmt: &Statement,
-) -> bool {
-    use crate::react_compiler_ast::expressions::Expression;
+fn insert_after_fn_in_expr(expr: &mut Expression, node_id: u32, new_stmt: &Statement) -> bool {
     match expr {
         Expression::ObjectExpression(obj) => {
             for prop in &mut obj.properties {

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/program.rs
@@ -16,17 +16,22 @@
 
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
+use serde_json::Value;
 
 use crate::react_compiler_ast::File;
 use crate::react_compiler_ast::Program;
 use crate::react_compiler_ast::common::BaseNode;
+use crate::react_compiler_ast::common::SourceLocation as AstSourceLocation;
 use crate::react_compiler_ast::declarations::Declaration;
 use crate::react_compiler_ast::declarations::ExportDefaultDecl;
 use crate::react_compiler_ast::declarations::ExportDefaultDeclaration;
+use crate::react_compiler_ast::declarations::ExportSpecifier;
 use crate::react_compiler_ast::declarations::ImportSpecifier;
 use crate::react_compiler_ast::declarations::ModuleExportName;
 use crate::react_compiler_ast::expressions::*;
+use crate::react_compiler_ast::patterns::ObjectPatternProperty;
 use crate::react_compiler_ast::patterns::PatternLike;
+use crate::react_compiler_ast::patterns::RestElement;
 use crate::react_compiler_ast::scope::ScopeId;
 use crate::react_compiler_ast::scope::ScopeInfo;
 use crate::react_compiler_ast::statements::*;
@@ -35,12 +40,19 @@ use crate::react_compiler_ast::visitor::MutVisitor;
 use crate::react_compiler_ast::visitor::VisitResult;
 use crate::react_compiler_ast::visitor::Visitor;
 use crate::react_compiler_ast::visitor::walk_program_mut;
+use crate::react_compiler_diagnostics::CompilerDiagnostic;
+use crate::react_compiler_diagnostics::CompilerDiagnosticDetail;
 use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_diagnostics::CompilerErrorDetail;
 use crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic;
+use crate::react_compiler_diagnostics::CompilerSuggestion;
+use crate::react_compiler_diagnostics::CompilerSuggestionOperation;
 use crate::react_compiler_diagnostics::ErrorCategory;
+use crate::react_compiler_diagnostics::Position;
 use crate::react_compiler_diagnostics::SourceLocation;
+use crate::react_compiler_diagnostics::code_frame::format_compiler_error;
 use crate::react_compiler_hir::ReactFunctionType;
+use crate::react_compiler_hir::environment::BindingRename;
 use crate::react_compiler_hir::environment_config::EnvironmentConfig;
 use crate::react_compiler_lowering::FunctionNode;
 
@@ -96,7 +108,7 @@ struct CompileSource<'a> {
     fn_name: Option<String>,
     fn_loc: Option<SourceLocation>,
     /// Original AST source location (with index and filename) for logger events.
-    fn_ast_loc: Option<crate::react_compiler_ast::common::SourceLocation>,
+    fn_ast_loc: Option<AstSourceLocation>,
     fn_start: Option<u32>,
     fn_end: Option<u32>,
     fn_node_id: Option<u32>,
@@ -766,17 +778,15 @@ fn calls_hooks_or_creates_jsx_in_expr(expr: &Expression) -> bool {
 /// We search the JSON tree, skipping nested function nodes (matching TS behavior where
 /// Babel's traverse skips ArrowFunctionExpression, FunctionExpression, FunctionDeclaration
 /// but recurses into class methods).
-fn calls_hooks_or_creates_jsx_in_class_body(
-    body: &crate::react_compiler_ast::expressions::ClassBody,
-) -> bool {
+fn calls_hooks_or_creates_jsx_in_class_body(body: &ClassBody) -> bool {
     body.body.iter().any(|member| calls_hooks_or_creates_jsx_in_json(&member.parse_value()))
 }
 
-fn calls_hooks_or_creates_jsx_in_json(value: &serde_json::Value) -> bool {
+fn calls_hooks_or_creates_jsx_in_json(value: &Value) -> bool {
     match value {
-        serde_json::Value::Object(obj) => {
+        Value::Object(obj) => {
             // Check the node type
-            if let Some(serde_json::Value::String(node_type)) = obj.get("type") {
+            if let Some(Value::String(node_type)) = obj.get("type") {
                 match node_type.as_str() {
                     // JSX nodes
                     "JSXElement" | "JSXFragment" => return true,
@@ -798,7 +808,7 @@ fn calls_hooks_or_creates_jsx_in_json(value: &serde_json::Value) -> bool {
             // Recurse into all values of the object
             obj.values().any(|v| calls_hooks_or_creates_jsx_in_json(v))
         }
-        serde_json::Value::Array(arr) => arr.iter().any(|v| calls_hooks_or_creates_jsx_in_json(v)),
+        Value::Array(arr) => arr.iter().any(|v| calls_hooks_or_creates_jsx_in_json(v)),
         _ => false,
     }
 }
@@ -807,11 +817,11 @@ fn calls_hooks_or_creates_jsx_in_json(value: &serde_json::Value) -> bool {
 /// Handles both Identifier (e.g. `useState`) and MemberExpression
 /// (e.g. `React.useState`) patterns, reusing `is_hook_name` for
 /// consistent naming checks.
-fn json_expr_is_hook(callee: &serde_json::Value) -> bool {
-    if let serde_json::Value::Object(obj) = callee {
-        if let Some(serde_json::Value::String(node_type)) = obj.get("type") {
+fn json_expr_is_hook(callee: &Value) -> bool {
+    if let Value::Object(obj) = callee {
+        if let Some(Value::String(node_type)) = obj.get("type") {
             if node_type == "Identifier" {
-                if let Some(serde_json::Value::String(name)) = obj.get("name") {
+                if let Some(Value::String(name)) = obj.get("name") {
                     return is_hook_name(name);
                 }
             } else if node_type == "MemberExpression" {
@@ -821,14 +831,14 @@ fn json_expr_is_hook(callee: &serde_json::Value) -> bool {
                     return false;
                 }
                 // Property must be a hook name
-                if let Some(serde_json::Value::Object(prop)) = obj.get("property") {
+                if let Some(Value::Object(prop)) = obj.get("property") {
                     if prop.get("type").and_then(|v| v.as_str()) == Some("Identifier") {
                         if let Some(name) = prop.get("name").and_then(|v| v.as_str()) {
                             if !is_hook_name(name) {
                                 return false;
                             }
                             // Object must be PascalCase identifier
-                            if let Some(serde_json::Value::Object(obj_node)) = obj.get("object") {
+                            if let Some(Value::Object(obj_node)) = obj.get("object") {
                                 if obj_node.get("type").and_then(|v| v.as_str())
                                     == Some("Identifier")
                                 {
@@ -878,10 +888,10 @@ fn calls_hooks_or_creates_jsx_in_pattern(pattern: &PatternLike) -> bool {
                 || calls_hooks_or_creates_jsx_in_pattern(&assign.left)
         }
         PatternLike::ObjectPattern(obj) => obj.properties.iter().any(|prop| match prop {
-            crate::react_compiler_ast::patterns::ObjectPatternProperty::ObjectProperty(p) => {
+            ObjectPatternProperty::ObjectProperty(p) => {
                 calls_hooks_or_creates_jsx_in_pattern(&p.value)
             }
-            crate::react_compiler_ast::patterns::ObjectPatternProperty::RestElement(rest) => {
+            ObjectPatternProperty::RestElement(rest) => {
                 calls_hooks_or_creates_jsx_in_pattern(&rest.argument)
             }
         }),
@@ -1154,18 +1164,10 @@ fn get_callee_name_if_react_api(callee: &Expression) -> Option<&str> {
 // -----------------------------------------------------------------------
 
 /// Convert an AST SourceLocation to a diagnostics SourceLocation
-fn convert_loc(loc: &crate::react_compiler_ast::common::SourceLocation) -> SourceLocation {
+fn convert_loc(loc: &AstSourceLocation) -> SourceLocation {
     SourceLocation {
-        start: crate::react_compiler_diagnostics::Position {
-            line: loc.start.line,
-            column: loc.start.column,
-            index: loc.start.index,
-        },
-        end: crate::react_compiler_diagnostics::Position {
-            line: loc.end.line,
-            column: loc.end.column,
-            index: loc.end.index,
-        },
+        start: Position { line: loc.start.line, column: loc.start.column, index: loc.start.index },
+        end: Position { line: loc.end.line, column: loc.end.column, index: loc.end.index },
     }
 }
 
@@ -1179,33 +1181,29 @@ fn base_node_loc(base: &BaseNode) -> Option<SourceLocation> {
 
 /// Convert CompilerDiagnostic details into serializable CompilerErrorItemInfo items.
 fn diagnostic_details_to_items(
-    d: &crate::react_compiler_diagnostics::CompilerDiagnostic,
+    d: &CompilerDiagnostic,
     filename: Option<&str>,
 ) -> Option<Vec<CompilerErrorItemInfo>> {
     let items: Vec<CompilerErrorItemInfo> = d
         .details
         .iter()
         .map(|item| match item {
-            crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Error {
-                loc,
-                message,
-                identifier_name,
-            } => CompilerErrorItemInfo {
-                kind: "error".to_string(),
-                loc: loc.as_ref().map(|l| {
-                    let mut logger_loc = diag_loc_to_logger_loc(l, filename);
-                    logger_loc.identifier_name = identifier_name.clone();
-                    logger_loc
-                }),
-                message: message.clone(),
-            },
-            crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Hint { message } => {
+            CompilerDiagnosticDetail::Error { loc, message, identifier_name } => {
                 CompilerErrorItemInfo {
-                    kind: "hint".to_string(),
-                    loc: None,
-                    message: Some(message.clone()),
+                    kind: "error".to_string(),
+                    loc: loc.as_ref().map(|l| {
+                        let mut logger_loc = diag_loc_to_logger_loc(l, filename);
+                        logger_loc.identifier_name = identifier_name.clone();
+                        logger_loc
+                    }),
+                    message: message.clone(),
                 }
             }
+            CompilerDiagnosticDetail::Hint { message } => CompilerErrorItemInfo {
+                kind: "hint".to_string(),
+                loc: None,
+                message: Some(message.clone()),
+            },
         })
         .collect();
     if items.is_empty() { None } else { Some(items) }
@@ -1213,7 +1211,7 @@ fn diagnostic_details_to_items(
 
 /// Convert an optional AST SourceLocation to a LoggerSourceLocation with filename.
 fn to_logger_loc(
-    ast_loc: Option<&crate::react_compiler_ast::common::SourceLocation>,
+    ast_loc: Option<&AstSourceLocation>,
     filename: Option<&str>,
 ) -> Option<LoggerSourceLocation> {
     ast_loc.map(|loc| LoggerSourceLocation {
@@ -1244,25 +1242,17 @@ fn diag_loc_to_logger_loc(loc: &SourceLocation, filename: Option<&str>) -> Logge
 
 /// Convert diagnostic suggestions to logger suggestion infos.
 fn suggestions_to_logger(
-    suggestions: &Option<Vec<crate::react_compiler_diagnostics::CompilerSuggestion>>,
+    suggestions: &Option<Vec<CompilerSuggestion>>,
 ) -> Option<Vec<LoggerSuggestionInfo>> {
     suggestions.as_ref().map(|suggestions| {
         suggestions
             .iter()
             .map(|s| {
                 let op = match s.op {
-                    crate::react_compiler_diagnostics::CompilerSuggestionOperation::InsertBefore => {
-                        LoggerSuggestionOp::InsertBefore
-                    }
-                    crate::react_compiler_diagnostics::CompilerSuggestionOperation::InsertAfter => {
-                        LoggerSuggestionOp::InsertAfter
-                    }
-                    crate::react_compiler_diagnostics::CompilerSuggestionOperation::Remove => {
-                        LoggerSuggestionOp::Remove
-                    }
-                    crate::react_compiler_diagnostics::CompilerSuggestionOperation::Replace => {
-                        LoggerSuggestionOp::Replace
-                    }
+                    CompilerSuggestionOperation::InsertBefore => LoggerSuggestionOp::InsertBefore,
+                    CompilerSuggestionOperation::InsertAfter => LoggerSuggestionOp::InsertAfter,
+                    CompilerSuggestionOperation::Remove => LoggerSuggestionOp::Remove,
+                    CompilerSuggestionOperation::Replace => LoggerSuggestionOp::Replace,
                 };
                 LoggerSuggestionInfo {
                     description: s.description.clone(),
@@ -1278,7 +1268,7 @@ fn suggestions_to_logger(
 /// Log an error as LoggerEvent(s) directly onto the ProgramContext.
 fn log_error(
     err: &CompilerError,
-    fn_ast_loc: Option<&crate::react_compiler_ast::common::SourceLocation>,
+    fn_ast_loc: Option<&AstSourceLocation>,
     context: &mut ProgramContext,
 ) {
     // Use the filename from the AST node's loc (set by parser's sourceFilename option),
@@ -1342,7 +1332,7 @@ fn log_error(
 /// otherwise returns None (error was logged only).
 fn handle_error(
     err: &CompilerError,
-    fn_ast_loc: Option<&crate::react_compiler_ast::common::SourceLocation>,
+    fn_ast_loc: Option<&AstSourceLocation>,
     context: &mut ProgramContext,
 ) -> Option<CompileResult> {
     // Log the error
@@ -1384,11 +1374,7 @@ fn handle_error(
         if error_info.raw_message.is_none() {
             if let Some(ref source) = context.code {
                 error_info.formatted_message =
-                    Some(crate::react_compiler_diagnostics::code_frame::format_compiler_error(
-                        err,
-                        source,
-                        source_fn.as_deref(),
-                    ));
+                    Some(format_compiler_error(err, source, source_fn.as_deref()));
             }
         }
 
@@ -1944,11 +1930,7 @@ impl<'a, 'ast> Visitor<'ast> for FunctionDiscoveryVisitor<'a, 'ast> {
         }
     }
 
-    fn enter_object_method(
-        &mut self,
-        _node: &'ast crate::react_compiler_ast::expressions::ObjectMethod,
-        _scope_stack: &[ScopeId],
-    ) {
+    fn enter_object_method(&mut self, _node: &'ast ObjectMethod, _scope_stack: &[ScopeId]) {
         self.skip_body = false;
     }
 }
@@ -2093,10 +2075,7 @@ fn stmt_references_identifier_at_top_level(stmt: &Statement, name: &str) -> bool
             } else {
                 // export { Name } - check specifiers
                 export.specifiers.iter().any(|s| {
-                    if let crate::react_compiler_ast::declarations::ExportSpecifier::ExportSpecifier(
-                        spec,
-                    ) = s
-                    {
+                    if let ExportSpecifier::ExportSpecifier(spec) = s {
                         match &spec.local {
                             ModuleExportName::Identifier(id) => id.name == name,
                             _ => false,
@@ -2129,19 +2108,17 @@ fn stmt_references_identifier_at_top_level(stmt: &Statement, name: &str) -> bool
 
 /// Conservatively detect an `Identifier` node with the given name anywhere in
 /// a raw unmodeled subtree.
-fn raw_node_references_identifier(value: &serde_json::Value, name: &str) -> bool {
+fn raw_node_references_identifier(value: &Value, name: &str) -> bool {
     match value {
-        serde_json::Value::Object(map) => {
-            if map.get("type").and_then(serde_json::Value::as_str) == Some("Identifier")
-                && map.get("name").and_then(serde_json::Value::as_str) == Some(name)
+        Value::Object(map) => {
+            if map.get("type").and_then(Value::as_str) == Some("Identifier")
+                && map.get("name").and_then(Value::as_str) == Some(name)
             {
                 return true;
             }
             map.values().any(|v| raw_node_references_identifier(v, name))
         }
-        serde_json::Value::Array(items) => {
-            items.iter().any(|v| raw_node_references_identifier(v, name))
-        }
+        Value::Array(items) => items.iter().any(|v| raw_node_references_identifier(v, name)),
         _ => false,
     }
 }
@@ -3019,20 +2996,18 @@ fn apply_gated_function_hoisted(
         let is_rest = matches!(&original_params[i], PatternLike::RestElement(_));
 
         if is_rest {
-            new_params.push(PatternLike::RestElement(
-                crate::react_compiler_ast::patterns::RestElement {
-                    base: BaseNode::typed("RestElement"),
-                    argument: Box::new(PatternLike::Identifier(Identifier {
-                        base: BaseNode::typed("Identifier"),
-                        name: arg_name.clone(),
-                        type_annotation: None,
-                        optional: None,
-                        decorators: None,
-                    })),
+            new_params.push(PatternLike::RestElement(RestElement {
+                base: BaseNode::typed("RestElement"),
+                argument: Box::new(PatternLike::Identifier(Identifier {
+                    base: BaseNode::typed("Identifier"),
+                    name: arg_name.clone(),
                     type_annotation: None,
+                    optional: None,
                     decorators: None,
-                },
-            ));
+                })),
+                type_annotation: None,
+                decorators: None,
+            }));
             optimized_args.push(Expression::SpreadElement(SpreadElement {
                 base: BaseNode::typed("SpreadElement"),
                 argument: Box::new(Expression::Identifier(Identifier {
@@ -3279,7 +3254,7 @@ fn insert_after_fn_in_stmt(stmt: &mut Statement, node_id: u32, new_stmt: &Statem
 }
 
 fn insert_after_fn_in_block(
-    block: &mut crate::react_compiler_ast::statements::BlockStatement,
+    block: &mut BlockStatement,
     node_id: u32,
     new_stmt: &Statement,
 ) -> bool {
@@ -3300,14 +3275,12 @@ fn insert_after_fn_in_expr(expr: &mut Expression, node_id: u32, new_stmt: &State
         Expression::ObjectExpression(obj) => {
             for prop in &mut obj.properties {
                 match prop {
-                    crate::react_compiler_ast::expressions::ObjectExpressionProperty::ObjectMethod(m) => {
+                    ObjectExpressionProperty::ObjectMethod(m) => {
                         if insert_after_fn_in_block(&mut m.body, node_id, new_stmt) {
                             return true;
                         }
                     }
-                    crate::react_compiler_ast::expressions::ObjectExpressionProperty::ObjectProperty(
-                        p,
-                    ) => {
+                    ObjectExpressionProperty::ObjectProperty(p) => {
                         if insert_after_fn_in_expr(&mut p.value, node_id, new_stmt) {
                             return true;
                         }
@@ -3326,12 +3299,10 @@ fn insert_after_fn_in_expr(expr: &mut Expression, node_id: u32, new_stmt: &State
             false
         }
         Expression::ArrowFunctionExpression(arrow) => match arrow.body.as_mut() {
-            crate::react_compiler_ast::expressions::ArrowFunctionBody::BlockStatement(block) => {
+            ArrowFunctionBody::BlockStatement(block) => {
                 insert_after_fn_in_block(block, node_id, new_stmt)
             }
-            crate::react_compiler_ast::expressions::ArrowFunctionBody::Expression(e) => {
-                insert_after_fn_in_expr(e, node_id, new_stmt)
-            }
+            ArrowFunctionBody::Expression(e) => insert_after_fn_in_expr(e, node_id, new_stmt),
         },
         Expression::FunctionExpression(f) => {
             insert_after_fn_in_block(&mut f.body, node_id, new_stmt)
@@ -3713,15 +3684,9 @@ pub fn compile_program(mut file: File, scope: ScopeInfo, options: PluginOptions)
             // Fallback: try the first statement's loc
             program.body.first().and_then(|stmt| {
                 let base = match stmt {
-                    crate::react_compiler_ast::statements::Statement::ExpressionStatement(s) => {
-                        &s.base
-                    }
-                    crate::react_compiler_ast::statements::Statement::VariableDeclaration(s) => {
-                        &s.base
-                    }
-                    crate::react_compiler_ast::statements::Statement::FunctionDeclaration(s) => {
-                        &s.base
-                    }
+                    Statement::ExpressionStatement(s) => &s.base,
+                    Statement::VariableDeclaration(s) => &s.base,
+                    Statement::FunctionDeclaration(s) => &s.base,
                     _ => return None,
                 };
                 base.loc.as_ref().and_then(|loc| loc.filename.clone())
@@ -3923,9 +3888,7 @@ pub fn compile_program(mut file: File, scope: ScopeInfo, options: PluginOptions)
 }
 
 /// Convert internal BindingRename structs to the serializable BindingRenameInfo format.
-fn convert_renames(
-    renames: &[crate::react_compiler_hir::environment::BindingRename],
-) -> Vec<BindingRenameInfo> {
+fn convert_renames(renames: &[BindingRename]) -> Vec<BindingRenameInfo> {
     renames
         .iter()
         .map(|r| BindingRenameInfo {

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/suppression.rs
@@ -7,7 +7,7 @@
 use crate::react_compiler_ast::common::{Comment, CommentData};
 use crate::react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, CompilerError, CompilerSuggestion,
-    CompilerSuggestionOperation, ErrorCategory,
+    CompilerSuggestionOperation, ErrorCategory, Position, SourceLocation,
 };
 
 #[derive(Debug, Clone)]
@@ -258,19 +258,9 @@ pub fn suppressions_to_compiler_error(suppressions: &[SuppressionRange]) -> Comp
         }]);
 
         // Add error detail with location info
-        let loc = suppression.disable_comment.loc.as_ref().map(|l| {
-            crate::react_compiler_diagnostics::SourceLocation {
-                start: crate::react_compiler_diagnostics::Position {
-                    line: l.start.line,
-                    column: l.start.column,
-                    index: l.start.index,
-                },
-                end: crate::react_compiler_diagnostics::Position {
-                    line: l.end.line,
-                    column: l.end.column,
-                    index: l.end.index,
-                },
-            }
+        let loc = suppression.disable_comment.loc.as_ref().map(|l| SourceLocation {
+            start: Position { line: l.start.line, column: l.start.column, index: l.start.index },
+            end: Position { line: l.end.line, column: l.end.column, index: l.end.index },
         });
 
         diagnostic = diagnostic.with_detail(CompilerDiagnosticDetail::Error {

--- a/crates/oxc_react_compiler/src/react_compiler/entrypoint/validate_source_locations.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/entrypoint/validate_source_locations.rs
@@ -18,7 +18,7 @@ use crate::react_compiler_ast::expressions::{
     ArrowFunctionBody, ArrowFunctionExpression, Expression, FunctionExpression,
     ObjectExpressionProperty,
 };
-use crate::react_compiler_ast::patterns::PatternLike;
+use crate::react_compiler_ast::patterns::{ObjectPatternProperty, PatternLike};
 use crate::react_compiler_ast::statements::{ForInOfLeft, ForInit, Statement, VariableDeclaration};
 use crate::react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, ErrorCategory, Position as DiagPosition,
@@ -696,9 +696,7 @@ fn collect_original_pattern(
         PatternLike::ObjectPattern(op) => {
             for prop in &op.properties {
                 match prop {
-                    crate::react_compiler_ast::patterns::ObjectPatternProperty::ObjectProperty(
-                        p,
-                    ) => {
+                    ObjectPatternProperty::ObjectProperty(p) => {
                         if p.computed {
                             collect_original_expression(&p.key, locations);
                         } else if let Expression::Identifier(id) = p.key.as_ref() {
@@ -706,7 +704,7 @@ fn collect_original_pattern(
                         }
                         collect_original_pattern(&p.value, locations);
                     }
-                    crate::react_compiler_ast::patterns::ObjectPatternProperty::RestElement(r) => {
+                    ObjectPatternProperty::RestElement(r) => {
                         collect_original_pattern(&r.argument, locations);
                     }
                 }
@@ -1189,14 +1187,12 @@ fn collect_generated_pattern(
             record_generated("ObjectPattern", &op.base.loc, locations);
             for prop in &op.properties {
                 match prop {
-                    crate::react_compiler_ast::patterns::ObjectPatternProperty::ObjectProperty(
-                        p,
-                    ) => {
+                    ObjectPatternProperty::ObjectProperty(p) => {
                         record_generated("ObjectProperty", &p.base.loc, locations);
                         collect_generated_expression(&p.key, locations);
                         collect_generated_pattern(&p.value, locations);
                     }
-                    crate::react_compiler_ast::patterns::ObjectPatternProperty::RestElement(r) => {
+                    ObjectPatternProperty::RestElement(r) => {
                         record_generated("RestElement", &r.base.loc, locations);
                         collect_generated_pattern(&r.argument, locations);
                     }

--- a/crates/oxc_react_compiler/src/react_compiler/fixture_utils.rs
+++ b/crates/oxc_react_compiler/src/react_compiler/fixture_utils.rs
@@ -1,6 +1,7 @@
 use crate::react_compiler_ast::File;
 use crate::react_compiler_ast::declarations::{Declaration, ExportDefaultDecl};
 use crate::react_compiler_ast::expressions::Expression;
+use crate::react_compiler_ast::patterns::PatternLike;
 use crate::react_compiler_ast::statements::Statement;
 use crate::react_compiler_lowering::FunctionNode;
 
@@ -105,9 +106,7 @@ pub fn extract_function(
                             Expression::FunctionExpression(func) => {
                                 if index == function_index {
                                     let name = match &declarator.id {
-                                        crate::react_compiler_ast::patterns::PatternLike::Identifier(
-                                            ident,
-                                        ) => Some(ident.name.as_str()),
+                                        PatternLike::Identifier(ident) => Some(ident.name.as_str()),
                                         _ => func.id.as_ref().map(|id| id.name.as_str()),
                                     };
                                     return Some((FunctionNode::FunctionExpression(func), name));
@@ -117,9 +116,7 @@ pub fn extract_function(
                             Expression::ArrowFunctionExpression(arrow) => {
                                 if index == function_index {
                                     let name = match &declarator.id {
-                                        crate::react_compiler_ast::patterns::PatternLike::Identifier(
-                                            ident,
-                                        ) => Some(ident.name.as_str()),
+                                        PatternLike::Identifier(ident) => Some(ident.name.as_str()),
                                         _ => None,
                                     };
                                     return Some((
@@ -151,8 +148,12 @@ pub fn extract_function(
                                         Expression::FunctionExpression(func) => {
                                             if index == function_index {
                                                 let name = match &declarator.id {
-                                                    crate::react_compiler_ast::patterns::PatternLike::Identifier(ident) => Some(ident.name.as_str()),
-                                                    _ => func.id.as_ref().map(|id| id.name.as_str()),
+                                                    PatternLike::Identifier(ident) => {
+                                                        Some(ident.name.as_str())
+                                                    }
+                                                    _ => {
+                                                        func.id.as_ref().map(|id| id.name.as_str())
+                                                    }
                                                 };
                                                 return Some((
                                                     FunctionNode::FunctionExpression(func),
@@ -164,7 +165,9 @@ pub fn extract_function(
                                         Expression::ArrowFunctionExpression(arrow) => {
                                             if index == function_index {
                                                 let name = match &declarator.id {
-                                                    crate::react_compiler_ast::patterns::PatternLike::Identifier(ident) => Some(ident.name.as_str()),
+                                                    PatternLike::Identifier(ident) => {
+                                                        Some(ident.name.as_str())
+                                                    }
                                                     _ => None,
                                                 };
                                                 return Some((

--- a/crates/oxc_react_compiler/src/react_compiler_ast/declarations.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ast/declarations.rs
@@ -5,14 +5,17 @@ use crate::react_compiler_ast::common::RawNode;
 use crate::react_compiler_ast::expressions::Expression;
 use crate::react_compiler_ast::expressions::Identifier;
 use crate::react_compiler_ast::literals::StringLiteral;
+use crate::react_compiler_ast::statements::ClassDeclaration;
+use crate::react_compiler_ast::statements::FunctionDeclaration;
+use crate::react_compiler_ast::statements::VariableDeclaration;
 
 /// Union of Declaration types that can appear in export declarations
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type")]
 pub enum Declaration {
-    FunctionDeclaration(crate::react_compiler_ast::statements::FunctionDeclaration),
-    ClassDeclaration(crate::react_compiler_ast::statements::ClassDeclaration),
-    VariableDeclaration(crate::react_compiler_ast::statements::VariableDeclaration),
+    FunctionDeclaration(FunctionDeclaration),
+    ClassDeclaration(ClassDeclaration),
+    VariableDeclaration(VariableDeclaration),
     TSTypeAliasDeclaration(TSTypeAliasDeclaration),
     TSInterfaceDeclaration(TSInterfaceDeclaration),
     TSEnumDeclaration(TSEnumDeclaration),
@@ -28,8 +31,8 @@ pub enum Declaration {
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type")]
 pub enum ExportDefaultDecl {
-    FunctionDeclaration(crate::react_compiler_ast::statements::FunctionDeclaration),
-    ClassDeclaration(crate::react_compiler_ast::statements::ClassDeclaration),
+    FunctionDeclaration(FunctionDeclaration),
+    ClassDeclaration(ClassDeclaration),
     EnumDeclaration(EnumDeclaration),
     #[serde(untagged)]
     Expression(Box<Expression>),

--- a/crates/oxc_react_compiler/src/react_compiler_ast/patterns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ast/patterns.rs
@@ -2,6 +2,12 @@ use serde::Serialize;
 
 use crate::react_compiler_ast::common::BaseNode;
 use crate::react_compiler_ast::common::RawNode;
+use crate::react_compiler_ast::expressions::MemberExpression;
+use crate::react_compiler_ast::expressions::TSAsExpression;
+use crate::react_compiler_ast::expressions::TSNonNullExpression;
+use crate::react_compiler_ast::expressions::TSSatisfiesExpression;
+use crate::react_compiler_ast::expressions::TSTypeAssertion;
+use crate::react_compiler_ast::expressions::TypeCastExpression;
 use crate::react_compiler_ast::expressions::{Expression, Identifier};
 
 /// Covers assignment targets and patterns.
@@ -16,13 +22,13 @@ pub enum PatternLike {
     AssignmentPattern(AssignmentPattern),
     RestElement(RestElement),
     // Expressions can appear in pattern positions (e.g., MemberExpression as LVal)
-    MemberExpression(crate::react_compiler_ast::expressions::MemberExpression),
-    TSAsExpression(crate::react_compiler_ast::expressions::TSAsExpression),
-    TSSatisfiesExpression(crate::react_compiler_ast::expressions::TSSatisfiesExpression),
-    TSNonNullExpression(crate::react_compiler_ast::expressions::TSNonNullExpression),
-    TSTypeAssertion(crate::react_compiler_ast::expressions::TSTypeAssertion),
+    MemberExpression(MemberExpression),
+    TSAsExpression(TSAsExpression),
+    TSSatisfiesExpression(TSSatisfiesExpression),
+    TSNonNullExpression(TSNonNullExpression),
+    TSTypeAssertion(TSTypeAssertion),
     // Flow's analogue of the TS cast wrappers: `(expr: SomeType)`.
-    TypeCastExpression(crate::react_compiler_ast::expressions::TypeCastExpression),
+    TypeCastExpression(TypeCastExpression),
 }
 
 impl PatternLike {

--- a/crates/oxc_react_compiler/src/react_compiler_ast/scope.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ast/scope.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_utils::FxIndexMap;
 use serde::Serialize;
@@ -197,7 +197,7 @@ impl ScopeInfo {
         name: &str,
         ancestor: ScopeId,
     ) -> Option<&BindingData> {
-        let mut descendants = rustc_hash::FxHashSet::default();
+        let mut descendants = FxHashSet::default();
         descendants.insert(ancestor);
         let mut changed = true;
         while changed {
@@ -228,7 +228,7 @@ impl ScopeInfo {
         name: &str,
         ancestor: ScopeId,
     ) -> Option<(BindingId, &BindingData)> {
-        let mut descendants = rustc_hash::FxHashSet::default();
+        let mut descendants = FxHashSet::default();
         descendants.insert(ancestor);
         let mut changed = true;
         while changed {
@@ -291,7 +291,7 @@ impl ScopeInfo {
         ancestor: ScopeId,
         is_claimed: impl Fn(ScopeId) -> bool,
     ) -> Option<ScopeId> {
-        let mut descendants = rustc_hash::FxHashSet::default();
+        let mut descendants = FxHashSet::default();
         descendants.insert(ancestor);
         let mut changed = true;
         while changed {

--- a/crates/oxc_react_compiler/src/react_compiler_ast/statements.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ast/statements.rs
@@ -3,6 +3,31 @@ use serde::Serializer;
 
 use crate::react_compiler_ast::common::BaseNode;
 use crate::react_compiler_ast::common::RawNode;
+use crate::react_compiler_ast::common::from_json_str_unbounded;
+use crate::react_compiler_ast::declarations::DeclareClass;
+use crate::react_compiler_ast::declarations::DeclareExportAllDeclaration;
+use crate::react_compiler_ast::declarations::DeclareExportDeclaration;
+use crate::react_compiler_ast::declarations::DeclareFunction;
+use crate::react_compiler_ast::declarations::DeclareInterface;
+use crate::react_compiler_ast::declarations::DeclareModule;
+use crate::react_compiler_ast::declarations::DeclareModuleExports;
+use crate::react_compiler_ast::declarations::DeclareOpaqueType;
+use crate::react_compiler_ast::declarations::DeclareTypeAlias;
+use crate::react_compiler_ast::declarations::DeclareVariable;
+use crate::react_compiler_ast::declarations::EnumDeclaration;
+use crate::react_compiler_ast::declarations::ExportAllDeclaration;
+use crate::react_compiler_ast::declarations::ExportDefaultDeclaration;
+use crate::react_compiler_ast::declarations::ExportNamedDeclaration;
+use crate::react_compiler_ast::declarations::ImportDeclaration;
+use crate::react_compiler_ast::declarations::InterfaceDeclaration;
+use crate::react_compiler_ast::declarations::OpaqueType;
+use crate::react_compiler_ast::declarations::TSDeclareFunction;
+use crate::react_compiler_ast::declarations::TSEnumDeclaration;
+use crate::react_compiler_ast::declarations::TSInterfaceDeclaration;
+use crate::react_compiler_ast::declarations::TSModuleDeclaration;
+use crate::react_compiler_ast::declarations::TSTypeAliasDeclaration;
+use crate::react_compiler_ast::declarations::TypeAlias;
+use crate::react_compiler_ast::expressions::ClassBody;
 use crate::react_compiler_ast::expressions::Expression;
 use crate::react_compiler_ast::expressions::Identifier;
 use crate::react_compiler_ast::patterns::PatternLike;
@@ -38,33 +63,31 @@ pub enum Statement {
     FunctionDeclaration(FunctionDeclaration),
     ClassDeclaration(ClassDeclaration),
     // Import/export declarations
-    ImportDeclaration(crate::react_compiler_ast::declarations::ImportDeclaration),
-    ExportNamedDeclaration(crate::react_compiler_ast::declarations::ExportNamedDeclaration),
-    ExportDefaultDeclaration(crate::react_compiler_ast::declarations::ExportDefaultDeclaration),
-    ExportAllDeclaration(crate::react_compiler_ast::declarations::ExportAllDeclaration),
+    ImportDeclaration(ImportDeclaration),
+    ExportNamedDeclaration(ExportNamedDeclaration),
+    ExportDefaultDeclaration(ExportDefaultDeclaration),
+    ExportAllDeclaration(ExportAllDeclaration),
     // TypeScript declarations
-    TSTypeAliasDeclaration(crate::react_compiler_ast::declarations::TSTypeAliasDeclaration),
-    TSInterfaceDeclaration(crate::react_compiler_ast::declarations::TSInterfaceDeclaration),
-    TSEnumDeclaration(crate::react_compiler_ast::declarations::TSEnumDeclaration),
-    TSModuleDeclaration(crate::react_compiler_ast::declarations::TSModuleDeclaration),
-    TSDeclareFunction(crate::react_compiler_ast::declarations::TSDeclareFunction),
+    TSTypeAliasDeclaration(TSTypeAliasDeclaration),
+    TSInterfaceDeclaration(TSInterfaceDeclaration),
+    TSEnumDeclaration(TSEnumDeclaration),
+    TSModuleDeclaration(TSModuleDeclaration),
+    TSDeclareFunction(TSDeclareFunction),
     // Flow declarations
-    TypeAlias(crate::react_compiler_ast::declarations::TypeAlias),
-    OpaqueType(crate::react_compiler_ast::declarations::OpaqueType),
-    InterfaceDeclaration(crate::react_compiler_ast::declarations::InterfaceDeclaration),
-    DeclareVariable(crate::react_compiler_ast::declarations::DeclareVariable),
-    DeclareFunction(crate::react_compiler_ast::declarations::DeclareFunction),
-    DeclareClass(crate::react_compiler_ast::declarations::DeclareClass),
-    DeclareModule(crate::react_compiler_ast::declarations::DeclareModule),
-    DeclareModuleExports(crate::react_compiler_ast::declarations::DeclareModuleExports),
-    DeclareExportDeclaration(crate::react_compiler_ast::declarations::DeclareExportDeclaration),
-    DeclareExportAllDeclaration(
-        crate::react_compiler_ast::declarations::DeclareExportAllDeclaration,
-    ),
-    DeclareInterface(crate::react_compiler_ast::declarations::DeclareInterface),
-    DeclareTypeAlias(crate::react_compiler_ast::declarations::DeclareTypeAlias),
-    DeclareOpaqueType(crate::react_compiler_ast::declarations::DeclareOpaqueType),
-    EnumDeclaration(crate::react_compiler_ast::declarations::EnumDeclaration),
+    TypeAlias(TypeAlias),
+    OpaqueType(OpaqueType),
+    InterfaceDeclaration(InterfaceDeclaration),
+    DeclareVariable(DeclareVariable),
+    DeclareFunction(DeclareFunction),
+    DeclareClass(DeclareClass),
+    DeclareModule(DeclareModule),
+    DeclareModuleExports(DeclareModuleExports),
+    DeclareExportDeclaration(DeclareExportDeclaration),
+    DeclareExportAllDeclaration(DeclareExportAllDeclaration),
+    DeclareInterface(DeclareInterface),
+    DeclareTypeAlias(DeclareTypeAlias),
+    DeclareOpaqueType(DeclareOpaqueType),
+    EnumDeclaration(EnumDeclaration),
     /// Catch-all for statement `type`s the typed AST does not model, e.g. the
     /// TypeScript module-interop statements `import x = require(...)`,
     /// `export = x`, and `export as namespace X`. Carries the complete raw
@@ -99,10 +122,8 @@ impl UnknownStatement {
             Some(_) => {
                 // Parsing into BaseNode reads only the fields BaseNode declares,
                 // not the whole (arbitrarily large) unknown subtree.
-                let base = crate::react_compiler_ast::common::from_json_str_unbounded::<BaseNode>(
-                    raw.get(),
-                )
-                .map_err(|err| format!("failed to read unknown statement base: {err}"))?;
+                let base = from_json_str_unbounded::<BaseNode>(raw.get())
+                    .map_err(|err| format!("failed to read unknown statement base: {err}"))?;
                 Ok(Self { raw, base })
             }
             None => Err("unknown statement is missing a string `type` field".to_string()),
@@ -130,8 +151,7 @@ impl UnknownStatement {
             self.raw = saved;
             return Err("unknown statement mutation removed the string `type` field".to_string());
         }
-        match crate::react_compiler_ast::common::from_json_str_unbounded::<BaseNode>(self.raw.get())
-        {
+        match from_json_str_unbounded::<BaseNode>(self.raw.get()) {
             Ok(base) => {
                 self.base = base;
                 Ok(result)
@@ -410,7 +430,7 @@ pub struct ClassDeclaration {
     pub id: Option<Identifier>,
     #[serde(rename = "superClass")]
     pub super_class: Option<Box<Expression>>,
-    pub body: crate::react_compiler_ast::expressions::ClassBody,
+    pub body: ClassBody,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub decorators: Option<Vec<RawNode>>,
     #[serde(default, skip_serializing_if = "Option::is_none", rename = "abstract")]

--- a/crates/oxc_react_compiler/src/react_compiler_ast/visitor.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ast/visitor.rs
@@ -68,11 +68,7 @@ pub trait Visitor<'ast> {
         _scope_stack: &[ScopeId],
     ) {
     }
-    fn enter_class_declaration(
-        &mut self,
-        _node: &'ast crate::react_compiler_ast::statements::ClassDeclaration,
-        _scope_stack: &[ScopeId],
-    ) {
+    fn enter_class_declaration(&mut self, _node: &'ast ClassDeclaration, _scope_stack: &[ScopeId]) {
     }
     fn enter_class_expression(&mut self, _node: &'ast ClassExpression, _scope_stack: &[ScopeId]) {}
     fn enter_object_method(&mut self, _node: &'ast ObjectMethod, _scope_stack: &[ScopeId]) {}
@@ -1340,17 +1336,16 @@ pub fn walk_expression_mut(v: &mut impl MutVisitor, expr: &mut Expression) -> Vi
 
 fn walk_jsx_mut(
     v: &mut impl MutVisitor,
-    attrs: &mut [crate::react_compiler_ast::jsx::JSXAttributeItem],
-    children: &mut [crate::react_compiler_ast::jsx::JSXChild],
+    attrs: &mut [JSXAttributeItem],
+    children: &mut [JSXChild],
 ) -> VisitResult {
     for attr in attrs.iter_mut() {
         match attr {
-            crate::react_compiler_ast::jsx::JSXAttributeItem::JSXAttribute(a) => {
+            JSXAttributeItem::JSXAttribute(a) => {
                 if let Some(ref mut val) = a.value {
                     match val {
-                        crate::react_compiler_ast::jsx::JSXAttributeValue::JSXExpressionContainer(c) => {
-                            if let crate::react_compiler_ast::jsx::JSXExpressionContainerExpr::Expression(ref mut e) =
-                                c.expression
+                        JSXAttributeValue::JSXExpressionContainer(c) => {
+                            if let JSXExpressionContainerExpr::Expression(ref mut e) = c.expression
                             {
                                 if walk_expression_mut(v, e).is_stop() {
                                     return VisitResult::Stop;
@@ -1361,7 +1356,7 @@ fn walk_jsx_mut(
                     }
                 }
             }
-            crate::react_compiler_ast::jsx::JSXAttributeItem::JSXSpreadAttribute(s) => {
+            JSXAttributeItem::JSXSpreadAttribute(s) => {
                 if walk_expression_mut(v, &mut s.argument).is_stop() {
                     return VisitResult::Stop;
                 }
@@ -1371,33 +1366,27 @@ fn walk_jsx_mut(
     walk_jsx_children_mut(v, children)
 }
 
-fn walk_jsx_children_mut(
-    v: &mut impl MutVisitor,
-    children: &mut [crate::react_compiler_ast::jsx::JSXChild],
-) -> VisitResult {
+fn walk_jsx_children_mut(v: &mut impl MutVisitor, children: &mut [JSXChild]) -> VisitResult {
     for child in children.iter_mut() {
         match child {
-            crate::react_compiler_ast::jsx::JSXChild::JSXElement(el) => {
+            JSXChild::JSXElement(el) => {
                 if walk_jsx_mut(v, &mut el.opening_element.attributes, &mut el.children).is_stop() {
                     return VisitResult::Stop;
                 }
             }
-            crate::react_compiler_ast::jsx::JSXChild::JSXFragment(f) => {
+            JSXChild::JSXFragment(f) => {
                 if walk_jsx_children_mut(v, &mut f.children).is_stop() {
                     return VisitResult::Stop;
                 }
             }
-            crate::react_compiler_ast::jsx::JSXChild::JSXExpressionContainer(c) => {
-                if let crate::react_compiler_ast::jsx::JSXExpressionContainerExpr::Expression(
-                    ref mut e,
-                ) = c.expression
-                {
+            JSXChild::JSXExpressionContainer(c) => {
+                if let JSXExpressionContainerExpr::Expression(ref mut e) = c.expression {
                     if walk_expression_mut(v, e).is_stop() {
                         return VisitResult::Stop;
                     }
                 }
             }
-            crate::react_compiler_ast::jsx::JSXChild::JSXSpreadChild(s) => {
+            JSXChild::JSXSpreadChild(s) => {
                 if walk_expression_mut(v, &mut s.expression).is_stop() {
                     return VisitResult::Stop;
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_diagnostics/code_frame.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_diagnostics/code_frame.rs
@@ -4,6 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+use std::cmp::min;
+
+use rustc_hash::FxHashMap;
+
 use crate::react_compiler_diagnostics::{
     CompilerDiagnosticDetail, CompilerError, CompilerErrorOrDiagnostic,
 };
@@ -83,7 +87,7 @@ fn get_marker_lines(
     } else {
         0
     };
-    let end = std::cmp::min(source_line_count, end_line + lines_below as usize);
+    let end = min(source_line_count, end_line + lines_below as usize);
 
     let line_diff = end_line - start_line;
     let mut marker_lines: Vec<(usize, MarkerEntry)> = Vec::new();
@@ -158,8 +162,7 @@ pub fn code_frame_columns(
     let number_max_width = format!("{}", end).len();
 
     // Build a lookup map for marker lines
-    let mut marker_map: rustc_hash::FxHashMap<usize, MarkerEntry> =
-        rustc_hash::FxHashMap::default();
+    let mut marker_map: FxHashMap<usize, MarkerEntry> = FxHashMap::default();
     let line_diff = end_line as usize - start_line as usize;
     for (line_number, entry) in marker_lines_raw {
         // Resolve placeholder lengths using actual source lines
@@ -226,7 +229,7 @@ pub fn code_frame_columns(
                 MarkerEntry::Range(col, len) => {
                     // Build marker spacing: replace non-tab chars with spaces
                     let max_col = if *col > 0 { col - 1 } else { 0 };
-                    let byte_end = std::cmp::min(max_col, line.len());
+                    let byte_end = min(max_col, line.len());
                     // Ensure we don't slice in the middle of a multi-byte UTF-8 character
                     let safe_end = if byte_end < line.len() && !line.is_char_boundary(byte_end) {
                         line.floor_char_boundary(byte_end)

--- a/crates/oxc_react_compiler/src/react_compiler_diagnostics/js_string.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_diagnostics/js_string.rs
@@ -12,8 +12,9 @@
 //! JS side of the bridge unchanged.
 
 use std::fmt;
+use std::str::from_utf8;
 
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 /// Invariant: `Repr::Utf8` holds every well-formed value and `Repr::Wtf16`
 /// only ill-formed ones (at least one unpaired surrogate). The derived
@@ -114,7 +115,7 @@ impl JsString {
                     .iter()
                     .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_lowercase());
             if well_formed {
-                let hex = std::str::from_utf8(&tail[PREFIX.len()..PREFIX.len() + 4])
+                let hex = from_utf8(&tail[PREFIX.len()..PREFIX.len() + 4])
                     .expect("ascii hex is valid utf8");
                 let unit = u16::from_str_radix(hex, 16).expect("validated hex digits");
                 units.extend(s[segment_start..idx].encode_utf16());
@@ -241,7 +242,7 @@ impl fmt::Display for JsString {
 }
 
 impl Serialize for JsString {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&self.to_marker_string())
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_diagnostics/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_diagnostics/mod.rs
@@ -3,6 +3,9 @@ pub mod js_string;
 
 pub use js_string::JsString;
 
+use std::error::Error;
+use std::fmt::{Display, Formatter, Result};
+
 use serde::{Deserialize, Serialize};
 
 /// Error categories matching the TS ErrorCategory enum
@@ -404,8 +407,8 @@ impl From<CompilerDiagnostic> for CompilerError {
     }
 }
 
-impl std::fmt::Display for CompilerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for CompilerError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         for detail in &self.details {
             match detail {
                 CompilerErrorOrDiagnostic::Diagnostic(d) => {
@@ -427,7 +430,7 @@ impl std::fmt::Display for CompilerError {
     }
 }
 
-impl std::error::Error for CompilerError {}
+impl Error for CompilerError {}
 
 pub fn format_category_heading(category: ErrorCategory) -> &'static str {
     match category {

--- a/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/environment.rs
@@ -1,9 +1,12 @@
+use std::mem::take;
+
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
 use crate::react_compiler_diagnostics::CompilerDiagnostic;
 use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_diagnostics::CompilerErrorDetail;
+use crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic;
 use crate::react_compiler_diagnostics::ErrorCategory;
 
 use crate::react_compiler_hir::default_module_type_provider::default_module_type_provider;
@@ -361,7 +364,7 @@ impl Environment {
     }
 
     pub fn take_errors(&mut self) -> CompilerError {
-        let mut errors = std::mem::take(&mut self.errors);
+        let mut errors = take(&mut self.errors);
         // Mark as not thrown — these are accumulated errors returned at the end
         // of the pipeline, not errors thrown by a pass.
         errors.is_thrown = false;
@@ -384,15 +387,11 @@ impl Environment {
     pub fn take_invariant_errors(&mut self) -> CompilerError {
         let mut invariant = CompilerError::new();
         let mut remaining = CompilerError::new();
-        let old = std::mem::take(&mut self.errors);
+        let old = take(&mut self.errors);
         for detail in old.details {
             let is_invariant = match &detail {
-                crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic::Diagnostic(d) => {
-                    d.category == crate::react_compiler_diagnostics::ErrorCategory::Invariant
-                }
-                crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic::ErrorDetail(d) => {
-                    d.category == crate::react_compiler_diagnostics::ErrorCategory::Invariant
-                }
+                CompilerErrorOrDiagnostic::Diagnostic(d) => d.category == ErrorCategory::Invariant,
+                CompilerErrorOrDiagnostic::ErrorDetail(d) => d.category == ErrorCategory::Invariant,
             };
             if is_invariant {
                 invariant.details.push(detail);
@@ -408,12 +407,8 @@ impl Environment {
     /// In TS, Todo errors throw immediately via CompilerError.throwTodo().
     pub fn has_todo_errors(&self) -> bool {
         self.errors.details.iter().any(|d| match d {
-            crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic::Diagnostic(d) => {
-                d.category == crate::react_compiler_diagnostics::ErrorCategory::Todo
-            }
-            crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic::ErrorDetail(d) => {
-                d.category == crate::react_compiler_diagnostics::ErrorCategory::Todo
-            }
+            CompilerErrorOrDiagnostic::Diagnostic(d) => d.category == ErrorCategory::Todo,
+            CompilerErrorOrDiagnostic::ErrorDetail(d) => d.category == ErrorCategory::Todo,
         })
     }
 
@@ -422,16 +417,14 @@ impl Environment {
     pub fn take_thrown_errors(&mut self) -> CompilerError {
         let mut thrown = CompilerError::new();
         let mut remaining = CompilerError::new();
-        let old = std::mem::take(&mut self.errors);
+        let old = take(&mut self.errors);
         for detail in old.details {
             let is_thrown = match &detail {
-                crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic::Diagnostic(d) => {
-                    d.category == crate::react_compiler_diagnostics::ErrorCategory::Invariant
-                        || d.category == crate::react_compiler_diagnostics::ErrorCategory::Todo
+                CompilerErrorOrDiagnostic::Diagnostic(d) => {
+                    d.category == ErrorCategory::Invariant || d.category == ErrorCategory::Todo
                 }
-                crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic::ErrorDetail(d) => {
-                    d.category == crate::react_compiler_diagnostics::ErrorCategory::Invariant
-                        || d.category == crate::react_compiler_diagnostics::ErrorCategory::Todo
+                CompilerErrorOrDiagnostic::ErrorDetail(d) => {
+                    d.category == ErrorCategory::Invariant || d.category == ErrorCategory::Todo
                 }
             };
             if is_thrown {
@@ -910,7 +903,7 @@ impl Environment {
 
     /// Take the outlined functions, leaving the vec empty.
     pub fn take_outlined_functions(&mut self) -> Vec<OutlinedFunctionEntry> {
-        std::mem::take(&mut self.outlined_functions)
+        take(&mut self.outlined_functions)
     }
 
     /// Whether memoization is enabled for this compilation.

--- a/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/globals.rs
@@ -13,6 +13,7 @@ use std::sync::LazyLock;
 
 use crate::react_compiler_hir::Effect;
 use crate::react_compiler_hir::Type;
+use crate::react_compiler_hir::environment::is_hook_name;
 use crate::react_compiler_hir::object_shape::*;
 use crate::react_compiler_hir::type_config::AliasingEffectConfig;
 use crate::react_compiler_hir::type_config::AliasingSignatureConfig;
@@ -240,7 +241,7 @@ fn install_type_config_inner(
                             );
                             // Validate hook-name vs hook-type consistency (matching TS installTypeConfig)
                             if let Some(errs) = errors {
-                                let expect_hook = crate::react_compiler_hir::environment::is_hook_name(key);
+                                let expect_hook = is_hook_name(key);
                                 let is_hook = match &ty {
                                     Type::Function { shape_id: Some(id), .. } => {
                                         shapes.get(id)

--- a/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/mod.rs
@@ -9,14 +9,23 @@ pub mod reactive;
 pub mod type_config;
 pub mod visitors;
 
+use crate::react_compiler_ast::OriginalNode;
 pub use crate::react_compiler_diagnostics::CompilerDiagnostic;
 pub use crate::react_compiler_diagnostics::ErrorCategory;
 pub use crate::react_compiler_diagnostics::GENERATED_SOURCE;
+use crate::react_compiler_diagnostics::JsString;
 pub use crate::react_compiler_diagnostics::Position;
 pub use crate::react_compiler_diagnostics::SourceLocation;
 use crate::react_compiler_utils::FxIndexMap;
 use crate::react_compiler_utils::FxIndexSet;
 pub use reactive::*;
+use serde::Serialize;
+use serde_json::Value;
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
+use std::hash::Hash;
+use std::hash::Hasher;
 
 // =============================================================================
 // ID newtypes
@@ -91,14 +100,14 @@ impl PartialEq for FloatValue {
 
 impl Eq for FloatValue {}
 
-impl std::hash::Hash for FloatValue {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl Hash for FloatValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }
 }
 
-impl std::fmt::Display for FloatValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for FloatValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "{}", format_js_number(self.value()))
     }
 }
@@ -199,8 +208,8 @@ pub enum BlockKind {
     Catch,
 }
 
-impl std::fmt::Display for BlockKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for BlockKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             BlockKind::Block => write!(f, "block"),
             BlockKind::Value => write!(f, "value"),
@@ -498,8 +507,8 @@ pub enum LogicalOperator {
     NullishCoalescing,
 }
 
-impl std::fmt::Display for LogicalOperator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for LogicalOperator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             LogicalOperator::And => write!(f, "&&"),
             LogicalOperator::Or => write!(f, "||"),
@@ -633,7 +642,7 @@ pub enum InstructionValue {
         /// The original AST type annotation node, preserved for codegen.
         /// For Flow: the inner type from TypeAnnotation.typeAnnotation
         /// For TS: the TSType node from TSAsExpression/TSSatisfiesExpression
-        type_annotation: Option<Box<serde_json::Value>>,
+        type_annotation: Option<Box<Value>>,
         loc: Option<SourceLocation>,
     },
     JsxExpression {
@@ -781,7 +790,7 @@ pub enum InstructionValue {
     UnsupportedNode {
         node_type: Option<String>,
         /// The original AST node, preserved verbatim so codegen can re-emit it.
-        original_node: Option<crate::react_compiler_ast::OriginalNode>,
+        original_node: Option<OriginalNode>,
         loc: Option<SourceLocation>,
     },
 }
@@ -846,7 +855,7 @@ pub enum PrimitiveValue {
     Undefined,
     Boolean(bool),
     Number(FloatValue),
-    String(crate::react_compiler_diagnostics::JsString),
+    String(JsString),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -875,8 +884,8 @@ pub enum BinaryOperator {
     InstanceOf,
 }
 
-impl std::fmt::Display for BinaryOperator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for BinaryOperator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             BinaryOperator::Equal => write!(f, "=="),
             BinaryOperator::NotEqual => write!(f, "!="),
@@ -914,8 +923,8 @@ pub enum UnaryOperator {
     Void,
 }
 
-impl std::fmt::Display for UnaryOperator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for UnaryOperator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             UnaryOperator::Minus => write!(f, "-"),
             UnaryOperator::Plus => write!(f, "+"),
@@ -933,8 +942,8 @@ pub enum UpdateOperator {
     Decrement,
 }
 
-impl std::fmt::Display for UpdateOperator {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for UpdateOperator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             UpdateOperator::Increment => write!(f, "++"),
             UpdateOperator::Decrement => write!(f, "--"),
@@ -1037,7 +1046,7 @@ impl IdentifierName {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum Effect {
     #[serde(rename = "<unknown>")]
     Unknown,
@@ -1073,8 +1082,8 @@ impl Effect {
     }
 }
 
-impl std::fmt::Display for Effect {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for Effect {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             Effect::Unknown => write!(f, "<unknown>"),
             Effect::Freeze => write!(f, "freeze"),
@@ -1144,8 +1153,8 @@ pub enum ObjectPropertyType {
     Method,
 }
 
-impl std::fmt::Display for ObjectPropertyType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for ObjectPropertyType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             ObjectPropertyType::Property => write!(f, "property"),
             ObjectPropertyType::Method => write!(f, "method"),
@@ -1159,8 +1168,8 @@ pub enum PropertyLiteral {
     Number(FloatValue),
 }
 
-impl std::fmt::Display for PropertyLiteral {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for PropertyLiteral {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             PropertyLiteral::String(s) => write!(f, "{}", s),
             PropertyLiteral::Number(n) => write!(f, "{}", n),

--- a/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
@@ -8,6 +8,8 @@
 //! Defines the shape registry used by Environment to resolve property types
 //! and function call signatures for built-in objects, hooks, and user-defined types.
 
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use rustc_hash::FxHashMap;
 
 use crate::react_compiler_hir::Effect;
@@ -178,7 +180,6 @@ impl Clone for ShapeRegistry {
 /// Thread-local counter for generating unique anonymous shape IDs.
 /// Mirrors TS `nextAnonId` in ObjectShape.ts.
 fn next_anon_id() -> String {
-    use std::sync::atomic::{AtomicU32, Ordering};
     static COUNTER: AtomicU32 = AtomicU32::new(0);
     let id = COUNTER.fetch_add(1, Ordering::Relaxed);
     format!("<generated_{}>", id)

--- a/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/object_shape.rs
@@ -8,6 +8,9 @@
 //! Defines the shape registry used by Environment to resolve property types
 //! and function call signatures for built-in objects, hooks, and user-defined types.
 
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use rustc_hash::FxHashMap;
@@ -76,8 +79,8 @@ pub enum HookKind {
     Custom,
 }
 
-impl std::fmt::Display for HookKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for HookKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             HookKind::UseContext => write!(f, "useContext"),
             HookKind::UseState => write!(f, "useState"),

--- a/crates/oxc_react_compiler/src/react_compiler_hir/print.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/print.rs
@@ -15,18 +15,32 @@ use crate::react_compiler_diagnostics::CompilerErrorOrDiagnostic;
 use crate::react_compiler_diagnostics::SourceLocation;
 
 use crate::react_compiler_hir::AliasingEffect;
+use crate::react_compiler_hir::ArrayElement;
+use crate::react_compiler_hir::ArrayPatternElement;
 use crate::react_compiler_hir::HirFunction;
 use crate::react_compiler_hir::IdentifierId;
 use crate::react_compiler_hir::IdentifierName;
 use crate::react_compiler_hir::InstructionValue;
+use crate::react_compiler_hir::JsxAttribute;
+use crate::react_compiler_hir::JsxTag;
 use crate::react_compiler_hir::LValue;
+use crate::react_compiler_hir::ManualMemoDependencyRoot;
 use crate::react_compiler_hir::MutationReason;
+use crate::react_compiler_hir::NonLocalBinding;
+use crate::react_compiler_hir::ObjectPropertyKey;
+use crate::react_compiler_hir::ObjectPropertyOrSpread;
 use crate::react_compiler_hir::Pattern;
 use crate::react_compiler_hir::Place;
+use crate::react_compiler_hir::PlaceOrSpread;
 use crate::react_compiler_hir::PlaceOrSpreadOrHole;
+use crate::react_compiler_hir::PrimitiveValue;
+use crate::react_compiler_hir::PropertyLiteral;
+use crate::react_compiler_hir::PropertyNameKind;
 use crate::react_compiler_hir::ScopeId;
 use crate::react_compiler_hir::Type;
+use crate::react_compiler_hir::TypeId;
 use crate::react_compiler_hir::environment::Environment;
+use crate::react_compiler_hir::format_js_number;
 use crate::react_compiler_hir::type_config::ValueKind;
 use crate::react_compiler_hir::type_config::ValueReason;
 
@@ -71,15 +85,13 @@ pub fn format_js_string(s: &str) -> String {
     result
 }
 
-pub fn format_primitive(prim: &crate::react_compiler_hir::PrimitiveValue) -> String {
+pub fn format_primitive(prim: &PrimitiveValue) -> String {
     match prim {
-        crate::react_compiler_hir::PrimitiveValue::Null => "null".to_string(),
-        crate::react_compiler_hir::PrimitiveValue::Undefined => "undefined".to_string(),
-        crate::react_compiler_hir::PrimitiveValue::Boolean(b) => format!("{}", b),
-        crate::react_compiler_hir::PrimitiveValue::Number(n) => {
-            crate::react_compiler_hir::format_js_number(n.value())
-        }
-        crate::react_compiler_hir::PrimitiveValue::String(s) => match s.as_str() {
+        PrimitiveValue::Null => "null".to_string(),
+        PrimitiveValue::Undefined => "undefined".to_string(),
+        PrimitiveValue::Boolean(b) => format!("{}", b),
+        PrimitiveValue::Number(n) => format_js_number(n.value()),
+        PrimitiveValue::String(s) => match s.as_str() {
             Some(utf8) => format_js_string(utf8),
             // Ill-formed strings: escape the well-formed segments exactly like
             // format_js_string and render each unpaired surrogate as \uXXXX,
@@ -129,47 +141,45 @@ pub fn format_primitive(prim: &crate::react_compiler_hir::PrimitiveValue) -> Str
     }
 }
 
-pub fn format_property_literal(prop: &crate::react_compiler_hir::PropertyLiteral) -> String {
+pub fn format_property_literal(prop: &PropertyLiteral) -> String {
     match prop {
-        crate::react_compiler_hir::PropertyLiteral::String(s) => s.clone(),
-        crate::react_compiler_hir::PropertyLiteral::Number(n) => {
-            crate::react_compiler_hir::format_js_number(n.value())
-        }
+        PropertyLiteral::String(s) => s.clone(),
+        PropertyLiteral::Number(n) => format_js_number(n.value()),
     }
 }
 
-pub fn format_object_property_key(key: &crate::react_compiler_hir::ObjectPropertyKey) -> String {
+pub fn format_object_property_key(key: &ObjectPropertyKey) -> String {
     match key {
-        crate::react_compiler_hir::ObjectPropertyKey::String { name } => {
+        ObjectPropertyKey::String { name } => {
             format!("String(\"{}\")", name)
         }
-        crate::react_compiler_hir::ObjectPropertyKey::Identifier { name } => {
+        ObjectPropertyKey::Identifier { name } => {
             format!("Identifier(\"{}\")", name)
         }
-        crate::react_compiler_hir::ObjectPropertyKey::Computed { name } => {
+        ObjectPropertyKey::Computed { name } => {
             format!("Computed({})", name.identifier.0)
         }
-        crate::react_compiler_hir::ObjectPropertyKey::Number { name } => {
-            format!("Number({})", crate::react_compiler_hir::format_js_number(name.value()))
+        ObjectPropertyKey::Number { name } => {
+            format!("Number({})", format_js_number(name.value()))
         }
     }
 }
 
-pub fn format_non_local_binding(binding: &crate::react_compiler_hir::NonLocalBinding) -> String {
+pub fn format_non_local_binding(binding: &NonLocalBinding) -> String {
     match binding {
-        crate::react_compiler_hir::NonLocalBinding::Global { name } => {
+        NonLocalBinding::Global { name } => {
             format!("Global {{ name: \"{}\" }}", name)
         }
-        crate::react_compiler_hir::NonLocalBinding::ModuleLocal { name } => {
+        NonLocalBinding::ModuleLocal { name } => {
             format!("ModuleLocal {{ name: \"{}\" }}", name)
         }
-        crate::react_compiler_hir::NonLocalBinding::ImportDefault { name, module } => {
+        NonLocalBinding::ImportDefault { name, module } => {
             format!("ImportDefault {{ name: \"{}\", module: \"{}\" }}", name, module)
         }
-        crate::react_compiler_hir::NonLocalBinding::ImportNamespace { name, module } => {
+        NonLocalBinding::ImportNamespace { name, module } => {
             format!("ImportNamespace {{ name: \"{}\", module: \"{}\" }}", name, module)
         }
-        crate::react_compiler_hir::NonLocalBinding::ImportSpecifier { name, module, imported } => {
+        NonLocalBinding::ImportSpecifier { name, module, imported } => {
             format!(
                 "ImportSpecifier {{ name: \"{}\", module: \"{}\", imported: \"{}\" }}",
                 name, module, imported
@@ -471,10 +481,8 @@ impl<'a> PrintFormatter<'a> {
                         .iter()
                         .map(|p| {
                             let prop = match &p.property {
-                                crate::react_compiler_hir::PropertyLiteral::String(s) => s.clone(),
-                                crate::react_compiler_hir::PropertyLiteral::Number(n) => {
-                                    crate::react_compiler_hir::format_js_number(n.value())
-                                }
+                                PropertyLiteral::String(s) => s.clone(),
+                                PropertyLiteral::Number(n) => format_js_number(n.value()),
                             };
                             format!("{}{}", if p.optional { "?." } else { "." }, prop)
                         })
@@ -536,7 +544,7 @@ impl<'a> PrintFormatter<'a> {
     // Type
     // =========================================================================
 
-    pub fn format_type(&self, type_id: crate::react_compiler_hir::TypeId) -> String {
+    pub fn format_type(&self, type_id: TypeId) -> String {
         if let Some(ty) = self.env.types.get(type_id.0 as usize) {
             self.format_type_value(ty)
         } else {
@@ -576,10 +584,10 @@ impl<'a> PrintFormatter<'a> {
             }
             Type::Property { object_type, object_name, property_name } => {
                 let prop_str = match property_name {
-                    crate::react_compiler_hir::PropertyNameKind::Literal { value } => {
+                    PropertyNameKind::Literal { value } => {
                         format!("\"{}\"", format_property_literal(value))
                     }
-                    crate::react_compiler_hir::PropertyNameKind::Computed { value } => {
+                    PropertyNameKind::Computed { value } => {
                         format!("computed({})", self.format_type_value(value))
                     }
                 };
@@ -619,13 +627,13 @@ impl<'a> PrintFormatter<'a> {
                 self.indent();
                 for (i, item) in arr.items.iter().enumerate() {
                     match item {
-                        crate::react_compiler_hir::ArrayPatternElement::Hole => {
+                        ArrayPatternElement::Hole => {
                             self.line(&format!("[{}] Hole", i));
                         }
-                        crate::react_compiler_hir::ArrayPatternElement::Place(p) => {
+                        ArrayPatternElement::Place(p) => {
                             self.format_place_field(&format!("[{}]", i), p);
                         }
-                        crate::react_compiler_hir::ArrayPatternElement::Spread(s) => {
+                        ArrayPatternElement::Spread(s) => {
                             self.line(&format!("[{}] Spread:", i));
                             self.indent();
                             self.format_place_field("place", &s.place);
@@ -645,7 +653,7 @@ impl<'a> PrintFormatter<'a> {
                 self.indent();
                 for (i, prop) in obj.properties.iter().enumerate() {
                     match prop {
-                        crate::react_compiler_hir::ObjectPropertyOrSpread::Property(p) => {
+                        ObjectPropertyOrSpread::Property(p) => {
                             self.line(&format!("[{}] ObjectProperty {{", i));
                             self.indent();
                             self.line(&format!("key: {}", format_object_property_key(&p.key)));
@@ -654,7 +662,7 @@ impl<'a> PrintFormatter<'a> {
                             self.dedent();
                             self.line("}");
                         }
-                        crate::react_compiler_hir::ObjectPropertyOrSpread::Spread(s) => {
+                        ObjectPropertyOrSpread::Spread(s) => {
                             self.line(&format!("[{}] Spread:", i));
                             self.indent();
                             self.format_place_field("place", &s.place);
@@ -674,16 +682,12 @@ impl<'a> PrintFormatter<'a> {
     // Arguments
     // =========================================================================
 
-    pub fn format_argument(
-        &mut self,
-        arg: &crate::react_compiler_hir::PlaceOrSpread,
-        index: usize,
-    ) {
+    pub fn format_argument(&mut self, arg: &PlaceOrSpread, index: usize) {
         match arg {
-            crate::react_compiler_hir::PlaceOrSpread::Place(p) => {
+            PlaceOrSpread::Place(p) => {
                 self.format_place_field(&format!("[{}]", index), p);
             }
-            crate::react_compiler_hir::PlaceOrSpread::Spread(s) => {
+            PlaceOrSpread::Spread(s) => {
                 self.line(&format!("[{}] Spread:", index));
                 self.indent();
                 self.format_place_field("place", &s.place);
@@ -712,13 +716,13 @@ impl<'a> PrintFormatter<'a> {
                 self.indent();
                 for (i, elem) in elements.iter().enumerate() {
                     match elem {
-                        crate::react_compiler_hir::ArrayElement::Place(p) => {
+                        ArrayElement::Place(p) => {
                             self.format_place_field(&format!("[{}]", i), p);
                         }
-                        crate::react_compiler_hir::ArrayElement::Hole => {
+                        ArrayElement::Hole => {
                             self.line(&format!("[{}] Hole", i));
                         }
-                        crate::react_compiler_hir::ArrayElement::Spread(s) => {
+                        ArrayElement::Spread(s) => {
                             self.line(&format!("[{}] Spread:", i));
                             self.indent();
                             self.format_place_field("place", &s.place);
@@ -738,7 +742,7 @@ impl<'a> PrintFormatter<'a> {
                 self.indent();
                 for (i, prop) in properties.iter().enumerate() {
                     match prop {
-                        crate::react_compiler_hir::ObjectPropertyOrSpread::Property(p) => {
+                        ObjectPropertyOrSpread::Property(p) => {
                             self.line(&format!("[{}] ObjectProperty {{", i));
                             self.indent();
                             self.line(&format!("key: {}", format_object_property_key(&p.key)));
@@ -747,7 +751,7 @@ impl<'a> PrintFormatter<'a> {
                             self.dedent();
                             self.line("}");
                         }
-                        crate::react_compiler_hir::ObjectPropertyOrSpread::Spread(s) => {
+                        ObjectPropertyOrSpread::Spread(s) => {
                             self.line(&format!("[{}] Spread:", i));
                             self.indent();
                             self.format_place_field("place", &s.place);
@@ -869,10 +873,10 @@ impl<'a> PrintFormatter<'a> {
                 self.line("JsxExpression {");
                 self.indent();
                 match tag {
-                    crate::react_compiler_hir::JsxTag::Place(p) => {
+                    JsxTag::Place(p) => {
                         self.format_place_field("tag", p);
                     }
-                    crate::react_compiler_hir::JsxTag::Builtin(b) => {
+                    JsxTag::Builtin(b) => {
                         self.line(&format!("tag: BuiltinTag(\"{}\")", b.name));
                     }
                 }
@@ -880,7 +884,7 @@ impl<'a> PrintFormatter<'a> {
                 self.indent();
                 for (i, prop) in props.iter().enumerate() {
                     match prop {
-                        crate::react_compiler_hir::JsxAttribute::Attribute { name, place } => {
+                        JsxAttribute::Attribute { name, place } => {
                             self.line(&format!("[{}] JsxAttribute {{", i));
                             self.indent();
                             self.line(&format!("name: \"{}\"", name));
@@ -888,7 +892,7 @@ impl<'a> PrintFormatter<'a> {
                             self.dedent();
                             self.line("}");
                         }
-                        crate::react_compiler_hir::JsxAttribute::SpreadAttribute { argument } => {
+                        JsxAttribute::SpreadAttribute { argument } => {
                             self.line(&format!("[{}] JsxSpreadAttribute:", i));
                             self.indent();
                             self.format_place_field("argument", argument);
@@ -1300,13 +1304,10 @@ impl<'a> PrintFormatter<'a> {
                         self.indent();
                         for (i, dep) in d.iter().enumerate() {
                             let root_str = match &dep.root {
-                                crate::react_compiler_hir::ManualMemoDependencyRoot::Global { identifier_name } => {
+                                ManualMemoDependencyRoot::Global { identifier_name } => {
                                     format!("Global(\"{}\")", identifier_name)
                                 }
-                                crate::react_compiler_hir::ManualMemoDependencyRoot::NamedLocal {
-                                    value: val,
-                                    constant,
-                                } => {
+                                ManualMemoDependencyRoot::NamedLocal { value: val, constant } => {
                                     format!(
                                         "NamedLocal({}, constant={})",
                                         val.identifier.0, constant

--- a/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_hir/reactive.rs
@@ -11,6 +11,10 @@
 //!
 //! Corresponds to the reactive types in `HIR.ts`.
 
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::fmt::Result as FmtResult;
+
 use crate::react_compiler_diagnostics::SourceLocation;
 
 use crate::react_compiler_hir::{
@@ -131,8 +135,8 @@ pub enum ReactiveTerminalTargetKind {
     Unlabeled,
 }
 
-impl std::fmt::Display for ReactiveTerminalTargetKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for ReactiveTerminalTargetKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             ReactiveTerminalTargetKind::Implicit => write!(f, "implicit"),
             ReactiveTerminalTargetKind::Labeled => write!(f, "labeled"),

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_method_call_scopes.rs
@@ -9,12 +9,16 @@
 //!
 //! Ported from TypeScript `src/ReactiveScopes/AlignMethodCallScopes.ts`.
 
+use std::cmp::{max, min};
+use std::mem::replace;
+
 use rustc_hash::FxHashMap;
 
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
-    EvaluationOrder, HirFunction, IdentifierId, InstructionValue, ScopeId,
+    EvaluationOrder, HirFunction, IdentifierId, InstructionValue, MutableRangeId, ScopeId,
 };
+use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 use crate::react_compiler_utils::DisjointSet;
 
 // =============================================================================
@@ -63,10 +67,8 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
                     // Recurse into inner functions
                     let func_id = lowered_func.func;
-                    let mut inner_func = std::mem::replace(
-                        &mut env.functions[func_id.0 as usize],
-                        crate::react_compiler_ssa::enter_ssa::placeholder_function(),
-                    );
+                    let mut inner_func =
+                        replace(&mut env.functions[func_id.0 as usize], placeholder_function());
                     align_method_call_scopes(&mut inner_func, env);
                     env.functions[func_id.0 as usize] = inner_func;
                 }
@@ -90,19 +92,18 @@ pub fn align_method_call_scopes(func: &mut HirFunction, env: &mut Environment) {
 
         let entry =
             range_updates.entry(root_id).or_insert_with(|| (root_range.start, root_range.end));
-        entry.0 = EvaluationOrder(std::cmp::min(entry.0.0, scope_range.start.0));
-        entry.1 = EvaluationOrder(std::cmp::max(entry.1.0, scope_range.end.0));
+        entry.0 = EvaluationOrder(min(entry.0.0, scope_range.start.0));
+        entry.1 = EvaluationOrder(max(entry.1.0, scope_range.end.0));
     });
 
     // Save original scope range IDs before updating
-    let original_range_ids: FxHashMap<ScopeId, crate::react_compiler_hir::MutableRangeId> =
-        range_updates
-            .keys()
-            .map(|&root_id| {
-                let range_id = env.scopes[root_id.0 as usize].range.id;
-                (root_id, range_id)
-            })
-            .collect();
+    let original_range_ids: FxHashMap<ScopeId, MutableRangeId> = range_updates
+        .keys()
+        .map(|&root_id| {
+            let range_id = env.scopes[root_id.0 as usize].range.id;
+            (root_id, range_id)
+        })
+        .collect();
 
     for (root_id, (new_start, new_end)) in &range_updates {
         env.scopes[root_id.0 as usize].range.start = *new_start;

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_object_method_scopes.rs
@@ -11,11 +11,14 @@
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::cmp;
+use std::mem::replace;
 
+use crate::react_compiler_hir::MutableRangeId;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     EvaluationOrder, HirFunction, IdentifierId, InstructionValue, ObjectPropertyOrSpread, ScopeId,
 };
+use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 use crate::react_compiler_utils::DisjointSet;
 
 // =============================================================================
@@ -84,10 +87,8 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
                 InstructionValue::FunctionExpression { lowered_func, .. }
                 | InstructionValue::ObjectMethod { lowered_func, .. } => {
                     let func_id = lowered_func.func;
-                    let mut inner_func = std::mem::replace(
-                        &mut env.functions[func_id.0 as usize],
-                        crate::react_compiler_ssa::enter_ssa::placeholder_function(),
-                    );
+                    let mut inner_func =
+                        replace(&mut env.functions[func_id.0 as usize], placeholder_function());
                     align_object_method_scopes(&mut inner_func, env);
                     env.functions[func_id.0 as usize] = inner_func;
                 }
@@ -118,14 +119,13 @@ pub fn align_object_method_scopes(func: &mut HirFunction, env: &mut Environment)
     });
 
     // Save original scope range IDs before updating
-    let original_range_ids: FxHashMap<ScopeId, crate::react_compiler_hir::MutableRangeId> =
-        range_updates
-            .keys()
-            .map(|&root_id| {
-                let range_id = env.scopes[root_id.0 as usize].range.id;
-                (root_id, range_id)
-            })
-            .collect();
+    let original_range_ids: FxHashMap<ScopeId, MutableRangeId> = range_updates
+        .keys()
+        .map(|&root_id| {
+            let range_id = env.scopes[root_id.0 as usize].range.id;
+            (root_id, range_id)
+        })
+        .collect();
 
     for (root_id, (new_start, new_end)) in &range_updates {
         env.scopes[root_id.0 as usize].range.start = *new_start;

--- a/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/align_reactive_scopes_to_block_scopes_hir.rs
@@ -30,6 +30,7 @@ use crate::react_compiler_hir::BlockKind;
 use crate::react_compiler_hir::EvaluationOrder;
 use crate::react_compiler_hir::HirFunction;
 use crate::react_compiler_hir::IdentifierId;
+use crate::react_compiler_hir::InstructionId;
 use crate::react_compiler_hir::MutableRange;
 use crate::react_compiler_hir::ScopeId;
 use crate::react_compiler_hir::Terminal;
@@ -38,6 +39,8 @@ use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::visitors::each_instruction_lvalue_ids;
 use crate::react_compiler_hir::visitors::each_instruction_value_operand_ids;
 use crate::react_compiler_hir::visitors::each_terminal_operand_ids;
+use std::cmp::max;
+use std::cmp::min;
 
 // =============================================================================
 // ValueBlockNode — stores the valueRange for scope alignment in value blocks
@@ -119,7 +122,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                 // extend their start to include the range start.
                 for &scope_id in &active_scopes {
                     let scope = &mut env.scopes[scope_id.0 as usize];
-                    scope.range.start = std::cmp::min(scope.range.start, top.range.start);
+                    scope.range.start = min(scope.range.start, top.range.start);
                 }
             }
         }
@@ -128,8 +131,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
 
         // Visit instruction lvalues and operands
         let block = func.body.blocks.get(&block_id).unwrap();
-        let instr_ids: Vec<crate::react_compiler_hir::InstructionId> =
-            block.instructions.iter().copied().collect();
+        let instr_ids: Vec<InstructionId> = block.instructions.iter().copied().collect();
         for &instr_id in &instr_ids {
             let instr = &func.instructions[instr_id.0 as usize];
             let eval_order = instr.id;
@@ -182,7 +184,7 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                 for &scope_id in &active_scopes {
                     let scope = &mut env.scopes[scope_id.0 as usize];
                     if scope.range.end > terminal_eval_order {
-                        scope.range.end = std::cmp::max(scope.range.end, next_id);
+                        scope.range.end = max(scope.range.end, next_id);
                     }
                 }
 
@@ -218,9 +220,8 @@ pub fn align_reactive_scopes_to_block_scopes_hir(func: &mut HirFunction, env: &m
                         if scope.range.end <= terminal_eval_order {
                             continue;
                         }
-                        scope.range.start =
-                            std::cmp::min(start_range.range.start, scope.range.start);
-                        scope.range.end = std::cmp::max(first_id, scope.range.end);
+                        scope.range.start = min(start_range.range.start, scope.range.start);
+                        scope.range.end = max(first_id, scope.range.end);
                     }
                 }
             }
@@ -308,8 +309,8 @@ fn record_place_id(
 
         if let Some(n) = node {
             let scope = &mut env.scopes[scope_id.0 as usize];
-            scope.range.start = std::cmp::min(n.value_range.start, scope.range.start);
-            scope.range.end = std::cmp::max(n.value_range.end, scope.range.end);
+            scope.range.start = min(n.value_range.start, scope.range.start);
+            scope.range.end = max(n.value_range.end, scope.range.end);
         }
     }
 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/analyse_functions.rs
@@ -14,8 +14,14 @@
 
 use crate::react_compiler_diagnostics::{CompilerDiagnostic, ErrorCategory};
 use crate::react_compiler_hir::environment::Environment;
+use crate::react_compiler_inference::infer_mutation_aliasing_effects::infer_mutation_aliasing_effects;
+use crate::react_compiler_inference::infer_mutation_aliasing_ranges::infer_mutation_aliasing_ranges;
+use crate::react_compiler_inference::infer_reactive_scope_variables::infer_reactive_scope_variables;
+use crate::react_compiler_optimization::dead_code_elimination;
+use crate::react_compiler_ssa::rewrite_instruction_kinds_based_on_reassignment;
 use crate::react_compiler_utils::FxIndexMap;
 use rustc_hash::FxHashSet;
+use std::mem::replace;
 
 use crate::react_compiler_hir::{
     AliasingEffect, BlockId, Effect, EvaluationOrder, FunctionId, HIR, HirFunction, IdentifierId,
@@ -61,7 +67,7 @@ where
     for func_id in inner_func_ids {
         // Take the inner function out of the arena to avoid borrow conflicts
         let mut inner_func =
-            std::mem::replace(&mut env.functions[func_id.0 as usize], placeholder_function());
+            replace(&mut env.functions[func_id.0 as usize], placeholder_function());
 
         lower_with_mutation_aliasing(&mut inner_func, env, debug_logger)?;
 
@@ -106,7 +112,7 @@ where
     analyse_functions(func, env, debug_logger)?;
 
     // inferMutationAliasingEffects on the inner function
-    crate::react_compiler_inference::infer_mutation_aliasing_effects::infer_mutation_aliasing_effects(func, env, true)?;
+    infer_mutation_aliasing_effects(func, env, true)?;
 
     // Check for invariant errors (e.g., uninitialized value kind)
     // In TS, these throw from within inferMutationAliasingEffects, aborting
@@ -116,22 +122,19 @@ where
     }
 
     // deadCodeElimination for inner functions
-    crate::react_compiler_optimization::dead_code_elimination(func, env);
+    dead_code_elimination(func, env);
 
     // inferMutationAliasingRanges — returns the externally-visible function effects
-    let function_effects =
-        crate::react_compiler_inference::infer_mutation_aliasing_ranges::infer_mutation_aliasing_ranges(func, env, true)?;
+    let function_effects = infer_mutation_aliasing_ranges(func, env, true)?;
 
     // rewriteInstructionKindsBasedOnReassignment
-    if let Err(err) =
-        crate::react_compiler_ssa::rewrite_instruction_kinds_based_on_reassignment(func, env)
-    {
+    if let Err(err) = rewrite_instruction_kinds_based_on_reassignment(func, env) {
         env.errors.merge(err);
         return Ok(());
     }
 
     // inferReactiveScopeVariables on the inner function
-    crate::react_compiler_inference::infer_reactive_scope_variables::infer_reactive_scope_variables(func, env)?;
+    infer_reactive_scope_variables(func, env)?;
 
     func.aliasing_effects = Some(function_effects.clone());
 

--- a/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/build_reactive_scope_terminals_hir.rs
@@ -11,6 +11,8 @@
 //!
 //! Ported from TypeScript `src/HIR/BuildReactiveScopeTerminalsHIR.ts`.
 
+use std::cmp::Ordering;
+
 use crate::react_compiler_utils::FxIndexSet;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
@@ -21,6 +23,7 @@ use crate::react_compiler_hir::EvaluationOrder;
 use crate::react_compiler_hir::GotoVariant;
 use crate::react_compiler_hir::HirFunction;
 use crate::react_compiler_hir::IdentifierId;
+use crate::react_compiler_hir::MutableRange;
 use crate::react_compiler_hir::ScopeId;
 use crate::react_compiler_hir::Terminal;
 use crate::react_compiler_hir::environment::Environment;
@@ -111,7 +114,7 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
         let a_range = &env.scopes[a.0 as usize].range;
         let b_range = &env.scopes[b.0 as usize].range;
         let start_diff = a_range.start.0.cmp(&b_range.start.0);
-        if start_diff != std::cmp::Ordering::Equal {
+        if start_diff != Ordering::Equal {
             return start_diff;
         }
         b_range.end.0.cmp(&a_range.end.0)
@@ -354,7 +357,7 @@ fn fix_scope_and_identifier_ranges(func: &HirFunction, env: &mut Environment) {
     // reference as scope.range see the update automatically. We simulate
     // this by only syncing identifiers whose mutableRange matches the
     // scope's pre-update range.
-    let original_scope_ranges: Vec<crate::react_compiler_hir::MutableRange> =
+    let original_scope_ranges: Vec<MutableRange> =
         env.scopes.iter().map(|s| s.range.clone()).collect();
 
     for (_block_id, block) in &func.body.blocks {

--- a/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/flatten_scopes_with_hooks_or_use_hir.rs
@@ -28,7 +28,9 @@
 
 use crate::react_compiler_diagnostics::{CompilerDiagnostic, ErrorCategory};
 use crate::react_compiler_hir::environment::Environment;
-use crate::react_compiler_hir::{BlockId, HirFunction, InstructionValue, Terminal, Type};
+use crate::react_compiler_hir::{
+    BlockId, HirFunction, InstructionValue, Terminal, Type, is_use_operator_type,
+};
 
 /// Flattens reactive scopes that contain hook calls or `use()` calls.
 ///
@@ -124,6 +126,5 @@ struct ActiveScope {
 }
 
 fn is_hook_or_use(env: &Environment, ty: &Type) -> Result<bool, CompilerDiagnostic> {
-    Ok(env.get_hook_kind_for_type(ty)?.is_some()
-        || crate::react_compiler_hir::is_use_operator_type(ty))
+    Ok(env.get_hook_kind_for_type(ty)?.is_some() || is_use_operator_type(ty))
 }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -35,6 +35,7 @@ use crate::react_compiler_hir::PlaceOrSpread;
 use crate::react_compiler_hir::PlaceOrSpreadOrHole;
 use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::SourceLocation;
+use crate::react_compiler_hir::Terminal;
 use crate::react_compiler_hir::Type;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::object_shape::BUILT_IN_ARRAY_ID;
@@ -3182,8 +3183,7 @@ fn create_temp_place(env: &mut Environment, loc: Option<SourceLocation>) -> Plac
 /// successors but NOT pseudo-successors (fallthroughs). Fallthroughs for
 /// Logical/Ternary/Optional and Try/Scope/PrunedScope are reached naturally
 /// via the block iteration order (blocks are stored in topological order).
-fn terminal_successors(terminal: &crate::react_compiler_hir::Terminal) -> Vec<BlockId> {
-    use crate::react_compiler_hir::Terminal;
+fn terminal_successors(terminal: &Terminal) -> Vec<BlockId> {
     match terminal {
         Terminal::Goto { block, .. } => vec![*block],
         Terminal::If { consequent, alternate, .. } => vec![*consequent, *alternate],

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_effects.rs
@@ -17,36 +17,53 @@ use rustc_hash::FxHashSet;
 
 use crate::react_compiler_diagnostics::CompilerDiagnostic;
 use crate::react_compiler_diagnostics::CompilerDiagnosticDetail;
+use crate::react_compiler_diagnostics::CompilerErrorDetail;
 use crate::react_compiler_diagnostics::ErrorCategory;
 use crate::react_compiler_hir::AliasingEffect;
 use crate::react_compiler_hir::AliasingSignature;
+use crate::react_compiler_hir::ArrayElement;
+use crate::react_compiler_hir::ArrayPatternElement;
 use crate::react_compiler_hir::BlockId;
 use crate::react_compiler_hir::DeclarationId;
 use crate::react_compiler_hir::Effect;
 use crate::react_compiler_hir::FunctionId;
 use crate::react_compiler_hir::HirFunction;
 use crate::react_compiler_hir::IdentifierId;
+use crate::react_compiler_hir::IdentifierName;
+use crate::react_compiler_hir::Instruction;
 use crate::react_compiler_hir::InstructionKind;
 use crate::react_compiler_hir::InstructionValue;
+use crate::react_compiler_hir::JsxAttribute;
 use crate::react_compiler_hir::MutationReason;
+use crate::react_compiler_hir::ObjectPropertyOrSpread;
 use crate::react_compiler_hir::ParamPattern;
+use crate::react_compiler_hir::Pattern;
 use crate::react_compiler_hir::Place;
 use crate::react_compiler_hir::PlaceOrSpread;
 use crate::react_compiler_hir::PlaceOrSpreadOrHole;
+use crate::react_compiler_hir::PropertyLiteral;
 use crate::react_compiler_hir::ReactFunctionType;
 use crate::react_compiler_hir::SourceLocation;
+use crate::react_compiler_hir::SpreadPattern;
 use crate::react_compiler_hir::Terminal;
 use crate::react_compiler_hir::Type;
 use crate::react_compiler_hir::environment::Environment;
+use crate::react_compiler_hir::is_jsx_type;
+use crate::react_compiler_hir::is_primitive_type;
+use crate::react_compiler_hir::is_ref_or_ref_value;
 use crate::react_compiler_hir::object_shape::BUILT_IN_ARRAY_ID;
 use crate::react_compiler_hir::object_shape::BUILT_IN_MAP_ID;
 use crate::react_compiler_hir::object_shape::BUILT_IN_SET_ID;
 use crate::react_compiler_hir::object_shape::FunctionSignature;
 use crate::react_compiler_hir::object_shape::HookKind;
+use crate::react_compiler_hir::type_config::AliasingEffectConfig;
+use crate::react_compiler_hir::type_config::AliasingSignatureConfig;
+use crate::react_compiler_hir::type_config::ApplyArgConfig;
 use crate::react_compiler_hir::type_config::ValueKind;
 use crate::react_compiler_hir::type_config::ValueReason;
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_utils::FxIndexSet;
+use std::cell::Cell;
 
 // =============================================================================
 // Public entry point
@@ -272,7 +289,7 @@ struct InferenceState {
     /// Uses Cell so it can be set from `&self` methods like `kind()`.
     /// Stores (IdentifierId, usage_loc) where usage_loc is the source location
     /// of the Place that triggered the uninitialized access.
-    uninitialized_access: std::cell::Cell<Option<(IdentifierId, Option<SourceLocation>)>>,
+    uninitialized_access: Cell<Option<(IdentifierId, Option<SourceLocation>)>>,
 }
 
 impl InferenceState {
@@ -281,7 +298,7 @@ impl InferenceState {
             is_function_expression,
             values: FxHashMap::default(),
             variables: FxHashMap::default(),
-            uninitialized_access: std::cell::Cell::new(None),
+            uninitialized_access: Cell::new(None),
         }
     }
 
@@ -445,7 +462,7 @@ impl InferenceState {
         usage_loc: Option<SourceLocation>,
     ) -> MutationResult {
         let ty = &env.types[env.identifiers[place_id.0 as usize].type_.0 as usize];
-        if crate::react_compiler_hir::is_ref_or_ref_value(ty) {
+        if is_ref_or_ref_value(ty) {
             return MutationResult::MutateRef;
         }
         let kind = self.kind_with_loc(place_id, usage_loc).kind;
@@ -522,7 +539,7 @@ impl InferenceState {
                 is_function_expression: self.is_function_expression,
                 values: next_values.unwrap_or_else(|| self.values.clone()),
                 variables: next_variables.unwrap_or_else(|| self.variables.clone()),
-                uninitialized_access: std::cell::Cell::new(None),
+                uninitialized_access: Cell::new(None),
             })
         }
     }
@@ -825,12 +842,9 @@ fn find_non_mutated_destructure_spreads(
                         continue;
                     }
                     match &lvalue.pattern {
-                        crate::react_compiler_hir::Pattern::Object(obj_pat) => {
+                        Pattern::Object(obj_pat) => {
                             for prop in &obj_pat.properties {
-                                if let crate::react_compiler_hir::ObjectPropertyOrSpread::Spread(
-                                    s,
-                                ) = prop
-                                {
+                                if let ObjectPropertyOrSpread::Spread(s) = prop {
                                     candidate_non_mutating_spreads
                                         .insert(s.place.identifier, s.place.identifier);
                                 }
@@ -975,15 +989,13 @@ fn infer_block(
     let action = {
         let block = &func.body.blocks[&block_id];
         match &block.terminal {
-            crate::react_compiler_hir::Terminal::Try {
-                handler,
-                handler_binding: Some(binding),
-                ..
-            } => TerminalAction::Try { handler: *handler, binding: binding.clone() },
-            crate::react_compiler_hir::Terminal::MaybeThrow {
-                handler: Some(handler_id), ..
-            } => TerminalAction::MaybeThrow { handler_id: *handler_id },
-            crate::react_compiler_hir::Terminal::Return { .. } => TerminalAction::Return,
+            Terminal::Try { handler, handler_binding: Some(binding), .. } => {
+                TerminalAction::Try { handler: *handler, binding: binding.clone() }
+            }
+            Terminal::MaybeThrow { handler: Some(handler_id), .. } => {
+                TerminalAction::MaybeThrow { handler_id: *handler_id }
+            }
+            Terminal::Return { .. } => TerminalAction::Return,
             _ => TerminalAction::None,
         }
     };
@@ -1019,10 +1031,8 @@ fn infer_block(
                         }
                     }
                     let block_mut = func.body.blocks.get_mut(&block_id).unwrap();
-                    if let crate::react_compiler_hir::Terminal::MaybeThrow {
-                        effects: ref mut term_effects,
-                        ..
-                    } = block_mut.terminal
+                    if let Terminal::MaybeThrow { effects: ref mut term_effects, .. } =
+                        block_mut.terminal
                     {
                         *term_effects =
                             if terminal_effects.is_empty() { None } else { Some(terminal_effects) };
@@ -1033,11 +1043,8 @@ fn infer_block(
         TerminalAction::Return => {
             if !context.is_function_expression {
                 let block_mut = func.body.blocks.get_mut(&block_id).unwrap();
-                if let crate::react_compiler_hir::Terminal::Return {
-                    ref value,
-                    effects: ref mut term_effects,
-                    ..
-                } = block_mut.terminal
+                if let Terminal::Return { ref value, effects: ref mut term_effects, .. } =
+                    block_mut.terminal
                 {
                     *term_effects = Some(vec![context.intern_effect(AliasingEffect::Freeze {
                         value: value.clone(),
@@ -1059,7 +1066,7 @@ fn apply_signature(
     context: &mut Context,
     state: &mut InferenceState,
     instr_idx: u32,
-    instr: &crate::react_compiler_hir::Instruction,
+    instr: &Instruction,
     env: &mut Environment,
     func: &HirFunction,
 ) -> Result<Option<Vec<AliasingEffect>>, CompilerDiagnostic> {
@@ -1090,7 +1097,7 @@ fn apply_signature(
                         let reason_str = get_write_error_reason(&value_abstract);
                         let ident = &env.identifiers[mutate_value.identifier.0 as usize];
                         let variable = match &ident.name {
-                            Some(crate::react_compiler_hir::IdentifierName::Named(n)) => {
+                            Some(IdentifierName::Named(n)) => {
                                 format!("`{}`", n)
                             }
                             _ => "value".to_string(),
@@ -1100,20 +1107,18 @@ fn apply_signature(
                             "This value cannot be modified",
                             Some(reason_str),
                         );
-                        diagnostic.details.push(
-                            crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Error {
-                                loc: mutate_value.loc,
-                                message: Some(format!("{} cannot be modified", variable)),
-                                identifier_name: None,
-                            },
-                        );
+                        diagnostic.details.push(CompilerDiagnosticDetail::Error {
+                            loc: mutate_value.loc,
+                            message: Some(format!("{} cannot be modified", variable)),
+                            identifier_name: None,
+                        });
                         if is_mutate {
                             if let AliasingEffect::Mutate {
                                 reason: Some(MutationReason::AssignCurrentProperty),
                                 ..
                             } = effect
                             {
-                                diagnostic.details.push(crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Hint {
+                                diagnostic.details.push(CompilerDiagnosticDetail::Hint {
                                     message: "Hint: If this value is a Ref (value returned by `useRef()`), rename the variable to end in \"Ref\".".to_string()
                                 });
                             }
@@ -1600,8 +1605,7 @@ fn apply_effect(
                 }
 
                 // Legacy signature
-                let mut todo_errors: Vec<crate::react_compiler_diagnostics::CompilerErrorDetail> =
-                    Vec::new();
+                let mut todo_errors: Vec<CompilerErrorDetail> = Vec::new();
                 let legacy_effects = compute_effects_for_legacy_signature(
                     state,
                     sig,
@@ -1742,9 +1746,7 @@ fn apply_effect(
                     && context.hoisted_context_declarations.contains_key(&decl_id)
                 {
                     let variable = match &ident.name {
-                        Some(crate::react_compiler_hir::IdentifierName::Named(n)) => {
-                            Some(format!("`{}`", n))
-                        }
+                        Some(IdentifierName::Named(n)) => Some(format!("`{}`", n)),
                         _ => None,
                     };
                     let hoisted_access =
@@ -1759,28 +1761,24 @@ fn apply_effect(
                     );
                     if let Some(ref access) = hoisted_access {
                         if access.loc != value.loc {
-                            diagnostic.details.push(
-                                crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Error {
-                                    loc: access.loc,
-                                    message: Some(format!(
-                                        "{} accessed before it is declared",
-                                        variable.as_deref().unwrap_or("variable")
-                                    )),
-                                    identifier_name: None,
-                                },
-                            );
+                            diagnostic.details.push(CompilerDiagnosticDetail::Error {
+                                loc: access.loc,
+                                message: Some(format!(
+                                    "{} accessed before it is declared",
+                                    variable.as_deref().unwrap_or("variable")
+                                )),
+                                identifier_name: None,
+                            });
                         }
                     }
-                    diagnostic.details.push(
-                        crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Error {
-                            loc: value.loc,
-                            message: Some(format!(
-                                "{} is declared here",
-                                variable.as_deref().unwrap_or("variable")
-                            )),
-                            identifier_name: None,
-                        },
-                    );
+                    diagnostic.details.push(CompilerDiagnosticDetail::Error {
+                        loc: value.loc,
+                        message: Some(format!(
+                            "{} is declared here",
+                            variable.as_deref().unwrap_or("variable")
+                        )),
+                        identifier_name: None,
+                    });
                     apply_effect(
                         context,
                         state,
@@ -1793,7 +1791,7 @@ fn apply_effect(
                 } else {
                     let reason_str = get_write_error_reason(&abstract_value);
                     let variable = match &ident.name {
-                        Some(crate::react_compiler_hir::IdentifierName::Named(n)) => {
+                        Some(IdentifierName::Named(n)) => {
                             format!("`{}`", n)
                         }
                         _ => "value".to_string(),
@@ -1803,20 +1801,18 @@ fn apply_effect(
                         "This value cannot be modified",
                         Some(reason_str),
                     );
-                    diagnostic.details.push(
-                        crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Error {
-                            loc: value.loc,
-                            message: Some(format!("{} cannot be modified", variable)),
-                            identifier_name: None,
-                        },
-                    );
+                    diagnostic.details.push(CompilerDiagnosticDetail::Error {
+                        loc: value.loc,
+                        message: Some(format!("{} cannot be modified", variable)),
+                        identifier_name: None,
+                    });
 
                     if let AliasingEffect::Mutate {
                         reason: Some(MutationReason::AssignCurrentProperty),
                         ..
                     } = &effect
                     {
-                        diagnostic.details.push(crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Hint {
+                        diagnostic.details.push(CompilerDiagnosticDetail::Hint {
                             message: "Hint: If this value is a Ref (value returned by `useRef()`), rename the variable to end in \"Ref\".".to_string(),
                         });
                     }
@@ -1847,7 +1843,7 @@ fn apply_effect(
 fn compute_signature_for_instruction(
     context: &mut Context,
     env: &Environment,
-    instr: &crate::react_compiler_hir::Instruction,
+    instr: &Instruction,
     _func: &HirFunction,
 ) -> InstructionSignature {
     let lvalue = &instr.lvalue;
@@ -1863,13 +1859,13 @@ fn compute_signature_for_instruction(
             });
             for element in elements {
                 match element {
-                    crate::react_compiler_hir::ArrayElement::Place(p) => {
+                    ArrayElement::Place(p) => {
                         effects.push(AliasingEffect::Capture {
                             from: p.clone(),
                             into: lvalue.clone(),
                         });
                     }
-                    crate::react_compiler_hir::ArrayElement::Spread(s) => {
+                    ArrayElement::Spread(s) => {
                         let ty = &env.types
                             [env.identifiers[s.place.identifier.0 as usize].type_.0 as usize];
                         if let Some(mutate_iter) = conditionally_mutate_iterator(&s.place, ty) {
@@ -1880,7 +1876,7 @@ fn compute_signature_for_instruction(
                             into: lvalue.clone(),
                         });
                     }
-                    crate::react_compiler_hir::ArrayElement::Hole => {}
+                    ArrayElement::Hole => {}
                 }
             }
         }
@@ -1892,13 +1888,13 @@ fn compute_signature_for_instruction(
             });
             for property in properties {
                 match property {
-                    crate::react_compiler_hir::ObjectPropertyOrSpread::Property(p) => {
+                    ObjectPropertyOrSpread::Property(p) => {
                         effects.push(AliasingEffect::Capture {
                             from: p.place.clone(),
                             into: lvalue.clone(),
                         });
                     }
-                    crate::react_compiler_hir::ObjectPropertyOrSpread::Spread(s) => {
+                    ObjectPropertyOrSpread::Spread(s) => {
                         effects.push(AliasingEffect::Capture {
                             from: s.place.clone(),
                             into: lvalue.clone(),
@@ -1966,7 +1962,7 @@ fn compute_signature_for_instruction(
         InstructionValue::PropertyLoad { object, .. }
         | InstructionValue::ComputedLoad { object, .. } => {
             let ty = &env.types[env.identifiers[lvalue.identifier.0 as usize].type_.0 as usize];
-            if crate::react_compiler_hir::is_primitive_type(ty) {
+            if is_primitive_type(ty) {
                 effects.push(AliasingEffect::Create {
                     into: lvalue.clone(),
                     value: ValueKind::Primitive,
@@ -1983,7 +1979,7 @@ fn compute_signature_for_instruction(
             let mutation_reason: Option<MutationReason> = {
                 let obj_ty =
                     &env.types[env.identifiers[object.identifier.0 as usize].type_.0 as usize];
-                if let crate::react_compiler_hir::PropertyLiteral::String(prop_name) = property {
+                if let PropertyLiteral::String(prop_name) = property {
                     if prop_name == "current" && matches!(obj_ty, Type::TypeVar { .. }) {
                         Some(MutationReason::AssignCurrentProperty)
                     } else {
@@ -2084,17 +2080,11 @@ fn compute_signature_for_instruction(
                 }
             }
             for prop in props {
-                if let crate::react_compiler_hir::JsxAttribute::Attribute {
-                    place: prop_place,
-                    ..
-                } = prop
-                {
+                if let JsxAttribute::Attribute { place: prop_place, .. } = prop {
                     let prop_ty = &env.types
                         [env.identifiers[prop_place.identifier.0 as usize].type_.0 as usize];
                     if let Type::Function { return_type, .. } = prop_ty {
-                        if crate::react_compiler_hir::is_jsx_type(return_type)
-                            || is_phi_with_jsx(return_type)
-                        {
+                        if is_jsx_type(return_type) || is_phi_with_jsx(return_type) {
                             effects.push(AliasingEffect::Render { place: prop_place.clone() });
                         }
                     }
@@ -2134,7 +2124,7 @@ fn compute_signature_for_instruction(
                     PatternItem::Place(place) => {
                         let ty = &env.types
                             [env.identifiers[place.identifier.0 as usize].type_.0 as usize];
-                        if crate::react_compiler_hir::is_primitive_type(ty) {
+                        if is_primitive_type(ty) {
                             effects.push(AliasingEffect::Create {
                                 into: place.clone(),
                                 value: ValueKind::Primitive,
@@ -2240,13 +2230,11 @@ fn compute_signature_for_instruction(
                     variable
                 )),
             );
-            diagnostic.details.push(
-                crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Error {
-                    loc: instr.loc,
-                    message: Some(format!("{} cannot be reassigned", variable)),
-                    identifier_name: None,
-                },
-            );
+            diagnostic.details.push(CompilerDiagnosticDetail::Error {
+                loc: instr.loc,
+                message: Some(format!("{} cannot be reassigned", variable)),
+                identifier_name: None,
+            });
             effects
                 .push(AliasingEffect::MutateGlobal { place: sg_value.clone(), error: diagnostic });
             effects.push(AliasingEffect::Assign { from: sg_value.clone(), into: lvalue.clone() });
@@ -2311,7 +2299,7 @@ fn compute_effects_for_legacy_signature(
     _loc: Option<&SourceLocation>,
     env: &Environment,
     function_values: &FxHashMap<ValueId, FunctionId>,
-    todo_errors: &mut Vec<crate::react_compiler_diagnostics::CompilerErrorDetail>,
+    todo_errors: &mut Vec<CompilerErrorDetail>,
 ) -> Vec<AliasingEffect> {
     let return_value_reason = signature.return_value_reason.unwrap_or(ValueReason::Other);
     let mut effects: Vec<AliasingEffect> = Vec::new();
@@ -2335,13 +2323,11 @@ fn compute_effects_for_legacy_signature(
                 }
             )),
         );
-        diagnostic.details.push(
-            crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Error {
-                loc: _loc.copied(),
-                message: Some("Cannot call impure function".to_string()),
-                identifier_name: None,
-            },
-        );
+        diagnostic.details.push(CompilerDiagnosticDetail::Error {
+            loc: _loc.copied(),
+            message: Some("Cannot call impure function".to_string()),
+            identifier_name: None,
+        });
         effects.push(AliasingEffect::Impure { place: receiver.clone(), error: diagnostic });
     }
 
@@ -2358,8 +2344,7 @@ fn compute_effects_for_legacy_signature(
             match arg {
                 PlaceOrSpreadOrHole::Hole => continue,
                 PlaceOrSpreadOrHole::Place(place)
-                | PlaceOrSpreadOrHole::Spread(crate::react_compiler_hir::SpreadPattern { place }) =>
-                {
+                | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
                     effects.push(AliasingEffect::ImmutableCapture {
                         from: place.clone(),
                         into: lvalue.clone(),
@@ -2417,7 +2402,7 @@ fn compute_effects_for_legacy_signature(
         match arg {
             PlaceOrSpreadOrHole::Hole => continue,
             PlaceOrSpreadOrHole::Place(place)
-            | PlaceOrSpreadOrHole::Spread(crate::react_compiler_hir::SpreadPattern { place }) => {
+            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
                 let is_spread = matches!(arg, PlaceOrSpreadOrHole::Spread(_));
                 let sig_effect = if !is_spread && i < signature.positional_params.len() {
                     signature.positional_params[i]
@@ -2457,7 +2442,7 @@ fn get_argument_effect(
     sig_effect: Effect,
     is_spread: bool,
     spread_loc: Option<SourceLocation>,
-) -> (Effect, Option<crate::react_compiler_diagnostics::CompilerErrorDetail>) {
+) -> (Effect, Option<CompilerErrorDetail>) {
     if !is_spread {
         (sig_effect, None)
     } else if sig_effect == Effect::Mutate || sig_effect == Effect::ConditionallyMutate {
@@ -2466,7 +2451,7 @@ fn get_argument_effect(
         // Spread with Freeze effect is unsupported for hook arguments
         // (matches TS CompilerError.throwTodo)
         let detail = if sig_effect == Effect::Freeze {
-            Some(crate::react_compiler_diagnostics::CompilerErrorDetail {
+            Some(CompilerErrorDetail {
                 reason: "Support spread syntax for hook arguments".to_string(),
                 description: None,
                 category: ErrorCategory::Todo,
@@ -2494,7 +2479,7 @@ fn are_arguments_immutable_and_non_mutating(
         match arg {
             PlaceOrSpreadOrHole::Hole => continue,
             PlaceOrSpreadOrHole::Place(place)
-            | PlaceOrSpreadOrHole::Spread(crate::react_compiler_hir::SpreadPattern { place }) => {
+            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
                 // Check if it's a function type with a known signature
                 let is_place = matches!(arg, PlaceOrSpreadOrHole::Place(_));
                 if is_place {
@@ -2565,7 +2550,7 @@ fn is_known_mutable_effect(effect: Effect) -> bool {
 
 fn compute_effects_for_aliasing_signature_config(
     env: &mut Environment,
-    config: &crate::react_compiler_hir::type_config::AliasingSignatureConfig,
+    config: &AliasingSignatureConfig,
     lvalue: &Place,
     receiver: &Place,
     args: &[PlaceOrSpreadOrHole],
@@ -2584,7 +2569,7 @@ fn compute_effects_for_aliasing_signature_config(
         match arg {
             PlaceOrSpreadOrHole::Hole => continue,
             PlaceOrSpreadOrHole::Place(place)
-            | PlaceOrSpreadOrHole::Spread(crate::react_compiler_hir::SpreadPattern { place }) => {
+            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
                 if i < config.params.len() && !matches!(arg, PlaceOrSpreadOrHole::Spread(_)) {
                     substitutions.insert(config.params[i].clone(), vec![place.clone()]);
                 } else if let Some(ref rest) = config.rest {
@@ -2626,7 +2611,7 @@ fn compute_effects_for_aliasing_signature_config(
 
     for eff_config in &config.effects {
         match eff_config {
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::Freeze { value, reason } => {
+            AliasingEffectConfig::Freeze { value, reason } => {
                 let values = substitutions.get(value).cloned().unwrap_or_default();
                 for v in values {
                     if mutable_spreads.contains(&v.identifier) {
@@ -2638,22 +2623,27 @@ fn compute_effects_for_aliasing_signature_config(
                     effects.push(AliasingEffect::Freeze { value: v, reason: *reason });
                 }
             }
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::Create { into, value, reason } => {
+            AliasingEffectConfig::Create { into, value, reason } => {
                 let intos = substitutions.get(into).cloned().unwrap_or_default();
                 for v in intos {
-                    effects.push(AliasingEffect::Create { into: v, value: *value, reason: *reason });
+                    effects.push(AliasingEffect::Create {
+                        into: v,
+                        value: *value,
+                        reason: *reason,
+                    });
                 }
             }
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::CreateFrom { from, into } => {
+            AliasingEffectConfig::CreateFrom { from, into } => {
                 let froms = substitutions.get(from).cloned().unwrap_or_default();
                 let intos = substitutions.get(into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
-                        effects.push(AliasingEffect::CreateFrom { from: f.clone(), into: t.clone() });
+                        effects
+                            .push(AliasingEffect::CreateFrom { from: f.clone(), into: t.clone() });
                     }
                 }
             }
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::Assign { from, into } => {
+            AliasingEffectConfig::Assign { from, into } => {
                 let froms = substitutions.get(from).cloned().unwrap_or_default();
                 let intos = substitutions.get(into).cloned().unwrap_or_default();
                 for f in &froms {
@@ -2662,7 +2652,7 @@ fn compute_effects_for_aliasing_signature_config(
                     }
                 }
             }
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::Alias { from, into } => {
+            AliasingEffectConfig::Alias { from, into } => {
                 let froms = substitutions.get(from).cloned().unwrap_or_default();
                 let intos = substitutions.get(into).cloned().unwrap_or_default();
                 for f in &froms {
@@ -2671,7 +2661,7 @@ fn compute_effects_for_aliasing_signature_config(
                     }
                 }
             }
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::Capture { from, into } => {
+            AliasingEffectConfig::Capture { from, into } => {
                 let froms = substitutions.get(from).cloned().unwrap_or_default();
                 let intos = substitutions.get(into).cloned().unwrap_or_default();
                 for f in &froms {
@@ -2680,37 +2670,50 @@ fn compute_effects_for_aliasing_signature_config(
                     }
                 }
             }
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::ImmutableCapture { from, into } => {
+            AliasingEffectConfig::ImmutableCapture { from, into } => {
                 let froms = substitutions.get(from).cloned().unwrap_or_default();
                 let intos = substitutions.get(into).cloned().unwrap_or_default();
                 for f in &froms {
                     for t in &intos {
-                        effects.push(AliasingEffect::ImmutableCapture { from: f.clone(), into: t.clone() });
+                        effects.push(AliasingEffect::ImmutableCapture {
+                            from: f.clone(),
+                            into: t.clone(),
+                        });
                     }
                 }
             }
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::Impure { place } => {
+            AliasingEffectConfig::Impure { place } => {
                 let values = substitutions.get(place).cloned().unwrap_or_default();
                 for v in values {
                     effects.push(AliasingEffect::Impure {
                         place: v,
-                        error: CompilerDiagnostic::new(ErrorCategory::Purity, "Impure function call", None),
+                        error: CompilerDiagnostic::new(
+                            ErrorCategory::Purity,
+                            "Impure function call",
+                            None,
+                        ),
                     });
                 }
             }
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::Mutate { value } => {
+            AliasingEffectConfig::Mutate { value } => {
                 let values = substitutions.get(value).cloned().unwrap_or_default();
                 for v in values {
                     effects.push(AliasingEffect::Mutate { value: v, reason: None });
                 }
             }
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::MutateTransitiveConditionally { value } => {
+            AliasingEffectConfig::MutateTransitiveConditionally { value } => {
                 let values = substitutions.get(value).cloned().unwrap_or_default();
                 for v in values {
                     effects.push(AliasingEffect::MutateTransitiveConditionally { value: v });
                 }
             }
-            crate::react_compiler_hir::type_config::AliasingEffectConfig::Apply { receiver: r, function: f, mutates_function, args: a, into: i } => {
+            AliasingEffectConfig::Apply {
+                receiver: r,
+                function: f,
+                mutates_function,
+                args: a,
+                into: i,
+            } => {
                 let recv = substitutions.get(r).and_then(|v| v.first()).cloned();
                 let func = substitutions.get(f).and_then(|v| v.first()).cloned();
                 let into = substitutions.get(i).and_then(|v| v.first()).cloned();
@@ -2718,20 +2721,22 @@ fn compute_effects_for_aliasing_signature_config(
                     let mut apply_args: Vec<PlaceOrSpreadOrHole> = Vec::new();
                     for arg in a {
                         match arg {
-                            crate::react_compiler_hir::type_config::ApplyArgConfig::Hole { .. } => {
+                            ApplyArgConfig::Hole { .. } => {
                                 apply_args.push(PlaceOrSpreadOrHole::Hole);
                             }
-                            crate::react_compiler_hir::type_config::ApplyArgConfig::Place(name) => {
+                            ApplyArgConfig::Place(name) => {
                                 if let Some(places) = substitutions.get(name) {
                                     if let Some(p) = places.first() {
                                         apply_args.push(PlaceOrSpreadOrHole::Place(p.clone()));
                                     }
                                 }
                             }
-                            crate::react_compiler_hir::type_config::ApplyArgConfig::Spread { place: name, .. } => {
+                            ApplyArgConfig::Spread { place: name, .. } => {
                                 if let Some(places) = substitutions.get(name) {
                                     if let Some(p) = places.first() {
-                                        apply_args.push(PlaceOrSpreadOrHole::Spread(crate::react_compiler_hir::SpreadPattern { place: p.clone() }));
+                                        apply_args.push(PlaceOrSpreadOrHole::Spread(
+                                            SpreadPattern { place: p.clone() },
+                                        ));
                                     }
                                 }
                             }
@@ -2820,7 +2825,7 @@ fn compute_effects_for_aliasing_signature(
         match arg {
             PlaceOrSpreadOrHole::Hole => continue,
             PlaceOrSpreadOrHole::Place(place)
-            | PlaceOrSpreadOrHole::Spread(crate::react_compiler_hir::SpreadPattern { place }) => {
+            | PlaceOrSpreadOrHole::Spread(SpreadPattern { place }) => {
                 let is_spread = matches!(arg, PlaceOrSpreadOrHole::Spread(_));
                 if !is_spread && i < signature.params.len() {
                     substitutions.insert(signature.params[i], vec![place.clone()]);
@@ -2992,9 +2997,7 @@ fn compute_effects_for_aliasing_signature(
                                 if let Some(places) = substitutions.get(&sp.place.identifier) {
                                     if let Some(place) = places.first() {
                                         apply_args.push(PlaceOrSpreadOrHole::Spread(
-                                            crate::react_compiler_hir::SpreadPattern {
-                                                place: place.clone(),
-                                            },
+                                            SpreadPattern { place: place.clone() },
                                         ));
                                     }
                                 }
@@ -3093,7 +3096,7 @@ fn get_function_call_signature(
 
 fn is_ref_or_ref_value_for_id(env: &Environment, id: IdentifierId) -> bool {
     let ty = &env.types[env.identifiers[id.0 as usize].type_.0 as usize];
-    crate::react_compiler_hir::is_ref_or_ref_value(ty)
+    is_ref_or_ref_value(ty)
 }
 
 fn get_hook_kind_for_type<'a>(
@@ -3135,11 +3138,7 @@ fn format_type_for_print(ty: &Type) -> String {
 }
 
 fn is_phi_with_jsx(ty: &Type) -> bool {
-    if let Type::Phi { operands } = ty {
-        operands.iter().any(|op| crate::react_compiler_hir::is_jsx_type(op))
-    } else {
-        false
-    }
+    if let Type::Phi { operands } = ty { operands.iter().any(|op| is_jsx_type(op)) } else { false }
 }
 
 fn place_or_spread_to_hole(pos: &PlaceOrSpread) -> PlaceOrSpreadOrHole {
@@ -3222,31 +3221,23 @@ enum PatternItem<'a> {
     Spread(&'a Place),
 }
 
-fn each_pattern_items(pattern: &crate::react_compiler_hir::Pattern) -> Vec<PatternItem<'_>> {
+fn each_pattern_items(pattern: &Pattern) -> Vec<PatternItem<'_>> {
     let mut items = Vec::new();
     match pattern {
-        crate::react_compiler_hir::Pattern::Array(arr) => {
+        Pattern::Array(arr) => {
             for el in &arr.items {
                 match el {
-                    crate::react_compiler_hir::ArrayPatternElement::Place(p) => {
-                        items.push(PatternItem::Place(p))
-                    }
-                    crate::react_compiler_hir::ArrayPatternElement::Spread(s) => {
-                        items.push(PatternItem::Spread(&s.place))
-                    }
-                    crate::react_compiler_hir::ArrayPatternElement::Hole => {}
+                    ArrayPatternElement::Place(p) => items.push(PatternItem::Place(p)),
+                    ArrayPatternElement::Spread(s) => items.push(PatternItem::Spread(&s.place)),
+                    ArrayPatternElement::Hole => {}
                 }
             }
         }
-        crate::react_compiler_hir::Pattern::Object(obj) => {
+        Pattern::Object(obj) => {
             for prop in &obj.properties {
                 match prop {
-                    crate::react_compiler_hir::ObjectPropertyOrSpread::Property(p) => {
-                        items.push(PatternItem::Place(&p.place))
-                    }
-                    crate::react_compiler_hir::ObjectPropertyOrSpread::Spread(s) => {
-                        items.push(PatternItem::Spread(&s.place))
-                    }
+                    ObjectPropertyOrSpread::Property(p) => items.push(PatternItem::Place(&p.place)),
+                    ObjectPropertyOrSpread::Spread(s) => items.push(PatternItem::Spread(&s.place)),
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_mutation_aliasing_ranges.rs
@@ -27,7 +27,8 @@ use crate::react_compiler_hir::visitors::{
 };
 use crate::react_compiler_hir::{
     AliasingEffect, BlockId, Effect, EvaluationOrder, FunctionId, HirFunction, IdentifierId,
-    InstructionValue, MutationReason, Place, SourceLocation, is_jsx_type, is_primitive_type,
+    InstructionValue, MutationReason, ParamPattern, Place, SourceLocation, Terminal, is_jsx_type,
+    is_primitive_type,
 };
 
 // =============================================================================
@@ -466,8 +467,8 @@ pub fn infer_mutation_aliasing_ranges(
     // Create nodes for params, context vars, and return
     for param in &func.params {
         let place = match param {
-            crate::react_compiler_hir::ParamPattern::Place(p) => p,
-            crate::react_compiler_hir::ParamPattern::Spread(s) => &s.place,
+            ParamPattern::Place(p) => p,
+            ParamPattern::Spread(s) => &s.place,
         };
         state.create(place, NodeValue::Object);
     }
@@ -619,15 +620,16 @@ pub fn infer_mutation_aliasing_ranges(
 
         // Handle return terminal
         let terminal = &block.terminal;
-        if let crate::react_compiler_hir::Terminal::Return { value, .. } = terminal {
+        if let Terminal::Return { value, .. } = terminal {
             state.assign(index, value, &func.returns);
             index += 1;
         }
 
         // Handle terminal effects (MaybeThrow and Return)
         let terminal_effects = match terminal {
-            crate::react_compiler_hir::Terminal::MaybeThrow { effects, .. }
-            | crate::react_compiler_hir::Terminal::Return { effects, .. } => effects.clone(),
+            Terminal::MaybeThrow { effects, .. } | Terminal::Return { effects, .. } => {
+                effects.clone()
+            }
             _ => None,
         };
         if let Some(effects) = terminal_effects {
@@ -678,8 +680,8 @@ pub fn infer_mutation_aliasing_ranges(
     }
     for param in &func.params {
         let place = match param {
-            crate::react_compiler_hir::ParamPattern::Place(p) => p,
-            crate::react_compiler_hir::ParamPattern::Spread(s) => &s.place,
+            ParamPattern::Place(p) => p,
+            ParamPattern::Spread(s) => &s.place,
         };
         collect_param_effects(&state, place, &mut function_effects);
     }
@@ -690,8 +692,8 @@ pub fn infer_mutation_aliasing_ranges(
     let mut captured_params: FxHashSet<IdentifierId> = FxHashSet::default();
     for param in &func.params {
         let place = match param {
-            crate::react_compiler_hir::ParamPattern::Place(p) => p,
-            crate::react_compiler_hir::ParamPattern::Spread(s) => &s.place,
+            ParamPattern::Place(p) => p,
+            ParamPattern::Spread(s) => &s.place,
         };
         if let Some(node) = state.nodes.get(&place.identifier) {
             if node.local.is_some() || node.transitive.is_some() {
@@ -710,8 +712,8 @@ pub fn infer_mutation_aliasing_ranges(
     // Now mutate the effects on params/context in place
     for param in &mut func.params {
         let place = match param {
-            crate::react_compiler_hir::ParamPattern::Place(p) => p,
-            crate::react_compiler_hir::ParamPattern::Spread(s) => &mut s.place,
+            ParamPattern::Place(p) => p,
+            ParamPattern::Spread(s) => &mut s.place,
         };
         if captured_params.contains(&place.identifier) {
             place.effect = Effect::Capture;
@@ -966,7 +968,7 @@ pub fn infer_mutation_aliasing_ranges(
         // Set terminal operand effects
         let block = func.body.blocks.get_mut(&block_id).unwrap();
         match &mut block.terminal {
-            crate::react_compiler_hir::Terminal::Return { value, .. } => {
+            Terminal::Return { value, .. } => {
                 value.effect = if is_function_expression { Effect::Read } else { Effect::Freeze };
             }
             terminal => {
@@ -1001,8 +1003,8 @@ pub fn infer_mutation_aliasing_ranges(
     let mut tracked: Vec<Place> = Vec::new();
     for param in &func.params {
         let place = match param {
-            crate::react_compiler_hir::ParamPattern::Place(p) => p.clone(),
-            crate::react_compiler_hir::ParamPattern::Spread(s) => s.place.clone(),
+            ParamPattern::Place(p) => p.clone(),
+            ParamPattern::Spread(s) => s.place.clone(),
         };
         tracked.push(place);
     }

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_places.rs
@@ -17,13 +17,15 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_diagnostics::{CompilerDiagnostic, ErrorCategory};
-use crate::react_compiler_hir::dominator::post_dominator_frontier;
+use crate::react_compiler_hir::dominator::{
+    PostDominator, compute_post_dominator_tree, post_dominator_frontier,
+};
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::{
-    BlockId, Effect, FunctionId, HirFunction, IdentifierId, InstructionValue, ParamPattern,
-    Terminal, Type,
+    BlockId, Effect, FunctionId, HirFunction, IdentifierId, Instruction, InstructionId,
+    InstructionValue, ParamPattern, Terminal, Type,
 };
 
 use crate::react_compiler_utils::DisjointSet;
@@ -55,11 +57,7 @@ pub fn infer_reactive_places(
     }
 
     // Compute control dominators
-    let post_dominators = crate::react_compiler_hir::dominator::compute_post_dominator_tree(
-        func,
-        env.next_block_id().0,
-        false,
-    )?;
+    let post_dominators = compute_post_dominator_tree(func, env.next_block_id().0, false)?;
 
     // Collect block IDs for iteration
     let block_ids: Vec<BlockId> = func.body.blocks.keys().copied().collect();
@@ -277,11 +275,7 @@ impl StableSidemap {
         StableSidemap { map: FxHashMap::default() }
     }
 
-    fn handle_instruction(
-        &mut self,
-        instr: &crate::react_compiler_hir::Instruction,
-        env: &Environment,
-    ) {
+    fn handle_instruction(&mut self, instr: &Instruction, env: &Environment) {
         let lvalue_id = instr.lvalue.identifier;
         let value = &instr.value;
 
@@ -368,7 +362,7 @@ impl StableSidemap {
 fn is_reactive_controlled_block(
     block_id: BlockId,
     func: &HirFunction,
-    post_dominators: &crate::react_compiler_hir::dominator::PostDominator,
+    post_dominators: &PostDominator,
     reactive_map: &mut ReactivityMap,
 ) -> bool {
     let frontier = post_dominator_frontier(func, post_dominators, block_id);
@@ -573,7 +567,7 @@ fn apply_reactive_flags_replay(
 
         // 2b. Instructions
         let block = func.body.blocks.get(block_id).unwrap();
-        let instr_ids: Vec<crate::react_compiler_hir::InstructionId> = block.instructions.clone();
+        let instr_ids: Vec<InstructionId> = block.instructions.clone();
 
         for instr_id in &instr_ids {
             let instr = &func.instructions[instr_id.0 as usize];

--- a/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/infer_reactive_scope_variables.rs
@@ -22,7 +22,7 @@ use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::{
     DeclarationId, EvaluationOrder, HirFunction, IdentifierId, InstructionValue, Pattern, Position,
-    SourceLocation,
+    ScopeId, SourceLocation, is_primitive_type,
 };
 use crate::react_compiler_utils::DisjointSet;
 
@@ -133,7 +133,7 @@ pub fn infer_reactive_scope_variables(
 }
 
 struct ScopeState {
-    scope_id: crate::react_compiler_hir::ScopeId,
+    scope_id: ScopeId,
     loc: Option<SourceLocation>,
 }
 
@@ -314,8 +314,7 @@ pub(crate) fn find_disjoint_mutable_values(
             let lvalue_id = instr.lvalue.identifier;
             let lvalue_range = &env.identifiers[lvalue_id.0 as usize].mutable_range;
             let lvalue_type = &env.types[env.identifiers[lvalue_id.0 as usize].type_.0 as usize];
-            let lvalue_type_is_primitive =
-                crate::react_compiler_hir::is_primitive_type(lvalue_type);
+            let lvalue_type_is_primitive = is_primitive_type(lvalue_type);
 
             if lvalue_range.end.0 > lvalue_range.start.0 + 1
                 || may_allocate(&instr.value, lvalue_type_is_primitive)

--- a/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/merge_overlapping_reactive_scopes_hir.rs
@@ -16,8 +16,11 @@
 //! Ported from TypeScript `src/HIR/MergeOverlappingReactiveScopesHIR.ts`.
 
 use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use std::cmp;
 
+use crate::react_compiler_hir::Instruction;
+use crate::react_compiler_hir::MutableRangeId;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::visitors::{each_instruction_lvalue_ids, each_terminal_operand_ids};
@@ -137,7 +140,7 @@ fn collect_scope_info(func: &HirFunction, env: &Environment) -> ScopeInfo {
     // We must NOT sort by ScopeId here — the insertion order determines which scope
     // becomes the root in the disjoint set union.
     fn dedup_preserve_order(scopes: &mut Vec<ScopeId>) {
-        let mut seen = rustc_hash::FxHashSet::default();
+        let mut seen = FxHashSet::default();
         scopes.retain(|s| seen.insert(*s));
     }
     for scopes in scope_starts_map.values_mut() {
@@ -331,8 +334,7 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
     // When scope.range is updated, ALL identifiers referencing that range object
     // automatically see the new values. We use MutableRangeId to identify which
     // identifiers share the same logical range as a root scope.
-    let mut original_root_range_ids: FxHashMap<ScopeId, crate::react_compiler_hir::MutableRangeId> =
-        FxHashMap::default();
+    let mut original_root_range_ids: FxHashMap<ScopeId, MutableRangeId> = FxHashMap::default();
     for (_, root_id) in &scope_groups {
         if !original_root_range_ids.contains_key(root_id) {
             let range_id = env.scopes[root_id.0 as usize].range.id;
@@ -383,7 +385,7 @@ pub fn merge_overlapping_reactive_scopes_hir(func: &mut HirFunction, env: &mut E
 /// Collect operand IdentifierIds with their types from an instruction value.
 /// Used to check for Primitive type on FunctionExpression/ObjectMethod operands.
 fn each_instruction_operand_ids_with_types(
-    instr: &crate::react_compiler_hir::Instruction,
+    instr: &Instruction,
     env: &Environment,
 ) -> Vec<(IdentifierId, Type)> {
     visitors::each_instruction_operand(instr, env)

--- a/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_inference/propagate_scope_dependencies_hir.rs
@@ -15,14 +15,17 @@
 use crate::react_compiler_utils::FxIndexMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::BTreeSet;
+use std::ptr::eq;
 
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors::{ScopeBlockInfo, ScopeBlockTraversal};
 use crate::react_compiler_hir::{
     BasicBlock, BlockId, DeclarationId, DependencyPathEntry, EvaluationOrder, FunctionId,
     GotoVariant, HirFunction, IdentifierId, Instruction, InstructionId, InstructionKind,
-    InstructionValue, MutableRange, ParamPattern, Place, PlaceOrSpread, PropertyLiteral,
-    ReactFunctionType, ReactiveScopeDependency, ScopeId, Terminal, Type, visitors,
+    InstructionValue, JsxAttribute, ManualMemoDependencyRoot, MutableRange, ParamPattern, Place,
+    PlaceOrSpread, PropertyLiteral, ReactFunctionType, ReactiveScopeDeclaration,
+    ReactiveScopeDependency, ScopeId, SourceLocation, Terminal, Type, is_ref_value_type,
+    is_use_ref_type, visitors,
 };
 
 // =============================================================================
@@ -341,7 +344,7 @@ fn get_property(
     object: &Place,
     property_name: &PropertyLiteral,
     optional: bool,
-    loc: Option<crate::react_compiler_hir::SourceLocation>,
+    loc: Option<SourceLocation>,
     temporaries: &FxHashMap<IdentifierId, ReactiveScopeDependency>,
     _env: &Environment,
 ) -> ReactiveScopeDependency {
@@ -441,7 +444,7 @@ struct MatchConsequentResult {
     property_id: IdentifierId,
     store_local_lvalue_id: IdentifierId,
     consequent_goto: BlockId,
-    property_load_loc: Option<crate::react_compiler_hir::SourceLocation>,
+    property_load_loc: Option<SourceLocation>,
 }
 
 fn match_optional_test_block(
@@ -697,7 +700,7 @@ fn traverse_optional_block(
             // This is O(n) but only happens for optional chains.
             let mut found_block = BlockId(0);
             for (bid, blk) in &func.body.blocks {
-                if std::ptr::eq(&blk.terminal, test_terminal) {
+                if eq(&blk.terminal, test_terminal) {
                     found_block = *bid;
                     break;
                 }
@@ -742,7 +745,7 @@ impl PropertyPathRegistry {
         &mut self,
         identifier_id: IdentifierId,
         reactive: bool,
-        loc: Option<crate::react_compiler_hir::SourceLocation>,
+        loc: Option<SourceLocation>,
     ) -> usize {
         if let Some(&idx) = self.roots.get(&identifier_id) {
             return idx;
@@ -1052,10 +1055,7 @@ fn get_assumed_invoked_functions_impl(
                 InstructionValue::JsxExpression { props, children, .. } => {
                     // Assume JSX attributes and children are safe to invoke
                     for prop in props {
-                        if let crate::react_compiler_hir::JsxAttribute::Attribute {
-                            place, ..
-                        } = prop
-                        {
+                        if let JsxAttribute::Attribute { place, .. } = prop {
                             if let Some(entry) = temporaries.get(&place.identifier) {
                                 hoistable.insert(entry.0);
                             }
@@ -1167,11 +1167,7 @@ fn collect_non_nulls_in_blocks(
             if env.enable_preserve_existing_memoization_guarantees {
                 if let InstructionValue::StartMemoize { deps: Some(deps), .. } = &instr.value {
                     for dep in deps {
-                        if let crate::react_compiler_hir::ManualMemoDependencyRoot::NamedLocal {
-                            value: val,
-                            ..
-                        } = &dep.root
-                        {
+                        if let ManualMemoDependencyRoot::NamedLocal { value: val, .. } = &dep.root {
                             if !is_immutable_at_instr(val.identifier, instr.id, env, ctx) {
                                 continue;
                             }
@@ -1500,7 +1496,7 @@ struct HoistableNodeEntry {
 struct DependencyNode {
     properties: FxIndexMap<PropertyLiteral, Box<DependencyNodeEntry>>,
     access_type: PropertyAccessType,
-    loc: Option<crate::react_compiler_hir::SourceLocation>,
+    loc: Option<SourceLocation>,
 }
 
 struct DependencyNodeEntry {
@@ -1758,7 +1754,7 @@ impl<'a> DependencyCollectionContext<'a> {
     fn check_valid_dependency(&self, dep: &ReactiveScopeDependency, env: &Environment) -> bool {
         // Ref value is not a valid dep
         let ty = &env.types[env.identifiers[dep.identifier.0 as usize].type_.0 as usize];
-        if crate::react_compiler_hir::is_ref_value_type(ty) {
+        if is_ref_value_type(ty) {
             return false;
         }
         // Object methods are not deps
@@ -1798,7 +1794,7 @@ impl<'a> DependencyCollectionContext<'a> {
         object: &Place,
         property: &PropertyLiteral,
         optional: bool,
-        loc: Option<crate::react_compiler_hir::SourceLocation>,
+        loc: Option<SourceLocation>,
         env: &mut Environment,
     ) {
         let dep = get_property(object, property, optional, loc, self.temporaries, env);
@@ -1822,7 +1818,7 @@ impl<'a> DependencyCollectionContext<'a> {
                         });
                         if !already_declared {
                             let orig_scope_id = *orig_scope_stack.last().unwrap();
-                            let new_decl = crate::react_compiler_hir::ReactiveScopeDeclaration {
+                            let new_decl = ReactiveScopeDeclaration {
                                 identifier: dep.identifier,
                                 scope: orig_scope_id,
                             };
@@ -1836,7 +1832,7 @@ impl<'a> DependencyCollectionContext<'a> {
         }
 
         // Handle ref.current access
-        let dep = if crate::react_compiler_hir::is_use_ref_type(
+        let dep = if is_use_ref_type(
             &env.types[env.identifiers[dep.identifier.0 as usize].type_.0 as usize],
         ) && dep
             .path

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -77,13 +77,13 @@ fn original_expression(expr: &Expression) -> Option<OriginalNode> {
     Some(OriginalNode::Expression(Box::new(expr.clone())))
 }
 
-/// Wrap a statement as an [`OriginalNode`](crate::react_compiler_ast::OriginalNode)
+/// Wrap a statement as an [`OriginalNode`]
 /// for `UnsupportedNode`'s `original_node`.
 fn original_statement(stmt: &Statement) -> Option<OriginalNode> {
     Some(OriginalNode::Statement(Box::new(stmt.clone())))
 }
 
-/// Wrap a pattern as an [`OriginalNode`](crate::react_compiler_ast::OriginalNode) for
+/// Wrap a pattern as an [`OriginalNode`] for
 /// `UnsupportedNode`'s `original_node`.
 fn original_pattern(pat: &PatternLike) -> Option<OriginalNode> {
     Some(OriginalNode::Pattern(Box::new(pat.clone())))

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1,19 +1,35 @@
+use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
+use crate::react_compiler_ast::OriginalNode;
+use crate::react_compiler_ast::common::RawNode;
+use crate::react_compiler_ast::common::SourceLocation as AstSourceLocation;
 use crate::react_compiler_ast::expressions::{ArrowFunctionBody, Expression, ObjectMethodKind};
+use crate::react_compiler_ast::expressions::{
+    MemberExpression, ObjectExpressionProperty, ObjectMethod, OptionalCallExpression,
+    OptionalMemberExpression,
+};
 use crate::react_compiler_ast::jsx::{
     JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild, JSXElementName,
     JSXExpressionContainerExpr, JSXMemberExprObject,
 };
+use crate::react_compiler_ast::jsx::{JSXElement, JSXMemberExpression};
 use crate::react_compiler_ast::operators::{
     AssignmentOperator, BinaryOperator as AstBinaryOperator, UnaryOperator as AstUnaryOperator,
 };
+use crate::react_compiler_ast::operators::{
+    LogicalOperator as AstLogicalOperator, UpdateOperator as AstUpdateOperator,
+};
 use crate::react_compiler_ast::patterns::{ObjectPatternProperty, PatternLike};
+use crate::react_compiler_ast::scope::BindingData;
 use crate::react_compiler_ast::scope::BindingId;
 use crate::react_compiler_ast::scope::BindingKind as AstBindingKind;
 use crate::react_compiler_ast::scope::ScopeId;
 use crate::react_compiler_ast::scope::ScopeInfo;
 use crate::react_compiler_ast::scope::ScopeKind;
+use crate::react_compiler_ast::statements::{
+    BlockStatement, ForInOfLeft, ForInit, FunctionDeclaration,
+};
 use crate::react_compiler_ast::statements::{Statement, VariableDeclarationKind};
 use crate::react_compiler_diagnostics::CompilerDiagnostic;
 use crate::react_compiler_diagnostics::CompilerDiagnosticDetail;
@@ -26,8 +42,10 @@ use crate::react_compiler_utils::FxIndexMap;
 use crate::react_compiler_utils::FxIndexSet;
 
 use crate::react_compiler_lowering::FunctionNode;
+use crate::react_compiler_lowering::convert_binding_kind;
 use crate::react_compiler_lowering::find_context_identifiers::find_context_identifiers;
 use crate::react_compiler_lowering::hir_builder::HirBuilder;
+use crate::react_compiler_lowering::hir_builder::create_temporary_place;
 use crate::react_compiler_lowering::hir_builder::is_always_reserved_word;
 use crate::react_compiler_lowering::hir_builder::reserved_identifier_diagnostic;
 use crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex;
@@ -38,7 +56,7 @@ use crate::react_compiler_lowering::identifier_loc_index::build_identifier_loc_i
 // =============================================================================
 
 /// Convert an AST SourceLocation to an HIR SourceLocation.
-fn convert_loc(loc: &crate::react_compiler_ast::common::SourceLocation) -> SourceLocation {
+fn convert_loc(loc: &AstSourceLocation) -> SourceLocation {
     SourceLocation {
         start: Position { line: loc.start.line, column: loc.start.column, index: loc.start.index },
         end: Position { line: loc.end.line, column: loc.end.column, index: loc.end.index },
@@ -46,9 +64,7 @@ fn convert_loc(loc: &crate::react_compiler_ast::common::SourceLocation) -> Sourc
 }
 
 /// Convert an optional AST SourceLocation to an optional HIR SourceLocation.
-fn convert_opt_loc(
-    loc: &Option<crate::react_compiler_ast::common::SourceLocation>,
-) -> Option<SourceLocation> {
+fn convert_opt_loc(loc: &Option<AstSourceLocation>) -> Option<SourceLocation> {
     loc.as_ref().map(convert_loc)
 }
 
@@ -57,31 +73,23 @@ fn convert_opt_loc(
 /// before deciding to create an `UnsupportedNode`.
 ///
 /// [`OriginalNode`]: crate::react_compiler_ast::OriginalNode
-fn original_expression(
-    expr: &crate::react_compiler_ast::expressions::Expression,
-) -> Option<crate::react_compiler_ast::OriginalNode> {
-    Some(crate::react_compiler_ast::OriginalNode::Expression(Box::new(expr.clone())))
+fn original_expression(expr: &Expression) -> Option<OriginalNode> {
+    Some(OriginalNode::Expression(Box::new(expr.clone())))
 }
 
 /// Wrap a statement as an [`OriginalNode`](crate::react_compiler_ast::OriginalNode)
 /// for `UnsupportedNode`'s `original_node`.
-fn original_statement(
-    stmt: &crate::react_compiler_ast::statements::Statement,
-) -> Option<crate::react_compiler_ast::OriginalNode> {
-    Some(crate::react_compiler_ast::OriginalNode::Statement(Box::new(stmt.clone())))
+fn original_statement(stmt: &Statement) -> Option<OriginalNode> {
+    Some(OriginalNode::Statement(Box::new(stmt.clone())))
 }
 
 /// Wrap a pattern as an [`OriginalNode`](crate::react_compiler_ast::OriginalNode) for
 /// `UnsupportedNode`'s `original_node`.
-fn original_pattern(
-    pat: &crate::react_compiler_ast::patterns::PatternLike,
-) -> Option<crate::react_compiler_ast::OriginalNode> {
-    Some(crate::react_compiler_ast::OriginalNode::Pattern(Box::new(pat.clone())))
+fn original_pattern(pat: &PatternLike) -> Option<OriginalNode> {
+    Some(OriginalNode::Pattern(Box::new(pat.clone())))
 }
 
-fn pattern_like_loc(
-    pattern: &crate::react_compiler_ast::patterns::PatternLike,
-) -> Option<crate::react_compiler_ast::common::SourceLocation> {
+fn pattern_like_loc(pattern: &PatternLike) -> Option<AstSourceLocation> {
     match pattern {
         PatternLike::Identifier(id) => id.base.loc.clone(),
         PatternLike::ObjectPattern(p) => p.base.loc.clone(),
@@ -98,9 +106,7 @@ fn pattern_like_loc(
 }
 
 /// Extract the HIR SourceLocation from an Expression AST node.
-fn expression_loc(
-    expr: &crate::react_compiler_ast::expressions::Expression,
-) -> Option<SourceLocation> {
+fn expression_loc(expr: &Expression) -> Option<SourceLocation> {
     let loc = match expr {
         Expression::Identifier(e) => e.base.loc.clone(),
         Expression::StringLiteral(e) => e.base.loc.clone(),
@@ -211,7 +217,7 @@ fn validate_ts_this_parameters_in_function_range(
 }
 
 /// Get the Babel-style type name of an Expression node (e.g. "Identifier", "NumericLiteral").
-fn expression_type_name(expr: &crate::react_compiler_ast::expressions::Expression) -> &'static str {
+fn expression_type_name(expr: &Expression) -> &'static str {
     match expr {
         Expression::Identifier(_) => "Identifier",
         Expression::StringLiteral(_) => "StringLiteral",
@@ -265,9 +271,7 @@ fn expression_type_name(expr: &crate::react_compiler_ast::expressions::Expressio
 /// { "type": "TSTypeAnnotation", "typeAnnotation": { "type": "TSTypeReference", ... } }
 /// or { "type": "TypeAnnotation", "typeAnnotation": { "type": "GenericTypeAnnotation", ... } }
 /// We extract the inner typeAnnotation's `type` field name.
-fn extract_type_annotation_name(
-    type_annotation: &Option<crate::react_compiler_ast::common::RawNode>,
-) -> Option<String> {
+fn extract_type_annotation_name(type_annotation: &Option<RawNode>) -> Option<String> {
     let val = type_annotation.as_ref()?.parse_value();
     // Navigate: typeAnnotation.typeAnnotation.type
     let inner = val.get("typeAnnotation")?;
@@ -318,7 +322,7 @@ fn lower_value_to_temporary(
 
 fn lower_expression_to_temporary(
     builder: &mut HirBuilder,
-    expr: &crate::react_compiler_ast::expressions::Expression,
+    expr: &Expression,
 ) -> Result<Place, CompilerError> {
     let value = lower_expression(builder, expr)?;
     Ok(lower_value_to_temporary(builder, value)?)
@@ -433,7 +437,7 @@ fn lower_identifier(
 
 fn lower_arguments(
     builder: &mut HirBuilder,
-    args: &[crate::react_compiler_ast::expressions::Expression],
+    args: &[Expression],
 ) -> Result<Vec<PlaceOrSpread>, CompilerError> {
     let mut result = Vec::new();
     for arg in args {
@@ -451,16 +455,10 @@ fn lower_arguments(
     Ok(result)
 }
 
-fn convert_update_operator(
-    op: &crate::react_compiler_ast::operators::UpdateOperator,
-) -> UpdateOperator {
+fn convert_update_operator(op: &AstUpdateOperator) -> UpdateOperator {
     match op {
-        crate::react_compiler_ast::operators::UpdateOperator::Increment => {
-            UpdateOperator::Increment
-        }
-        crate::react_compiler_ast::operators::UpdateOperator::Decrement => {
-            UpdateOperator::Decrement
-        }
+        AstUpdateOperator::Increment => UpdateOperator::Increment,
+        AstUpdateOperator::Decrement => UpdateOperator::Decrement,
     }
 }
 
@@ -481,14 +479,14 @@ struct LoweredMemberExpression {
 
 fn lower_member_expression(
     builder: &mut HirBuilder,
-    member: &crate::react_compiler_ast::expressions::MemberExpression,
+    member: &MemberExpression,
 ) -> Result<LoweredMemberExpression, CompilerError> {
     Ok(lower_member_expression_impl(builder, member, None)?)
 }
 
 fn lower_member_expression_with_object(
     builder: &mut HirBuilder,
-    member: &crate::react_compiler_ast::expressions::OptionalMemberExpression,
+    member: &OptionalMemberExpression,
     lowered_object: Place,
 ) -> Result<LoweredMemberExpression, CompilerError> {
     // OptionalMemberExpression has the same shape as MemberExpression for property access
@@ -517,11 +515,9 @@ fn lower_member_expression_with_object(
                     property: MemberProperty::Literal(PropertyLiteral::String("".to_string())),
                     value: InstructionValue::UnsupportedNode {
                         node_type: Some("OptionalMemberExpression".to_string()),
-                        original_node: original_expression(
-                            &crate::react_compiler_ast::expressions::Expression::OptionalMemberExpression(
-                                member.clone(),
-                            ),
-                        ),
+                        original_node: original_expression(&Expression::OptionalMemberExpression(
+                            member.clone(),
+                        )),
                         loc,
                     },
                 });
@@ -563,7 +559,7 @@ fn lower_member_expression_with_object(
 
 fn lower_member_expression_impl(
     builder: &mut HirBuilder,
-    member: &crate::react_compiler_ast::expressions::MemberExpression,
+    member: &MemberExpression,
     lowered_object: Option<Place>,
 ) -> Result<LoweredMemberExpression, CompilerError> {
     let loc = convert_opt_loc(&member.base.loc);
@@ -595,11 +591,9 @@ fn lower_member_expression_impl(
                     property: MemberProperty::Literal(PropertyLiteral::String("".to_string())),
                     value: InstructionValue::UnsupportedNode {
                         node_type: Some("MemberExpression".to_string()),
-                        original_node: original_expression(
-                            &crate::react_compiler_ast::expressions::Expression::MemberExpression(
-                                member.clone(),
-                            ),
-                        ),
+                        original_node: original_expression(&Expression::MemberExpression(
+                            member.clone(),
+                        )),
                         loc,
                     },
                 });
@@ -647,7 +641,7 @@ fn lower_member_expression_impl(
 
 fn lower_expression(
     builder: &mut HirBuilder,
-    expr: &crate::react_compiler_ast::expressions::Expression,
+    expr: &Expression,
 ) -> Result<InstructionValue, CompilerError> {
     match expr {
         Expression::Identifier(ident) => {
@@ -687,10 +681,7 @@ fn lower_expression(
         Expression::BinaryExpression(bin) => {
             let loc = convert_opt_loc(&bin.base.loc);
             // Check for pipeline operator before lowering operands
-            if matches!(
-                bin.operator,
-                crate::react_compiler_ast::operators::BinaryOperator::Pipeline
-            ) {
+            if matches!(bin.operator, AstBinaryOperator::Pipeline) {
                 builder.record_error(CompilerErrorDetail {
                     category: ErrorCategory::Todo,
                     reason: "(BuildHIR::lowerExpression) Pipe operator not supported".to_string(),
@@ -712,7 +703,7 @@ fn lower_expression(
         Expression::UnaryExpression(unary) => {
             let loc = convert_opt_loc(&unary.base.loc);
             match &unary.operator {
-                crate::react_compiler_ast::operators::UnaryOperator::Delete => {
+                AstUnaryOperator::Delete => {
                     // Delete can be on member expressions or identifiers
                     let loc = convert_opt_loc(&unary.base.loc);
                     match &*unary.argument {
@@ -765,7 +756,7 @@ fn lower_expression(
                         }
                     }
                 }
-                crate::react_compiler_ast::operators::UnaryOperator::Throw => {
+                AstUnaryOperator::Throw => {
                     // throw as unary operator (Babel-specific)
                     let loc = convert_opt_loc(&unary.base.loc);
                     builder.record_error(CompilerErrorDetail {
@@ -863,11 +854,9 @@ fn lower_expression(
             });
 
             let hir_op = match expr.operator {
-                crate::react_compiler_ast::operators::LogicalOperator::And => LogicalOperator::And,
-                crate::react_compiler_ast::operators::LogicalOperator::Or => LogicalOperator::Or,
-                crate::react_compiler_ast::operators::LogicalOperator::NullishCoalescing => {
-                    LogicalOperator::NullishCoalescing
-                }
+                AstLogicalOperator::And => LogicalOperator::And,
+                AstLogicalOperator::Or => LogicalOperator::Or,
+                AstLogicalOperator::NullishCoalescing => LogicalOperator::NullishCoalescing,
             };
 
             builder.terminate_with_continuation(
@@ -910,12 +899,8 @@ fn lower_expression(
             match update.argument.as_ref() {
                 Expression::MemberExpression(member) => {
                     let binary_op = match &update.operator {
-                        crate::react_compiler_ast::operators::UpdateOperator::Increment => {
-                            BinaryOperator::Add
-                        }
-                        crate::react_compiler_ast::operators::UpdateOperator::Decrement => {
-                            BinaryOperator::Subtract
-                        }
+                        AstUpdateOperator::Increment => BinaryOperator::Add,
+                        AstUpdateOperator::Decrement => BinaryOperator::Subtract,
                     };
                     // Use the member expression's loc (not the update expression's)
                     // to match TS behavior where the inner operations use leftExpr.node.loc
@@ -1163,7 +1148,7 @@ fn lower_expression(
             if matches!(expr.operator, AssignmentOperator::Assign) {
                 // Simple `=` assignment
                 match &*expr.left {
-                    crate::react_compiler_ast::patterns::PatternLike::Identifier(ident) => {
+                    PatternLike::Identifier(ident) => {
                         // Handle simple identifier assignment directly
                         let start = ident.base.start.unwrap_or(0);
                         let right = lower_expression_to_temporary(builder, &expr.right)?;
@@ -1259,22 +1244,16 @@ fn lower_expression(
                             }
                         }
                     }
-                    crate::react_compiler_ast::patterns::PatternLike::MemberExpression(member) => {
+                    PatternLike::MemberExpression(member) => {
                         // Member expression assignment: a.b = value or a[b] = value
                         let right = lower_expression_to_temporary(builder, &expr.right)?;
                         let left_loc = convert_opt_loc(&member.base.loc);
                         let object = lower_expression_to_temporary(builder, &member.object)?;
                         let temp = if !member.computed
-                            || matches!(
-                                &*member.property,
-                                crate::react_compiler_ast::expressions::Expression::NumericLiteral(
-                                    _
-                                )
-                            ) {
+                            || matches!(&*member.property, Expression::NumericLiteral(_))
+                        {
                             match &*member.property {
-                                crate::react_compiler_ast::expressions::Expression::Identifier(
-                                    prop_id,
-                                ) => lower_value_to_temporary(
+                                Expression::Identifier(prop_id) => lower_value_to_temporary(
                                     builder,
                                     InstructionValue::PropertyStore {
                                         object,
@@ -1283,9 +1262,7 @@ fn lower_expression(
                                         loc: left_loc,
                                     },
                                 )?,
-                                crate::react_compiler_ast::expressions::Expression::NumericLiteral(
-                                    num,
-                                ) => lower_value_to_temporary(
+                                Expression::NumericLiteral(num) => lower_value_to_temporary(
                                     builder,
                                     InstructionValue::PropertyStore {
                                         object,
@@ -1400,13 +1377,11 @@ fn lower_expression(
                 };
 
                 match &*expr.left {
-                    crate::react_compiler_ast::patterns::PatternLike::Identifier(ident) => {
+                    PatternLike::Identifier(ident) => {
                         let start = ident.base.start.unwrap_or(0);
                         let left_place = lower_expression_to_temporary(
                             builder,
-                            &crate::react_compiler_ast::expressions::Expression::Identifier(
-                                ident.clone(),
-                            ),
+                            &Expression::Identifier(ident.clone()),
                         )?;
                         let right = lower_expression_to_temporary(builder, &expr.right)?;
                         let binary_place = lower_value_to_temporary(
@@ -1484,7 +1459,7 @@ fn lower_expression(
                             }
                         }
                     }
-                    crate::react_compiler_ast::patterns::PatternLike::MemberExpression(member) => {
+                    PatternLike::MemberExpression(member) => {
                         // a.b += right: read, compute, store
                         // Match TS behavior: return the PropertyStore/ComputedStore value
                         // directly (let the caller lower it to a temporary)
@@ -1614,9 +1589,7 @@ fn lower_expression(
             let mut properties: Vec<ObjectPropertyOrSpread> = Vec::new();
             for prop in &obj.properties {
                 match prop {
-                    crate::react_compiler_ast::expressions::ObjectExpressionProperty::ObjectProperty(
-                        p,
-                    ) => {
+                    ObjectExpressionProperty::ObjectProperty(p) => {
                         let key = lower_object_property_key(builder, &p.key, p.computed)?;
                         let key = match key {
                             Some(k) => k,
@@ -1629,15 +1602,11 @@ fn lower_expression(
                             place: value,
                         }));
                     }
-                    crate::react_compiler_ast::expressions::ObjectExpressionProperty::SpreadElement(
-                        spread,
-                    ) => {
+                    ObjectExpressionProperty::SpreadElement(spread) => {
                         let place = lower_expression_to_temporary(builder, &spread.argument)?;
                         properties.push(ObjectPropertyOrSpread::Spread(SpreadPattern { place }));
                     }
-                    crate::react_compiler_ast::expressions::ObjectExpressionProperty::ObjectMethod(
-                        method,
-                    ) => {
+                    ObjectExpressionProperty::ObjectMethod(method) => {
                         if let Some(prop) = lower_object_method(builder, method)? {
                             properties.push(ObjectPropertyOrSpread::Property(prop));
                         }
@@ -1925,20 +1894,14 @@ fn lower_expression(
                                 }
                             }
                             Some(JSXAttributeValue::JSXElement(el)) => {
-                                let val = lower_expression(
-                                    builder,
-                                    &crate::react_compiler_ast::expressions::Expression::JSXElement(
-                                        el.clone(),
-                                    ),
-                                )?;
+                                let val =
+                                    lower_expression(builder, &Expression::JSXElement(el.clone()))?;
                                 lower_value_to_temporary(builder, val)?
                             }
                             Some(JSXAttributeValue::JSXFragment(frag)) => {
                                 let val = lower_expression(
                                     builder,
-                                    &crate::react_compiler_ast::expressions::Expression::JSXFragment(
-                                        frag.clone(),
-                                    ),
+                                    &Expression::JSXFragment(frag.clone()),
                                 )?;
                                 lower_value_to_temporary(builder, val)?
                             }
@@ -1971,9 +1934,7 @@ fn lower_expression(
                     _ => "fbt".to_string(),
                 };
                 // Get the opening element's name identifier and check if it's a local binding
-                if let crate::react_compiler_ast::jsx::JSXElementName::JSXIdentifier(jsx_id) =
-                    &jsx_element.opening_element.name
-                {
+                if let JSXElementName::JSXIdentifier(jsx_id) = &jsx_element.opening_element.name {
                     let id_loc = convert_opt_loc(&jsx_id.base.loc);
                     // Check if fbt/fbs tag name resolves to a local binding.
                     // JSX identifiers may not be in our position-based reference map,
@@ -2032,7 +1993,7 @@ fn lower_expression(
                                 identifier_name: None,
                             })
                             .collect();
-                        let mut diag = crate::react_compiler_diagnostics::CompilerDiagnostic::new(
+                        let mut diag = CompilerDiagnostic::new(
                             ErrorCategory::Todo,
                             "Support duplicate fbt tags",
                             Some(format!(
@@ -2206,10 +2167,7 @@ fn lower_expression(
 /// ClassDeclaration statements. This avoids false positives when two bindings
 /// share the same name but are declared in different scopes (e.g., `const x`
 /// inside an if-branch and `const x` after it).
-fn is_binding_in_block_direct_statements(
-    binding: &crate::react_compiler_ast::scope::BindingData,
-    stmts: &[crate::react_compiler_ast::statements::Statement],
-) -> bool {
+fn is_binding_in_block_direct_statements(binding: &BindingData, stmts: &[Statement]) -> bool {
     let decl_start = match binding.declaration_start {
         Some(pos) => pos,
         None => return false,
@@ -2244,19 +2202,12 @@ fn is_binding_in_block_direct_statements(
 }
 
 #[allow(dead_code)]
-fn pattern_declares_name(
-    pattern: &crate::react_compiler_ast::patterns::PatternLike,
-    name: &str,
-) -> bool {
+fn pattern_declares_name(pattern: &PatternLike, name: &str) -> bool {
     match pattern {
         PatternLike::Identifier(id) => id.name == name,
         PatternLike::ObjectPattern(op) => op.properties.iter().any(|prop| match prop {
-            crate::react_compiler_ast::patterns::ObjectPatternProperty::ObjectProperty(p) => {
-                pattern_declares_name(&p.value, name)
-            }
-            crate::react_compiler_ast::patterns::ObjectPatternProperty::RestElement(r) => {
-                pattern_declares_name(&r.argument, name)
-            }
+            ObjectPatternProperty::ObjectProperty(p) => pattern_declares_name(&p.value, name),
+            ObjectPatternProperty::RestElement(r) => pattern_declares_name(&r.argument, name),
         }),
         PatternLike::ArrayPattern(ap) => ap
             .elements
@@ -2277,7 +2228,7 @@ fn pattern_declares_name(
 // Statement position helpers
 // =============================================================================
 
-fn statement_start(stmt: &crate::react_compiler_ast::statements::Statement) -> Option<u32> {
+fn statement_start(stmt: &Statement) -> Option<u32> {
     match stmt {
         Statement::BlockStatement(s) => s.base.start,
         Statement::ReturnStatement(s) => s.base.start,
@@ -2327,7 +2278,7 @@ fn statement_start(stmt: &crate::react_compiler_ast::statements::Statement) -> O
     }
 }
 
-fn statement_end(stmt: &crate::react_compiler_ast::statements::Statement) -> Option<u32> {
+fn statement_end(stmt: &Statement) -> Option<u32> {
     match stmt {
         Statement::BlockStatement(s) => s.base.end,
         Statement::ReturnStatement(s) => s.base.end,
@@ -2378,9 +2329,7 @@ fn statement_end(stmt: &crate::react_compiler_ast::statements::Statement) -> Opt
 }
 
 /// Extract the HIR SourceLocation from a Statement AST node.
-fn statement_loc(
-    stmt: &crate::react_compiler_ast::statements::Statement,
-) -> Option<SourceLocation> {
+fn statement_loc(stmt: &Statement) -> Option<SourceLocation> {
     let loc = match stmt {
         Statement::BlockStatement(s) => s.base.loc.clone(),
         Statement::ReturnStatement(s) => s.base.loc.clone(),
@@ -2433,8 +2382,8 @@ fn statement_loc(
 
 /// Collect binding names from a pattern that are declared in the given scope.
 fn collect_binding_names_from_pattern(
-    pattern: &crate::react_compiler_ast::patterns::PatternLike,
-    scope_id: crate::react_compiler_ast::scope::ScopeId,
+    pattern: &PatternLike,
+    scope_id: ScopeId,
     scope_info: &ScopeInfo,
     out: &mut FxHashSet<BindingId>,
 ) {
@@ -2448,12 +2397,10 @@ fn collect_binding_names_from_pattern(
         PatternLike::ObjectPattern(obj) => {
             for prop in &obj.properties {
                 match prop {
-                    crate::react_compiler_ast::patterns::ObjectPatternProperty::ObjectProperty(
-                        p,
-                    ) => {
+                    ObjectPatternProperty::ObjectProperty(p) => {
                         collect_binding_names_from_pattern(&p.value, scope_id, scope_info, out);
                     }
-                    crate::react_compiler_ast::patterns::ObjectPatternProperty::RestElement(r) => {
+                    ObjectPatternProperty::RestElement(r) => {
                         collect_binding_names_from_pattern(&r.argument, scope_id, scope_info, out);
                     }
                 }
@@ -2491,8 +2438,8 @@ fn collect_binding_names_from_pattern(
 /// block-scoped bindings and emits DeclareContext instructions to hoist them.
 fn lower_block_statement(
     builder: &mut HirBuilder,
-    block: &crate::react_compiler_ast::statements::BlockStatement,
-    parent_scope: Option<crate::react_compiler_ast::scope::ScopeId>,
+    block: &BlockStatement,
+    parent_scope: Option<ScopeId>,
 ) -> Result<(), CompilerError> {
     let _ = lower_block_statement_inner(builder, block, None, parent_scope);
     Ok(())
@@ -2500,8 +2447,8 @@ fn lower_block_statement(
 
 fn lower_block_statement_with_scope(
     builder: &mut HirBuilder,
-    block: &crate::react_compiler_ast::statements::BlockStatement,
-    scope_override: crate::react_compiler_ast::scope::ScopeId,
+    block: &BlockStatement,
+    scope_override: ScopeId,
 ) -> Result<(), CompilerError> {
     let _ = lower_block_statement_inner(builder, block, Some(scope_override), None);
     Ok(())
@@ -2509,9 +2456,9 @@ fn lower_block_statement_with_scope(
 
 fn lower_block_statement_inner(
     builder: &mut HirBuilder,
-    block: &crate::react_compiler_ast::statements::BlockStatement,
-    scope_override: Option<crate::react_compiler_ast::scope::ScopeId>,
-    parent_scope: Option<crate::react_compiler_ast::scope::ScopeId>,
+    block: &BlockStatement,
+    scope_override: Option<ScopeId>,
+    parent_scope: Option<ScopeId>,
 ) -> Result<(), CompilerDiagnostic> {
     // Look up the block's scope to identify hoistable bindings.
     // Use the scope override if provided (for function body blocks that share the function's scope).
@@ -2526,8 +2473,7 @@ fn lower_block_statement_inner(
         for stmt in &block.body {
             if let Statement::VariableDeclaration(vd) = stmt {
                 for d in &vd.declarations {
-                    if let crate::react_compiler_ast::patterns::PatternLike::Identifier(id) = &d.id
-                    {
+                    if let PatternLike::Identifier(id) = &d.id {
                         decl_names.push(id.name.as_str());
                     }
                 }
@@ -2859,9 +2805,9 @@ fn lower_block_statement_inner(
 
 fn lower_statement(
     builder: &mut HirBuilder,
-    stmt: &crate::react_compiler_ast::statements::Statement,
+    stmt: &Statement,
     label: Option<&str>,
-    parent_scope: Option<crate::react_compiler_ast::scope::ScopeId>,
+    parent_scope: Option<ScopeId>,
 ) -> Result<(), CompilerDiagnostic> {
     match stmt {
         Statement::EmptyStatement(_) => {
@@ -2966,9 +2912,7 @@ fn lower_statement(
                             .scope_info()
                             .find_binding_id_in_descendants(&id.name, builder.function_scope())
                         {
-                            let binding_kind = crate::react_compiler_lowering::convert_binding_kind(
-                                &binding_data.kind,
-                            );
+                            let binding_kind = convert_binding_kind(&binding_data.kind);
                             let identifier = builder.resolve_binding_with_loc(
                                 &id.name,
                                 binding_id,
@@ -3145,12 +3089,12 @@ fn lower_statement(
                     }
                     Some(init) => {
                         match init.as_ref() {
-                            crate::react_compiler_ast::statements::ForInit::VariableDeclaration(var_decl) => {
+                            ForInit::VariableDeclaration(var_decl) => {
                                 let init_loc = convert_opt_loc(&var_decl.base.loc);
                                 lower_statement(builder, &Statement::VariableDeclaration(var_decl.clone()), None, parent_scope)?;
                                 init_loc
                             }
-                            crate::react_compiler_ast::statements::ForInit::Expression(expr) => {
+                            ForInit::Expression(expr) => {
                                 let init_loc = expression_loc(expr);
                                 builder.record_error(CompilerErrorDetail {
                                     category: ErrorCategory::Todo,
@@ -3412,12 +3356,10 @@ fn lower_statement(
 
             // Lower the init: NextPropertyOf + assignment
             let left_loc = match for_in.left.as_ref() {
-                crate::react_compiler_ast::statements::ForInOfLeft::VariableDeclaration(
-                    var_decl,
-                ) => convert_opt_loc(&var_decl.base.loc).or(loc.clone()),
-                crate::react_compiler_ast::statements::ForInOfLeft::Pattern(pat) => {
-                    pattern_like_hir_loc(pat).or(loc.clone())
+                ForInOfLeft::VariableDeclaration(var_decl) => {
+                    convert_opt_loc(&var_decl.base.loc).or(loc.clone())
                 }
+                ForInOfLeft::Pattern(pat) => pattern_like_hir_loc(pat).or(loc.clone()),
             };
             let next_property = lower_value_to_temporary(
                 builder,
@@ -3425,9 +3367,7 @@ fn lower_statement(
             )?;
 
             let assign_result = match for_in.left.as_ref() {
-                crate::react_compiler_ast::statements::ForInOfLeft::VariableDeclaration(
-                    var_decl,
-                ) => {
+                ForInOfLeft::VariableDeclaration(var_decl) => {
                     if var_decl.declarations.len() != 1 {
                         builder.record_error(CompilerErrorDetail {
                             category: ErrorCategory::Invariant,
@@ -3453,16 +3393,14 @@ fn lower_statement(
                         None
                     }
                 }
-                crate::react_compiler_ast::statements::ForInOfLeft::Pattern(pattern) => {
-                    lower_assignment(
-                        builder,
-                        left_loc.clone(),
-                        InstructionKind::Reassign,
-                        pattern,
-                        next_property.clone(),
-                        AssignmentStyle::Assignment,
-                    )?
-                }
+                ForInOfLeft::Pattern(pattern) => lower_assignment(
+                    builder,
+                    left_loc.clone(),
+                    InstructionKind::Reassign,
+                    pattern,
+                    next_property.clone(),
+                    AssignmentStyle::Assignment,
+                )?,
             };
             // Use the assign result (StoreLocal temp) as the test, matching TS behavior
             let test_value = assign_result.unwrap_or(next_property);
@@ -3550,12 +3488,10 @@ fn lower_statement(
 
             // Test block: IteratorNext, assign, branch
             let left_loc = match for_of.left.as_ref() {
-                crate::react_compiler_ast::statements::ForInOfLeft::VariableDeclaration(
-                    var_decl,
-                ) => convert_opt_loc(&var_decl.base.loc).or(loc.clone()),
-                crate::react_compiler_ast::statements::ForInOfLeft::Pattern(pat) => {
-                    pattern_like_hir_loc(pat).or(loc.clone())
+                ForInOfLeft::VariableDeclaration(var_decl) => {
+                    convert_opt_loc(&var_decl.base.loc).or(loc.clone())
                 }
+                ForInOfLeft::Pattern(pat) => pattern_like_hir_loc(pat).or(loc.clone()),
             };
             let advance_iterator = lower_value_to_temporary(
                 builder,
@@ -3567,9 +3503,7 @@ fn lower_statement(
             )?;
 
             let assign_result = match for_of.left.as_ref() {
-                crate::react_compiler_ast::statements::ForInOfLeft::VariableDeclaration(
-                    var_decl,
-                ) => {
+                ForInOfLeft::VariableDeclaration(var_decl) => {
                     if var_decl.declarations.len() != 1 {
                         builder.record_error(CompilerErrorDetail {
                             category: ErrorCategory::Invariant,
@@ -3595,16 +3529,14 @@ fn lower_statement(
                         None
                     }
                 }
-                crate::react_compiler_ast::statements::ForInOfLeft::Pattern(pattern) => {
-                    lower_assignment(
-                        builder,
-                        left_loc.clone(),
-                        InstructionKind::Reassign,
-                        pattern,
-                        advance_iterator.clone(),
-                        AssignmentStyle::Assignment,
-                    )?
-                }
+                ForInOfLeft::Pattern(pattern) => lower_assignment(
+                    builder,
+                    left_loc.clone(),
+                    InstructionKind::Reassign,
+                    pattern,
+                    advance_iterator.clone(),
+                    AssignmentStyle::Assignment,
+                )?,
             };
             // Use the assign result (StoreLocal temp) as the test, matching TS behavior
             let test_value = assign_result.unwrap_or(advance_iterator);
@@ -3731,43 +3663,37 @@ fn lower_statement(
             }
 
             // Set up handler binding if catch has a param
-            let handler_binding_info: Option<(
-                Place,
-                crate::react_compiler_ast::patterns::PatternLike,
-            )> = if let Some(param) = &handler_clause.param {
+            let handler_binding_info: Option<(Place, PatternLike)> = if let Some(param) =
+                &handler_clause.param
+            {
                 // Check for destructuring in catch clause params.
                 // Match TS behavior: Babel doesn't register destructured catch bindings
                 // in its scope, so resolveIdentifier fails and records an invariant error.
-                let is_destructuring = matches!(
-                    param,
-                    crate::react_compiler_ast::patterns::PatternLike::ObjectPattern(_)
-                        | crate::react_compiler_ast::patterns::PatternLike::ArrayPattern(_)
-                );
+                let is_destructuring =
+                    matches!(param, PatternLike::ObjectPattern(_) | PatternLike::ArrayPattern(_));
                 if is_destructuring {
                     // Iterate the pattern to find all identifier locs for error reporting
                     fn collect_identifier_locs(
-                        pat: &crate::react_compiler_ast::patterns::PatternLike,
+                        pat: &PatternLike,
                         locs: &mut Vec<Option<SourceLocation>>,
                     ) {
                         match pat {
-                            crate::react_compiler_ast::patterns::PatternLike::Identifier(id) => {
+                            PatternLike::Identifier(id) => {
                                 locs.push(convert_opt_loc(&id.base.loc));
                             }
-                            crate::react_compiler_ast::patterns::PatternLike::ObjectPattern(
-                                obj,
-                            ) => {
+                            PatternLike::ObjectPattern(obj) => {
                                 for prop in &obj.properties {
                                     match prop {
-                                            crate::react_compiler_ast::patterns::ObjectPatternProperty::ObjectProperty(p) => {
-                                                collect_identifier_locs(&p.value, locs);
-                                            }
-                                            crate::react_compiler_ast::patterns::ObjectPatternProperty::RestElement(r) => {
-                                                collect_identifier_locs(&r.argument, locs);
-                                            }
+                                        ObjectPatternProperty::ObjectProperty(p) => {
+                                            collect_identifier_locs(&p.value, locs);
                                         }
+                                        ObjectPatternProperty::RestElement(r) => {
+                                            collect_identifier_locs(&r.argument, locs);
+                                        }
+                                    }
                                 }
                             }
-                            crate::react_compiler_ast::patterns::PatternLike::ArrayPattern(arr) => {
+                            PatternLike::ArrayPattern(arr) => {
                                 for elem in &arr.elements {
                                     if let Some(e) = elem {
                                         collect_identifier_locs(e, locs);
@@ -4018,9 +3944,7 @@ fn lower_statement(
         // TypeScript/Flow declarations are type-only, skip them
         Statement::TSEnumDeclaration(e) => {
             let loc = convert_opt_loc(&e.base.loc);
-            let original_node = original_statement(
-                &crate::react_compiler_ast::statements::Statement::TSEnumDeclaration(e.clone()),
-            );
+            let original_node = original_statement(&Statement::TSEnumDeclaration(e.clone()));
             lower_value_to_temporary(
                 builder,
                 InstructionValue::UnsupportedNode {
@@ -4032,9 +3956,7 @@ fn lower_statement(
         }
         Statement::EnumDeclaration(e) => {
             let loc = convert_opt_loc(&e.base.loc);
-            let original_node = original_statement(
-                &crate::react_compiler_ast::statements::Statement::EnumDeclaration(e.clone()),
-            );
+            let original_node = original_statement(&Statement::EnumDeclaration(e.clone()));
             lower_value_to_temporary(
                 builder,
                 InstructionValue::UnsupportedNode {
@@ -4080,9 +4002,7 @@ fn lower_statement(
                 builder,
                 InstructionValue::UnsupportedNode {
                     node_type: Some(node_type),
-                    original_node: original_statement(
-                        &crate::react_compiler_ast::statements::Statement::Unknown(unknown.clone()),
-                    ),
+                    original_node: original_statement(&Statement::Unknown(unknown.clone())),
                     loc,
                 },
             )?;
@@ -4096,8 +4016,8 @@ fn lower_statement(
 // =============================================================================
 
 enum FunctionBody<'a> {
-    Block(&'a crate::react_compiler_ast::statements::BlockStatement),
-    Expression(&'a crate::react_compiler_ast::expressions::Expression),
+    Block(&'a BlockStatement),
+    Expression(&'a Expression),
 }
 
 /// Main entry point: lower a function AST node into HIR.
@@ -4138,12 +4058,8 @@ pub fn lower(
         ),
         FunctionNode::ArrowFunctionExpression(arrow) => {
             let body = match arrow.body.as_ref() {
-                crate::react_compiler_ast::expressions::ArrowFunctionBody::BlockStatement(
-                    block,
-                ) => FunctionBody::Block(block),
-                crate::react_compiler_ast::expressions::ArrowFunctionBody::Expression(expr) => {
-                    FunctionBody::Expression(expr)
-                }
+                ArrowFunctionBody::BlockStatement(block) => FunctionBody::Block(block),
+                ArrowFunctionBody::Expression(expr) => FunctionBody::Expression(expr),
             };
             (
                 &arrow.params[..],
@@ -4170,10 +4086,7 @@ pub fn lower(
     let context_identifiers = find_context_identifiers(func, scope_info, env, &identifier_locs)?;
 
     // For top-level functions, context is empty (no captured refs)
-    let context_map: FxIndexMap<
-        crate::react_compiler_ast::scope::BindingId,
-        Option<SourceLocation>,
-    > = FxIndexMap::default();
+    let context_map: FxIndexMap<BindingId, Option<SourceLocation>> = FxIndexMap::default();
 
     let (hir_func, _used_names, _child_bindings) = lower_inner(
         params,
@@ -4225,7 +4138,7 @@ fn lower_identifier_for_assignment(
         if let Some((binding_id, binding_data)) =
             builder.scope_info().find_binding_id_in_descendants(name, builder.function_scope())
         {
-            let bk = crate::react_compiler_lowering::convert_binding_kind(&binding_data.kind);
+            let bk = convert_binding_kind(&binding_data.kind);
             let identifier =
                 builder.resolve_binding_with_loc(name, binding_id, ident_loc.clone())?;
             binding = VariableBinding::Identifier { identifier, binding_kind: bk };
@@ -4291,7 +4204,7 @@ fn lower_assignment(
     builder: &mut HirBuilder,
     loc: Option<SourceLocation>,
     kind: InstructionKind,
-    target: &crate::react_compiler_ast::patterns::PatternLike,
+    target: &PatternLike,
     value: Place,
     assignment_style: AssignmentStyle,
 ) -> Result<Option<Place>, CompilerError> {
@@ -4401,35 +4314,27 @@ fn lower_assignment(
             }
             let object = lower_expression_to_temporary(builder, &member.object)?;
             let temp = if !member.computed
-                || matches!(
-                    &*member.property,
-                    crate::react_compiler_ast::expressions::Expression::NumericLiteral(_)
-                ) {
+                || matches!(&*member.property, Expression::NumericLiteral(_))
+            {
                 match &*member.property {
-                    crate::react_compiler_ast::expressions::Expression::Identifier(prop_id) => {
-                        lower_value_to_temporary(
-                            builder,
-                            InstructionValue::PropertyStore {
-                                object,
-                                property: PropertyLiteral::String(prop_id.name.clone()),
-                                value,
-                                loc,
-                            },
-                        )?
-                    }
-                    crate::react_compiler_ast::expressions::Expression::NumericLiteral(num) => {
-                        lower_value_to_temporary(
-                            builder,
-                            InstructionValue::PropertyStore {
-                                object,
-                                property: PropertyLiteral::Number(FloatValue::new(
-                                    num.precise_value(),
-                                )),
-                                value,
-                                loc,
-                            },
-                        )?
-                    }
+                    Expression::Identifier(prop_id) => lower_value_to_temporary(
+                        builder,
+                        InstructionValue::PropertyStore {
+                            object,
+                            property: PropertyLiteral::String(prop_id.name.clone()),
+                            value,
+                            loc,
+                        },
+                    )?,
+                    Expression::NumericLiteral(num) => lower_value_to_temporary(
+                        builder,
+                        InstructionValue::PropertyStore {
+                            object,
+                            property: PropertyLiteral::Number(FloatValue::new(num.precise_value())),
+                            value,
+                            loc,
+                        },
+                    )?,
                     _ => {
                         builder.record_error(CompilerErrorDetail {
                             reason: format!("(BuildHIR::lowerAssignment) Handle {} properties in MemberExpression", expression_type_name(&member.property)),
@@ -4449,10 +4354,7 @@ fn lower_assignment(
                     }
                 }
             } else {
-                if matches!(
-                    &*member.property,
-                    crate::react_compiler_ast::expressions::Expression::PrivateName(_)
-                ) {
+                if matches!(&*member.property, Expression::PrivateName(_)) {
                     builder.record_error(CompilerErrorDetail {
                         reason: "(BuildHIR::lowerAssignment) Expected private name to appear as a non-computed property".to_string(),
                         category: ErrorCategory::Todo,
@@ -4714,9 +4616,7 @@ fn lower_assignment(
 
             for prop in &pattern.properties {
                 match prop {
-                    crate::react_compiler_ast::patterns::ObjectPatternProperty::RestElement(
-                        rest,
-                    ) => match &*rest.argument {
+                    ObjectPatternProperty::RestElement(rest) => match &*rest.argument {
                         PatternLike::Identifier(id) => {
                             let start = id.base.start.unwrap_or(0);
                             let is_context =
@@ -4777,9 +4677,7 @@ fn lower_assignment(
                                 })?;
                         }
                     },
-                    crate::react_compiler_ast::patterns::ObjectPatternProperty::ObjectProperty(
-                        obj_prop,
-                    ) => {
+                    ObjectPatternProperty::ObjectProperty(obj_prop) => {
                         if obj_prop.computed {
                             builder.record_error(CompilerErrorDetail {
                                 reason: "(BuildHIR::lowerAssignment) Handle computed properties in ObjectPattern".to_string(),
@@ -5004,15 +4902,13 @@ fn lower_assignment(
 }
 
 /// Helper to extract HIR loc from a PatternLike (converts AST loc)
-fn pattern_like_hir_loc(
-    pat: &crate::react_compiler_ast::patterns::PatternLike,
-) -> Option<SourceLocation> {
+fn pattern_like_hir_loc(pat: &PatternLike) -> Option<SourceLocation> {
     convert_opt_loc(&pattern_like_loc(pat))
 }
 
 fn lower_optional_member_expression(
     builder: &mut HirBuilder,
-    expr: &crate::react_compiler_ast::expressions::OptionalMemberExpression,
+    expr: &OptionalMemberExpression,
 ) -> Result<InstructionValue, CompilerError> {
     let place = lower_optional_member_expression_impl(builder, expr, None)?.1;
     Ok(InstructionValue::LoadLocal { loc: place.loc.clone(), place })
@@ -5023,7 +4919,7 @@ fn lower_optional_member_expression(
 /// via LoadLocal for the top-level call.
 fn lower_optional_member_expression_impl(
     builder: &mut HirBuilder,
-    expr: &crate::react_compiler_ast::expressions::OptionalMemberExpression,
+    expr: &OptionalMemberExpression,
     parent_alternate: Option<BlockId>,
 ) -> Result<(Place, Place), CompilerError> {
     let optional = expr.optional;
@@ -5129,14 +5025,14 @@ fn lower_optional_member_expression_impl(
 
 fn lower_optional_call_expression(
     builder: &mut HirBuilder,
-    expr: &crate::react_compiler_ast::expressions::OptionalCallExpression,
+    expr: &OptionalCallExpression,
 ) -> Result<InstructionValue, CompilerError> {
     Ok(lower_optional_call_expression_impl(builder, expr, None)?)
 }
 
 fn lower_optional_call_expression_impl(
     builder: &mut HirBuilder,
-    expr: &crate::react_compiler_ast::expressions::OptionalCallExpression,
+    expr: &OptionalCallExpression,
     parent_alternate: Option<BlockId>,
 ) -> Result<InstructionValue, CompilerError> {
     let optional = expr.optional;
@@ -5291,7 +5187,7 @@ fn lower_optional_call_expression_impl(
 
 fn lower_function_to_value(
     builder: &mut HirBuilder,
-    expr: &crate::react_compiler_ast::expressions::Expression,
+    expr: &Expression,
     expr_type: FunctionExpressionType,
 ) -> Result<InstructionValue, CompilerDiagnostic> {
     let loc = match expr {
@@ -5309,19 +5205,15 @@ fn lower_function_to_value(
 
 fn lower_function(
     builder: &mut HirBuilder,
-    expr: &crate::react_compiler_ast::expressions::Expression,
+    expr: &Expression,
 ) -> Result<LoweredFunction, CompilerDiagnostic> {
     // Extract function parts from the AST node
     let (params, body, id, generator, is_async, func_start, func_end, func_loc, func_node_id) =
         match expr {
             Expression::ArrowFunctionExpression(arrow) => {
                 let body = match arrow.body.as_ref() {
-                    crate::react_compiler_ast::expressions::ArrowFunctionBody::BlockStatement(
-                        block,
-                    ) => FunctionBody::Block(block),
-                    crate::react_compiler_ast::expressions::ArrowFunctionBody::Expression(expr) => {
-                        FunctionBody::Expression(expr)
-                    }
+                    ArrowFunctionBody::BlockStatement(block) => FunctionBody::Block(block),
+                    ArrowFunctionBody::Expression(expr) => FunctionBody::Expression(expr),
                 };
                 (
                     &arrow.params[..],
@@ -5357,65 +5249,61 @@ fn lower_function(
 
     // Find the function's scope. For synthetic zero-width functions (e.g., desugared
     // match IIFEs from Hermes with start=end=0), node_id_to_scope won't have an entry.
-    let function_scope =
-        if let Some(scope) = builder.scope_info().resolve_scope_for_node(func_node_id) {
-            scope
-        } else if func_start < func_end {
-            builder.scope_info().program_scope
-        } else {
-            let parent = builder.function_scope();
-            let scope_info = builder.scope_info();
-            let mapped: rustc_hash::FxHashSet<crate::react_compiler_ast::scope::ScopeId> =
-                scope_info.node_id_to_scope.values().copied().collect();
-            let param_names: Vec<String> = params
-                .iter()
-                .filter_map(|p| {
-                    if let crate::react_compiler_ast::patterns::PatternLike::Identifier(id) = p {
-                        Some(id.name.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            let mut descendants = rustc_hash::FxHashSet::default();
-            descendants.insert(parent);
-            let mut changed = true;
-            while changed {
-                changed = false;
-                for (i, scope) in scope_info.scopes.iter().enumerate() {
-                    let sid = crate::react_compiler_ast::scope::ScopeId(i as u32);
-                    if let Some(p) = scope.parent {
-                        if descendants.contains(&p) && !descendants.contains(&sid) {
-                            descendants.insert(sid);
-                            changed = true;
-                        }
-                    }
-                }
-            }
-            let mut found = scope_info.program_scope;
+    let function_scope = if let Some(scope) =
+        builder.scope_info().resolve_scope_for_node(func_node_id)
+    {
+        scope
+    } else if func_start < func_end {
+        builder.scope_info().program_scope
+    } else {
+        let parent = builder.function_scope();
+        let scope_info = builder.scope_info();
+        let mapped: FxHashSet<ScopeId> = scope_info.node_id_to_scope.values().copied().collect();
+        let param_names: Vec<String> = params
+            .iter()
+            .filter_map(|p| {
+                if let PatternLike::Identifier(id) = p { Some(id.name.clone()) } else { None }
+            })
+            .collect();
+        let mut descendants = FxHashSet::default();
+        descendants.insert(parent);
+        let mut changed = true;
+        while changed {
+            changed = false;
             for (i, scope) in scope_info.scopes.iter().enumerate() {
-                let sid = crate::react_compiler_ast::scope::ScopeId(i as u32);
+                let sid = ScopeId(i as u32);
                 if let Some(p) = scope.parent {
-                    if descendants.contains(&p)
-                        && matches!(scope.kind, ScopeKind::Function)
-                        && !mapped.contains(&sid)
-                        && !builder.is_synthetic_scope_claimed(sid)
-                    {
-                        if !param_names.is_empty() {
-                            let all_match =
-                                param_names.iter().all(|name| scope.bindings.contains_key(name));
-                            if !all_match {
-                                continue;
-                            }
-                        }
-                        found = sid;
-                        break;
+                    if descendants.contains(&p) && !descendants.contains(&sid) {
+                        descendants.insert(sid);
+                        changed = true;
                     }
                 }
             }
-            builder.claim_synthetic_scope(found);
-            found
-        };
+        }
+        let mut found = scope_info.program_scope;
+        for (i, scope) in scope_info.scopes.iter().enumerate() {
+            let sid = ScopeId(i as u32);
+            if let Some(p) = scope.parent {
+                if descendants.contains(&p)
+                    && matches!(scope.kind, ScopeKind::Function)
+                    && !mapped.contains(&sid)
+                    && !builder.is_synthetic_scope_claimed(sid)
+                {
+                    if !param_names.is_empty() {
+                        let all_match =
+                            param_names.iter().all(|name| scope.bindings.contains_key(name));
+                        if !all_match {
+                            continue;
+                        }
+                    }
+                    found = sid;
+                    break;
+                }
+            }
+        }
+        builder.claim_synthetic_scope(found);
+        found
+    };
 
     let component_scope = builder.component_scope();
     let scope_info = builder.scope_info();
@@ -5443,10 +5331,7 @@ fn lower_function(
         ident_locs,
         ref_override.as_ref(),
     );
-    let merged_context: FxIndexMap<
-        crate::react_compiler_ast::scope::BindingId,
-        Option<SourceLocation>,
-    > = {
+    let merged_context: FxIndexMap<BindingId, Option<SourceLocation>> = {
         let parent_context = builder.context().clone();
         let mut merged = parent_context;
         for (k, v) in captured_context {
@@ -5486,7 +5371,7 @@ fn lower_function(
 /// Lower a function declaration statement to a FunctionExpression + StoreLocal.
 fn lower_function_declaration(
     builder: &mut HirBuilder,
-    func_decl: &crate::react_compiler_ast::statements::FunctionDeclaration,
+    func_decl: &FunctionDeclaration,
 ) -> Result<(), CompilerError> {
     let loc = convert_opt_loc(&func_decl.base.loc);
     let func_start = func_decl.base.start.unwrap_or(0);
@@ -5518,10 +5403,7 @@ fn lower_function_declaration(
         ident_locs,
         None,
     );
-    let merged_context: FxIndexMap<
-        crate::react_compiler_ast::scope::BindingId,
-        Option<SourceLocation>,
-    > = {
+    let merged_context: FxIndexMap<BindingId, Option<SourceLocation>> = {
         let parent_context = builder.context().clone();
         let mut merged = parent_context;
         for (k, v) in captured_context {
@@ -5584,7 +5466,7 @@ fn lower_function_declaration(
             let binding = match scope_binding {
                 Some(binding_id) => {
                     is_context = builder.is_context_binding(binding_id);
-                    let binding_kind = crate::react_compiler_lowering::convert_binding_kind(
+                    let binding_kind = convert_binding_kind(
                         &builder.scope_info().bindings[binding_id.0 as usize].kind,
                     );
                     let identifier =
@@ -5685,7 +5567,7 @@ fn lower_function_declaration(
 /// Lower a function expression used as an object method.
 fn lower_function_for_object_method(
     builder: &mut HirBuilder,
-    method: &crate::react_compiler_ast::expressions::ObjectMethod,
+    method: &ObjectMethod,
 ) -> Result<LoweredFunction, CompilerError> {
     let func_start = method.base.start.unwrap_or(0);
     let func_end = method.base.end.unwrap_or(0);
@@ -5713,10 +5595,7 @@ fn lower_function_for_object_method(
         ident_locs,
         None,
     );
-    let merged_context: FxIndexMap<
-        crate::react_compiler_ast::scope::BindingId,
-        Option<SourceLocation>,
-    > = {
+    let merged_context: FxIndexMap<BindingId, Option<SourceLocation>> = {
         let parent_context = builder.context().clone();
         let mut merged = parent_context;
         for (k, v) in captured_context {
@@ -5755,7 +5634,7 @@ fn lower_function_for_object_method(
 /// Internal helper: lower a function given its extracted parts.
 /// Used by both the top-level `lower()` and nested `lower_function()`.
 fn lower_inner(
-    params: &[crate::react_compiler_ast::patterns::PatternLike],
+    params: &[PatternLike],
     body: FunctionBody<'_>,
     id: Option<&str>,
     generator: bool,
@@ -5763,20 +5642,16 @@ fn lower_inner(
     loc: Option<SourceLocation>,
     scope_info: &ScopeInfo,
     env: &mut Environment,
-    parent_bindings: Option<FxIndexMap<crate::react_compiler_ast::scope::BindingId, IdentifierId>>,
-    parent_used_names: Option<FxIndexMap<String, crate::react_compiler_ast::scope::BindingId>>,
-    context_map: FxIndexMap<crate::react_compiler_ast::scope::BindingId, Option<SourceLocation>>,
-    function_scope: crate::react_compiler_ast::scope::ScopeId,
-    component_scope: crate::react_compiler_ast::scope::ScopeId,
-    context_identifiers: &FxHashSet<crate::react_compiler_ast::scope::BindingId>,
+    parent_bindings: Option<FxIndexMap<BindingId, IdentifierId>>,
+    parent_used_names: Option<FxIndexMap<String, BindingId>>,
+    context_map: FxIndexMap<BindingId, Option<SourceLocation>>,
+    function_scope: ScopeId,
+    component_scope: ScopeId,
+    context_identifiers: &FxHashSet<BindingId>,
     is_top_level: bool,
     identifier_locs: &IdentifierLocIndex,
 ) -> Result<
-    (
-        HirFunction,
-        FxIndexMap<String, crate::react_compiler_ast::scope::BindingId>,
-        FxIndexMap<crate::react_compiler_ast::scope::BindingId, IdentifierId>,
-    ),
+    (HirFunction, FxIndexMap<String, BindingId>, FxIndexMap<BindingId, IdentifierId>),
     CompilerError,
 > {
     validate_ts_this_parameter(scope_info, function_scope)?;
@@ -5811,7 +5686,7 @@ fn lower_inner(
     let mut hir_params: Vec<ParamPattern> = Vec::new();
     for param in params {
         match param {
-            crate::react_compiler_ast::patterns::PatternLike::Identifier(ident) => {
+            PatternLike::Identifier(ident) => {
                 if is_always_reserved_word(&ident.name) {
                     return Err(CompilerError::from(reserved_identifier_diagnostic(&ident.name)));
                 }
@@ -5831,9 +5706,7 @@ fn lower_inner(
                         .scope_info()
                         .find_binding_id_in_descendants(&ident.name, builder.function_scope())
                     {
-                        let binding_kind = crate::react_compiler_lowering::convert_binding_kind(
-                            &binding_data.kind,
-                        );
+                        let binding_kind = convert_binding_kind(&binding_data.kind);
                         let identifier = builder.resolve_binding_with_loc(
                             &ident.name,
                             binding_id,
@@ -5874,7 +5747,7 @@ fn lower_inner(
                     }
                 }
             }
-            crate::react_compiler_ast::patterns::PatternLike::RestElement(rest) => {
+            PatternLike::RestElement(rest) => {
                 let rest_loc = convert_opt_loc(&rest.base.loc);
                 // Create a temporary place for the spread param
                 let place = build_temporary_place(&mut builder, rest_loc.clone());
@@ -5889,9 +5762,9 @@ fn lower_inner(
                     AssignmentStyle::Assignment,
                 )?;
             }
-            crate::react_compiler_ast::patterns::PatternLike::ObjectPattern(_)
-            | crate::react_compiler_ast::patterns::PatternLike::ArrayPattern(_)
-            | crate::react_compiler_ast::patterns::PatternLike::AssignmentPattern(_) => {
+            PatternLike::ObjectPattern(_)
+            | PatternLike::ArrayPattern(_)
+            | PatternLike::AssignmentPattern(_) => {
                 let param_loc = convert_opt_loc(&pattern_like_loc(param));
                 let place = build_temporary_place(&mut builder, param_loc.clone());
                 promote_temporary(&mut builder, place.identifier);
@@ -5905,7 +5778,7 @@ fn lower_inner(
                     AssignmentStyle::Assignment,
                 )?;
             }
-            crate::react_compiler_ast::patterns::PatternLike::MemberExpression(member) => {
+            PatternLike::MemberExpression(member) => {
                 builder.record_diagnostic(
                     CompilerDiagnostic::new(
                         ErrorCategory::Todo,
@@ -5919,11 +5792,11 @@ fn lower_inner(
                     }),
                 );
             }
-            crate::react_compiler_ast::patterns::PatternLike::TSAsExpression(_)
-            | crate::react_compiler_ast::patterns::PatternLike::TSSatisfiesExpression(_)
-            | crate::react_compiler_ast::patterns::PatternLike::TSNonNullExpression(_)
-            | crate::react_compiler_ast::patterns::PatternLike::TSTypeAssertion(_)
-            | crate::react_compiler_ast::patterns::PatternLike::TypeCastExpression(_) => {}
+            PatternLike::TSAsExpression(_)
+            | PatternLike::TSSatisfiesExpression(_)
+            | PatternLike::TSNonNullExpression(_)
+            | PatternLike::TSTypeAssertion(_)
+            | PatternLike::TypeCastExpression(_) => {}
         }
     }
 
@@ -5972,8 +5845,7 @@ fn lower_inner(
     let (hir_body, instructions, used_names, child_bindings) = builder.build()?;
 
     // Create the returns place
-    let returns =
-        crate::react_compiler_lowering::hir_builder::create_temporary_place(env, loc.clone());
+    let returns = create_temporary_place(env, loc.clone());
 
     Ok((
         HirFunction {
@@ -5999,7 +5871,7 @@ fn lower_inner(
 
 fn lower_jsx_element_name(
     builder: &mut HirBuilder,
-    name: &crate::react_compiler_ast::jsx::JSXElementName,
+    name: &JSXElementName,
 ) -> Result<JsxTag, CompilerError> {
     match name {
         JSXElementName::JSXIdentifier(id) => {
@@ -6054,7 +5926,7 @@ fn lower_jsx_element_name(
 
 fn lower_jsx_member_expression(
     builder: &mut HirBuilder,
-    expr: &crate::react_compiler_ast::jsx::JSXMemberExpression,
+    expr: &JSXMemberExpression,
 ) -> Result<Place, CompilerError> {
     // Use the full member expression's loc for instruction locs (matching TS: exprPath.node.loc)
     let expr_loc = convert_opt_loc(&expr.base.loc);
@@ -6086,7 +5958,7 @@ fn lower_jsx_member_expression(
 
 fn lower_jsx_element(
     builder: &mut HirBuilder,
-    child: &crate::react_compiler_ast::jsx::JSXChild,
+    child: &JSXChild,
 ) -> Result<Option<Place>, CompilerError> {
     match child {
         JSXChild::JSXText(text) => {
@@ -6111,17 +5983,11 @@ fn lower_jsx_element(
             }
         }
         JSXChild::JSXElement(element) => {
-            let value = lower_expression(
-                builder,
-                &crate::react_compiler_ast::expressions::Expression::JSXElement(element.clone()),
-            )?;
+            let value = lower_expression(builder, &Expression::JSXElement(element.clone()))?;
             Ok(Some(lower_value_to_temporary(builder, value)?))
         }
         JSXChild::JSXFragment(fragment) => {
-            let value = lower_expression(
-                builder,
-                &crate::react_compiler_ast::expressions::Expression::JSXFragment(fragment.clone()),
-            )?;
+            let value = lower_expression(builder, &Expression::JSXFragment(fragment.clone()))?;
             Ok(Some(lower_value_to_temporary(builder, value)?))
         }
         JSXChild::JSXExpressionContainer(container) => match &container.expression {
@@ -6212,7 +6078,7 @@ fn trim_jsx_text(original: &str) -> Option<String> {
 
 fn lower_object_method(
     builder: &mut HirBuilder,
-    method: &crate::react_compiler_ast::expressions::ObjectMethod,
+    method: &ObjectMethod,
 ) -> Result<Option<ObjectProperty>, CompilerError> {
     if !matches!(method.kind, ObjectMethodKind::Method) {
         let kind_str = match method.kind {
@@ -6246,7 +6112,7 @@ fn lower_object_method(
 
 fn lower_object_property_key(
     builder: &mut HirBuilder,
-    key: &crate::react_compiler_ast::expressions::Expression,
+    key: &Expression,
     computed: bool,
 ) -> Result<Option<ObjectPropertyKey>, CompilerError> {
     match key {
@@ -6284,7 +6150,7 @@ fn lower_object_property_key(
 
 fn lower_reorderable_expression(
     builder: &mut HirBuilder,
-    expr: &crate::react_compiler_ast::expressions::Expression,
+    expr: &Expression,
 ) -> Result<Place, CompilerError> {
     if !is_reorderable_expression(builder, expr, true) {
         builder.record_error(CompilerErrorDetail {
@@ -6303,7 +6169,7 @@ fn lower_reorderable_expression(
 
 fn is_reorderable_expression(
     builder: &HirBuilder,
-    expr: &crate::react_compiler_ast::expressions::Expression,
+    expr: &Expression,
     allow_local_identifiers: bool,
 ) -> bool {
     match expr {
@@ -6354,7 +6220,7 @@ fn is_reorderable_expression(
             })
         }
         Expression::ObjectExpression(obj) => obj.properties.iter().all(|prop| match prop {
-            crate::react_compiler_ast::expressions::ObjectExpressionProperty::ObjectProperty(p) => {
+            ObjectExpressionProperty::ObjectProperty(p) => {
                 !p.computed && is_reorderable_expression(builder, &p.value, allow_local_identifiers)
             }
             _ => false,
@@ -6487,13 +6353,13 @@ fn lower_type_annotation(val: &serde_json::Value, builder: &mut HirBuilder) -> T
 /// and the component scope. These are "free variables" that become the function's `context`.
 fn gather_captured_context(
     scope_info: &ScopeInfo,
-    function_scope: crate::react_compiler_ast::scope::ScopeId,
-    component_scope: crate::react_compiler_ast::scope::ScopeId,
+    function_scope: ScopeId,
+    component_scope: ScopeId,
     func_start: u32,
     func_end: u32,
     identifier_locs: &IdentifierLocIndex,
     ref_node_ids_override: Option<&FxIndexSet<u32>>,
-) -> FxIndexMap<crate::react_compiler_ast::scope::BindingId, Option<SourceLocation>> {
+) -> FxIndexMap<BindingId, Option<SourceLocation>> {
     let parent_scope = scope_info.scopes[function_scope.0 as usize].parent;
     let pure_scopes = match parent_scope {
         Some(parent) => capture_scopes(scope_info, parent, component_scope),
@@ -6504,10 +6370,10 @@ fn gather_captured_context(
     // captured binding. Using the minimum position makes the result independent of
     // ref_node_id_to_binding iteration order, matching the behavior the TS compiler
     // gets from Babel's position-ordered traversal.
-    let mut captured: rustc_hash::FxHashMap<
-        crate::react_compiler_ast::scope::BindingId,
+    let mut captured: FxHashMap<
+        BindingId,
         (u32, Option<SourceLocation>), // (min_position, loc)
-    > = rustc_hash::FxHashMap::default();
+    > = FxHashMap::default();
 
     for (&ref_nid, &binding_id) in &scope_info.ref_node_id_to_binding {
         if let Some(allowed) = ref_node_ids_override {
@@ -6587,11 +6453,7 @@ fn gather_captured_context(
     sorted.into_iter().map(|(bid, (_, loc))| (bid, loc)).collect()
 }
 
-fn capture_scopes(
-    scope_info: &ScopeInfo,
-    from: crate::react_compiler_ast::scope::ScopeId,
-    to: crate::react_compiler_ast::scope::ScopeId,
-) -> FxIndexSet<crate::react_compiler_ast::scope::ScopeId> {
+fn capture_scopes(scope_info: &ScopeInfo, from: ScopeId, to: ScopeId) -> FxIndexSet<ScopeId> {
     let mut result = FxIndexSet::default();
     let mut current = Some(from);
     while let Some(scope_id) = current {
@@ -6616,7 +6478,7 @@ pub enum AssignmentStyle {
 /// Collect locations of fbt:enum, fbt:plural, fbt:pronoun sub-tags
 /// within the children of an fbt/fbs JSX element.
 fn collect_fbt_sub_tags(
-    children: &[crate::react_compiler_ast::jsx::JSXChild],
+    children: &[JSXChild],
     tag_name: &str,
     enum_locs: &mut Vec<Option<SourceLocation>>,
     plural_locs: &mut Vec<Option<SourceLocation>>,
@@ -6643,10 +6505,7 @@ fn collect_fbt_sub_tags(
                 );
             }
             JSXChild::JSXExpressionContainer(container) => {
-                if let crate::react_compiler_ast::jsx::JSXExpressionContainerExpr::Expression(
-                    expr,
-                ) = &container.expression
-                {
+                if let JSXExpressionContainerExpr::Expression(expr) = &container.expression {
                     collect_fbt_sub_tags_from_expr(
                         expr,
                         tag_name,
@@ -6662,7 +6521,7 @@ fn collect_fbt_sub_tags(
 }
 
 fn collect_fbt_sub_tags_from_element(
-    el: &crate::react_compiler_ast::jsx::JSXElement,
+    el: &JSXElement,
     tag_name: &str,
     enum_locs: &mut Vec<Option<SourceLocation>>,
     plural_locs: &mut Vec<Option<SourceLocation>>,
@@ -6682,16 +6541,10 @@ fn collect_fbt_sub_tags_from_element(
     collect_fbt_sub_tags(&el.children, tag_name, enum_locs, plural_locs, pronoun_locs);
     // Also traverse JSX attributes (matching TS expr.traverse which visits all nodes)
     for attr in &el.opening_element.attributes {
-        if let crate::react_compiler_ast::jsx::JSXAttributeItem::JSXAttribute(a) = attr {
+        if let JSXAttributeItem::JSXAttribute(a) = attr {
             if let Some(val) = &a.value {
-                if let crate::react_compiler_ast::jsx::JSXAttributeValue::JSXExpressionContainer(
-                    container,
-                ) = val
-                {
-                    if let crate::react_compiler_ast::jsx::JSXExpressionContainerExpr::Expression(
-                        expr,
-                    ) = &container.expression
-                    {
+                if let JSXAttributeValue::JSXExpressionContainer(container) = val {
+                    if let JSXExpressionContainerExpr::Expression(expr) = &container.expression {
                         collect_fbt_sub_tags_from_expr(
                             expr,
                             tag_name,
@@ -6700,10 +6553,7 @@ fn collect_fbt_sub_tags_from_element(
                             pronoun_locs,
                         );
                     }
-                } else if let crate::react_compiler_ast::jsx::JSXAttributeValue::JSXElement(
-                    nested,
-                ) = val
-                {
+                } else if let JSXAttributeValue::JSXElement(nested) = val {
                     collect_fbt_sub_tags_from_element(
                         nested,
                         tag_name,
@@ -6718,7 +6568,7 @@ fn collect_fbt_sub_tags_from_element(
 }
 
 fn collect_fbt_sub_tags_from_expr(
-    expr: &crate::react_compiler_ast::expressions::Expression,
+    expr: &Expression,
     tag_name: &str,
     enum_locs: &mut Vec<Option<SourceLocation>>,
     plural_locs: &mut Vec<Option<SourceLocation>>,
@@ -6773,7 +6623,7 @@ fn collect_fbt_sub_tags_from_expr(
             );
         }
         Expression::ArrowFunctionExpression(arrow) => match arrow.body.as_ref() {
-            crate::react_compiler_ast::expressions::ArrowFunctionBody::Expression(body_expr) => {
+            ArrowFunctionBody::Expression(body_expr) => {
                 collect_fbt_sub_tags_from_expr(
                     body_expr,
                     tag_name,
@@ -6782,7 +6632,7 @@ fn collect_fbt_sub_tags_from_expr(
                     pronoun_locs,
                 );
             }
-            crate::react_compiler_ast::expressions::ArrowFunctionBody::BlockStatement(block) => {
+            ArrowFunctionBody::BlockStatement(block) => {
                 collect_fbt_sub_tags_from_stmts(
                     &block.body,
                     tag_name,
@@ -6802,21 +6652,18 @@ fn collect_fbt_sub_tags_from_expr(
 }
 
 fn collect_fbt_sub_tags_from_stmts(
-    stmts: &[crate::react_compiler_ast::statements::Statement],
+    stmts: &[Statement],
     tag_name: &str,
     enum_locs: &mut Vec<Option<SourceLocation>>,
     plural_locs: &mut Vec<Option<SourceLocation>>,
     pronoun_locs: &mut Vec<Option<SourceLocation>>,
 ) {
     for stmt in stmts {
-        if let crate::react_compiler_ast::statements::Statement::ReturnStatement(ret) = stmt {
+        if let Statement::ReturnStatement(ret) = stmt {
             if let Some(arg) = &ret.argument {
                 collect_fbt_sub_tags_from_expr(arg, tag_name, enum_locs, plural_locs, pronoun_locs);
             }
-        } else if let crate::react_compiler_ast::statements::Statement::ExpressionStatement(
-            expr_stmt,
-        ) = stmt
-        {
+        } else if let Statement::ExpressionStatement(expr_stmt) = stmt {
             collect_fbt_sub_tags_from_expr(
                 &expr_stmt.expression,
                 tag_name,
@@ -6843,10 +6690,7 @@ fn collect_identifier_node_ids_from_body(body: &FunctionBody) -> FxIndexSet<u32>
     positions
 }
 
-fn collect_identifier_node_ids_from_stmt(
-    stmt: &crate::react_compiler_ast::statements::Statement,
-    positions: &mut FxIndexSet<u32>,
-) {
+fn collect_identifier_node_ids_from_stmt(stmt: &Statement, positions: &mut FxIndexSet<u32>) {
     match stmt {
         Statement::ExpressionStatement(s) => {
             collect_identifier_node_ids_from_expr(&s.expression, positions)
@@ -6882,10 +6726,7 @@ fn collect_identifier_node_ids_from_stmt(
     }
 }
 
-fn collect_identifier_node_ids_from_expr(
-    expr: &crate::react_compiler_ast::expressions::Expression,
-    positions: &mut FxIndexSet<u32>,
-) {
+fn collect_identifier_node_ids_from_expr(expr: &Expression, positions: &mut FxIndexSet<u32>) {
     match expr {
         Expression::Identifier(id) => {
             if let Some(nid) = id.base.node_id {
@@ -6941,30 +6782,29 @@ fn collect_identifier_node_ids_from_expr(
             collect_identifier_node_ids_from_expr(&e.expression, positions);
         }
         Expression::ArrowFunctionExpression(arrow) => match arrow.body.as_ref() {
-            crate::react_compiler_ast::expressions::ArrowFunctionBody::BlockStatement(block) => {
+            ArrowFunctionBody::BlockStatement(block) => {
                 for stmt in &block.body {
                     collect_identifier_node_ids_from_stmt(stmt, positions);
                 }
             }
-            crate::react_compiler_ast::expressions::ArrowFunctionBody::Expression(e) => {
+            ArrowFunctionBody::Expression(e) => {
                 collect_identifier_node_ids_from_expr(e, positions);
             }
         },
         Expression::JSXElement(el) => {
-            if let crate::react_compiler_ast::jsx::JSXElementName::JSXIdentifier(id) =
-                &el.opening_element.name
-            {
+            if let JSXElementName::JSXIdentifier(id) = &el.opening_element.name {
                 if let Some(nid) = id.base.node_id {
                     positions.insert(nid);
                 }
             }
             for attr in &el.opening_element.attributes {
                 match attr {
-                    crate::react_compiler_ast::jsx::JSXAttributeItem::JSXAttribute(a) => {
+                    JSXAttributeItem::JSXAttribute(a) => {
                         if let Some(val) = &a.value {
                             match val {
-                                crate::react_compiler_ast::jsx::JSXAttributeValue::JSXExpressionContainer(c) => {
-                                    if let crate::react_compiler_ast::jsx::JSXExpressionContainerExpr::Expression(e) = &c.expression {
+                                JSXAttributeValue::JSXExpressionContainer(c) => {
+                                    if let JSXExpressionContainerExpr::Expression(e) = &c.expression
+                                    {
                                         collect_identifier_node_ids_from_expr(e, positions);
                                     }
                                 }
@@ -6972,27 +6812,25 @@ fn collect_identifier_node_ids_from_expr(
                             }
                         }
                     }
-                    crate::react_compiler_ast::jsx::JSXAttributeItem::JSXSpreadAttribute(a) => {
+                    JSXAttributeItem::JSXSpreadAttribute(a) => {
                         collect_identifier_node_ids_from_expr(&a.argument, positions);
                     }
                 }
             }
             for child in &el.children {
                 match child {
-                    crate::react_compiler_ast::jsx::JSXChild::JSXExpressionContainer(c) => {
-                        if let crate::react_compiler_ast::jsx::JSXExpressionContainerExpr::Expression(e) =
-                            &c.expression
-                        {
+                    JSXChild::JSXExpressionContainer(c) => {
+                        if let JSXExpressionContainerExpr::Expression(e) = &c.expression {
                             collect_identifier_node_ids_from_expr(e, positions);
                         }
                     }
-                    crate::react_compiler_ast::jsx::JSXChild::JSXElement(child_el) => {
+                    JSXChild::JSXElement(child_el) => {
                         collect_identifier_node_ids_from_expr(
                             &Expression::JSXElement(child_el.clone()),
                             positions,
                         );
                     }
-                    crate::react_compiler_ast::jsx::JSXChild::JSXSpreadChild(s) => {
+                    JSXChild::JSXSpreadChild(s) => {
                         collect_identifier_node_ids_from_expr(&s.expression, positions);
                     }
                     _ => {}
@@ -7002,14 +6840,12 @@ fn collect_identifier_node_ids_from_expr(
         Expression::JSXFragment(frag) => {
             for child in &frag.children {
                 match child {
-                    crate::react_compiler_ast::jsx::JSXChild::JSXExpressionContainer(c) => {
-                        if let crate::react_compiler_ast::jsx::JSXExpressionContainerExpr::Expression(e) =
-                            &c.expression
-                        {
+                    JSXChild::JSXExpressionContainer(c) => {
+                        if let JSXExpressionContainerExpr::Expression(e) = &c.expression {
                             collect_identifier_node_ids_from_expr(e, positions);
                         }
                     }
-                    crate::react_compiler_ast::jsx::JSXChild::JSXElement(child_el) => {
+                    JSXChild::JSXElement(child_el) => {
                         collect_identifier_node_ids_from_expr(
                             &Expression::JSXElement(child_el.clone()),
                             positions,
@@ -7029,12 +6865,10 @@ fn collect_identifier_node_ids_from_expr(
         Expression::ObjectExpression(obj) => {
             for prop in &obj.properties {
                 match prop {
-                    crate::react_compiler_ast::expressions::ObjectExpressionProperty::ObjectProperty(
-                        p,
-                    ) => {
+                    ObjectExpressionProperty::ObjectProperty(p) => {
                         collect_identifier_node_ids_from_expr(&p.value, positions);
                     }
-                    crate::react_compiler_ast::expressions::ObjectExpressionProperty::SpreadElement(s) => {
+                    ObjectExpressionProperty::SpreadElement(s) => {
                         collect_identifier_node_ids_from_expr(&s.argument, positions);
                     }
                     _ => {}

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/build_hir.rs
@@ -1,10 +1,20 @@
 use rustc_hash::FxHashSet;
 
+use crate::react_compiler_ast::expressions::{ArrowFunctionBody, Expression, ObjectMethodKind};
+use crate::react_compiler_ast::jsx::{
+    JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild, JSXElementName,
+    JSXExpressionContainerExpr, JSXMemberExprObject,
+};
+use crate::react_compiler_ast::operators::{
+    AssignmentOperator, BinaryOperator as AstBinaryOperator, UnaryOperator as AstUnaryOperator,
+};
+use crate::react_compiler_ast::patterns::{ObjectPatternProperty, PatternLike};
 use crate::react_compiler_ast::scope::BindingId;
 use crate::react_compiler_ast::scope::BindingKind as AstBindingKind;
 use crate::react_compiler_ast::scope::ScopeId;
 use crate::react_compiler_ast::scope::ScopeInfo;
 use crate::react_compiler_ast::scope::ScopeKind;
+use crate::react_compiler_ast::statements::{Statement, VariableDeclarationKind};
 use crate::react_compiler_diagnostics::CompilerDiagnostic;
 use crate::react_compiler_diagnostics::CompilerDiagnosticDetail;
 use crate::react_compiler_diagnostics::CompilerError;
@@ -72,7 +82,6 @@ fn original_pattern(
 fn pattern_like_loc(
     pattern: &crate::react_compiler_ast::patterns::PatternLike,
 ) -> Option<crate::react_compiler_ast::common::SourceLocation> {
-    use crate::react_compiler_ast::patterns::PatternLike;
     match pattern {
         PatternLike::Identifier(id) => id.base.loc.clone(),
         PatternLike::ObjectPattern(p) => p.base.loc.clone(),
@@ -92,7 +101,6 @@ fn pattern_like_loc(
 fn expression_loc(
     expr: &crate::react_compiler_ast::expressions::Expression,
 ) -> Option<SourceLocation> {
-    use crate::react_compiler_ast::expressions::Expression;
     let loc = match expr {
         Expression::Identifier(e) => e.base.loc.clone(),
         Expression::StringLiteral(e) => e.base.loc.clone(),
@@ -204,7 +212,6 @@ fn validate_ts_this_parameters_in_function_range(
 
 /// Get the Babel-style type name of an Expression node (e.g. "Identifier", "NumericLiteral").
 fn expression_type_name(expr: &crate::react_compiler_ast::expressions::Expression) -> &'static str {
-    use crate::react_compiler_ast::expressions::Expression;
     match expr {
         Expression::Identifier(_) => "Identifier",
         Expression::StringLiteral(_) => "StringLiteral",
@@ -321,51 +328,47 @@ fn lower_expression_to_temporary(
 // Operator conversion
 // =============================================================================
 
-fn convert_binary_operator(
-    op: &crate::react_compiler_ast::operators::BinaryOperator,
-) -> BinaryOperator {
-    use crate::react_compiler_ast::operators::BinaryOperator as AstOp;
+fn convert_binary_operator(op: &AstBinaryOperator) -> BinaryOperator {
     match op {
-        AstOp::Add => BinaryOperator::Add,
-        AstOp::Sub => BinaryOperator::Subtract,
-        AstOp::Mul => BinaryOperator::Multiply,
-        AstOp::Div => BinaryOperator::Divide,
-        AstOp::Rem => BinaryOperator::Modulo,
-        AstOp::Exp => BinaryOperator::Exponent,
-        AstOp::Eq => BinaryOperator::Equal,
-        AstOp::StrictEq => BinaryOperator::StrictEqual,
-        AstOp::Neq => BinaryOperator::NotEqual,
-        AstOp::StrictNeq => BinaryOperator::StrictNotEqual,
-        AstOp::Lt => BinaryOperator::LessThan,
-        AstOp::Lte => BinaryOperator::LessEqual,
-        AstOp::Gt => BinaryOperator::GreaterThan,
-        AstOp::Gte => BinaryOperator::GreaterEqual,
-        AstOp::Shl => BinaryOperator::ShiftLeft,
-        AstOp::Shr => BinaryOperator::ShiftRight,
-        AstOp::UShr => BinaryOperator::UnsignedShiftRight,
-        AstOp::BitOr => BinaryOperator::BitwiseOr,
-        AstOp::BitXor => BinaryOperator::BitwiseXor,
-        AstOp::BitAnd => BinaryOperator::BitwiseAnd,
-        AstOp::In => BinaryOperator::In,
-        AstOp::Instanceof => BinaryOperator::InstanceOf,
-        AstOp::Pipeline => {
+        AstBinaryOperator::Add => BinaryOperator::Add,
+        AstBinaryOperator::Sub => BinaryOperator::Subtract,
+        AstBinaryOperator::Mul => BinaryOperator::Multiply,
+        AstBinaryOperator::Div => BinaryOperator::Divide,
+        AstBinaryOperator::Rem => BinaryOperator::Modulo,
+        AstBinaryOperator::Exp => BinaryOperator::Exponent,
+        AstBinaryOperator::Eq => BinaryOperator::Equal,
+        AstBinaryOperator::StrictEq => BinaryOperator::StrictEqual,
+        AstBinaryOperator::Neq => BinaryOperator::NotEqual,
+        AstBinaryOperator::StrictNeq => BinaryOperator::StrictNotEqual,
+        AstBinaryOperator::Lt => BinaryOperator::LessThan,
+        AstBinaryOperator::Lte => BinaryOperator::LessEqual,
+        AstBinaryOperator::Gt => BinaryOperator::GreaterThan,
+        AstBinaryOperator::Gte => BinaryOperator::GreaterEqual,
+        AstBinaryOperator::Shl => BinaryOperator::ShiftLeft,
+        AstBinaryOperator::Shr => BinaryOperator::ShiftRight,
+        AstBinaryOperator::UShr => BinaryOperator::UnsignedShiftRight,
+        AstBinaryOperator::BitOr => BinaryOperator::BitwiseOr,
+        AstBinaryOperator::BitXor => BinaryOperator::BitwiseXor,
+        AstBinaryOperator::BitAnd => BinaryOperator::BitwiseAnd,
+        AstBinaryOperator::In => BinaryOperator::In,
+        AstBinaryOperator::Instanceof => BinaryOperator::InstanceOf,
+        AstBinaryOperator::Pipeline => {
             unreachable!("Pipeline operator is checked before calling convert_binary_operator")
         }
     }
 }
 
-fn convert_unary_operator(
-    op: &crate::react_compiler_ast::operators::UnaryOperator,
-) -> UnaryOperator {
-    use crate::react_compiler_ast::operators::UnaryOperator as AstOp;
+fn convert_unary_operator(op: &AstUnaryOperator) -> UnaryOperator {
     match op {
-        AstOp::Neg => UnaryOperator::Minus,
-        AstOp::Plus => UnaryOperator::Plus,
-        AstOp::Not => UnaryOperator::Not,
-        AstOp::BitNot => UnaryOperator::BitwiseNot,
-        AstOp::TypeOf => UnaryOperator::TypeOf,
-        AstOp::Void => UnaryOperator::Void,
-        AstOp::Delete | AstOp::Throw => unreachable!("delete/throw handled separately"),
+        AstUnaryOperator::Neg => UnaryOperator::Minus,
+        AstUnaryOperator::Plus => UnaryOperator::Plus,
+        AstUnaryOperator::Not => UnaryOperator::Not,
+        AstUnaryOperator::BitNot => UnaryOperator::BitwiseNot,
+        AstUnaryOperator::TypeOf => UnaryOperator::TypeOf,
+        AstUnaryOperator::Void => UnaryOperator::Void,
+        AstUnaryOperator::Delete | AstUnaryOperator::Throw => {
+            unreachable!("delete/throw handled separately")
+        }
     }
 }
 
@@ -432,7 +435,6 @@ fn lower_arguments(
     builder: &mut HirBuilder,
     args: &[crate::react_compiler_ast::expressions::Expression],
 ) -> Result<Vec<PlaceOrSpread>, CompilerError> {
-    use crate::react_compiler_ast::expressions::Expression;
     let mut result = Vec::new();
     for arg in args {
         match arg {
@@ -490,7 +492,6 @@ fn lower_member_expression_with_object(
     lowered_object: Place,
 ) -> Result<LoweredMemberExpression, CompilerError> {
     // OptionalMemberExpression has the same shape as MemberExpression for property access
-    use crate::react_compiler_ast::expressions::Expression;
     let loc = convert_opt_loc(&member.base.loc);
     let object = lowered_object;
 
@@ -565,7 +566,6 @@ fn lower_member_expression_impl(
     member: &crate::react_compiler_ast::expressions::MemberExpression,
     lowered_object: Option<Place>,
 ) -> Result<LoweredMemberExpression, CompilerError> {
-    use crate::react_compiler_ast::expressions::Expression;
     let loc = convert_opt_loc(&member.base.loc);
     let object = match lowered_object {
         Some(obj) => obj,
@@ -649,8 +649,6 @@ fn lower_expression(
     builder: &mut HirBuilder,
     expr: &crate::react_compiler_ast::expressions::Expression,
 ) -> Result<InstructionValue, CompilerError> {
-    use crate::react_compiler_ast::expressions::Expression;
-
     match expr {
         Expression::Identifier(ident) => {
             let loc = convert_opt_loc(&ident.base.loc);
@@ -1160,7 +1158,6 @@ fn lower_expression(
             Ok(InstructionValue::LoadLocal { place: place.clone(), loc: place.loc.clone() })
         }
         Expression::AssignmentExpression(expr) => {
-            use crate::react_compiler_ast::operators::AssignmentOperator;
             let loc = convert_opt_loc(&expr.base.loc);
 
             if matches!(expr.operator, AssignmentOperator::Assign) {
@@ -1875,9 +1872,6 @@ fn lower_expression(
             // Lower attributes (props)
             let mut props: Vec<JsxAttribute> = Vec::new();
             for attr_item in &jsx_element.opening_element.attributes {
-                use crate::react_compiler_ast::jsx::JSXAttributeItem;
-                use crate::react_compiler_ast::jsx::JSXAttributeName;
-                use crate::react_compiler_ast::jsx::JSXAttributeValue;
                 match attr_item {
                     JSXAttributeItem::JSXSpreadAttribute(spread) => {
                         let argument = lower_expression_to_temporary(builder, &spread.argument)?;
@@ -1920,7 +1914,6 @@ fn lower_expression(
                                 )?
                             }
                             Some(JSXAttributeValue::JSXExpressionContainer(container)) => {
-                                use crate::react_compiler_ast::jsx::JSXExpressionContainerExpr;
                                 match &container.expression {
                                     JSXExpressionContainerExpr::JSXEmptyExpression(_) => {
                                         // Empty expression container - skip this attribute
@@ -2028,7 +2021,6 @@ fn lower_expression(
                     [("enum", &enum_locs), ("plural", &plural_locs), ("pronoun", &pronoun_locs)]
                 {
                     if locations.len() > 1 {
-                        use crate::react_compiler_diagnostics::CompilerDiagnosticDetail;
                         let details: Vec<CompilerDiagnosticDetail> = locations
                             .iter()
                             .map(|loc| CompilerDiagnosticDetail::Error {
@@ -2218,7 +2210,6 @@ fn is_binding_in_block_direct_statements(
     binding: &crate::react_compiler_ast::scope::BindingData,
     stmts: &[crate::react_compiler_ast::statements::Statement],
 ) -> bool {
-    use crate::react_compiler_ast::statements::Statement;
     let decl_start = match binding.declaration_start {
         Some(pos) => pos,
         None => return false,
@@ -2257,7 +2248,6 @@ fn pattern_declares_name(
     pattern: &crate::react_compiler_ast::patterns::PatternLike,
     name: &str,
 ) -> bool {
-    use crate::react_compiler_ast::patterns::PatternLike;
     match pattern {
         PatternLike::Identifier(id) => id.name == name,
         PatternLike::ObjectPattern(op) => op.properties.iter().any(|prop| match prop {
@@ -2288,7 +2278,6 @@ fn pattern_declares_name(
 // =============================================================================
 
 fn statement_start(stmt: &crate::react_compiler_ast::statements::Statement) -> Option<u32> {
-    use crate::react_compiler_ast::statements::Statement;
     match stmt {
         Statement::BlockStatement(s) => s.base.start,
         Statement::ReturnStatement(s) => s.base.start,
@@ -2339,7 +2328,6 @@ fn statement_start(stmt: &crate::react_compiler_ast::statements::Statement) -> O
 }
 
 fn statement_end(stmt: &crate::react_compiler_ast::statements::Statement) -> Option<u32> {
-    use crate::react_compiler_ast::statements::Statement;
     match stmt {
         Statement::BlockStatement(s) => s.base.end,
         Statement::ReturnStatement(s) => s.base.end,
@@ -2393,7 +2381,6 @@ fn statement_end(stmt: &crate::react_compiler_ast::statements::Statement) -> Opt
 fn statement_loc(
     stmt: &crate::react_compiler_ast::statements::Statement,
 ) -> Option<SourceLocation> {
-    use crate::react_compiler_ast::statements::Statement;
     let loc = match stmt {
         Statement::BlockStatement(s) => s.base.loc.clone(),
         Statement::ReturnStatement(s) => s.base.loc.clone(),
@@ -2451,7 +2438,6 @@ fn collect_binding_names_from_pattern(
     scope_info: &ScopeInfo,
     out: &mut FxHashSet<BindingId>,
 ) {
-    use crate::react_compiler_ast::patterns::PatternLike;
     match pattern {
         PatternLike::Identifier(id) => {
             if let Some(&binding_id) = scope_info.scopes[scope_id.0 as usize].bindings.get(&id.name)
@@ -2527,9 +2513,6 @@ fn lower_block_statement_inner(
     scope_override: Option<crate::react_compiler_ast::scope::ScopeId>,
     parent_scope: Option<crate::react_compiler_ast::scope::ScopeId>,
 ) -> Result<(), CompilerDiagnostic> {
-    use crate::react_compiler_ast::scope::BindingKind as AstBindingKind;
-    use crate::react_compiler_ast::statements::Statement;
-
     // Look up the block's scope to identify hoistable bindings.
     // Use the scope override if provided (for function body blocks that share the function's scope).
     let block_scope_id = scope_override.or_else(|| {
@@ -2880,8 +2863,6 @@ fn lower_statement(
     label: Option<&str>,
     parent_scope: Option<crate::react_compiler_ast::scope::ScopeId>,
 ) -> Result<(), CompilerDiagnostic> {
-    use crate::react_compiler_ast::statements::Statement;
-
     match stmt {
         Statement::EmptyStatement(_) => {
             // no-op
@@ -2941,8 +2922,6 @@ fn lower_statement(
             lower_block_statement(builder, block, parent_scope)?;
         }
         Statement::VariableDeclaration(var_decl) => {
-            use crate::react_compiler_ast::patterns::PatternLike;
-            use crate::react_compiler_ast::statements::VariableDeclarationKind;
             if matches!(var_decl.kind, VariableDeclarationKind::Var) {
                 builder.record_error(CompilerErrorDetail {
                     reason: "(BuildHIR::lowerStatement) Handle var kinds in VariableDeclaration"
@@ -4316,8 +4295,6 @@ fn lower_assignment(
     value: Place,
     assignment_style: AssignmentStyle,
 ) -> Result<Option<Place>, CompilerError> {
-    use crate::react_compiler_ast::patterns::PatternLike;
-
     match target {
         PatternLike::Identifier(id) => {
             let id_loc = convert_opt_loc(&id.base.loc);
@@ -4699,7 +4676,6 @@ fn lower_assignment(
 
             // Compute forceTemporaries for ObjectPattern
             let force_temporaries = if kind == InstructionKind::Reassign {
-                use crate::react_compiler_ast::patterns::ObjectPatternProperty;
                 let mut found = false;
                 for prop in &pattern.properties {
                     match prop {
@@ -5050,7 +5026,6 @@ fn lower_optional_member_expression_impl(
     expr: &crate::react_compiler_ast::expressions::OptionalMemberExpression,
     parent_alternate: Option<BlockId>,
 ) -> Result<(Place, Place), CompilerError> {
-    use crate::react_compiler_ast::expressions::Expression;
     let optional = expr.optional;
     let loc = convert_opt_loc(&expr.base.loc);
     let place = build_temporary_place(builder, loc.clone());
@@ -5164,7 +5139,6 @@ fn lower_optional_call_expression_impl(
     expr: &crate::react_compiler_ast::expressions::OptionalCallExpression,
     parent_alternate: Option<BlockId>,
 ) -> Result<InstructionValue, CompilerError> {
-    use crate::react_compiler_ast::expressions::Expression;
     let optional = expr.optional;
     let loc = convert_opt_loc(&expr.base.loc);
     let place = build_temporary_place(builder, loc.clone());
@@ -5320,7 +5294,6 @@ fn lower_function_to_value(
     expr: &crate::react_compiler_ast::expressions::Expression,
     expr_type: FunctionExpressionType,
 ) -> Result<InstructionValue, CompilerDiagnostic> {
-    use crate::react_compiler_ast::expressions::Expression;
     let loc = match expr {
         Expression::ArrowFunctionExpression(arrow) => convert_opt_loc(&arrow.base.loc),
         Expression::FunctionExpression(func) => convert_opt_loc(&func.base.loc),
@@ -5338,8 +5311,6 @@ fn lower_function(
     builder: &mut HirBuilder,
     expr: &crate::react_compiler_ast::expressions::Expression,
 ) -> Result<LoweredFunction, CompilerDiagnostic> {
-    use crate::react_compiler_ast::expressions::Expression;
-
     // Extract function parts from the AST node
     let (params, body, id, generator, is_async, func_start, func_end, func_loc, func_node_id) =
         match expr {
@@ -6030,7 +6001,6 @@ fn lower_jsx_element_name(
     builder: &mut HirBuilder,
     name: &crate::react_compiler_ast::jsx::JSXElementName,
 ) -> Result<JsxTag, CompilerError> {
-    use crate::react_compiler_ast::jsx::JSXElementName;
     match name {
         JSXElementName::JSXIdentifier(id) => {
             let tag = &id.name;
@@ -6086,7 +6056,6 @@ fn lower_jsx_member_expression(
     builder: &mut HirBuilder,
     expr: &crate::react_compiler_ast::jsx::JSXMemberExpression,
 ) -> Result<Place, CompilerError> {
-    use crate::react_compiler_ast::jsx::JSXMemberExprObject;
     // Use the full member expression's loc for instruction locs (matching TS: exprPath.node.loc)
     let expr_loc = convert_opt_loc(&expr.base.loc);
     let object = match &*expr.object {
@@ -6119,8 +6088,6 @@ fn lower_jsx_element(
     builder: &mut HirBuilder,
     child: &crate::react_compiler_ast::jsx::JSXChild,
 ) -> Result<Option<Place>, CompilerError> {
-    use crate::react_compiler_ast::jsx::JSXChild;
-    use crate::react_compiler_ast::jsx::JSXExpressionContainerExpr;
     match child {
         JSXChild::JSXText(text) => {
             // FBT whitespace normalization differs from standard JSX.
@@ -6247,7 +6214,6 @@ fn lower_object_method(
     builder: &mut HirBuilder,
     method: &crate::react_compiler_ast::expressions::ObjectMethod,
 ) -> Result<Option<ObjectProperty>, CompilerError> {
-    use crate::react_compiler_ast::expressions::ObjectMethodKind;
     if !matches!(method.kind, ObjectMethodKind::Method) {
         let kind_str = match method.kind {
             ObjectMethodKind::Get => "get",
@@ -6283,7 +6249,6 @@ fn lower_object_property_key(
     key: &crate::react_compiler_ast::expressions::Expression,
     computed: bool,
 ) -> Result<Option<ObjectPropertyKey>, CompilerError> {
-    use crate::react_compiler_ast::expressions::Expression;
     match key {
         // Property keys stay String-typed; the marker wire form preserves the
         // pre-JsString behavior for pathological surrogate keys end to end.
@@ -6341,7 +6306,6 @@ fn is_reorderable_expression(
     expr: &crate::react_compiler_ast::expressions::Expression,
     allow_local_identifiers: bool,
 ) -> bool {
-    use crate::react_compiler_ast::expressions::Expression;
     match expr {
         Expression::Identifier(ident) => {
             let binding = builder.scope_info().resolve_reference_for_node(ident.base.node_id);
@@ -6367,9 +6331,10 @@ fn is_reorderable_expression(
         | Expression::BooleanLiteral(_)
         | Expression::BigIntLiteral(_) => true,
         Expression::UnaryExpression(unary) => {
-            use crate::react_compiler_ast::operators::UnaryOperator;
-            matches!(unary.operator, UnaryOperator::Not | UnaryOperator::Plus | UnaryOperator::Neg)
-                && is_reorderable_expression(builder, &unary.argument, allow_local_identifiers)
+            matches!(
+                unary.operator,
+                AstUnaryOperator::Not | AstUnaryOperator::Plus | AstUnaryOperator::Neg
+            ) && is_reorderable_expression(builder, &unary.argument, allow_local_identifiers)
         }
         Expression::LogicalExpression(logical) => {
             is_reorderable_expression(builder, &logical.left, allow_local_identifiers)
@@ -6412,15 +6377,12 @@ fn is_reorderable_expression(
                 false
             }
         }
-        Expression::ArrowFunctionExpression(arrow) => {
-            use crate::react_compiler_ast::expressions::ArrowFunctionBody;
-            match arrow.body.as_ref() {
-                ArrowFunctionBody::BlockStatement(block) => block.body.is_empty(),
-                ArrowFunctionBody::Expression(body_expr) => {
-                    is_reorderable_expression(builder, body_expr, false)
-                }
+        Expression::ArrowFunctionExpression(arrow) => match arrow.body.as_ref() {
+            ArrowFunctionBody::BlockStatement(block) => block.body.is_empty(),
+            ArrowFunctionBody::Expression(body_expr) => {
+                is_reorderable_expression(builder, body_expr, false)
             }
-        }
+        },
         Expression::CallExpression(call) => {
             is_reorderable_expression(builder, &call.callee, allow_local_identifiers)
                 && call
@@ -6660,7 +6622,6 @@ fn collect_fbt_sub_tags(
     plural_locs: &mut Vec<Option<SourceLocation>>,
     pronoun_locs: &mut Vec<Option<SourceLocation>>,
 ) {
-    use crate::react_compiler_ast::jsx::JSXChild;
     for child in children {
         match child {
             JSXChild::JSXElement(el) => {
@@ -6707,7 +6668,6 @@ fn collect_fbt_sub_tags_from_element(
     plural_locs: &mut Vec<Option<SourceLocation>>,
     pronoun_locs: &mut Vec<Option<SourceLocation>>,
 ) {
-    use crate::react_compiler_ast::jsx::JSXElementName;
     if let JSXElementName::JSXNamespacedName(ns) = &el.opening_element.name {
         if ns.namespace.name == tag_name {
             let loc = convert_opt_loc(&ns.base.loc);
@@ -6764,7 +6724,6 @@ fn collect_fbt_sub_tags_from_expr(
     plural_locs: &mut Vec<Option<SourceLocation>>,
     pronoun_locs: &mut Vec<Option<SourceLocation>>,
 ) {
-    use crate::react_compiler_ast::expressions::Expression;
     match expr {
         Expression::JSXElement(el) => {
             collect_fbt_sub_tags_from_element(el, tag_name, enum_locs, plural_locs, pronoun_locs);
@@ -6888,7 +6847,6 @@ fn collect_identifier_node_ids_from_stmt(
     stmt: &crate::react_compiler_ast::statements::Statement,
     positions: &mut FxIndexSet<u32>,
 ) {
-    use crate::react_compiler_ast::statements::Statement;
     match stmt {
         Statement::ExpressionStatement(s) => {
             collect_identifier_node_ids_from_expr(&s.expression, positions)
@@ -6928,7 +6886,6 @@ fn collect_identifier_node_ids_from_expr(
     expr: &crate::react_compiler_ast::expressions::Expression,
     positions: &mut FxIndexSet<u32>,
 ) {
-    use crate::react_compiler_ast::expressions::Expression;
     match expr {
         Expression::Identifier(id) => {
             if let Some(nid) = id.base.node_id {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/find_context_identifiers.rs
@@ -7,7 +7,9 @@
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
+use crate::react_compiler_ast::common::SourceLocation as AstSourceLocation;
 use crate::react_compiler_ast::expressions::*;
+use crate::react_compiler_ast::jsx::JSXIdentifier;
 use crate::react_compiler_ast::patterns::*;
 use crate::react_compiler_ast::scope::*;
 use crate::react_compiler_ast::statements::FunctionDeclaration;
@@ -21,6 +23,7 @@ use crate::react_compiler_diagnostics::SourceLocation;
 use crate::react_compiler_hir::environment::Environment;
 
 use crate::react_compiler_lowering::FunctionNode;
+use crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex;
 
 #[derive(Default)]
 struct BindingInfo {
@@ -122,11 +125,7 @@ impl<'ast> Visitor<'ast> for ContextIdentifierVisitor<'_> {
         self.check_captured_reference(node.base.start, node.base.node_id);
     }
 
-    fn enter_jsx_identifier(
-        &mut self,
-        node: &'ast crate::react_compiler_ast::jsx::JSXIdentifier,
-        _scope_stack: &[ScopeId],
-    ) {
+    fn enter_jsx_identifier(&mut self, node: &'ast JSXIdentifier, _scope_stack: &[ScopeId]) {
         self.check_captured_reference(node.base.start, node.base.node_id);
     }
 
@@ -229,16 +228,14 @@ fn walk_lval_for_reassignment(
     Ok(())
 }
 
-fn convert_loc(loc: &crate::react_compiler_ast::common::SourceLocation) -> SourceLocation {
+fn convert_loc(loc: &AstSourceLocation) -> SourceLocation {
     SourceLocation {
         start: Position { line: loc.start.line, column: loc.start.column, index: loc.start.index },
         end: Position { line: loc.end.line, column: loc.end.column, index: loc.end.index },
     }
 }
 
-fn convert_opt_loc(
-    loc: &Option<crate::react_compiler_ast::common::SourceLocation>,
-) -> Option<SourceLocation> {
+fn convert_opt_loc(loc: &Option<AstSourceLocation>) -> Option<SourceLocation> {
     loc.as_ref().map(convert_loc)
 }
 
@@ -324,7 +321,7 @@ pub fn find_context_identifiers(
     func: &FunctionNode<'_>,
     scope_info: &ScopeInfo,
     env: &mut Environment,
-    identifier_locs: &crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex,
+    identifier_locs: &IdentifierLocIndex,
 ) -> Result<FxHashSet<BindingId>, CompilerError> {
     let func_scope =
         scope_info.resolve_scope_for_node(func.node_id()).unwrap_or(scope_info.program_scope);

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/hir_builder.rs
@@ -7,6 +7,7 @@ use crate::react_compiler_diagnostics::CompilerDiagnosticDetail;
 use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_diagnostics::CompilerErrorDetail;
 use crate::react_compiler_diagnostics::ErrorCategory;
+use crate::react_compiler_hir::environment::BindingRename;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors::each_terminal_successor;
 use crate::react_compiler_hir::visitors::terminal_fallthrough;
@@ -14,7 +15,13 @@ use crate::react_compiler_hir::*;
 use crate::react_compiler_utils::FxIndexMap;
 use crate::react_compiler_utils::FxIndexSet;
 
+use crate::react_compiler_lowering::convert_binding_kind;
 use crate::react_compiler_lowering::identifier_loc_index::IdentifierLocIndex;
+
+use rustc_hash::FxHashSet;
+
+use std::mem::replace;
+use std::mem::take;
 
 // ---------------------------------------------------------------------------
 // Reserved word check (matches TS isReservedWord)
@@ -152,10 +159,10 @@ pub struct HirBuilder<'a> {
     /// Set of BindingIds for variables declared in scopes between component_scope
     /// and any inner function scope, that are referenced from an inner function scope.
     /// These need StoreContext/LoadContext instead of StoreLocal/LoadLocal.
-    context_identifiers: rustc_hash::FxHashSet<BindingId>,
+    context_identifiers: FxHashSet<BindingId>,
     /// Set of ScopeIds that have been matched to synthetic blocks/functions.
     /// Prevents the same scope from being reused for different synthetic nodes.
-    claimed_synthetic_scopes: rustc_hash::FxHashSet<ScopeId>,
+    claimed_synthetic_scopes: FxHashSet<ScopeId>,
     /// Index mapping identifier byte offsets to source locations and JSX status.
     identifier_locs: &'a IdentifierLocIndex,
 }
@@ -178,7 +185,7 @@ impl<'a> HirBuilder<'a> {
         scope_info: &'a ScopeInfo,
         function_scope: ScopeId,
         component_scope: ScopeId,
-        context_identifiers: rustc_hash::FxHashSet<BindingId>,
+        context_identifiers: FxHashSet<BindingId>,
         bindings: Option<FxIndexMap<BindingId, IdentifierId>>,
         context: Option<FxIndexMap<BindingId, Option<SourceLocation>>>,
         entry_block_kind: Option<BlockKind>,
@@ -203,7 +210,7 @@ impl<'a> HirBuilder<'a> {
             function_scope,
             component_scope,
             context_identifiers,
-            claimed_synthetic_scopes: rustc_hash::FxHashSet::default(),
+            claimed_synthetic_scopes: FxHashSet::default(),
             identifier_locs,
         }
     }
@@ -277,7 +284,7 @@ impl<'a> HirBuilder<'a> {
     }
 
     /// Access the pre-computed context identifiers set.
-    pub fn context_identifiers(&self) -> &rustc_hash::FxHashSet<BindingId> {
+    pub fn context_identifiers(&self) -> &FxHashSet<BindingId> {
         &self.context_identifiers
     }
 
@@ -372,8 +379,7 @@ impl<'a> HirBuilder<'a> {
         // next_block_kind is None, meaning this is the final terminate() call.
         // It will never be read or completed because build() consumes self
         // immediately after, and no further operations should occur on the builder.
-        let wip =
-            std::mem::replace(&mut self.current, new_block(BlockId(u32::MAX), BlockKind::Block));
+        let wip = replace(&mut self.current, new_block(BlockId(u32::MAX), BlockKind::Block));
         let block_id = wip.id;
 
         self.completed.insert(
@@ -398,7 +404,7 @@ impl<'a> HirBuilder<'a> {
     /// Terminate the current block with the given terminal, and set
     /// a previously reserved block as the new current block.
     pub fn terminate_with_continuation(&mut self, terminal: Terminal, continuation: WipBlock) {
-        let wip = std::mem::replace(&mut self.current, continuation);
+        let wip = replace(&mut self.current, continuation);
         let block_id = wip.id;
         self.completed.insert(
             block_id,
@@ -441,9 +447,9 @@ impl<'a> HirBuilder<'a> {
     /// it and obtain its terminal, then completes the block and restores the
     /// previous current block.
     pub fn enter_reserved(&mut self, wip: WipBlock, f: impl FnOnce(&mut Self) -> Terminal) {
-        let prev = std::mem::replace(&mut self.current, wip);
+        let prev = replace(&mut self.current, wip);
         let terminal = f(self);
-        let completed_wip = std::mem::replace(&mut self.current, prev);
+        let completed_wip = replace(&mut self.current, prev);
         self.completed.insert(
             completed_wip.id,
             BasicBlock {
@@ -463,9 +469,9 @@ impl<'a> HirBuilder<'a> {
         wip: WipBlock,
         f: impl FnOnce(&mut Self) -> Result<Terminal, CompilerDiagnostic>,
     ) -> Result<(), CompilerDiagnostic> {
-        let prev = std::mem::replace(&mut self.current, wip);
+        let prev = replace(&mut self.current, wip);
         let terminal = f(self)?;
-        let completed_wip = std::mem::replace(&mut self.current, prev);
+        let completed_wip = replace(&mut self.current, prev);
         self.completed.insert(
             completed_wip.id,
             BasicBlock {
@@ -715,9 +721,9 @@ impl<'a> HirBuilder<'a> {
         (HIR, Vec<Instruction>, FxIndexMap<String, BindingId>, FxIndexMap<BindingId, IdentifierId>),
         CompilerError,
     > {
-        let mut hir = HIR { blocks: std::mem::take(&mut self.completed), entry: self.entry };
+        let mut hir = HIR { blocks: take(&mut self.completed), entry: self.entry };
 
-        let mut instructions = std::mem::take(&mut self.instruction_table);
+        let mut instructions = take(&mut self.instruction_table);
 
         let rpo_blocks = get_reverse_postordered_blocks(&hir, &instructions);
 
@@ -854,7 +860,7 @@ impl<'a> HirBuilder<'a> {
         if candidate != name {
             let binding = &self.scope_info.bindings[binding_id.0 as usize];
             if let Some(decl_start) = binding.declaration_start {
-                self.env.renames.push(crate::react_compiler_hir::environment::BindingRename {
+                self.env.renames.push(BindingRename {
                     original: name.to_string(),
                     renamed: candidate.clone(),
                     declaration_start: decl_start,
@@ -957,8 +963,7 @@ impl<'a> HirBuilder<'a> {
                     Ok(VariableBinding::ModuleLocal { name: name.to_string() })
                 } else {
                     let binding_id = binding.id;
-                    let binding_kind =
-                        crate::react_compiler_lowering::convert_binding_kind(&binding.kind);
+                    let binding_kind = convert_binding_kind(&binding.kind);
                     let identifier_id = self.resolve_binding_with_loc(name, binding_id, loc)?;
                     Ok(VariableBinding::Identifier { identifier: identifier_id, binding_kind })
                 }
@@ -1183,7 +1188,7 @@ pub fn remove_dead_do_while_statements(hir: &mut HIR) {
             false
         };
         if should_replace {
-            if let Terminal::DoWhile { loop_block, id, loc, .. } = std::mem::replace(
+            if let Terminal::DoWhile { loop_block, id, loc, .. } = replace(
                 &mut block.terminal,
                 Terminal::Unreachable { id: EvaluationOrder(0), loc: None },
             ) {

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/identifier_loc_index.rs
@@ -7,14 +7,17 @@
 
 use rustc_hash::FxHashMap;
 
+use crate::react_compiler_ast::common::SourceLocation as AstSourceLocation;
 use crate::react_compiler_ast::expressions::*;
 use crate::react_compiler_ast::jsx::JSXIdentifier;
 use crate::react_compiler_ast::jsx::JSXOpeningElement;
 use crate::react_compiler_ast::scope::ScopeId;
 use crate::react_compiler_ast::scope::ScopeInfo;
+use crate::react_compiler_ast::statements::ClassDeclaration;
 use crate::react_compiler_ast::statements::FunctionDeclaration;
 use crate::react_compiler_ast::visitor::AstWalker;
 use crate::react_compiler_ast::visitor::Visitor;
+use crate::react_compiler_hir::Position;
 use crate::react_compiler_hir::SourceLocation;
 
 use crate::react_compiler_lowering::FunctionNode;
@@ -53,18 +56,10 @@ struct IdentifierLocVisitor {
     current_opening_element_loc: Option<SourceLocation>,
 }
 
-fn convert_loc(loc: &crate::react_compiler_ast::common::SourceLocation) -> SourceLocation {
+fn convert_loc(loc: &AstSourceLocation) -> SourceLocation {
     SourceLocation {
-        start: crate::react_compiler_hir::Position {
-            line: loc.start.line,
-            column: loc.start.column,
-            index: loc.start.index,
-        },
-        end: crate::react_compiler_hir::Position {
-            line: loc.end.line,
-            column: loc.end.column,
-            index: loc.end.index,
-        },
+        start: Position { line: loc.start.line, column: loc.start.column, index: loc.start.index },
+        end: Position { line: loc.end.line, column: loc.end.column, index: loc.end.index },
     }
 }
 
@@ -148,12 +143,12 @@ impl IdentifierLocVisitor {
         let start = loc.get("start")?.as_object()?;
         let end = loc.get("end")?.as_object()?;
         Some(SourceLocation {
-            start: crate::react_compiler_hir::Position {
+            start: Position {
                 line: start.get("line")?.as_u64()? as u32,
                 column: start.get("column")?.as_u64()? as u32,
                 index: start.get("index").and_then(|i| i.as_u64()).map(|i| i as u32),
             },
-            end: crate::react_compiler_hir::Position {
+            end: Position {
                 line: end.get("line")?.as_u64()? as u32,
                 column: end.get("column")?.as_u64()? as u32,
                 index: end.get("index").and_then(|i| i.as_u64()).map(|i| i as u32),
@@ -224,11 +219,7 @@ impl<'ast> Visitor<'ast> for IdentifierLocVisitor {
         }
     }
 
-    fn enter_class_declaration(
-        &mut self,
-        node: &'ast crate::react_compiler_ast::statements::ClassDeclaration,
-        _scope_stack: &[ScopeId],
-    ) {
+    fn enter_class_declaration(&mut self, node: &'ast ClassDeclaration, _scope_stack: &[ScopeId]) {
         if let Some(id) = &node.id {
             self.insert_identifier(id, true);
         }
@@ -240,11 +231,7 @@ impl<'ast> Visitor<'ast> for IdentifierLocVisitor {
         }
     }
 
-    fn enter_class_expression(
-        &mut self,
-        node: &'ast crate::react_compiler_ast::expressions::ClassExpression,
-        _scope_stack: &[ScopeId],
-    ) {
+    fn enter_class_expression(&mut self, node: &'ast ClassExpression, _scope_stack: &[ScopeId]) {
         if let Some(id) = &node.id {
             self.insert_identifier(id, true);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_lowering/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_lowering/mod.rs
@@ -5,20 +5,21 @@ pub mod identifier_loc_index;
 
 use crate::react_compiler_ast::expressions::ArrowFunctionExpression;
 use crate::react_compiler_ast::expressions::FunctionExpression;
+use crate::react_compiler_ast::scope::BindingKind as AstBindingKind;
 use crate::react_compiler_ast::statements::FunctionDeclaration;
 use crate::react_compiler_hir::BindingKind;
 
 /// Convert AST binding kind to HIR binding kind.
-pub fn convert_binding_kind(kind: &crate::react_compiler_ast::scope::BindingKind) -> BindingKind {
+pub fn convert_binding_kind(kind: &AstBindingKind) -> BindingKind {
     match kind {
-        crate::react_compiler_ast::scope::BindingKind::Var => BindingKind::Var,
-        crate::react_compiler_ast::scope::BindingKind::Let => BindingKind::Let,
-        crate::react_compiler_ast::scope::BindingKind::Const => BindingKind::Const,
-        crate::react_compiler_ast::scope::BindingKind::Param => BindingKind::Param,
-        crate::react_compiler_ast::scope::BindingKind::Module => BindingKind::Module,
-        crate::react_compiler_ast::scope::BindingKind::Hoisted => BindingKind::Hoisted,
-        crate::react_compiler_ast::scope::BindingKind::Local => BindingKind::Local,
-        crate::react_compiler_ast::scope::BindingKind::Unknown => BindingKind::Unknown,
+        AstBindingKind::Var => BindingKind::Var,
+        AstBindingKind::Let => BindingKind::Let,
+        AstBindingKind::Const => BindingKind::Const,
+        AstBindingKind::Param => BindingKind::Param,
+        AstBindingKind::Module => BindingKind::Module,
+        AstBindingKind::Hoisted => BindingKind::Hoisted,
+        AstBindingKind::Local => BindingKind::Local,
+        AstBindingKind::Unknown => BindingKind::Unknown,
     }
 }
 

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/constant_propagation.rs
@@ -24,19 +24,23 @@
 //!
 //! Analogous to TS `Optimization/ConstantPropagation.ts`.
 
+use std::mem::replace;
+
 use rustc_hash::FxHashMap;
 
 use crate::react_compiler_diagnostics::JsString;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     BinaryOperator, BlockKind, FloatValue, FunctionId, GotoVariant, HirFunction, IdentifierId,
-    InstructionValue, NonLocalBinding, Phi, Place, PrimitiveValue, PropertyLiteral, SourceLocation,
-    Terminal, UnaryOperator, UpdateOperator, format_js_number,
+    InstructionId, InstructionValue, ManualMemoDependencyRoot, NonLocalBinding, Phi, Place,
+    PrimitiveValue, PropertyLiteral, SourceLocation, Terminal, UnaryOperator, UpdateOperator,
+    format_js_number,
 };
 use crate::react_compiler_lowering::{
     get_reverse_postordered_blocks, mark_instruction_ids, mark_predecessors,
     remove_dead_do_while_statements, remove_unnecessary_try_catch, remove_unreachable_for_updates,
 };
+use crate::react_compiler_ssa::eliminate_redundant_phi;
 use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 
 use crate::react_compiler_optimization::merge_consecutive_blocks::merge_consecutive_blocks;
@@ -107,7 +111,7 @@ fn constant_propagation_impl(
          * By removing some phi operands, there may be phis that were not previously
          * redundant but now are
          */
-        crate::react_compiler_ssa::eliminate_redundant_phi(func, env);
+        eliminate_redundant_phi(func, env);
 
         /*
          * Finally, merge together any blocks that are now guaranteed to execute
@@ -260,7 +264,7 @@ fn evaluate_instruction(
     constants: &mut Constants,
     func: &mut HirFunction,
     env: &mut Environment,
-    instr_id: crate::react_compiler_hir::InstructionId,
+    instr_id: InstructionId,
 ) -> Option<Constant> {
     let instr = &func.instructions[instr_id.0 as usize];
     match &instr.value {
@@ -569,11 +573,7 @@ fn evaluate_instruction(
                     .iter()
                     .enumerate()
                     .filter_map(|(i, dep)| {
-                        if let crate::react_compiler_hir::ManualMemoDependencyRoot::NamedLocal {
-                            value,
-                            ..
-                        } = &dep.root
-                        {
+                        if let ManualMemoDependencyRoot::NamedLocal { value, .. } = &dep.root {
                             let pv = read(constants, value);
                             if matches!(pv, Some(Constant::Primitive { .. })) {
                                 return Some(i);
@@ -586,10 +586,8 @@ fn evaluate_instruction(
                     if let InstructionValue::StartMemoize { deps: Some(ref mut deps), .. } =
                         func.instructions[instr_id.0 as usize].value
                     {
-                        if let crate::react_compiler_hir::ManualMemoDependencyRoot::NamedLocal {
-                            constant,
-                            ..
-                        } = &mut deps[idx].root
+                        if let ManualMemoDependencyRoot::NamedLocal { constant, .. } =
+                            &mut deps[idx].root
                         {
                             *constant = true;
                         }
@@ -635,8 +633,7 @@ fn evaluate_instruction(
 // =============================================================================
 
 fn process_inner_function(func_id: FunctionId, env: &mut Environment, constants: &mut Constants) {
-    let mut inner =
-        std::mem::replace(&mut env.functions[func_id.0 as usize], placeholder_function());
+    let mut inner = replace(&mut env.functions[func_id.0 as usize], placeholder_function());
     constant_propagation_impl(&mut inner, env, constants);
     env.functions[func_id.0 as usize] = inner;
 }
@@ -775,9 +772,7 @@ fn evaluate_binary_op(
                 // halves split across the operands.
                 let mut units = l.code_units();
                 units.extend(r.code_units());
-                Some(PrimitiveValue::String(
-                    crate::react_compiler_diagnostics::JsString::from_code_units(units),
-                ))
+                Some(PrimitiveValue::String(JsString::from_code_units(units)))
             }
             _ => None,
         },

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/dead_code_elimination.rs
@@ -17,8 +17,8 @@ use crate::react_compiler_hir::environment::{Environment, OutputMode};
 use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::visitors;
 use crate::react_compiler_hir::{
-    ArrayPatternElement, BlockId, BlockKind, HirFunction, IdentifierId, InstructionKind,
-    InstructionValue, ObjectPropertyOrSpread, Pattern,
+    ArrayPatternElement, BlockId, BlockKind, HirFunction, Identifier, IdentifierId, InstructionId,
+    InstructionKind, InstructionValue, ObjectPropertyOrSpread, Pattern,
 };
 
 /// Implements dead-code elimination, eliminating instructions whose values are unused.
@@ -32,7 +32,7 @@ pub fn dead_code_elimination(func: &mut HirFunction, env: &Environment) {
 
     // Phase 2: Prune / sweep unreferenced identifiers and instructions
     // Collect instructions to rewrite (two-phase: collect then apply to avoid borrow conflicts)
-    let mut instructions_to_rewrite: Vec<crate::react_compiler_hir::InstructionId> = Vec::new();
+    let mut instructions_to_rewrite: Vec<InstructionId> = Vec::new();
 
     for (_block_id, block) in &mut func.body.blocks {
         // Remove unused phi nodes
@@ -82,11 +82,7 @@ impl State {
 }
 
 /// Mark an identifier as being referenced (not dead code).
-fn reference(
-    state: &mut State,
-    identifiers: &[crate::react_compiler_hir::Identifier],
-    identifier_id: IdentifierId,
-) {
+fn reference(state: &mut State, identifiers: &[Identifier], identifier_id: IdentifierId) {
     state.identifiers.insert(identifier_id);
     let ident = &identifiers[identifier_id.0 as usize];
     if let Some(ref name) = ident.name {
@@ -98,7 +94,7 @@ fn reference(
 /// Checks both the specific SSA id and (for named identifiers) any usage of that name.
 fn is_id_or_name_used(
     state: &State,
-    identifiers: &[crate::react_compiler_hir::Identifier],
+    identifiers: &[Identifier],
     identifier_id: IdentifierId,
 ) -> bool {
     if state.identifiers.contains(&identifier_id) {
@@ -189,7 +185,7 @@ fn find_referenced_identifiers(func: &HirFunction, env: &Environment) -> State {
 /// Rewrite a retained instruction (destructuring cleanup, StoreLocal -> DeclareLocal).
 fn rewrite_instruction(
     func: &mut HirFunction,
-    instr_id: crate::react_compiler_hir::InstructionId,
+    instr_id: InstructionId,
     state: &State,
     env: &Environment,
 ) {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -35,6 +35,7 @@ use crate::react_compiler_hir::Place;
 use crate::react_compiler_hir::PlaceOrSpread;
 use crate::react_compiler_hir::PropertyLiteral;
 use crate::react_compiler_hir::SourceLocation;
+use crate::react_compiler_hir::Terminal;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_lowering::create_temporary_place;
 use crate::react_compiler_lowering::mark_instruction_ids;
@@ -614,8 +615,6 @@ fn extract_manual_memoization_args(
 // =============================================================================
 
 fn find_optional_places(func: &HirFunction) -> Result<FxHashSet<IdentifierId>, CompilerDiagnostic> {
-    use crate::react_compiler_hir::Terminal;
-
     let mut optionals = FxHashSet::default();
     for block in func.body.blocks.values() {
         if let Terminal::Optional { optional: true, test, fallthrough, .. } = &block.terminal {

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/drop_manual_memoization.rs
@@ -12,6 +12,8 @@
 //!
 //! Analogous to TS `Inference/DropManualMemoization.ts`.
 
+use std::mem::discriminant;
+
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
@@ -656,7 +658,7 @@ fn find_optional_places(func: &HirFunction) -> Result<FxHashSet<IdentifierId>, C
                             ErrorCategory::Invariant,
                             format!(
                                 "Unexpected terminal kind in optional: {:?}",
-                                std::mem::discriminant(other)
+                                discriminant(other)
                             ),
                             None,
                         ));

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/merge_consecutive_blocks.rs
@@ -13,6 +13,8 @@
 //!
 //! Analogous to TS `HIR/MergeConsecutiveBlocks.ts`.
 
+use std::mem::replace;
+
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_hir::visitors;
@@ -47,7 +49,7 @@ pub fn merge_consecutive_blocks(func: &mut HirFunction, functions: &mut [HirFunc
     for func_id in inner_func_ids {
         // Use std::mem::replace to temporarily take the inner function out,
         // process it, then put it back (standard borrow checker workaround)
-        let mut inner_func = std::mem::replace(&mut functions[func_id], placeholder_function());
+        let mut inner_func = replace(&mut functions[func_id], placeholder_function());
         merge_consecutive_blocks(&mut inner_func, functions);
         functions[func_id] = inner_func;
     }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/name_anonymous_functions.rs
@@ -11,6 +11,8 @@
 //!
 //! Conditional on `env.config.enable_name_anonymous_functions`.
 
+use std::mem::take;
+
 use rustc_hash::FxHashMap;
 
 use crate::react_compiler_hir::environment::Environment;
@@ -77,7 +79,7 @@ pub fn name_anonymous_functions(func: &mut HirFunction, env: &mut Environment) {
     // Update name_hint on FunctionExpression instruction values in all arena functions
     for i in 0..env.functions.len() {
         // We need to temporarily take the instructions to avoid borrow issues
-        let mut instructions = std::mem::take(&mut env.functions[i].instructions);
+        let mut instructions = take(&mut env.functions[i].instructions);
         apply_name_hints_to_instructions(&mut instructions, &update_map);
         env.functions[i].instructions = instructions;
     }

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_for_ssr.rs
@@ -23,8 +23,9 @@ use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::visitors::{each_instruction_value_operand, each_terminal_operand};
 use crate::react_compiler_hir::{
-    ArrayPatternElement, HirFunction, IdentifierId, InstructionValue, PlaceOrSpread,
-    PrimitiveValue, is_set_state_type, is_start_transition_type,
+    ArrayPatternElement, HirFunction, IdentifierId, InstructionValue, JsxAttribute, JsxTag, LValue,
+    Pattern, Place, PlaceOrSpread, PrimitiveValue, SourceLocation, is_array_type,
+    is_plain_object_type, is_primitive_type, is_set_state_type, is_start_transition_type,
 };
 
 /// Optimizes a function for SSR by inlining state hooks, removing effects,
@@ -52,7 +53,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                 InstructionValue::Destructure { value, lvalue, .. } => {
                     if inlined_state.contains_key(&env.identifiers[value.identifier.0 as usize].id)
                     {
-                        if let crate::react_compiler_hir::Pattern::Array(arr) = &lvalue.pattern {
+                        if let Pattern::Array(arr) = &lvalue.pattern {
                             if !arr.items.is_empty() {
                                 if let ArrayPatternElement::Place(_) = &arr.items[0] {
                                     // Allow destructuring of inlined states
@@ -112,9 +113,9 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                                         .type_
                                         .0
                                         as usize];
-                                    if crate::react_compiler_hir::is_primitive_type(arg_type)
-                                        || crate::react_compiler_hir::is_plain_object_type(arg_type)
-                                        || crate::react_compiler_hir::is_array_type(arg_type)
+                                    if is_primitive_type(arg_type)
+                                        || is_plain_object_type(arg_type)
+                                        || is_array_type(arg_type)
                                     {
                                         let lvalue_id =
                                             env.identifiers[instr.lvalue.identifier.0 as usize].id;
@@ -174,7 +175,7 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                     }
                 }
                 InstructionValue::JsxExpression { tag, .. } => {
-                    if let crate::react_compiler_hir::JsxTag::Builtin(builtin) = tag {
+                    if let JsxTag::Builtin(builtin) = tag {
                         // Only optimize non-custom-element builtin tags
                         if !builtin.name.contains('-') {
                             let tag_name = builtin.name.clone();
@@ -182,13 +183,10 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                             if let InstructionValue::JsxExpression { props, .. } = &mut instr.value
                             {
                                 props.retain(|prop| match prop {
-                                    crate::react_compiler_hir::JsxAttribute::SpreadAttribute {
-                                        ..
-                                    } => true,
-                                    crate::react_compiler_hir::JsxAttribute::Attribute {
-                                        name,
-                                        ..
-                                    } => !is_known_event_handler(&tag_name, name) && name != "ref",
+                                    JsxAttribute::SpreadAttribute { .. } => true,
+                                    JsxAttribute::Attribute { name, .. } => {
+                                        !is_known_event_handler(&tag_name, name) && name != "ref"
+                                    }
                                 });
                             }
                         }
@@ -198,16 +196,13 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
                     let value_id = env.identifiers[value.identifier.0 as usize].id;
                     if inlined_state.contains_key(&value_id) {
                         // Invariant: destructuring pattern must be ArrayPattern with at least one Identifier item
-                        if let crate::react_compiler_hir::Pattern::Array(arr) = &lvalue.pattern {
+                        if let Pattern::Array(arr) = &lvalue.pattern {
                             if !arr.items.is_empty() {
                                 if let ArrayPatternElement::Place(first_place) = &arr.items[0] {
                                     let loc = *loc;
                                     let kind = lvalue.kind;
                                     let store = InstructionValue::StoreLocal {
-                                        lvalue: crate::react_compiler_hir::LValue {
-                                            place: first_place.clone(),
-                                            kind,
-                                        },
+                                        lvalue: LValue { place: first_place.clone(), kind },
                                         value: value.clone(),
                                         type_annotation: None,
                                         loc,
@@ -278,16 +273,9 @@ pub fn optimize_for_ssr(func: &mut HirFunction, env: &Environment) {
 #[derive(Debug, Clone)]
 enum InlinedStateReplacement {
     /// Replace with `LoadLocal { place }` — used for useState and useReducer(reducer, initialArg)
-    LoadLocal {
-        place: crate::react_compiler_hir::Place,
-        loc: Option<crate::react_compiler_hir::SourceLocation>,
-    },
+    LoadLocal { place: Place, loc: Option<SourceLocation> },
     /// Replace with `CallExpression { callee, args: [arg] }` — used for useReducer(reducer, initialArg, init)
-    CallExpression {
-        callee: crate::react_compiler_hir::Place,
-        arg: crate::react_compiler_hir::Place,
-        loc: Option<crate::react_compiler_hir::SourceLocation>,
-    },
+    CallExpression { callee: Place, arg: Place, loc: Option<SourceLocation> },
 }
 
 /// Returns true if the function body contains a call to setState or startTransition.

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_props_method_calls.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/optimize_props_method_calls.rs
@@ -13,6 +13,8 @@
 //!
 //! Analogous to TS `Optimization/OptimizePropsMethodCalls.ts`.
 
+use std::mem::replace;
+
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{HirFunction, InstructionValue, is_props_type};
 
@@ -33,8 +35,7 @@ pub fn optimize_props_method_calls(func: &mut HirFunction, env: &Environment) {
             if should_replace {
                 // Take the old value out, replacing with a temporary.
                 // The if-let is guaranteed to match since we checked above.
-                let old =
-                    std::mem::replace(&mut instr.value, InstructionValue::Debugger { loc: None });
+                let old = replace(&mut instr.value, InstructionValue::Debugger { loc: None });
                 match old {
                     InstructionValue::MethodCall { property, args, loc, .. } => {
                         instr.value =

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_functions.rs
@@ -11,6 +11,8 @@
 //!
 //! Conditional on `env.config.enable_function_outlining`.
 
+use std::mem::replace;
+
 use rustc_hash::FxHashSet;
 
 use crate::react_compiler_hir::environment::Environment;
@@ -78,19 +80,15 @@ pub fn outline_functions(
     for action in actions {
         match action {
             Action::Recurse(function_id) => {
-                let mut inner_func = std::mem::replace(
-                    &mut env.functions[function_id.0 as usize],
-                    placeholder_function(),
-                );
+                let mut inner_func =
+                    replace(&mut env.functions[function_id.0 as usize], placeholder_function());
                 outline_functions(&mut inner_func, env, fbt_operands);
                 env.functions[function_id.0 as usize] = inner_func;
             }
             Action::RecurseAndOutline { instr_idx, function_id } => {
                 // First recurse into the inner function (depth-first)
-                let mut inner_func = std::mem::replace(
-                    &mut env.functions[function_id.0 as usize],
-                    placeholder_function(),
-                );
+                let mut inner_func =
+                    replace(&mut env.functions[function_id.0 as usize], placeholder_function());
                 outline_functions(&mut inner_func, env, fbt_operands);
                 env.functions[function_id.0 as usize] = inner_func;
 

--- a/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_optimization/outline_jsx.rs
@@ -11,6 +11,7 @@
 use crate::react_compiler_utils::FxIndexSet;
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use crate::react_compiler_hir::Effect;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     BasicBlock, BlockId, BlockKind, EvaluationOrder, FunctionId, HIR, HirFunction, IdentifierId,
@@ -19,7 +20,9 @@ use crate::react_compiler_hir::{
     ObjectPropertyOrSpread, ObjectPropertyType, ParamPattern, Pattern, Place, ReactFunctionType,
     ReturnVariant, Terminal,
 };
+use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 use crate::react_compiler_utils::FxIndexMap;
+use std::mem::replace;
 
 /// Outline JSX expressions in inner functions into separate outlined components.
 ///
@@ -127,10 +130,8 @@ fn outline_jsx_impl(
                     globals.insert(lvalue_id, instr_idx);
                 }
                 InstrAction::FunctionExpr { func_id } => {
-                    let mut inner_func = std::mem::replace(
-                        &mut env.functions[func_id.0 as usize],
-                        crate::react_compiler_ssa::enter_ssa::placeholder_function(),
-                    );
+                    let mut inner_func =
+                        replace(&mut env.functions[func_id.0 as usize], placeholder_function());
                     outline_jsx_impl(&mut inner_func, env, outlined_fns);
                     env.functions[func_id.0 as usize] = inner_func;
                 }
@@ -335,12 +336,8 @@ fn emit_outlined_jsx(
     env.identifiers[load_id.0 as usize].name =
         Some(IdentifierName::Promoted(format!("#T{}", decl_id.0)));
 
-    let load_place = Place {
-        identifier: load_id,
-        effect: crate::react_compiler_hir::Effect::Unknown,
-        reactive: false,
-        loc: None,
-    };
+    let load_place =
+        Place { identifier: load_id, effect: Effect::Unknown, reactive: false, loc: None };
 
     let load_jsx = Instruction {
         id: EvaluationOrder(0),
@@ -388,12 +385,8 @@ fn emit_outlined_fn(
     let decl_id = env.identifiers[props_obj_id.0 as usize].declaration_id;
     env.identifiers[props_obj_id.0 as usize].name =
         Some(IdentifierName::Promoted(format!("#t{}", decl_id.0)));
-    let props_obj = Place {
-        identifier: props_obj_id,
-        effect: crate::react_compiler_hir::Effect::Unknown,
-        reactive: false,
-        loc: None,
-    };
+    let props_obj =
+        Place { identifier: props_obj_id, effect: Effect::Unknown, reactive: false, loc: None };
 
     // Create destructure instruction
     let destructure_instr = emit_destructure_props(env, &props_obj, &old_to_new_props);
@@ -424,12 +417,8 @@ fn emit_outlined_fn(
 
     // Create return place
     let returns_id = env.next_identifier_id();
-    let returns_place = Place {
-        identifier: returns_id,
-        effect: crate::react_compiler_hir::Effect::Unknown,
-        reactive: false,
-        loc: None,
-    };
+    let returns_place =
+        Place { identifier: returns_id, effect: Effect::Unknown, reactive: false, loc: None };
 
     let block = BasicBlock {
         kind: BlockKind::Block,
@@ -580,12 +569,8 @@ fn create_old_to_new_props_mapping(
         env.identifiers[new_id.0 as usize].name =
             Some(IdentifierName::Named(old_prop.new_name.clone()));
 
-        let new_place = Place {
-            identifier: new_id,
-            effect: crate::react_compiler_hir::Effect::Unknown,
-            reactive: false,
-            loc: None,
-        };
+        let new_place =
+            Place { identifier: new_id, effect: Effect::Unknown, reactive: false, loc: None };
 
         old_to_new.insert(
             old_prop.place.identifier,
@@ -615,12 +600,8 @@ fn emit_destructure_props(
     }
 
     let lvalue_id = env.next_identifier_id();
-    let lvalue = Place {
-        identifier: lvalue_id,
-        effect: crate::react_compiler_hir::Effect::Unknown,
-        reactive: false,
-        loc: None,
-    };
+    let lvalue =
+        Place { identifier: lvalue_id, effect: Effect::Unknown, reactive: false, loc: None };
 
     Instruction {
         id: EvaluationOrder(0),

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/build_reactive_function.rs
@@ -7,6 +7,8 @@
 //!
 //! Corresponds to `src/ReactiveScopes/BuildReactiveFunction.ts`.
 
+use std::mem::discriminant;
+
 use rustc_hash::FxHashSet;
 
 use crate::react_compiler_diagnostics::{
@@ -14,10 +16,11 @@ use crate::react_compiler_diagnostics::{
 };
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
-    BasicBlock, BlockId, EvaluationOrder, GotoVariant, HirFunction, InstructionValue, Place,
-    PrunedReactiveScopeBlock, ReactiveBlock, ReactiveFunction, ReactiveInstruction, ReactiveLabel,
-    ReactiveScopeBlock, ReactiveStatement, ReactiveSwitchCase, ReactiveTerminal,
-    ReactiveTerminalStatement, ReactiveTerminalTargetKind, ReactiveValue, Terminal,
+    BasicBlock, BlockId, EvaluationOrder, GotoVariant, HirFunction, InstructionId,
+    InstructionValue, Place, PrimitiveValue, PrunedReactiveScopeBlock, ReactiveBlock,
+    ReactiveFunction, ReactiveInstruction, ReactiveLabel, ReactiveScopeBlock, ReactiveStatement,
+    ReactiveSwitchCase, ReactiveTerminal, ReactiveTerminalStatement, ReactiveTerminalTargetKind,
+    ReactiveValue, Terminal,
 };
 
 /// Convert the HIR CFG into a tree-structured ReactiveFunction.
@@ -1094,7 +1097,7 @@ impl<'a, 'b> Driver<'a, 'b> {
                 format!(
                     "Expected a branch terminal for {} test block, got {:?}",
                     terminal_kind,
-                    std::mem::discriminant(other)
+                    discriminant(other)
                 ),
                 None,
             )),
@@ -1211,7 +1214,7 @@ impl<'a, 'b> Driver<'a, 'b> {
 
     fn extract_value_block_result(
         &self,
-        instructions: &[crate::react_compiler_hir::InstructionId],
+        instructions: &[InstructionId],
         block_id: BlockId,
         loc: Option<SourceLocation>,
     ) -> ValueBlockResult {
@@ -1275,7 +1278,7 @@ impl<'a, 'b> Driver<'a, 'b> {
 
     fn wrap_with_sequence(
         &self,
-        instructions: &[crate::react_compiler_hir::InstructionId],
+        instructions: &[InstructionId],
         continuation: ValueBlockResult,
         loc: Option<SourceLocation>,
     ) -> ValueBlockResult {
@@ -1361,7 +1364,7 @@ impl<'a, 'b> Driver<'a, 'b> {
             instructions,
             id: result.id,
             value: Box::new(ReactiveValue::Instruction(InstructionValue::Primitive {
-                value: crate::react_compiler_hir::PrimitiveValue::Undefined,
+                value: PrimitiveValue::Undefined,
                 loc,
             })),
             loc,

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -3899,13 +3899,14 @@ fn apply_renames_to_json_inner(
 
 #[cfg(test)]
 mod tests {
+    use super::source_file_hash;
+
     /// The Fast Refresh source hash must match Node's
     /// `createHmac('sha256', code).digest('hex')` byte-for-byte, or hot-reload
     /// cache invalidation would diverge from the TS compiler. Reference values
     /// were computed with Node's `crypto` module.
     #[test]
     fn source_file_hash_matches_node_create_hmac() {
-        use super::source_file_hash;
         assert_eq!(
             source_file_hash("hello world"),
             "0de8bee5d7f9c5d209f8c6fabed0ea84cb3fca1244e8ed38079a61b599a84c47"

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/codegen_reactive_function.rs
@@ -10,8 +10,16 @@
 //!
 //! Corresponds to `src/ReactiveScopes/CodegenReactiveFunction.ts` in the TS compiler.
 
+use std::cmp::Ordering;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::mem::discriminant;
+use std::mem::replace;
+
+use hmac_sha256::HMAC;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
+use serde_json::Value;
 
 use crate::react_compiler_ast::OriginalNode;
 use crate::react_compiler_ast::common::BaseNode;
@@ -55,6 +63,7 @@ use crate::react_compiler_ast::operators::LogicalOperator as AstLogicalOperator;
 use crate::react_compiler_ast::operators::UnaryOperator as AstUnaryOperator;
 use crate::react_compiler_ast::operators::UpdateOperator as AstUpdateOperator;
 use crate::react_compiler_ast::patterns::ArrayPattern as AstArrayPattern;
+use crate::react_compiler_ast::patterns::ObjectPattern as AstObjectPattern;
 use crate::react_compiler_ast::patterns::ObjectPatternProp;
 use crate::react_compiler_ast::patterns::ObjectPatternProperty;
 use crate::react_compiler_ast::patterns::PatternLike;
@@ -69,6 +78,7 @@ use crate::react_compiler_ast::statements::DirectiveLiteral;
 use crate::react_compiler_ast::statements::DoWhileStatement;
 use crate::react_compiler_ast::statements::EmptyStatement;
 use crate::react_compiler_ast::statements::ExpressionStatement;
+use crate::react_compiler_ast::statements::ForInOfLeft;
 use crate::react_compiler_ast::statements::ForInStatement;
 use crate::react_compiler_ast::statements::ForInit;
 use crate::react_compiler_ast::statements::ForOfStatement;
@@ -91,18 +101,23 @@ use crate::react_compiler_diagnostics::CompilerDiagnosticDetail;
 use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_diagnostics::CompilerErrorDetail;
 use crate::react_compiler_diagnostics::ErrorCategory;
+use crate::react_compiler_diagnostics::Position;
 use crate::react_compiler_diagnostics::SourceLocation as DiagSourceLocation;
 use crate::react_compiler_hir::ArrayElement;
 use crate::react_compiler_hir::ArrayPattern;
+use crate::react_compiler_hir::ArrayPatternElement;
+use crate::react_compiler_hir::BinaryOperator;
 use crate::react_compiler_hir::BlockId;
 use crate::react_compiler_hir::DeclarationId;
 use crate::react_compiler_hir::FunctionExpressionType;
 use crate::react_compiler_hir::IdentifierId;
+use crate::react_compiler_hir::IdentifierName;
 use crate::react_compiler_hir::InstructionKind;
 use crate::react_compiler_hir::InstructionValue;
 use crate::react_compiler_hir::JsxAttribute;
 use crate::react_compiler_hir::JsxTag;
 use crate::react_compiler_hir::LogicalOperator;
+use crate::react_compiler_hir::LoweredFunction;
 use crate::react_compiler_hir::ObjectPattern;
 use crate::react_compiler_hir::ObjectPropertyKey;
 use crate::react_compiler_hir::ObjectPropertyOrSpread;
@@ -113,9 +128,16 @@ use crate::react_compiler_hir::Place;
 use crate::react_compiler_hir::PlaceOrSpread;
 use crate::react_compiler_hir::PrimitiveValue;
 use crate::react_compiler_hir::PropertyLiteral;
+use crate::react_compiler_hir::ReactFunctionType;
+use crate::react_compiler_hir::ReactiveScopeDeclaration;
+use crate::react_compiler_hir::ReactiveScopeDependency;
 use crate::react_compiler_hir::ScopeId;
 use crate::react_compiler_hir::SpreadPattern;
+use crate::react_compiler_hir::UnaryOperator;
+use crate::react_compiler_hir::UpdateOperator;
+use crate::react_compiler_hir::environment::BindingRename;
 use crate::react_compiler_hir::environment::Environment;
+use crate::react_compiler_hir::environment::OutputMode;
 use crate::react_compiler_hir::reactive::PrunedReactiveScopeBlock;
 use crate::react_compiler_hir::reactive::ReactiveBlock;
 use crate::react_compiler_hir::reactive::ReactiveFunction;
@@ -125,6 +147,7 @@ use crate::react_compiler_hir::reactive::ReactiveStatement;
 use crate::react_compiler_hir::reactive::ReactiveTerminal;
 use crate::react_compiler_hir::reactive::ReactiveTerminalTargetKind;
 use crate::react_compiler_hir::reactive::ReactiveValue;
+use crate::react_compiler_hir::visitors::each_pattern_operand;
 
 use crate::react_compiler_reactive_scopes::build_reactive_function::build_reactive_function;
 use crate::react_compiler_reactive_scopes::prune_hoisted_contexts::prune_hoisted_contexts;
@@ -161,8 +184,8 @@ pub struct CodegenFunction {
     pub outlined: Vec<OutlinedFunction>,
 }
 
-impl std::fmt::Debug for CodegenFunction {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Debug for CodegenFunction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CodegenFunction")
             .field("memo_slots_used", &self.memo_slots_used)
             .field("memo_blocks", &self.memo_blocks)
@@ -176,7 +199,7 @@ impl std::fmt::Debug for CodegenFunction {
 /// An outlined function extracted during compilation.
 pub struct OutlinedFunction {
     pub func: CodegenFunction,
-    pub fn_type: Option<crate::react_compiler_hir::ReactFunctionType>,
+    pub fn_type: Option<ReactFunctionType>,
 }
 
 /// Top-level entry point: generates code for a reactive function.
@@ -185,7 +208,7 @@ pub struct OutlinedFunction {
 /// `createHmac('sha256', code).digest('hex')`: an HMAC-SHA256 keyed by the
 /// source code, hashing empty data.
 fn source_file_hash(code: &str) -> String {
-    hmac_sha256::HMAC::mac(b"", code.as_bytes()).iter().map(|b| format!("{b:02x}")).collect()
+    HMAC::mac(b"", code.as_bytes()).iter().map(|b| format!("{b:02x}")).collect()
 }
 
 pub fn codegen_function(
@@ -216,11 +239,9 @@ pub fn codegen_function(
     // enableEmitHookGuards: wrap entire function body in try/finally with
     // $dispatcherGuard(PushHookGuard=0) / $dispatcherGuard(PopHookGuard=1).
     // Per-hook-call wrapping is done inline during codegen (CallExpression/MethodCall).
-    if cx.env.hook_guard_name.is_some()
-        && cx.env.output_mode == crate::react_compiler_hir::environment::OutputMode::Client
-    {
+    if cx.env.hook_guard_name.is_some() && cx.env.output_mode == OutputMode::Client {
         let guard_name = cx.env.hook_guard_name.as_ref().unwrap().clone();
-        let body_stmts = std::mem::replace(&mut compiled.body.body, Vec::new());
+        let body_stmts = replace(&mut compiled.body.body, Vec::new());
         compiled.body.body = vec![create_function_body_hook_guard(&guard_name, body_stmts, 0, 1)];
     }
 
@@ -436,9 +457,7 @@ pub fn codegen_function(
     // Instrument forget: emit instrumentation call at the top of the function body
     let emit_instrument_forget = cx.env.config.enable_emit_instrument_forget.clone();
     if let Some(ref instrument_config) = emit_instrument_forget {
-        if func.id.is_some()
-            && cx.env.output_mode == crate::react_compiler_hir::environment::OutputMode::Client
-        {
+        if func.id.is_some() && cx.env.output_mode == OutputMode::Client {
             // Use pre-resolved import names from environment (set by program-level code)
             let instrument_fn_local = cx
                 .env
@@ -553,10 +572,7 @@ struct Context<'env> {
     next_cache_index: u32,
     declarations: FxHashSet<DeclarationId>,
     temp: Temporaries,
-    object_methods: FxHashMap<
-        IdentifierId,
-        (InstructionValue, Option<crate::react_compiler_diagnostics::SourceLocation>),
-    >,
+    object_methods: FxHashMap<IdentifierId, (InstructionValue, Option<DiagSourceLocation>)>,
     unique_identifiers: FxHashSet<String>,
     fbt_operands: FxHashSet<IdentifierId>,
     synthesized_names: FxHashMap<String, String>,
@@ -981,8 +997,8 @@ fn codegen_reactive_scope(
     if let Some(ref early_return) = early_return_value {
         let early_ident = &cx.env.identifiers[early_return.value.0 as usize];
         let name = match &early_ident.name {
-            Some(crate::react_compiler_hir::IdentifierName::Named(n)) => n.clone(),
-            Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => n.clone(),
+            Some(IdentifierName::Named(n)) => n.clone(),
+            Some(IdentifierName::Promoted(n)) => n.clone(),
             None => {
                 return Err(invariant_err(
                     "Expected early return value to be promoted to a named variable",
@@ -1217,19 +1233,17 @@ fn codegen_for_in(
     let body = codegen_block(cx, loop_block)?;
     Ok(Some(Statement::ForInStatement(ForInStatement {
         base: base_node_with_loc("ForInStatement", loc),
-        left: Box::new(crate::react_compiler_ast::statements::ForInOfLeft::VariableDeclaration(
-            VariableDeclaration {
-                base: BaseNode::typed("VariableDeclaration"),
-                declarations: vec![VariableDeclarator {
-                    base: BaseNode::typed("VariableDeclarator"),
-                    id: lval,
-                    init: None,
-                    definite: None,
-                }],
-                kind: var_decl_kind,
-                declare: None,
-            },
-        )),
+        left: Box::new(ForInOfLeft::VariableDeclaration(VariableDeclaration {
+            base: BaseNode::typed("VariableDeclaration"),
+            declarations: vec![VariableDeclarator {
+                base: BaseNode::typed("VariableDeclarator"),
+                id: lval,
+                init: None,
+                definite: None,
+            }],
+            kind: var_decl_kind,
+            declare: None,
+        })),
         right: Box::new(right),
         body: Box::new(Statement::BlockStatement(body)),
     })))
@@ -1280,19 +1294,17 @@ fn codegen_for_of(
     let body = codegen_block(cx, loop_block)?;
     Ok(Some(Statement::ForOfStatement(ForOfStatement {
         base: base_node_with_loc("ForOfStatement", loc),
-        left: Box::new(crate::react_compiler_ast::statements::ForInOfLeft::VariableDeclaration(
-            VariableDeclaration {
-                base: BaseNode::typed("VariableDeclaration"),
-                declarations: vec![VariableDeclarator {
-                    base: BaseNode::typed("VariableDeclarator"),
-                    id: lval,
-                    init: None,
-                    definite: None,
-                }],
-                kind: var_decl_kind,
-                declare: None,
-            },
-        )),
+        left: Box::new(ForInOfLeft::VariableDeclaration(VariableDeclaration {
+            base: BaseNode::typed("VariableDeclaration"),
+            declarations: vec![VariableDeclarator {
+                base: BaseNode::typed("VariableDeclarator"),
+                id: lval,
+                init: None,
+                definite: None,
+            }],
+            kind: var_decl_kind,
+            declare: None,
+        })),
         right: Box::new(right),
         body: Box::new(Statement::BlockStatement(body)),
         is_await: false,
@@ -1331,7 +1343,7 @@ fn extract_for_in_of_lval(
                 &format!(
                     "Expected a StoreLocal or Destructure in {} collection, found {:?}",
                     context_name,
-                    std::mem::discriminant(instr_value)
+                    discriminant(instr_value)
                 ),
                 None,
             ));
@@ -1550,8 +1562,7 @@ fn codegen_store_or_declare(
         InstructionValue::Destructure { lvalue, value: val, .. } => {
             let kind = lvalue.kind;
             // Register temporaries for unnamed pattern operands
-            for place in crate::react_compiler_hir::visitors::each_pattern_operand(&lvalue.pattern)
-            {
+            for place in each_pattern_operand(&lvalue.pattern) {
                 let ident = &cx.env.identifiers[place.identifier.0 as usize];
                 if kind != InstructionKind::Reassign && ident.name.is_none() {
                     cx.temp.insert(ident.declaration_id, None);
@@ -1893,7 +1904,7 @@ fn codegen_instruction_value(
                 other => Err(invariant_err(
                     &format!(
                         "Expected optional value to resolve to call or member expression, got {:?}",
-                        std::mem::discriminant(&other)
+                        discriminant(&other)
                     ),
                     None,
                 )),
@@ -2362,7 +2373,7 @@ fn codegen_base_instruction_value(
         | InstructionValue::Destructure { .. }
         | InstructionValue::ObjectMethod { .. }
         | InstructionValue::StoreContext { .. } => Err(invariant_err(
-            &format!("Unexpected {:?} in codegenInstructionValue", std::mem::discriminant(iv)),
+            &format!("Unexpected {:?} in codegenInstructionValue", discriminant(iv)),
             None,
         )),
     }
@@ -2376,7 +2387,7 @@ fn codegen_function_expression(
     cx: &mut Context,
     name: &Option<String>,
     name_hint: &Option<String>,
-    lowered_func: &crate::react_compiler_hir::LoweredFunction,
+    lowered_func: &LoweredFunction,
     expr_type: &FunctionExpressionType,
 ) -> Result<ExpressionOrJsxText, CompilerError> {
     let func = &cx.env.functions[lowered_func.func.0 as usize];
@@ -2934,13 +2945,13 @@ fn codegen_array_pattern(
         .items
         .iter()
         .map(|item| match item {
-            crate::react_compiler_hir::ArrayPatternElement::Place(place) => {
+            ArrayPatternElement::Place(place) => {
                 Ok(Some(codegen_lvalue(cx, &LvalueRef::Place(place))?))
             }
-            crate::react_compiler_hir::ArrayPatternElement::Spread(spread) => {
+            ArrayPatternElement::Spread(spread) => {
                 Ok(Some(codegen_lvalue(cx, &LvalueRef::Spread(spread))?))
             }
-            crate::react_compiler_hir::ArrayPatternElement::Hole => Ok(None),
+            ArrayPatternElement::Hole => Ok(None),
         })
         .collect::<Result<_, CompilerError>>()?;
     Ok(PatternLike::ArrayPattern(AstArrayPattern {
@@ -2985,7 +2996,7 @@ fn codegen_object_pattern(
             }
         })
         .collect::<Result<_, CompilerError>>()?;
-    Ok(PatternLike::ObjectPattern(crate::react_compiler_ast::patterns::ObjectPattern {
+    Ok(PatternLike::ObjectPattern(AstObjectPattern {
         base: base_node_with_loc("ObjectPattern", pattern.loc),
         properties,
         type_annotation: None,
@@ -3042,8 +3053,8 @@ fn convert_identifier(
 ) -> Result<AstIdentifier, CompilerError> {
     let ident = &env.identifiers[identifier_id.0 as usize];
     let name = match &ident.name {
-        Some(crate::react_compiler_hir::IdentifierName::Named(n)) => n.clone(),
-        Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => n.clone(),
+        Some(IdentifierName::Named(n)) => n.clone(),
+        Some(IdentifierName::Promoted(n)) => n.clone(),
         None => {
             // Use CompilerDiagnostic (with details array) to match TS CompilerError.invariant()
             // which creates a CompilerDiagnostic with details: [{kind: "error", loc, message}].
@@ -3089,7 +3100,7 @@ fn codegen_argument(cx: &mut Context, arg: &PlaceOrSpread) -> Result<Expression,
 
 fn codegen_dependency(
     cx: &mut Context,
-    dep: &crate::react_compiler_hir::ReactiveScopeDependency,
+    dep: &ReactiveScopeDependency,
 ) -> Result<Expression, CompilerError> {
     let mut object: Expression =
         Expression::Identifier(convert_identifier(dep.identifier, cx.env)?);
@@ -3177,41 +3188,41 @@ fn count_memo_blocks(func: &ReactiveFunction, env: &Environment) -> (u32, u32, u
 // Operator conversions
 // =============================================================================
 
-fn convert_binary_operator(op: &crate::react_compiler_hir::BinaryOperator) -> AstBinaryOperator {
+fn convert_binary_operator(op: &BinaryOperator) -> AstBinaryOperator {
     match op {
-        crate::react_compiler_hir::BinaryOperator::Equal => AstBinaryOperator::Eq,
-        crate::react_compiler_hir::BinaryOperator::NotEqual => AstBinaryOperator::Neq,
-        crate::react_compiler_hir::BinaryOperator::StrictEqual => AstBinaryOperator::StrictEq,
-        crate::react_compiler_hir::BinaryOperator::StrictNotEqual => AstBinaryOperator::StrictNeq,
-        crate::react_compiler_hir::BinaryOperator::LessThan => AstBinaryOperator::Lt,
-        crate::react_compiler_hir::BinaryOperator::LessEqual => AstBinaryOperator::Lte,
-        crate::react_compiler_hir::BinaryOperator::GreaterThan => AstBinaryOperator::Gt,
-        crate::react_compiler_hir::BinaryOperator::GreaterEqual => AstBinaryOperator::Gte,
-        crate::react_compiler_hir::BinaryOperator::ShiftLeft => AstBinaryOperator::Shl,
-        crate::react_compiler_hir::BinaryOperator::ShiftRight => AstBinaryOperator::Shr,
-        crate::react_compiler_hir::BinaryOperator::UnsignedShiftRight => AstBinaryOperator::UShr,
-        crate::react_compiler_hir::BinaryOperator::Add => AstBinaryOperator::Add,
-        crate::react_compiler_hir::BinaryOperator::Subtract => AstBinaryOperator::Sub,
-        crate::react_compiler_hir::BinaryOperator::Multiply => AstBinaryOperator::Mul,
-        crate::react_compiler_hir::BinaryOperator::Divide => AstBinaryOperator::Div,
-        crate::react_compiler_hir::BinaryOperator::Modulo => AstBinaryOperator::Rem,
-        crate::react_compiler_hir::BinaryOperator::Exponent => AstBinaryOperator::Exp,
-        crate::react_compiler_hir::BinaryOperator::BitwiseOr => AstBinaryOperator::BitOr,
-        crate::react_compiler_hir::BinaryOperator::BitwiseXor => AstBinaryOperator::BitXor,
-        crate::react_compiler_hir::BinaryOperator::BitwiseAnd => AstBinaryOperator::BitAnd,
-        crate::react_compiler_hir::BinaryOperator::In => AstBinaryOperator::In,
-        crate::react_compiler_hir::BinaryOperator::InstanceOf => AstBinaryOperator::Instanceof,
+        BinaryOperator::Equal => AstBinaryOperator::Eq,
+        BinaryOperator::NotEqual => AstBinaryOperator::Neq,
+        BinaryOperator::StrictEqual => AstBinaryOperator::StrictEq,
+        BinaryOperator::StrictNotEqual => AstBinaryOperator::StrictNeq,
+        BinaryOperator::LessThan => AstBinaryOperator::Lt,
+        BinaryOperator::LessEqual => AstBinaryOperator::Lte,
+        BinaryOperator::GreaterThan => AstBinaryOperator::Gt,
+        BinaryOperator::GreaterEqual => AstBinaryOperator::Gte,
+        BinaryOperator::ShiftLeft => AstBinaryOperator::Shl,
+        BinaryOperator::ShiftRight => AstBinaryOperator::Shr,
+        BinaryOperator::UnsignedShiftRight => AstBinaryOperator::UShr,
+        BinaryOperator::Add => AstBinaryOperator::Add,
+        BinaryOperator::Subtract => AstBinaryOperator::Sub,
+        BinaryOperator::Multiply => AstBinaryOperator::Mul,
+        BinaryOperator::Divide => AstBinaryOperator::Div,
+        BinaryOperator::Modulo => AstBinaryOperator::Rem,
+        BinaryOperator::Exponent => AstBinaryOperator::Exp,
+        BinaryOperator::BitwiseOr => AstBinaryOperator::BitOr,
+        BinaryOperator::BitwiseXor => AstBinaryOperator::BitXor,
+        BinaryOperator::BitwiseAnd => AstBinaryOperator::BitAnd,
+        BinaryOperator::In => AstBinaryOperator::In,
+        BinaryOperator::InstanceOf => AstBinaryOperator::Instanceof,
     }
 }
 
-fn convert_unary_operator(op: &crate::react_compiler_hir::UnaryOperator) -> AstUnaryOperator {
+fn convert_unary_operator(op: &UnaryOperator) -> AstUnaryOperator {
     match op {
-        crate::react_compiler_hir::UnaryOperator::Minus => AstUnaryOperator::Neg,
-        crate::react_compiler_hir::UnaryOperator::Plus => AstUnaryOperator::Plus,
-        crate::react_compiler_hir::UnaryOperator::Not => AstUnaryOperator::Not,
-        crate::react_compiler_hir::UnaryOperator::BitwiseNot => AstUnaryOperator::BitNot,
-        crate::react_compiler_hir::UnaryOperator::TypeOf => AstUnaryOperator::TypeOf,
-        crate::react_compiler_hir::UnaryOperator::Void => AstUnaryOperator::Void,
+        UnaryOperator::Minus => AstUnaryOperator::Neg,
+        UnaryOperator::Plus => AstUnaryOperator::Plus,
+        UnaryOperator::Not => AstUnaryOperator::Not,
+        UnaryOperator::BitwiseNot => AstUnaryOperator::BitNot,
+        UnaryOperator::TypeOf => AstUnaryOperator::TypeOf,
+        UnaryOperator::Void => AstUnaryOperator::Void,
     }
 }
 
@@ -3223,10 +3234,10 @@ fn convert_logical_operator(op: &LogicalOperator) -> AstLogicalOperator {
     }
 }
 
-fn convert_update_operator(op: &crate::react_compiler_hir::UpdateOperator) -> AstUpdateOperator {
+fn convert_update_operator(op: &UpdateOperator) -> AstUpdateOperator {
     match op {
-        crate::react_compiler_hir::UpdateOperator::Increment => AstUpdateOperator::Increment,
-        crate::react_compiler_hir::UpdateOperator::Decrement => AstUpdateOperator::Decrement,
+        UpdateOperator::Increment => AstUpdateOperator::Increment,
+        UpdateOperator::Decrement => AstUpdateOperator::Decrement,
     }
 }
 
@@ -3551,16 +3562,12 @@ fn invariant_err_with_detail_message(
     loc: Option<DiagSourceLocation>,
 ) -> CompilerError {
     let mut err = CompilerError::new();
-    let diagnostic = crate::react_compiler_diagnostics::CompilerDiagnostic::new(
-        ErrorCategory::Invariant,
-        reason,
-        None::<String>,
-    )
-    .with_detail(crate::react_compiler_diagnostics::CompilerDiagnosticDetail::Error {
-        loc,
-        message: Some(message.to_string()),
-        identifier_name: None,
-    });
+    let diagnostic = CompilerDiagnostic::new(ErrorCategory::Invariant, reason, None::<String>)
+        .with_detail(CompilerDiagnosticDetail::Error {
+            loc,
+            message: Some(message.to_string()),
+            identifier_name: None,
+        });
     err.push_diagnostic(diagnostic);
     err
 }
@@ -3614,37 +3621,26 @@ fn get_statement_loc(stmt: &Statement) -> Option<DiagSourceLocation> {
         _ => return None,
     };
     base.loc.as_ref().map(|loc| DiagSourceLocation {
-        start: crate::react_compiler_diagnostics::Position {
-            line: loc.start.line,
-            column: loc.start.column,
-            index: loc.start.index,
-        },
-        end: crate::react_compiler_diagnostics::Position {
-            line: loc.end.line,
-            column: loc.end.column,
-            index: loc.end.index,
-        },
+        start: Position { line: loc.start.line, column: loc.start.column, index: loc.start.index },
+        end: Position { line: loc.end.line, column: loc.end.column, index: loc.end.index },
     })
 }
 
 fn compare_scope_dependency(
-    a: &crate::react_compiler_hir::ReactiveScopeDependency,
-    b: &crate::react_compiler_hir::ReactiveScopeDependency,
+    a: &ReactiveScopeDependency,
+    b: &ReactiveScopeDependency,
     env: &Environment,
-) -> std::cmp::Ordering {
+) -> Ordering {
     let a_name = dep_to_sort_key(a, env);
     let b_name = dep_to_sort_key(b, env);
     a_name.cmp(&b_name)
 }
 
-fn dep_to_sort_key(
-    dep: &crate::react_compiler_hir::ReactiveScopeDependency,
-    env: &Environment,
-) -> String {
+fn dep_to_sort_key(dep: &ReactiveScopeDependency, env: &Environment) -> String {
     let ident = &env.identifiers[dep.identifier.0 as usize];
     let base = match &ident.name {
-        Some(crate::react_compiler_hir::IdentifierName::Named(n)) => n.clone(),
-        Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => n.clone(),
+        Some(IdentifierName::Named(n)) => n.clone(),
+        Some(IdentifierName::Promoted(n)) => n.clone(),
         None => format!("_t{}", dep.identifier.0),
     };
     let mut parts = vec![base];
@@ -3660,10 +3656,10 @@ fn dep_to_sort_key(
 }
 
 fn compare_scope_declaration(
-    a: &crate::react_compiler_hir::ReactiveScopeDeclaration,
-    b: &crate::react_compiler_hir::ReactiveScopeDeclaration,
+    a: &ReactiveScopeDeclaration,
+    b: &ReactiveScopeDeclaration,
     env: &Environment,
-) -> std::cmp::Ordering {
+) -> Ordering {
     let a_name = ident_sort_key(a.identifier, env);
     let b_name = ident_sort_key(b.identifier, env);
     a_name.cmp(&b_name)
@@ -3672,8 +3668,8 @@ fn compare_scope_declaration(
 fn ident_sort_key(id: IdentifierId, env: &Environment) -> String {
     let ident = &env.identifiers[id.0 as usize];
     match &ident.name {
-        Some(crate::react_compiler_hir::IdentifierName::Named(n)) => n.clone(),
-        Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => n.clone(),
+        Some(IdentifierName::Named(n)) => n.clone(),
+        Some(IdentifierName::Promoted(n)) => n.clone(),
         None => format!("_t{}", id.0),
     }
 }
@@ -3693,9 +3689,7 @@ fn maybe_wrap_hook_call(
     callee_id: IdentifierId,
 ) -> Expression {
     if let Some(ref guard_name) = cx.env.hook_guard_name {
-        if cx.env.output_mode == crate::react_compiler_hir::environment::OutputMode::Client
-            && is_hook_identifier(cx, callee_id)
-        {
+        if cx.env.output_mode == OutputMode::Client && is_hook_identifier(cx, callee_id) {
             return wrap_hook_call_with_guard(guard_name, call_expr, 2, 3);
         }
     }
@@ -3828,24 +3822,24 @@ fn create_function_body_hook_guard(
 }
 
 fn apply_renames_to_json(
-    value: &mut serde_json::Value,
-    renames: &[crate::react_compiler_hir::environment::BindingRename],
-    reference_node_ids: &rustc_hash::FxHashSet<u32>,
+    value: &mut Value,
+    renames: &[BindingRename],
+    reference_node_ids: &FxHashSet<u32>,
 ) {
     apply_renames_to_json_inner(value, renames, reference_node_ids, false);
 }
 
 fn apply_renames_to_json_inner(
-    value: &mut serde_json::Value,
-    renames: &[crate::react_compiler_hir::environment::BindingRename],
-    reference_node_ids: &rustc_hash::FxHashSet<u32>,
+    value: &mut Value,
+    renames: &[BindingRename],
+    reference_node_ids: &FxHashSet<u32>,
     is_property_key: bool,
 ) {
     if renames.is_empty() {
         return;
     }
     match value {
-        serde_json::Value::Object(map) => {
+        Value::Object(map) => {
             let node_type = map.get("type").and_then(|v| v.as_str()).unwrap_or("").to_string();
             // Rename Identifier nodes that are NOT object property keys.
             // Property keys in object type annotations (e.g., `id: string`)
@@ -3875,7 +3869,7 @@ fn apply_renames_to_json_inner(
                     None
                 };
                 if let Some(renamed) = maybe_rename {
-                    map.insert("name".to_string(), serde_json::Value::String(renamed));
+                    map.insert("name".to_string(), Value::String(renamed));
                 }
                 if let Some(id) = map.get_mut("id") {
                     apply_renames_to_json_inner(id, renames, reference_node_ids, false);
@@ -3888,7 +3882,7 @@ fn apply_renames_to_json_inner(
                 apply_renames_to_json_inner(val, renames, reference_node_ids, child_is_key);
             }
         }
-        serde_json::Value::Array(arr) => {
+        Value::Array(arr) => {
             for item in arr {
                 apply_renames_to_json_inner(item, renames, reference_node_ids, false);
             }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/extract_scope_declarations_from_destructuring.rs
@@ -10,6 +10,7 @@
 
 use rustc_hash::FxHashSet;
 
+use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_hir::{
     DeclarationId, IdentifierId, IdentifierName, InstructionKind, InstructionValue, LValue,
     ParamPattern, Place, ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock,
@@ -30,7 +31,7 @@ use crate::react_compiler_reactive_scopes::visitors::{
 pub fn extract_scope_declarations_from_destructuring(
     func: &mut ReactiveFunction,
     env: &mut Environment,
-) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+) -> Result<(), CompilerError> {
     let mut declared: FxHashSet<DeclarationId> = FxHashSet::default();
     for param in &func.params {
         let place = match param {
@@ -64,7 +65,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         &mut self,
         scope: &mut ReactiveScopeBlock,
         state: &mut ExtractState,
-    ) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+    ) -> Result<(), CompilerError> {
         let scope_data = &self.env.scopes[scope.scope.0 as usize];
         let decl_ids: Vec<DeclarationId> = scope_data
             .declarations
@@ -84,8 +85,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         &mut self,
         instruction: &mut ReactiveInstruction,
         state: &mut ExtractState,
-    ) -> Result<Transformed<ReactiveStatement>, crate::react_compiler_diagnostics::CompilerError>
-    {
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
         self.visit_instruction(instruction, state)?;
 
         let mut extra_instructions: Option<Vec<ReactiveInstruction>> = None;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/merge_reactive_scopes_that_invalidate_together.rs
@@ -8,9 +8,11 @@
 //!
 //! Corresponds to `src/ReactiveScopes/MergeReactiveScopesThatInvalidateTogether.ts`.
 
+use std::mem::take;
+
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::react_compiler_diagnostics::CompilerError;
+use crate::react_compiler_diagnostics::{CompilerDiagnostic, CompilerError, ErrorCategory};
 use crate::react_compiler_hir::{
     DeclarationId, DependencyPathEntry, EvaluationOrder, InstructionKind, InstructionValue, Place,
     ReactiveBlock, ReactiveFunction, ReactiveScopeBlock, ReactiveScopeDependency,
@@ -105,7 +107,7 @@ impl<'a> ReactiveFunctionTransform for MergeTransform<'a> {
         // If parent has deps and they match, flatten the inner scope
         if let Some(parent_deps) = state.as_ref() {
             if are_equal_dependencies(parent_deps, &scope_deps, self.env) {
-                let instructions = std::mem::take(&mut scope.instructions);
+                let instructions = take(&mut scope.instructions);
                 return Ok(Transformed::ReplaceMany(instructions));
             }
         }
@@ -335,7 +337,7 @@ impl<'a> MergeTransform<'a> {
 
         let mut next_instructions: Vec<ReactiveStatement> = Vec::new();
         let mut index = 0;
-        let all_stmts: Vec<ReactiveStatement> = std::mem::take(block);
+        let all_stmts: Vec<ReactiveStatement> = take(block);
 
         for entry in &merged {
             // Push everything before the merge range
@@ -347,8 +349,8 @@ impl<'a> MergeTransform<'a> {
             let mut merged_scope = match &all_stmts[entry.from] {
                 ReactiveStatement::Scope(s) => s.clone(),
                 _ => {
-                    return Err(crate::react_compiler_diagnostics::CompilerDiagnostic::new(
-                        crate::react_compiler_diagnostics::ErrorCategory::Invariant,
+                    return Err(CompilerDiagnostic::new(
+                        ErrorCategory::Invariant,
                         "MergeConsecutiveScopes: Expected scope at starting index",
                         None,
                     )

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/promote_used_temporaries.rs
@@ -29,6 +29,7 @@ use crate::react_compiler_hir::ReactiveTerminalStatement;
 use crate::react_compiler_hir::ReactiveValue;
 use crate::react_compiler_hir::ScopeId;
 use crate::react_compiler_hir::environment::Environment;
+use crate::react_compiler_hir::visitors::{each_instruction_value_operand, each_pattern_operand};
 
 // =============================================================================
 // State
@@ -183,10 +184,7 @@ fn collect_promotable_value(
     match value {
         ReactiveValue::Instruction(instr_value) => {
             // Visit operands
-            for place in crate::react_compiler_hir::visitors::each_instruction_value_operand(
-                instr_value,
-                env,
-            ) {
+            for place in each_instruction_value_operand(instr_value, env) {
                 collect_promotable_place(&place, state, active_scopes, env);
             }
             // Check for JSX tag
@@ -584,9 +582,7 @@ fn promote_interposed_instruction(
                         if lvalue.kind == InstructionKind::Const
                             || lvalue.kind == InstructionKind::HoistedConst
                         {
-                            for operand in crate::react_compiler_hir::visitors::each_pattern_operand(
-                                &lvalue.pattern,
-                            ) {
+                            for operand in each_pattern_operand(&lvalue.pattern) {
                                 consts.insert(operand.identifier);
                             }
                             const_store = true;
@@ -597,9 +593,7 @@ fn promote_interposed_instruction(
                     }
 
                     // Visit operands
-                    for place in
-                        crate::react_compiler_hir::visitors::each_instruction_value_operand(iv, env)
-                    {
+                    for place in each_instruction_value_operand(iv, env) {
                         promote_interposed_place(&place, state, inter_state, consts, env);
                     }
 
@@ -633,9 +627,7 @@ fn promote_interposed_instruction(
                         consts.insert(lvalue.place.identifier);
                     }
                     // Visit operands
-                    for place in
-                        crate::react_compiler_hir::visitors::each_instruction_value_operand(iv, env)
-                    {
+                    for place in each_instruction_value_operand(iv, env) {
                         promote_interposed_place(&place, state, inter_state, consts, env);
                     }
                 }
@@ -651,9 +643,7 @@ fn promote_interposed_instruction(
                         }
                     }
                     // Visit operands
-                    for place in
-                        crate::react_compiler_hir::visitors::each_instruction_value_operand(iv, env)
-                    {
+                    for place in each_instruction_value_operand(iv, env) {
                         promote_interposed_place(&place, state, inter_state, consts, env);
                     }
                 }
@@ -670,9 +660,7 @@ fn promote_interposed_instruction(
                         }
                     }
                     // Visit operands
-                    for place in
-                        crate::react_compiler_hir::visitors::each_instruction_value_operand(iv, env)
-                    {
+                    for place in each_instruction_value_operand(iv, env) {
                         promote_interposed_place(&place, state, inter_state, consts, env);
                     }
                 }
@@ -681,17 +669,13 @@ fn promote_interposed_instruction(
                         globals.insert(lvalue.identifier);
                     }
                     // Visit operands
-                    for place in
-                        crate::react_compiler_hir::visitors::each_instruction_value_operand(iv, env)
-                    {
+                    for place in each_instruction_value_operand(iv, env) {
                         promote_interposed_place(&place, state, inter_state, consts, env);
                     }
                 }
                 _ => {
                     // Default: visit operands
-                    for place in
-                        crate::react_compiler_hir::visitors::each_instruction_value_operand(iv, env)
-                    {
+                    for place in each_instruction_value_operand(iv, env) {
                         promote_interposed_place(&place, state, inter_state, consts, env);
                     }
                 }
@@ -728,9 +712,7 @@ fn promote_interposed_value(
 ) {
     match value {
         ReactiveValue::Instruction(iv) => {
-            for place in
-                crate::react_compiler_hir::visitors::each_instruction_value_operand(iv, env)
-            {
+            for place in each_instruction_value_operand(iv, env) {
                 promote_interposed_place(&place, state, inter_state, consts, env);
             }
         }
@@ -916,9 +898,7 @@ fn promote_all_instances_instruction(
 fn promote_all_instances_value(value: &ReactiveValue, state: &mut State, env: &mut Environment) {
     match value {
         ReactiveValue::Instruction(iv) => {
-            for place in
-                crate::react_compiler_hir::visitors::each_instruction_value_operand(iv, env)
-            {
+            for place in each_instruction_value_operand(iv, env) {
                 promote_all_instances_place(&place, state, env);
             }
             // Visit inner functions

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/propagate_early_returns.rs
@@ -10,6 +10,9 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PropagateEarlyReturns.ts`.
 
+use std::mem::take;
+
+use crate::react_compiler_diagnostics::{CompilerError, SourceLocation};
 use crate::react_compiler_hir::{
     BlockId, Effect, EvaluationOrder, IdentifierId, IdentifierName, InstructionKind,
     InstructionValue, LValue, NonLocalBinding, Place, PlaceOrSpread, PrimitiveValue,
@@ -17,7 +20,6 @@ use crate::react_compiler_hir::{
     ReactiveScopeDeclaration, ReactiveScopeEarlyReturn, ReactiveStatement, ReactiveTerminal,
     ReactiveTerminalStatement, ReactiveTerminalTargetKind, ReactiveValue, environment::Environment,
 };
-
 use crate::react_compiler_reactive_scopes::visitors::{
     ReactiveFunctionTransform, Transformed, transform_reactive_function,
 };
@@ -46,7 +48,7 @@ pub fn propagate_early_returns(func: &mut ReactiveFunction, env: &mut Environmen
 #[derive(Debug, Clone)]
 struct EarlyReturnInfo {
     value: IdentifierId,
-    loc: Option<crate::react_compiler_diagnostics::SourceLocation>,
+    loc: Option<SourceLocation>,
     label: BlockId,
 }
 
@@ -76,7 +78,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         &mut self,
         scope_block: &mut ReactiveScopeBlock,
         parent_state: &mut State,
-    ) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+    ) -> Result<(), CompilerError> {
         let scope_id = scope_block.scope;
 
         // Exit early if an earlier pass has already created an early return
@@ -108,8 +110,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement,
         state: &mut State,
-    ) -> Result<Transformed<ReactiveStatement>, crate::react_compiler_diagnostics::CompilerError>
-    {
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
         if state.within_reactive_scope {
             if let ReactiveTerminal::Return { value, .. } = &stmt.terminal {
                 let loc = value.loc;
@@ -201,7 +202,7 @@ fn apply_early_return_to_scope(
     let for_temp = create_temporary_place_id(env, loc);
     let arg_temp = create_temporary_place_id(env, loc);
 
-    let original_instructions = std::mem::take(&mut scope_block.instructions);
+    let original_instructions = take(&mut scope_block.instructions);
 
     scope_block.instructions = vec![
         // LoadGlobal Symbol
@@ -333,10 +334,7 @@ fn apply_early_return_to_scope(
 // Helper: create a temporary place identifier
 // =============================================================================
 
-fn create_temporary_place_id(
-    env: &mut Environment,
-    loc: Option<crate::react_compiler_diagnostics::SourceLocation>,
-) -> IdentifierId {
+fn create_temporary_place_id(env: &mut Environment, loc: Option<SourceLocation>) -> IdentifierId {
     let id = env.next_identifier_id();
     env.identifiers[id.0 as usize].loc = loc;
     id

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_always_invalidating_scopes.rs
@@ -11,8 +11,11 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PruneAlwaysInvalidatingScopes.ts`.
 
+use std::mem::take;
+
 use rustc_hash::FxHashSet;
 
+use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_hir::{
     IdentifierId, InstructionValue, PrunedReactiveScopeBlock, ReactiveFunction,
     ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveValue,
@@ -29,7 +32,7 @@ use crate::react_compiler_reactive_scopes::visitors::{
 pub fn prune_always_invalidating_scopes(
     func: &mut ReactiveFunction,
     env: &Environment,
-) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+) -> Result<(), CompilerError> {
     let mut transform = Transform {
         env,
         always_invalidating_values: FxHashSet::default(),
@@ -56,8 +59,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         &mut self,
         instruction: &mut ReactiveInstruction,
         within_scope: &mut bool,
-    ) -> Result<Transformed<ReactiveStatement>, crate::react_compiler_diagnostics::CompilerError>
-    {
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
         self.visit_instruction(instruction, within_scope)?;
 
         let lvalue = &instruction.lvalue;
@@ -107,8 +109,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         &mut self,
         scope: &mut ReactiveScopeBlock,
         _within_scope: &mut bool,
-    ) -> Result<Transformed<ReactiveStatement>, crate::react_compiler_diagnostics::CompilerError>
-    {
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
         let mut within_scope = true;
         self.visit_scope(scope, &mut within_scope)?;
 
@@ -137,7 +138,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
                 return Ok(Transformed::Replace(ReactiveStatement::PrunedScope(
                     PrunedReactiveScopeBlock {
                         scope: scope.scope,
-                        instructions: std::mem::take(&mut scope.instructions),
+                        instructions: take(&mut scope.instructions),
                     },
                 )));
             }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_hoisted_contexts.rs
@@ -8,7 +8,7 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PruneHoistedContexts.ts`.
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_diagnostics::{CompilerError, CompilerErrorDetail, ErrorCategory};
 use crate::react_compiler_hir::{
@@ -48,7 +48,7 @@ enum UninitializedKind {
 }
 
 struct VisitorState {
-    active_scopes: Vec<rustc_hash::FxHashSet<IdentifierId>>,
+    active_scopes: Vec<FxHashSet<IdentifierId>>,
     uninitialized: FxHashMap<IdentifierId, UninitializedKind>,
 }
 
@@ -80,7 +80,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         state: &mut VisitorState,
     ) -> Result<(), CompilerError> {
         let scope_data = &self.env.scopes[scope.scope.0 as usize];
-        let decl_ids: rustc_hash::FxHashSet<IdentifierId> =
+        let decl_ids: FxHashSet<IdentifierId> =
             scope_data.declarations.iter().map(|(id, _)| *id).collect();
 
         // Add declared but not initialized variables

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_escaping_scopes.rs
@@ -8,9 +8,12 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PruneNonEscapingScopes.ts`.
 
+use std::mem::take;
+
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 
+use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_hir::ArrayPatternElement;
 use crate::react_compiler_hir::DeclarationId;
 use crate::react_compiler_hir::Effect;
@@ -21,6 +24,7 @@ use crate::react_compiler_hir::InstructionValue;
 use crate::react_compiler_hir::JsxAttribute;
 use crate::react_compiler_hir::JsxTag;
 use crate::react_compiler_hir::ObjectPropertyOrSpread;
+use crate::react_compiler_hir::ParamPattern;
 use crate::react_compiler_hir::Pattern;
 use crate::react_compiler_hir::Place;
 use crate::react_compiler_hir::PlaceOrSpread;
@@ -51,14 +55,14 @@ use crate::react_compiler_reactive_scopes::visitors::visit_reactive_function;
 pub fn prune_non_escaping_scopes(
     func: &mut ReactiveFunction,
     env: &mut Environment,
-) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+) -> Result<(), CompilerError> {
     // First build up a map of which instructions are involved in creating which values,
     // and which values are returned.
     let mut state = CollectState::new();
     for param in &func.params {
         let place = match param {
-            crate::react_compiler_hir::ParamPattern::Place(p) => p,
-            crate::react_compiler_hir::ParamPattern::Spread(s) => &s.place,
+            ParamPattern::Place(p) => p,
+            ParamPattern::Spread(s) => &s.place,
         };
         let identifier = &env.identifiers[place.identifier.0 as usize];
         state.declare(identifier.declaration_id);
@@ -1080,8 +1084,7 @@ impl<'a> ReactiveFunctionTransform for PruneScopesTransform<'a> {
         &mut self,
         scope: &mut ReactiveScopeBlock,
         state: &mut FxHashSet<DeclarationId>,
-    ) -> Result<Transformed<ReactiveStatement>, crate::react_compiler_diagnostics::CompilerError>
-    {
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
         self.visit_scope(scope, state)?;
 
         let scope_id = scope.scope;
@@ -1107,7 +1110,7 @@ impl<'a> ReactiveFunctionTransform for PruneScopesTransform<'a> {
             Ok(Transformed::Keep)
         } else {
             self.pruned_scopes.insert(scope_id);
-            Ok(Transformed::ReplaceMany(std::mem::take(&mut scope.instructions)))
+            Ok(Transformed::ReplaceMany(take(&mut scope.instructions)))
         }
     }
 
@@ -1115,8 +1118,7 @@ impl<'a> ReactiveFunctionTransform for PruneScopesTransform<'a> {
         &mut self,
         instruction: &mut ReactiveInstruction,
         state: &mut FxHashSet<DeclarationId>,
-    ) -> Result<Transformed<ReactiveStatement>, crate::react_compiler_diagnostics::CompilerError>
-    {
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
         self.traverse_instruction(instruction, state)?;
 
         match &mut instruction.value {

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_non_reactive_dependencies.rs
@@ -10,9 +10,10 @@
 
 use rustc_hash::FxHashSet;
 
+use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_hir::{
     EvaluationOrder, IdentifierId, InstructionValue, Place, PrunedReactiveScopeBlock,
-    ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveValue,
+    ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveValue, Type,
     environment::Environment, is_primitive_type, is_use_ref_type, object_shape,
     visitors as hir_visitors,
 };
@@ -33,9 +34,7 @@ pub fn collect_reactive_identifiers(
 ) -> FxHashSet<IdentifierId> {
     let visitor = CollectVisitor { env };
     let mut state = FxHashSet::default();
-    crate::react_compiler_reactive_scopes::visitors::visit_reactive_function(
-        func, &visitor, &mut state,
-    );
+    visitors::visit_reactive_function(func, &visitor, &mut state);
     state
 }
 
@@ -77,7 +76,7 @@ impl<'a> ReactiveFunctionVisitor for CollectVisitor<'a> {
 
 /// TS: `isStableRefType`
 fn is_stable_ref_type(
-    ty: &crate::react_compiler_hir::Type,
+    ty: &Type,
     reactive_identifiers: &FxHashSet<IdentifierId>,
     id: IdentifierId,
 ) -> bool {
@@ -89,7 +88,7 @@ fn is_stable_ref_type(
 // =============================================================================
 
 /// TS: `isStableType`
-fn is_stable_type(ty: &crate::react_compiler_hir::Type) -> bool {
+fn is_stable_type(ty: &Type) -> bool {
     is_set_state_type(ty)
         || is_set_action_state_type(ty)
         || is_dispatcher_type(ty)
@@ -98,24 +97,24 @@ fn is_stable_type(ty: &crate::react_compiler_hir::Type) -> bool {
         || is_set_optimistic_type(ty)
 }
 
-fn is_set_state_type(ty: &crate::react_compiler_hir::Type) -> bool {
-    matches!(ty, crate::react_compiler_hir::Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_SET_STATE_ID)
+fn is_set_state_type(ty: &Type) -> bool {
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_SET_STATE_ID)
 }
 
-fn is_set_action_state_type(ty: &crate::react_compiler_hir::Type) -> bool {
-    matches!(ty, crate::react_compiler_hir::Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_SET_ACTION_STATE_ID)
+fn is_set_action_state_type(ty: &Type) -> bool {
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_SET_ACTION_STATE_ID)
 }
 
-fn is_dispatcher_type(ty: &crate::react_compiler_hir::Type) -> bool {
-    matches!(ty, crate::react_compiler_hir::Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_DISPATCH_ID)
+fn is_dispatcher_type(ty: &Type) -> bool {
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_DISPATCH_ID)
 }
 
-fn is_start_transition_type(ty: &crate::react_compiler_hir::Type) -> bool {
-    matches!(ty, crate::react_compiler_hir::Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_START_TRANSITION_ID)
+fn is_start_transition_type(ty: &Type) -> bool {
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_START_TRANSITION_ID)
 }
 
-fn is_set_optimistic_type(ty: &crate::react_compiler_hir::Type) -> bool {
-    matches!(ty, crate::react_compiler_hir::Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_SET_OPTIMISTIC_ID)
+fn is_set_optimistic_type(ty: &Type) -> bool {
+    matches!(ty, Type::Function { shape_id: Some(id), .. } if id == object_shape::BUILT_IN_SET_OPTIMISTIC_ID)
 }
 
 // =============================================================================
@@ -147,7 +146,7 @@ impl<'a> ReactiveFunctionTransform for PruneVisitor<'a> {
         &mut self,
         instruction: &mut ReactiveInstruction,
         state: &mut Self::State,
-    ) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+    ) -> Result<(), CompilerError> {
         self.traverse_instruction(instruction, state)?;
 
         let lvalue = &instruction.lvalue;
@@ -217,7 +216,7 @@ impl<'a> ReactiveFunctionTransform for PruneVisitor<'a> {
         &mut self,
         scope: &mut ReactiveScopeBlock,
         state: &mut Self::State,
-    ) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+    ) -> Result<(), CompilerError> {
         self.traverse_scope(scope, state)?;
 
         let scope_id = scope.scope;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_labels.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_labels.rs
@@ -8,8 +8,11 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PruneUnusedLabels.ts`.
 
+use std::mem::take;
+
 use rustc_hash::FxHashSet;
 
+use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_hir::{
     BlockId, ReactiveFunction, ReactiveStatement, ReactiveTerminal, ReactiveTerminalStatement,
     ReactiveTerminalTargetKind, environment::Environment,
@@ -23,7 +26,7 @@ use crate::react_compiler_reactive_scopes::visitors::{
 pub fn prune_unused_labels(
     func: &mut ReactiveFunction,
     env: &Environment,
-) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+) -> Result<(), CompilerError> {
     let mut transform = Transform { env };
     let mut labels: FxHashSet<BlockId> = FxHashSet::default();
     transform_reactive_function(func, &mut transform, &mut labels)
@@ -44,8 +47,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement,
         state: &mut FxHashSet<BlockId>,
-    ) -> Result<Transformed<ReactiveStatement>, crate::react_compiler_diagnostics::CompilerError>
-    {
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
         // Traverse children first
         self.traverse_terminal(stmt, state)?;
 
@@ -76,7 +78,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
                 // Note: In TS, there's a check for `last.terminal.target === null`
                 // to pop a trailing break, but since target is always a BlockId (number),
                 // that check is always false, so the trailing break is never removed.
-                let flattened = std::mem::take(block);
+                let flattened = take(block);
                 return Ok(Transformed::ReplaceMany(flattened));
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_lvalues.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHashSet;
 
 use crate::react_compiler_hir::{
     DeclarationId, EvaluationOrder, Place, ReactiveFunction, ReactiveInstruction,
-    ReactiveStatement, ReactiveValue, environment::Environment,
+    ReactiveStatement, ReactiveTerminal, ReactiveValue, environment::Environment,
 };
 
 use crate::react_compiler_reactive_scopes::visitors::{self, ReactiveFunctionVisitor};
@@ -150,11 +150,10 @@ fn null_unused_in_value(
 }
 
 fn null_unused_in_terminal(
-    terminal: &mut crate::react_compiler_hir::ReactiveTerminal,
+    terminal: &mut ReactiveTerminal,
     env: &Environment,
     unused: &FxHashSet<DeclarationId>,
 ) {
-    use crate::react_compiler_hir::ReactiveTerminal;
     match terminal {
         ReactiveTerminal::Break { .. } | ReactiveTerminal::Continue { .. } => {}
         ReactiveTerminal::Return { .. } | ReactiveTerminal::Throw { .. } => {}

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_scopes.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/prune_unused_scopes.rs
@@ -7,9 +7,13 @@
 //!
 //! Corresponds to `src/ReactiveScopes/PruneUnusedScopes.ts`.
 
+use std::mem::take;
+
+use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_hir::{
-    PrunedReactiveScopeBlock, ReactiveFunction, ReactiveScopeBlock, ReactiveStatement,
-    ReactiveTerminal, ReactiveTerminalStatement, environment::Environment,
+    PrunedReactiveScopeBlock, ReactiveFunction, ReactiveScope, ReactiveScopeBlock,
+    ReactiveStatement, ReactiveTerminal, ReactiveTerminalStatement, ScopeId,
+    environment::Environment,
 };
 
 use crate::react_compiler_reactive_scopes::visitors::{
@@ -25,7 +29,7 @@ struct State {
 pub fn prune_unused_scopes(
     func: &mut ReactiveFunction,
     env: &Environment,
-) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+) -> Result<(), CompilerError> {
     let mut transform = Transform { env };
     let mut state = State { has_return_statement: false };
     transform_reactive_function(func, &mut transform, &mut state)
@@ -46,7 +50,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement,
         state: &mut State,
-    ) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+    ) -> Result<(), CompilerError> {
         self.traverse_terminal(stmt, state)?;
         if matches!(stmt.terminal, ReactiveTerminal::Return { .. }) {
             state.has_return_statement = true;
@@ -58,8 +62,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
         &mut self,
         scope: &mut ReactiveScopeBlock,
         _state: &mut State,
-    ) -> Result<Transformed<ReactiveStatement>, crate::react_compiler_diagnostics::CompilerError>
-    {
+    ) -> Result<Transformed<ReactiveStatement>, CompilerError> {
         let mut scope_state = State { has_return_statement: false };
         self.visit_scope(scope, &mut scope_state)?;
 
@@ -73,7 +76,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
             // Replace with pruned scope
             Ok(Transformed::Replace(ReactiveStatement::PrunedScope(PrunedReactiveScopeBlock {
                 scope: scope.scope,
-                instructions: std::mem::take(&mut scope.instructions),
+                instructions: take(&mut scope.instructions),
             })))
         } else {
             Ok(Transformed::Keep)
@@ -84,10 +87,7 @@ impl<'a> ReactiveFunctionTransform for Transform<'a> {
 /// Does the scope block declare any values of its own?
 /// Returns false if all declarations are propagated from nested scopes.
 /// TS: `hasOwnDeclaration`
-fn has_own_declaration(
-    scope_data: &crate::react_compiler_hir::ReactiveScope,
-    scope_id: crate::react_compiler_hir::ScopeId,
-) -> bool {
+fn has_own_declaration(scope_data: &ReactiveScope, scope_id: ScopeId) -> bool {
     for (_, decl) in &scope_data.declarations {
         if decl.scope == scope_id {
             return true;

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/rename_variables.rs
@@ -14,6 +14,7 @@ use rustc_hash::FxHashSet;
 use crate::react_compiler_hir::DeclarationId;
 use crate::react_compiler_hir::EvaluationOrder;
 use crate::react_compiler_hir::FunctionId;
+use crate::react_compiler_hir::IdentifierId;
 use crate::react_compiler_hir::IdentifierName;
 use crate::react_compiler_hir::InstructionValue;
 use crate::react_compiler_hir::ParamPattern;
@@ -22,6 +23,9 @@ use crate::react_compiler_hir::PrunedReactiveScopeBlock;
 use crate::react_compiler_hir::ReactiveBlock;
 use crate::react_compiler_hir::ReactiveFunction;
 use crate::react_compiler_hir::ReactiveScopeBlock;
+use crate::react_compiler_hir::ReactiveStatement;
+use crate::react_compiler_hir::ReactiveTerminal;
+use crate::react_compiler_hir::ReactiveTerminalStatement;
 use crate::react_compiler_hir::ReactiveValue;
 use crate::react_compiler_hir::environment::Environment;
 
@@ -49,11 +53,7 @@ impl Scopes {
         }
     }
 
-    fn visit_identifier(
-        &mut self,
-        identifier_id: crate::react_compiler_hir::IdentifierId,
-        env: &Environment,
-    ) {
+    fn visit_identifier(&mut self, identifier_id: IdentifierId, env: &Environment) {
         let identifier = &env.identifiers[identifier_id.0 as usize];
         let original_name = match &identifier.name {
             Some(name) => name.clone(),
@@ -166,7 +166,7 @@ impl ReactiveFunctionVisitor for Visitor<'_> {
     /// TS: `visitScope(scope, state) { for (const [_, decl] of scope.scope.declarations) state.visit(decl.identifier); this.traverseScope(scope, state) }`
     fn visit_scope(&self, scope: &ReactiveScopeBlock, state: &mut Scopes) {
         let scope_data = &self.env.scopes[scope.scope.0 as usize];
-        let decl_ids: Vec<crate::react_compiler_hir::IdentifierId> =
+        let decl_ids: Vec<IdentifierId> =
             scope_data.declarations.iter().map(|(_, d)| d.identifier).collect();
         for id in decl_ids {
             state.visit_identifier(id, self.env);
@@ -270,16 +270,16 @@ fn collect_globals_block(
 ) {
     for stmt in block {
         match stmt {
-            crate::react_compiler_hir::ReactiveStatement::Instruction(instr) => {
+            ReactiveStatement::Instruction(instr) => {
                 collect_globals_value(&instr.value, globals, env);
             }
-            crate::react_compiler_hir::ReactiveStatement::Scope(scope) => {
+            ReactiveStatement::Scope(scope) => {
                 collect_globals_block(&scope.instructions, globals, env);
             }
-            crate::react_compiler_hir::ReactiveStatement::PrunedScope(scope) => {
+            ReactiveStatement::PrunedScope(scope) => {
                 collect_globals_block(&scope.instructions, globals, env);
             }
-            crate::react_compiler_hir::ReactiveStatement::Terminal(terminal) => {
+            ReactiveStatement::Terminal(terminal) => {
                 collect_globals_terminal(terminal, globals, env);
             }
         }
@@ -355,18 +355,14 @@ fn collect_globals_hir_function(
 }
 
 fn collect_globals_terminal(
-    stmt: &crate::react_compiler_hir::ReactiveTerminalStatement,
+    stmt: &ReactiveTerminalStatement,
     globals: &mut FxHashSet<String>,
     env: &Environment,
 ) {
     match &stmt.terminal {
-        crate::react_compiler_hir::ReactiveTerminal::Break { .. }
-        | crate::react_compiler_hir::ReactiveTerminal::Continue { .. } => {}
-        crate::react_compiler_hir::ReactiveTerminal::Return { .. }
-        | crate::react_compiler_hir::ReactiveTerminal::Throw { .. } => {}
-        crate::react_compiler_hir::ReactiveTerminal::For {
-            init, test, update, loop_block, ..
-        } => {
+        ReactiveTerminal::Break { .. } | ReactiveTerminal::Continue { .. } => {}
+        ReactiveTerminal::Return { .. } | ReactiveTerminal::Throw { .. } => {}
+        ReactiveTerminal::For { init, test, update, loop_block, .. } => {
             collect_globals_value(init, globals, env);
             collect_globals_value(test, globals, env);
             collect_globals_block(loop_block, globals, env);
@@ -374,40 +370,40 @@ fn collect_globals_terminal(
                 collect_globals_value(update, globals, env);
             }
         }
-        crate::react_compiler_hir::ReactiveTerminal::ForOf { init, test, loop_block, .. } => {
+        ReactiveTerminal::ForOf { init, test, loop_block, .. } => {
             collect_globals_value(init, globals, env);
             collect_globals_value(test, globals, env);
             collect_globals_block(loop_block, globals, env);
         }
-        crate::react_compiler_hir::ReactiveTerminal::ForIn { init, loop_block, .. } => {
+        ReactiveTerminal::ForIn { init, loop_block, .. } => {
             collect_globals_value(init, globals, env);
             collect_globals_block(loop_block, globals, env);
         }
-        crate::react_compiler_hir::ReactiveTerminal::DoWhile { loop_block, test, .. } => {
+        ReactiveTerminal::DoWhile { loop_block, test, .. } => {
             collect_globals_block(loop_block, globals, env);
             collect_globals_value(test, globals, env);
         }
-        crate::react_compiler_hir::ReactiveTerminal::While { test, loop_block, .. } => {
+        ReactiveTerminal::While { test, loop_block, .. } => {
             collect_globals_value(test, globals, env);
             collect_globals_block(loop_block, globals, env);
         }
-        crate::react_compiler_hir::ReactiveTerminal::If { consequent, alternate, .. } => {
+        ReactiveTerminal::If { consequent, alternate, .. } => {
             collect_globals_block(consequent, globals, env);
             if let Some(alt) = alternate {
                 collect_globals_block(alt, globals, env);
             }
         }
-        crate::react_compiler_hir::ReactiveTerminal::Switch { cases, .. } => {
+        ReactiveTerminal::Switch { cases, .. } => {
             for case in cases {
                 if let Some(block) = &case.block {
                     collect_globals_block(block, globals, env);
                 }
             }
         }
-        crate::react_compiler_hir::ReactiveTerminal::Label { block, .. } => {
+        ReactiveTerminal::Label { block, .. } => {
             collect_globals_block(block, globals, env);
         }
-        crate::react_compiler_hir::ReactiveTerminal::Try { block, handler, .. } => {
+        ReactiveTerminal::Try { block, handler, .. } => {
             collect_globals_block(block, globals, env);
             collect_globals_block(handler, globals, env);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/stabilize_block_ids.rs
@@ -12,6 +12,7 @@
 
 use rustc_hash::FxHashMap;
 
+use crate::react_compiler_diagnostics::CompilerError;
 use crate::react_compiler_hir::{
     BlockId, ReactiveFunction, ReactiveScopeBlock, ReactiveTerminal, ReactiveTerminalStatement,
     environment::Environment,
@@ -101,7 +102,7 @@ impl<'a> ReactiveFunctionTransform for RewriteBlockIds<'a> {
         &mut self,
         scope: &mut ReactiveScopeBlock,
         state: &mut Self::State,
-    ) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+    ) -> Result<(), CompilerError> {
         let scope_data = &mut self.env.scopes[scope.scope.0 as usize];
         if let Some(ref mut early_return) = scope_data.early_return_value {
             early_return.label = get_or_insert_mapping(state, early_return.label);
@@ -113,7 +114,7 @@ impl<'a> ReactiveFunctionTransform for RewriteBlockIds<'a> {
         &mut self,
         stmt: &mut ReactiveTerminalStatement,
         state: &mut Self::State,
-    ) -> Result<(), crate::react_compiler_diagnostics::CompilerError> {
+    ) -> Result<(), CompilerError> {
         if let Some(ref mut label) = stmt.label {
             label.id = get_or_insert_mapping(state, label.id);
         }

--- a/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_reactive_scopes/visitors.rs
@@ -7,7 +7,12 @@
 //!
 //! Corresponds to `src/ReactiveScopes/visitors.ts` in the TypeScript compiler.
 
+use std::mem::replace;
+
 use crate::react_compiler_diagnostics::CompilerError;
+use crate::react_compiler_hir::visitors::{
+    each_instruction_value_lvalue, each_instruction_value_operand, each_terminal_operand,
+};
 use crate::react_compiler_hir::{
     EvaluationOrder, FunctionId, InstructionValue, ParamPattern, Place, PrunedReactiveScopeBlock,
     ReactiveBlock, ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement,
@@ -57,8 +62,7 @@ pub trait ReactiveFunctionVisitor {
             let inner_func = &self.env().functions[func_id.0 as usize];
             let block = &inner_func.body.blocks[&block_id];
             let instr_ids: Vec<_> = block.instructions.clone();
-            let terminal_operands: Vec<Place> =
-                crate::react_compiler_hir::visitors::each_terminal_operand(&block.terminal);
+            let terminal_operands: Vec<Place> = each_terminal_operand(&block.terminal);
             let terminal_id = block.terminal.evaluation_order();
 
             for instr_id in &instr_ids {
@@ -115,10 +119,7 @@ pub trait ReactiveFunctionVisitor {
                 self.visit_value(*seq_id, inner, state);
             }
             ReactiveValue::Instruction(instr_value) => {
-                let operands = crate::react_compiler_hir::visitors::each_instruction_value_operand(
-                    instr_value,
-                    self.env(),
-                );
+                let operands = each_instruction_value_operand(instr_value, self.env());
                 for place in &operands {
                     self.visit_place(id, place, state);
                 }
@@ -138,7 +139,7 @@ pub trait ReactiveFunctionVisitor {
         }
         // Visit value-level lvalues (TS: eachInstructionValueLValue)
         if let ReactiveValue::Instruction(iv) = &instruction.value {
-            for place in crate::react_compiler_hir::visitors::each_instruction_value_lvalue(iv) {
+            for place in each_instruction_value_lvalue(iv) {
                 self.visit_lvalue(instruction.id, &place, state);
             }
         }
@@ -394,10 +395,7 @@ pub trait ReactiveFunctionTransform {
             ReactiveValue::Instruction(instr_value) => {
                 // Collect operands before visiting to avoid borrow conflict
                 // (self.env() borrows self immutably, self.visit_place() needs &mut self).
-                let operands = crate::react_compiler_hir::visitors::each_instruction_value_operand(
-                    instr_value,
-                    self.env(),
-                );
+                let operands = each_instruction_value_operand(instr_value, self.env());
                 for place in &operands {
                     self.visit_place(id, place, state)?;
                 }
@@ -436,7 +434,7 @@ pub trait ReactiveFunctionTransform {
         }
         // Visit value-level lvalues (TS: eachInstructionValueLValue)
         if let ReactiveValue::Instruction(iv) = &instruction.value {
-            for place in crate::react_compiler_hir::visitors::each_instruction_value_lvalue(iv) {
+            for place in each_instruction_value_lvalue(iv) {
                 self.visit_lvalue(instruction.id, &place, state)?;
             }
         }
@@ -644,15 +642,13 @@ pub trait ReactiveFunctionTransform {
         let len = block.len();
         for i in 0..len {
             // Take the statement out temporarily
-            let mut stmt = std::mem::replace(
+            let mut stmt = replace(
                 &mut block[i],
                 // Placeholder — will be overwritten or discarded
                 ReactiveStatement::Instruction(ReactiveInstruction {
                     id: EvaluationOrder(0),
                     lvalue: None,
-                    value: ReactiveValue::Instruction(
-                        crate::react_compiler_hir::InstructionValue::Debugger { loc: None },
-                    ),
+                    value: ReactiveValue::Instruction(InstructionValue::Debugger { loc: None }),
                     effects: None,
                     loc: None,
                 }),

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/eliminate_redundant_phi.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/eliminate_redundant_phi.rs
@@ -1,3 +1,5 @@
+use std::mem::replace;
+
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_hir::environment::Environment;
@@ -131,10 +133,8 @@ fn eliminate_redundant_phi_impl(
                     }
 
                     // Take inner function out, process it, put it back
-                    let mut inner_func = std::mem::replace(
-                        &mut env.functions[fid.0 as usize],
-                        placeholder_function(),
-                    );
+                    let mut inner_func =
+                        replace(&mut env.functions[fid.0 as usize], placeholder_function());
 
                     eliminate_redundant_phi_impl(&mut inner_func, env, rewrites);
 

--- a/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_ssa/enter_ssa.rs
@@ -1,3 +1,5 @@
+use std::mem::{replace, take};
+
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_diagnostics::{
@@ -309,7 +311,7 @@ fn enter_ssa_impl(
                     None,
                 ));
             }
-            let params = std::mem::take(&mut func.params);
+            let params = take(&mut func.params);
             let mut new_params = Vec::with_capacity(params.len());
             for param in params {
                 new_params.push(match param {
@@ -342,7 +344,7 @@ fn enter_ssa_impl(
 
             // Map context places for function expressions before other operands
             if let Some(fid) = func_expr_id {
-                let context = std::mem::take(&mut env.functions[fid.0 as usize].context);
+                let context = take(&mut env.functions[fid.0 as usize].context);
                 env.functions[fid.0 as usize].context =
                     context.into_iter().map(|place| builder.get_place(&place, env)).collect();
             }
@@ -397,7 +399,7 @@ fn enter_ssa_impl(
                 let saved_current = builder.current;
 
                 // Map inner function params
-                let inner_params = std::mem::take(&mut env.functions[fid.0 as usize].params);
+                let inner_params = take(&mut env.functions[fid.0 as usize].params);
                 let mut new_inner_params = Vec::with_capacity(inner_params.len());
                 for param in inner_params {
                     new_inner_params.push(match param {
@@ -413,7 +415,7 @@ fn enter_ssa_impl(
 
                 // Take the inner function out of the arena to process it
                 let mut inner_func =
-                    std::mem::replace(&mut env.functions[fid.0 as usize], placeholder_function());
+                    replace(&mut env.functions[fid.0 as usize], placeholder_function());
 
                 enter_ssa_impl(&mut inner_func, builder, env, root_entry)?;
 

--- a/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_typeinference/infer_types.rs
@@ -8,6 +8,8 @@
 //! Generates type equations from the HIR, unifies them, and applies the
 //! resolved types back to identifiers. Analogous to TS `InferTypes.ts`.
 
+use std::mem::replace;
+
 use rustc_hash::FxHashMap;
 
 use crate::react_compiler_diagnostics::{CompilerDiagnostic, ErrorCategory};
@@ -18,11 +20,11 @@ use crate::react_compiler_hir::object_shape::{
     BUILT_IN_USE_REF_ID, ShapeRegistry,
 };
 use crate::react_compiler_hir::{
-    ArrayPatternElement, BinaryOperator, FunctionId, HirFunction, Identifier, IdentifierId,
-    IdentifierName, InstructionId, InstructionKind, InstructionValue, JsxAttribute,
-    LoweredFunction, ManualMemoDependencyRoot, NonLocalBinding, ObjectPropertyKey,
-    ObjectPropertyOrSpread, ParamPattern, Pattern, PropertyLiteral, PropertyNameKind,
-    ReactFunctionType, SourceLocation, Terminal, Type, TypeId,
+    ArrayElement, ArrayPatternElement, BinaryOperator, FunctionId, HirFunction, Identifier,
+    IdentifierId, IdentifierName, Instruction, InstructionId, InstructionKind, InstructionValue,
+    JsxAttribute, JsxTag, LoweredFunction, ManualMemoDependencyRoot, NonLocalBinding,
+    ObjectPropertyKey, ObjectPropertyOrSpread, ParamPattern, Pattern, PlaceOrSpread,
+    PropertyLiteral, PropertyNameKind, ReactFunctionType, SourceLocation, Terminal, Type, TypeId,
 };
 use crate::react_compiler_ssa::enter_ssa::placeholder_function;
 
@@ -385,7 +387,7 @@ fn generate_for_function_id(
     unifier: &mut Unifier,
 ) -> Result<(), CompilerDiagnostic> {
     // Take the function out temporarily to avoid borrow conflicts
-    let inner = std::mem::replace(&mut functions[func_id.0 as usize], placeholder_function());
+    let inner = replace(&mut functions[func_id.0 as usize], placeholder_function());
 
     // Process params for component inner functions
     if inner.fn_type == ReactFunctionType::Component {
@@ -458,7 +460,7 @@ fn generate_for_function_id(
 }
 
 fn generate_instruction_types(
-    instr: &crate::react_compiler_hir::Instruction,
+    instr: &Instruction,
     instr_id: InstructionId,
     function_key: u32,
     identifiers: &[Identifier],
@@ -1011,10 +1013,10 @@ fn apply_instruction_operands(
             resolve_identifier(callee.identifier, identifiers, types, unifier);
             for arg in args {
                 match arg {
-                    crate::react_compiler_hir::PlaceOrSpread::Place(p) => {
+                    PlaceOrSpread::Place(p) => {
                         resolve_identifier(p.identifier, identifiers, types, unifier);
                     }
-                    crate::react_compiler_hir::PlaceOrSpread::Spread(s) => {
+                    PlaceOrSpread::Spread(s) => {
                         resolve_identifier(s.place.identifier, identifiers, types, unifier);
                     }
                 }
@@ -1025,10 +1027,10 @@ fn apply_instruction_operands(
             resolve_identifier(property.identifier, identifiers, types, unifier);
             for arg in args {
                 match arg {
-                    crate::react_compiler_hir::PlaceOrSpread::Place(p) => {
+                    PlaceOrSpread::Place(p) => {
                         resolve_identifier(p.identifier, identifiers, types, unifier);
                     }
-                    crate::react_compiler_hir::PlaceOrSpread::Spread(s) => {
+                    PlaceOrSpread::Spread(s) => {
                         resolve_identifier(s.place.identifier, identifiers, types, unifier);
                     }
                 }
@@ -1038,10 +1040,10 @@ fn apply_instruction_operands(
             resolve_identifier(callee.identifier, identifiers, types, unifier);
             for arg in args {
                 match arg {
-                    crate::react_compiler_hir::PlaceOrSpread::Place(p) => {
+                    PlaceOrSpread::Place(p) => {
                         resolve_identifier(p.identifier, identifiers, types, unifier);
                     }
-                    crate::react_compiler_hir::PlaceOrSpread::Spread(s) => {
+                    PlaceOrSpread::Spread(s) => {
                         resolve_identifier(s.place.identifier, identifiers, types, unifier);
                     }
                 }
@@ -1094,18 +1096,18 @@ fn apply_instruction_operands(
         InstructionValue::ArrayExpression { elements, .. } => {
             for elem in elements {
                 match elem {
-                    crate::react_compiler_hir::ArrayElement::Place(p) => {
+                    ArrayElement::Place(p) => {
                         resolve_identifier(p.identifier, identifiers, types, unifier);
                     }
-                    crate::react_compiler_hir::ArrayElement::Spread(s) => {
+                    ArrayElement::Spread(s) => {
                         resolve_identifier(s.place.identifier, identifiers, types, unifier);
                     }
-                    crate::react_compiler_hir::ArrayElement::Hole => {}
+                    ArrayElement::Hole => {}
                 }
             }
         }
         InstructionValue::JsxExpression { tag, props, children, .. } => {
-            if let crate::react_compiler_hir::JsxTag::Place(p) = tag {
+            if let JsxTag::Place(p) = tag {
                 resolve_identifier(p.identifier, identifiers, types, unifier);
             }
             for attr in props {

--- a/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_utils/mod.rs
@@ -1,8 +1,11 @@
+use indexmap::{IndexMap, IndexSet};
+use rustc_hash::FxBuildHasher;
+
 pub mod disjoint_set;
 
 pub use disjoint_set::DisjointSet;
 
 /// `IndexMap` keyed with the fast `FxHasher` (rustc-hash) instead of the default SipHash.
-pub type FxIndexMap<K, V> = indexmap::IndexMap<K, V, rustc_hash::FxBuildHasher>;
+pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
 /// `IndexSet` keyed with the fast `FxHasher` (rustc-hash) instead of the default SipHash.
-pub type FxIndexSet<T> = indexmap::IndexSet<T, rustc_hash::FxBuildHasher>;
+pub type FxIndexSet<T> = IndexSet<T, FxBuildHasher>;

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_context_variable_lvalues.rs
@@ -1,4 +1,6 @@
 use rustc_hash::FxHashMap;
+use std::fmt::Display;
+use std::fmt::Formatter;
 
 use crate::react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, CompilerError, ErrorCategory,
@@ -17,8 +19,8 @@ enum VarRefKind {
     Destructure,
 }
 
-impl std::fmt::Display for VarRefKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for VarRefKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             VarRefKind::Local => write!(f, "local"),
             VarRefKind::Context => write!(f, "context"),

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_exhaustive_dependencies.rs
@@ -1,3 +1,6 @@
+use std::cmp::Ordering;
+use std::mem::{replace, take};
+
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_diagnostics::{
@@ -11,7 +14,7 @@ use crate::react_compiler_hir::visitors::{
     each_terminal_operand,
 };
 use crate::react_compiler_hir::{
-    ArrayElement, BlockId, DependencyPathEntry, HirFunction, Identifier, IdentifierId,
+    ArrayElement, BlockId, DependencyPathEntry, Effect, HirFunction, Identifier, IdentifierId,
     InstructionKind, InstructionValue, ManualMemoDependency, ManualMemoDependencyRoot,
     NonLocalBinding, ParamPattern, Place, PlaceOrSpread, PropertyLiteral, Terminal, Type,
 };
@@ -729,9 +732,9 @@ fn collect_dependencies(
                         });
                         // Save current state and clear, matching TS which clears the shared
                         // dependencies/locals sets on StartMemoize
-                        saved_dependencies = Some(std::mem::take(&mut dependencies));
-                        saved_dep_keys = Some(std::mem::take(&mut dep_keys));
-                        saved_locals = Some(std::mem::take(&mut locals));
+                        saved_dependencies = Some(take(&mut dependencies));
+                        saved_dep_keys = Some(take(&mut dep_keys));
+                        saved_locals = Some(take(&mut locals));
                     }
                 }
                 InstructionValue::FinishMemoize { manual_memo_id, decl, .. } => {
@@ -779,8 +782,8 @@ fn collect_dependencies(
                             // We restore instead of just clearing because we need the outer deps back
                             if let Some(saved) = saved_dependencies.take() {
                                 // Merge current memo-block deps into the restored outer deps
-                                let memo_deps = std::mem::replace(&mut dependencies, saved);
-                                let _memo_keys = std::mem::replace(
+                                let memo_deps = replace(&mut dependencies, saved);
+                                let _memo_keys = replace(
                                     &mut dep_keys,
                                     saved_dep_keys.take().unwrap_or_default(),
                                 );
@@ -878,18 +881,18 @@ fn collect_dependencies(
                                                         loc,
                                                         ..
                                                     } => ManualMemoDependency {
-                                                        root: ManualMemoDependencyRoot::NamedLocal {
-                                                            value: Place {
-                                                                identifier: *identifier,
-                                                                effect:
-                                                                    crate::react_compiler_hir::Effect::Read,
-                                                                reactive: cb
-                                                                    .reactive
-                                                                    .contains(identifier),
-                                                                loc: *loc,
+                                                        root:
+                                                            ManualMemoDependencyRoot::NamedLocal {
+                                                                value: Place {
+                                                                    identifier: *identifier,
+                                                                    effect: Effect::Read,
+                                                                    reactive: cb
+                                                                        .reactive
+                                                                        .contains(identifier),
+                                                                    loc: *loc,
+                                                                },
+                                                                constant: false,
                                                             },
-                                                            constant: false,
-                                                        },
                                                         path: path.clone(),
                                                         loc: *loc,
                                                     },
@@ -987,18 +990,18 @@ fn collect_dependencies(
                                                         loc,
                                                         ..
                                                     } => ManualMemoDependency {
-                                                        root: ManualMemoDependencyRoot::NamedLocal {
-                                                            value: Place {
-                                                                identifier: *identifier,
-                                                                effect:
-                                                                    crate::react_compiler_hir::Effect::Read,
-                                                                reactive: cb
-                                                                    .reactive
-                                                                    .contains(identifier),
-                                                                loc: *loc,
+                                                        root:
+                                                            ManualMemoDependencyRoot::NamedLocal {
+                                                                value: Place {
+                                                                    identifier: *identifier,
+                                                                    effect: Effect::Read,
+                                                                    reactive: cb
+                                                                        .reactive
+                                                                        .contains(identifier),
+                                                                    loc: *loc,
+                                                                },
+                                                                constant: false,
                                                             },
-                                                            constant: false,
-                                                        },
                                                         path: path.clone(),
                                                         loc: *loc,
                                                     },
@@ -1141,14 +1144,14 @@ fn validate_dependencies(
                                 }
                                 let prop_cmp =
                                     ap.property.to_string().cmp(&bp.property.to_string());
-                                if prop_cmp != std::cmp::Ordering::Equal {
+                                if prop_cmp != Ordering::Equal {
                                     return prop_cmp;
                                 }
                             }
-                            std::cmp::Ordering::Equal
+                            Ordering::Equal
                         }
                     }
-                    _ => std::cmp::Ordering::Equal,
+                    _ => Ordering::Equal,
                 }
             }
             (
@@ -1159,7 +1162,7 @@ fn validate_dependencies(
                 let b_name = get_identifier_name(*b_id, identifiers);
                 match b_name.as_deref() {
                     Some(bn) => a_name.cmp(bn),
-                    None => std::cmp::Ordering::Equal,
+                    None => Ordering::Equal,
                 }
             }
             (
@@ -1170,7 +1173,7 @@ fn validate_dependencies(
                 let b_name = bb.name();
                 match a_name.as_deref() {
                     Some(an) => an.cmp(b_name),
-                    None => std::cmp::Ordering::Equal,
+                    None => Ordering::Equal,
                 }
             }
         }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_hooks_usage.rs
@@ -10,6 +10,8 @@
 //! and not called dynamically. Also validates that hooks are not
 //! called inside function expressions.
 
+use std::iter::once;
+
 use rustc_hash::FxHashMap;
 
 use crate::react_compiler_diagnostics::{
@@ -21,7 +23,7 @@ use crate::react_compiler_hir::object_shape::HookKind;
 use crate::react_compiler_hir::visitors::{each_pattern_operand, each_terminal_operand};
 use crate::react_compiler_hir::{
     FunctionId, HirFunction, Identifier, IdentifierId, InstructionValue, ParamPattern, Place,
-    PropertyLiteral, Type, visitors,
+    PlaceOrSpread, PropertyLiteral, Type, visitors,
 };
 use crate::react_compiler_utils::FxIndexMap;
 
@@ -193,7 +195,7 @@ fn record_dynamic_hook_usage_error(
 pub fn validate_hooks_usage(
     func: &HirFunction,
     env: &mut Environment,
-) -> Result<(), crate::react_compiler_diagnostics::CompilerDiagnostic> {
+) -> Result<(), CompilerDiagnostic> {
     let unconditional_blocks = compute_unconditional_blocks(func, env.next_block_id().0)?;
     let mut errors_by_loc: FxIndexMap<SourceLocation, CompilerErrorDetail> = FxIndexMap::default();
     let mut value_kinds: FxHashMap<IdentifierId, Kind> = FxHashMap::default();
@@ -312,8 +314,8 @@ pub fn validate_hooks_usage(
                     // Visit all operands except callee
                     for arg in args {
                         let place = match arg {
-                            crate::react_compiler_hir::PlaceOrSpread::Place(p) => p,
-                            crate::react_compiler_hir::PlaceOrSpread::Spread(s) => &s.place,
+                            PlaceOrSpread::Place(p) => p,
+                            PlaceOrSpread::Spread(s) => &s.place,
                         };
                         visit_place(place, &value_kinds, &mut errors_by_loc, env)?;
                     }
@@ -336,8 +338,8 @@ pub fn validate_hooks_usage(
                     visit_place(receiver, &value_kinds, &mut errors_by_loc, env)?;
                     for arg in args {
                         let place = match arg {
-                            crate::react_compiler_hir::PlaceOrSpread::Place(p) => p,
-                            crate::react_compiler_hir::PlaceOrSpread::Spread(s) => &s.place,
+                            PlaceOrSpread::Place(p) => p,
+                            PlaceOrSpread::Spread(s) => &s.place,
                         };
                         visit_place(place, &value_kinds, &mut errors_by_loc, env)?;
                     }
@@ -347,8 +349,7 @@ pub fn validate_hooks_usage(
                     let object_kind = get_kind_for_place(value, &value_kinds, &env.identifiers);
                     // Process instr.lvalue and all pattern operands (matching TS eachInstructionLValue)
                     let pattern_places = each_pattern_operand(&lvalue.pattern);
-                    let all_lvalues =
-                        std::iter::once(instr.lvalue.clone()).chain(pattern_places.into_iter());
+                    let all_lvalues = once(instr.lvalue.clone()).chain(pattern_places.into_iter());
                     for place in all_lvalues {
                         let is_hook_property =
                             ident_is_hook_name(place.identifier, &env.identifiers);

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_derived_computations_in_effects.rs
@@ -16,6 +16,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, CompilerError, CompilerErrorDetail, ErrorCategory,
 };
+use crate::react_compiler_hir::BasicBlock;
+use crate::react_compiler_hir::Instruction;
+use crate::react_compiler_hir::Terminal;
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::visitors::{
     each_instruction_lvalue_ids, each_instruction_operand as canonical_each_instruction_operand,
@@ -308,7 +311,7 @@ fn get_root_set_state(
 }
 
 fn maybe_record_set_state_for_instr(
-    instr: &crate::react_compiler_hir::Instruction,
+    instr: &Instruction,
     env: &Environment,
     set_state_loads: &mut FxHashMap<IdentifierId, Option<IdentifierId>>,
     set_state_usages: &mut FxHashMap<IdentifierId, FxHashSet<LocKey>>,
@@ -450,11 +453,7 @@ pub fn validate_no_derived_computations_in_effects_exp(
     Ok(errors)
 }
 
-fn record_phi_derivations(
-    block: &crate::react_compiler_hir::BasicBlock,
-    context: &mut ValidationContext,
-    env: &Environment,
-) {
+fn record_phi_derivations(block: &BasicBlock, context: &mut ValidationContext, env: &Environment) {
     let identifiers = &env.identifiers;
     for phi in &block.phis {
         let mut type_of_value = TypeOfValue::Ignored;
@@ -482,7 +481,7 @@ fn record_phi_derivations(
 }
 
 fn record_instruction_derivations(
-    instr: &crate::react_compiler_hir::Instruction,
+    instr: &Instruction,
     context: &mut ValidationContext,
     is_first_pass: bool,
     _outer_func: &HirFunction,
@@ -527,10 +526,8 @@ fn record_instruction_derivations(
         InstructionValue::CallExpression { callee, args, .. } => {
             let callee_type = &types[identifiers[callee.identifier.0 as usize].type_.0 as usize];
             if is_use_effect_hook_type(callee_type) && args.len() == 2 {
-                if let (
-                    crate::react_compiler_hir::PlaceOrSpread::Place(arg0),
-                    crate::react_compiler_hir::PlaceOrSpread::Place(arg1),
-                ) = (&args[0], &args[1])
+                if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
+                    (&args[0], &args[1])
                 {
                     let effect_function = context.functions.get(&arg0.identifier).copied();
                     let deps = context.candidate_dependencies.get(&arg1.identifier).cloned();
@@ -560,10 +557,8 @@ fn record_instruction_derivations(
         InstructionValue::MethodCall { property, args, .. } => {
             let prop_type = &types[identifiers[property.identifier.0 as usize].type_.0 as usize];
             if is_use_effect_hook_type(prop_type) && args.len() == 2 {
-                if let (
-                    crate::react_compiler_hir::PlaceOrSpread::Place(arg0),
-                    crate::react_compiler_hir::PlaceOrSpread::Place(arg1),
-                ) = (&args[0], &args[1])
+                if let (PlaceOrSpread::Place(arg0), PlaceOrSpread::Place(arg1)) =
+                    (&args[0], &args[1])
                 {
                     let effect_function = context.functions.get(&arg0.identifier).copied();
                     let deps = context.candidate_dependencies.get(&arg1.identifier).cloned();
@@ -682,7 +677,7 @@ struct OperandWithEffect {
 /// Collects operand (IdentifierId, loc) pairs from an instruction.
 /// Thin wrapper around canonical `each_instruction_operand` that maps Places to (id, loc) pairs.
 fn each_instruction_operand(
-    instr: &crate::react_compiler_hir::Instruction,
+    instr: &Instruction,
     env: &Environment,
 ) -> Vec<(IdentifierId, Option<SourceLocation>)> {
     canonical_each_instruction_operand(instr, env)
@@ -694,7 +689,7 @@ fn each_instruction_operand(
 /// Collects operands with their effects.
 /// Thin wrapper around canonical `each_instruction_operand` that maps Places to OperandWithEffect.
 fn each_instruction_operand_with_effect(
-    instr: &crate::react_compiler_hir::Instruction,
+    instr: &Instruction,
     env: &Environment,
 ) -> Vec<OperandWithEffect> {
     canonical_each_instruction_operand(instr, env)
@@ -882,11 +877,8 @@ fn validate_effect(
 
     for (_block_id, block) in &effect_function.body.blocks {
         // Check for return -> cleanup function
-        if let crate::react_compiler_hir::Terminal::Return {
-            value,
-            return_variant: ReturnVariant::Explicit,
-            ..
-        } = &block.terminal
+        if let Terminal::Return { value, return_variant: ReturnVariant::Explicit, .. } =
+            &block.terminal
         {
             let func_id = context.functions.get(&value.identifier).copied();
             cleanup_function_deps = get_fn_local_deps(func_id, env);
@@ -937,7 +929,7 @@ fn validate_effect(
                     let callee_type =
                         &types[identifiers[callee.identifier.0 as usize].type_.0 as usize];
                     if is_set_state_type(callee_type) && args.len() == 1 {
-                        if let crate::react_compiler_hir::PlaceOrSpread::Place(arg0) = &args[0] {
+                        if let PlaceOrSpread::Place(arg0) = &args[0] {
                             let callee_metadata =
                                 context.derivation_cache.cache.get(&callee.identifier);
 
@@ -1313,19 +1305,17 @@ fn validate_effect_non_exp(
         }
 
         match &block.terminal {
-            crate::react_compiler_hir::Terminal::Return { value, .. }
-            | crate::react_compiler_hir::Terminal::Throw { value, .. } => {
+            Terminal::Return { value, .. } | Terminal::Throw { value, .. } => {
                 if dep_values.contains_key(&value.identifier) {
                     return Vec::new();
                 }
             }
-            crate::react_compiler_hir::Terminal::If { test, .. }
-            | crate::react_compiler_hir::Terminal::Branch { test, .. } => {
+            Terminal::If { test, .. } | Terminal::Branch { test, .. } => {
                 if dep_values.contains_key(&test.identifier) {
                     return Vec::new();
                 }
             }
-            crate::react_compiler_hir::Terminal::Switch { test, .. } => {
+            Terminal::Switch { test, .. } => {
                 if dep_values.contains_key(&test.identifier) {
                     return Vec::new();
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_ref_access_in_render.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::react_compiler_diagnostics::{
@@ -10,8 +12,8 @@ use crate::react_compiler_hir::visitors::{
     each_pattern_operand, each_terminal_operand,
 };
 use crate::react_compiler_hir::{
-    AliasingEffect, BlockId, HirFunction, Identifier, IdentifierId, InstructionValue, Place,
-    PrimitiveValue, PropertyLiteral, Terminal, Type, UnaryOperator,
+    AliasingEffect, BlockId, HirFunction, Identifier, IdentifierId, InstructionValue, ParamPattern,
+    Place, PrimitiveValue, PropertyLiteral, Terminal, Type, UnaryOperator, is_use_ref_type,
 };
 
 const ERROR_DESCRIPTION: &str = "React refs are values that are not needed for rendering. \
@@ -23,10 +25,10 @@ const ERROR_DESCRIPTION: &str = "React refs are values that are not needed for r
 
 type RefId = u32;
 
-static REF_ID_COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+static REF_ID_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 fn next_ref_id() -> RefId {
-    REF_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    REF_ID_COUNTER.fetch_add(1, Ordering::Relaxed)
 }
 
 // --- RefAccessType / RefAccessRefType / RefFnType ---
@@ -257,7 +259,7 @@ fn ref_type_of_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]
     let ty = &types[identifier.type_.0 as usize];
     if crate::react_compiler_hir::is_ref_value_type(ty) {
         RefAccessType::RefValue { loc: None, ref_id: None }
-    } else if crate::react_compiler_hir::is_use_ref_type(ty) {
+    } else if is_use_ref_type(ty) {
         RefAccessType::Ref { ref_id: next_ref_id() }
     } else {
         RefAccessType::None
@@ -266,7 +268,7 @@ fn ref_type_of_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]
 
 fn is_ref_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]) -> bool {
     let identifier = &identifiers[id.0 as usize];
-    crate::react_compiler_hir::is_use_ref_type(&types[identifier.type_.0 as usize])
+    is_use_ref_type(&types[identifier.type_.0 as usize])
 }
 
 fn is_ref_value_type(id: IdentifierId, identifiers: &[Identifier], types: &[Type]) -> bool {
@@ -529,8 +531,8 @@ fn validate_no_ref_access_in_render_impl(
     // Process params
     for param in &func.params {
         let place = match param {
-            crate::react_compiler_hir::ParamPattern::Place(p) => p,
-            crate::react_compiler_hir::ParamPattern::Spread(s) => &s.place,
+            ParamPattern::Place(p) => p,
+            ParamPattern::Spread(s) => &s.place,
         };
         ref_env.set(place.identifier, ref_type_of_type(place.identifier, identifiers, types));
     }
@@ -1128,7 +1130,7 @@ fn validate_no_ref_access_in_render_impl(
 
     if ref_env.has_changed() {
         errors.push(CompilerDiagnostic::new(
-            crate::react_compiler_diagnostics::ErrorCategory::Invariant,
+            ErrorCategory::Invariant,
             "Ref type environment did not converge",
             None,
         ));

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_effects.rs
@@ -17,6 +17,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::react_compiler_diagnostics::{
     CompilerDiagnostic, CompilerDiagnosticDetail, CompilerError, ErrorCategory,
 };
+use crate::react_compiler_hir::ArrayPatternElement;
+use crate::react_compiler_hir::ObjectPropertyOrSpread;
+use crate::react_compiler_hir::Pattern;
 use crate::react_compiler_hir::dominator::{compute_post_dominator_tree, post_dominator_frontier};
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
@@ -242,31 +245,28 @@ fn push_error(errors: &mut CompilerError, info: &SetStateInfo, enable_verbose: b
 }
 
 /// Recursively collect all Place identifiers from a destructure pattern.
-fn collect_destructure_places(
-    pattern: &crate::react_compiler_hir::Pattern,
-    ref_derived_values: &mut FxHashSet<IdentifierId>,
-) {
+fn collect_destructure_places(pattern: &Pattern, ref_derived_values: &mut FxHashSet<IdentifierId>) {
     match pattern {
-        crate::react_compiler_hir::Pattern::Array(arr) => {
+        Pattern::Array(arr) => {
             for item in &arr.items {
                 match item {
-                    crate::react_compiler_hir::ArrayPatternElement::Place(p) => {
+                    ArrayPatternElement::Place(p) => {
                         ref_derived_values.insert(p.identifier);
                     }
-                    crate::react_compiler_hir::ArrayPatternElement::Spread(s) => {
+                    ArrayPatternElement::Spread(s) => {
                         ref_derived_values.insert(s.place.identifier);
                     }
-                    crate::react_compiler_hir::ArrayPatternElement::Hole => {}
+                    ArrayPatternElement::Hole => {}
                 }
             }
         }
-        crate::react_compiler_hir::Pattern::Object(obj) => {
+        Pattern::Object(obj) => {
             for prop in &obj.properties {
                 match prop {
-                    crate::react_compiler_hir::ObjectPropertyOrSpread::Property(p) => {
+                    ObjectPropertyOrSpread::Property(p) => {
                         ref_derived_values.insert(p.place.identifier);
                     }
-                    crate::react_compiler_hir::ObjectPropertyOrSpread::Spread(s) => {
+                    ObjectPropertyOrSpread::Spread(s) => {
                         ref_derived_values.insert(s.place.identifier);
                     }
                 }

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_render.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_no_set_state_in_render.rs
@@ -14,6 +14,7 @@ use crate::react_compiler_diagnostics::{
 };
 use crate::react_compiler_hir::dominator::compute_unconditional_blocks;
 use crate::react_compiler_hir::environment::Environment;
+use crate::react_compiler_hir::is_set_state_type;
 use crate::react_compiler_hir::{
     BlockId, HirFunction, Identifier, IdentifierId, InstructionValue, Type,
 };
@@ -46,7 +47,7 @@ fn is_set_state_id(
 ) -> bool {
     let ident = &identifiers[identifier_id.0 as usize];
     let ty = &types[ident.type_.0 as usize];
-    crate::react_compiler_hir::is_set_state_type(ty)
+    is_set_state_type(ty)
 }
 
 fn validate_impl(

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -16,6 +16,10 @@ use crate::react_compiler_diagnostics::{
 };
 use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
+    ArrayPatternElement, Effect, ObjectPropertyOrSpread, Pattern, PropertyLiteral,
+    PrunedReactiveScopeBlock, ReactiveTerminalStatement,
+};
+use crate::react_compiler_hir::{
     DeclarationId, DependencyPathEntry, Identifier, IdentifierId, IdentifierName, InstructionKind,
     InstructionValue, ManualMemoDependency, ManualMemoDependencyRoot, Place, ReactiveBlock,
     ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveTerminal,
@@ -93,10 +97,7 @@ fn visit_statement(stmt: &ReactiveStatement, state: &mut VisitorState) {
     }
 }
 
-fn visit_terminal(
-    terminal: &crate::react_compiler_hir::ReactiveTerminalStatement,
-    state: &mut VisitorState,
-) {
+fn visit_terminal(terminal: &ReactiveTerminalStatement, state: &mut VisitorState) {
     match &terminal.terminal {
         ReactiveTerminal::If { consequent, alternate, .. } => {
             visit_block(consequent, state);
@@ -165,10 +166,7 @@ fn visit_scope(scope_block: &ReactiveScopeBlock, state: &mut VisitorState) {
     }
 }
 
-fn visit_pruned_scope(
-    pruned: &crate::react_compiler_hir::PrunedReactiveScopeBlock,
-    state: &mut VisitorState,
-) {
+fn visit_pruned_scope(pruned: &PrunedReactiveScopeBlock, state: &mut VisitorState) {
     visit_block(&pruned.instructions, state);
     state.pruned_scopes.insert(pruned.scope);
 }
@@ -464,29 +462,29 @@ fn start_memoize_operands(deps: &Option<Vec<ManualMemoDependency>>) -> Vec<Place
 }
 
 /// Get lvalue places from a Destructure pattern.
-fn destructure_lvalue_places(pattern: &crate::react_compiler_hir::Pattern) -> Vec<&Place> {
+fn destructure_lvalue_places(pattern: &Pattern) -> Vec<&Place> {
     let mut result = Vec::new();
     match pattern {
-        crate::react_compiler_hir::Pattern::Array(arr) => {
+        Pattern::Array(arr) => {
             for item in &arr.items {
                 match item {
-                    crate::react_compiler_hir::ArrayPatternElement::Place(place) => {
+                    ArrayPatternElement::Place(place) => {
                         result.push(place);
                     }
-                    crate::react_compiler_hir::ArrayPatternElement::Spread(spread) => {
+                    ArrayPatternElement::Spread(spread) => {
                         result.push(&spread.place);
                     }
-                    crate::react_compiler_hir::ArrayPatternElement::Hole => {}
+                    ArrayPatternElement::Hole => {}
                 }
             }
         }
-        crate::react_compiler_hir::Pattern::Object(obj) => {
+        Pattern::Object(obj) => {
             for entry in &obj.properties {
                 match entry {
-                    crate::react_compiler_hir::ObjectPropertyOrSpread::Property(prop) => {
+                    ObjectPropertyOrSpread::Property(prop) => {
                         result.push(&prop.place);
                     }
-                    crate::react_compiler_hir::ObjectPropertyOrSpread::Spread(spread) => {
+                    ObjectPropertyOrSpread::Spread(spread) => {
                         result.push(&spread.place);
                     }
                 }
@@ -552,18 +550,19 @@ fn compare_deps(
     if is_subpath
         && (source.path.len() == inferred.path.len()
             || (inferred.path.len() >= source.path.len()
-                && !inferred.path.iter().any(|t| {
-                    t.property
-                        == crate::react_compiler_hir::PropertyLiteral::String("current".to_string())
-                })))
+                && !inferred
+                    .path
+                    .iter()
+                    .any(|t| t.property == PropertyLiteral::String("current".to_string()))))
     {
         CompareDependencyResult::Ok
     } else if is_subpath {
-        if source.path.iter().any(|t| {
-            t.property == crate::react_compiler_hir::PropertyLiteral::String("current".to_string())
-        }) || inferred.path.iter().any(|t| {
-            t.property == crate::react_compiler_hir::PropertyLiteral::String("current".to_string())
-        }) {
+        if source.path.iter().any(|t| t.property == PropertyLiteral::String("current".to_string()))
+            || inferred
+                .path
+                .iter()
+                .any(|t| t.property == PropertyLiteral::String("current".to_string()))
+        {
             CompareDependencyResult::RefAccessDifference
         } else {
             CompareDependencyResult::Subpath
@@ -577,20 +576,20 @@ fn compare_deps(
 fn pretty_print_scope_dependency(
     dep_id: IdentifierId,
     dep_path: &[DependencyPathEntry],
-    identifiers: &[crate::react_compiler_hir::Identifier],
+    identifiers: &[Identifier],
 ) -> String {
     let ident = &identifiers[dep_id.0 as usize];
     let root_str = match &ident.name {
-        Some(crate::react_compiler_hir::IdentifierName::Named(n)) => n.clone(),
-        Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => n.clone(),
+        Some(IdentifierName::Named(n)) => n.clone(),
+        Some(IdentifierName::Promoted(n)) => n.clone(),
         None => "[unnamed]".to_string(),
     };
     let path_str: String = dep_path
         .iter()
         .map(|entry| {
             let prop = match &entry.property {
-                crate::react_compiler_hir::PropertyLiteral::String(s) => s.clone(),
-                crate::react_compiler_hir::PropertyLiteral::Number(n) => format!("{}", n),
+                PropertyLiteral::String(s) => s.clone(),
+                PropertyLiteral::Number(n) => format!("{}", n),
             };
             if entry.optional { format!("?.{}", prop) } else { format!(".{}", prop) }
         })
@@ -601,15 +600,15 @@ fn pretty_print_scope_dependency(
 /// Pretty-print a manual memo dependency for error messages.
 fn print_manual_memo_dependency(
     dep: &ManualMemoDependency,
-    identifiers: &[crate::react_compiler_hir::Identifier],
+    identifiers: &[Identifier],
     with_optional: bool,
 ) -> String {
     let root_str = match &dep.root {
         ManualMemoDependencyRoot::NamedLocal { value, .. } => {
             let ident = &identifiers[value.identifier.0 as usize];
             match &ident.name {
-                Some(crate::react_compiler_hir::IdentifierName::Named(n)) => n.clone(),
-                Some(crate::react_compiler_hir::IdentifierName::Promoted(n)) => n.clone(),
+                Some(IdentifierName::Named(n)) => n.clone(),
+                Some(IdentifierName::Promoted(n)) => n.clone(),
                 None => "[unnamed]".to_string(),
             }
         }
@@ -620,8 +619,8 @@ fn print_manual_memo_dependency(
         .iter()
         .map(|entry| {
             let prop = match &entry.property {
-                crate::react_compiler_hir::PropertyLiteral::String(s) => s.clone(),
-                crate::react_compiler_hir::PropertyLiteral::Number(n) => format!("{}", n),
+                PropertyLiteral::String(s) => s.clone(),
+                PropertyLiteral::Number(n) => format!("{}", n),
             };
             if with_optional && entry.optional {
                 format!("?.{}", prop)
@@ -670,7 +669,7 @@ fn validate_inferred_dep(
             root: ManualMemoDependencyRoot::NamedLocal {
                 value: Place {
                     identifier: dep_id,
-                    effect: crate::react_compiler_hir::Effect::Read,
+                    effect: Effect::Read,
                     reactive: false,
                     loc: ident.loc,
                 },

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_preserved_manual_memoization.rs
@@ -18,8 +18,8 @@ use crate::react_compiler_hir::environment::Environment;
 use crate::react_compiler_hir::{
     DeclarationId, DependencyPathEntry, Identifier, IdentifierId, IdentifierName, InstructionKind,
     InstructionValue, ManualMemoDependency, ManualMemoDependencyRoot, Place, ReactiveBlock,
-    ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveValue,
-    ScopeId,
+    ReactiveFunction, ReactiveInstruction, ReactiveScopeBlock, ReactiveStatement, ReactiveTerminal,
+    ReactiveValue, ScopeId,
 };
 
 /// State tracked during manual memo validation within a StartMemoize..FinishMemoize range.
@@ -97,7 +97,6 @@ fn visit_terminal(
     terminal: &crate::react_compiler_hir::ReactiveTerminalStatement,
     state: &mut VisitorState,
 ) {
-    use crate::react_compiler_hir::ReactiveTerminal;
     match &terminal.terminal {
         ReactiveTerminal::If { consequent, alternate, .. } => {
             visit_block(consequent, state);

--- a/crates/oxc_react_compiler/src/react_compiler_validation/validate_use_memo.rs
+++ b/crates/oxc_react_compiler/src/react_compiler_validation/validate_use_memo.rs
@@ -9,7 +9,7 @@ use crate::react_compiler_hir::visitors::{
 };
 use crate::react_compiler_hir::{
     FunctionId, HirFunction, IdentifierId, InstructionValue, ParamPattern, Place, PlaceOrSpread,
-    ReturnVariant, Terminal,
+    PropertyLiteral, ReturnVariant, Terminal,
 };
 
 /// Validates useMemo() usage patterns.
@@ -68,9 +68,7 @@ fn validate_use_memo_impl(
                 }
                 InstructionValue::PropertyLoad { object, property, .. } => {
                     if react.contains(&object.identifier) {
-                        if let crate::react_compiler_hir::PropertyLiteral::String(prop_name) =
-                            property
-                        {
+                        if let PropertyLiteral::String(prop_name) = property {
                             if prop_name == "useMemo" {
                                 use_memos.insert(lvalue.identifier);
                             }


### PR DESCRIPTION
Readability refactor of `oxc_react_compiler` — pure import relocation, no behavior change.

**1. Trim module allows** — the 12 vendored-module `#[allow(clippy::all, dead_code, unused)]` become `#[allow(clippy::all)]`. `dead_code`/`unused` suppressed nothing: the modules are `pub`, and the few genuinely-dead private items keep their own targeted `#[allow(dead_code)]`.

**2. Hoist function-local imports** — function-local `use` statements moved to the module top across the crate.

**3. Shorten inline module paths** — ~1230 inline `crate::`/extern-crate module-path qualifiers in the code body replaced with top-level `use` imports + short names, so the code reads without long paths. Collisions are aliased, not shadowed:
- AST vs HIR types under the `react_compiler_hir::*` glob (e.g. `BinaryOperator as AstBinaryOperator`)
- `std::fmt::Result as FmtResult` — bare `Result` would shadow the prelude `Result<T, E>` and leak through the hir glob into sibling modules
- `SourceType as AstSourceType` vs `oxc_span::SourceType`

Doc-comment intra-doc links and a few paths disambiguating a same-named local function are intentionally left fully-qualified.